### PR TITLE
Add logging when chat is reset

### DIFF
--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -53,6 +53,12 @@ export const useGetCombinedChat = ( canConnectToZendesk: boolean ) => {
 				provider: 'odie',
 				status: 'loaded',
 			} );
+
+			trackEvent( 'zendesk_chat_reset_to_odie', {
+				interaction: currentSupportInteraction.uuid,
+				conversation_id: conversationId,
+				chat_id: odieChat?.odieId,
+			} );
 		} else if ( isChatLoaded && canFetchConversation ) {
 			try {
 				getZendeskConversation( {

--- a/packages/odie-client/src/hooks/use-zendesk-message-listener.ts
+++ b/packages/odie-client/src/hooks/use-zendesk-message-listener.ts
@@ -1,4 +1,3 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { HelpCenterSelect } from '@automattic/data-stores';
 import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { useSelect } from '@wordpress/data';
@@ -37,11 +36,6 @@ export const useZendeskMessageListener = () => {
 					status: 'loaded',
 				} ) );
 				Smooch.markAllAsRead( data.conversation.id );
-			} else {
-				recordTracksEvent( 'calypso_zendesk_message_received_wrong_conversation', {
-					conversation_id: data?.conversation?.id,
-					chat_id: chat?.conversationId,
-				} );
 			}
 		},
 		[ chat.conversationId, setChat ]


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Add logging for users who have conversation id in interaction but they are not allowed to access zd.

Part of #

## Proposed Changes

* Add logging when zendesk chat is switched to odie

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To isolate and fix possible issues

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start a conversation in the hc
* Block the network request to zd embeddable/config to trigger this scenario
* Check tracks for the relevant event

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
