### PR TITLE
Reader onboarding: update profile complete criteria and Gravatar status

### DIFF
--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -18,6 +18,7 @@ import {
 } from 'calypso/state/analytics/actions';
 import { setCurrentUser } from 'calypso/state/current-user/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { receiveGravatarDetails } from 'calypso/state/gravatar-status/actions';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
 import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
 
@@ -37,12 +38,18 @@ export class EditGravatar extends Component {
 		user: PropTypes.object,
 		recordClickButtonEvent: PropTypes.func,
 		recordAvatarUpdatedEvent: PropTypes.func,
+		receiveGravatarDetails: PropTypes.func,
 	};
 
 	quickEditor = null;
 
 	componentDidMount() {
-		const { user, setCurrentUser: setUser, recordAvatarUpdatedEvent } = this.props;
+		const {
+			user,
+			setCurrentUser: setUser,
+			recordAvatarUpdatedEvent,
+			receiveGravatarDetails: updateGravatarDetails,
+		} = this.props;
 
 		this.quickEditor = new GravatarQuickEditorCore( {
 			email: user.email,
@@ -52,6 +59,8 @@ export class EditGravatar extends Component {
 				recordAvatarUpdatedEvent();
 				// Update the avatar URL to force a refresh.
 				setUser( { ...user, avatar_URL: addQueryArgs( user.avatar_URL, { ver: Date.now() } ) } );
+				// Update Gravatar details
+				updateGravatarDetails( { has_gravatar: true } );
 			},
 		} );
 
@@ -198,5 +207,6 @@ export default connect(
 		setCurrentUser,
 		recordClickButtonEvent,
 		recordAvatarUpdatedEvent,
+		receiveGravatarDetails,
 	}
 )( localize( EditGravatar ) );

--- a/client/blocks/edit-gravatar/test/index.jsx
+++ b/client/blocks/edit-gravatar/test/index.jsx
@@ -39,6 +39,7 @@ const baseProps = {
 	recordClickButtonEvent: jest.fn(),
 	recordAvatarUpdatedEvent: jest.fn(),
 	setCurrentUser: jest.fn(),
+	receiveGravatarDetails: jest.fn(),
 };
 
 const setup = ( overrides = {} ) =>
