### PR TITLE
Adjust the marketing tools CSS for non-English locales

### DIFF
--- a/client/sites/marketing/tools/style.scss
+++ b/client/sites/marketing/tools/style.scss
@@ -36,7 +36,8 @@
 }
 .marketing-tools__searchbox-container {
 	position: relative;
-	width: 250px;
+	width: 290px;
+	flex-shrink: 0;
 	height: 40px;
 	&.marketing-tools__searchbox-container--mobile {
 		width: 100%;
@@ -49,7 +50,9 @@
 }
 
 .responsive-toolbar-group.marketing-tools__search-categories-toolbar {
-	width: 280px;
+	display: flex;
+	justify-content: flex-start;
+	width: 100%;
 	padding: 0;
 	margin-right: 16px;
 }

--- a/client/sites/marketing/tools/style.scss
+++ b/client/sites/marketing/tools/style.scss
@@ -43,6 +43,12 @@
 		width: 100%;
 		margin-left: 16px;
 	}
+	.search-component__icon-navigation svg {
+		width: 40px;
+	}
+}
+.marketing-tools__searchbox .search-component__input-fade {
+	width: 200px;
 }
 .panel-with-sidebar .marketing-tools__searchbox-container--mobile {
 	margin-left: 0;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13070

## Proposed Changes

* Adjust the CSS for the /marketing/tools page to prevent the tools categories to be shown in a dropdown for non-English locales.
* Fix the positioning of the search/close icons in the search input to avoid it overlapping with the right border of the input.

Before|After|
------|-------|
<img width="857" alt="en-before" src="https://github.com/user-attachments/assets/69ad7777-38d9-42f9-ac6e-7a16cd8cc0a0" />|<img width="857" alt="en-after" src="https://github.com/user-attachments/assets/5b61683d-6249-424b-b477-b76548fd203f" />
<img width="857" alt="de-before" src="https://github.com/user-attachments/assets/e6ece704-378c-4d4a-b380-da79ca2beced" />|<img width="857" alt="de-after" src="https://github.com/user-attachments/assets/870640da-8fe6-449e-b97f-79b3c25b7b6e" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the non-English experience by not hiding the items unnecessarily, as well as fix the search input styling.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To reproduce the issue switch to a non-English Calypso locale with relatively longer words (Spanish, French, German, Dutch, Russian, Indonesian, Brazilian Portuguese etc.), then go to https://wordpress.com/marketing/tools/{your site} and check the appearance of the search input and the tools menu.
* Gradually change the width of the browser window to observe how the elements behave at different breakpoints.
* Repeat the previous steps on calypso.live or locale Calypso instance to observe the fixes.
* Check both scenarios with an English locale.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
