### PR TITLE
[WiP] Show `EligibilityWarnings` on `ThemeSheet`

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1255,15 +1255,14 @@ class ThemeSheet extends Component {
 	}
 }
 
-const withSiteGlobalStylesStatus = createHigherOrderComponent(
-	( Wrapped ) => ( props ) => {
+const withSiteGlobalStylesStatus = createHigherOrderComponent( ( Wrapped ) => {
+	return function WithSiteGlobalStylesStatus( props ) {
 		const { siteId } = props;
 		const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( siteId );
 
 		return <Wrapped { ...props } shouldLimitGlobalStyles={ shouldLimitGlobalStyles } />;
-	},
-	'withSiteGlobalStylesStatus'
-);
+	};
+}, 'WithSiteGlobalStylesStatus' );
 
 const ConnectedThemeSheet = connectOptions( ThemeSheet );
 

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -43,6 +43,7 @@ import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-s
 import ThemeSiteSelectorModal from 'calypso/components/theme-site-selector-modal';
 import ThemeTierBadge from 'calypso/components/theme-tier/theme-tier-badge';
 import { HOSTING_THEME_SELCETED_HASH } from 'calypso/hosting/constants';
+import { EligibilityWarningsModal } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/design-setup/eligibility-warnings-modal';
 import { withCompleteLaunchpadTasksWithNotice } from 'calypso/launchpad/hooks/with-complete-launchpad-tasks-with-notice';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { decodeEntities } from 'calypso/lib/formatting';
@@ -53,10 +54,11 @@ import { connectOptions } from 'calypso/my-sites/themes/theme-options';
 import ThemePreview from 'calypso/my-sites/themes/theme-preview';
 import { useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getEligibility } from 'calypso/state/automated-transfer/selectors';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
-import { isUserPaid } from 'calypso/state/purchases/selectors';
+import { hasPurchasedDomain, isUserPaid } from 'calypso/state/purchases/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getProductionSiteForWpcomStaging from 'calypso/state/selectors/get-production-site-for-wpcom-staging';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -68,7 +70,7 @@ import { useSiteOption } from 'calypso/state/sites/hooks';
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import { withSiteGlobalStylesOnPersonal } from 'calypso/state/sites/hooks/with-site-global-styles-on-personal';
 import { getCurrentPlan, isSiteOnECommerceTrial } from 'calypso/state/sites/plans/selectors';