@@ -73,7 +74,7 @@ describe( 'EditGravatar', () => {
 	} );
 
 	describe( 'actions', () => {
-		test( 'opens quick editor and updates avatar URL', () => {
+		test( 'opens quick editor and updates avatar URL and Gravatar details', () => {
 			setup();
 
 			clickEditAvatarLink();
@@ -84,6 +85,8 @@ describe( 'EditGravatar', () => {
 			expect( baseProps.setCurrentUser ).toHaveBeenCalledWith(
 				expect.objectContaining( { avatar_URL: expect.stringContaining( `ver=${ FIXED_NOW }` ) } )
 			);
+
+			expect( baseProps.receiveGravatarDetails ).toHaveBeenCalledWith( { has_gravatar: true } );
 		} );
 
 		test( 'shows email‑verification dialog', () => {

--- a/client/state/data-layer/wpcom/gravatar-upload/index.js
+++ b/client/state/data-layer/wpcom/gravatar-upload/index.js
@@ -4,6 +4,7 @@ import {
 	GRAVATAR_UPLOAD_REQUEST,
 	GRAVATAR_UPLOAD_REQUEST_SUCCESS,
 	GRAVATAR_UPLOAD_REQUEST_FAILURE,
+	GRAVATAR_DETAILS_RECEIVE,
 } from 'calypso/state/action-types';
 import {
 	bumpStat,
@@ -87,4 +88,5 @@ registerHandlers( 'state/data-layer/wpcom/gravatar-upload/index.js', {
 		} ),
 	],
 	[ GRAVATAR_UPLOAD_REQUEST_SUCCESS ]: [ dispatchProfileCompleteNotice ],
+	[ GRAVATAR_DETAILS_RECEIVE ]: [ dispatchProfileCompleteNotice ],
 } );

--- a/client/state/data-layer/wpcom/me/settings/index.js
+++ b/client/state/data-layer/wpcom/me/settings/index.js
@@ -1,3 +1,4 @@
+import { getQueryArg } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { isEmpty, mapValues } from 'lodash';
 import { decodeEntities } from 'calypso/lib/formatting';
@@ -148,6 +149,11 @@ export const userSettingsSaveSuccess =
 				PROPERTIES_TO_SUPRESS_NOTIFICATIONS.has( key )
 			)
 		) {
+			return;
+		}
+
+		// Don't show success notice if we're in reader onboarding
+		if ( getQueryArg( window.location.href, 'ref' ) === 'reader-onboarding' ) {
 			return;
 		}
 

--- a/client/state/data-layer/wpcom/me/settings/index.js
+++ b/client/state/data-layer/wpcom/me/settings/index.js
@@ -153,8 +153,13 @@ export const userSettingsSaveSuccess =
 		}
 
 		// Don't show success notice if we're in reader onboarding
-		if ( getQueryArg( window.location.href, 'ref' ) === 'reader-onboarding' ) {
-			return;
+		try {
+			const currentUrl = typeof window !== 'undefined' ? window.location.href : '';
+			if ( getQueryArg( currentUrl, 'ref' ) === 'reader-onboarding' ) {
+				return;
+			}
+		} catch ( error ) {
+			// If we can't check the URL, default to showing the notice
 		}
 
 		dispatch(

--- a/client/state/data-layer/wpcom/me/settings/test/index.js
+++ b/client/state/data-layer/wpcom/me/settings/test/index.js
@@ -16,6 +16,10 @@ jest.mock( 'calypso/state/current-user/actions', () => ( {
 	fetchCurrentUser: jest.fn(),
 } ) );
 
+jest.mock( '@wordpress/url', () => ( {
+	getQueryArg: jest.fn().mockReturnValue( null ),
+} ) );
+
 describe( 'wpcom-api', () => {
 	describe( 'user settings request', () => {
 		describe( '#requestUserSettings', () => {
@@ -142,6 +146,13 @@ describe( 'wpcom-api', () => {
 		} );
 
 		describe( '#userSettingsSaveSuccess', () => {
+			const { getQueryArg } = require( '@wordpress/url' );
+
+			beforeEach( () => {
+				getQueryArg.mockReset();
+				getQueryArg.mockReturnValue( null );
+			} );
+
 			test( 'should dispatch user settings update and clear all unsaved settings on full save', async () => {
 				const dispatch = jest.fn();
 				const action = { type: 'DUMMY' };
@@ -158,6 +169,29 @@ describe( 'wpcom-api', () => {
 				);
 				expect( dispatch ).toHaveBeenCalledWith( clearUnsavedUserSettings() );
 				expect( dispatch ).toHaveBeenCalledWith(
+					successNotice( 'Settings saved successfully!', {
+						id: 'save-user-settings',
+					} )
+				);
+			} );
+
+			test( 'should not show success notice when ref=reader-onboarding', async () => {
+				const dispatch = jest.fn();
+				const action = { type: 'DUMMY' };
+				getQueryArg.mockReturnValue( 'reader-onboarding' );
+
+				await userSettingsSaveSuccess( action, {
+					language: 'qix',
+				} )( dispatch );
+
+				expect( dispatch ).toHaveBeenCalledTimes( 3 );
+				expect( dispatch ).toHaveBeenCalledWith(
+					saveUserSettingsSuccess( {
+						language: 'qix',
+					} )
+				);
+				expect( dispatch ).toHaveBeenCalledWith( clearUnsavedUserSettings() );
+				expect( dispatch ).not.toHaveBeenCalledWith(
 					successNotice( 'Settings saved successfully!', {
 						id: 'save-user-settings',
 					} )

--- a/client/state/reader/onboarding/handlers.ts
+++ b/client/state/reader/onboarding/handlers.ts
@@ -3,17 +3,14 @@ import page from '@automattic/calypso-router';
 import { translate } from 'i18n-calypso';
 import { Store, UnknownAction } from 'redux';
 import { READER_ONBOARDING_TRACKS_EVENT_PREFIX } from 'calypso/reader/onboarding/constants';
-import {
-	USER_SETTINGS_SAVE_SUCCESS,
-	GRAVATAR_UPLOAD_REQUEST_SUCCESS,
-} from 'calypso/state/action-types';
+import { USER_SETTINGS_SAVE_SUCCESS, GRAVATAR_DETAILS_RECEIVE } from 'calypso/state/action-types';
 import { successNotice } from 'calypso/state/notices/actions';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import { isProfileComplete } from './utils';
 
 function dispatchNotice( dispatch: Store[ 'dispatch' ] ) {
 	dispatch(
-		successNotice( translate( 'Settings saved!' ), {
+		successNotice( translate( 'Profile updated!' ), {
 			id: 'reader-profile-complete',
 			button: translate( 'Return to Reader' ),
 			onClick: () => {
@@ -45,10 +42,9 @@ export const dispatchProfileCompleteNotice = ( store: Store, action: UnknownActi
 		}
 	}
 
-	if ( action.type === GRAVATAR_UPLOAD_REQUEST_SUCCESS ) {
+	if ( action.type === GRAVATAR_DETAILS_RECEIVE ) {
 		const updatedSettings = { ...state.userSettings.settings };
-		const gravatarDetails = { ...state.gravatarStatus, gravatarDetails: { has_gravatar: true } };
-		if ( isProfileComplete( updatedSettings, gravatarDetails ) ) {
+		if ( isProfileComplete( updatedSettings, state.gravatarStatus ) ) {
 			dispatchNotice( dispatch );
 		}
 	}

--- a/client/state/reader/onboarding/handlers.ts
+++ b/client/state/reader/onboarding/handlers.ts
@@ -13,7 +13,7 @@ import { isProfileComplete } from './utils';
 
 function dispatchNotice( dispatch: Store[ 'dispatch' ] ) {
 	dispatch(
-		successNotice( translate( 'Profile complete!' ), {
+		successNotice( translate( 'Settings saved!' ), {
 			id: 'reader-profile-complete',
 			button: translate( 'Return to Reader' ),
 			onClick: () => {
@@ -40,11 +40,7 @@ export const dispatchProfileCompleteNotice = ( store: Store, action: UnknownActi
 			...state.userSettings.settings,
 			...( typeof action.settingValues === 'object' ? action.settingValues : {} ),
 		};
-		const gravatarDetails = {
-			...state.gravatarStatus,
-			gravatarDetails: { has_gravatar: !! state.gravatarStatus.tempImage },
-		};
-		if ( isProfileComplete( updatedSettings, gravatarDetails ) ) {
+		if ( isProfileComplete( updatedSettings, state.gravatarStatus ) ) {
 			dispatchNotice( dispatch );
 		}
 	}

--- a/client/state/reader/onboarding/utils.ts
+++ b/client/state/reader/onboarding/utils.ts
@@ -4,7 +4,7 @@ export const isProfileComplete = (
 	settings: AppState[ 'userSettings' ][ 'settings' ],
 	gravatarStatus: AppState[ 'gravatarStatus' ]
 ) =>
-	settings.first_name &&
-	settings.last_name &&
-	settings.description &&
+	settings.first_name ||
+	settings.last_name ||
+	settings.description ||
 	gravatarStatus?.gravatarDetails?.has_gravatar;

--- a/client/state/reader/onboarding/utils.ts
+++ b/client/state/reader/onboarding/utils.ts
@@ -4,7 +4,7 @@ export const isProfileComplete = (
 	settings: AppState[ 'userSettings' ][ 'settings' ],
 	gravatarStatus: AppState[ 'gravatarStatus' ]
 ) =>
-	!!(
+	!! (
 		settings.first_name ||
 		settings.last_name ||
 		settings.description ||

--- a/client/state/reader/onboarding/utils.ts
+++ b/client/state/reader/onboarding/utils.ts
@@ -1,5 +1,12 @@
 import { AppState } from 'calypso/types';
 
+/**
+ * Determines if a user's profile is complete for Reader onboarding.
+ * We consider the profile complete if ANY field is filled or if they have a Gravatar.
+ * This relaxed criteria encourages users to proceed with Reader onboarding
+ * while still ensuring they've made at least one meaningful profile customization.
+ * Previously, ALL fields were required, which created unnecessary friction in the onboarding flow.
+ */
 export const isProfileComplete = (
 	settings: AppState[ 'userSettings' ][ 'settings' ],
 	gravatarStatus: AppState[ 'gravatarStatus' ]

--- a/client/state/reader/onboarding/utils.ts
+++ b/client/state/reader/onboarding/utils.ts
@@ -4,7 +4,9 @@ export const isProfileComplete = (
 	settings: AppState[ 'userSettings' ][ 'settings' ],
 	gravatarStatus: AppState[ 'gravatarStatus' ]
 ) =>
-	settings.first_name ||
-	settings.last_name ||
-	settings.description ||
-	gravatarStatus?.gravatarDetails?.has_gravatar;
+	!!(
+		settings.first_name ||
+		settings.last_name ||
+		settings.description ||
+		gravatarStatus?.gravatarDetails?.has_gravatar
+	);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CML-497/no-link-back-to-reader

## Proposed Changes

* Change the profile complete criteria: as long as they've filled in at least one field, show a success notice.
* Update `has_gravatar` to `true` when avatar is updated, and show a success notice.
* Prevent the normal settings saved success notice from showing when the URL includes `ref=reader-onboarding`.

<img width="492" alt="Screenshot 2025-05-21 at 3 35 14 PM" src="https://github.com/user-attachments/assets/6ed76a3b-d0db-4739-be70-717c9ed7bf12" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* So that the user can get back to the Reader.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make a new account and confirm your email
* Go to the Reader to start the onboarding
* On the third step, click "Add your avatar and fill out your profile"
* Upload an avatar. You should see a success notice.
* Edit your name or about description and click "Save profile details."
* You should see a success notice that links back to the Reader.
* Click to return to the Reader.

Note that the success notice will show even if you delete your Gravatar image, because that's also a change, but that's unlikely to be the case for someone in Reader Onboarding.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
