### PR TITLE
A4A: Submit the 'Expansion Planned' answer as part of the Signup endpoint payload.

### DIFF
--- a/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-create-agency-mutation.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-create-agency-mutation.ts
@@ -18,7 +18,7 @@ function createAgency( details: AgencyDetailsPayload ): Promise< Agency > {
 			services_offered: details.servicesOffered,
 			products_offered: details.productsOffered,
 			products_to_offer: details.productsToOffer,
-			plans_to_offer: details.plansToOfferProducts,
+			expansion_planned: details.plansToOfferProducts,
 			address_line1: details.line1 || '',
 			address_line2: details.line2 || '',
 			address_city: details.city || '',

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-create-agency-mutation.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-create-agency-mutation.ts
@@ -18,6 +18,7 @@ function createAgency( details: AgencyDetailsPayload ): Promise< Agency > {
 			services_offered: details.servicesOffered,
 			products_offered: details.productsOffered,
 			products_to_offer: details.productsToOffer,
+			plans_to_offer: details.plansToOfferProducts,
 			address_line1: details.line1 || '',
 			address_line2: details.line2 || '',
 			address_city: details.city || '',

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/types.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/types.ts
@@ -9,6 +9,7 @@ export interface AgencyDetailsPayload {
 	servicesOffered: string[];
 	productsOffered: string[];
 	productsToOffer: string[];
+	plansToOfferProducts?: 'Yes' | 'No';
 	city: string;
 	line1: string;
 	line2: string;

--- a/client/a8c-for-agencies/sections/signup/hooks/use-create-signup-mutation.ts
+++ b/client/a8c-for-agencies/sections/signup/hooks/use-create-signup-mutation.ts
@@ -19,7 +19,7 @@ function createSignup( details: AgencyDetailsSignupPayload ): Promise< Agency > 
 			services_offered: details.servicesOffered,
 			products_offered: details.productsOffered,
 			products_to_offer: details.productsToOffer,
-			plans_to_offer: details.plansToOfferProducts,
+			expansion_planned: details.plansToOfferProducts,
 			address_line1: details.line1,
 			address_line2: details.line2,
 			address_city: details.city,

--- a/client/a8c-for-agencies/sections/signup/hooks/use-create-signup-mutation.ts
+++ b/client/a8c-for-agencies/sections/signup/hooks/use-create-signup-mutation.ts
@@ -19,6 +19,7 @@ function createSignup( details: AgencyDetailsSignupPayload ): Promise< Agency > 
 			services_offered: details.servicesOffered,
 			products_offered: details.productsOffered,
 			products_to_offer: details.productsToOffer,
+			plans_to_offer: details.plansToOfferProducts,
 			address_line1: details.line1,
 			address_line2: details.line2,
 			address_city: details.city,

--- a/client/a8c-for-agencies/sections/signup/hooks/use-create-signup-mutation.ts
+++ b/client/a8c-for-agencies/sections/signup/hooks/use-create-signup-mutation.ts
@@ -13,6 +13,7 @@ function createSignup( details: AgencyDetailsSignupPayload ): Promise< Agency > 
 			email: details.email,
 			agency_name: details.agencyName,
 			agency_url: details.agencyUrl,
+			initial_source: details.initialSource,
 			agency_size: details.agencySize,
 			number_sites: details.managedSites,
 			user_type: details.userType,

--- a/client/a8c-for-agencies/sections/signup/lib/signup-data-from-reqest-parameters.ts
+++ b/client/a8c-for-agencies/sections/signup/lib/signup-data-from-reqest-parameters.ts
@@ -12,6 +12,14 @@ const sanitizeString = ( value: string | null ): string => {
 	return value.trim().replace( /[^\p{L}\p{N}\s._-]/gu, '' );
 };
 
+const sanitizePlansToOfferProducts = ( value: string | null ): 'Yes' | 'No' | undefined => {
+	if ( value && [ 'Yes', 'No' ].includes( value ) ) {
+		return value as 'Yes' | 'No';
+	}
+
+	return undefined;
+};
+
 /**
  * Sanitizes a URL by validating and cleaning it
  */
@@ -88,6 +96,7 @@ export function getSignupDataFromRequestParameters(): AgencyDetailsPayload | nul
 		servicesOffered,
 		productsOffered,
 		productsToOffer,
+		plansToOfferProducts: sanitizePlansToOfferProducts( searchParams.get( 'plans_to_offer' ) ),
 		line1: sanitizeString( searchParams.get( 'address_line1' ) ),
 		line2: sanitizeString( searchParams.get( 'address_line2' ) ),
 		city: sanitizeString( searchParams.get( 'address_city' ) ),

--- a/client/a8c-for-agencies/sections/signup/lib/signup-data-from-reqest-parameters.ts
+++ b/client/a8c-for-agencies/sections/signup/lib/signup-data-from-reqest-parameters.ts
@@ -96,7 +96,7 @@ export function getSignupDataFromRequestParameters(): AgencyDetailsPayload | nul
 		servicesOffered,
 		productsOffered,
 		productsToOffer,
-		plansToOfferProducts: sanitizePlansToOfferProducts( searchParams.get( 'plans_to_offer' ) ),
+		plansToOfferProducts: sanitizePlansToOfferProducts( searchParams.get( 'expansion_planned' ) ),
 		line1: sanitizeString( searchParams.get( 'address_line1' ) ),
 		line2: sanitizeString( searchParams.get( 'address_line2' ) ),
 		city: sanitizeString( searchParams.get( 'address_city' ) ),

--- a/client/a8c-for-agencies/sections/signup/primary/agency-signup-finish/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/primary/agency-signup-finish/index.tsx
@@ -78,7 +78,7 @@ export default function AgencySignupFinish() {
 					services_offered: ( signupData.servicesOffered || [] ).join( ',' ),
 					products_offered: ( signupData.productsOffered || [] ).join( ',' ),
 					products_to_offer: ( signupData.productsToOffer || [] ).join( ',' ),
-					plans_to_offer: signupData.plansToOfferProducts,
+					expansion_planned: signupData.plansToOfferProducts,
 					city: signupData.city,
 					line1: signupData.line1,
 					line2: signupData.line2,

--- a/client/a8c-for-agencies/sections/signup/primary/agency-signup-finish/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/primary/agency-signup-finish/index.tsx
@@ -78,6 +78,7 @@ export default function AgencySignupFinish() {
 					services_offered: ( signupData.servicesOffered || [] ).join( ',' ),
 					products_offered: ( signupData.productsOffered || [] ).join( ',' ),
 					products_to_offer: ( signupData.productsToOffer || [] ).join( ',' ),
+					plans_to_offer: signupData.plansToOfferProducts,
 					city: signupData.city,
 					line1: signupData.line1,
 					line2: signupData.line2,

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
@@ -24,6 +24,7 @@ import PersonalizationForm from './personalization';
 import './style.scss';
 
 type Props = {
+	sourceName?: string;
 	withPersonalizedBlueprint?: boolean;
 	signupWithMagicLinkFlow?: boolean;
 };
@@ -78,6 +79,7 @@ const getFinishSurveyProgress = ( step: number ): number => {
 const MultiStepForm = ( {
 	withPersonalizedBlueprint = false,
 	signupWithMagicLinkFlow = false,
+	sourceName,
 }: Props ) => {
 	const notificationId = 'a4a-agency-signup-form';
 	const translate = useTranslate();
@@ -159,10 +161,10 @@ const MultiStepForm = ( {
 					...rest
 				} = newFormData;
 				const payload = isBlueprintRequested ? newFormData : rest;
-				submitSurvey( payload as AgencyDetailsSignupPayload );
+				submitSurvey( { ...payload, initialSource: sourceName } as AgencyDetailsSignupPayload );
 			}
 		},
-		[ formData, signupWithMagicLinkFlow, submitSurvey ]
+		[ sourceName, formData, signupWithMagicLinkFlow, submitSurvey ]
 	);
 
 	const closeSurvey = () => {

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/hooks/use-personalization-form-validation.ts
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/hooks/use-personalization-form-validation.ts
@@ -33,7 +33,7 @@ const usePersonalizationFormValidation = () => {
 				newValidationError.productsOffered = translate( 'Please select products you offer' );
 			}
 
-			if ( payload.plansToOfferProducts && ! payload.productsToOffer?.length ) {
+			if ( payload.plansToOfferProducts === 'Yes' && ! payload.productsToOffer?.length ) {
 				newValidationError.productsToOffer = translate(
 					'Please select products you plan to offer'
 				);

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
@@ -74,7 +74,7 @@ export default function PersonalizationForm( {
 		servicesOffered: initialFormData.servicesOffered || [],
 		productsOffered: initialFormData.productsOffered || [],
 		productsToOffer: initialFormData.productsToOffer || [],
-		plansToOfferProducts: !! initialFormData.plansToOfferProducts,
+		plansToOfferProducts: initialFormData.plansToOfferProducts,
 	} );
 
 	const servicesOfferedOptions = useMemo(
@@ -152,7 +152,10 @@ export default function PersonalizationForm( {
 				! prev.productsOffered?.includes( 'None' ) && products.value.includes( 'None' ) // If 'None' is selected, we need to clear other value.
 					? [ 'None' ]
 					: products.value.filter( ( product ) => product !== 'None' ),
-			plansToOfferProducts: hasAllProductsOffered ? false : prev.plansToOfferProducts, // If all products are offered, then there is no more products to be offered
+			plansToOfferProducts:
+				hasAllProductsOffered || productsOfferedOptions.length === 0
+					? undefined
+					: prev.plansToOfferProducts, // If all products are offered, then there is no more products to be offered
 			productsToOffer: prev.productsToOffer?.filter(
 				( product ) => ! products.value.includes( product )
 			),
@@ -168,10 +171,11 @@ export default function PersonalizationForm( {
 		updateValidationError( { productsToOffer: undefined } );
 	};
 
-	const handleSetPlansToOfferProducts = ( plansToOfferProducts: boolean ) => {
+	const handleSetPlansToOfferProducts = ( plansToOfferProducts?: 'Yes' | 'No' ) => {
 		setFormData( ( prev ) => ( {
 			...prev,
 			plansToOfferProducts,
+			productsToOffer: plansToOfferProducts === 'Yes' ? prev.productsToOffer : [],
 		} ) );
 	};
 
@@ -337,19 +341,19 @@ export default function PersonalizationForm( {
 									<FormField label={ translate( 'Do you plan to offer more products?' ) }>
 										<PersonalizationFormRadio
 											label={ translate( 'Yes' ) }
-											checked={ formData.plansToOfferProducts }
-											onChange={ () => handleSetPlansToOfferProducts( true ) }
+											checked={ formData.plansToOfferProducts === 'Yes' }
+											onChange={ () => handleSetPlansToOfferProducts( 'Yes' ) }
 										/>
 
 										<PersonalizationFormRadio
 											label={ translate( 'No' ) }
-											checked={ ! formData.plansToOfferProducts }
-											onChange={ () => handleSetPlansToOfferProducts( false ) }
+											checked={ formData.plansToOfferProducts === 'No' }
+											onChange={ () => handleSetPlansToOfferProducts( 'No' ) }
 										/>
 									</FormField>
 								</FormFieldset>
 
-								{ formData.plansToOfferProducts && (
+								{ formData.plansToOfferProducts === 'Yes' && (
 									<FormFieldset className="signup-personalization-form__checkbox">
 										<FormField
 											error={ validationError.productsToOffer }

--- a/client/a8c-for-agencies/sections/signup/signup-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/index.tsx
@@ -12,7 +12,10 @@ const AgencySignupV2 = () => {
 
 	return (
 		<SignupWrapper>
-			<MultiStepForm signupWithMagicLinkFlow={ isEnabled( 'a4a-signup-v2-via-email' ) } />
+			<MultiStepForm
+				signupWithMagicLinkFlow={ isEnabled( 'a4a-signup-v2-via-email' ) }
+				sourceName="Signup V2 Flow"
+			/>
 		</SignupWrapper>
 	);
 };

--- a/client/a8c-for-agencies/sections/signup/signup-v2/wc-asia.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/wc-asia.tsx
@@ -4,7 +4,11 @@ import SignupWrapper from './components/signup-wrapper';
 const AgencySignupWCAsia = () => {
 	return (
 		<SignupWrapper>
-			<MultiStepForm signupWithMagicLinkFlow withPersonalizedBlueprint />
+			<MultiStepForm
+				signupWithMagicLinkFlow
+				withPersonalizedBlueprint
+				sourceName="WC Asia Signup Flow"
+			/>
 		</SignupWrapper>
 	);
 };

--- a/client/a8c-for-agencies/sections/signup/types.ts
+++ b/client/a8c-for-agencies/sections/signup/types.ts
@@ -24,5 +24,5 @@ export interface AgencyDetailsSignupPayload {
 	workWithClientsOther?: string;
 	approachAndChallenges?: string;
 	agencySize?: string;
-	plansToOfferProducts?: boolean;
+	plansToOfferProducts?: 'Yes' | 'No';
 }

--- a/client/a8c-for-agencies/sections/signup/types.ts
+++ b/client/a8c-for-agencies/sections/signup/types.ts
@@ -25,4 +25,5 @@ export interface AgencyDetailsSignupPayload {
 	approachAndChallenges?: string;
 	agencySize?: string;
 	plansToOfferProducts?: 'Yes' | 'No';
+	initialSource?: string;
 }


### PR DESCRIPTION
This PR ensure that the **'expansion_planned'** is sent to the Signup endpoint.

**NOTE: This needs to be tested with 183453-ghe-Automattic/wpcom**

Depends on https://github.com/Automattic/wp-calypso/pull/103583
Closes  https://linear.app/a8c/issue/A4A-937/update-hubspot-record-to-include-new-fields
## Proposed Changes

* Update the hooks and form to pass the 'expansion_planned' field as a string with possible values: 'Yes' | 'No' | undefined.

## Why are these changes being made?

* This is part of the Improved A4A Onboarding project that enhances the conversion rate.

## Testing Instructions
* Follow 183453-ghe-Automattic/wpcom test instructions to setup sandbox.
* Spin up this branch locally.
* Navigate to http://agencies.localhost:3000/signup
* Complete a signup and test the new fields (Agency size, plans to offer products and products planning to offer) are submitted properly. see 183453-ghe-Automattic/wpcom on how to verify the correctness of the data in the HubSpot.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?