### PR TITLE
Dashboard v2: lazy load uptime

### DIFF
--- a/client/dashboard/components/text-blur/index.tsx
+++ b/client/dashboard/components/text-blur/index.tsx
@@ -1,0 +1,5 @@
+import './style.scss';
+
+export function TextBlur( { text }: { text: string } ) {
+	return <span className="text-blur" data-text={ text } />;
+}

--- a/client/dashboard/components/text-blur/style.scss
+++ b/client/dashboard/components/text-blur/style.scss
@@ -1,0 +1,6 @@
+.text-blur::after {
+	content: attr(data-text);
+    // The larger the font-size, the more blurring is needed.
+	filter: blur(0.3em);
+	opacity: 0.5;
+}

--- a/client/dashboard/sites/overview-card/index.tsx
+++ b/client/dashboard/sites/overview-card/index.tsx
@@ -13,7 +13,7 @@ import './style.scss';
 
 interface OverviewCardProps {
 	title: string;
-	heading?: string;
+	heading?: ReactNode;
 	customHeading?: ReactNode;
 	icon?: ReactElement;
 	metaText?: string;

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -80,7 +80,7 @@ function SiteOverview() {
 					</OverviewSection>
 					<OverviewSection title={ __( 'Site health' ) } actions={ [] }>
 						<PerformanceCards site={ site } />
-						<UptimeCard siteSlug={ siteSlug } site={ site } />
+						<UptimeCard site={ site } />
 						<StorageCard siteSlug={ siteSlug } />
 					</OverviewSection>
 				</VStack>

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -9,12 +9,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
-import {
-	siteQuery,
-	siteMonitorUptimeQuery,
-	siteCurrentPlanQuery,
-	siteEngagementStatsQuery,
-} from '../../app/queries';
+import { siteQuery, siteCurrentPlanQuery, siteEngagementStatsQuery } from '../../app/queries';
 import { siteRoute } from '../../app/router';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -34,10 +29,6 @@ import './style.scss';
 function SiteOverview() {
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useQuery( siteQuery( siteSlug ) );
-	const { data: siteMonitorUptime } = useQuery( {
-		...siteMonitorUptimeQuery( siteSlug ),
-		enabled: site?.jetpack && site?.jetpack_modules.includes( 'monitor' ),
-	} );
 	const { data: currentPlan } = useQuery( siteCurrentPlanQuery( siteSlug ) );
 	const { data: engagementStats } = useQuery( siteEngagementStatsQuery( siteSlug ) );
 
@@ -89,7 +80,7 @@ function SiteOverview() {
 					</OverviewSection>
 					<OverviewSection title={ __( 'Site health' ) } actions={ [] }>
 						<PerformanceCards site={ site } />
-						<UptimeCard siteMonitorUptime={ siteMonitorUptime } />
+						<UptimeCard siteSlug={ siteSlug } site={ site } />
 						<StorageCard siteSlug={ siteSlug } />
 					</OverviewSection>
 				</VStack>

--- a/client/dashboard/sites/overview/site-card.tsx
+++ b/client/dashboard/sites/overview/site-card.tsx
@@ -10,13 +10,10 @@ import {
 import { dateI18n } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
 import { sitePHPVersionQuery } from '../../app/queries';
+import { TextBlur } from '../../components/text-blur';
 import { getSiteStatusLabel } from '../../utils/site-status';
 import SitePreview from '../site-preview';
 import type { Site, Plan } from '../../data/types';
-
-function TextBlur( { text }: { text: string } ) {
-	return <span className="text-blur" data-text={ text } />;
-}
 
 function PHPVersion( { siteSlug }: { siteSlug: string } ) {
 	return useQuery( sitePHPVersionQuery( siteSlug ) ).data ?? <TextBlur text="X.Y" />;

--- a/client/dashboard/sites/overview/style.scss
+++ b/client/dashboard/sites/overview/style.scss
@@ -24,8 +24,3 @@
 		display: none;
 	}
 }
-
-.text-blur::after {
-	content: attr(data-text);
-	filter: blur(4px);
-}

--- a/client/dashboard/sites/overview/uptime-card.tsx
+++ b/client/dashboard/sites/overview/uptime-card.tsx
@@ -1,34 +1,56 @@
+import { useQuery } from '@tanstack/react-query';
+import { VisuallyHidden } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { connection } from '@wordpress/icons';
+import { siteMonitorUptimeQuery } from '../../app/queries';
+import { TextBlur } from '../../components/text-blur';
 import OverviewCard, { OverviewCardProgressBar } from '../overview-card';
-import type { MonitorUptime } from '../../data/types';
+import type { Site } from '../../data/types';
+
 import './style.scss';
 
-export default function UptimeCard( { siteMonitorUptime }: { siteMonitorUptime?: MonitorUptime } ) {
-	if ( ! siteMonitorUptime ) {
-		return;
+function UptimeCardEnabled( { siteSlug }: { siteSlug: string } ) {
+	const { data: siteMonitorUptime } = useQuery( siteMonitorUptimeQuery( siteSlug ) );
+
+	let uptimePercentage;
+
+	if ( siteMonitorUptime ) {
+		const { upDays, downDays } = Object.entries( siteMonitorUptime ).reduce(
+			( accumulator, [ , { status } = {} ] ) => {
+				accumulator[ status === 'up' ? 'upDays' : 'downDays' ] += 1;
+				return accumulator;
+			},
+			{ upDays: 0, downDays: 0 }
+		);
+		uptimePercentage = Math.round( ( ( upDays / ( upDays + downDays ) ) * 1000 ) / 10 );
 	}
-	const { upDays, downDays } = Object.entries( siteMonitorUptime || {} ).reduce(
-		( accumulator, [ , { status } = {} ] ) => {
-			accumulator[ status === 'up' ? 'upDays' : 'downDays' ] += 1;
-			return accumulator;
-		},
-		{ upDays: 0, downDays: 0 }
-	);
-	const uptimePercentage = Math.round( ( ( upDays / ( upDays + downDays ) ) * 1000 ) / 10 );
+
+	/* translators: %s: percentage of site uptime. Eg. 99% */
+	const percentageString = __( '%s%%' );
+
 	return (
-		<>
-			<OverviewCard
-				title={ __( 'Uptime' ) }
-				icon={ connection }
-				heading={
-					/* translators: %s: percentage of site uptime. Eg. 99% */
-					sprintf( __( '%s%%' ), uptimePercentage )
-				}
-				metaText={ __( 'Past 30 days' ) }
-			>
-				<OverviewCardProgressBar value={ uptimePercentage } />
-			</OverviewCard>
-		</>
+		<OverviewCard
+			title={ __( 'Uptime' ) }
+			icon={ connection }
+			heading={
+				uptimePercentage === undefined ? (
+					<>
+						<TextBlur text={ sprintf( percentageString, '100' ) } />
+						<VisuallyHidden>{ __( 'Loading…' ) }</VisuallyHidden>
+					</>
+				) : (
+					sprintf( percentageString, uptimePercentage )
+				)
+			}
+			metaText={ __( 'Past 30 days' ) }
+		>
+			<OverviewCardProgressBar value={ uptimePercentage } />
+		</OverviewCard>
 	);
+}
+
+export default function UptimeCard( { siteSlug, site }: { siteSlug: string; site: Site } ) {
+	return site.jetpack && site.jetpack_modules.includes( 'monitor' ) ? (
+		<UptimeCardEnabled siteSlug={ siteSlug } />
+	) : null /* Opportunity for upsell? */;
 }

--- a/client/dashboard/sites/overview/uptime-card.tsx
+++ b/client/dashboard/sites/overview/uptime-card.tsx
@@ -49,8 +49,8 @@ function UptimeCardEnabled( { siteSlug }: { siteSlug: string } ) {
 	);
 }
 
-export default function UptimeCard( { siteSlug, site }: { siteSlug: string; site: Site } ) {
+export default function UptimeCard( { site }: { site: Site } ) {
 	return site.jetpack && site.jetpack_modules.includes( 'monitor' ) ? (
-		<UptimeCardEnabled siteSlug={ siteSlug } />
+		<UptimeCardEnabled siteSlug={ site.slug } />
 	) : null /* Opportunity for upsell? */;
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Similar to #103547 and #103558.

<img width="930" alt="image" src="https://github.com/user-attachments/assets/a9fd3c03-0518-41cd-a6fb-0bdaf2b943d1" />

Btw, in reality, the uptime pops in so fast it's not even visible. I had to set it to undefined to be able to take the screenshot.


## Proposed Changes

* Lazy load media uptime data. It's not data that will result in a layout shift and it's fine to pop in a few ms later. Additionally the other site health cards are loaded in way later and have the same loading state.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The less requests needed for the initial site endpoint, the better.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check that it still loads.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
