### PR TITLE
Dashboard v2: switcher: enable add site button

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -1,11 +1,11 @@
 import { DataViews, filterSortAndPaginate } from '@automattic/dataviews';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate, Link } from '@tanstack/react-router';
-import { Button, Dropdown } from '@wordpress/components';
+import { Button, Modal } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { sitesQuery } from '../app/queries';
 import { sitesRoute } from '../app/router';
 import DataViewsCard from '../components/dataviews-card';
@@ -191,6 +191,7 @@ export default function Sites() {
 			hasA8CSites ? DEFAULT_FIELDS : DEFAULT_FIELDS.filter( ( field ) => field.id !== 'is_a8c' ),
 		[ hasA8CSites ]
 	);
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
 	if ( ! sites ) {
 		return;
@@ -200,26 +201,23 @@ export default function Sites() {
 
 	return (
 		<>
+			{ isModalOpen && (
+				<Modal title={ __( 'Add New Site' ) } onRequestClose={ () => setIsModalOpen( false ) }>
+					<AddNewSite context="sites-dashboard" />
+				</Modal>
+			) }
 			<PageLayout
 				header={
 					<PageHeader
 						title={ __( 'Sites' ) }
 						actions={
-							<Dropdown
-								popoverProps={ { placement: 'bottom-end', offset: 10, noArrow: false } }
-								focusOnMount
-								renderToggle={ ( { isOpen, onToggle } ) => (
-									<Button
-										variant="primary"
-										onClick={ onToggle }
-										__next40pxDefaultSize
-										aria-expanded={ isOpen }
-									>
-										{ __( 'Add New Site' ) }
-									</Button>
-								) }
-								renderContent={ () => <AddNewSite context="sites-dashboard" /> }
-							/>
+							<Button
+								variant="primary"
+								onClick={ () => setIsModalOpen( true ) }
+								__next40pxDefaultSize
+							>
+								{ __( 'Add New Site' ) }
+							</Button>
 						}
 					/>
 				}

--- a/client/dashboard/sites/site/switcher.scss
+++ b/client/dashboard/sites/site/switcher.scss
@@ -1,0 +1,4 @@
+// Above the site switcher dropdown.
+.components-modal__screen-overlay:has(.dashboard-site-switcher__modal) {
+    z-index: 1000000;
+}

--- a/client/dashboard/sites/site/switcher.tsx
+++ b/client/dashboard/sites/site/switcher.tsx
@@ -1,13 +1,16 @@
 import { filterSortAndPaginate } from '@automattic/dataviews';
 import { useQuery } from '@tanstack/react-query';
-import { MenuGroup, MenuItem, SearchControl, Icon } from '@wordpress/components';
+import { MenuGroup, MenuItem, SearchControl, Icon, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import { useState } from 'react';
 import { sitesQuery } from '../../app/queries';
 import RouterLinkMenuItem from '../../components/router-link-menu-item';
+import AddNewSite from '../add-new-site';
 import SiteIcon from '../site-icon';
 import type { View } from '@automattic/dataviews';
+
+import './switcher.scss';
 
 const fields = [ { id: 'name', enableGlobalSearch: true } ];
 
@@ -21,6 +24,7 @@ const DEFAULT_VIEW: View = {
 export default function Switcher( { onClose }: { onClose: () => void } ) {
 	const sites = useQuery( sitesQuery() ).data;
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
 	if ( ! sites ) {
 		return __( 'Loading…' );
@@ -53,13 +57,22 @@ export default function Switcher( { onClose }: { onClose: () => void } ) {
 				) ) }
 			</MenuGroup>
 			<MenuGroup>
-				<MenuItem>
+				<MenuItem onClick={ () => setIsModalOpen( true ) }>
 					<div style={ { display: 'flex', gap: '8px', alignItems: 'center' } }>
 						<Icon icon={ plus } />
 						{ __( 'Add New Site' ) }
 					</div>
 				</MenuItem>
 			</MenuGroup>
+			{ isModalOpen && (
+				<Modal
+					title={ __( 'Add New Site' ) }
+					onRequestClose={ () => setIsModalOpen( false ) }
+					className="dashboard-site-switcher__modal"
+				>
+					<AddNewSite context="sites-dashboard" />
+				</Modal>
+			) }
 		</div>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

See #103344.

## Proposed Changes

<img width="1352" alt="image" src="https://github.com/user-attachments/assets/7191e4a2-68c8-4076-ab45-ee386454b1c5" />
<img width="1352" alt="image" src="https://github.com/user-attachments/assets/76ee6ce2-8924-42fe-ba32-fe708349c757" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The button currently doesn't work.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Click the site switcher's add new site button.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
