### PR TITLE
Dashboard v2: switcher: use RouterLinkMenuItem

### DIFF
--- a/client/dashboard/sites/site/switcher.tsx
+++ b/client/dashboard/sites/site/switcher.tsx
@@ -1,11 +1,11 @@
 import { filterSortAndPaginate } from '@automattic/dataviews';
 import { useQuery } from '@tanstack/react-query';
-import { useNavigate } from '@tanstack/react-router';
 import { MenuGroup, MenuItem, SearchControl, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import { useState } from 'react';
 import { sitesQuery } from '../../app/queries';
+import RouterLinkMenuItem from '../../components/router-link-menu-item';
 import SiteIcon from '../site-icon';
 import type { View } from '@automattic/dataviews';
 
@@ -19,7 +19,6 @@ const DEFAULT_VIEW: View = {
 };
 
 export default function Switcher( { onClose }: { onClose: () => void } ) {
-	const navigate = useNavigate();
 	const sites = useQuery( sitesQuery() ).data;
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
 
@@ -41,13 +40,7 @@ export default function Switcher( { onClose }: { onClose: () => void } ) {
 			</MenuGroup>
 			<MenuGroup>
 				{ filteredData.map( ( site ) => (
-					<MenuItem
-						key={ site.ID }
-						onClick={ async () => {
-							await navigate( { to: `/sites/${ site.slug }` } );
-							onClose();
-						} }
-					>
+					<RouterLinkMenuItem key={ site.ID } to={ `/sites/${ site.slug }` } onClick={ onClose }>
 						<div style={ { display: 'flex', gap: '8px', alignItems: 'center', width: '100%' } }>
 							<SiteIcon site={ site } size={ 24 } />
 							<span
@@ -56,7 +49,7 @@ export default function Switcher( { onClose }: { onClose: () => void } ) {
 								{ site.name }
 							</span>
 						</div>
-					</MenuItem>
+					</RouterLinkMenuItem>
 				) ) }
 			</MenuGroup>
 			<MenuGroup>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->


## Proposed Changes



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* So resources are preloaded.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Click on site switcher items

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
