### PR TITLE
STATS-63: Download CSV for email.

### DIFF
--- a/client/my-sites/stats/stats-download-csv/index.jsx
+++ b/client/my-sites/stats/stats-download-csv/index.jsx
@@ -30,6 +30,7 @@ class StatsDownloadCsv extends Component {
 		siteId: PropTypes.number,
 		isMobile: PropTypes.bool,
 		hideIfNoData: PropTypes.bool,
+		headers: PropTypes.array,
 		rowModifierFn: PropTypes.func,
 	};
 
@@ -52,7 +53,7 @@ class StatsDownloadCsv extends Component {
 
 	downloadCsv = ( event ) => {
 		event.preventDefault();
-		const { siteSlug, path, period, data } = this.props;
+		const { siteSlug, path, period, data, headers } = this.props;
 
 		const fileName =
 			[
@@ -65,7 +66,11 @@ class StatsDownloadCsv extends Component {
 
 		this.props.recordGoogleEvent( 'Stats', 'CSV Download ' + titlecase( path ) );
 
-		const csvData = this.processExportData( data )
+		const csvData = headers
+			? [ headers, ...this.processExportData( data ) ]
+			: this.processExportData( data );
+
+		const csvString = csvData
 			.map( ( row ) => {
 				if ( Array.isArray( row ) ) {
 					return row.join( ',' );
@@ -77,7 +82,7 @@ class StatsDownloadCsv extends Component {
 			} )
 			.join( '\n' );
 
-		const blob = new Blob( [ csvData ], { type: 'text/csv;charset=utf-8' } );
+		const blob = new Blob( [ csvString ], { type: 'text/csv;charset=utf-8' } );
 
 		saveAs( blob, fileName );
 	};

--- a/client/my-sites/stats/stats-download-csv/index.jsx
+++ b/client/my-sites/stats/stats-download-csv/index.jsx
@@ -30,6 +30,7 @@ class StatsDownloadCsv extends Component {
 		siteId: PropTypes.number,
 		isMobile: PropTypes.bool,
 		hideIfNoData: PropTypes.bool,
+		rowModifierFn: PropTypes.func,
 	};
 
 	processExportData = ( data ) => {
@@ -137,11 +138,11 @@ const connectComponent = connect(
 			return { data: ownProps.data, siteSlug, siteId, isLoading: false };
 		}
 
-		const { statType, query } = ownProps;
+		const { statType, query, rowModifierFn } = ownProps;
 		const data =
 			statType === 'statsVideoPlays'
 				? getSiteStatsNormalizedData( state, siteId, statType, query )
-				: getSiteStatsCSVData( state, siteId, statType, query );
+				: getSiteStatsCSVData( state, siteId, statType, query, rowModifierFn );
 		const isLoading = isRequestingSiteStatsForQuery( state, siteId, statType, query );
 
 		return { data, siteSlug, siteId, isLoading };

--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -6,10 +6,14 @@ import { useMemo, useEffect } from 'react';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import NavigationHeader from 'calypso/components/navigation-header';
 import Main from 'calypso/my-sites/stats/components/stats-main';
+import { useShouldGateStats } from 'calypso/my-sites/stats/hooks/use-should-gate-stats';
 import { recordCurrentScreen } from 'calypso/my-sites/stats/hooks/use-stats-navigation-history';
+import DownloadCsv from 'calypso/my-sites/stats/stats-download-csv';
+import DownloadCsvUpsell from 'calypso/my-sites/stats/stats-download-csv-upsell';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import PageHeader from '../components/headers/page-header';
+import { STATS_FEATURE_DOWNLOAD_CSV } from '../constants';
 import {
 	TooltipWrapper,
 	OpensTooltipContent,
@@ -28,6 +32,7 @@ const StatsEmailSummary = ( { period, query, context } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state, siteId ) );
+	const shouldGateCsvDownloads = useShouldGateStats( STATS_FEATURE_DOWNLOAD_CSV );
 
 	// TODO: align with all summary pages.
 	const navigationItems = useMemo( () => {
@@ -79,6 +84,25 @@ const StatsEmailSummary = ( { period, query, context } ) => {
 		titleLogo: null,
 	};
 
+	const downloadCsvElement = shouldGateCsvDownloads ? (
+		<DownloadCsvUpsell siteId={ siteId } borderless />
+	) : (
+		<DownloadCsv
+			statType="statsEmailsSummary"
+			path="emails"
+			query={ query }
+			period={ period }
+			rowModifierFn={ ( row, data ) => {
+				if ( ! row?.length ) {
+					return row;
+				}
+
+				const [ label, ...rest ] = row;
+				return [ label, data.opens_rate, ...rest ];
+			} }
+		/>
+	);
+
 	return (
 		<Main
 			className={ clsx( {
@@ -93,6 +117,7 @@ const StatsEmailSummary = ( { period, query, context } ) => {
 						className="stats__section-header modernized-header"
 						titleProps={ titleProps }
 						backLinkProps={ backLinkProps }
+						rightSection={ downloadCsvElement }
 					/>
 				) }
 

--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -94,7 +94,7 @@ const StatsEmailSummary = ( { period, query, context } ) => {
 			period={ period }
 			headers={ [ 'title', 'opens_rate', 'unique_clicks', 'link' ] }
 			rowModifierFn={ ( row, data ) => {
-				if ( ! row?.length ) {
+				if ( ! Array.isArray( row ) || row.length === 0 ) {
 					return row;
 				}
 

--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -92,6 +92,7 @@ const StatsEmailSummary = ( { period, query, context } ) => {
 			path="emails"
 			query={ query }
 			period={ period }
+			headers={ [ 'title', 'opens_rate', 'unique_clicks', 'link' ] }
 			rowModifierFn={ ( row, data ) => {
 				if ( ! row?.length ) {
 					return row;

--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -118,7 +118,9 @@ const StatsEmailSummary = ( { period, query, context } ) => {
 						className="stats__section-header modernized-header"
 						titleProps={ titleProps }
 						backLinkProps={ backLinkProps }
-						rightSection={ downloadCsvElement }
+						rightSection={
+							<div className="stats-module__header-nav-button">{ downloadCsvElement }</div>
+						}
 					/>
 				) }
 

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -160,13 +160,15 @@ export const getSiteStatsNormalizedData = treeSelect(
 
 /**
  * Returns an array of stats data ready for csv export
- * @param   {Object}  state    Global state tree
- * @param   {number}  siteId   Site ID
- * @param   {string}  statType Type of stat
- * @param   {Object}  query    Stats query object
- * @returns {Array}            Array of stats data ready for CSV export
+ * @template T
+ * @param   {Object}  state                                             Global state tree
+ * @param   {number}  siteId                                            Site ID
+ * @param   {string}  statType                                          Type of stat
+ * @param   {Object}  query                                             Stats query object
+ * @param   {(value: unknown[], data?: Object) => unknown[]} modifierFn Modifies the export row.
+ * @returns {Array}                                                     Array of stats data ready for CSV export
  */
-export function getSiteStatsCSVData( state, siteId, statType, query ) {
+export function getSiteStatsCSVData( state, siteId, statType, query, modifierFn = null ) {
 	const data = getSiteStatsNormalizedData( state, siteId, statType, query );
 	if ( ! data || ! Array.isArray( data ) ) {
 		return [];
@@ -174,7 +176,7 @@ export function getSiteStatsCSVData( state, siteId, statType, query ) {
 
 	return flatten(
 		map( data, ( item ) => {
-			return buildExportArray( item );
+			return buildExportArray( item, modifierFn );
 		} )
 	);
 }

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -176,7 +176,7 @@ export function getSiteStatsCSVData( state, siteId, statType, query, modifierFn 
 
 	return flatten(
 		map( data, ( item ) => {
-			return buildExportArray( item, modifierFn );
+			return buildExportArray( item, null, modifierFn );
 		} )
 	);
 }

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -213,6 +213,7 @@ describe( 'utils', () => {
 						value: 10,
 						others: [ 1, 2, 3 ],
 					},
+					null,
 					( row, data ) => [ ...row, data.others[ 2 ] ]
 				)
 			).toEqual( [ [ '"Chicken"', 10, 'https://example.com/chicken', 3 ] ] );

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -199,6 +199,25 @@ describe( 'utils', () => {
 			).toEqual( [ [ '"Chicken and ""Ribs""', 10, 'https://example.com/chicken' ] ] );
 		} );
 
+		test( 'should modify each row in csv by a modifier function', () => {
+			expect(
+				buildExportArray(
+					{
+						actions: [
+							{
+								type: 'link',
+								data: 'https://example.com/chicken',
+							},
+						],
+						label: 'Chicken',
+						value: 10,
+						others: [ 1, 2, 3 ],
+					},
+					( row, data ) => [ ...row, data.others[ 2 ] ]
+				)
+			).toEqual( [ [ '"Chicken"', 10, 'https://example.com/chicken', 3 ] ] );
+		} );
+
 		test( 'should recurse child data', () => {
 			expect(
 				buildExportArray( {

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -85,11 +85,11 @@ export function parseAvatar( avatarUrl ) {
 /**
  * Builds data into escaped array for CSV export
  * @param   {Object} data                                               Normalized stats data object
- * @param   {(value: unknown[], data?: Object) => unknown[]} modifierFn Modifies the export row.
  * @param   {string} parent                                             Label of parent
+ * @param   {(value: unknown[], data?: Object) => unknown[]} modifierFn Modifies the export row.
  * @returns {Array}                                                     CSV Row
  */
-export function buildExportArray( data, modifierFn = null, parent = null ) {
+export function buildExportArray( data, parent = null, modifierFn = null ) {
 	if ( ! data || ! data.label || ! data.value ) {
 		return [];
 	}
@@ -109,7 +109,7 @@ export function buildExportArray( data, modifierFn = null, parent = null ) {
 
 	if ( data.children ) {
 		const childData = map( data.children, ( child ) => {
-			return buildExportArray( child, modifierFn, label );
+			return buildExportArray( child, label, modifierFn );
 		} );
 
 		exportData = exportData.concat( flatten( childData ) );

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -84,11 +84,12 @@ export function parseAvatar( avatarUrl ) {
 
 /**
  * Builds data into escaped array for CSV export
- * @param   {Object} data   Normalized stats data object
- * @param   {string} parent Label of parent
- * @returns {Array}         CSV Row
+ * @param   {Object} data                                               Normalized stats data object
+ * @param   {(value: unknown[], data?: Object) => unknown[]} modifierFn Modifies the export row.
+ * @param   {string} parent                                             Label of parent
+ * @returns {Array}                                                     CSV Row
  */
-export function buildExportArray( data, parent = null ) {
+export function buildExportArray( data, modifierFn = null, parent = null ) {
 	if ( ! data || ! data.label || ! data.value ) {
 		return [];
 	}
@@ -102,9 +103,13 @@ export function buildExportArray( data, parent = null ) {
 		exportData = [ [ '"' + escapedLabel + '"', data.value, data.actions[ 0 ].data ] ];
 	}
 
+	if ( modifierFn ) {
+		exportData = [ modifierFn( exportData[ 0 ], data ) ];
+	}
+
 	if ( data.children ) {
 		const childData = map( data.children, ( child ) => {
-			return buildExportArray( child, label );
+			return buildExportArray( child, modifierFn, label );
 		} );
 
 		exportData = exportData.concat( flatten( childData ) );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes #STATS-63

## Proposed Changes

* Added a download CSV button in the **Stats for Emails** page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To enable CSV download for email stats.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Download the CSV from here [http://calypso.localhost:3000/stats/day/emails/jetpack.com](http://calypso.localhost:3000/stats/day/emails/jetpack.com)
* It should contain the fields available in the page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
