### PR TITLE
A4A > Feedback: Show Pressable purchase feedback if purchase was made within 7 days

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -56,6 +56,40 @@ interface Props {
 	productId: number;
 }
 
+export const ManageInPressable = ( { attachedAt }: { attachedAt: string | null } ) => {
+	const translate = useTranslate();
+
+	const { isFeedbackShown } = useShowFeedback( FeedbackType.PurchaseCompleted, attachedAt );
+	const isOwner = useSelector( isAgencyOwner );
+
+	return isOwner ? (
+		<a
+			className="license-preview__product-pressable-link"
+			target="_blank"
+			rel="norefferer noopener noreferrer"
+			href="https://my.pressable.com/agency/auth"
+			onClick={ () => {
+				if ( ! isFeedbackShown ) {
+					page.redirect(
+						addQueryArgs(
+							{
+								type: FeedbackType.PurchaseCompleted,
+								redirectUrl: A4A_LICENSES_LINK,
+							},
+							A4A_FEEDBACK_LINK
+						)
+					);
+				}
+			} }
+		>
+			{ translate( 'Manage in Pressable' ) }
+			<Icon className="gridicon" icon={ external } size={ 18 } />
+		</a>
+	) : (
+		translate( 'Managed by agency owner' )
+	);
+};
+
 export default function LicensePreview( {
 	license,
 	licenseType,
@@ -77,12 +111,9 @@ export default function LicensePreview( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const { isFeedbackShown } = useShowFeedback( FeedbackType.PurchaseCompleted );
-
 	const site = useSelector( ( state ) => getSite( state, blogId as number ) );
 	const isPressableLicense = isPressableHostingProduct( licenseKey );
 	const isWPCOMLicense = isWPCOMHostingProduct( licenseKey );
-	const pressableManageUrl = 'https://my.pressable.com/agency/auth';
 
 	const isOwner = useSelector( isAgencyOwner );
 
@@ -284,34 +315,9 @@ export default function LicensePreview( {
 						<>
 							<div className="license-preview__product-small">{ productName }</div>
 							{ domain }
-							{ isPressableLicense &&
-								! revokedAt &&
-								( isOwner ? (
-									<a
-										className="license-preview__product-pressable-link"
-										target="_blank"
-										rel="norefferer noopener noreferrer"
-										href={ pressableManageUrl }
-										onClick={ () => {
-											if ( ! isFeedbackShown ) {
-												page.redirect(
-													addQueryArgs(
-														{
-															type: FeedbackType.PurchaseCompleted,
-															redirectUrl: A4A_LICENSES_LINK,
-														},
-														A4A_FEEDBACK_LINK
-													)
-												);
-											}
-										} }
-									>
-										{ translate( 'Manage in Pressable' ) }
-										<Icon className="gridicon" icon={ external } size={ 18 } />
-									</a>
-								) : (
-									translate( 'Managed by agency owner' )
-								) ) }
+							{ isPressableLicense && ! revokedAt && (
+								<ManageInPressable attachedAt={ attachedAt } />
+							) }
 							{ ! domain && licenseState === LicenseState.Detached && (
 								<span className="license-preview__unassigned">
 									<Badge type="warning">{ translate( 'Unassigned' ) }</Badge>


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-941/feedback-mechanism-show-pressable-feedback-only-if-the-purchase-was

## Proposed Changes

- Adds start date support to useShowFeedback hook so that we can show the feedback only if the action was done within 7 days.
- Uses the date support on Pressable feedback
- Minor refactoring to the `LicensePreview` component to improve performance. We were earlier calling the useShowFeedback for all the licenses. Now, we will do it only for Pressable. 

## Why are these changes being made?

* To show the Pressable purchase feedback only if the purchase was made within 7 days of showing the feedback. 

## Testing Instructions

* Switch to the branch locally & start the server.
* Go to Licenses > Find the Pressable license
* Update the SEVEN_DAYS_IN_MS here: https://github.com/Automattic/wp-calypso/blob/75ee469f21c86248a891d8d9ad48fab9f5c9bc07/client/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback.tsx#L22 according to your Pressable purchase date so that we can test this accurately. 
* Ensure the preference is reset: `purchase-completed` is the key
* Click the `Manage in Pressable` license > Verify the feedback form is shown on the A4A dashboard > Submit or skip it.
* Repeat the step and verify the feedback is not shown again.
* Reset the preference > Undo the code changes > Repeat the step and verify the feedback is not shown if the purchase was done before 7 days.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
