### PR TITLE
Dashboard v2: fix broken subscription link

### DIFF
--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -5,7 +5,6 @@ import {
 	fetchSiteMonitorUptime,
 	fetchPHPVersion,
 	fetchCurrentPlan,
-	fetchSitePrimaryDomain,
 	fetchSiteEngagementStats,
 	fetchDomains,
 	fetchEmails,
@@ -40,13 +39,6 @@ export function siteCurrentPlanQuery( siteIdOrSlug: string ) {
 	return {
 		queryKey: [ 'site', siteIdOrSlug, 'current-plan' ],
 		queryFn: () => fetchCurrentPlan( siteIdOrSlug ),
-	};
-}
-
-export function sitePrimaryDomainQuery( siteIdOrSlug: string ) {
-	return {
-		queryKey: [ 'site', siteIdOrSlug, 'primary-domain' ],
-		queryFn: () => fetchSitePrimaryDomain( siteIdOrSlug ),
 	};
 }
 

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -16,7 +16,6 @@ import {
 	emailsQuery,
 	profileQuery,
 	siteCurrentPlanQuery,
-	sitePrimaryDomainQuery,
 	siteEngagementStatsQuery,
 	siteMonitorUptimeQuery,
 	sitePHPVersionQuery,
@@ -83,14 +82,12 @@ const siteOverviewRoute = createRoute( {
 		const sitePromise = queryClient.ensureQueryData( siteQuery( siteSlug ) );
 		// Kick off all independent promises in parallel.
 		const currentPlanPromise = queryClient.ensureQueryData( siteCurrentPlanQuery( siteSlug ) );
-		const primaryDomainPromise = queryClient.ensureQueryData( sitePrimaryDomainQuery( siteSlug ) );
 		const engagementStatsPromise = queryClient.ensureQueryData(
 			siteEngagementStatsQuery( siteSlug )
 		);
 		const site = await sitePromise;
 		await Promise.all( [
 			currentPlanPromise,
-			primaryDomainPromise,
 			engagementStatsPromise,
 			// Kick off dependent promises in parallel.
 			site.jetpack && site.jetpack_modules.includes( 'monitor' )

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -11,7 +11,6 @@ import type {
 	Profile,
 	TwoStep,
 	EngagementStatsDataPoint,
-	SiteDomain,
 	BasicMetricsData,
 	SiteSettings,
 	UrlPerformanceInsights,
@@ -130,23 +129,6 @@ export const fetchSiteEngagementStats = async ( siteIdOrSlug: string ) => {
 export const fetchDomains = async (): Promise< Domain[] > => {
 	return ( await wpcom.req.get( '/all-domains', { no_wpcom: true, resolve_status: true } ) )
 		.domains;
-};
-
-export const fetchSiteDomains = async ( id: string ): Promise< { domains: SiteDomain[] } > => {
-	try {
-		const domains = await wpcom.req.get( { path: `/sites/${ id }/domains`, apiVersion: '1.2' } );
-		return domains;
-	} catch ( error ) {
-		// TODO: check how to properly fetch for all sites..
-		return { domains: [] };
-	}
-};
-
-export const fetchSitePrimaryDomain = async (
-	siteIdOrSlug: string
-): Promise< SiteDomain | undefined > => {
-	const { domains } = await fetchSiteDomains( siteIdOrSlug );
-	return domains.find( ( domain: SiteDomain ) => domain.primary_domain );
 };
 
 export const EMAIL_DATA: Email[] = [

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -73,12 +73,7 @@ function SiteOverview() {
 			}
 		>
 			<HStack alignment="flex-start" spacing={ 8 }>
-				<Sidebar
-					site={ site }
-					phpVersion={ phpVersion }
-					siteSlug={ siteSlug }
-					currentPlan={ currentPlan }
-				/>
+				<Sidebar site={ site } phpVersion={ phpVersion } currentPlan={ currentPlan } />
 				<VStack spacing={ 8 }>
 					<Card style={ { padding: '16px' } }>
 						<VStack>

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -14,7 +14,6 @@ import {
 	siteMonitorUptimeQuery,
 	sitePHPVersionQuery,
 	siteCurrentPlanQuery,
-	sitePrimaryDomainQuery,
 	siteEngagementStatsQuery,
 } from '../../app/queries';
 import { siteRoute } from '../../app/router';
@@ -45,10 +44,9 @@ function SiteOverview() {
 		enabled: site?.is_wpcom_atomic,
 	} );
 	const { data: currentPlan } = useQuery( siteCurrentPlanQuery( siteSlug ) );
-	const { data: primaryDomain } = useQuery( sitePrimaryDomainQuery( siteSlug ) );
 	const { data: engagementStats } = useQuery( siteEngagementStatsQuery( siteSlug ) );
 
-	if ( ! site || ! currentPlan || ! primaryDomain || ! engagementStats ) {
+	if ( ! site || ! currentPlan || ! engagementStats ) {
 		return;
 	}
 	return (
@@ -78,7 +76,7 @@ function SiteOverview() {
 				<Sidebar
 					site={ site }
 					phpVersion={ phpVersion }
-					primaryDomain={ primaryDomain }
+					siteSlug={ siteSlug }
 					currentPlan={ currentPlan }
 				/>
 				<VStack spacing={ 8 }>

--- a/client/dashboard/sites/overview/sidebar.tsx
+++ b/client/dashboard/sites/overview/sidebar.tsx
@@ -5,12 +5,7 @@ import type { Site, Plan } from '../../data/types';
 /**
  * Sidebar component for the site overview page
  */
-export default function Sidebar( props: {
-	siteSlug: string;
-	site: Site;
-	phpVersion?: string;
-	currentPlan: Plan;
-} ) {
+export default function Sidebar( props: { site: Site; phpVersion?: string; currentPlan: Plan } ) {
 	return (
 		<VStack spacing={ 4 } style={ { minWidth: '300px' } }>
 			<SiteCard { ...props } />

--- a/client/dashboard/sites/overview/sidebar.tsx
+++ b/client/dashboard/sites/overview/sidebar.tsx
@@ -1,14 +1,14 @@
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import SiteCard from './site-card';
-import type { Site, SiteDomain, Plan } from '../../data/types';
+import type { Site, Plan } from '../../data/types';
 
 /**
  * Sidebar component for the site overview page
  */
 export default function Sidebar( props: {
+	siteSlug: string;
 	site: Site;
 	phpVersion?: string;
-	primaryDomain?: SiteDomain;
 	currentPlan: Plan;
 } ) {
 	return (

--- a/client/dashboard/sites/overview/site-card.tsx
+++ b/client/dashboard/sites/overview/site-card.tsx
@@ -16,12 +16,10 @@ import type { Site, Plan } from '../../data/types';
  * SiteCard component to display site information in a card format
  */
 export default function SiteCard( {
-	siteSlug,
 	site,
 	phpVersion,
 	currentPlan,
 }: {
-	siteSlug: string;
 	site: Site;
 	phpVersion?: string;
 	currentPlan: Plan;
@@ -73,7 +71,7 @@ export default function SiteCard( {
 						) }
 						{ phpVersion && <Field title={ __( 'PHP' ) }>{ phpVersion }</Field> }
 					</HStack>
-					<PlanDetails site={ site } currentPlan={ currentPlan } siteSlug={ siteSlug } />
+					<PlanDetails site={ site } currentPlan={ currentPlan } />
 				</VStack>
 			</VStack>
 		</Card>
@@ -99,15 +97,7 @@ function FieldTitle( { children }: { children: React.ReactNode } ) {
 	);
 }
 
-function PlanDetails( {
-	site,
-	currentPlan,
-	siteSlug,
-}: {
-	site: Site;
-	currentPlan: Plan;
-	siteSlug: string;
-} ) {
+function PlanDetails( { site, currentPlan }: { site: Site; currentPlan: Plan } ) {
 	if ( ! site.plan || ! currentPlan ) {
 		return null;
 	}
@@ -122,11 +112,11 @@ function PlanDetails( {
 			{ product_name_short && <Text>{ product_name_short }</Text> }
 			<Text>{ getPlanExpirationMessage( { isFree, expiry } ) }</Text>
 			{ id ? (
-				<Button href={ `/purchases/subscriptions/${ siteSlug }/${ id }` } variant="link">
+				<Button href={ `/purchases/subscriptions/${ site.slug }/${ id }` } variant="link">
 					{ __( 'Manage subscription' ) }
 				</Button>
 			) : (
-				<Button href={ `/plans/${ siteSlug }` } variant="link">
+				<Button href={ `/plans/${ site.slug }` } variant="link">
 					{ __( 'Upgrade' ) }
 				</Button>
 			) }

--- a/client/dashboard/sites/overview/site-card.tsx
+++ b/client/dashboard/sites/overview/site-card.tsx
@@ -10,20 +10,20 @@ import { dateI18n } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
 import { getSiteStatusLabel } from '../../utils/site-status';
 import SitePreview from '../site-preview';
-import type { Site, SiteDomain, Plan } from '../../data/types';
+import type { Site, Plan } from '../../data/types';
 
 /**
  * SiteCard component to display site information in a card format
  */
 export default function SiteCard( {
+	siteSlug,
 	site,
 	phpVersion,
-	primaryDomain,
 	currentPlan,
 }: {
+	siteSlug: string;
 	site: Site;
 	phpVersion?: string;
-	primaryDomain?: SiteDomain;
 	currentPlan: Plan;
 } ) {
 	const { options, URL: url, is_private } = site;
@@ -59,13 +59,11 @@ export default function SiteCard( {
 					) }
 				</div>
 				<VStack spacing={ 6 } className="site-card-contents">
-					{ primaryDomain && (
-						<Field title={ __( 'Domain' ) }>
-							<ExternalLink href={ url } style={ { overflowWrap: 'anywhere' } }>
-								{ primaryDomain.domain }
-							</ExternalLink>
-						</Field>
-					) }
+					<Field title={ __( 'Domain' ) }>
+						<ExternalLink href={ url } style={ { overflowWrap: 'anywhere' } }>
+							{ new URL( url ).hostname }
+						</ExternalLink>
+					</Field>
 					<HStack justify="space-between">
 						<Field title={ __( 'Status' ) }>{ getSiteStatusLabel( site ) }</Field>
 					</HStack>
@@ -75,7 +73,7 @@ export default function SiteCard( {
 						) }
 						{ phpVersion && <Field title={ __( 'PHP' ) }>{ phpVersion }</Field> }
 					</HStack>
-					<PlanDetails site={ site } currentPlan={ currentPlan } primaryDomain={ primaryDomain } />
+					<PlanDetails site={ site } currentPlan={ currentPlan } siteSlug={ siteSlug } />
 				</VStack>
 			</VStack>
 		</Card>
@@ -104,11 +102,11 @@ function FieldTitle( { children }: { children: React.ReactNode } ) {
 function PlanDetails( {
 	site,
 	currentPlan,
-	primaryDomain,
+	siteSlug,
 }: {
 	site: Site;
 	currentPlan: Plan;
-	primaryDomain?: SiteDomain;
+	siteSlug: string;
 } ) {
 	if ( ! site.plan || ! currentPlan ) {
 		return null;
@@ -123,12 +121,13 @@ function PlanDetails( {
 			<FieldTitle>{ __( 'Plan' ) }</FieldTitle>
 			{ product_name_short && <Text>{ product_name_short }</Text> }
 			<Text>{ getPlanExpirationMessage( { isFree, expiry } ) }</Text>
-			{ primaryDomain && (
-				<Button
-					href={ `/purchases/subscriptions/${ primaryDomain.domain }/${ id }` }
-					variant="link"
-				>
+			{ id ? (
+				<Button href={ `/purchases/subscriptions/${ siteSlug }/${ id }` } variant="link">
 					{ __( 'Manage subscription' ) }
+				</Button>
+			) : (
+				<Button href={ `/plans/${ siteSlug }` } variant="link">
+					{ __( 'Upgrade' ) }
 				</Button>
 			) }
 		</VStack>

--- a/client/dashboard/sites/settings-subscription-gifting/summary.tsx
+++ b/client/dashboard/sites/settings-subscription-gifting/summary.tsx
@@ -6,11 +6,9 @@ import { hasSubscriptionGiftingFeature } from './utils';
 import type { Site, SiteSettings } from '../../data/types';
 
 export default function SubscriptionGiftingSettingsSummary( {
-	siteSlug,
 	site,
 	settings,
 }: {
-	siteSlug: string;
 	site: Site;
 	settings: SiteSettings;
 } ) {
@@ -19,7 +17,7 @@ export default function SubscriptionGiftingSettingsSummary( {
 	}
 	return (
 		<RouterLinkSummaryButton
-			to={ `/sites/${ siteSlug }/settings/subscription-gifting` }
+			to={ `/sites/${ site.slug }/settings/subscription-gifting` }
 			title={ __( 'Accept a gift subscription' ) }
 			density="medium"
 			decoration={ <Icon icon={ heading } /> }

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -26,11 +26,7 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 			<Card>
 				<VStack>
 					<SiteVisibilitySettingsSummary site={ site } />
-					<SubscriptionGiftingSettingsSummary
-						siteSlug={ siteSlug }
-						site={ site }
-						settings={ settings }
-					/>
+					<SubscriptionGiftingSettingsSummary site={ site } settings={ settings } />
 				</VStack>
 			</Card>
 			<SiteActions site={ site } />


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* For free plans, the plan ID is null, so we should fall back to an upgrade link. The current link is broken for free plans.
* Use the siteSlug instead, which is always available.
* Remove primary domain fetching.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Broken link.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to a site item, check the link at the bottom for both paid and free plans.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
