### PR TITLE
Help Center: Direct Escalation additional checks and logging

### DIFF
--- a/packages/odie-client/src/components/message/direct-escalation-link.tsx
+++ b/packages/odie-client/src/components/message/direct-escalation-link.tsx
@@ -1,25 +1,46 @@
+import { HelpCenterSelect } from '@automattic/data-stores';
+import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
+import { useSelect } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useNavigate } from 'react-router-dom';
 import { useOdieAssistantContext } from '../../context';
 import { useCreateZendeskConversation } from '../../hooks';
-import { getHelpCenterZendeskConversationStarted } from '../../utils';
+import { getHelpCenterZendeskConversationStarted, interactionHasZendeskEvent } from '../../utils';
 
 export const DirectEscalationLink = ( { messageId }: { messageId: number | undefined } ) => {
 	const conversationStarted = Boolean( getHelpCenterZendeskConversationStarted() );
 	const newConversation = useCreateZendeskConversation();
-	const { trackEvent, isUserEligibleForPaidSupport } = useOdieAssistantContext();
+	const { trackEvent, isUserEligibleForPaidSupport, chat } = useOdieAssistantContext();
 	const navigate = useNavigate();
 
-	const [ newConversationButtonDisabled, setNewConversationButtonDisabled ] =
+	const { currentSupportInteraction } = useSelect( ( select ) => {
+		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
+		return {
+			currentSupportInteraction: store.getCurrentSupportInteraction(),
+		};
+	}, [] );
+
+	const [ hideNewConversationButton, setHideNewConversationButton ] =
 		useState( conversationStarted );
 
 	const handleClick = useCallback( () => {
-		setNewConversationButtonDisabled( true );
+		setHideNewConversationButton( true );
+
+		const hasZendeskConversationAlreadyStarted =
+			interactionHasZendeskEvent( currentSupportInteraction );
+
 		trackEvent( 'chat_message_direct_escalation_link_click', {
 			message_id: messageId,
 			is_user_eligible_for_paid_support: isUserEligibleForPaidSupport,
+			chat_provider: chat?.provider,
+			conversation_id: chat?.conversationId,
+			has_zendesk_conversation_already_started: hasZendeskConversationAlreadyStarted,
 		} );
+
+		if ( hasZendeskConversationAlreadyStarted ) {
+			return;
+		}
 
 		if ( isUserEligibleForPaidSupport ) {
 			if ( conversationStarted ) {
@@ -36,20 +57,19 @@ export const DirectEscalationLink = ( { messageId }: { messageId: number | undef
 		conversationStarted,
 		newConversation,
 		navigate,
+		chat?.provider,
+		currentSupportInteraction,
+		chat?.conversationId,
 	] );
 
-	if ( newConversationButtonDisabled ) {
+	if ( hideNewConversationButton ) {
 		return null;
 	}
 
 	return (
 		<div className="disclaimer">
 			{ __( 'Feeling stuck?', __i18n_text_domain__ ) }{ ' ' }
-			<button
-				onClick={ handleClick }
-				className="odie-button-link"
-				disabled={ newConversationButtonDisabled }
-			>
+			<button onClick={ handleClick } className="odie-button-link">
 				{ isUserEligibleForPaidSupport
 					? __( 'Contact our support team.', __i18n_text_domain__ )
 					: __( 'Ask in our forums.', __i18n_text_domain__ ) }

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -52,7 +52,12 @@ export const useCreateZendeskConversation = (): ( ( {
 		createdFrom?: string;
 	} ) => {
 		const currentInteractionID = interactionId || currentSupportInteraction!.uuid;
-		if ( isSubmittingZendeskUserFields || chat.conversationId || chat.status === 'transfer' ) {
+		if (
+			isSubmittingZendeskUserFields ||
+			chat.conversationId ||
+			chat.status === 'transfer' ||
+			chat.provider === 'zendesk'
+		) {
 			return;
 		}
 
@@ -72,7 +77,7 @@ export const useCreateZendeskConversation = (): ( ( {
 			messaging_flow: userFieldFlowName || null,
 			messaging_source: section,
 		} );
-
+		setHelpCenterZendeskConversationStarted();
 		const conversation = await Smooch.createConversation( {
 			metadata: {
 				createdAt: Date.now(),
@@ -80,7 +85,6 @@ export const useCreateZendeskConversation = (): ( ( {
 				...( chatId ? { odieChatId: chatId } : {} ),
 			},
 		} );
-		setHelpCenterZendeskConversationStarted();
 
 		trackEvent( 'new_zendesk_conversation', {
 			support_interaction: currentInteractionID,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Adds additional props to `calypso_odie_chat_message_direct_escalation_link_click`, that seems users are clicking and doing so be able to create duplicate chats
* Add some more additional checks that a Zendesk conversation is not ongoing before creating a new one.



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the help center and a chat which has more `contact support` links visible
* Slow down the `Smooch.createConversation` call by doing something like
```		
const [ first, conversation ] = await Promise.all( [
			new Promise( ( r ) => setTimeout( r, 15000 ) ),
			Smooch.createConversation( {
				metadata: {
					createdAt: Date.now(),
					supportInteractionId: currentInteractionID,
					...( chatId ? { odieChatId: chatId } : {} ),
				},
			} ),
		] );
```
* Click two of the  `contact support` links. 
* Test for regressions

