### PR TITLE
Make SummaryButton spacing match CardBody and Figma.

### DIFF
--- a/packages/components/src/summary-button/style.scss
+++ b/packages/components/src/summary-button/style.scss
@@ -70,7 +70,7 @@
 	}
 
 	&.has-density-medium {
-		padding: $grid-unit-15;
+		padding: $grid-unit-20 $grid-unit-30;
 		box-shadow: 0 2px 1px -1px $gray-100;
 
 		// TODO: this should be handled better in `SummaryButtonList` component.


### PR DESCRIPTION
I noticed while testing #103543 that the SummaryButton padding does not match the Action list padding.

| Current | Designs |
|--------|--------|
| <img  alt="Screenshot 2025-05-21 at 2 31 52 PM" src="https://github.com/user-attachments/assets/8dcce26b-53f8-4dd6-be59-846bd88929e1" /> | <img  alt="Screenshot 2025-05-21 at 2 37 04 PM" src="https://github.com/user-attachments/assets/b2164a63-f646-4d95-8583-ada6c050e428" /> |

Designs: QOBjujZah0UlGDDdLKZhzi-fi-563_33067


## Proposed

This PR updates, maybe naively, the `medium` density left/right padding to ensure consistency.

| Before | After |
|--------|--------|
| <img width="669" alt="Screenshot 2025-05-21 at 2 34 07 PM" src="https://github.com/user-attachments/assets/b739218e-69bc-45bc-8ea7-8afbaf098685" />  | <img width="634" alt="Screenshot 2025-05-21 at 2 34 30 PM" src="https://github.com/user-attachments/assets/5e3ddd40-a324-4c0a-b1e6-3bbd777650ba" /> | 





## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?