### PR TITLE
Remove color override from stepper nav top bar right element

### DIFF
--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -62,7 +62,7 @@
 }
 
 /* Gravatar & WP Job Manager */
-.layout.is-section-login.is-grav-powered-client {
+.is-grav-powered-client {
 	.components-button:not(.is-destructive) {
 		--color-gravatar-darker: color-mix(in srgb, var(--color-gravatar), #000 13%);
 
@@ -86,8 +86,7 @@
 .is-white-login.is-akismet .login,
 .is-white-login.is-akismet .magic-login,
 .is-akismet .signup-form,
-.is-akismet .auth-form__social,
-.is-akismet .step-container-v2 {
+.is-akismet .auth-form__social {
 	.components-button:not(.is-destructive) {
 		--wp-components-color-accent: var(--color-akismet);
 		--wp-components-color-accent-darker-10: var(--color-akismet);

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -86,7 +86,8 @@
 .is-white-login.is-akismet .login,
 .is-white-login.is-akismet .magic-login,
 .is-akismet .signup-form,
-.is-akismet .auth-form__social {
+.is-akismet .auth-form__social,
+.is-akismet .step-container-v2 {
 	.components-button:not(.is-destructive) {
 		--wp-components-color-accent: var(--color-akismet);
 		--wp-components-color-accent-darker-10: var(--color-akismet);

--- a/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
@@ -69,5 +69,12 @@
 		margin-left: auto;
 		font-size: 0.875rem;
 		line-height: 1;
+
+		a,
+		button {
+			&.components-button:not(.is-destructive).is-link {
+				--wp-components-color-accent: var( --color-neutral-100 );
+			}
+		}
 	}
 }

--- a/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
@@ -66,8 +66,6 @@
 	}
 
 	&-right-element {
-		--color-accent: var( --color-neutral-100 );
-
 		margin-left: auto;
 		font-size: 0.875rem;
 		line-height: 1;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DSGCOM-92: Update primary buttons on 'Continue as user'](https://linear.app/a8c/issue/DSGCOM-92/update-primary-buttons-on-continue-as-user)

## Proposed Changes

* Remove color override from stepper top nav right element
* ~Extend Akismet branding to cover the stepper nav, as this is the only branded login to use the stepper nav (afaik)~

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Overrides to the design system should be avoided, see [discussion](https://github.com/Automattic/wp-calypso/pull/103097#discussion_r2089778003).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the [login page](http://calypso.localhost:3000/log-in)
* Check that the navigation link in the top right corner uses the accent color
* Visit the [Akismet login page](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fr-login.wordpress.com%2Fremote-login.php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet.com%252Faccount%252F&signup_url=%2Fstart%2Faccount%2Fuser-social%3Fredirect_to%3Dhttps%253A%252F%252Fr-login.wordpress.com%252Fremote-login.php%253Faction%253Dlink%2526back%253Dhttps%25253A%25252F%25252Fakismet.com%25252Faccount%25252F) and do the same.

### Screenshots

| Before | After |
|-|-|
| ![wordpress com_log-in(Desktop) (5)](https://github.com/user-attachments/assets/24ed731a-4a14-444f-be58-cb8f8856175a) | ![calypso localhost_3000_log-in(Desktop) (3)](https://github.com/user-attachments/assets/6469b1f1-50fb-4371-92a3-9bb47121f9f9) |
| ![wordpress com_log-in_redirect_to=https%3A%2F%2Fr-login wordpress com%2Fremote-login php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet com%252Faccount%252F(Desktop) (1)](https://github.com/user-attachments/assets/5e9f10dc-3355-440f-bebf-7b7de2bd6227) | ![calypso localhost_3000_log-in_redirect_to=https%3A%2F%2Fr-login wordpress com%2Fremote-login php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet com%252Faccount%252F signup_url=%2Fstart%2Faccount%2Fuser-social%3Fredirect_to%3Dhttps (3)](https://github.com/user-attachments/assets/4e497e5c-c700-4f78-81bf-fac4326fdcb3) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
