### PR TITLE
Stats: Fix Subscriber Stats Email module View all link

### DIFF
--- a/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
@@ -52,6 +52,11 @@ const StatsEmails: React.FC< StatsDefaultModuleProps > = ( {
 		getSiteStatsNormalizedData( state, siteId, statType, query )
 	) as [ id: number, label: string ];
 
+	// The period unit is not used in the Email Stats Summary because it always fetches the all-time period.
+	// To make the Email Stats module work with the Stats module component and route for Email Stats Summary,
+	// we need to force the period to be `day`.
+	const forcedDailyPeriodForStatsModule = Object.assign( {}, period, { period: 'day' } );
+
 	return (
 		<>
 			{ ! shouldGateStatsModule && siteId && statType && (
@@ -103,7 +108,7 @@ const StatsEmails: React.FC< StatsDefaultModuleProps > = ( {
 						},
 					} }
 					moduleStrings={ moduleStrings }
-					period={ period }
+					period={ forcedDailyPeriodForStatsModule }
 					query={ query }
 					statType={ statType }
 					mainItemLabel={ translate( 'Latest emails' ) }

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -344,7 +344,7 @@ class StatsModule extends Component {
 					showMore={
 						displaySummaryLink && ! summary
 							? {
-									url: this.getSummaryLink(),
+									url: summaryLink,
 									label:
 										data.length >= 10
 											? translate( 'View all', {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixed STATS-82

## Proposed Changes

* Force the period unit of the Email Stats module `View all` link to `day` to align the Email Stats Summary with the route.
* Update the summaryLink usage in `StatsModule`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix the broken `View all` link of the Email Stats module on the Subscriber Stats page for a period other than `day`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up.
* Navigate to Stats > Subscribers.
* Toggle the chart period to `Weeks`.
* Click on the View all link of the `Emails` module.
* Ensure the Email Stats Summary page shows rather than being redirected to the Traffic page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
