### PR TITLE
Hide cancel migration link if migration is complete

### DIFF
--- a/client/sites/overview/components/migration-overview/components/cancel-difm-migration/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/cancel-difm-migration/index.tsx
@@ -107,6 +107,9 @@ const CancelDifmMigrationForm = ( { siteId }: { siteId: number } ) => {
 	>( null );
 
 	const isMigrationInProgress = stickers.includes( 'migration-in-progress' );
+	const isMigationCompleted =
+		stickers.includes( 'site-migration-complete' ) ||
+		stickers.includes( 'migration-completed-difm' );
 
 	const handleSendCancellationRequest = async ( siteId: number ) => {
 		try {
@@ -154,7 +157,7 @@ const CancelDifmMigrationForm = ( { siteId }: { siteId: number } ) => {
 			{ cancellationStatus === 'pending' && (
 				<LoadingBar className="migration-started-difm__cancel-loading-bar" progress={ 0.5 } />
 			) }
-			{ cancellationStatus === null && (
+			{ ! isMigationCompleted && cancellationStatus === null && (
 				<CancelMigrationButton
 					isMigrationInProgress={ isMigrationInProgress }
 					onClick={ openModal }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCON-26

## Proposed Changes

There can be situations where a site has both the `migration-started-difm` sticker _and_ the `site-migration-complete` sticker. This is usually because the user did the migration themselves but then requested a DIFM migration after the fact.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

In this particular case, the user will see the 'Cancel migration' button on the overview page but clicking it fails because the ticket is already closed.

Now we hide the 'Cancel migration' button if `site-migration-complete` is set.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the calypso.live url or run this locally. NOTE: If you run it locally, you'll need to share credentials instead of authorizing the application password once you reach that step.
* Go to `/start` and continue to the Goals step.
* Select the 'import or migrate' intent.
* Continue with the migration flow and select a DIFM migration.
* When you reach the step of sharing credentials, do not continue yet. Instead, manually add the `site-migration-complete` sticker to the site.
* Continue until you reach the site overview.
* You should _not_ see a 'Cancel migration' button.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
