### PR TITLE
Dashboard v2: Implement WP version settings

### DIFF
--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -15,6 +15,8 @@ import {
 	fetchPerformanceInsights,
 	updateSiteSettings,
 	restoreSitePlanSoftware,
+	fetchWordPressVersion,
+	updateWordPressVersion,
 } from '../data';
 import { SITE_FIELDS } from '../data/constants';
 import { queryClient } from './query-client';
@@ -67,6 +69,24 @@ export function sitePHPVersionQuery( siteIdOrSlug: string ) {
 	return {
 		queryKey: [ 'site', siteIdOrSlug, 'php-version' ],
 		queryFn: () => fetchPHPVersion( siteIdOrSlug ),
+	};
+}
+
+export function siteWordPressVersionQuery( siteSlug: string ) {
+	return {
+		queryKey: [ 'site', siteSlug, 'wp-version' ],
+		queryFn: () => {
+			return fetchWordPressVersion( siteSlug );
+		},
+	};
+}
+
+export function siteWordPressVersionMutation( siteSlug: string ) {
+	return {
+		mutationFn: ( version: string ) => updateWordPressVersion( siteSlug, version ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'site', siteSlug, 'wp-version' ] } );
+		},
 	};
 }
 

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -6,6 +6,7 @@ import {
 	createLazyRoute,
 } from '@tanstack/react-router';
 import { fetchTwoStep } from '../data';
+import { canUpdateWordPressVersion } from '../sites/settings-wordpress/utils';
 import NotFound from './404';
 import UnknownError from './500';
 import {
@@ -17,6 +18,7 @@ import {
 	profileQuery,
 	siteCurrentPlanQuery,
 	siteEngagementStatsQuery,
+	siteWordPressVersionQuery,
 } from './queries';
 import { queryClient } from './query-client';
 import Root from './root';
@@ -145,6 +147,23 @@ const siteSettingsSubscriptionGiftingRoute = createRoute( {
 } ).lazy( () =>
 	import( '../sites/settings-subscription-gifting' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-subscription-gifting' )( {
+			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+const siteSettingsWordPressRoute = createRoute( {
+	getParentRoute: () => siteRoute,
+	path: 'settings/wordpress',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteQuery( siteSlug ) );
+		if ( canUpdateWordPressVersion( site ) ) {
+			return await queryClient.ensureQueryData( siteWordPressVersionQuery( siteSlug ) );
+		}
+	},
+} ).lazy( () =>
+	import( '../sites/settings-wordpress' ).then( ( d ) =>
+		createLazyRoute( 'site-settings-wordpress' )( {
 			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
 		} )
 	)
@@ -326,6 +345,7 @@ const createRouteTree = ( config: AppConfig ) => {
 				siteSettingsRoute,
 				siteSettingsSiteVisibilityRoute,
 				siteSettingsSubscriptionGiftingRoute,
+				siteSettingsWordPressRoute,
 				siteSettingsTransferSiteRoute,
 			] )
 		);

--- a/client/dashboard/data/constants.ts
+++ b/client/dashboard/data/constants.ts
@@ -18,6 +18,7 @@ export const SITE_FIELDS = [
 	'is_coming_soon',
 	'is_private',
 	'is_wpcom_atomic',
+	'is_wpcom_staging_site',
 	'launch_status',
 	'site_migration',
 	'site_owner',

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -85,6 +85,26 @@ export const fetchPHPVersion = async ( id: string ): Promise< string | undefined
 	} );
 };
 
