### PR TITLE
Components: Make local copy of `Icon`

### DIFF
--- a/packages/components/src/icon/index.stories.tsx
+++ b/packages/components/src/icon/index.stories.tsx
@@ -1,25 +1,12 @@
-/**
- * External dependencies
- */
-
-/**
- * WordPress dependencies
- */
 import { wordpress } from '@wordpress/icons';
 import { SVG, Path } from '@wordpress/primitives';
-
-/**
- * Internal dependencies
- */
-import Icon from '..';
-import { VStack } from '../../v-stack';
+import { Icon } from '.';
 import type { Meta, StoryFn } from '@storybook/react';
 
 const meta: Meta< typeof Icon > = {
-	title: 'Components/Icon',
+	title: 'Still Internal/Icon',
 	component: Icon,
 	parameters: {
-		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},
 };
@@ -119,22 +106,4 @@ WithAnSVG.args = {
 			<Path d="M5 4v3h5.5v12h3V7H19V4z" />
 		</SVG>
 	),
-};
-
-/**
- * Although it's preferred to use icons from the `@wordpress/icons` package, [Dashicons](https://developer.wordpress.org/resource/dashicons/) are still supported,
- * as long as you are in a context where the Dashicons stylesheet is loaded. To simulate that here,
- * use the Global CSS Injector in the Storybook toolbar at the top and select the "WordPress" preset.
- */
-export const WithADashicon: StoryFn< typeof Icon > = ( args ) => {
-	return (
-		<VStack>
-			<Icon { ...args } />
-			<small>This won’t show an icon if the Dashicons stylesheet isn’t loaded.</small>
-		</VStack>
-	);
-};
-WithADashicon.args = {
-	...Default.args,
-	icon: 'wordpress',
 };

--- a/packages/components/src/icon/index.stories.tsx
+++ b/packages/components/src/icon/index.stories.tsx
@@ -1,0 +1,140 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { wordpress } from '@wordpress/icons';
+import { SVG, Path } from '@wordpress/primitives';
+
+/**
+ * Internal dependencies
+ */
+import Icon from '..';
+import { VStack } from '../../v-stack';
+import type { Meta, StoryFn } from '@storybook/react';
+
+const meta: Meta< typeof Icon > = {
+	title: 'Components/Icon',
+	component: Icon,
+	parameters: {
+		controls: { expanded: true },
+		docs: { canvas: { sourceState: 'shown' } },
+	},
+};
+export default meta;
+
+const Template: StoryFn< typeof Icon > = ( args ) => <Icon { ...args } />;
+
+export const Default = Template.bind( {} );
+Default.args = {
+	icon: wordpress,
+};
+
+export const FillColor: StoryFn< typeof Icon > = ( args ) => {
+	return (
+		<div
+			style={ {
+				fill: 'blue',
+			} }
+		>
+			<Icon { ...args } />
+		</div>
+	);
+};
+FillColor.args = {
+	...Default.args,
+};
+
+/**
+ * When `icon` is a function, it will be passed the `size` prop and any other additional props.
+ */
+export const WithAFunction = Template.bind( {} );
+WithAFunction.args = {
+	...Default.args,
+	icon: ( { size }: { size?: number } ) => (
+		<img
+			width={ size }
+			height={ size }
+			src="https://s.w.org/style/images/about/WordPress-logotype-wmark.png"
+			alt="WordPress"
+		/>
+	),
+};
+WithAFunction.parameters = {
+	docs: {
+		source: {
+			code: `
+<Icon
+  icon={ ( { size } ) => (
+    <img
+      width={ size }
+      height={ size }
+      src="https://s.w.org/style/images/about/WordPress-logotype-wmark.png"
+      alt="WordPress"
+    />
+  ) }
+/>
+		`,
+		},
+	},
+};
+
+const MyIconComponent = ( { size }: { size?: number } ) => (
+	<SVG width={ size } height={ size }>
+		<Path d="M5 4v3h5.5v12h3V7H19V4z" />
+	</SVG>
+);
+
+/**
+ * When `icon` is a component, it will be passed the `size` prop and any other additional props.
+ */
+export const WithAComponent = Template.bind( {} );
+WithAComponent.args = {
+	...Default.args,
+	icon: <MyIconComponent />,
+};
+WithAComponent.parameters = {
+	docs: {
+		source: {
+			code: `
+const MyIconComponent = ( { size } ) => (
+  <SVG width={ size } height={ size }>
+    <Path d="M5 4v3h5.5v12h3V7H19V4z" />
+  </SVG>
+);
+
+<Icon icon={ <MyIconComponent /> } />
+		`,
+		},
+	},
+};
+
+export const WithAnSVG = Template.bind( {} );
+WithAnSVG.args = {
+	...Default.args,
+	icon: (
+		<SVG>
+			<Path d="M5 4v3h5.5v12h3V7H19V4z" />
+		</SVG>
+	),
+};
+
+/**
+ * Although it's preferred to use icons from the `@wordpress/icons` package, [Dashicons](https://developer.wordpress.org/resource/dashicons/) are still supported,
+ * as long as you are in a context where the Dashicons stylesheet is loaded. To simulate that here,
+ * use the Global CSS Injector in the Storybook toolbar at the top and select the "WordPress" preset.
+ */
+export const WithADashicon: StoryFn< typeof Icon > = ( args ) => {
+	return (
+		<VStack>
+			<Icon { ...args } />
+			<small>This won’t show an icon if the Dashicons stylesheet isn’t loaded.</small>
+		</VStack>
+	);
+};
+WithADashicon.args = {
+	...Default.args,
+	icon: 'wordpress',
+};

