### PR TITLE
Reader - fix broken logged out scrolling.

### DIFF
--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -9,6 +9,11 @@ body.is-reader-page,
 .layout.is-section-reader .layout__content,
 .is-section-reader {
 	background: initial;
+}
+
+// Ensure this is only applied in logged in 'global' interface.
+// Applying this more broadly breaks scrolling in logged out reader.
+.is-section-reader.is-global {
 	overflow-y: hidden;
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # p1747833352543889-slack-C03NLNTPZ2T / regression from https://github.com/Automattic/wp-calypso/pull/103417

## Proposed Changes

Only hides the top level reader scrollbar if we are in the global interface (logged in). The wider rule was preventing scrolling in logged out reader pages.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Broken scrolling in logged out reader.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the reader logged in.
* Go through the reader pages and verify there is no duplicate scrollbar on the outer edge.
* Open an incognito tab.
* While logged out in incognito verify that /discover, /tags, /tag/{slug}, and /reader/search are again scrollable.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?