### PR TITLE
Add feature flag for magic code login

### DIFF
--- a/client/blocks/login/utils/should-use-magic-code.ts
+++ b/client/blocks/login/utils/should-use-magic-code.ts
@@ -1,0 +1,23 @@
+import config from '@automattic/calypso-config';
+
+type ShouldUseMagicCodeProps = {
+	/**
+	 * Whether the login is for a Jetpack site.
+	 */
+	isJetpack: boolean;
+};
+
+/**
+ * Returns true if the login should use magic code.
+ * @param {ShouldUseMagicCodeProps} options
+ * @returns {boolean}
+ */
+export function shouldUseMagicCode( { isJetpack }: ShouldUseMagicCodeProps ): boolean {
+	const isMagicCodeEnabled = config.isEnabled( 'login/use-magic-code' );
+
+	if ( isJetpack && isMagicCodeEnabled ) {
+		return true;
+	}
+
+	return false;
+}

--- a/config/development.json
+++ b/config/development.json
@@ -113,7 +113,7 @@
 		"livechat_solution": true,
 		"login/last-used-method": true,
 		"login/magic-login": true,
-		"login/use-magic-code": true,
+		"login/use-magic-code": false,
 		"logmein": true,
 		"mailchimp": true,
 		"manage/import/site-importer-endpoints": true,

--- a/config/development.json
+++ b/config/development.json
@@ -113,6 +113,7 @@
 		"livechat_solution": true,
 		"login/last-used-method": true,
 		"login/magic-login": true,
+		"login/use-magic-code": true,
 		"logmein": true,
 		"mailchimp": true,
 		"manage/import/site-importer-endpoints": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -87,6 +87,7 @@
 		"livechat_solution": true,
 		"login/last-used-method": true,
 		"login/magic-login": true,
+		"login/use-magic-code": false,
 		"mailchimp": true,
 		"marketplace-fetch-all-dynamic-products": true,
 		"marketplace-personal-premium": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -89,6 +89,7 @@
 		"livechat_solution": true,
 		"login/last-used-method": true,
 		"login/magic-login": true,
+		"login/use-magic-code": false,
 		"logmein": true,
 		"mailchimp": true,
 		"marketplace-fetch-all-dynamic-products": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes MYJP-89

## Proposed Changes

This is a part of the magic login changes, to make the changes more atomic

* Added a feature flag to be used for the Magic Code login
* Added a utility function that can be used to check if the flag is on, and it is Jetpack


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* For this change just do a sanity check, make sure it looks good and nothing changes with the current login flows.
* If you want to test the magic code login flow, you can check out https://github.com/Automattic/wp-calypso/pull/103554 and follow the instructions 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
