### PR TITLE
Hosting Dashboard: Add Snackbar to the Site Settings backport

### DIFF
--- a/client/sites/settings/v2/index.tsx
+++ b/client/sites/settings/v2/index.tsx
@@ -4,7 +4,6 @@ import { useEffect, useRef } from 'react';
 import { createRoot } from 'react-dom/client';
 import { persistPromise, queryClient } from 'calypso/dashboard/app/query-client';
 import { getRouter } from './router';
-import './style.scss';
 
 export default function DashboardBackportSiteSettingsRenderer() {
 	const rootInstanceRef = useRef< ReturnType< typeof createRoot > | null >( null );

--- a/client/sites/settings/v2/root.tsx
+++ b/client/sites/settings/v2/root.tsx
@@ -1,25 +1,12 @@
 import { Outlet } from '@tanstack/react-router';
-import { Suspense, lazy } from 'react';
 import Snackbars from 'calypso/dashboard/app/snackbars';
 import './style.scss';
-
-const WebpackBuildMonitor = lazy(
-	() =>
-		import(
-			/* webpackChunkName: "async-webpack-build-monitor" */ 'calypso/components/webpack-build-monitor'
-		)
-);
 
 export default function Root() {
 	return (
 		<>
 			<Outlet />
 			<Snackbars />
-			{ 'development' === process.env.NODE_ENV && (
-				<Suspense fallback={ null }>
-					<WebpackBuildMonitor />
-				</Suspense>
-			) }
 		</>
 	);
 }

--- a/client/sites/settings/v2/root.tsx
+++ b/client/sites/settings/v2/root.tsx
@@ -1,0 +1,25 @@
+import { Outlet } from '@tanstack/react-router';
+import { Suspense, lazy } from 'react';
+import Snackbars from 'calypso/dashboard/app/snackbars';
+import './style.scss';
+
+const WebpackBuildMonitor = lazy(
+	() =>
+		import(
+			/* webpackChunkName: "async-webpack-build-monitor" */ 'calypso/components/webpack-build-monitor'
+		)
+);
+
+export default function Root() {
+	return (
+		<>
+			<Outlet />
+			<Snackbars />
+			{ 'development' === process.env.NODE_ENV && (
+				<Suspense fallback={ null }>
+					<WebpackBuildMonitor />
+				</Suspense>
+			) }
+		</>
+	);
+}

--- a/client/sites/settings/v2/router.tsx
+++ b/client/sites/settings/v2/router.tsx
@@ -10,8 +10,9 @@ import {
 } from '@tanstack/react-router';
 import { siteSettingsQuery } from 'calypso/dashboard/app/queries';
 import { queryClient } from 'calypso/dashboard/app/query-client';
+import Root from './root';
 
-const rootRoute = createRootRoute( { component: () => <Outlet /> } );
+const rootRoute = createRootRoute( { component: Root } );
 
 const dashboardSiteSettingsCompatibilityRouteRoot = createRoute( {
 	getParentRoute: () => rootRoute,
@@ -137,6 +138,7 @@ export const getRouter = () => {
 		defaultPreload: 'intent',
 		defaultPreloadStaleTime: 0,
 		defaultNotFoundComponent: () => null,
+		defaultViewTransition: true,
 
 		// Use memory history to compartmentalize TanStack Router's history management.
 		// This way, we separate TanStack Router's history implementation from the browser history used by page.js.

--- a/client/sites/settings/v2/style.scss
+++ b/client/sites/settings/v2/style.scss
@@ -1,19 +1,25 @@
 @import 'calypso/dashboard/app-dotcom/style.scss';
 
-.dashboard-backport-site-settings-root .dashboard-page-layout {
-	align-self: center;
-	margin: 0;
-	padding: 0;
+.dashboard-backport-site-settings-root {
+	.dashboard-page-layout {
+	    align-self: center;
+	    margin: 0;
+	    padding: 0;
 
-	h1 {
-		font-family: var( --dashboard-h1__font-family );
-		font-weight: var( --dashboard-h1__font-weight ) !important;
+	    h1 {
+	    	font-family: var( --dashboard-h1__font-family );
+	    	font-weight: var( --dashboard-h1__font-weight ) !important;
+	    }
+
+	    h2 {
+	    	font-size: 1.25rem;
+	    	font-weight: 500;
+	    	line-height: 1.5;
+	    	margin-bottom: 0;
+		}
 	}
 
-	h2 {
-		font-size: 1.25rem;
-		font-weight: 500;
-		line-height: 1.5;
-		margin-bottom: 0;
+	.site-preview-pane:has( & .dashboard-snackbars ) {
+		z-index: 176;
 	}
 }


### PR DESCRIPTION
## Proposed Changes

This PR implements the Snackbar to the Site Settings backport as feature parity.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Backport.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /sites/settings/v2/:siteSlug
* Click on the "Restore" button from the "Re-install plugins & themes" section.
* Ensure you see the snackbar.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
