### PR TITLE
[DRAFT] Jetpack: Add magic code login

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -57,6 +57,7 @@ import ContinueAsUser from './continue-as-user';
 import ErrorNotice from './error-notice';
 import LoginForm from './login-form';
 import { LoginHeader } from './login-header';
+import { shouldUseMagicCode } from './utils/should-use-magic-code';
 
 import './style.scss';
 
@@ -740,6 +741,7 @@ export default connect(
 				redirectTo: stateProps.redirectTo,
 				loginFormFlow: true,
 				showGlobalNotices: false,
+				...( shouldUseMagicCode( { isJetpack: ownProps.isJetpack } ) && { tokenType: 'code' } ),
 				source: stateProps.isWooJPC ? 'woo-passwordless-jpc' + '-' + get( stateProps, 'from' ) : '',
 				flow:
 					( ownProps.isJetpack && 'jetpack' ) ||

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -69,6 +69,7 @@ import isWooJPCFlow from 'calypso/state/selectors/is-woo-jpc-flow';
 import ErrorNotice from './error-notice';
 import SocialLoginForm from './social';
 import { isA4AReferralClient } from './utils/is-a4a-referral-for-client';
+import { shouldUseMagicCode } from './utils/should-use-magic-code';
 
 import './login-form.scss';
 
@@ -335,6 +336,7 @@ export class LoginForm extends Component {
 				redirectTo: this.props.redirectTo,
 				requestLoginEmailFormFlow: true,
 				createAccount: true,
+				...( shouldUseMagicCode( { isJetpack: this.props.isJetpack } ) && { tokenType: 'code' } ),
 				flow: 'jetpack',
 			} );
 		}

--- a/client/blocks/login/utils/should-use-magic-code.ts
+++ b/client/blocks/login/utils/should-use-magic-code.ts
@@ -1,0 +1,23 @@
+import config from '@automattic/calypso-config';
+
+type ShouldUseMagicCodeProps = {
+	/**
+	 * Whether the login is for a Jetpack site.
+	 */
+	isJetpack: boolean;
+};
+
+/**
+ * Returns true if the login should use magic code.
+ * @param {ShouldUseMagicCodeProps} options
+ * @returns {boolean}
+ */
+export function shouldUseMagicCode( { isJetpack }: ShouldUseMagicCodeProps ): boolean {
+	const isMagicCodeEnabled = config.isEnabled( 'login/use-magic-code' );
+
+	if ( isJetpack && isMagicCodeEnabled ) {
+		return true;
+	}
+
+	return false;
+}

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -10,6 +10,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
 import AppPromo from 'calypso/blocks/app-promo';
+import { shouldUseMagicCode } from 'calypso/blocks/login/utils/should-use-magic-code';
 import FormButton from 'calypso/components/forms/form-button';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import GlobalNotices from 'calypso/components/global-notices';
@@ -62,6 +63,7 @@ import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-
 import getIsWCCOM from 'calypso/state/selectors/get-is-wccom';
 import getLocaleSuggestions from 'calypso/state/selectors/get-locale-suggestions';
 import getMagicLoginCurrentView from 'calypso/state/selectors/get-magic-login-current-view';
+import getMagicLoginPublicToken from 'calypso/state/selectors/get-magic-login-public-token';
 import getMagicLoginRequestAuthError from 'calypso/state/selectors/get-magic-login-request-auth-error';
 import getMagicLoginRequestEmailError from 'calypso/state/selectors/get-magic-login-request-email-error';
 import getMagicLoginRequestedAuthSuccessfully from 'calypso/state/selectors/get-magic-login-requested-auth-successfully';
@@ -71,6 +73,7 @@ import isMagicLoginEmailRequested from 'calypso/state/selectors/is-magic-login-e
 import isWooJPCFlow from 'calypso/state/selectors/is-woo-jpc-flow';
 import { withEnhancers } from 'calypso/state/utils';
 import MainContentWooCoreProfiler from './main-content-woo-core-profiler';
+import RequestLoginCode from './request-login-code';
 import RequestLoginEmailForm from './request-login-email-form';
 import './style.scss';
 
@@ -1280,6 +1283,10 @@ class MagicLogin extends Component {
 		return <p className="studio-magic-login__tos">{ tosText }</p>;
 	};
 
