### PR TITLE
Domains: Enable support for CAA DNS records

### DIFF
--- a/client/my-sites/domains/domain-management/dns/caa-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/caa-record.jsx
@@ -30,7 +30,6 @@ class CaaRecord extends Component {
 		} );
 		const isValueValid = isValid( 'value' );
 		const isTTLValid = isValid( 'ttl' );
-		const label = translate( 'Name', { context: 'DNS record' } );
 
 		const namePlaceholder = translate( 'Enter subdomain', {
 			context: 'Placeholder shown when entering the subdomain part of a new DNS record',
@@ -39,7 +38,7 @@ class CaaRecord extends Component {
 		return (
 			<div className={ classes }>
 				<FormFieldset>
-					<FormLabel>{ label }</FormLabel>
+					<FormLabel>{ translate( 'Name (optional)', { context: 'DNS record' } ) }</FormLabel>
 					<FormTextInputWithAffixes
 						name="name"
 						placeholder={ namePlaceholder }
@@ -58,6 +57,8 @@ class CaaRecord extends Component {
 						isError={ ! isFlagsValid }
 						onChange={ onChange }
 						value={ fieldValues.flags }
+						defaultValue={ 0 }
+						placeholder={ 0 }
 					/>
 					{ ! isFlagsValid && (
 						<FormInputValidation text={ translate( 'Invalid flags' ) } isError />
@@ -78,6 +79,7 @@ class CaaRecord extends Component {
 						isError={ ! isValueValid }
 						onChange={ onChange }
 						value={ fieldValues.value }
+						placeholder={ translate( 'e.g. letsencrypt.org' ) }
 					/>
 					{ ! isValueValid && (
 						<FormInputValidation text={ translate( 'Invalid value' ) } isError />

--- a/client/my-sites/domains/domain-management/dns/caa-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/caa-record.jsx
@@ -1,0 +1,109 @@
+import { FormInputValidation, FormLabel } from '@automattic/components';
+import clsx from 'clsx';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormSelect from 'calypso/components/forms/form-select';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
+
+class CaaRecord extends Component {
+	static propTypes = {
+		fieldValues: PropTypes.object.isRequired,
+		onChange: PropTypes.func.isRequired,
+		selectedDomainName: PropTypes.string.isRequired,
+		show: PropTypes.bool.isRequired,
+	};
+
+	render() {
+		const { fieldValues, isValid, onChange, selectedDomainName, show, translate } = this.props;
+		const classes = clsx( { 'is-hidden': ! show } );
+		const isNameValid = isValid( 'name' );
+		const isFlagsValid = isValid( 'flags' );
+		const tagOptions = [ 'issue', 'issuewild', 'issuemail', 'iodef' ].map( ( tag ) => {
+			return (
+				<option key={ tag } value={ tag }>
+					{ tag }
+				</option>
+			);
+		} );
+		const isValueValid = isValid( 'value' );
+		const isTTLValid = isValid( 'ttl' );
+		const label = translate( 'Name', { context: 'DNS record' } );
+
+		const namePlaceholder = translate( 'Enter subdomain', {
+			context: 'Placeholder shown when entering the subdomain part of a new DNS record',
+		} );
+
+		return (
+			<div className={ classes }>
+				<FormFieldset>
+					<FormLabel>{ label }</FormLabel>
+					<FormTextInputWithAffixes
+						name="name"
+						placeholder={ namePlaceholder }
+						isError={ ! isNameValid }
+						onChange={ onChange }
+						value={ fieldValues.name }
+						suffix={ '.' + selectedDomainName }
+					/>
+					{ ! isNameValid && <FormInputValidation text={ translate( 'Invalid Name' ) } isError /> }
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLabel>{ translate( 'Flags' ) }</FormLabel>
+					<FormTextInput
+						name="flags"
+						isError={ ! isFlagsValid }
+						onChange={ onChange }
+						value={ fieldValues.flags }
+					/>
+					{ ! isFlagsValid && (
+						<FormInputValidation text={ translate( 'Invalid flags' ) } isError />
+					) }
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLabel>{ translate( 'Tag' ) }</FormLabel>
+					<FormSelect name="tag" onChange={ onChange } value={ fieldValues.tag }>
+						{ tagOptions }
+					</FormSelect>
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLabel>{ translate( 'Value' ) }</FormLabel>
+					<FormTextInput
+						name="value"
+						isError={ ! isValueValid }
+						onChange={ onChange }
+						value={ fieldValues.value }
+					/>
+					{ ! isValueValid && (
+						<FormInputValidation text={ translate( 'Invalid value' ) } isError />
+					) }
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLabel>TTL (time to live)</FormLabel>
+					<FormTextInput
+						name="ttl"
+						isError={ ! isTTLValid }
+						onChange={ onChange }
+						value={ fieldValues.ttl }
+						defaultValue={ 3600 }
+						placeholder={ 3600 }
+					/>
+					{ ! isTTLValid && (
+						<FormInputValidation
+							text={ translate( 'Invalid TTL value - Use a value between 300 and 86400' ) }
+							isError
+						/>
+					) }
+				</FormFieldset>
+			</div>
+		);
+	}
+}
+
+export default localize( CaaRecord );

--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -18,6 +18,7 @@ import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ARecord from './a-record';
 import AliasRecord from './alias-record';
+import CaaRecord from './caa-record';
 import CnameRecord from './cname-record';
 import MxRecord from './mx-record';
 import NsRecord from './ns-record';
@@ -65,6 +66,17 @@ class DnsAddNew extends React.Component {
 					name: '@',
 					ttl: 3600,
 					data: '',
+				},
+			},
+			{
+				component: CaaRecord,
+				types: [ 'CAA' ],
+				initialFields: {
+					name: '',
+					flags: '0',
+					tag: 'issue',
+					value: '',
+					ttl: 3600,
 				},
 			},
 			{

--- a/client/my-sites/domains/domain-management/domain-connect/domain-connect-dns-record.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect/domain-connect-dns-record.jsx
@@ -53,6 +53,14 @@ class DomainConnectDnsRecord extends Component {
 					},
 				} );
 
+			case 'CAA':
+				return translate( '%(tag)s %(value)s', {
+					args: {
+						value: record.value,
+						tag: record.tag,
+					},
+				} );
+
 			case 'CNAME':
 				return translate( 'Alias of %(data)s', {
 					args: {

--- a/client/state/domains/dns/utils.js
+++ b/client/state/domains/dns/utils.js
@@ -21,9 +21,11 @@ function validateField( { name, value, type, domain, domainName } ) {
 		case 'target':
 			return isValidDomain( value, type );
 		case 'data':
+		case 'value':
 			return isValidData( value, type );
 		case 'protocol':
 			return [ '_tcp', '_udp', '_tls' ].includes( value );
+		case 'flags':
 		case 'weight':
 		case 'aux':
 		case 'port': {
@@ -84,6 +86,7 @@ function isValidData( data, type ) {
 		case 'MX':
 		case 'NS':
 			return isValidDomain( data );
+		case 'CAA':
 		case 'TXT':
 			return data.length > 0 && data.length <= 2048;
 	}
@@ -136,7 +139,7 @@ function canBeRootDomain( type, domain ) {
 		return true;
 	}
 
-	return [ 'A', 'AAAA', 'ALIAS', 'MX', 'SRV', 'TXT' ].includes( type );
+	return [ 'A', 'AAAA', 'ALIAS', 'CAA', 'MX', 'SRV', 'TXT' ].includes( type );
 }
 
 function getFieldWithDot( field ) {

--- a/client/state/domains/dns/utils.js
+++ b/client/state/domains/dns/utils.js
@@ -25,7 +25,10 @@ function validateField( { name, value, type, domain, domainName } ) {
 			return isValidData( value, type );
 		case 'protocol':
 			return [ '_tcp', '_udp', '_tls' ].includes( value );
-		case 'flags':
+		case 'flags': {
+			const intValue = parseInt( value, 10 );
+			return intValue >= 0 && intValue <= 255;
+		}
 		case 'weight':
 		case 'aux':
 		case 'port': {


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/NOMADO-178/enable-support-for-caa-records

## Proposed Changes

This PR enable support for managing CAA DNS records in Calypso.

### Screenshots

- DNS management page

<img width="1096" alt="Screenshot 2025-05-21 at 16 12 18" src="https://github.com/user-attachments/assets/88406f2c-0307-4462-ab9c-d8dd11175389" />

- CAA record edit page

<img width="1085" alt="Screenshot 2025-05-21 at 16 11 46" src="https://github.com/user-attachments/assets/76775621-fff1-46d1-a230-3bedd9298c5d" />

## Why are these changes being made?

CAA records are used to have greater control over which Certificate Authorities can issue SSL certificates for a domain. From time to time users request this feature, e.g. p2MSmN-dH3-p2. It's important that we support a more complete set of DNS features if we want users to purchase and keep domains with us.

## Testing Instructions

Test this alongside this WPCOM PR: 183390-ghe-Automattic/wpcom

- Open the live Calypso link or build this branch locally
- Go to the DNS management page of a domain you own
- Add, edit and remove CAA records and ensure everything works normally

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
