### PR TITLE
Accounts settings: Fix language switcher.

### DIFF
--- a/client/components/language-picker/modal.scss
+++ b/client/components/language-picker/modal.scss
@@ -10,42 +10,38 @@
 	justify-content: center;
 }
 
-.language-picker__modal {
-	max-width:80%;
-	min-width: 80%;
-	@media (max-width: $break-mobile) {
-		max-width: 90%;
-		min-width: 90%;
+.language-picker-modal__wrapper {
+	// Limit the height to prevent modal resize on content change, when the modal is not full height.
+	@media (min-width: $break-small) {
+		max-height: 600px;
+		// Limit height on smaller screens.
+		height:80%;
 	}
-	.components-modal__header {
-		display:none;
+
+	.language-picker-modal__content {
+		display:flex;
+		flex-direction: column;
+		// Limit height to container, instead of overflowing and pushing down the footer.
+		height: 100%;
+	}
+	.language-picker-modal__body {
+		overflow-y: auto;
+		// Fix cropped box shadow.
+		padding-left:1px;
+		margin-left:-1px;
+	}
+	.language-picker-modal__footer {
+		margin-top: auto;
 	}
 
 	.components-modal__content {
-		padding: 24px 0 0 0;
-		margin-top: 24px;
-		display:flex;
-		/* Targeting the content div, we can't alter the HTML of the modal itself */
-		>div:nth-child(2) {
-			height: 100%;
-			display: flex;
-			flex-direction: column;
-		}
-
-		.components-flex-block {
-			flex:none;
-		}
-		.language-picker-component {
-			overflow-y: auto;
-			padding:0 24px;
-			.language-picker-component__heading {
-				margin: 6px 0 24px;
-			}
-			.components-flex {
-				flex:initial;
-			}
-		}
+		display: flex;
 	}
+	// Force width to 100% even if the content is not that wide.
+	.components-modal__content > div {
+		width: 100%;
+	}
+
 }
 
 .language-picker__modal-empathy-mode {
@@ -101,7 +97,7 @@
 }
 
 .language-picker__modal-buttons {
-	padding: 24px;
+	padding: 24px 24px 0;
 	width: 100%;
 	display: flex;
 	flex-direction: row;

--- a/client/components/language-picker/modal.tsx
+++ b/client/components/language-picker/modal.tsx
@@ -197,19 +197,24 @@ const LanguagePickerModal: React.FC< Props > = ( {
 	return (
 		<Modal
 			onRequestClose={ onClose }
-			className="language-picker__modal"
-			overlayClassName="language-picker__overlay"
+			className="language-picker-modal__wrapper"
+			size="large"
+			title={ __( 'Select a language' ) }
 		>
-			<QueryLanguageNames />
-			<LanguagePicker
-				headingTitle={ __( 'Select a language' ) }
-				languages={ languages }
-				languageGroups={ createLanguageGroups( __ ) }
-				onSelectLanguage={ setSelectedLanguage }
-				selectedLanguage={ selectedLanguage }
-				localizedLanguageNames={ localizedLanguageNames }
-			/>
-			<div>{ buttons }</div>
+			<div className="language-picker-modal__content">
+				<div className="language-picker-modal__body">
+					<QueryLanguageNames />
+					<LanguagePicker
+						headingTitle
+						languages={ languages }
+						languageGroups={ createLanguageGroups( __ ) }
+						onSelectLanguage={ setSelectedLanguage }
+						selectedLanguage={ selectedLanguage }
+						localizedLanguageNames={ localizedLanguageNames }
+					/>
+				</div>
+				<div className="language-picker-modal__footer">{ buttons }</div>
+			</div>
 		</Modal>
 	);
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes [DOTCOM-12873](https://linear.app/a8c/issue/DOTCOM-12873)

## Proposed Changes

Based on feedback, remove the title formatting. Update the language switcher to work correctly on wide displays:

![image](https://github.com/user-attachments/assets/fc1a2b79-0587-4de8-960c-3829811321fb)


![image](https://github.com/user-attachments/assets/e8d52b9d-fdec-453e-ab30-9b4d4a22fbf0)




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* My previous attempt in [this PR ](https://github.com/Automattic/wp-calypso/pull/103503) introduced an issue on ultrawide display sizes, causing the action buttons to be displayed incorrectly. This PR addresses the problem, together with a refactoring of the CSS to keep styling the `Modal` component to a minimum.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit /me/account, open the language switcher modal, and confirm it works correctly.


__Note__: I couldn't avoid styling the `Modal` components, but the changes revolve around `components-modal__content` referenced in the documentation and should be safe to style.
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
