### PR TITLE
Plugins: Fix the underline styling on related plugins links

### DIFF
--- a/client/my-sites/plugins/related-plugins/style.scss
+++ b/client/my-sites/plugins/related-plugins/style.scss
@@ -28,6 +28,9 @@
 	column-gap: 24px;
 	row-gap: 32px;
 
+	.related-plugins-item {
+		text-decoration: none;
+	}
 
 	.related-plugins-item__icon {
 		float: left;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13069

## Proposed Changes

* Remove the text underline from links to related plugins on a plugin details page.

Before:
<img width="578" alt="Screenshot 2025-05-20 at 19 12 59" src="https://github.com/user-attachments/assets/7a6a3c2f-5e3f-4f62-a72b-09ffb7ce83ac" />
After:
<img width="578" alt="Screenshot 2025-05-20 at 19 12 39" src="https://github.com/user-attachments/assets/d5d9b056-4edd-42c1-94c8-10936591ed7b" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Various browsers are underlining the links by default, unless `text-underline: none` is set.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the plugins page, navigate to an individual plugin and scroll to the bottom to the list of related plugins.
* Observe that the related plugins links are underlined.
* Check the fix of local Calypso instance or calypso.live.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
