### PR TITLE
Dashboard v2: performance: only fetch needed site options

### DIFF
--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -16,21 +16,21 @@ import {
 	updateSiteSettings,
 	restoreSitePlanSoftware,
 } from '../data';
-import { SITE_FIELDS } from '../data/constants';
+import { SITE_FIELDS, SITE_OPTIONS } from '../data/constants';
 import { queryClient } from './query-client';
 import type { Profile, SiteSettings, UrlPerformanceInsights } from '../data/types';
 import type { Query } from '@tanstack/react-query';
 
 export function sitesQuery() {
 	return {
-		queryKey: [ 'sites', SITE_FIELDS ],
+		queryKey: [ 'sites', SITE_FIELDS, SITE_OPTIONS ],
 		queryFn: fetchSites,
 	};
 }
 
 export function siteQuery( siteIdOrSlug: string ) {
 	return {
-		queryKey: [ 'site', siteIdOrSlug, SITE_FIELDS ],
+		queryKey: [ 'site', siteIdOrSlug, SITE_FIELDS, SITE_OPTIONS ],
 		queryFn: () => fetchSite( siteIdOrSlug ),
 	};
 }

--- a/client/dashboard/data/constants.ts
+++ b/client/dashboard/data/constants.ts
@@ -24,3 +24,5 @@ export const SITE_FIELDS = [
 	'jetpack',
 	'jetpack_modules',
 ];
+
+export const SITE_OPTIONS = [ 'admin_url', 'software_version', 'is_redirect' ];

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -1,5 +1,5 @@
 import wpcom from 'calypso/lib/wp';
-import { SITE_FIELDS } from './constants';
+import { SITE_FIELDS, SITE_OPTIONS } from './constants';
 import type {
 	Domain,
 	Email,
@@ -31,6 +31,7 @@ export const updateProfile = async ( data: Partial< Profile > ) => {
 };
 
 const JOINED_SITE_FIELDS = SITE_FIELDS.join( ',' );
+const JOINED_SITE_OPTIONS = SITE_OPTIONS.join( ',' );
 
 export const fetchSites = async (): Promise< Site[] > => {
 	const { sites } = await wpcom.req.get(
@@ -43,6 +44,7 @@ export const fetchSites = async (): Promise< Site[] > => {
 			include_domain_only: 'true',
 			site_activity: 'active',
 			fields: JOINED_SITE_FIELDS,
+			options: JOINED_SITE_OPTIONS,
 		}
 	);
 	return sites;
@@ -51,7 +53,7 @@ export const fetchSites = async (): Promise< Site[] > => {
 export const fetchSite = async ( siteIdOrSlug: string ): Promise< Site > => {
 	return await wpcom.req.get(
 		{ path: `/sites/${ siteIdOrSlug }` },
-		{ fields: JOINED_SITE_FIELDS }
+		{ fields: JOINED_SITE_FIELDS, options: JOINED_SITE_OPTIONS }
 	);
 };
 

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -67,7 +67,6 @@ export interface SiteCapabilities {
 export interface SiteOptions {
 	software_version: string;
 	admin_url: string;
-	blog_public: number;
 	is_redirect?: boolean;
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->


## Proposed Changes

* Fetching `/sites` went from ~3s on average to ~2s on average.
* We're currently fetching _all_ the site options. That's a ton of stuff. Not just makes this the request longer, but increases the bytes transferred and the bytes to stored in query cache (from 55kb to 24kb).
* Let's only fetch the option we need in our UI.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check the network tab for the `/sites` and `/sites/id` requests.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