--- a/packages/components/src/icon/index.tsx
+++ b/packages/components/src/icon/index.tsx
@@ -1,0 +1,111 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { cloneElement, createElement, isValidElement } from '@wordpress/element';
+import { SVG } from '@wordpress/primitives';
+
+/**
+ * Internal dependencies
+ */
+import Dashicon from '../dashicon';
+import type { IconKey as DashiconIconKey } from '../dashicon/types';
+import type { ComponentType, HTMLProps, SVGProps } from 'react';
+
+export type IconType =
+	| DashiconIconKey
+	| ComponentType< { size?: number } >
+	| ( ( props: { size?: number } ) => JSX.Element )
+	| JSX.Element;
+
+type AdditionalProps< T > = T extends ComponentType< infer U >
+	? U
+	: T extends DashiconIconKey
+	? SVGProps< SVGSVGElement >
+	: {};
+
+export type Props = {
+	/**
+	 * The icon to render. In most cases, you should use an icon from
+	 * [the `@wordpress/icons` package](https://wordpress.github.io/gutenberg/?path=/story/icons-icon--library).
+	 *
+	 * Other supported values are: component instances, functions,
+	 * [Dashicons](https://developer.wordpress.org/resource/dashicons/)
+	 * (specified as strings), and `null`.
+	 *
+	 * The `size` value, as well as any other additional props, will be passed through.
+	 * @default null
+	 */
+	icon?: IconType | null;
+	/**
+	 * The size (width and height) of the icon.
+	 *
+	 * Defaults to `20` when `icon` is a string (i.e. a Dashicon id), otherwise `24`.
+	 * @default `'string' === typeof icon ? 20 : 24`.
+	 */
+	size?: number;
+} & AdditionalProps< IconType >;
+
+/**
+ * Renders a raw icon without any initial styling or wrappers.
+ *
+ * ```jsx
+ * import { wordpress } from '@wordpress/icons';
+ *
+ * <Icon icon={ wordpress } />
+ * ```
+ */
+function Icon( {
+	icon = null,
+	size = 'string' === typeof icon ? 20 : 24,
+	...additionalProps
+}: Props ) {
+	if ( 'string' === typeof icon ) {
+		return (
+			<Dashicon
+				icon={ icon }
+				size={ size }
+				{ ...( additionalProps as HTMLProps< HTMLSpanElement > ) }
+			/>
+		);
+	}
+
+	if ( isValidElement( icon ) && Dashicon === icon.type ) {
+		return cloneElement( icon, {
+			...additionalProps,
+		} );
+	}
+
+	if ( 'function' === typeof icon ) {
+		return createElement( icon, {
+			size,
+			...additionalProps,
+		} );
+	}
+
+	if ( icon && ( icon.type === 'svg' || icon.type === SVG ) ) {
+		const appliedProps = {
+			...icon.props,
+			width: size,
+			height: size,
+			...additionalProps,
+		};
+
+		return <SVG { ...appliedProps } />;
+	}
+
+	if ( isValidElement( icon ) ) {
+		return cloneElement( icon, {
+			// @ts-ignore Just forwarding the size prop along
+			size,
+			...additionalProps,
+		} );
+	}
+
+	return icon;
+}
+
+export default Icon;

