### PR TITLE
Hosting Dashboard V2: Add webpack build monitor for hot-reload

### DIFF
--- a/client/dashboard/app/root/index.tsx
+++ b/client/dashboard/app/root/index.tsx
@@ -1,6 +1,7 @@
 import { WordPressLogo } from '@automattic/components';
 import { useIsFetching } from '@tanstack/react-query';
 import { CatchNotFound, Outlet, useRouterState } from '@tanstack/react-router';
+import { Suspense, lazy } from 'react';
 import { LoadingLine } from '../../components/loading-line';
 import NotFound from '../404';
 import CommandPalette from '../command-palette';
@@ -8,6 +9,13 @@ import { useAppContext } from '../context';
 import Header from '../header';
 import Snackbars from '../snackbars';
 import './style.scss';
+
+const WebpackBuildMonitor = lazy(
+	() =>
+		import(
+			/* webpackChunkName: "async-webpack-build-monitor" */ 'calypso/components/webpack-build-monitor'
+		)
+);
 
 function Root() {
 	const { LoadingLogo = WordPressLogo } = useAppContext();
@@ -31,6 +39,11 @@ function Root() {
 			</main>
 			<CommandPalette />
 			<Snackbars />
+			{ 'development' === process.env.NODE_ENV && (
+				<Suspense fallback={ null }>
+					<WebpackBuildMonitor />
+				</Suspense>
+			) }
 		</div>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of p1747648982058949-slack-C08JZTRS6NA

## Proposed Changes

* Fix the hot-reload mechanism in Hosting Dashboard V2 by adding WebpackBuildMonitor component
* The color of the status isn't rendered correctly as those colors are not defined in V2 but it seems ok for now.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It's important to have hot-reload

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run Calypso on your local
* Go to /v2
* Change any code
* Ensure you can see the status of the webpack
* Ensure you can see the changes when the new build is finished without reloading the page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?