### PR TITLE
reader/notifications/controller: Pass correct property to getShouldShowGlobalSidebar

### DIFF
--- a/client/reader/notifications/controller.jsx
+++ b/client/reader/notifications/controller.jsx
@@ -15,7 +15,7 @@ export function notifications( context, next ) {
 	const state = context.store.getState();
 	const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( {
 		state,
-		currentSection: { group: 'reader' },
+		section: { group: 'reader' },
 	} );
 	const isGlobalNotificationsOpen = getIsNotificationsOpen( state );
 

--- a/client/reader/notifications/controller.jsx
+++ b/client/reader/notifications/controller.jsx
@@ -15,6 +15,7 @@ export function notifications( context, next ) {
 	const state = context.store.getState();
 	const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( {
 		state,
+		route: getCurrentRoute( state ),
 		section: { group: 'reader' },
 	} );
 	const isGlobalNotificationsOpen = getIsNotificationsOpen( state );

--- a/client/reader/notifications/controller.jsx
+++ b/client/reader/notifications/controller.jsx
@@ -15,7 +15,6 @@ export function notifications( context, next ) {
 	const state = context.store.getState();
 	const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( {
 		state,
-		route: getCurrentRoute( state ),
 		section: { group: 'reader' },
 	} );
 	const isGlobalNotificationsOpen = getIsNotificationsOpen( state );


### PR DESCRIPTION
Fixing an unexpected error on /reader/notifications

<img width="926" alt="Screenshot 2025-05-20 at 9 11 22 AM" src="https://github.com/user-attachments/assets/bb5562d2-c73b-4a64-bae1-3ff150386bfd" />


## Proposed Changes

*

## Why are these changes being made?

*

## Testing Instructions


* Visit `/reader/notifications`

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
