### PR TITLE
Help Center: Track creation of new interactions

### DIFF
--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -97,6 +97,15 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 				event_source: 'help-center',
 				event_external_id: crypto.randomUUID(),
 			} );
+			recordTracksEvent( 'calypso_helpcenter_new_interaction_started', {
+				pathname: location.pathname,
+				search: location.search,
+				section: sectionName,
+				location: 'help-center',
+				event_source: 'help-center',
+				is_free_user: ! isUserEligibleForPaidSupport,
+				user_field_flow_name: userFieldFlowName,
+			} );
 		} else if (
 			( openSupportInteractions || resolvedSupportInteractions ) &&
 			! currentSupportInteraction


### PR DESCRIPTION
## Description
Adds tracking for new interaction starts in the Help Center to better isolate errors.

## Changes
- Added `calypso_helpcenter_new_interaction_started` event tracking when a new support interaction begins
- Includes relevant context like pathname, search params, section name, and user eligibility for paid support

## Testing Instructions
1. Open the Help Center
2. Verify in Tracks Vigilante that the new tracking event is fired with the correct parameters

## Additional Notes
This change helps improve our understanding of how users interact with the Help Center by tracking when new support interactions begin. The additional context (user eligibility, section name, etc.) will help identify patterns in support needs and user behavior.