### PR TITLE
A4A: Reduce the agency name in the signup social proof component.

### DIFF
--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/signup-wrapper/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/signup-wrapper/style.scss
@@ -93,6 +93,7 @@
 		}
 
 		.signup-wrapper__testimonial-info {
+			@include body-large;
 			display: flex;
 			flex-direction: column;
 			gap: 4px;


### PR DESCRIPTION
Minor improvement on the Social proof component found in the new Signup form visuals.

| Before | After |
|--------|--------|
| <img width="345" alt="Screenshot 2025-05-22 at 9 37 46 PM" src="https://github.com/user-attachments/assets/247103bc-7a51-43d5-a90d-4e6abfcb7cc1" />  | <img width="352" alt="Screenshot 2025-05-22 at 9 37 05 PM" src="https://github.com/user-attachments/assets/bc74473f-e139-4c2f-9875-946e928a7e33" /> | 

## Proposed Changes

* Set Testimonial's font size to `body medium`.

## Why are these changes being made?

* Makes the UI more balance and polished.

## Testing Instructions

* Use the A4A live link and navigate to `/signup`.
* Confirm that the Agency name appears smaller than the title.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