--- a/packages/components/src/icon/index.tsx
+++ b/packages/components/src/icon/index.tsx
@@ -1,40 +1,28 @@
 /**
- * External dependencies
+ * Forked from `@wordpress/components`
+ *
+ * Only forked for CSS collision safety, in case styles or classnames are added upstream.
+ *
+ * - Removed Gridicons support (non-critical).
  */
 
-/**
- * WordPress dependencies
- */
 import { cloneElement, createElement, isValidElement } from '@wordpress/element';
 import { SVG } from '@wordpress/primitives';
+import type { ComponentType } from 'react';
 
-/**
- * Internal dependencies
- */
-import Dashicon from '../dashicon';
-import type { IconKey as DashiconIconKey } from '../dashicon/types';
-import type { ComponentType, HTMLProps, SVGProps } from 'react';
-
-export type IconType =
-	| DashiconIconKey
+type IconType =
 	| ComponentType< { size?: number } >
 	| ( ( props: { size?: number } ) => JSX.Element )
 	| JSX.Element;
 
-type AdditionalProps< T > = T extends ComponentType< infer U >
-	? U
-	: T extends DashiconIconKey
-	? SVGProps< SVGSVGElement >
-	: {};
+type AdditionalProps< T > = T extends ComponentType< infer U > ? U : Record< string, unknown >;
 