-import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSite, getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import {
 	setThemePreviewOptions,
 	themeStartActivationSync as themeStartActivationSyncAction,
@@ -106,7 +108,7 @@ import { getIsLoadingCart } from 'calypso/state/themes/selectors/get-is-loading-
 import { getBackPath } from 'calypso/state/themes/themes-ui/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { ReviewsModal } from '../marketplace/components/reviews-modal';
-import EligibilityWarningModal from '../themes/atomic-transfer-dialog';
+import AtomicTransferDialog from '../themes/atomic-transfer-dialog';
 import ThemeDownloadCard from './theme-download-card';
 import ThemeFeaturesCard from './theme-features-card';
 import ThemeNotFoundError from './theme-not-found-error';
@@ -173,6 +175,7 @@ class ThemeSheet extends Component {
 	 * Its assigned to state to guarantee the initial state will be the same for SSR
 	 */
 	state = {
+		showEligibilityWarningsModal: false,
 		showUnlockStyleUpgradeModal: false,
 		isAtomicTransferCompleted: false,
 		isReviewsModalVisible: false,
@@ -944,6 +947,8 @@ class ThemeSheet extends Component {
 		const label = this.getDefaultOptionLabel();
 		const placeholder = <span className="theme__sheet-button-placeholder">loading......</span>;
 		const {
+			didPurchaseDomain,
+			hasEligibilityMessages,
 			isActive,
 			isExternallyManagedTheme,
 			isLoggedIn,
@@ -980,7 +985,14 @@ class ThemeSheet extends Component {
 						...( action && { action } ),
 					} );
 
-					this.onButtonClick( event );
+					const shouldShowEligibilityWarningsModal =
+						! isActive && isExternallyManagedTheme && hasEligibilityMessages && ! didPurchaseDomain;
+
+					if ( shouldShowEligibilityWarningsModal ) {
+						this.setState( { showEligibilityWarningsModal: true } );
+					} else {
+						this.onButtonClick( event );
+					}
 				} }
 				primary
 				busy={ this.isRequestingActivatingTheme() }
@@ -1106,8 +1118,10 @@ class ThemeSheet extends Component {
 		const section = this.validateSection( this.props.section );
 		const {
 			themeId,
+			site,
 			siteId,
 			translate,
+			isExternallyManagedTheme,
 			isLoggedIn,
 			isThemeActivationSyncStarted,
 			successNotice: showSuccessNotice,
@@ -1241,7 +1255,23 @@ class ThemeSheet extends Component {
 						onFailure={ this.onAtomicThemeActiveFailure }
 					/>
 				) }
-				<EligibilityWarningModal />
+				<AtomicTransferDialog />
+				<EligibilityWarningsModal
+					site={ site ?? undefined }
+					isMarketplace={ isExternallyManagedTheme }
+					isOpen={ this.state.showEligibilityWarningsModal }
+					handleClose={ () => {
+						recordTracksEvent( 'calypso_automated_transfer_eligibility_modal_dismiss', {
+							// flow: 'onboarding',
+							theme: themeId,
+						} );
+						this.setState( { showEligibilityWarningsModal: false } );
+					} }
+					handleContinue={ () => {
+						this.onButtonClick();
+						this.setState( { showEligibilityWarningsModal: false } );
+					} }
+				/>
 			</Main>
 		);
 	};
@@ -1272,6 +1302,8 @@ const ThemeSheetWithOptions = ( props ) => {
 		canInstallPlugins,
 		canInstallThemes,
 		isActive,
+		isAtomic,
+		isJetpack,
 		isLoggedIn,
 		isPremium,
 		isThemePurchased,
@@ -1292,7 +1324,16 @@ const ThemeSheetWithOptions = ( props ) => {
 	let secondaryOption = 'tryandcustomize';
 	const needsJetpackPlanUpgrade = isStandaloneJetpack && isPremium && ! isThemePurchased;
 	const activeThemeId = useSelector( ( state ) => getActiveTheme( state, siteId ) );
+	const site = useSelector( ( state ) => getSite( state, siteId ) );
 	const siteIntent = useSiteOption( 'site_intent' );
+	const eligibility = useSelector( ( state ) => site && getEligibility( state, siteId ) );
+	const hasEligibilityMessages =
+		! isAtomic &&
+		! isJetpack &&
+		( eligibility?.eligibilityHolds?.length || eligibility?.eligibilityWarnings?.length );
+	const didPurchaseDomain = useSelector(
+		( state ) => siteId && hasPurchasedDomain( state, siteId )
+	);
 
 	if ( ! showTryAndCustomize ) {
 		secondaryOption = null;
@@ -1337,8 +1378,11 @@ const ThemeSheetWithOptions = ( props ) => {
 		<ConnectedThemeSheet
 			{ ...props }
 			themeTier={ themeTier }
+			hasEligibilityMessages={ hasEligibilityMessages }
 			isThemeAllowed={ isThemeAllowed }
 			demo_uri={ demoUrl }
+			didPurchaseDomain={ didPurchaseDomain }
+			site={ site }
 			siteId={ siteId }
 			defaultOption={ defaultOption }
 			secondaryOption={ secondaryOption }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -16,6 +16,7 @@ import {
 } from '@automattic/design-picker';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
+import { Modal } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { Icon, external } from '@wordpress/icons';
 import { hasQueryArg } from '@wordpress/url';
@@ -26,6 +27,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
+import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import AsyncLoad from 'calypso/components/async-load';
 import Banner from 'calypso/components/banner';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -43,7 +45,6 @@ import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-s
 import ThemeSiteSelectorModal from 'calypso/components/theme-site-selector-modal';
 import ThemeTierBadge from 'calypso/components/theme-tier/theme-tier-badge';
 import { HOSTING_THEME_SELCETED_HASH } from 'calypso/hosting/constants';
-import { EligibilityWarningsModal } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/design-setup/eligibility-warnings-modal';
 import { withCompleteLaunchpadTasksWithNotice } from 'calypso/launchpad/hooks/with-complete-launchpad-tasks-with-notice';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { decodeEntities } from 'calypso/lib/formatting';
@@ -1254,22 +1255,48 @@ class ThemeSheet extends Component {
 						onFailure={ this.onAtomicThemeActiveFailure }
 					/>
 				) }
-				<EligibilityWarningsModal
+				{ this.state.showEligibilityWarningsModal && (
+					<Modal
+						className="eligibility-warnings-modal__dialog-content"
+						title={ translate( 'Before you continue' ) }
+						onRequestClose={ () => {
+							recordTracksEvent( 'calypso_automated_transfer_eligibility_modal_dismiss', {
+								// flow: 'onboarding',
+								theme: themeId,
+							} );
+							this.setState( { showEligibilityWarningsModal: false } );
+						} }
+						size="medium"
+					>
+						<EligibilityWarnings
+							siteId={ site?.ID }
+							standaloneProceed
+							// isOnboarding
+							isMarketplace={ isExternallyManagedTheme }
+							// currentContext="plugin-details"
+							onProceed={ () => {
+								this.onButtonClick();
+								this.setState( { showEligibilityWarningsModal: false } );
+							} }
+							onDismiss={ () => {
+								recordTracksEvent( 'calypso_automated_transfer_eligibility_modal_dismiss', {
+									// flow: 'onboarding',
+									theme: themeId,
+								} );
+								this.setState( { showEligibilityWarningsModal: false } );
+							} }
+						/>
+					</Modal>
+				) }
+				{ /* <EligibilityWarningsModal
 					site={ site ?? undefined }
 					isMarketplace={ isExternallyManagedTheme }
 					isOpen={ this.state.showEligibilityWarningsModal }
-					handleClose={ () => {
-						recordTracksEvent( 'calypso_automated_transfer_eligibility_modal_dismiss', {
-							// flow: 'onboarding',
-							theme: themeId,
-						} );
-						this.setState( { showEligibilityWarningsModal: false } );
-					} }
-					handleContinue={ () => {
+	@@ -1270,7 +1304,7 @@ class ThemeSheet extends Component {
 						this.onButtonClick();
 						this.setState( { showEligibilityWarningsModal: false } );
 					} }
-				/>
+				/> */ }
 			</Main>
 		);
 	};

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1395,7 +1395,6 @@ const ThemeSheetWithOptions = ( props ) => {
 			isThemeAllowed={ isThemeAllowed }
 			demo_uri={ demoUrl }
 			didPurchaseDomain={ didPurchaseDomain }
-			site={ site }
 			siteId={ siteId }
 			defaultOption={ defaultOption }
 			secondaryOption={ secondaryOption }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1119,7 +1119,6 @@ class ThemeSheet extends Component {
 		const section = this.validateSection( this.props.section );
 		const {
 			themeId,
-			site,
 			siteId,
 			translate,
 			isExternallyManagedTheme,
@@ -1127,6 +1126,12 @@ class ThemeSheet extends Component {
 			isThemeActivationSyncStarted,
 			successNotice: showSuccessNotice,
 		} = this.props;
+		const {
+			isWide,
+			isSiteSelectorModalVisible,
+			showEligibilityWarningsModal,
+			showUnlockStyleUpgradeModal,
+		} = this.state;
 		const analyticsPath = `/theme/${ themeId }${ section ? '/' + section : '' }${
 			siteId ? '/:site' : ''
 		}`;
@@ -1175,6 +1180,13 @@ class ThemeSheet extends Component {
 			{ label: title },
 		];
 
+		const dismissEligibilityWarnings = () => {
+			recordTracksEvent( 'calypso_automated_transfer_eligibility_modal_dismiss', {
+				theme: themeId,
+			} );
+			this.setState( { showEligibilityWarningsModal: false } );
+		};
+
 		return (
 			<Main className="theme__sheet">
 				<QueryEligibility siteId={ siteId } />
@@ -1200,7 +1212,7 @@ class ThemeSheet extends Component {
 					) /* TODO: Make QueryActiveTheme handle falsey siteId */
 				}
 				<ThemeSiteSelectorModal
-					isOpen={ this.state.isSiteSelectorModalVisible }
+					isOpen={ isSiteSelectorModalVisible }
 					onClose={ ( args ) => {
 						this.setState( { isSiteSelectorModalVisible: false } );
 
@@ -1223,10 +1235,7 @@ class ThemeSheet extends Component {
 						}
 					} }
 				/>
-				<NavigationHeader
-					navigationItems={ navigationItems }
-					compactBreadcrumb={ ! this.state.isWide }
-				/>
+				<NavigationHeader navigationItems={ navigationItems } compactBreadcrumb={ ! isWide } />
 				<div className={ columnsClassName }>
 					<div className="theme__sheet-column-header">
 						{ this.renderStagingPaidThemeNotice() }
@@ -1246,7 +1255,7 @@ class ThemeSheet extends Component {
 					checkout={ this.onPremiumGlobalStylesUpgradeModalCheckout }
 					tryStyle={ this.onPremiumGlobalStylesUpgradeModalTryStyle }
 					closeModal={ this.onPremiumGlobalStylesUpgradeModalClose }
-					isOpen={ this.state.showUnlockStyleUpgradeModal }
+					isOpen={ showUnlockStyleUpgradeModal }
 				/>
 				<PerformanceTrackerStop />
 				{ isThemeActivationSyncStarted && (
@@ -1257,48 +1266,25 @@ class ThemeSheet extends Component {
 						onFailure={ this.onAtomicThemeActiveFailure }
 					/>
 				) }
-				{ this.state.showEligibilityWarningsModal && (
+				{ showEligibilityWarningsModal && (
 					<Modal
 						className="eligibility-warnings-modal__dialog-content"
 						title={ translate( 'Before you continue' ) }
-						onRequestClose={ () => {
-							recordTracksEvent( 'calypso_automated_transfer_eligibility_modal_dismiss', {
-								// flow: 'onboarding',
-								theme: themeId,
-							} );
-							this.setState( { showEligibilityWarningsModal: false } );
-						} }
+						onRequestClose={ dismissEligibilityWarnings }
 						size="medium"
 					>
 						<EligibilityWarnings
-							siteId={ site?.ID }
+							siteId={ siteId }
 							standaloneProceed
-							// isOnboarding
 							isMarketplace={ isExternallyManagedTheme }
-							// currentContext="plugin-details"
 							onProceed={ () => {
 								this.onButtonClick();
 								this.setState( { showEligibilityWarningsModal: false } );
 							} }
-							onDismiss={ () => {
-								recordTracksEvent( 'calypso_automated_transfer_eligibility_modal_dismiss', {
-									// flow: 'onboarding',
-									theme: themeId,
-								} );
-								this.setState( { showEligibilityWarningsModal: false } );
-							} }
+							onDismiss={ dismissEligibilityWarnings }
 						/>
 					</Modal>
 				) }
-				{ /* <EligibilityWarningsModal
-					site={ site ?? undefined }
-					isMarketplace={ isExternallyManagedTheme }
-					isOpen={ this.state.showEligibilityWarningsModal }
-	@@ -1270,7 +1304,7 @@ class ThemeSheet extends Component {
-						this.onButtonClick();
-						this.setState( { showEligibilityWarningsModal: false } );
-					} }
-				/> */ }
 			</Main>
 		);
 	};

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -32,6 +32,7 @@ import AsyncLoad from 'calypso/components/async-load';
 import Banner from 'calypso/components/banner';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryActiveTheme from 'calypso/components/data/query-active-theme';
+import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
 import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
@@ -1176,6 +1177,7 @@ class ThemeSheet extends Component {
 
 		return (
 			<Main className="theme__sheet">
+				<QueryEligibility siteId={ siteId } />
 				<QueryCanonicalTheme themeId={ this.props.themeId } siteId={ siteId } />
 				<QueryProductsList />
 				<QueryUserPurchases />

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -108,7 +108,6 @@ import { getIsLoadingCart } from 'calypso/state/themes/selectors/get-is-loading-
 import { getBackPath } from 'calypso/state/themes/themes-ui/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { ReviewsModal } from '../marketplace/components/reviews-modal';
-import AtomicTransferDialog from '../themes/atomic-transfer-dialog';
 import ThemeDownloadCard from './theme-download-card';
 import ThemeFeaturesCard from './theme-features-card';
 import ThemeNotFoundError from './theme-not-found-error';
@@ -1255,7 +1254,6 @@ class ThemeSheet extends Component {
 						onFailure={ this.onAtomicThemeActiveFailure }
 					/>
 				) }
-				<AtomicTransferDialog />
 				<EligibilityWarningsModal
 					site={ site ?? undefined }
 					isMarketplace={ isExternallyManagedTheme }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -42,7 +42,6 @@ import {
 	getThemeTiers,
 } from 'calypso/state/themes/selectors';
 import { getThemesBookmark } from 'calypso/state/themes/themes-ui/selectors';
-import EligibilityWarningModal from './atomic-transfer-dialog';
 import { CustomSelectWrapper } from './custom-select-wrapper';
 import {
 	addTracking,
@@ -764,7 +763,6 @@ class ThemeShowcase extends Component {
 					{ siteId && <QuerySitePlans siteId={ siteId } /> }
 					{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 					<QueryProductsList />
-					<EligibilityWarningModal />
 					<ThemePreview />
 				</div>
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/81597
Fixes DOTCOM-10657

## Proposed Changes

* When installing a theme, the atomic upgrade eligibility modal should be displayed for simple sites. This already happens when you install the theme while onboarding (added on https://github.com/Automattic/wp-calypso/pull/81412), and this PR takes care of it for the `ThemeSheet`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to `/theme/makoney` with a simple business site
* Click on `Activate`
* Check that you get an eligibility warning on the site's address:

![image](https://github.com/user-attachments/assets/ecdb55f2-3679-4cb5-8548-0a21bf54d5c9)

* Check the site does indeed go atomic once the checkout is completed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