+export const fetchWordPressVersion = async ( siteIdOrSlug: string ): Promise< string > => {
+	return wpcom.req.get( {
+		path: `/sites/${ siteIdOrSlug }/hosting/wp-version`,
+		apiNamespace: 'wpcom/v2',
+	} );
+};
+
+export const updateWordPressVersion = async (
+	siteIdOrSlug: string,
+	version: string
+): Promise< void > => {
+	return wpcom.req.post(
+		{
+			path: `/sites/${ siteIdOrSlug }/hosting/wp-version`,
+			apiNamespace: 'wpcom/v2',
+		},
+		{ version }
+	);
+};
+
 export const fetchCurrentPlan = async ( siteIdOrSlug: string ): Promise< Plan > => {
 	const plans: Record< string, Plan > = await wpcom.req.get( {
 		path: `/sites/${ siteIdOrSlug }/plans`,

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -91,6 +91,7 @@ export interface Site {
 	is_coming_soon: boolean;
 	is_private: boolean;
 	is_wpcom_atomic: boolean;
+	is_wpcom_staging_site: boolean;
 	launch_status: string | boolean;
 	site_migration: {
 		migration_status: string;

--- a/client/dashboard/sites/overview/site-card.tsx
+++ b/client/dashboard/sites/overview/site-card.tsx
@@ -12,6 +12,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { sitePHPVersionQuery } from '../../app/queries';
 import { TextBlur } from '../../components/text-blur';
 import { getSiteStatusLabel } from '../../utils/site-status';
+import { getFormattedWordPressVersion } from '../../utils/wp-version';
 import SitePreview from '../site-preview';
 import type { Site, Plan } from '../../data/types';
 
@@ -23,7 +24,9 @@ function PHPVersion( { siteSlug }: { siteSlug: string } ) {
  * SiteCard component to display site information in a card format
  */
 export default function SiteCard( { site, currentPlan }: { site: Site; currentPlan: Plan } ) {
-	const { options, URL: url, is_private, is_wpcom_atomic } = site;
+	const { URL: url, is_private, is_wpcom_atomic } = site;
+	const wpVersion = getFormattedWordPressVersion( site );
+
 	// If the site is a private A8C site, X-Frame-Options is set to same
 	// origin.
 	const iframeDisabled = site.is_a8c && is_private;
@@ -64,11 +67,9 @@ export default function SiteCard( { site, currentPlan }: { site: Site; currentPl
 					<HStack justify="space-between">
 						<Field title={ __( 'Status' ) }>{ getSiteStatusLabel( site ) }</Field>
 					</HStack>
-					{ ( options?.software_version || is_wpcom_atomic ) && (
+					{ ( wpVersion || is_wpcom_atomic ) && (
 						<HStack justify="space-between">
-							{ options?.software_version && (
-								<Field title={ __( 'WordPress' ) }>{ options.software_version }</Field>
-							) }
+							{ wpVersion && <Field title={ __( 'WordPress' ) }>{ wpVersion }</Field> }
 							{ is_wpcom_atomic && (
 								<Field title={ __( 'PHP' ) }>
 									<PHPVersion siteSlug={ site.slug } />

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -1,0 +1,146 @@
+import { DataForm } from '@automattic/dataviews';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { notFound } from '@tanstack/react-router';
+import {
+	Card,
+	CardBody,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	Button,
+	Notice,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useState } from 'react';
+import {
+	siteQuery,
+	siteWordPressVersionQuery,
+	siteWordPressVersionMutation,
+} from '../../app/queries';
+import PageLayout from '../../components/page-layout';
+import { getFormattedWordPressVersion } from '../../utils/wp-version';
+import SettingsPageHeader from '../settings-page-header';
+import { canUpdateWordPressVersion } from './utils';
+import type { Field } from '@automattic/dataviews';
+
+export default function WordPressVersionSettings( { siteSlug }: { siteSlug: string } ) {
+	const { data: site } = useQuery( siteQuery( siteSlug ) );
+	const canUpdate = site && canUpdateWordPressVersion( site );
+
+	const { data: version } = useQuery( {
+		...siteWordPressVersionQuery( siteSlug ),
+		enabled: canUpdate,
+	} );
+	const mutation = useMutation( siteWordPressVersionMutation( siteSlug ) );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const [ formData, setFormData ] = useState< { version: string } >( {
+		version: version ?? '',
+	} );
+
+	if ( ! site ) {
+		return null;
+	}
+
+	if ( ! canUpdate && ! site.is_wpcom_atomic ) {
+		throw notFound();
+	}
+
+	const fields: Field< { version: string } >[] = [
+		{
+			id: 'version',
+			label: __( 'WordPress version' ),
+			Edit: 'select',
+			elements: [
+				{ value: 'latest', label: getFormattedWordPressVersion( site, 'latest' ) },
+				{ value: 'beta', label: getFormattedWordPressVersion( site, 'beta' ) },
+			],
+		},
+	];
+
+	const form = {
+		type: 'regular' as const,
+		fields: [ 'version' ],
+	};
+
+	const isDirty = formData.version !== version;
+	const { isPending } = mutation;
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		mutation.mutate( formData.version, {
+			onSuccess: () => {
+				createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
+			},
+			onError: () => {
+				createErrorNotice( __( 'Failed to save settings.' ), {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
+
+	const renderForm = () => {
+		return (
+			<Card>
+				<CardBody>
+					<form onSubmit={ handleSubmit }>
+						<VStack spacing={ 4 }>
+							<DataForm< { version: string } >
+								data={ formData }
+								fields={ fields }
+								form={ form }
+								onChange={ ( edits: { version?: string } ) => {
+									setFormData( ( data ) => ( { ...data, ...edits } ) );
+								} }
+							/>
+							<HStack justify="flex-start">
+								<Button
+									variant="primary"
+									type="submit"
+									isBusy={ isPending }
+									disabled={ isPending || ! isDirty }
+								>
+									{ __( 'Save' ) }
+								</Button>
+							</HStack>
+						</VStack>
+					</form>
+				</CardBody>
+			</Card>
+		);
+	};
+
+	const renderNotice = () => {
+		return (
+			<Notice isDismissible={ false }>
+				<Text>
+					{ createInterpolateElement(
+						sprintf(
+							// translators: %s: WordPress version, e.g. 6.8
+							__(
+								'Every WordPress.com site runs the latest WordPress version (%s). For testing purposes, you can switch to the beta version of the next WordPress release on <a>your staging site</a>.'
+							),
+							getFormattedWordPressVersion( site )
+						),
+						{
+							// TODO: use correct staging site URL when it's available.
+							// eslint-disable-next-line jsx-a11y/anchor-is-valid
+							a: <a href="#" />,
+						}
+					) }
+				</Text>
+			</Notice>
+		);
+	};
+
+	return (
+		<PageLayout size="small">
+			<SettingsPageHeader title="WordPress" />
+			{ canUpdate ? renderForm() : renderNotice() }
+		</PageLayout>
+	);
+}

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -1,6 +1,5 @@
 import { DataForm } from '@automattic/dataviews';
 import { useQuery, useMutation } from '@tanstack/react-query';
-import { notFound } from '@tanstack/react-router';
 import {
 	Card,
 	CardBody,
@@ -43,10 +42,6 @@ export default function WordPressVersionSettings( { siteSlug }: { siteSlug: stri
 
 	if ( ! site ) {
 		return null;
-	}
-
-	if ( ! canUpdate && ! site.is_wpcom_atomic ) {
-		throw notFound();
 	}
 
 	const fields: Field< { version: string } >[] = [
@@ -118,20 +113,26 @@ export default function WordPressVersionSettings( { siteSlug }: { siteSlug: stri
 		return (
 			<Notice isDismissible={ false }>
 				<Text>
-					{ createInterpolateElement(
-						sprintf(
-							// translators: %s: WordPress version, e.g. 6.8
-							__(
-								'Every WordPress.com site runs the latest WordPress version (%s). For testing purposes, you can switch to the beta version of the next WordPress release on <a>your staging site</a>.'
-							),
-							getFormattedWordPressVersion( site )
-						),
-						{
-							// TODO: use correct staging site URL when it's available.
-							// eslint-disable-next-line jsx-a11y/anchor-is-valid
-							a: <a href="#" />,
-						}
-					) }
+					{ site.is_wpcom_atomic
+						? createInterpolateElement(
+								sprintf(
+									// translators: %s: WordPress version, e.g. 6.8
+									__(
+										'Every WordPress.com site runs the latest WordPress version (%s). For testing purposes, you can switch to the beta version of the next WordPress release on <a>your staging site</a>.'
+									),
+									getFormattedWordPressVersion( site )
+								),
+								{
+									// TODO: use correct staging site URL when it's available.
+									// eslint-disable-next-line jsx-a11y/anchor-is-valid
+									a: <a href="#" />,
+								}
+						  )
+						: sprintf(
+								// translators: %s: WordPress version, e.g. 6.8
+								__( 'Every WordPress.com site runs the latest WordPress version (%s).' ),
+								getFormattedWordPressVersion( site )
+						  ) }
 				</Text>
 			</Notice>
 		);

--- a/client/dashboard/sites/settings-wordpress/summary.tsx
+++ b/client/dashboard/sites/settings-wordpress/summary.tsx
@@ -1,0 +1,38 @@
+import { useQuery } from '@tanstack/react-query';
+import { Icon } from '@wordpress/components';
+import { wordpress } from '@wordpress/icons';
+import { siteWordPressVersionQuery } from '../../app/queries';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import { getFormattedWordPressVersion } from '../../utils/wp-version';
+import { canUpdateWordPressVersion } from './utils';
+import type { Site } from '../../data/types';
+
+export default function WordPressSettingsSummary( { site }: { site: Site } ) {
+	const { data: versionTag } = useQuery( {
+		...siteWordPressVersionQuery( site.slug ),
+		enabled: canUpdateWordPressVersion( site ),
+	} );
+
+	const wpVersion = getFormattedWordPressVersion( site, versionTag );
+	if ( ! wpVersion ) {
+		return null;
+	}
+
+	const badges = [
+		{
+			text: wpVersion,
+			intent: versionTag === 'beta' ? ( 'warning' as const ) : ( 'success' as const ),
+		},
+	];
+
+	return (
+		<RouterLinkSummaryButton
+			disabled={ ! site.is_wpcom_atomic }
+			to={ `/sites/${ site.slug }/settings/wordpress` }
+			title="WordPress"
+			density="medium"
+			decoration={ <Icon icon={ wordpress } /> }
+			badges={ badges }
+		/>
+	);
+}

--- a/client/dashboard/sites/settings-wordpress/summary.tsx
+++ b/client/dashboard/sites/settings-wordpress/summary.tsx
@@ -27,7 +27,6 @@ export default function WordPressSettingsSummary( { site }: { site: Site } ) {
 
 	return (
 		<RouterLinkSummaryButton
-			disabled={ ! site.is_wpcom_atomic }
 			to={ `/sites/${ site.slug }/settings/wordpress` }
 			title="WordPress"
 			density="medium"

--- a/client/dashboard/sites/settings-wordpress/utils.ts
+++ b/client/dashboard/sites/settings-wordpress/utils.ts
@@ -1,0 +1,5 @@
+import { Site } from '../../data/types';
+
+export function canUpdateWordPressVersion( site: Site ) {
+	return site.is_wpcom_staging_site;
+}

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -10,6 +10,7 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import SiteVisibilitySettingsSummary from '../settings-site-visibility/summary';
 import SubscriptionGiftingSettingsSummary from '../settings-subscription-gifting/summary';
+import WordPressSettingsSummary from '../settings-wordpress/summary';
 import DangerZone from './danger-zone';
 import SiteActions from './site-actions';
 
@@ -28,6 +29,12 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 				<VStack>
 					<SiteVisibilitySettingsSummary site={ site } />
 					<SubscriptionGiftingSettingsSummary site={ site } settings={ settings } />
+				</VStack>
+			</Card>
+			<Heading>{ __( 'Server' ) }</Heading>
+			<Card>
+				<VStack>
+					<WordPressSettingsSummary site={ site } />
 				</VStack>
 			</Card>
 			<SiteActions site={ site } />

--- a/client/dashboard/utils/wp-version.ts
+++ b/client/dashboard/utils/wp-version.ts
@@ -1,0 +1,33 @@
+import { __ } from '@wordpress/i18n';
+import type { Site } from '../data/types';
+
+function getWordPressVersionTagName( versionTag: string ) {
+	if ( versionTag === 'latest' ) {
+		return __( 'Latest' );
+	}
+	if ( versionTag === 'beta' ) {
+		return __( 'Beta' );
+	}
+	return '';
+}
+
+export function getFormattedWordPressVersion(
+	site: Site,
+	versionTag: string | undefined = undefined
+) {
+	let wpVersion = site.options?.software_version;
+	if ( ! wpVersion ) {
+		return '';
+	}
+
+	if ( ! site.is_wpcom_atomic ) {
+		// On Simple sites, the version string has suffix e.g. 6.8.1-alpha-60199
+		wpVersion = wpVersion.split( '-' )[ 0 ];
+	}
+
+	if ( versionTag ) {
+		wpVersion = `${ wpVersion } (${ getWordPressVersionTagName( versionTag ) })`;
+	}
+
+	return wpVersion;
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->


Part of DOTCOM-13166

## Proposed Changes

This PR implements the WordPress version settings in dashboard v2.

### Simple sites

|||
|-|-|
|<img width="500" src="https://github.com/user-attachments/assets/39278f61-d0bd-40cb-a987-94af55ab7abf">|<img width="350" alt="image" src="https://github.com/user-attachments/assets/f895d3a3-4c54-4aa4-a995-ad35ef729fe8" />|

### Atomic sites

|||
|-|-|
|<img width="500" src="https://github.com/user-attachments/assets/39278f61-d0bd-40cb-a987-94af55ab7abf">|<img width="350" alt="image" src="https://github.com/user-attachments/assets/98d65720-9ba8-4eb6-b9a4-4bbb9a52f5ae" />|


### Staging sites

|||
|-|-|
|<img width="500" src="https://github.com/user-attachments/assets/792fd8f2-0099-4a3c-a810-2d8a2f23242e"><br><br><img width="500" src="https://github.com/user-attachments/assets/b7586aea-036e-4c46-b9bc-e5bdd7f52eff">|<img width="350"  src="https://github.com/user-attachments/assets/b7d335f4-c86c-4068-be70-09a0fe021b60" >|


## Testing Instructions

1. Go to /v2/sites.
2. Select a site.
3. Go to Settings.
4. Verify you can see and update the WordPress version as shown in the screenshot above. Test staging and non-staging sites.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
