### PR TITLE
Logged out layout: Fix masterbar

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -336,7 +336,8 @@ export default withCurrentRoute(
 			const isWooJPC = isWooJPCFlow( state );
 
 			const isWhiteLogin =
-				( ! isJetpackLogin &&
+				( currentRoute.startsWith( '/log-in' ) &&
+					! isJetpackLogin &&
 					Boolean( currentQuery?.client_id ) === false &&
 					Boolean( currentQuery?.oauth2_client_id ) === false &&
 					! isWooJPC ) ||


### PR DESCRIPTION
## Proposed Changes

Fix the logic determining the masterbar hidden status on logged out pages.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* [This PR](https://github.com/Automattic/wp-calypso/commit/8e23cf76115748b2e6c874e1c4fc15bea99422cc) refactored the previous `isWPComLogin` check, but omitted the previous `currentRoute.startsWith( '/log-in' ) ` condition. 

This results in the nav bar being hidden on multiple pages. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/themes` and confirm the navigation menu is displayed correctly.
* Visit `/log-in` and confirm the navigation menu is still hidden.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
