### PR TITLE
Disable creating new conversations while chat is being transferred

### DIFF
--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -52,17 +52,17 @@ export const useCreateZendeskConversation = (): ( ( {
 		createdFrom?: string;
 	} ) => {
 		const currentInteractionID = interactionId || currentSupportInteraction!.uuid;
-		if ( isSubmittingZendeskUserFields || chat.conversationId ) {
+		if ( isSubmittingZendeskUserFields || chat.conversationId || chat.status === 'transfer' ) {
 			return;
 		}
 
-		if ( ! avoidTransfer ) {
-			setChat( ( prevChat ) => ( {
-				...prevChat,
-				messages: [ ...prevChat.messages, ...ODIE_TRANSFER_MESSAGE ],
-				status: 'transfer',
-			} ) );
-		}
+		setChat( ( prevChat ) => ( {
+			...prevChat,
+			messages: avoidTransfer
+				? prevChat.messages
+				: [ ...prevChat.messages, ...ODIE_TRANSFER_MESSAGE ],
+			status: 'transfer',
+		} ) );
 
 		await submitUserFields( {
 			messaging_initial_message: userFieldMessage || undefined,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

In order to create a zd conversation and transfer the chat we need to issue few backend calls.
In rare cases its possible to trigger this twice for same support interaction.
This PR sets the chat status to tranfer while the backend calls are ongoing.

Part of #

## Proposed Changes

* Avoid creating conversations when the chat is transferring to ZD

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Avoid multiple zd chats for one interaction

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the help center and a chat which has more `contact support` links visible
* Slow down the `Smooch.createConversation` call by doing something like
```		
const [ first, conversation ] = await Promise.all( [
			new Promise( ( r ) => setTimeout( r, 15000 ) ),
			Smooch.createConversation( {
				metadata: {
					createdAt: Date.now(),
					supportInteractionId: currentInteractionID,
					...( chatId ? { odieChatId: chatId } : {} ),
				},
			} ),
		] );
```
* Click two of the  `contact support` links. This will trigger the  condition and two chats will get created under one interaction
* Test for regressions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
