### PR TITLE
Reader: Remove Reddit table styles

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -625,7 +625,10 @@ export class FullPostView extends Component {
 
 		const isDefaultLayout = this.props.layout !== 'recent';
 		const siteName = getSiteName( { site, post } );
-		const classes = { 'reader-full-post': true };
+		const classes = {
+			'reader-full-post': true,
+			'is-reddit-post': post.is_reddit_post,
+		};
 		const showRelatedPosts = post && ! post.is_external && post.site_ID && isDefaultLayout;
 		const relatedPostsFromOtherSitesTitle = translate(
 			'More on {{wpLink}}WordPress.com{{/wpLink}}',

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -845,3 +845,24 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 		}
 	}
 }
+
+.reader-full-post.is-reddit-post {
+	.reader-full-post__story-content {
+		// Remove Reddit table styles
+		table {
+			width: 100%;
+			border-collapse: collapse;
+			display: block;
+
+			tr, td {
+				display: block;
+				width: 100%;
+			}
+
+			// Add a margin above the submitted by meta
+			td .md {
+				margin-bottom: 24px;
+			}
+		}
+	}
+}

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -107,6 +107,19 @@ export function classifyPost( post ) {
 	return post;
 }
 
+function identifyRedditPost( post ) {
+	if ( ! post ) {
+		return post;
+	}
+
+	post.is_reddit_post =
+		post.site_URL?.includes( 'reddit.com' ) ||
+		post.site_name?.includes( 'reddit' ) ||
+		post.author?.name?.includes( 'reddit' );
+
+	return post;
+}
+
 const fastPostNormalizationRules = flow( [
 	decodeEntities,
 	stripHtml,
@@ -134,6 +147,7 @@ const fastPostNormalizationRules = flow( [
 	addMinutesToRead,
 	pickCanonicalImage,
 	pickCanonicalMedia,
+	identifyRedditPost,
 	classifyPost,
 ] );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/CML-498/reddit-posts-have-weird-layout

## Proposed Changes

* Reddit posts include tables. This removes the default table styling to make them more readable.
* Adds a margin above the "Submitted by..." meta that's otherwise immediately under the post content.

Before | After
---- | ----
<img width="1378" alt="Screenshot 2025-05-20 at 4 24 32 PM" src="https://github.com/user-attachments/assets/17bc93e4-dedf-46c0-b2e9-a6503578acf5" /> | <img width="1368" alt="Screenshot 2025-05-20 at 4 24 22 PM" src="https://github.com/user-attachments/assets/bb0177e7-774b-4f6b-9070-65ad96506e43" />
<img width="859" alt="Screenshot 2025-05-20 at 4 48 54 PM" src="https://github.com/user-attachments/assets/2abba897-34fd-459f-9550-51e22ead781b" /> | <img width="793" alt="Screenshot 2025-05-20 at 4 48 39 PM" src="https://github.com/user-attachments/assets/7683048a-a494-4a0b-9673-f01d373d5540" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve styling and readability.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add a Reddit feed via Discover -> Reddit. 
* Go to your recent feed and click into that Reddit feed. Then click into a Reddit post with an image.
* Check that the "Submitted by..." meta doesn't show to the right.
* Check other posts with and without images, and in both the full post and scrolling feed views, and at different screen sizes.
* Regression test that non-Reddit posts with tables and images still display correctly in the Reader.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
