### PR TITLE
A4A: Signup v2 UI/UX improvements.

### DIFF
--- a/client/a8c-for-agencies/sections/signup/primary/agency-signup-finish/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/primary/agency-signup-finish/index.tsx
@@ -100,7 +100,7 @@ export default function AgencySignupFinish() {
 				size={ 48 }
 			/>
 			<h1 className="agency-signup-finish__text">
-				{ translate( 'Please hold, great things are coming.' ) }
+				{ translate( 'Please give us a minute to customize your experience…' ) }
 			</h1>
 		</div>
 	);

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/finish-signup-survey/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/finish-signup-survey/index.tsx
@@ -47,7 +47,7 @@ const FinishSignupSurvey: React.FC< Props > = ( { onContinue, isPending } ) => {
 
 			<FormFooter>
 				<Button variant="primary" onClick={ onContinue } __next40pxDefaultSize>
-					{ translate( 'Close survey' ) }
+					{ translate( 'Return home' ) }
 				</Button>
 			</FormFooter>
 		</Form>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/finish-signup-survey/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/finish-signup-survey/index.tsx
@@ -3,32 +3,42 @@ import { useTranslate } from 'i18n-calypso';
 import Form from 'calypso/a8c-for-agencies/components/form';
 import FormFooter from 'calypso/a8c-for-agencies/components/form/footer';
 
+import './style.scss';
+
 type Props = {
 	onContinue: () => void;
-	blueprintRequested: boolean;
 };
 
-const FinishSignupSurvey: React.FC< Props > = ( { onContinue, blueprintRequested } ) => {
+const FinishSignupSurvey: React.FC< Props > = ( { onContinue } ) => {
 	const translate = useTranslate();
 
 	return (
 		<Form
-			title={ translate( 'Thank you!' ) }
-			description={
-				blueprintRequested
-					? translate(
-							'We have sent you an email with more details about the program and instructions for logging in. A member of our team will be reaching out to you soon with your custom blueprint; keep an eye out for an email from {{b}}partnerships@automattic.com{{/b}}.',
-							{
-								components: {
-									b: <b />,
-								},
-							}
-					  )
-					: translate(
-							'We have sent you an email with more details about the program and instructions for logging in.'
-					  )
-			}
+			className="signup-finish-survey"
+			title={ translate( 'Welcome to Automattic for Agencies!' ) }
 		>
+			<div className="signup-finish-survey__content">
+				<p>
+					{ translate( '{{b}}Last step:{{/b}} Check your email for a magic link to log in.', {
+						components: {
+							b: <b />,
+						},
+					} ) }
+				</p>
+
+				<p>
+					{ translate(
+						"You're just moments away from exclusive benefits, revenue opportunities, and more streamlined workflows that will build trust with your clients."
+					) }
+				</p>
+
+				<p>
+					{ translate(
+						"Automattic for Agencies is more than a site management tool—we're your partner in growing your WordPress agency."
+					) }
+				</p>
+			</div>
+
 			<FormFooter>
 				<Button variant="primary" onClick={ onContinue } __next40pxDefaultSize>
 					{ translate( 'Close survey' ) }

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/finish-signup-survey/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/finish-signup-survey/index.tsx
@@ -2,15 +2,21 @@ import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import Form from 'calypso/a8c-for-agencies/components/form';
 import FormFooter from 'calypso/a8c-for-agencies/components/form/footer';
+import FinishSignupSurveyPlaceHolder from './placeholder';
 
 import './style.scss';
 
 type Props = {
 	onContinue: () => void;
+	isPending?: boolean;
 };
 
-const FinishSignupSurvey: React.FC< Props > = ( { onContinue } ) => {
+const FinishSignupSurvey: React.FC< Props > = ( { onContinue, isPending } ) => {
 	const translate = useTranslate();
+
+	if ( isPending ) {
+		return <FinishSignupSurveyPlaceHolder />;
+	}
 
 	return (
 		<Form

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/finish-signup-survey/placeholder.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/finish-signup-survey/placeholder.tsx
@@ -1,0 +1,15 @@
+import Form from 'calypso/a8c-for-agencies/components/form';
+
+import './style.scss';
+
+export default function FinishSignupSurveyPlaceHolder() {
+	return (
+		<Form className="signup-finish-survey">
+			<div className="signup-finish-survey__content">
+				<span className="signup-finish-survey__content-placeholder" style={ { width: '80%' } } />
+				<span className="signup-finish-survey__content-placeholder" style={ { width: '60%' } } />
+				<span className="signup-finish-survey__content-placeholder" style={ { width: '65%' } } />
+			</div>
+		</Form>
+	);
+}

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/finish-signup-survey/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/finish-signup-survey/style.scss
@@ -1,0 +1,17 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
+
+.signup-finish-survey__content {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+
+	p {
+		@include body-large;
+
+		@media (prefers-color-scheme: dark) {
+			color: var(--color-text-inverted);
+		}
+	}
+}

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/finish-signup-survey/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/finish-signup-survey/style.scss
@@ -1,6 +1,11 @@
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
 
+@mixin loading-effect {
+	animation: loading-fade 1.6s ease-in-out infinite;
+	background: var(--color-neutral-10);
+}
+
 
 .signup-finish-survey__content {
 	display: flex;
@@ -14,4 +19,11 @@
 			color: var(--color-text-inverted);
 		}
 	}
+}
+
+.signup-finish-survey__content-placeholder {
+	@include loading-effect;
+	width: 100%;
+	height: 24px;
+	display: block;
 }

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
@@ -10,7 +10,7 @@ import A4ALogo, {
 import { useIsDarkMode } from 'calypso/a8c-for-agencies/hooks/use-is-dark-mode';
 import { AgencyDetailsSignupPayload } from 'calypso/a8c-for-agencies/sections/signup/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
 import useCreateSignupMutation from '../../../hooks/use-create-signup-mutation';
 import StepProgress from '../step-progress';
 import BlueprintForm from './blueprint-form';
@@ -109,10 +109,7 @@ const MultiStepForm = ( {
 			: [] ),
 	];
 
-	const { mutate: submitSurvey } = useCreateSignupMutation( {
-		onSuccess: () => {
-			dispatch( successNotice( 'Signup successful', { id: notificationId } ) );
-		},
+	const { mutate: submitSurvey, isPending: isSubmittingSurveyPending } = useCreateSignupMutation( {
 		onError: ( error: APIError ) => {
 			dispatch( errorNotice( error?.message, { id: notificationId } ) );
 		},
@@ -229,13 +226,16 @@ const MultiStepForm = ( {
 					/>
 				);
 			case 6:
-				return <FinishSignupSurvey onContinue={ closeSurvey } />;
+				return (
+					<FinishSignupSurvey onContinue={ closeSurvey } isPending={ isSubmittingSurveyPending } />
+				);
 			default:
 				return null;
 		}
 	}, [
 		currentStep,
 		formData,
+		isSubmittingSurveyPending,
 		onCreateAgency,
 		signupWithMagicLinkFlow,
 		trackView,

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
@@ -200,6 +200,7 @@ const MultiStepForm = ( {
 						isFinalStep={ ! signupWithMagicLinkFlow }
 						initialFormData={ formData }
 						goBack={ () => setCurrentStep( 1 ) }
+						withPersonalizedBlueprint={ withPersonalizedBlueprint }
 					/>
 				);
 			case 3:

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
@@ -110,6 +110,9 @@ const MultiStepForm = ( {
 	];
 
 	const { mutate: submitSurvey, isPending: isSubmittingSurveyPending } = useCreateSignupMutation( {
+		onSuccess: () => {
+			dispatch( recordTracksEvent( 'calypso_a4a_agency_signup_form_via_magic_link_submitted' ) );
+		},
 		onError: ( error: APIError ) => {
 			dispatch( errorNotice( error?.message, { id: notificationId } ) );
 		},

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
@@ -86,7 +86,6 @@ const MultiStepForm = ( {
 	const isDarkMode = useIsDarkMode();
 
 	const [ formData, setFormData ] = useState< Partial< AgencyDetailsSignupPayload > >( {} );
-	const [ blueprintRequested, setBlueprintRequested ] = useState( false );
 
 	const steps: Step[] = [
 		{
@@ -168,7 +167,6 @@ const MultiStepForm = ( {
 
 	const closeSurvey = () => {
 		setFormData( {} );
-		setBlueprintRequested( false );
 		page( 'https://automattic.com/for-agencies/' );
 	};
 
@@ -224,7 +222,6 @@ const MultiStepForm = ( {
 				return (
 					<BlueprintForm2
 						onContinue={ ( data ) => {
-							setBlueprintRequested( true );
 							updateDataAndContinue( data, 6, true );
 						} }
 						initialFormData={ formData }
@@ -232,17 +229,11 @@ const MultiStepForm = ( {
 					/>
 				);
 			case 6:
-				return (
-					<FinishSignupSurvey
-						onContinue={ closeSurvey }
-						blueprintRequested={ blueprintRequested }
-					/>
-				);
+				return <FinishSignupSurvey onContinue={ closeSurvey } />;
 			default:
 				return null;
 		}
 	}, [
-		blueprintRequested,
 		currentStep,
 		formData,
 		onCreateAgency,

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
@@ -1,3 +1,4 @@
+import page from '@automattic/calypso-router';
 import { APIError } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState, useCallback } from 'react';
@@ -165,10 +166,10 @@ const MultiStepForm = ( {
 		[ formData, signupWithMagicLinkFlow, submitSurvey ]
 	);
 
-	const clearDataAndRefresh = () => {
+	const closeSurvey = () => {
 		setFormData( {} );
 		setBlueprintRequested( false );
-		window.location.reload();
+		page( 'https://automattic.com/for-agencies/' );
 	};
 
 	const onCreateAgency = useCallback(
@@ -233,7 +234,7 @@ const MultiStepForm = ( {
 			case 6:
 				return (
 					<FinishSignupSurvey
-						onContinue={ clearDataAndRefresh }
+						onContinue={ closeSurvey }
 						blueprintRequested={ blueprintRequested }
 					/>
 				);

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
@@ -278,6 +278,9 @@ export default function PersonalizationForm( {
 							<FormField
 								error={ validationError.servicesOffered }
 								label={ translate( 'What services do you offer?' ) }
+								sub={ translate(
+									'Understanding your strategy helps us tailor the program to your needs'
+								) }
 								isRequired
 							>
 								<MultiCheckbox
@@ -295,6 +298,9 @@ export default function PersonalizationForm( {
 								error={ validationError.productsOffered }
 								label={ translate(
 									'What Automattic products do you currently offer your clients?'
+								) }
+								sub={ translate(
+									"We'll help you deliver more value to your clients with our products"
 								) }
 								isRequired
 							>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
@@ -134,7 +134,10 @@ export default function PersonalizationForm( {
 
 		setFormData( ( prev ) => ( {
 			...prev,
-			productsOffered: products.value,
+			productsOffered:
+				! prev.productsOffered?.includes( 'None' ) && products.value.includes( 'None' ) // If 'None' is selected, we need to clear other value.
+					? [ 'None' ]
+					: products.value.filter( ( product ) => product !== 'None' ),
 			plansToOfferProducts: hasAllProductsOffered ? false : prev.plansToOfferProducts, // If all products are offered, then there is no more products to be offered
 			productsToOffer: prev.productsToOffer?.filter(
 				( product ) => ! products.value.includes( product )

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
@@ -24,6 +24,7 @@ interface Props {
 	goBack: () => void;
 	initialFormData: Partial< AgencyDetailsSignupPayload >;
 	isFinalStep?: boolean;
+	withPersonalizedBlueprint?: boolean;
 }
 
 const PersonalizationFormRadio = ( {
@@ -58,6 +59,7 @@ export default function PersonalizationForm( {
 	goBack,
 	initialFormData,
 	isFinalStep = false,
+	withPersonalizedBlueprint = false,
 }: Props ) {
 	const translate = useTranslate();
 	const { countryOptions } = useCountriesAndStates();
@@ -110,6 +112,18 @@ export default function PersonalizationForm( {
 		],
 		[ formData.productsOffered, productsOfferedOptions, translate ]
 	);
+
+	const ctaButtonLabel = useMemo( () => {
+		if ( isFinalStep ) {
+			return translate( 'Finish and Log in' );
+		}
+
+		if ( withPersonalizedBlueprint ) {
+			return translate( 'Continue' );
+		}
+
+		return translate( 'Finish sign up' );
+	}, [ isFinalStep, translate, withPersonalizedBlueprint ] );
 
 	const handleInputChange =
 		( field: keyof AgencyDetailsSignupPayload ) => ( event: ChangeEvent< HTMLSelectElement > ) => {
@@ -380,7 +394,7 @@ export default function PersonalizationForm( {
 								onClick={ handleSubmit }
 								isBusy={ isSubmitting }
 							>
-								{ isFinalStep ? translate( 'Finish and Log in' ) : translate( 'Continue' ) }
+								{ ctaButtonLabel }
 							</Button>
 						</FormFooter>
 					</>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/style.scss
@@ -108,10 +108,17 @@
 		@include heading-medium;
 	}
 
+	.a4a-form__section-field-sub {
+		@include body-medium;
+		font-style: italic;
+		margin-block-end: 4px;
+	}
+
 	@media (prefers-color-scheme: dark) {
 		.a4a-form__heading .a4a-form__heading-title,
 		.a4a-form__heading .a4a-form__heading-description,
 		.a4a-form__section-field-label,
+		.a4a-form__section-field-sub,
 		.a4a-form__section-field-required,
 		.signup-personalization-form .multi-checkbox label,
 		.choice-blueprint__content li,

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/step-progress/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/step-progress/style.scss
@@ -58,7 +58,7 @@ $progress-bar-bg-color-dark: #1490C7;
 
 	.step-progress__step:not(.is-active) {
 		.step-progress__step-label {
-			color: var(--color-neutral-40);
+			color: var(--color-neutral-70);
 
 			@media (prefers-color-scheme: dark) {
 				color: var(--color-text-inverted);


### PR DESCRIPTION
This PR tackles several UI/UX enhancement recommendations we collected during our CFT.


Closes https://linear.app/a8c/issue/A4A-942/show-context-on-why-we-collect-certain-information
Closes https://linear.app/a8c/issue/A4A-935/close-survey-should-redirect-to-httpsagenciesautomatticcom
Closes https://linear.app/a8c/issue/A4A-939/remove-redundant-success-notification
Closes https://linear.app/a8c/issue/A4A-936/clear-and-disable-rest-of-product-offered-options-when-none-is

## Proposed Changes

| Description | Screenshot |
|--------|--------|
| Closing the survey will now redirect the user to A4A Landing page. https://automattic.com/for-agencies/ | <img width="531" alt="Screenshot 2025-05-21 at 5 48 14 PM" src="https://github.com/user-attachments/assets/edbae41c-71da-49a6-b689-4019f2b05794" /> |
| Provide additional context on the reasons for collecting specific information and set expectations for completing the signup process. | <img width="666" alt="Screenshot 2025-05-21 at 5 47 31 PM" src="https://github.com/user-attachments/assets/3bf17d16-e99c-4e70-aeca-6f2064efa5fc" /> <img width="728" alt="Screenshot 2025-05-21 at 5 48 03 PM" src="https://github.com/user-attachments/assets/c6feae88-0671-42d5-aa0b-4ee7985fd1ad" /> |
| The language on the Finish screen has been updated to show that the submission is being processed and will take time.  | <img width="1034" alt="Screenshot 2025-05-21 at 6 56 26 PM" src="https://github.com/user-attachments/assets/a955e0ea-c87e-4ec5-8fb2-58f50d9f9acf" /> |
| We implement a smart check to prevent selecting the 'None' option along with the other options in the products offered. | <img width="494" alt="Screenshot 2025-05-21 at 6 53 20 PM" src="https://github.com/user-attachments/assets/ebdcad45-950f-4258-9519-a0d2c2a7c4b0" /> |
| We now show a loading state when submitting a survey instead of a redundant Success notification. **The pending state is needed to avoid user from closing the survey while request is being handled by the backend endpoint.** | <img width="747" alt="Screenshot 2025-05-21 at 6 48 14 PM" src="https://github.com/user-attachments/assets/012dad0f-983f-4b8c-87b6-cc049c0e9b93" /> | 

## Why are these changes being made?

This is part of the Improved A4A Onboarding project that enhances the conversion rate.

## Testing Instructions

* Spin up the branch locally.
* Test all changes above in http://agencies.localhost:3000/signup

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
