### PR TITLE
DataViews: Add `className` prop to `DataViews.Layout` component

### DIFF
--- a/packages/dataviews/.storybook/style.scss
+++ b/packages/dataviews/.storybook/style.scss
@@ -5,6 +5,7 @@
 @import "@wordpress/base-styles/variables";
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/z-index";
 @import "@wordpress/components/build-style/style";
 
 @import "../src/style.scss";

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -14,6 +14,7 @@
 - Add new filter operators: `lessThan`, `greaterThan`, `lessThanOrEqual`, and `greaterThanOrEqual` for numeric and comparable fields.
 - Add new filter operators: `contains`, `notContains`, `startsWith` for text fields.
 - Add `email` type to the fields of the form.
+- Add `className` prop to the `DataViews.Layout` component to allow customizing the layout styles.
 
 ## 0.1.1
 

--- a/packages/dataviews/src/components/dataviews-layout/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layout/index.tsx
@@ -15,7 +15,11 @@ import DataViewsContext from '../dataviews-context';
 import { VIEW_LAYOUTS } from '../../dataviews-layouts';
 import type { ViewBaseProps } from '../../types';
 
-export default function DataViewsLayout() {
+type DataViewsLayoutProps = {
+	className?: string;
+};
+
+export default function DataViewsLayout( { className }: DataViewsLayoutProps ) {
 	const {
 		actions = [],
 		data,
@@ -38,6 +42,7 @@ export default function DataViewsLayout() {
 
 	return (
 		<ViewComponent
+			className={ className }
 			actions={ actions }
 			data={ data }
 			fields={ fields }

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -140,18 +140,15 @@ function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
 
 	return (
 		<>
+			<Heading className="free-composition-heading" level={ 2 }>
+				{ __( 'Solar System numbers' ) }
+			</Heading>
 			<Grid
 				templateColumns="repeat(auto-fit, minmax(330px, 1fr))"
 				align="flex-start"
 				className="free-composition-header"
 			>
 				<Card variant="secondary">
-					<CardHeader>
-						<Heading level={ 2 }>
-							{ __( 'Solar System numbers' ) }
-						</Heading>
-					</CardHeader>
-
 					<CardBody>
 						<VStack>
 							<Text size={ 18 } as="p">
@@ -206,7 +203,7 @@ function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
 				</VStack>
 			</Grid>
 
-			<DataViews.Layout />
+			<DataViews.Layout className="free-composition-dataviews-layout" />
 		</>
 	);
 }
@@ -243,20 +240,22 @@ export const FreeComposition = () => {
 	);
 
 	return (
-		<DataViews
-			getItemId={ ( item ) => item.id.toString() }
-			paginationInfo={ paginationInfo }
-			data={ processedData }
-			view={ view }
-			fields={ fields }
-			actions={ actions }
-			onChangeView={ setView }
-			defaultLayouts={ {
-				table: {},
-				grid: {},
-			} }
-		>
-			<PlanetOverview planets={ planets } />
-		</DataViews>
+		<div className="free-composition">
+			<DataViews
+				getItemId={ ( item ) => item.id.toString() }
+				paginationInfo={ paginationInfo }
+				data={ processedData }
+				view={ view }
+				fields={ fields }
+				actions={ actions }
+				onChangeView={ setView }
+				defaultLayouts={ {
+					table: {},
+					grid: {},
+				} }
+			>
+				<PlanetOverview planets={ planets } />
+			</DataViews>
+		</div>
 	);
 };

--- a/packages/dataviews/src/components/dataviews/stories/style.css
+++ b/packages/dataviews/src/components/dataviews/stories/style.css
@@ -3,6 +3,23 @@
     text-wrap: pretty;
 }
 
+.free-composition {
+	height: 600px;
+	overflow: auto;
+}
+
+.free-composition-heading,
 .free-composition-header {
     padding: 16px 48px;
+}
+
+.free-composition-heading {
+	position: sticky;
+	top: 0;
+	z-index: 2;
+	background-color: white;
+}
+
+.free-composition-dataviews-layout thead {
+	inset-block-start: 67px;
 }

--- a/packages/dataviews/src/components/dataviews/stories/style.css
+++ b/packages/dataviews/src/components/dataviews/stories/style.css
@@ -17,7 +17,7 @@
 	position: sticky;
 	top: 0;
 	z-index: 2;
-	background-color: white;
+	background-color: #fff;
 }
 
 .free-composition-dataviews-layout thead {

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -253,6 +253,7 @@ function ViewGrid< Item >( {
 	renderItemLink,
 	selection,
 	view,
+	className,
 }: ViewGridProps< Item > ) {
 	const titleField = fields.find(
 		( field ) => field.id === view?.titleField
@@ -299,7 +300,7 @@ function ViewGrid< Item >( {
 					gap={ 8 }
 					columns={ 2 }
 					alignment="top"
-					className="dataviews-view-grid"
+					className={ clsx( 'dataviews-view-grid', className ) }
 					style={ gridStyle }
 					aria-busy={ isLoading }
 				>

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -353,6 +353,7 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 		onChangeSelection,
 		selection,
 		view,
+		className,
 	} = props;
 	const baseId = useInstanceId( ViewList, 'view-list' );
 
@@ -497,7 +498,7 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 		<Composite
 			id={ baseId }
 			render={ <div /> }
-			className="dataviews-view-list"
+			className={ clsx( 'dataviews-view-list', className ) }
 			role="grid"
 			activeId={ activeCompositeId }
 			setActiveId={ setActiveCompositeId }

--- a/packages/dataviews/src/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/index.tsx
@@ -240,6 +240,7 @@ function ViewTable< Item >( {
 	isItemClickable,
 	renderItemLink,
 	view,
+	className,
 }: ViewTableProps< Item > ) {
 	const { containerRef } = useContext( DataViewsContext );
 	const headerMenuRefs = useRef<
@@ -310,7 +311,7 @@ function ViewTable< Item >( {
 	return (
 		<>
 			<table
-				className={ clsx( 'dataviews-view-table', {
+				className={ clsx( 'dataviews-view-table', className, {
 					[ `has-${ view.layout?.density }-density` ]:
 						view.layout?.density &&
 						[ 'compact', 'comfortable' ].includes(

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -529,6 +529,7 @@ export interface ActionButton< Item > extends ActionBase< Item > {
 export type Action< Item > = ActionModal< Item > | ActionButton< Item >;
 
 export interface ViewBaseProps< Item > {
+	className?: string;
 	actions: Action< Item >[];
 	data: Item[];
 	fields: NormalizedField< Item >[];


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes WOOA7S-120

## Proposed Changes

p1747388646905689-slack-C05QAFZSFTL
  
This PR adds a `className` prop to the `DataViews.Layout` component, allowing customers to customize the dataview layout styles. This way, we limit the usage to DataViews free composition.

Initially, I considered adding a prop specifically for the table layout. However, since the `DataViews.Layout` component is utilized across all layouts, it seems more appropriate to implement a general `className` prop, which is more flexible and compatible with all layouts.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We recently tackled an issue in which the DataViews table header is covered by a sticky page header when filters are shown (see PR woocommerce/woocommerce-analytics#921). The issue was because two sticky elements were interfering with each other: the page header and the table header when they both under the same parent element.

We’re relying on internal classnames from DataViews (.dataviews-view-table thead) to apply a workaround via inset-block-start. With this PR, we can add a custom class to the DataViews layout and ensure that the styles are applied correctly without relying on internal classnames.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Run `yarn dataviews:storybook:start`
* Go to `http://localhost:57863/?path=/story/dataviews-dataviews--free-composition`
* Scroll down and see that both the page header and the table header are sticky and don't overlap.

<img width="1066" alt="Screenshot 2025-05-22 at 14 11 32" src="https://github.com/user-attachments/assets/9191de09-9086-475d-81dc-09a5933ee35e" />


https://github.com/user-attachments/assets/d01bd2aa-0865-45c4-b607-00535fe077e6

The demo set the offset to a magic number, but for our actual implementation, we calculated the offset based on the page header height dynamically.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?