### PR TITLE
Turn magic code feature flag off for development

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -113,7 +113,7 @@
 		"livechat_solution": true,
 		"login/last-used-method": true,
 		"login/magic-login": true,
-		"login/use-magic-code": true,
+		"login/use-magic-code": false,
 		"logmein": true,
 		"mailchimp": true,
 		"manage/import/site-importer-endpoints": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

In https://github.com/Automattic/wp-calypso/pull/103590 the feature flag got turned off by accident for dev, which should probably only be done after https://github.com/Automattic/wp-calypso/pull/103572 is merged. This change turns it off

## Proposed Changes

* Turn off the feature flag for magic codes

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sanity check
