### PR TITLE
Reader - Remove primary level back buttons.

### DIFF
--- a/client/reader/discover/components/header-and-navigation/index.tsx
+++ b/client/reader/discover/components/header-and-navigation/index.tsx
@@ -4,7 +4,6 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { addQueryArgs } from 'calypso/lib/url';
-import ReaderBackButton from 'calypso/reader/components/back-button';
 import DiscoverNavigation from 'calypso/reader/discover/components/navigation';
 import DiscoverTagsNavigation from 'calypso/reader/discover/components/tags-navigation';
 import { getSelectedTabTitle, FIRST_POSTS_TAB, ADD_NEW_TAB, REDDIT_TAB } from '../../helper';
@@ -51,7 +50,6 @@ export default function DiscoverHeaderAndNavigation(
 
 	return (
 		<>
-			<ReaderBackButton />
 			<NavigationHeader
 				title={ translate( 'Discover' ) }
 				subtitle={ subHeaderText }

--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -57,7 +57,6 @@ const DiscoverStream = ( props ) => {
 		<Stream
 			{ ...props }
 			streamKey={ buildDiscoverStreamKey( effectiveTabSelection, recommendedStreamTags ) }
-			showBack={ false } // We will instead add this through the header section, since not all discover tabs have a stream to render the back button
 			sidebarTabTitle={
 				selectedTab === DEFAULT_TAB ? translate( 'Sites' ) : translate( 'Related' )
 			}

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -15,7 +15,6 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import SearchInput from 'calypso/components/search';
 import { addQueryArgs } from 'calypso/lib/url';
 import withDimensions from 'calypso/lib/with-dimensions';
-import ReaderBackButton from 'calypso/reader/components/back-button';
 import BlankSuggestions from 'calypso/reader/components/reader-blank-suggestions';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { READER_SEARCH_POPULAR_SITES } from 'calypso/reader/follow-sources';
@@ -173,7 +172,6 @@ class SearchStream extends React.Component {
 		return (
 			<div>
 				<DocumentHead title={ documentTitle } />
-				<ReaderBackButton />
 				<NavigationHeader
 					title={ translate( 'Search' ) }
 					subtitle={ translate( 'Search for specific topics, authors, or blogs.' ) }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -17,7 +17,6 @@ import NavTabs from 'calypso/components/section-nav/tabs';
 import { Interval, EVERY_MINUTE } from 'calypso/lib/interval';
 import scrollTo from 'calypso/lib/scroll-to';
 import withDimensions from 'calypso/lib/with-dimensions';
-import ReaderBackButton from 'calypso/reader/components/back-button';
 import { isEditorIframeFocused } from 'calypso/reader/components/quick-post/utils';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { shouldShowLikes } from 'calypso/reader/like-helper';
@@ -82,7 +81,6 @@ class ReaderStream extends Component {
 		showDefaultEmptyContentIfMissing: PropTypes.bool,
 		showFollowButton: PropTypes.bool,
 		showFollowInHeader: PropTypes.bool,
-		showBack: PropTypes.bool,
 		sidebarTabTitle: PropTypes.string,
 		streamHeader: PropTypes.func,
 		streamSidebar: PropTypes.func,
@@ -105,7 +103,6 @@ class ReaderStream extends Component {
 		showDefaultEmptyContentIfMissing: true,
 		showFollowButton: true,
 		showFollowInHeader: false,
-		showBack: true,
 		suppressSiteNameLink: false,
 		useCompactCards: false,
 		isLoggedIn: false,
@@ -754,7 +751,6 @@ class ReaderStream extends Component {
 				<div ref={ this.overlayRef } className="stream__init-overlay" />
 				{ shouldPoll && <Interval onTick={ this.poll } period={ EVERY_MINUTE } /> }
 				<UpdateNotice streamKey={ streamKey } onClick={ this.showUpdates } />
-				{ this.props.showBack && <ReaderBackButton /> }
 				{ this.props.children }
 				{ showingStream && items.length ? this.props.intro?.() : null }
 				{ body }

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -7,7 +7,6 @@ import titleCase from 'to-title-case';
 import QueryReaderFollowedTags from 'calypso/components/data/query-reader-followed-tags';
 import QueryReaderTag from 'calypso/components/data/query-reader-tag';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
-import ReaderBackButton from 'calypso/reader/components/back-button';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import Stream from 'calypso/reader/stream';
@@ -119,7 +118,6 @@ class TagStream extends Component {
 				<ReaderMain className="tag-stream__main">
 					<QueryReaderFollowedTags />
 					<QueryReaderTag tag={ this.props.decodedTagSlug } />
-					<ReaderBackButton />
 					<TagStreamHeader
 						title={ titleText }
 						encodedTagSlug={ encodedTagSlug }

--- a/client/reader/tags/main.tsx
+++ b/client/reader/tags/main.tsx
@@ -1,6 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
 import NavigationHeader from 'calypso/components/navigation-header';
-import ReaderBackButton from 'calypso/reader/components/back-button';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -20,7 +19,6 @@ export default function TagsPage( { trendingTags, alphabeticTags }: Props ) {
 
 	return (
 		<ReaderMain className="tags__main">
-			<ReaderBackButton />
 			{ isLoggedIn && (
 				<NavigationHeader
 					title={ translate( 'All the Tags' ) }

--- a/client/reader/user-profile/views/posts.tsx
+++ b/client/reader/user-profile/views/posts.tsx
@@ -17,7 +17,6 @@ const UserPosts = ( { user }: UserPostsProps ): JSX.Element => {
 			className="is-user-profile"
 			listName={ translate( 'User Posts' ) }
 			showFollowButton={ false }
-			showBack={ false }
 			showSiteNameOnCards
 			sidebarTabTitle={ translate( 'Related' ) }
 			useCompactCards

--- a/client/reader/user-profile/views/test/posts.tsx
+++ b/client/reader/user-profile/views/test/posts.tsx
@@ -19,7 +19,6 @@ jest.mock(
 			showSiteNameOnCards,
 			sidebarTabTitle,
 			useCompactCards,
-			showBack,
 		} ) => (
 			<div data-testid="reader-stream" data-stream-key={ streamKey } className={ className }>
 				<div data-testid="stream-props">
@@ -27,7 +26,6 @@ jest.mock(
 					<span data-prop="showSiteNameOnCards">{ String( showSiteNameOnCards ) }</span>
 					<span data-prop="sidebarTabTitle">{ sidebarTabTitle }</span>
 					<span data-prop="useCompactCards">{ String( useCompactCards ) }</span>
-					<span data-prop="showBack">{ String( showBack ) }</span>
 				</div>
 				{ emptyContent && <div data-testid="empty-content">{ emptyContent() }</div> }
 			</div>
@@ -77,7 +75,6 @@ describe( 'UserPosts', () => {
 		expect( propsContainer.querySelector( '[data-prop="useCompactCards"]' ) ).toHaveTextContent(
 			'true'
 		);
-		expect( propsContainer.querySelector( '[data-prop="showBack"]' ) ).toHaveTextContent( 'false' );
 	} );
 
 	test( 'should provide empty content function that renders correctly', () => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/CML-496/remove-primary-page-back-links / https://github.com/Automattic/loop/issues/698

## Proposed Changes

Removes the ReaderBackButton from everywhere in the reader except full post pages and user profiles, as these are the main nested levels a user may generally go into and back from while viewing a stream. Back buttons at stream levels have been noted as a bit overkill.
* Removes ReaderBackButton component from the main stream component, search, discover, tags, tag, etc.
* Removes unnecessary showBack prop on the stream component that was default to true, allowing us to also remove places we passed that prop as false.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Too much clutter for unnecessary back buttons. Definitely unnecessary at top levels like these, it could even be considered unnecessary for most other nested levels due to the browser back button doing the same thing but we will remove a small bit at a time.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the reader.
* Click from stream to stream, serach, discover, etc. etc.
* Verify there are no back buttons except in full post view and user profile pages.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
