### PR TITLE
Dashboard v2: lazy load php version

### DIFF
--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -18,7 +18,6 @@ import {
 	siteCurrentPlanQuery,
 	siteEngagementStatsQuery,
 	siteMonitorUptimeQuery,
-	sitePHPVersionQuery,
 } from './queries';
 import { queryClient } from './query-client';
 import Root from './root';
@@ -93,9 +92,6 @@ const siteOverviewRoute = createRoute( {
 			// Kick off dependent promises in parallel.
 			site.jetpack && site.jetpack_modules.includes( 'monitor' )
 				? queryClient.ensureQueryData( siteMonitorUptimeQuery( siteSlug ) )
-				: undefined,
-			site.is_wpcom_atomic
-				? queryClient.ensureQueryData( sitePHPVersionQuery( siteSlug ) )
 				: undefined,
 		] );
 	},

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -12,7 +12,6 @@ import { wordpress } from '@wordpress/icons';
 import {
 	siteQuery,
 	siteMonitorUptimeQuery,
-	sitePHPVersionQuery,
 	siteCurrentPlanQuery,
 	siteEngagementStatsQuery,
 } from '../../app/queries';
@@ -38,10 +37,6 @@ function SiteOverview() {
 	const { data: siteMonitorUptime } = useQuery( {
 		...siteMonitorUptimeQuery( siteSlug ),
 		enabled: site?.jetpack && site?.jetpack_modules.includes( 'monitor' ),
-	} );
-	const { data: phpVersion } = useQuery( {
-		...sitePHPVersionQuery( siteSlug ),
-		enabled: site?.is_wpcom_atomic,
 	} );
 	const { data: currentPlan } = useQuery( siteCurrentPlanQuery( siteSlug ) );
 	const { data: engagementStats } = useQuery( siteEngagementStatsQuery( siteSlug ) );
@@ -73,7 +68,7 @@ function SiteOverview() {
 			}
 		>
 			<HStack alignment="flex-start" spacing={ 8 }>
-				<Sidebar site={ site } phpVersion={ phpVersion } currentPlan={ currentPlan } />
+				<Sidebar site={ site } currentPlan={ currentPlan } />
 				<VStack spacing={ 8 }>
 					<Card style={ { padding: '16px' } }>
 						<VStack>

--- a/client/dashboard/sites/overview/site-card.tsx
+++ b/client/dashboard/sites/overview/site-card.tsx
@@ -15,7 +15,7 @@ import SitePreview from '../site-preview';
 import type { Site, Plan } from '../../data/types';
 
 function PHPVersion( { siteSlug }: { siteSlug: string } ) {
-	return useQuery( sitePHPVersionQuery( siteSlug ) ).data;
+	return useQuery( sitePHPVersionQuery( siteSlug ) ).data ?? '\u00A0';
 }
 
 /**
@@ -64,15 +64,13 @@ export default function SiteCard( { site, currentPlan }: { site: Site; currentPl
 						<Field title={ __( 'Status' ) }>{ getSiteStatusLabel( site ) }</Field>
 					</HStack>
 					<HStack justify="space-between">
-						<div style={ { flex: 1 } }>
-							<Field title={ __( 'WordPress' ) }>{ options?.software_version }</Field>
-						</div>
+						<Field title={ __( 'WordPress' ) }>
+							{ options?.software_version ?? __( 'Unknown' ) }
+						</Field>
 						{ is_wpcom_atomic && (
-							<div style={ { flex: 1 } }>
-								<Field title={ __( 'PHP' ) }>
-									<PHPVersion siteSlug={ site.slug } />
-								</Field>
-							</div>
+							<Field title={ __( 'PHP' ) }>
+								<PHPVersion siteSlug={ site.slug } />
+							</Field>
 						) }
 					</HStack>
 					<PlanDetails site={ site } currentPlan={ currentPlan } />
@@ -84,7 +82,7 @@ export default function SiteCard( { site, currentPlan }: { site: Site; currentPl
 
 function Field( { children, title }: { children: React.ReactNode; title: React.ReactNode } ) {
 	return (
-		<VStack className="site-overview-field">
+		<VStack className="site-overview-field" style={ { flex: 1 } }>
 			<FieldTitle>{ title }</FieldTitle>
 			<div className="site-overview-field-children">{ children }</div>
 		</VStack>

--- a/client/dashboard/sites/overview/site-card.tsx
+++ b/client/dashboard/sites/overview/site-card.tsx
@@ -63,16 +63,18 @@ export default function SiteCard( { site, currentPlan }: { site: Site; currentPl
 					<HStack justify="space-between">
 						<Field title={ __( 'Status' ) }>{ getSiteStatusLabel( site ) }</Field>
 					</HStack>
-					<HStack justify="space-between">
-						<Field title={ __( 'WordPress' ) }>
-							{ options?.software_version ?? __( 'Unknown' ) }
-						</Field>
-						{ is_wpcom_atomic && (
-							<Field title={ __( 'PHP' ) }>
-								<PHPVersion siteSlug={ site.slug } />
-							</Field>
-						) }
-					</HStack>
+					{ ( options?.software_version || is_wpcom_atomic ) && (
+						<HStack justify="space-between">
+							{ options?.software_version && (
+								<Field title={ __( 'WordPress' ) }>{ options.software_version }</Field>
+							) }
+							{ is_wpcom_atomic && (
+								<Field title={ __( 'PHP' ) }>
+									<PHPVersion siteSlug={ site.slug } />
+								</Field>
+							) }
+						</HStack>
+					) }
 					<PlanDetails site={ site } currentPlan={ currentPlan } />
 				</VStack>
 			</VStack>

--- a/client/dashboard/sites/overview/site-card.tsx
+++ b/client/dashboard/sites/overview/site-card.tsx
@@ -15,7 +15,11 @@ import SitePreview from '../site-preview';
 import type { Site, Plan } from '../../data/types';
 
 function PHPVersion( { siteSlug }: { siteSlug: string } ) {
-	return useQuery( sitePHPVersionQuery( siteSlug ) ).data ?? '\u00A0';
+	return (
+		useQuery( sitePHPVersionQuery( siteSlug ) ).data ?? (
+			<span className="text-blur" data-text="X.Y" />
+		)
+	);
 }
 
 /**

--- a/client/dashboard/sites/overview/site-card.tsx
+++ b/client/dashboard/sites/overview/site-card.tsx
@@ -14,12 +14,12 @@ import { getSiteStatusLabel } from '../../utils/site-status';
 import SitePreview from '../site-preview';
 import type { Site, Plan } from '../../data/types';
 
+function TextBlur( { text }: { text: string } ) {
+	return <span className="text-blur" data-text={ text } />;
+}
+
 function PHPVersion( { siteSlug }: { siteSlug: string } ) {
-	return (
-		useQuery( sitePHPVersionQuery( siteSlug ) ).data ?? (
-			<span className="text-blur" data-text="X.Y" />
-		)
-	);
+	return useQuery( sitePHPVersionQuery( siteSlug ) ).data ?? <TextBlur text="X.Y" />;
 }
 
 /**

--- a/client/dashboard/sites/overview/site-card.tsx
+++ b/client/dashboard/sites/overview/site-card.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from '@tanstack/react-query';
 import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
@@ -8,23 +9,20 @@ import {
 } from '@wordpress/components';
 import { dateI18n } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
+import { sitePHPVersionQuery } from '../../app/queries';
 import { getSiteStatusLabel } from '../../utils/site-status';
 import SitePreview from '../site-preview';
 import type { Site, Plan } from '../../data/types';
 
+function PHPVersion( { siteSlug }: { siteSlug: string } ) {
+	return useQuery( sitePHPVersionQuery( siteSlug ) ).data;
+}
+
 /**
  * SiteCard component to display site information in a card format
  */
-export default function SiteCard( {
-	site,
-	phpVersion,
-	currentPlan,
-}: {
-	site: Site;
-	phpVersion?: string;
-	currentPlan: Plan;
-} ) {
-	const { options, URL: url, is_private } = site;
+export default function SiteCard( { site, currentPlan }: { site: Site; currentPlan: Plan } ) {
+	const { options, URL: url, is_private, is_wpcom_atomic } = site;
 	// If the site is a private A8C site, X-Frame-Options is set to same
 	// origin.
 	const iframeDisabled = site.is_a8c && is_private;
@@ -66,10 +64,16 @@ export default function SiteCard( {
 						<Field title={ __( 'Status' ) }>{ getSiteStatusLabel( site ) }</Field>
 					</HStack>
 					<HStack justify="space-between">
-						{ options?.software_version && (
-							<Field title={ __( 'WordPress' ) }>{ options.software_version }</Field>
+						<div style={ { flex: 1 } }>
+							<Field title={ __( 'WordPress' ) }>{ options?.software_version }</Field>
+						</div>
+						{ is_wpcom_atomic && (
+							<div style={ { flex: 1 } }>
+								<Field title={ __( 'PHP' ) }>
+									<PHPVersion siteSlug={ site.slug } />
+								</Field>
+							</div>
 						) }
-						{ phpVersion && <Field title={ __( 'PHP' ) }>{ phpVersion }</Field> }
 					</HStack>
 					<PlanDetails site={ site } currentPlan={ currentPlan } />
 				</VStack>

--- a/client/dashboard/sites/overview/style.scss
+++ b/client/dashboard/sites/overview/style.scss
@@ -24,3 +24,8 @@
 		display: none;
 	}
 }
+
+.text-blur::after {
+	content: attr(data-text);
+	filter: blur(4px);
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

<img width="331" alt="image" src="https://github.com/user-attachments/assets/00ae23fb-d9a2-4e24-9fe3-a18c03c2e969" />


Btw, in reality, the version pops in so fast it's not even visible. I had to set it to undefined to be able to take the screenshot.

Similar to #103547.

## Proposed Changes

* Don't block the site overview from rendering for the php version. I've made sure the columns are fixed width so there will be no layout shift.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The less requests needed for the initial site endpoint, the better.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Site overview, check that php version loads for atomic sites.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
