### PR TITLE
Backup: clarify saved backups estimation in storage usage tooltip

### DIFF
--- a/client/components/backup-storage-space/storage-usage-help-popover.tsx
+++ b/client/components/backup-storage-space/storage-usage-help-popover.tsx
@@ -51,7 +51,7 @@ const StorageHelpPopover: React.FC< OwnProps > = ( {
 				<h3> { translate( 'Backup archive size' ) }</h3>
 				<p>
 					{ translate(
-						'Based on the current size of your site, Jetpack will save up to {{strong}}%(forecastInDays)d day of full backup{{/strong}}.',
+						'Based on the current size of your site, Jetpack will save up to {{strong}}%(forecastInDays)d full backup{{/strong}}.',
 						'Based on the current size of your site, Jetpack will save up to {{strong}}%(forecastInDays)d days of full backups{{/strong}}.',
 						{
 							components: { strong: <strong /> },

--- a/client/components/backup-storage-space/storage-usage-help-popover.tsx
+++ b/client/components/backup-storage-space/storage-usage-help-popover.tsx
@@ -51,8 +51,8 @@ const StorageHelpPopover: React.FC< OwnProps > = ( {
 				<h3> { translate( 'Backup archive size' ) }</h3>
 				<p>
 					{ translate(
-						'Based on the current size of your site, Jetpack will save {{strong}}%(forecastInDays)d day of full backup{{/strong}}.',
-						'Based on the current size of your site, Jetpack will save {{strong}}%(forecastInDays)d days of full backups{{/strong}}.',
+						'Based on the current size of your site, Jetpack will save up to {{strong}}%(forecastInDays)d day of full backup{{/strong}}.',
+						'Based on the current size of your site, Jetpack will save up to {{strong}}%(forecastInDays)d days of full backups{{/strong}}.',
 						{
 							components: { strong: <strong /> },
 							count: forecastInDays,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of BACKUP-136

## Proposed Changes

* Small copy change to clarify saved backups estimation in storage usage tooltip

| Before | After (note the "save up to") |
|---|---|
| ![CleanShot 2025-05-21 at 21 16 12@2x](https://github.com/user-attachments/assets/ccd50f15-5d24-46c7-9d1f-9fbfdc62b22d) | ![CleanShot 2025-05-21 at 21 16 56@2x](https://github.com/user-attachments/assets/0b7ebf7f-d089-4c77-b10e-aae1b11bc77e) |
## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

It is easy to confuse the number of backups already saved with the number that can still be saved. So we are updating the text to clarify that the latter is only an approximation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Given this is small copy change, you can just proofread the changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