-export type Props = {
+type Props = {
 	/**
 	 * The icon to render. In most cases, you should use an icon from
 	 * [the `@wordpress/icons` package](https://wordpress.github.io/gutenberg/?path=/story/icons-icon--library).
 	 *
-	 * Other supported values are: component instances, functions,
-	 * [Dashicons](https://developer.wordpress.org/resource/dashicons/)
-	 * (specified as strings), and `null`.
+	 * Other supported values are: component instances, functions, and `null`.
 	 *
 	 * The `size` value, as well as any other additional props, will be passed through.
 	 * @default null
@@ -42,9 +30,7 @@ export type Props = {
 	icon?: IconType | null;
 	/**
 	 * The size (width and height) of the icon.
-	 *
-	 * Defaults to `20` when `icon` is a string (i.e. a Dashicon id), otherwise `24`.
-	 * @default `'string' === typeof icon ? 20 : 24`.
+	 * @default 24
 	 */
 	size?: number;
 } & AdditionalProps< IconType >;
@@ -53,32 +39,13 @@ export type Props = {
  * Renders a raw icon without any initial styling or wrappers.
  *
  * ```jsx
+ * import { Icon } from '@automattic/ui';
  * import { wordpress } from '@wordpress/icons';
  *
  * <Icon icon={ wordpress } />
  * ```
  */
-function Icon( {
-	icon = null,
-	size = 'string' === typeof icon ? 20 : 24,
-	...additionalProps
-}: Props ) {
-	if ( 'string' === typeof icon ) {
-		return (
-			<Dashicon
-				icon={ icon }
-				size={ size }
-				{ ...( additionalProps as HTMLProps< HTMLSpanElement > ) }
-			/>
-		);
-	}
-
-	if ( isValidElement( icon ) && Dashicon === icon.type ) {
-		return cloneElement( icon, {
-			...additionalProps,
-		} );
-	}
-
+export function Icon( { icon = null, size = 24, ...additionalProps }: Props ) {
 	if ( 'function' === typeof icon ) {
 		return createElement( icon, {
 			size,
@@ -107,5 +74,3 @@ function Icon( {
 
 	return icon;
 }
-
-export default Icon;

--- a/packages/components/src/icon/test/index.tsx
+++ b/packages/components/src/icon/test/index.tsx
@@ -1,0 +1,103 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/primitives';
+
+/**
+ * Internal dependencies
+ */
+import Icon from '..';
+
+describe( 'Icon', () => {
+	const testId = 'icon';
+	const className = 'example-class';
+	const svg = (
+		<SVG>
+			<Path d="M5 4v3h5.5v12h3V7H19V4z" />
+		</SVG>
+	);
+
+	it( 'renders nothing when icon omitted', () => {
+		render( <Icon data-testid={ testId } /> );
+
+		expect( screen.queryByTestId( testId ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders a dashicon by slug', () => {
+		render( <Icon data-testid={ testId } icon="format-image" /> );
+
+		expect( screen.getByTestId( testId ) ).toHaveClass( 'dashicons-format-image' );
+	} );
+
+	it( 'renders a dashicon with custom size', () => {
+		render( <Icon data-testid={ testId } icon="format-image" size={ 10 } /> );
+
+		expect( screen.getByTestId( testId ) ).toHaveStyle( 'width:10px' );
+		expect( screen.getByTestId( testId ) ).toHaveStyle( 'height:10px' );
+		expect( screen.getByTestId( testId ) ).toHaveStyle( 'font-size:10px' );
+	} );
+
+	it( 'renders a function', () => {
+		render( <Icon icon={ () => <span data-testid={ testId } /> } /> );
+
+		expect( screen.getByTestId( testId ) ).toBeVisible();
+	} );
+
+	it( 'renders an element', () => {
+		render( <Icon icon={ <span data-testid={ testId } /> } /> );
+
+		expect( screen.getByTestId( testId ) ).toBeVisible();
+	} );
+
+	it( 'renders an svg element', () => {
+		render( <Icon data-testid={ testId } icon={ svg } /> );
+
+		expect( screen.getByTestId( testId ) ).toBeVisible();
+	} );
+
+	it( 'renders an svg element with a default width and height of 24', () => {
+		render( <Icon data-testid={ testId } icon={ svg } /> );
+		const icon = screen.getByTestId( testId );
+
+		expect( icon ).toHaveAttribute( 'width', '24' );
+		expect( icon ).toHaveAttribute( 'height', '24' );
+	} );
+
+	it( 'renders an svg element and override its width and height', () => {
+		render(
+			<Icon
+				data-testid={ testId }
+				icon={
+					<SVG width={ 64 } height={ 64 }>
+						<Path d="M5 4v3h5.5v12h3V7H19V4z" />
+					</SVG>
+				}
+				size={ 32 }
+			/>
+		);
+		const icon = screen.getByTestId( testId );
+
+		expect( icon ).toHaveAttribute( 'width', '32' );
+		expect( icon ).toHaveAttribute( 'height', '32' );
+	} );
+
+	it( 'renders an svg element and does not override width and height if already specified', () => {
+		render( <Icon data-testid={ testId } icon={ svg } size={ 32 } /> );
+		const icon = screen.getByTestId( testId );
+
+		expect( icon ).toHaveAttribute( 'width', '32' );
+		expect( icon ).toHaveAttribute( 'height', '32' );
+	} );
+
+	it( 'renders a component', () => {
+		const MyComponent = () => <span data-testid={ testId } className={ className } />;
+		render( <Icon icon={ MyComponent } /> );
+
+		expect( screen.getByTestId( testId ) ).toHaveClass( className );
+	} );
+} );

--- a/packages/components/src/icon/test/index.tsx
+++ b/packages/components/src/icon/test/index.tsx
@@ -1,17 +1,9 @@
 /**
- * External dependencies
+ * @jest-environment jsdom
  */
 import { render, screen } from '@testing-library/react';
-
-/**
- * WordPress dependencies
- */
 import { Path, SVG } from '@wordpress/primitives';
-
-/**
- * Internal dependencies
- */
-import Icon from '..';
+import { Icon } from '..';
 
 describe( 'Icon', () => {
 	const testId = 'icon';
@@ -26,20 +18,6 @@ describe( 'Icon', () => {
 		render( <Icon data-testid={ testId } /> );
 
 		expect( screen.queryByTestId( testId ) ).not.toBeInTheDocument();
-	} );
-
-	it( 'renders a dashicon by slug', () => {
-		render( <Icon data-testid={ testId } icon="format-image" /> );
-
-		expect( screen.getByTestId( testId ) ).toHaveClass( 'dashicons-format-image' );
-	} );
-
-	it( 'renders a dashicon with custom size', () => {
-		render( <Icon data-testid={ testId } icon="format-image" size={ 10 } /> );
-
-		expect( screen.getByTestId( testId ) ).toHaveStyle( 'width:10px' );
-		expect( screen.getByTestId( testId ) ).toHaveStyle( 'height:10px' );
-		expect( screen.getByTestId( testId ) ).toHaveStyle( 'font-size:10px' );
 	} );
 
 	it( 'renders a function', () => {


### PR DESCRIPTION
Closes ARC-206

## Proposed Changes

Makes a local copy of `@wordpress/components` `Icon`.

The only notable change is the removal of Gridicons support.

## Why are these changes being made?

For safe local forking of the `Badge` component (ARC-202). `Icon` can remain internal for now since we don't need it 
publicly exported for anything yet.

## Testing Instructions

See the second commit (f9c87be57c3df968255c076d393bba1e2879f77a) for easier review of the actual changes.

`yarn components:storybook:start` to check the Storybook.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
