### PR TITLE
Dashboard v2: cache site queries after sites fetch

### DIFF
--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -24,7 +24,13 @@ import type { Query } from '@tanstack/react-query';
 export function sitesQuery() {
 	return {
 		queryKey: [ 'sites', SITE_FIELDS ],
-		queryFn: fetchSites,
+		queryFn: async () => {
+			const sites = await fetchSites();
+			for ( const site of sites ) {
+				queryClient.setQueryData( [ 'site', site.slug, SITE_FIELDS ], site );
+			}
+			return sites;
+		},
 	};
 }
 

--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -18,7 +18,7 @@ import {
 } from '../data';
 import { SITE_FIELDS } from '../data/constants';
 import { queryClient } from './query-client';
-import type { Profile, SiteSettings, UrlPerformanceInsights } from '../data/types';
+import type { Profile, SiteSettings, UrlPerformanceInsights, Site } from '../data/types';
 import type { Query } from '@tanstack/react-query';
 
 export function sitesQuery() {
@@ -27,7 +27,13 @@ export function sitesQuery() {
 		queryFn: async () => {
 			const sites = await fetchSites();
 			for ( const site of sites ) {
-				queryClient.setQueryData( [ 'site', site.slug, SITE_FIELDS ], site );
+				queryClient.setQueryData(
+					[ 'site', site.slug, SITE_FIELDS ],
+					// Only set if the cache is empty. There's a possibility
+					// data from the /sites endpoint is slightly stale, so
+					// individual queries should take priority.
+					( current: Site | undefined ) => current ?? site
+				);
 			}
 			return sites;
 		},


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* When sites load from the `/sites` endpoint, there's an opportunity to cache all the individual requests as well.
* Please note that every single page navigation refetches the resources, the cache is only used to allow fast navigation.
* A con: for people with a lot of sites, the cache could be big.
* A pro: the site request is usually quite long, upwards of a second, and blocks page navigation when there is no cache yet:

<img width="1352" alt="Screenshot 2025-05-21 at 20 09 44" src="https://github.com/user-attachments/assets/100bb095-2f3d-4916-9d9d-7c29461e2662" />
<img width="1352" alt="Screenshot 2025-05-21 at 20 07 16" src="https://github.com/user-attachments/assets/776b6437-79c5-4e94-950d-aa988d6c67ab" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Faster page navigation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Clear the react query cache. Record performance/network and visit a site overview.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
