### PR TITLE
Hosting Dashboard V2: Add notice component

### DIFF
--- a/client/components/notice/index.tsx
+++ b/client/components/notice/index.tsx
@@ -61,6 +61,9 @@ function getIcon( status: NoticeStatus | undefined ): string {
 	}
 }
 
+/**
+ * @deprecated Use `Notice` from `client/dashboard/components/notice` instead.
+ */
 export default function Notice( {
 	children,
 	className,

--- a/client/dashboard/components/action-list/action-item.stories.tsx
+++ b/client/dashboard/components/action-list/action-item.stories.tsx
@@ -3,17 +3,18 @@ import { Button, Icon } from '@wordpress/components';
 import { cog } from '@wordpress/icons';
 import ActionItem from './action-item';
 
-const meta = {
+const meta: Meta< typeof ActionItem > = {
 	title: 'client/dashboard/ActionList/ActionItem',
 	component: ActionItem,
 	tags: [ 'autodocs' ],
 	parameters: {
 		actions: { argTypesRegex: '^on.*' },
 	},
-} satisfies Meta< typeof ActionItem >;
+};
 
 export default meta;
-type Story = StoryObj< typeof meta >;
+
+type Story = StoryObj< typeof ActionItem >;
 
 export const Default: Story = {
 	args: {

--- a/client/dashboard/components/action-list/action-item.tsx
+++ b/client/dashboard/components/action-list/action-item.tsx
@@ -9,7 +9,7 @@ import './action-item.scss';
 
 function UnforwardedActionItem(
 	{ title, description, decoration, actions }: ActionItemProps,
-	ref: React.ForwardedRef< HTMLAnchorElement | HTMLButtonElement >
+	ref: React.ForwardedRef< HTMLSpanElement >
 ) {
 	return (
 		<VStack className="action-item" ref={ ref } as="span">

--- a/client/dashboard/components/action-list/index.stories.tsx
+++ b/client/dashboard/components/action-list/index.stories.tsx
@@ -3,17 +3,18 @@ import { Button, Icon } from '@wordpress/components';
 import { cog } from '@wordpress/icons';
 import ActionList from './index';
 
-const meta = {
+const meta: Meta< typeof ActionList > = {
 	title: 'client/dashboard/ActionList',
 	component: ActionList,
 	tags: [ 'autodocs' ],
 	parameters: {
 		actions: { argTypesRegex: '^on.*' },
 	},
-} satisfies Meta< typeof ActionList >;
+};
 
 export default meta;
-type Story = StoryObj< typeof meta >;
+
+type Story = StoryObj< typeof ActionList >;
 
 export const Default: Story = {
 	args: {

--- a/client/dashboard/components/action-list/index.tsx
+++ b/client/dashboard/components/action-list/index.tsx
@@ -11,7 +11,7 @@ import './style.scss';
 
 function UnforwardedActionList(
 	{ title, description, children }: ActionListProps,
-	ref: React.ForwardedRef< HTMLAnchorElement | HTMLButtonElement >
+	ref: React.ForwardedRef< HTMLDivElement >
 ) {
 	return (
 		<Card className="action-list" ref={ ref }>

--- a/client/dashboard/components/notice/icons.tsx
+++ b/client/dashboard/components/notice/icons.tsx
@@ -1,0 +1,13 @@
+import { SVG, Path } from '@wordpress/primitives';
+
+// Use customize caution icon instead of importing from `@wordpress/icons` to differentiate
+// from the info icon which is very similar visually.
+// See https://github.com/Automattic/wp-calypso/pull/103578#issuecomment-2898451545.
+export const caution = (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+		<Path
+			d="M18 4C19.1046 4 20 4.89543 20 6V18C20 19.1046 19.1046 20 18 20H6C4.89543 20 4 19.1046 4 18V6C4 4.89543 4.89543 4 6 4H18ZM6 5.5C5.72386 5.5 5.5 5.72386 5.5 6V18C5.5 18.2761 5.72386 18.5 6 18.5H18C18.2761 18.5 18.5 18.2761 18.5 18V6C18.5 5.72386 18.2761 5.5 18 5.5H6ZM12.75 16H11.25V14.5H12.75V16ZM12.75 13H11.25V8H12.75V13Z"
+			fill="#A77F30"
+		/>
+	</SVG>
+);

--- a/client/dashboard/components/notice/index.stories.tsx
+++ b/client/dashboard/components/notice/index.stories.tsx
@@ -17,7 +17,7 @@ type Story = StoryObj< typeof Notice >;
 
 const defaultArgs = {
 	title: 'Title',
-	description: (
+	children: (
 		<>
 			Hello, I’m a notice with an inline <ExternalLink href="#">link</ExternalLink>.
 		</>

--- a/client/dashboard/components/notice/index.stories.tsx
+++ b/client/dashboard/components/notice/index.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import { Button, ExternalLink } from '@wordpress/components';
 import Notice from './index';
 
-const meta = {
+const meta: Meta< typeof Notice > = {
 	title: 'client/dashboard/Notice',
 	component: Notice,
 	tags: [ 'autodocs' ],
@@ -19,10 +19,11 @@ const meta = {
 	parameters: {
 		actions: { argTypesRegex: '^on.*' },
 	},
-} satisfies Meta< typeof Notice >;
+};
 
 export default meta;
-type Story = StoryObj< typeof meta >;
+
+type Story = StoryObj< typeof Notice >;
 
 const defaultArgs = {
 	title: 'Title',

--- a/client/dashboard/components/notice/index.stories.tsx
+++ b/client/dashboard/components/notice/index.stories.tsx
@@ -1,0 +1,110 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { Button, ExternalLink } from '@wordpress/components';
+import Notice from './index';
+
+const meta = {
+	title: 'client/dashboard/Notice',
+	component: Notice,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		density: {
+			control: { type: 'radio' },
+			options: [ 'low', 'medium', 'high' ],
+		},
+		variant: {
+			control: { type: 'radio' },
+			options: [ 'info', 'warning', 'success', 'error' ],
+		},
+	},
+	parameters: {
+		actions: { argTypesRegex: '^on.*' },
+	},
+} satisfies Meta< typeof Notice >;
+
+export default meta;
+type Story = StoryObj< typeof meta >;
+
+const defaultArgs = {
+	title: 'Title',
+	description: (
+		<>
+			Hello, I’m a notice with an inline <ExternalLink>link</ExternalLink>.
+		</>
+	),
+	actions: (
+		<>
+			<Button variant="primary">Label</Button>
+			<Button variant="secondary">Label</Button>
+			<Button variant="link">Label</Button>
+		</>
+	),
+};
+
+export const Default: Story = {
+	args: {
+		...defaultArgs,
+	},
+};
+
+export const IsInfo: Story = {
+	args: {
+		...defaultArgs,
+		variant: 'info',
+	},
+};
+
+export const IsWarning: Story = {
+	args: {
+		...defaultArgs,
+		variant: 'warning',
+	},
+};
+
+export const IsSuccess: Story = {
+	args: {
+		...defaultArgs,
+		variant: 'success',
+	},
+};
+
+export const IsError: Story = {
+	args: {
+		...defaultArgs,
+		variant: 'error',
+	},
+};
+
+export const hasLowDensity: Story = {
+	args: {
+		...defaultArgs,
+		density: 'low',
+	},
+};
+
+export const hasMediumDensity: Story = {
+	args: {
+		...defaultArgs,
+		density: 'medium',
+	},
+};
+
+export const hasHighDensity: Story = {
+	args: {
+		...defaultArgs,
+		density: 'high',
+	},
+};
+
+export const WithoutActions: Story = {
+	args: {
+		...defaultArgs,
+		actions: undefined,
+	},
+};
+
+export const NotDismissible: Story = {
+	args: {
+		...defaultArgs,
+		isDismissible: false,
+	},
+};

--- a/client/dashboard/components/notice/index.stories.tsx
+++ b/client/dashboard/components/notice/index.stories.tsx
@@ -28,7 +28,7 @@ const defaultArgs = {
 	title: 'Title',
 	description: (
 		<>
-			Hello, I’m a notice with an inline <ExternalLink>link</ExternalLink>.
+			Hello, I’m a notice with an inline <ExternalLink href="#">link</ExternalLink>.
 		</>
 	),
 	actions: (

--- a/client/dashboard/components/notice/index.stories.tsx
+++ b/client/dashboard/components/notice/index.stories.tsx
@@ -96,6 +96,6 @@ export const WithoutActions: Story = {
 export const Dismissible: Story = {
 	args: {
 		...defaultArgs,
-		isDismissible: true,
+		onClose: () => {},
 	},
 };

--- a/client/dashboard/components/notice/index.stories.tsx
+++ b/client/dashboard/components/notice/index.stories.tsx
@@ -93,9 +93,9 @@ export const WithoutActions: Story = {
 	},
 };
 
-export const NotDismissible: Story = {
+export const Dismissible: Story = {
 	args: {
 		...defaultArgs,
-		isDismissible: false,
+		isDismissible: true,
 	},
 };

--- a/client/dashboard/components/notice/index.stories.tsx
+++ b/client/dashboard/components/notice/index.stories.tsx
@@ -6,16 +6,6 @@ const meta: Meta< typeof Notice > = {
 	title: 'client/dashboard/Notice',
 	component: Notice,
 	tags: [ 'autodocs' ],
-	argTypes: {
-		density: {
-			control: { type: 'radio' },
-			options: [ 'low', 'medium', 'high' ],
-		},
-		variant: {
-			control: { type: 'radio' },
-			options: [ 'info', 'warning', 'success', 'error' ],
-		},
-	},
 	parameters: {
 		actions: { argTypesRegex: '^on.*' },
 	},
@@ -47,49 +37,49 @@ export const Default: Story = {
 	},
 };
 
-export const IsInfo: Story = {
+export const Info: Story = {
 	args: {
 		...defaultArgs,
 		variant: 'info',
 	},
 };
 
-export const IsWarning: Story = {
+export const Warning: Story = {
 	args: {
 		...defaultArgs,
 		variant: 'warning',
 	},
 };
 
-export const IsSuccess: Story = {
+export const Success: Story = {
 	args: {
 		...defaultArgs,
 		variant: 'success',
 	},
 };
 
-export const IsError: Story = {
+export const Error: Story = {
 	args: {
 		...defaultArgs,
 		variant: 'error',
 	},
 };
 
-export const hasLowDensity: Story = {
+export const LowDensity: Story = {
 	args: {
 		...defaultArgs,
 		density: 'low',
 	},
 };
 
-export const hasMediumDensity: Story = {
+export const MediumDensity: Story = {
 	args: {
 		...defaultArgs,
 		density: 'medium',
 	},
 };
 
-export const hasHighDensity: Story = {
+export const HighDensity: Story = {
 	args: {
 		...defaultArgs,
 		density: 'high',

--- a/client/dashboard/components/notice/index.tsx
+++ b/client/dashboard/components/notice/index.tsx
@@ -6,9 +6,10 @@ import {
 	CardBody,
 	Icon,
 } from '@wordpress/components';
-import { info, caution, published, error, closeSmall } from '@wordpress/icons';
+import { info, published, error, closeSmall } from '@wordpress/icons';
 import clsx from 'clsx';
 import { forwardRef } from 'react';
+import { caution } from './icons';
 import type { NoticeVariant, NoticeProps } from './types';
 import './style.scss';
 

--- a/client/dashboard/components/notice/index.tsx
+++ b/client/dashboard/components/notice/index.tsx
@@ -36,23 +36,14 @@ const icons: { [ key in NoticeVariant ]: any } = {
  * 		<Notice
  * 			title="Title"
  * 			content={ <>Hello, I’m a notice with an inline <ExternalLink href="#">link</ExternalLink></> }
- * 			decoration={<Icon icon={cog} />}
- * 			actions={<Button variant="primary">Label</Button>}
+ * 			actions={ <Button variant="primary">Label</Button> }
  * 		/>
  * 	);
  * }
  * ```
  */
 function UnforwardedNotice(
-	{
-		variant = 'info',
-		title,
-		content,
-		actions,
-		density = 'low',
-		isDismissible = false,
-		onRemove,
-	}: NoticeProps,
+	{ variant = 'info', title, content, actions, density = 'low', onClose }: NoticeProps,
 	ref: React.ForwardedRef< HTMLDivElement >
 ) {
 	const hasLowDensity = density === 'low';
@@ -76,11 +67,11 @@ function UnforwardedNotice(
 							</HStack>
 						) }
 					</VStack>
-					{ isDismissible && (
+					{ !! onClose && (
 						<Button
 							className="dashboard-notice__close-button"
 							icon={ closeSmall }
-							onClick={ onRemove }
+							onClick={ onClose }
 						/>
 					) }
 				</HStack>

--- a/client/dashboard/components/notice/index.tsx
+++ b/client/dashboard/components/notice/index.tsx
@@ -35,15 +35,16 @@ const icons: { [ key in NoticeVariant ]: any } = {
  * 	return (
  * 		<Notice
  * 			title="Title"
- * 			content={ <>Hello, I’m a notice with an inline <ExternalLink href="#">link</ExternalLink></> }
  * 			actions={ <Button variant="primary">Label</Button> }
- * 		/>
+ * 		>
+ * 			<>Hello, I’m a notice with an inline <ExternalLink href="#">link</ExternalLink></>
+ * 		</Notice>
  * 	);
  * }
  * ```
  */
 function UnforwardedNotice(
-	{ variant = 'info', title, content, actions, density = 'low', onClose }: NoticeProps,
+	{ variant = 'info', title, children, actions, density = 'low', onClose }: NoticeProps,
 	ref: React.ForwardedRef< HTMLDivElement >
 ) {
 	const hasLowDensity = density === 'low';
@@ -59,7 +60,7 @@ function UnforwardedNotice(
 					<VStack className="dashboard-notice__content" spacing={ 3 }>
 						<VStack className="dashboard-notice__heading" spacing={ 1 }>
 							{ title && <span className="dashboard-notice__title">{ title }</span> }
-							<span className="dashboard-notice__description">{ content }</span>
+							<span className="dashboard-notice__description">{ children }</span>
 						</VStack>
 						{ actions && (
 							<HStack className="dashboard-notice__actions" spacing={ 3 } justify="flex-start">

--- a/client/dashboard/components/notice/index.tsx
+++ b/client/dashboard/components/notice/index.tsx
@@ -1,0 +1,72 @@
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	Button,
+	Card,
+	CardBody,
+	Icon,
+} from '@wordpress/components';
+import { info, caution, published, error, closeSmall } from '@wordpress/icons';
+import clsx from 'clsx';
+import { forwardRef } from 'react';
+import type { NoticeVariant, NoticeProps } from './types';
+import './style.scss';
+
+const icons: { [ key in NoticeVariant ]: any } = {
+	info,
+	warning: caution,
+	success: published,
+	error,
+};
+
+function UnforwardedNotice(
+	{
+		variant = 'info',
+		title,
+		description,
+		actions,
+		density = 'low',
+		isDismissible = true,
+		onRemove,
+	}: NoticeProps,
+	ref: React.ForwardedRef< HTMLAnchorElement | HTMLButtonElement >
+) {
+	const hasLowDensity = density === 'low';
+
+	return (
+		<Card
+			className={ clsx( 'dashboard-notice', `is-${ variant }`, `has-density-${ density }` ) }
+			ref={ ref }
+		>
+			<CardBody className="dashboard-notice__body">
+				<HStack spacing={ hasLowDensity ? 2 : 1 } justify="flex-start" alignment="flex-start">
+					<Icon className="dashboard-notice__icon" icon={ icons[ variant ] } />
+					<VStack className="dashboard-notice__content" spacing={ 3 }>
+						<VStack className="dashboard-notice__heading" spacing={ 1 }>
+							<span className="dashboard-notice__title">{ title }</span>
+							{ description && (
+								<span className="dashboard-notice__description">{ description }</span>
+							) }
+						</VStack>
+						{ actions && (
+							<HStack className="dashboard-notice__actions" spacing={ 3 } justify="flex-start">
+								{ actions }
+							</HStack>
+						) }
+					</VStack>
+					{ isDismissible && (
+						<Button
+							className="dashboard-notice__close-button"
+							icon={ closeSmall }
+							onClick={ onRemove }
+						/>
+					) }
+				</HStack>
+			</CardBody>
+		</Card>
+	);
+}
+
+export const Notice = forwardRef( UnforwardedNotice );
+
+export default Notice;

--- a/client/dashboard/components/notice/index.tsx
+++ b/client/dashboard/components/notice/index.tsx
@@ -20,14 +20,37 @@ const icons: { [ key in NoticeVariant ]: any } = {
 	error,
 };
 
+/**
+ * The Notice component is a visually non-obtrusive element that communicates the system status
+ * and provides options and actions related to the message tone.
+ *
+ * This component is designed to sit inline with the page area and capture the user’s attention
+ * to inform them about relevant information.
+ *
+ * ```jsx
+ * import { Notice } from '@automattic/components';
+ * import { ExternalLink } from '@wordpress/components';
+ *
+ * function MyComponent() {
+ * 	return (
+ * 		<Notice
+ * 			title="Title"
+ * 			content={ <>Hello, I’m a notice with an inline <ExternalLink href="#">link</ExternalLink></> }
+ * 			decoration={<Icon icon={cog} />}
+ * 			actions={<Button variant="primary">Label</Button>}
+ * 		/>
+ * 	);
+ * }
+ * ```
+ */
 function UnforwardedNotice(
 	{
 		variant = 'info',
 		title,
-		description,
+		content,
 		actions,
 		density = 'low',
-		isDismissible = true,
+		isDismissible = false,
 		onRemove,
 	}: NoticeProps,
 	ref: React.ForwardedRef< HTMLDivElement >
@@ -44,10 +67,8 @@ function UnforwardedNotice(
 					<Icon className="dashboard-notice__icon" icon={ icons[ variant ] } />
 					<VStack className="dashboard-notice__content" spacing={ 3 }>
 						<VStack className="dashboard-notice__heading" spacing={ 1 }>
-							<span className="dashboard-notice__title">{ title }</span>
-							{ description && (
-								<span className="dashboard-notice__description">{ description }</span>
-							) }
+							{ title && <span className="dashboard-notice__title">{ title }</span> }
+							<span className="dashboard-notice__description">{ content }</span>
 						</VStack>
 						{ actions && (
 							<HStack className="dashboard-notice__actions" spacing={ 3 } justify="flex-start">

--- a/client/dashboard/components/notice/index.tsx
+++ b/client/dashboard/components/notice/index.tsx
@@ -29,7 +29,7 @@ function UnforwardedNotice(
 		isDismissible = true,
 		onRemove,
 	}: NoticeProps,
-	ref: React.ForwardedRef< HTMLAnchorElement | HTMLButtonElement >
+	ref: React.ForwardedRef< HTMLDivElement >
 ) {
 	const hasLowDensity = density === 'low';
 

--- a/client/dashboard/components/notice/style.scss
+++ b/client/dashboard/components/notice/style.scss
@@ -2,36 +2,6 @@
 @import "@wordpress/base-styles/variables";
 
 .dashboard-notice {
-	.dashboard-notice__icon {
-		width: 24px;
-		height: 24px;
-		flex-shrink: 0;
-	}
-
-	.dashboard-notice__content {
-		flex-grow: 1;
-	}
-
-	.dashboard-notice__heading {
-		padding: 2px 0;
-	}
-
-	.dashboard-notice__title {
-		@include heading-medium;
-	}
-
-	.dashboard-notice__description {
-		@include body-medium;
-	}
-
-	.dashboard-notice__actions {
-		padding-bottom: $grid-unit-05;
-	}
-
-	.dashboard-notice__close-button {
-		margin: -6px;
-	}
-
 	/**
 	 * Density
 	 */
@@ -87,4 +57,34 @@
 			fill: #8c0b0b;
 		}
 	}
+}
+
+.dashboard-notice__icon {
+	width: 24px;
+	height: 24px;
+	flex-shrink: 0;
+}
+
+.dashboard-notice__content {
+	flex-grow: 1;
+}
+
+.dashboard-notice__heading {
+	padding: 2px 0;
+}
+
+.dashboard-notice__title {
+	@include heading-medium;
+}
+
+.dashboard-notice__description {
+	@include body-medium;
+}
+
+.dashboard-notice__actions {
+	padding-bottom: $grid-unit-05;
+}
+
+.dashboard-notice__close-button {
+	margin: -6px;
 }

--- a/client/dashboard/components/notice/style.scss
+++ b/client/dashboard/components/notice/style.scss
@@ -8,18 +8,21 @@
 	&.has-density-low {
 		.dashboard-notice__body {
 			padding: $grid-unit-20;
+			border-radius: $radius-large;
 		}
 	}
 
 	&.has-density-medium {
 		.dashboard-notice__body {
 			padding: $grid-unit-15;
+			border-radius: $radius-small;
 		}
 	}
 
 	&.has-density-high {
 		.dashboard-notice__body {
 			padding: $grid-unit-05;
+			border-radius: $radius-small;
 		}
 	}
 

--- a/client/dashboard/components/notice/style.scss
+++ b/client/dashboard/components/notice/style.scss
@@ -1,0 +1,90 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
+.dashboard-notice {
+	.dashboard-notice__icon {
+		width: 24px;
+		height: 24px;
+		flex-shrink: 0;
+	}
+
+	.dashboard-notice__content {
+		flex-grow: 1;
+	}
+
+	.dashboard-notice__heading {
+		padding: 2px 0;
+	}
+
+	.dashboard-notice__title {
+		@include heading-medium;
+	}
+
+	.dashboard-notice__description {
+		@include body-medium;
+	}
+
+	.dashboard-notice__actions {
+		padding-bottom: $grid-unit-05;
+	}
+
+	.dashboard-notice__close-button {
+		margin: -6px;
+	}
+
+	/**
+	 * Density
+	 */
+	&.has-density-low {
+		.dashboard-notice__body {
+			padding: $grid-unit-20;
+		}
+	}
+
+	&.has-density-medium {
+		.dashboard-notice__body {
+			padding: $grid-unit-15;
+		}
+	}
+
+	&.has-density-high {
+		.dashboard-notice__body {
+			padding: $grid-unit-05;
+		}
+	}
+
+	/**
+	 * Variant
+	 */
+	&.is-info {
+		background-color: color-mix(in srgb, var(--wp-admin-theme-color) 4%, transparent);
+
+		.dashboard-notice__icon {
+			fill: var(--wp-admin-theme-color);
+		}
+	}
+
+	&.is-warning {
+		background-color: color-mix(in srgb, $alert-yellow 4%, transparent);
+
+		.dashboard-notice__icon {
+			fill: #a77f30;
+		}
+	}
+
+	&.is-success {
+		background-color: color-mix(in srgb, $alert-green 4%, transparent);
+
+		.dashboard-notice__icon {
+			fill: #2c723e;
+		}
+	}
+
+	&.is-error {
+		background-color: color-mix(in srgb, $alert-red 4%, transparent);
+
+		.dashboard-notice__icon {
+			fill: #8c0b0b;
+		}
+	}
+}

--- a/client/dashboard/components/notice/style.scss
+++ b/client/dashboard/components/notice/style.scss
@@ -6,23 +6,26 @@
 	 * Density
 	 */
 	&.has-density-low {
+		border-radius: $radius-large;
+
 		.dashboard-notice__body {
 			padding: $grid-unit-20;
-			border-radius: $radius-large;
 		}
 	}
 
 	&.has-density-medium {
+		border-radius: $radius-small;
+
 		.dashboard-notice__body {
 			padding: $grid-unit-15;
-			border-radius: $radius-small;
 		}
 	}
 
 	&.has-density-high {
+		border-radius: $radius-small;
+
 		.dashboard-notice__body {
 			padding: $grid-unit-05;
-			border-radius: $radius-small;
 		}
 	}
 

--- a/client/dashboard/components/notice/types.ts
+++ b/client/dashboard/components/notice/types.ts
@@ -6,34 +6,30 @@ export type NoticeVariant = 'warning' | 'success' | 'error' | 'info';
 
 export interface NoticeProps {
 	/**
-	 * Determines the color of the notice: `warning` (yellow),
-	 * `success` (green), `error` (red), or `'info'`.
-	 * By default `'info'` will be blue, but if there is a parent Theme component
-	 * with an accent color prop, the notice will take on that color instead.
+	 * Indicates visually the message tone. These can be four: Info, Warning, Success, and Error.
 	 *
 	 * @default 'info'
 	 */
 	variant?: NoticeVariant;
 
 	/**
-	 * The main label that identifies the notice.
+	 * A concise headline that clearly communicates the main message.
 	 */
-	title: React.ReactNode;
+	title?: React.ReactNode;
 
 	/**
-	 * Optional supporting text that provides additional context or
-	 * detail about the notice.
+	 * The main body content informing and guiding users about the system status change.
 	 */
-	description?: React.ReactNode;
+	content: React.ReactNode;
 
 	/**
-	 * Renders a button that invokes the related notice.
+	 * Optional actions that serve as a call to action.
 	 */
 	actions: React.ReactNode;
 
 	/**
-	 * Adjusts spacing and layout. Higher density reduces padding to
-	 * create a more compact appearance.
+	 * Adjusts internal spacings according to the section where the component is placed.
+	 * High density reduces padding.
 	 *
 	 * @default 'low'
 	 */
@@ -42,12 +38,12 @@ export interface NoticeProps {
 	/**
 	 * Whether the notice should be dismissible or not
 	 *
-	 * @default true
+	 * @default false
 	 */
 	isDismissible?: boolean;
 
 	/**
-	 * Function called when dismissing the notice
+	 * An optional action to close the component.
 	 *
 	 * @default noop
 	 */

--- a/client/dashboard/components/notice/types.ts
+++ b/client/dashboard/components/notice/types.ts
@@ -36,16 +36,7 @@ export interface NoticeProps {
 	density?: NoticeDensity;
 
 	/**
-	 * Whether the notice should be dismissible or not
-	 *
-	 * @default false
-	 */
-	isDismissible?: boolean;
-
-	/**
 	 * An optional action to close the component.
-	 *
-	 * @default noop
 	 */
-	onRemove?: () => void;
+	onClose?: () => void;
 }

--- a/client/dashboard/components/notice/types.ts
+++ b/client/dashboard/components/notice/types.ts
@@ -20,7 +20,7 @@ export interface NoticeProps {
 	/**
 	 * The main body content informing and guiding users about the system status change.
 	 */
-	content: React.ReactNode;
+	children: React.ReactNode;
 
 	/**
 	 * Optional actions that serve as a call to action.

--- a/client/dashboard/components/notice/types.ts
+++ b/client/dashboard/components/notice/types.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-type NoticeDensity = 'low' | 'medium';
+type NoticeDensity = 'low' | 'medium' | 'high';
 
 export type NoticeVariant = 'warning' | 'success' | 'error' | 'info';
 
@@ -18,13 +18,13 @@ export interface NoticeProps {
 	/**
 	 * The main label that identifies the notice.
 	 */
-	title: string;
+	title: React.ReactNode;
 
 	/**
 	 * Optional supporting text that provides additional context or
 	 * detail about the notice.
 	 */
-	description?: string;
+	description?: React.ReactNode;
 
 	/**
 	 * Renders a button that invokes the related notice.

--- a/client/dashboard/components/notice/types.ts
+++ b/client/dashboard/components/notice/types.ts
@@ -1,0 +1,55 @@
+import React from 'react';
+
+type NoticeDensity = 'low' | 'medium';
+
+export type NoticeVariant = 'warning' | 'success' | 'error' | 'info';
+
+export interface NoticeProps {
+	/**
+	 * Determines the color of the notice: `warning` (yellow),
+	 * `success` (green), `error` (red), or `'info'`.
+	 * By default `'info'` will be blue, but if there is a parent Theme component
+	 * with an accent color prop, the notice will take on that color instead.
+	 *
+	 * @default 'info'
+	 */
+	variant?: NoticeVariant;
+
+	/**
+	 * The main label that identifies the notice.
+	 */
+	title: string;
+
+	/**
+	 * Optional supporting text that provides additional context or
+	 * detail about the notice.
+	 */
+	description?: string;
+
+	/**
+	 * Renders a button that invokes the related notice.
+	 */
+	actions: React.ReactNode;
+
+	/**
+	 * Adjusts spacing and layout. Higher density reduces padding to
+	 * create a more compact appearance.
+	 *
+	 * @default 'low'
+	 */
+	density?: NoticeDensity;
+
+	/**
+	 * Whether the notice should be dismissible or not
+	 *
+	 * @default true
+	 */
+	isDismissible?: boolean;
+
+	/**
+	 * Function called when dismissing the notice
+	 *
+	 * @default noop
+	 */
+	onRemove?: () => void;
+}

--- a/client/dashboard/components/notice/types.ts
+++ b/client/dashboard/components/notice/types.ts
@@ -25,7 +25,7 @@ export interface NoticeProps {
 	/**
 	 * Optional actions that serve as a call to action.
 	 */
-	actions: React.ReactNode;
+	actions?: React.ReactNode;
 
 	/**
 	 * Adjusts internal spacings according to the section where the component is placed.

--- a/packages/components/src/summary-button/index.stories.tsx
+++ b/packages/components/src/summary-button/index.stories.tsx
@@ -19,7 +19,7 @@ const badgeOptions: Record< string, SummaryButtonBadgeProps[] > = {
 	'No Badges': [],
 };
 
-const meta = {
+const meta: Meta< typeof SummaryButton > = {
 	title: 'SummaryButton',
 	component: SummaryButton,
 	argTypes: {
@@ -43,10 +43,11 @@ const meta = {
 	parameters: {
 		actions: { argTypesRegex: '^on.*' },
 	},
-} satisfies Meta< typeof SummaryButton >;
+};
 
 export default meta;
-type Story = StoryObj< typeof meta >;
+
+type Story = StoryObj< typeof SummaryButton >;
 
 export const Default: Story = {
 	args: {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13192

## Proposed Changes

* Add the `Notice` component for use on the Transfer site.

**Variant**
| Info | Warning | Success | Error |
| - | - | - | - |
| ![image](https://github.com/user-attachments/assets/b1ab9e3f-243d-46ed-96fe-d38b41d8753b) | ![image](https://github.com/user-attachments/assets/ee06ae90-0b85-4135-8db4-fc140761ca99) | ![image](https://github.com/user-attachments/assets/88e923d2-3726-4077-bfbc-572b10741276) | ![image](https://github.com/user-attachments/assets/e2799dba-3888-4ab6-acbd-769d6bab341a) |

**Density**
| Low | Medium | High |
| - | - | - | 
| ![image](https://github.com/user-attachments/assets/eb9158df-b2be-475f-a8dc-fb6d0e382fca) | ![image](https://github.com/user-attachments/assets/71b34553-693f-4a3d-8181-cc6fa100657f) | ![image](https://github.com/user-attachments/assets/3a66c6a0-66ee-4e08-8d44-6203b2d5f8e2) |

**Others**

| Not dismissible | Without actions |
| - | - |
| ![image](https://github.com/user-attachments/assets/1e08e9fe-c74a-4af7-9965-9c2516bac2ef) | ![image](https://github.com/user-attachments/assets/4f66fc0e-35e2-4137-bf01-3e87850c1249) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Run `yarn run storybook:start`
* Go to http://localhost:6006/?path=/story/client-dashboard-notice--default

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