+	handlePublicTokenReceived = ( publicToken ) => {
+		this.setState( { publicToken } );
+	};
+
 	render() {
 		const {
 			oauth2Client,
@@ -1287,6 +1294,7 @@ class MagicLogin extends Component {
 			translate,
 			showCheckYourEmail: showEmailLinkVerification,
 			isWooJPC,
+			isJetpackLogin,
 			isFromJetpackOnboarding,
 		} = this.props;
 		const { showSecondaryEmailOptions, showEmailCodeVerification, usernameOrEmail } = this.state;
@@ -1382,7 +1390,17 @@ class MagicLogin extends Component {
 
 				<GlobalNotices id="notices" />
 
-				<RequestLoginEmailForm { ...requestLoginEmailFormProps } />
+				{ shouldUseMagicCode( { isJetpack: isJetpackLogin } ) ? (
+					<RequestLoginCode
+						{ ...requestLoginEmailFormProps }
+						emailRequested={ this.props.emailRequested }
+						publicToken={ this.props.publicToken }
+						onPublicTokenReceived={ this.handlePublicTokenReceived }
+					/>
+				) : (
+					<RequestLoginEmailForm { ...requestLoginEmailFormProps } />
+				) }
+
 				{ this.renderLinks() }
 			</Main>
 		);
@@ -1417,6 +1435,7 @@ const mapState = ( state ) => ( {
 		new URLSearchParams( getRedirectToOriginal( state )?.split( '?' )[ 1 ] ).get( 'from' ) ===
 		'jetpack-onboarding',
 	isWooJPC: isWooJPCFlow( state ),
+	publicToken: getMagicLoginPublicToken( state ),
 } );
 
 const mapDispatch = {

--- a/client/login/magic-login/request-login-code.jsx
+++ b/client/login/magic-login/request-login-code.jsx
@@ -1,0 +1,200 @@
+import { FormLabel } from '@automattic/components';
+import { Spinner } from '@wordpress/components';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { useRef, useState, useEffect } from 'react';
+import { connect } from 'react-redux';
+import FormButton from 'calypso/components/forms/form-button';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import LoggedOutForm from 'calypso/components/logged-out-form';
+import Notice from 'calypso/components/notice';
+import { sendEmailLogin } from 'calypso/state/auth/actions';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { hideMagicLoginRequestNotice } from 'calypso/state/login/magic-login/actions';
+import { getLastCheckedUsernameOrEmail } from 'calypso/state/login/selectors';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
+import getMagicLoginRequestEmailError from 'calypso/state/selectors/get-magic-login-request-email-error';
+import isFetchingMagicLoginEmail from 'calypso/state/selectors/is-fetching-magic-login-email';
+import VerifyLoginCode from './verify-login-code';
+
+const RequestLoginCode = ( {
+	currentUser,
+	emailRequested,
+	isFetching,
+	redirectTo,
+	requestError,
+	userEmail,
+	flow,
+	onReady,
+	onPublicTokenReceived,
+	sendEmailLogin: sendEmail,
+	hideMagicLoginRequestNotice: hideRequestNotice,
+	translate,
+	shouldShowLoadingEllipsis,
+	publicToken,
+} ) => {
+	const [ usernameOrEmail, setUsernameOrEmail ] = useState( userEmail || '' );
+	const usernameOrEmailRef = useRef( null );
+
+	useEffect( () => {
+		if ( onReady ) {
+			onReady();
+		}
+	}, [ onReady ] );
+
+	const onUsernameOrEmailFieldChange = ( event ) => {
+		setUsernameOrEmail( event.target.value );
+
+		if ( requestError ) {
+			hideRequestNotice();
+		}
+	};
+
+	const onNoticeDismiss = () => {
+		hideRequestNotice();
+	};
+
+	const handleSendEmail = ( email = usernameOrEmail ) => {
+		if ( ! email.length ) {
+			return;
+		}
+
+		sendEmail( email, {
+			redirectTo,
+			requestLoginEmailFormFlow: true,
+			createAccount: false,
+			tokenType: 'code', // Request code instead of link
+			...( flow ? { flow } : {} ),
+			onSuccess: ( response ) => {
+				if ( response && response.public_token ) {
+					if ( onPublicTokenReceived ) {
+						onPublicTokenReceived( response.public_token );
+					}
+				}
+			},
+		} );
+	};
+
+	const onSubmit = ( event ) => {
+		event.preventDefault();
+		handleSendEmail();
+	};
+
+	if ( shouldShowLoadingEllipsis ) {
+		return <Spinner className="magic-login__loading-spinner--jetpack" />;
+	}
+
+	// Show verification code form if email has been requested and we have a public token
+	if ( emailRequested && publicToken ) {
+		return (
+			<VerifyLoginCode
+				publicToken={ publicToken }
+				usernameOrEmail={ usernameOrEmail }
+				onResendEmail={ onSubmit }
+			/>
+		);
+	}
+
+	const submitEnabled =
+		usernameOrEmail.length && ! isFetching && ! emailRequested && ! requestError;
+
+	const errorText =
+		typeof requestError?.message === 'string' && requestError?.message.length
+			? requestError?.message
+			: translate( 'Unable to complete request' );
+
+	return (
+		<div className="magic-login__form">
+			<h1 className="magic-login__form-header">{ translate( 'Email me a login code' ) }</h1>
+			<LoggedOutForm onSubmit={ onSubmit }>
+				{ currentUser && currentUser.username && (
+					<Notice
+						showDismiss={ false }
+						className="magic-login__form-header-notice"
+						status="is-info"
+						theme="light"
+						text={ translate( 'You are already logged in as user: %(user)s', {
+							args: {
+								user: currentUser.username,
+							},
+						} ) }
+					></Notice>
+				) }
+
+				<p className="magic-login__form-sub-header">
+					{ translate( "We'll send you an email with a code that will log you in right away." ) }
+				</p>
+
+				<FormLabel htmlFor="usernameOrEmail">
+					{ translate( 'Email Address or Username' ) }
+				</FormLabel>
+				<FormFieldset className="magic-login__email-fields">
+					<FormTextInput
+						autoCapitalize="off"
+						autoComplete="username"
+						className="magic-login__request-login-email-form-fields"
+						disabled={ isFetching || emailRequested }
+						id="usernameOrEmail"
+						name="usernameOrEmail"
+						value={ usernameOrEmail }
+						onChange={ onUsernameOrEmailFieldChange }
+						placeholder={ translate( 'Email or Username' ) }
+						ref={ usernameOrEmailRef }
+					/>
+
+					{ requestError && (
+						<Notice
+							onDismissClick={ onNoticeDismiss }
+							className="magic-login__request-login-email-form-notice"
+							status="is-error"
+							text={ errorText }
+						/>
+					) }
+
+					<div className="magic-login__form-action">
+						<FormButton primary disabled={ ! submitEnabled } busy={ isFetching } type="submit">
+							{ translate( 'Send Code' ) }
+						</FormButton>
+					</div>
+				</FormFieldset>
+			</LoggedOutForm>
+		</div>
+	);
+};
+
+RequestLoginCode.propTypes = {
+	// mapped to state
+	currentUser: PropTypes.object,
+	emailRequested: PropTypes.bool,
+	isFetching: PropTypes.bool,
+	redirectTo: PropTypes.string,
+	requestError: PropTypes.object,
+	userEmail: PropTypes.string,
+	flow: PropTypes.string,
+
+	// mapped to dispatch
+	sendEmailLogin: PropTypes.func.isRequired,
+	hideMagicLoginRequestNotice: PropTypes.func.isRequired,
+
+	onReady: PropTypes.func,
+	onPublicTokenReceived: PropTypes.func,
+};
+
+const mapState = ( state ) => ( {
+	currentUser: getCurrentUser( state ),
+	isFetching: isFetchingMagicLoginEmail( state ),
+	requestError: getMagicLoginRequestEmailError( state ),
+	userEmail:
+		getLastCheckedUsernameOrEmail( state ) ||
+		getCurrentQueryArguments( state ).email_address ||
+		getInitialQueryArguments( state ).email_address,
+} );
+
+const mapDispatch = {
+	sendEmailLogin,
+	hideMagicLoginRequestNotice,
+};
+
+export default connect( mapState, mapDispatch )( localize( RequestLoginCode ) );

--- a/client/login/magic-login/verify-login-code.jsx
+++ b/client/login/magic-login/verify-login-code.jsx
@@ -1,0 +1,158 @@
+import { Button } from '@wordpress/components';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { useState, useEffect } from 'react';
+import { connect } from 'react-redux';
+import FormButton from 'calypso/components/forms/form-button';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import LoggedOutForm from 'calypso/components/logged-out-form';
+import Notice from 'calypso/components/notice';
+import { preventWidows } from 'calypso/lib/formatting';
+import { navigate } from 'calypso/lib/navigate';
+import { fetchMagicLoginAuthenticate } from 'calypso/state/login/magic-login/actions';
+import { getRedirectToOriginal } from 'calypso/state/login/selectors';
+import getMagicLoginAuthSuccessData from 'calypso/state/selectors/get-magic-login-auth-success-data';
+import getMagicLoginRequestAuthError from 'calypso/state/selectors/get-magic-login-request-auth-error';
+import getMagicLoginRequestedAuthSuccessfully from 'calypso/state/selectors/get-magic-login-requested-auth-successfully';
+import isFetchingMagicLoginAuth from 'calypso/state/selectors/is-fetching-magic-login-auth';
+
+const VerifyLoginCode = ( {
+	isValidating,
+	isAuthenticated,
+	authError,
+	publicToken,
+	usernameOrEmail,
+	authSuccessData,
+	fetchMagicLoginAuthenticate: authenticate,
+	redirectTo,
+	translate,
+	onResendEmail,
+} ) => {
+	const [ verificationCode, setVerificationCode ] = useState( '' );
+	const [ isRedirecting, setIsRedirecting ] = useState( false );
+
+	useEffect( () => {
+		if ( isAuthenticated && authSuccessData ) {
+			setIsRedirecting( true );
+			navigate( authSuccessData.redirect_to );
+		}
+	}, [ isAuthenticated, authSuccessData ] );
+
+	const onCodeChange = ( event ) => {
+		setVerificationCode( event.target.value );
+	};
+
+	const onSubmit = ( event ) => {
+		event.preventDefault();
+
+		if ( ! verificationCode || ! publicToken ) {
+			return;
+		}
+
+		// Format: publicToken:code
+		const loginToken = `${ publicToken }:${ btoa( verificationCode ) }`;
+
+		authenticate( loginToken, redirectTo );
+	};
+
+	const isDisabled = isValidating || isRedirecting;
+	const submitEnabled = verificationCode.length > 0 && ! isDisabled;
+
+	return (
+		<div className="magic-login__successfully-jetpack">
+			<h1 className="magic-login__form-header">{ translate( 'Check your inbox' ) }</h1>
+			<p>
+				{ translate(
+					'We sent a message to ({{strong}}%(email)s{{/strong}}) with a code to log in to WordPress.com.',
+					{
+						args: {
+							email: usernameOrEmail,
+						},
+						components: {
+							strong: <strong />,
+						},
+					}
+				) }
+			</p>
+			<LoggedOutForm onSubmit={ onSubmit }>
+				{ authError && (
+					<Notice
+						showDismiss={ false }
+						status="is-error"
+						text={ translate( 'Invalid code. Please try again.' ) }
+					/>
+				) }
+
+				<FormTextInput
+					autoCapitalize="off"
+					className="magic-login__verify-code-field"
+					disabled={ isDisabled }
+					name="verificationCode"
+					value={ verificationCode }
+					onChange={ onCodeChange }
+					placeholder={ translate( 'Enter your verification code' ) }
+				/>
+
+				<div className="magic-login__form-action">
+					<FormButton primary disabled={ ! submitEnabled } busy={ isDisabled } type="submit">
+						{ translate( 'Verify' ) }
+					</FormButton>
+				</div>
+			</LoggedOutForm>
+
+			<p>{ preventWidows( translate( "Only one step left—we'll connect your site next." ) ) }</p>
+			<div className="magic-login__successfully-jetpack-actions">
+				<p>
+					{ translate(
+						"Didn't get the code? Check your spam folder or {{button}}resend the email{{/button}}",
+						{
+							components: {
+								button: (
+									<Button
+										className="magic-login__resend-button"
+										variant="link"
+										onClick={ onResendEmail }
+										disabled={ isRedirecting }
+									/>
+								),
+							},
+						}
+					) }
+				</p>
+				<p>
+					{ translate( 'Wrong email or account? {{link}}Use a different account{{/link}}', {
+						components: {
+							link: <a className="magic-login__log-in-link" href="/log-in" />,
+						},
+					} ) }
+				</p>
+			</div>
+		</div>
+	);
+};
+
+VerifyLoginCode.propTypes = {
+	isValidating: PropTypes.bool,
+	isAuthenticated: PropTypes.bool,
+	authError: PropTypes.object,
+	publicToken: PropTypes.string,
+	usernameOrEmail: PropTypes.string,
+	authSuccessData: PropTypes.object,
+	fetchMagicLoginAuthenticate: PropTypes.func.isRequired,
+	redirectTo: PropTypes.string,
+	onResendEmail: PropTypes.func,
+};
+
+const mapState = ( state ) => ( {
+	isValidating: isFetchingMagicLoginAuth( state ),
+	isAuthenticated: getMagicLoginRequestedAuthSuccessfully( state ),
+	authError: getMagicLoginRequestAuthError( state ),
+	redirectTo: getRedirectToOriginal( state ),
+	authSuccessData: getMagicLoginAuthSuccessData( state ),
+} );
+
+const mapDispatch = {
+	fetchMagicLoginAuthenticate,
+};
+
+export default connect( mapState, mapDispatch )( localize( VerifyLoginCode ) );

--- a/client/state/auth/actions.js
+++ b/client/state/auth/actions.js
@@ -15,6 +15,7 @@ import 'calypso/state/data-layer/wpcom/auth/send-login-email';
  * @param {boolean} options.showGlobalNotices - if true, displays global notices to user about the email
  * @param {string} options.flow - name of the login flow
  * @param {boolean} options.createAccount - if true, instructs the API to create a WPCOM account associated with email
+ * @param {'link'|'code'} options.tokenType - type of token to send in the email
  * @param {boolean} options.source - source of the login request (optional)
  * @returns {Object} action object
  */
@@ -29,6 +30,7 @@ export const sendEmailLogin = (
 		isMobileAppLogin = false,
 		flow = null,
 		createAccount = false,
+		tokenType = 'link',
 		source = '',
 	}
 ) => {
@@ -48,6 +50,7 @@ export const sendEmailLogin = (
 		requestLoginEmailFormFlow,
 		flow,
 		createAccount,
+		tokenType,
 		source,
 	};
 };

--- a/client/state/data-layer/wpcom/auth/send-login-email/index.js
+++ b/client/state/data-layer/wpcom/auth/send-login-email/index.js
@@ -33,6 +33,7 @@ export const sendLoginEmail = ( action ) => {
 		flow,
 		createAccount,
 		source,
+		tokenType,
 	} = action;
 	const noticeAction = showGlobalNotices
 		? infoNotice( translate( 'Sending email' ), { duration: 4000 } )
@@ -73,6 +74,7 @@ export const sendLoginEmail = ( action ) => {
 					...( flow && { flow } ),
 					create_account: createAccount,
 					tos: getToSAcceptancePayload(),
+					...( tokenType && { token_type: tokenType } ),
 					source,
 					calypso_env:
 						window?.location?.host === 'wordpress.com' ? 'production' : config( 'env_id' ),
@@ -83,16 +85,13 @@ export const sendLoginEmail = ( action ) => {
 	];
 };
 
-export const onSuccess = ( {
-	email,
-	showGlobalNotices,
-	infoNoticeId = null,
-	loginFormFlow,
-	requestLoginEmailFormFlow,
-} ) => [
+export const onSuccess = (
+	{ email, showGlobalNotices, infoNoticeId = null, loginFormFlow, requestLoginEmailFormFlow },
+	response
+) => [
 	...( loginFormFlow || requestLoginEmailFormFlow
 		? [
-				{ type: MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_SUCCESS },
+				{ type: MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_SUCCESS, response },
 				{ type: MAGIC_LOGIN_SHOW_CHECK_YOUR_EMAIL_PAGE, email },
 		  ]
 		: [] ),

--- a/client/state/login/magic-login/actions.js
+++ b/client/state/login/magic-login/actions.js
@@ -86,6 +86,7 @@ export const fetchMagicLoginAuthenticate =
 
 				dispatch( {
 					type: MAGIC_LOGIN_REQUEST_AUTH_SUCCESS,
+					data: json.data,
 				} );
 			} )
 			.catch( ( error ) => {

--- a/client/state/login/magic-login/reducer.js
+++ b/client/state/login/magic-login/reducer.js
@@ -133,6 +133,30 @@ export const requestEmailSuccess = ( state = false, action ) => {
 	return state;
 };
 
+export const publicToken = ( state = null, action ) => {
+	switch ( action.type ) {
+		case MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_SUCCESS:
+			return action.response?.public_token || null;
+		case MAGIC_LOGIN_RESET_REQUEST_FORM:
+			return null;
+	}
+
+	return state;
+};
+
+export const authSuccessData = ( state = null, action ) => {
+	switch ( action.type ) {
+		case MAGIC_LOGIN_REQUEST_AUTH_SUCCESS:
+			return action.data || null;
+		case MAGIC_LOGIN_REQUEST_AUTH_ERROR:
+		case MAGIC_LOGIN_REQUEST_AUTH_FETCH:
+		case MAGIC_LOGIN_RESET_REQUEST_FORM:
+			return null;
+	}
+
+	return state;
+};
+
 export default combineReducers( {
 	isFetchingAuth,
 	isFetchingEmail,
@@ -141,4 +165,6 @@ export default combineReducers( {
 	requestEmailError,
 	requestEmailSuccess,
 	currentView,
+	publicToken,
+	authSuccessData,
 } );

--- a/client/state/selectors/get-magic-login-auth-success-data.js
+++ b/client/state/selectors/get-magic-login-auth-success-data.js
@@ -1,0 +1,8 @@
+/**
+ * Returns the magic login authentication success data if it exists
+ * @param  {Object}  state Global state tree
+ * @returns {Object | null}  The auth success data if it exists, null otherwise
+ */
+export default function getMagicLoginAuthSuccessData( state ) {
+	return state.login.magicLogin.authSuccessData;
+}

--- a/client/state/selectors/get-magic-login-public-token.js
+++ b/client/state/selectors/get-magic-login-public-token.js
@@ -1,0 +1,8 @@
+/**
+ * Returns the public token for magic login if it exists
+ * @param  {Object}  state Global state tree
+ * @returns {string|null}  The public token if it exists, null otherwise
+ */
+export default function getMagicLoginPublicToken( state ) {
+	return state.login.magicLogin.publicToken;
+}

--- a/config/development.json
+++ b/config/development.json
@@ -113,6 +113,7 @@
 		"livechat_solution": true,
 		"login/last-used-method": true,
 		"login/magic-login": true,
+		"login/use-magic-code": true,
 		"logmein": true,
 		"mailchimp": true,
 		"manage/import/site-importer-endpoints": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -87,6 +87,7 @@
 		"livechat_solution": true,
 		"login/last-used-method": true,
 		"login/magic-login": true,
+		"login/use-magic-code": false,
 		"mailchimp": true,
 		"marketplace-fetch-all-dynamic-products": true,
 		"marketplace-personal-premium": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -89,6 +89,7 @@
 		"livechat_solution": true,
 		"login/last-used-method": true,
 		"login/magic-login": true,
+		"login/use-magic-code": false,
 		"logmein": true,
 		"mailchimp": true,
 		"marketplace-fetch-all-dynamic-products": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

This is a bulk change for https://linear.app/a8c/project/implement-magic-code-login-be8919470557/overview

This change will be broken up into pieces, but this bulk change can be used to test the flow and the functionality.

- (IMPORTANT) Allow the browsers' 3rd-party cookies (e.g. [Google Chrome](https://support.google.com/accounts/answer/61416?hl=en&co=GENIE.Platform%3DDesktop)) otherwise you won't be able to test it because of CORS

- Check out this change and start your local Calypso intstance
- Go to `calypso.localhost:3000/log-in/jetpack` and use a non-automattician account
- Make sure you get the code in email
- Make sure after providing the code you get redirected to the homepage, and you are logged in
- You can also test the Jetpack Connect flow:
  - On JN/JT start connecting to Jetpack by clicking on `Supercharge my site`
  - On the redirected URL change the host to the local Calypso instance
  - Log in the same way as with the steps above

Also sanity check that other flows like `/log-in` is working as before with the magic link, and not the magic codes