### PR TITLE
Dashboard v2: remove active_modules & Protect field

### DIFF
--- a/client/dashboard/data/constants.ts
+++ b/client/dashboard/data/constants.ts
@@ -11,7 +11,6 @@ export const SITE_FIELDS = [
 	'icon',
 	'subscribers_count',
 	'plan',
-	'active_modules',
 	'capabilities',
 	'is_a8c',
 	'is_deleted',

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -80,7 +80,6 @@ export interface Site {
 		ico: string;
 	};
 	plan?: SitePlan;
-	active_modules?: string[];
 	capabilities: SiteCapabilities;
 	subscribers_count: number;
 	// Can be undefined for deleted sites.
@@ -95,7 +94,7 @@ export interface Site {
 		migration_status: string;
 	} | null;
 	jetpack: boolean;
-	jetpack_modules: string[];
+	jetpack_modules: string[] | null;
 }
 
 export type EmailProvider = 'titan' | 'google-workspace' | 'forwarding';

--- a/client/dashboard/docs/data-library.md
+++ b/client/dashboard/docs/data-library.md
@@ -40,7 +40,7 @@ export const fetchSite = async ( id: string ): Promise< Site > => {
 		return Promise.reject( new Error( 'Site ID is undefined' ) );
 	}
 	return await wpcom.req.get( {
-		path: `/sites/${ id }?fields=ID,URL,name,icon,subscribers_count,plan,active_modules,options`,
+		path: `/sites/${ id }?fields=ID,URL,name,icon,subscribers_count,plan,options`,
 	} );
 };
 ```

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -75,21 +75,6 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		},
 	},
 	{
-		id: 'protect',
-		type: 'boolean',
-		label: __( 'Protect' ),
-		getValue: ( { item }: { item: Site } ) => !! item.active_modules?.includes( 'protect' ),
-		render: ( { item }: { item: Site } ) =>
-			item.active_modules?.includes( 'protect' ) ? <Icon icon={ check } /> : __( 'Disabled' ),
-		elements: [
-			{ value: true, label: __( 'Enabled' ) },
-			{ value: false, label: __( 'Disabled' ) },
-		],
-		filterBy: {
-			operators: [ 'is' as Operator ],
-		},
-	},
-	{
 		id: 'status',
 		label: __( 'Status' ),
 		getValue: ( { item }: { item: Site } ) => getSiteStatus( item ),

--- a/client/dashboard/sites/overview/uptime-card.tsx
+++ b/client/dashboard/sites/overview/uptime-card.tsx
@@ -50,7 +50,7 @@ function UptimeCardEnabled( { siteSlug }: { siteSlug: string } ) {
 }
 
 export default function UptimeCard( { site }: { site: Site } ) {
-	return site.jetpack && site.jetpack_modules.includes( 'monitor' ) ? (
+	return site.jetpack_modules?.includes( 'monitor' ) ? (
 		<UptimeCardEnabled siteSlug={ site.slug } />
 	) : null /* Opportunity for upsell? */;
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

I don't know where this comes from, maybe it was dummy content? But `active_modules` is not a real field:

https://github.com/Automattic/jetpack/blob/e32e5c9427a92654bb1fe2ddb2488eb4caddd6a1/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php#L44-L91

Additionally, `jetpack_modules` can be null, so I adjusted the type.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
