### PR TITLE
Help Center: Fix race condition in setting interaction

### DIFF
--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -86,9 +86,11 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 	}, [ location, sectionName, isUserEligibleForPaidSupport ] );
 
 	useEffect( () => {
+		if ( isLoadingOpenSupportInteractions || isLoadingResolvedSupportInteractions ) {
+			return;
+		}
+
 		if (
-			! isLoadingOpenSupportInteractions &&
-			! isLoadingResolvedSupportInteractions &&
 			openSupportInteractions === null &&
 			resolvedSupportInteractions === null &&
 			! currentSupportInteraction


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

The code was not waiting to have both open and resolved support interactions searched, so in some cases even if we had a resolved interaction (users talking with Zendesk), we were instead showing a open interaction (users talking with Odie).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The fast way I found to test this is to open the help center and immediately click on "Still need help?".
* If you had a chat with HE, it is possible that this instead shows you a chat with AI.
* With this PR this shouldn't happen.

