### PR TITLE
Centralize brand color overrides for core buttons in login and signup

### DIFF
--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -10,6 +10,7 @@
 	justify-content: center;
 }
 
+/* Default */
 .components-button.is-primary:not(.is-destructive) {
 	// Background color, focus ring color
 	--wp-components-color-accent: var(--color-accent);
@@ -38,6 +39,14 @@
 .components-button.is-link:not(.is-destructive) {
 	// Text color, focus ring color
 	--wp-components-color-accent: var(--color-accent);
+}
+
+/* A8C for Agencies */
+.a8c-for-agencies {
+	.components-button {
+		--color-accent: var(--color-primary-40);
+		--color-accent-60: var(--color-primary-60);
+	}
 }
 
 /* Jetpack */

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -48,6 +48,21 @@
 	}
 }
 
+/* Gravatar & WP Job Manager */
+.layout.is-section-login.is-grav-powered-client {
+	.components-button {
+		--color-accent: var(--color-gravatar);
+		--color-accent-60: color-mix(in srgb, var(--color-gravatar), #000 13%);
+	}
+
+	&.is-wp-job-manager {
+		.components-button {
+			--color-accent: var(--color-wp-job-manager);
+			--color-accent-60: color-mix(in srgb, var(--color-wp-job-manager), #000 10%);
+		}
+	}
+}
+
 /* @wordpress/components ButtonGroup overrides */
 .components-button-group {
 	.components-button {

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -95,6 +95,15 @@
 	}
 }
 
+/* Blaze Pro */
+.blaze-pro,
+.is-blaze-pro {
+	.components-button {
+		--color-accent: var(--color-blaze-pro);
+		--color-accent-60: var(--color-blaze-pro);
+	}
+}
+
 /* @wordpress/components ButtonGroup overrides */
 .components-button-group {
 	.components-button {

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -91,7 +91,8 @@
 /* Akismet */
 .is-white-login.is-akismet .login,
 .is-white-login.is-akismet .magic-login,
-.is-akismet .signup-form {
+.is-akismet .signup-form,
+.is-akismet .auth-form__social {
 	.components-button:not(.is-destructive) {
 		--wp-components-color-accent: var(--color-akismet);
 		--wp-components-color-accent-darker-10: var(--color-akismet);

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -48,6 +48,13 @@
 	}
 }
 
+.jetpack-cloud {
+	.components-button {
+		--color-accent: var(--studio-jetpack-green-40);
+		--color-accent-60: var(--studio-jetpack-green-30);
+	}
+}
+
 /* Gravatar & WP Job Manager */
 .layout.is-section-login.is-grav-powered-client {
 	.components-button {

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -120,6 +120,36 @@
 		&:focus:not(:disabled) {
 			--wp-components-color-accent: var(--woo-purple-60);
 		}
+
+		&.is-primary,
+		&.social-buttons__button {
+			border-radius: 8px; /* stylelint-disable-line scales/radii */
+			font-size: 1rem;
+			font-weight: 500;
+			height: 48px;
+		}
+
+		&.social-buttons__button {
+			&:focus:not(:disabled) {
+				box-shadow: inset 0 0 0 1px var(--wp-components-color-background, #fff), 0 0 0 2px var(--wp-components-color-accent);
+			}
+		}
+
+		&.is-primary {
+			&:focus:not(:disabled) {
+				box-shadow: 0 0 0 2px var(--wp-components-color-accent);
+			}
+
+			&:disabled {
+				--wp-components-color-accent: var(--studio-gray-5);
+
+				color: var(--studio-gray-50);
+			}
+
+			.components-spinner {
+				margin-top: 0;
+			}
+		}
 	}
 }
 

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -83,6 +83,18 @@
 	}
 }
 
+/* Woo */
+.woo.is-woo-passwordless {
+	.components-button {
+		--color-accent: var(--woo-purple-40);
+		--color-accent-60: var(--woo-purple-60);
+
+		&:focus:not(:disabled) {
+			--color-accent: var(--woo-purple-60);
+		}
+	}
+}
+
 /* @wordpress/components ButtonGroup overrides */
 .components-button-group {
 	.components-button {

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -43,38 +43,47 @@
 
 /* A8C for Agencies */
 .a8c-for-agencies {
-	.components-button {
-		--color-accent: var(--color-primary-40);
-		--color-accent-60: var(--color-primary-60);
+	.components-button:not(.is-destructive) {
+		--wp-components-color-accent: var(--color-primary-40);
+		--wp-components-color-accent-darker-10: var(--color-primary-60);
+		--wp-components-color-accent-darker-20: var(--color-primary-60);
 	}
 }
 
 /* Jetpack */
 .layout.is-jetpack-login:not(.is-wccom-oauth-flow):not(.is-woocommerce-core-profiler-flow) {
-	.components-button {
-		--color-accent: var(--studio-jetpack-green-50);
-		--color-accent-60: var(--studio-jetpack-green-60);
+	.components-button:not(.is-destructive) {
+		--wp-components-color-accent: var(--studio-jetpack-green-50);
+		--wp-components-color-accent-darker-10: var(--studio-jetpack-green-60);
+		--wp-components-color-accent-darker-20: var(--studio-jetpack-green-60);
 	}
 }
 
 .jetpack-cloud {
-	.components-button {
-		--color-accent: var(--studio-jetpack-green-40);
-		--color-accent-60: var(--studio-jetpack-green-30);
+	.components-button:not(.is-destructive) {
+		--wp-components-color-accent: var(--studio-jetpack-green-40);
+		--wp-components-color-accent-darker-10: var(--studio-jetpack-green-30);
+		--wp-components-color-accent-darker-20: var(--studio-jetpack-green-30);
 	}
 }
 
 /* Gravatar & WP Job Manager */
 .layout.is-section-login.is-grav-powered-client {
-	.components-button {
-		--color-accent: var(--color-gravatar);
-		--color-accent-60: color-mix(in srgb, var(--color-gravatar), #000 13%);
+	.components-button:not(.is-destructive) {
+		--color-gravatar-darker: color-mix(in srgb, var(--color-gravatar), #000 13%);
+
+		--wp-components-color-accent: var(--color-gravatar);
+		--wp-components-color-accent-darker-10: var(--color-gravatar-darker);
+		--wp-components-color-accent-darker-20: var(--color-gravatar-darker);
 	}
 
 	&.is-wp-job-manager {
-		.components-button {
-			--color-accent: var(--color-wp-job-manager);
-			--color-accent-60: color-mix(in srgb, var(--color-wp-job-manager), #000 10%);
+		.components-button:not(.is-destructive) {
+			--color-wp-job-manager-darker: color-mix(in srgb, var(--color-wp-job-manager), #000 10%);
+
+			--wp-components-color-accent: var(--color-wp-job-manager);
+			--wp-components-color-accent-darker-10: var(--color-wp-job-manager-darker);
+			--wp-components-color-accent-darker-20: var(--color-wp-job-manager-darker);
 		}
 	}
 }
@@ -83,30 +92,33 @@
 .is-white-login.is-akismet .login,
 .is-white-login.is-akismet .magic-login,
 .is-akismet .signup-form {
-	.components-button {
-		--color-accent: var(--color-akismet);
-		--color-accent-60: var(--color-akismet);
+	.components-button:not(.is-destructive) {
+		--wp-components-color-accent: var(--color-akismet);
+		--wp-components-color-accent-darker-10: var(--color-akismet);
+		--wp-components-color-accent-darker-20: var(--color-akismet);
 	}
 }
 
 /* Crowdsignal */
 .signup.is-crowdsignal {
-	.components-button {
+	.components-button:not(.is-destructive) {
 		&.is-primary:not(.signup-form__crowdsignal-wpcom) {
-			--color-accent: var(--color-primary);
-			--color-accent-60: var(--color-primary-dark);
+			--wp-components-color-accent: var(--color-primary);
+			--wp-components-color-accent-darker-10: var(--color-primary-dark);
+			--wp-components-color-accent-darker-20: var(--color-primary-dark);
 		}
 	}
 }
 
 /* Woo */
 .woo.is-woo-passwordless {
-	.components-button {
-		--color-accent: var(--woo-purple-40);
-		--color-accent-60: var(--woo-purple-60);
+	.components-button:not(.is-destructive) {
+		--wp-components-color-accent: var(--woo-purple-40);
+		--wp-components-color-accent-darker-10: var(--woo-purple-60);
+		--wp-components-color-accent-darker-20: var(--woo-purple-60);
 
 		&:focus:not(:disabled) {
-			--color-accent: var(--woo-purple-60);
+			--wp-components-color-accent: var(--woo-purple-60);
 		}
 	}
 }
@@ -114,9 +126,10 @@
 /* Blaze Pro */
 .blaze-pro,
 .is-blaze-pro {
-	.components-button {
-		--color-accent: var(--color-blaze-pro);
-		--color-accent-60: var(--color-blaze-pro);
+	.components-button:not(.is-destructive) {
+		--wp-components-color-accent: var(--color-blaze-pro);
+		--wp-components-color-accent-darker-10: var(--color-blaze-pro);
+		--wp-components-color-accent-darker-20: var(--color-blaze-pro);
 	}
 }
 

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -1,3 +1,4 @@
+/* @wordpress/components FormToggle overrides ----------------------------------------- */
 .components-form-toggle {
 	input[type="checkbox"] {
 		cursor: pointer;
@@ -5,7 +6,7 @@
 	}
 }
 
-/* @wordpress/components Button overrides */
+/* @wordpress/components Button overrides --------------------------------------------- */
 .components-button {
 	justify-content: center;
 }
@@ -164,7 +165,7 @@
 	}
 }
 
-/* @wordpress/components ButtonGroup overrides */
+/* @wordpress/components ButtonGroup overrides ---------------------------------------- */
 .components-button-group {
 	.components-button {
 		&,
@@ -174,7 +175,7 @@
 	}
 }
 
-/* @wordpress/components RadioControl overrides */
+/* @wordpress/components RadioControl overrides --------------------------------------- */
 .components-radio-control {
 	&__input[type="radio"] {
 		padding: 6px;

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -40,6 +40,14 @@
 	--wp-components-color-accent: var(--color-accent);
 }
 
+/* Jetpack */
+.layout.is-jetpack-login:not(.is-wccom-oauth-flow):not(.is-woocommerce-core-profiler-flow) {
+	.components-button {
+		--color-accent: var(--studio-jetpack-green-50);
+		--color-accent-60: var(--studio-jetpack-green-60);
+	}
+}
+
 /* @wordpress/components ButtonGroup overrides */
 .components-button-group {
 	.components-button {

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -63,6 +63,16 @@
 	}
 }
 
+/* Akismet */
+.is-white-login.is-akismet .login,
+.is-white-login.is-akismet .magic-login,
+.is-akismet .signup-form {
+	.components-button {
+		--color-accent: var(--color-akismet);
+		--color-accent-60: var(--color-akismet);
+	}
+}
+
 /* @wordpress/components ButtonGroup overrides */
 .components-button-group {
 	.components-button {

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/colors";
+
 /* @wordpress/components FormToggle overrides ----------------------------------------- */
 .components-form-toggle {
 	input[type="checkbox"] {
@@ -124,17 +126,12 @@
 		}
 
 		&.is-primary,
-		&.social-buttons__button {
+		// Used for social auth buttons
+		&.a8c-components-wp-button {
 			border-radius: 8px; /* stylelint-disable-line scales/radii */
 			font-size: 1rem;
 			font-weight: 500;
 			height: 48px;
-		}
-
-		&.social-buttons__button {
-			&:focus:not(:disabled) {
-				box-shadow: inset 0 0 0 1px var(--wp-components-color-background, #fff), 0 0 0 2px var(--wp-components-color-accent);
-			}
 		}
 
 		&.is-primary {
@@ -150,6 +147,17 @@
 
 			.components-spinner {
 				margin-top: 0;
+			}
+		}
+
+		// Used for social auth buttons
+		&.a8c-components-wp-button {
+			&:not(:focus) {
+				box-shadow: inset 0 0 0 2px $gray-300, 0 0 0 currentColor;
+			}
+
+			&:focus:not(:disabled) {
+				box-shadow: inset 0 0 0 1px var(--wp-components-color-background, #fff), 0 0 0 2px var(--wp-components-color-accent);
 			}
 		}
 	}

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -73,6 +73,16 @@
 	}
 }
 
+/* Crowdsignal */
+.signup.is-crowdsignal {
+	.components-button {
+		&.is-primary:not(.signup-form__crowdsignal-wpcom) {
+			--color-accent: var(--color-primary);
+			--color-accent-60: var(--color-primary-dark);
+		}
+	}
+}
+
 /* @wordpress/components ButtonGroup overrides */
 .components-button-group {
 	.components-button {

--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -54,16 +54,6 @@ form {
 			}
 		}
 	}
-
-	&.is-akismet {
-		.login,
-		.magic-login {
-			.components-button {
-				--color-accent: var(--color-akismet);
-				--color-accent-60: var(--color-akismet);
-			}
-		}
-	}
 }
 
 .is-jetpack .login__form-account-tip {

--- a/client/blocks/login/social.scss
+++ b/client/blocks/login/social.scss
@@ -121,13 +121,4 @@
 			padding: 24px;
 		}
 	}
-
-	/**
-	* Akismet Login
-	*/
-	@at-root .is-akismet & {
-		.auth-form__social-buttons .auth-form__social-buttons-container .social-buttons__button {
-			--color-accent: var(--color-akismet);
-		}
-	}
 }

--- a/client/blocks/login/stories/shared.tsx
+++ b/client/blocks/login/stories/shared.tsx
@@ -30,12 +30,8 @@ export const A4AWrapper = ( Story: StoryFn ) => (
 );
 
 export const AkismetWrapper = ( Story: StoryFn ) => (
-	<div className="layout is-white-login">
-		<div className="login is-akismet" style={ { maxWidth: '360px', padding: '30px' } }>
-			<div className="login__form">
-				<Story />
-			</div>
-		</div>
+	<div className="is-white-login is-akismet">
+		<Story />
 	</div>
 );
 

--- a/client/blocks/login/stories/submit-button/akismet.stories.tsx
+++ b/client/blocks/login/stories/submit-button/akismet.stories.tsx
@@ -4,6 +4,7 @@ import {
 	LoginFormAction,
 	type SubmitButtonStory,
 	AkismetWrapper,
+	LoginFormWrapper,
 } from '../shared';
 import type { Meta } from '@storybook/react';
 
@@ -16,5 +17,5 @@ const meta: Meta = {
 export default meta;
 
 export const Akismet: SubmitButtonStory = {
-	decorators: [ LoginFormAction, AkismetWrapper ],
+	decorators: [ LoginFormAction, LoginFormWrapper, AkismetWrapper ],
 };

--- a/client/blocks/signup-form/crowdsignal.scss
+++ b/client/blocks/signup-form/crowdsignal.scss
@@ -44,15 +44,6 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	}
 }
 
-.signup.is-crowdsignal {
-	.components-button {
-		&.is-primary:not(.signup-form__crowdsignal-wpcom) {
-			--color-accent: var(--color-primary);
-			--color-accent-60: var(--color-primary-dark);
-		}
-	}
-}
-
 .signup-form__crowdsignal-layout {
 	display: flex;
 	flex-direction: column;

--- a/client/blocks/signup-form/stories/shared.tsx
+++ b/client/blocks/signup-form/stories/shared.tsx
@@ -36,9 +36,11 @@ export const BlazeWrapper = ( Story: StoryFn ) => (
 
 export const CrowdsignalWrapper = ( Story: StoryFn ) => (
 	<div className="crowdsignal">
-		<div className="signup-form__crowdsignal" style={ { maxWidth: '360px', padding: '30px' } }>
-			<div className="card logged-out-form__footer">
-				<Story />
+		<div className="signup is-crowdsignal">
+			<div className="signup-form__crowdsignal" style={ { maxWidth: '360px', padding: '30px' } }>
+				<div className="card logged-out-form__footer">
+					<Story />
+				</div>
 			</div>
 		</div>
 	</div>

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -370,16 +370,6 @@ body.is-section-accept-invite {
 
 }
 
-/**
-* Akismet Signup
-*/
-.is-akismet .signup-form {
-	.components-button {
-		--color-accent: var(--color-akismet);
-		--color-accent-60: var(--color-akismet);
-	}
-}
-
 .is-woo-passwordless .signup-form .auth-form__separator {
 	margin: 32px 0;
 }

--- a/client/layout/masterbar/blaze-pro.scss
+++ b/client/layout/masterbar/blaze-pro.scss
@@ -49,10 +49,9 @@ body.is-section-signup {
 	--color-white: #fff;
 	--color-black: $colorBlack;
 	--color-gray: #50575e;
-	--color-orange: #ff6433;
 
-	--color-link: var(--color-orange);
-	--color-link-dark: var(--color-orange);
+	--color-link: var(--color-blaze-pro);
+	--color-link-dark: var(--color-blaze-pro);
 
 	background: var(--color-white);
 	min-height: 100%;
@@ -60,9 +59,6 @@ body.is-section-signup {
 	$login-form-max-width: 327px;
 
 	.components-button {
-		--color-accent: var(--color-orange);
-		--color-accent-60: var(--color-orange);
-
 		font-weight: 600;
 	}
 
@@ -490,8 +486,8 @@ body.is-section-signup {
 		.login .button.is-primary,
 		.login .button.is-primary:hover,
 		.form-button {
-			background: var(--color-orange);
-			border-color: var(--color-orange);
+			background: var(--color-blaze-pro);
+			border-color: var(--color-blaze-pro);
 			color: var(--color-white);
 			font-size: rem(13px);
 			font-weight: 600;

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -661,11 +661,6 @@
 		}
 	}
 
-	.components-button {
-		--color-accent: var(--studio-jetpack-green-40);
-		--color-accent-60: var(--studio-jetpack-green-30);
-	}
-
 	.login__form-change-username,
 	.wp-login__links button {
 		color: var(--studio-jetpack-green-40);

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -734,11 +734,6 @@
 		}
 	}
 
-	.components-button {
-		--color-accent: var(--color-primary-40);
-		--color-accent-60: var(--color-primary-60);
-	}
-
 	.login__form-change-username,
 	.wp-login__links button {
 		color: var(--color-primary-40);

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1291,38 +1291,6 @@ $breakpoint-mobile: 660px;
 			}
 		}
 
-		.components-button {
-			&.is-primary,
-			&.social-buttons__button {
-				border-radius: 8px; /* stylelint-disable-line scales/radii */
-				font-size: 1rem;
-				font-weight: 500;
-				height: 48px;
-			}
-
-			&.social-buttons__button {
-				&:focus:not(:disabled) {
-					box-shadow: inset 0 0 0 1px var(--wp-components-color-background, #fff), 0 0 0 2px var(--wp-components-color-accent);
-				}
-			}
-
-			&.is-primary {
-				&:focus:not(:disabled) {
-					box-shadow: 0 0 0 2px var(--wp-components-color-accent);
-				}
-
-				&:disabled {
-					--color-accent: var(--studio-gray-5);
-
-					color: var(--studio-gray-50);
-				}
-
-				.components-spinner {
-					margin-top: 0;
-				}
-			}
-		}
-
 		input[type="text"].form-text-input,
 		input[type="email"].form-text-input,
 		input[type="password"].form-text-input,

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1556,10 +1556,6 @@ $breakpoint-mobile: 660px;
 				.social-buttons__button {
 					padding: 8px 16px;
 
-					&:not(:focus) {
-						box-shadow: inset 0 0 0 2px $gray-300, 0 0 0 currentColor;
-					}
-
 					> span {
 						color: var(--studio-gray-100);
 						font-family: $woo-inter-font;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1292,19 +1292,12 @@ $breakpoint-mobile: 660px;
 		}
 
 		.components-button {
-			--color-accent: var(--woo-purple-40);
-			--color-accent-60: var(--woo-purple-60);
-
 			&.is-primary,
 			&.social-buttons__button {
 				border-radius: 8px; /* stylelint-disable-line scales/radii */
 				font-size: 1rem;
 				font-weight: 500;
 				height: 48px;
-
-				&:focus:not(:disabled) {
-					--color-accent: var(--woo-purple-60);
-				}
 			}
 
 			&.social-buttons__button {

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -19,7 +19,7 @@ $image-height: 47px;
 		padding-bottom: $image-height;
 		min-height: calc(100% - #{$image-height});
 	}
-	
+
 	.layout__content {
 		position: static;
 	}
@@ -592,11 +592,6 @@ $image-height: 47px;
 				background-color: darken(#2404eb, 10%);
 			}
 		}
-
-		.components-button {
-			--color-accent: var(--color-wp-job-manager);
-			--color-accent-60: color-mix(in srgb, var(--color-wp-job-manager), #000 10%);
-		}
 	}
 
 	.wp-login__main .locale-suggestions .locale-suggestions__notice.is-light {
@@ -804,11 +799,6 @@ $image-height: 47px;
 		padding: 0;
 		width: fit-content;
 		clip-path: unset;
-	}
-
-	.components-button {
-		--color-accent: var(--color-gravatar);
-		--color-accent-60: color-mix(in srgb, var(--color-gravatar), #000 13%);
 	}
 
 	.social-buttons__button {

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -154,11 +154,6 @@ $image-height: 47px;
 
 .layout.is-jetpack-login:not(.is-wccom-oauth-flow):not(.is-woocommerce-core-profiler-flow) {
 	@include jetpack-connect-colors();
-
-	.components-button {
-		--color-accent: var(--studio-jetpack-green-50);
-		--color-accent-60: var(--studio-jetpack-green-60);
-	}
 }
 
 .layout.is-wccom-oauth-flow,

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -153,6 +153,7 @@
 	--color-jetpack-onboarding-background: var(--studio-blue-100);
 	--color-akismet: #357b49;
 	--color-automattic: var(--studio-blue-40);
+	--color-blaze-pro: #ff6433;
 	--color-gravatar: #1d4fc4;
 	--color-jetpack: var(--studio-jetpack-green);
 	--color-simplenote: var(--studio-simplenote-blue);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DSGCOM-92: Update primary buttons on 'Continue as user'](https://linear.app/a8c/issue/DSGCOM-92/update-primary-buttons-on-continue-as-user)

## Proposed Changes

* Move all color overrides for branding of core buttons in login and signup to the central overrides file
* Add Blaze Pro orange to the central colors list so that it can be used in the overrides file
* Fix Akismet login button story and Crowdsignal signup button story, which had outdated wrappers

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

As the design system grows it's helpful to have all the overrides for branding in a central place, see [discussion](https://github.com/Automattic/wp-calypso/pull/103097#discussion_r2089778003).

## Testing

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This PR is a straight refactor apart from the Blaze Pro color variable creation, so it is largely a regression testing exercise.

### Storybook

We have stories for the [social buttons](http://localhost:6006/?path=/story/client-components-social-button-default--apple) and [login](http://localhost:6006/?path=/story/client-blocks-login-submit-button--default) and [signup](http://localhost:6006/?path=/story/client-blocks-signup-submit-button--default) buttons

Run `yarn storybook:start`

### Instructions

For each brand:
1. For each login link below, visit the page
2. Check the branding of the primary button, social buttons and the stepper nav top right link button if applicable
3. Check the same on the signup page
4. Check the same on the magic login page

Note that button replacements are still in progress for [Lost Password](https://github.com/Automattic/wp-calypso/pull/103517), [Accept Email Invite](https://github.com/Automattic/wp-calypso/pull/103448) and [2FA](https://github.com/Automattic/wp-calypso/pull/103536)

#### Login links

[WordPress.com](http://calypso.localhost:3000/log-in)
[Crowdsignal](http://calypso.localhost:3000/log-in?client_id=978&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3Df5da55616562ed1b1ef36c8e88328853efcc0167150831e59437c3330ec11509%26redirect_uri%3Dhttps%253A%252F%252Fapp.crowdsignal.com%252Fconnect%253Fsource%253Dlogin%2526action%253Drequest_access_token%26wpcom_connect%3D1%26from-calypso%3D1)
[Jetpack Cloud](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D69040%26redirect_uri%3Dhttps%253A%252F%252Fcloud.jetpack.com%252Fconnect%252Foauth%252Ftoken%253Fnext%253D%25252F%26scope%3Dglobal%26blog_id%3D0%26from-calypso%3D1&client_id=69040&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D69040%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%253Fresponse_type%253Dtoken%2526client_id%253D69040%2526redirect_uri%253Dhttps%25253A%25252F%25252Fcloud.jetpack.com%25252Fconnect%25252Foauth%25252Ftoken%25253Fnext%25253D%2525252F%2526scope%253Dglobal%2526blog_id%253D0%2526from-calypso%253D1)
[Jetpack Login](http://calypso.localhost:3000/log-in/jetpack)
[Woo](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Db30d4e6a81f72b803c873f517f4189601c46a1bc8b9bfdb9ed27cf3d17ad5601%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26from-calypso%3D1&client_id=50916&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D50916%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%252F%253Fresponse_type%253Dcode%2526client_id%253D50916%2526state%253Db30d4e6a81f72b803c873f517f4189601c46a1bc8b9bfdb9ed27cf3d17ad5601%2526redirect_uri%253Dhttps%25253A%25252F%25252Fwoocommerce.com%25252Fwc-api%25252Fwpcom-signin%25253Fnext%25253D%2525252F%2526blog_id%253D0%2526wpcom_connect%253D1%2526wccom-from%2526calypso_env%253Dproduction%2526from-calypso%253D1)
[Blaze Pro](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D99370%26state%3D0f0d1f16975b65cf8e9e924461b7c892f78eabeeb190dc03654cef0465786da0%26redirect_uri%3Dhttps%253A%252F%252Fblazepro.tumblr.com%252Fauth%252Fconnected%26blog_id%3D0%26wpcom_connect%3D1%26calypso_env%3Dproduction%26scope%3Dglobal%26from-calypso%3D1&client_id=99370&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D99370%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%253Fresponse_type%253Dcode%2526client_id%253D99370%2526state%253D0f0d1f16975b65cf8e9e924461b7c892f78eabeeb190dc03654cef0465786da0%2526redirect_uri%253Dhttps%25253A%25252F%25252Fblazepro.tumblr.com%25252Fauth%25252Fconnected%2526blog_id%253D0%2526wpcom_connect%253D1%2526calypso_env%253Dproduction%2526scope%253Dglobal%2526from-calypso%253D1)
[Akismet](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fr-login.wordpress.com%2Fremote-login.php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet.com%252Faccount%252F&signup_url=%2Fstart%2Faccount%2Fuser-social%3Fredirect_to%3Dhttps%253A%252F%252Fr-login.wordpress.com%252Fremote-login.php%253Faction%253Dlink%2526back%253Dhttps%25253A%25252F%25252Fakismet.com%25252Faccount%25252F)
A4A - Can't link due to GitHub OSS scan rules: go to automatt_c.com/for-agencies/ and click 'Log in'. Edit the URL and change the host to calypso.localhost:3000
[Gravatar](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D4a5153e30a28e2ef24ca7e599abd80f3969340cd1f88327c1f5d2fbc88593fa1%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1&client_id=1854)
[WP Job Manager](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fclient_id%3D90057%26response_type%3Dcode%26state%3DeyJyZWRpcmVjdF90byI6Imh0dHBzOlwvXC93cGpvYm1hbmFnZXIuY29tXC9teS1hY2NvdW50In0%26redirect_uri%3Dhttps%253A%252F%252Fwpjobmanager.com%252Fwp-json%252Fwpjmcom-auth%252Fv1%252Fcallback%26blog_id%3D0%26from-calypso%3D1&client_id=90057)
[VIP](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fstate%3Dd01a004590fc4017316cef309b1e213de0cf6c1fd4b68d3152d9f9acbf9c%26scope%3Dauth%26response_type%3Dcode%26approval_prompt%3Dauto%26redirect_uri%3Dhttps%253A%252F%252Fid.wpvip.com%252Fwp-json%252Foauth%252Fv1%252Fcallback%252Fwpcom%26client_id%3D76596%26from-calypso%3D1&client_id=76596&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D76596%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%253Fstate%253Dd01a004590fc4017316cef309b1e213de0cf6c1fd4b68d3152d9f9acbf9c%2526scope%253Dauth%2526response_type%253Dcode%2526approval_prompt%253Dauto%2526redirect_uri%253Dhttps%25253A%25252F%25252Fid.wpvip.com%25252Fwp-json%25252Foauth%25252Fv1%25252Fcallback%25252Fwpcom%2526client_id%253D76596%2526from-calypso%253D1)
Partner Portal - Can't link due to GitHub OSS scan rules: go to hosts.automatt_c.com and you should be redirected to log in. Edit the URL and change the host to calypso.localhost:3000
WP.Cloud - Can't link due to GitHub OSS scan rules: go to [wp.cloud](https://wp.cloud/) and click 'start here'. Edit the URL and change the host to calypso.localhost:3000

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
