### PR TITLE
Hosting dashboard: load i18n data at boot

### DIFF
--- a/client/dashboard/app/i18n.tsx
+++ b/client/dashboard/app/i18n.tsx
@@ -27,12 +27,19 @@ async function fetchLocaleData( language: string, signal: AbortSignal ) {
 	}
 }
 
-export function I18nProvider( { children }: PropsWithChildren ) {
-	const [ loadedLocale, setLoadedLocale ] = useState< string | null >( null );
+// Determine the locale to use. The current implementation reads the logged-in user's
+// locale, but it can be made more flexible and support multiple sources. E.g., a locale
+// slug in the route path.
+function useLocaleSlug() {
 	const { user } = useAuth();
+	return user.locale_variant || user.language || 'en';
+}
+
+export function I18nProvider( { children }: PropsWithChildren ) {
+	const language = useLocaleSlug();
+	const [ loadedLocale, setLoadedLocale ] = useState< string | null >( null );
 
 	const i18n = defaultI18n;
-	const language = user.locale_variant || user.language || 'en';
 
 	useEffect( () => {
 		const abortController = new AbortController();

--- a/client/dashboard/app/i18n.tsx
+++ b/client/dashboard/app/i18n.tsx
@@ -1,0 +1,55 @@
+import { defaultI18n } from '@wordpress/i18n';
+import { I18nProvider as WPI18nProvider } from '@wordpress/react-i18n';
+import { useEffect, useRef, useState, type PropsWithChildren } from 'react';
+import { useAuth } from './auth';
+
+async function fetchLocaleData( language: string ) {
+	if ( language === 'en' ) {
+		return [ language, undefined ];
+	}
+
+	try {
+		const response = await fetch(
+			`https://widgets.wp.com/languages/calypso/${ language }-v1.1.json`
+		);
+
+		return [ language, await response.json() ];
+	} catch {
+		// Fall back to `en` when fetching the language data fails. Without this
+		// the i18n provider would be stuck forever in a non-loaded state.
+		return [ 'en', undefined ];
+	}
+}
+
+export function I18nProvider( { children }: PropsWithChildren ) {
+	const [ loadedLocale, setLoadedLocale ] = useState< string | null >( null );
+	const loadingLocaleRef = useRef< string | null >( null );
+	const { user } = useAuth();
+
+	const i18n = defaultI18n;
+	const language = user.locale_variant || user.language || 'en';
+
+	useEffect( () => {
+		loadingLocaleRef.current = language;
+
+		fetchLocaleData( language ).then( ( [ realLanguage, data ] ) => {
+			// Activate the data only if no other language switch has run in the meantime
+			if ( loadingLocaleRef.current !== language ) {
+				return;
+			}
+
+			i18n.resetLocaleData( data );
+			// `realLanguage` can be different from `language` when loading language data fails
+			// and it falls back to `en`.
+			setLoadedLocale( realLanguage );
+		} );
+	}, [ i18n, language ] );
+
+	// Render the sub-tree only after the initial locale data are loaded. We don't want a
+	// flash of `en` content on the initial render that's updated a moment later.
+	if ( loadedLocale === null ) {
+		return null;
+	}
+
+	return <WPI18nProvider i18n={ i18n } children={ children } />;
+}

--- a/client/dashboard/app/i18n.tsx
+++ b/client/dashboard/app/i18n.tsx
@@ -1,20 +1,26 @@
 import { defaultI18n } from '@wordpress/i18n';
 import { I18nProvider as WPI18nProvider } from '@wordpress/react-i18n';
-import { useEffect, useRef, useState, type PropsWithChildren } from 'react';
+import { useEffect, useState, type PropsWithChildren } from 'react';
 import { useAuth } from './auth';
 
-async function fetchLocaleData( language: string ) {
+async function fetchLocaleData( language: string, signal: AbortSignal ) {
 	if ( language === 'en' ) {
 		return [ language, undefined ];
 	}
 
 	try {
 		const response = await fetch(
-			`https://widgets.wp.com/languages/calypso/${ language }-v1.1.json`
+			`https://widgets.wp.com/languages/calypso/${ language }-v1.1.json`,
+			{ signal }
 		);
 
 		return [ language, await response.json() ];
-	} catch {
+	} catch ( error ) {
+		// Only fall back to `en` when the error is not an abort
+		if ( error instanceof Error && error.name === 'AbortError' ) {
+			throw error;
+		}
+
 		// Fall back to `en` when fetching the language data fails. Without this
 		// the i18n provider would be stuck forever in a non-loaded state.
 		return [ 'en', undefined ];
@@ -23,26 +29,28 @@ async function fetchLocaleData( language: string ) {
 
 export function I18nProvider( { children }: PropsWithChildren ) {
 	const [ loadedLocale, setLoadedLocale ] = useState< string | null >( null );
-	const loadingLocaleRef = useRef< string | null >( null );
 	const { user } = useAuth();
 
 	const i18n = defaultI18n;
 	const language = user.locale_variant || user.language || 'en';
 
 	useEffect( () => {
-		loadingLocaleRef.current = language;
+		const abortController = new AbortController();
 
-		fetchLocaleData( language ).then( ( [ realLanguage, data ] ) => {
-			// Activate the data only if no other language switch has run in the meantime
-			if ( loadingLocaleRef.current !== language ) {
-				return;
-			}
+		fetchLocaleData( language, abortController.signal )
+			.then( ( [ realLanguage, data ] ) => {
+				i18n.resetLocaleData( data );
+				// `realLanguage` can be different from `language` when loading language data fails
+				// and it falls back to `en`.
+				setLoadedLocale( realLanguage );
+			} )
+			.catch( () => {
+				// Ignore abort errors as they are expected during cleanup
+			} );
 
-			i18n.resetLocaleData( data );
-			// `realLanguage` can be different from `language` when loading language data fails
-			// and it falls back to `en`.
-			setLoadedLocale( realLanguage );
-		} );
+		return () => {
+			abortController.abort();
+		};
 	}, [ i18n, language ] );
 
 	// Render the sub-tree only after the initial locale data are loaded. We don't want a

--- a/client/dashboard/app/layout.tsx
+++ b/client/dashboard/app/layout.tsx
@@ -3,6 +3,7 @@ import { RouterProvider } from '@tanstack/react-router';
 import { useMemo } from 'react';
 import { AuthProvider, useAuth } from './auth';
 import { AppProvider, type AppConfig } from './context';
+import { I18nProvider } from './i18n';
 import { queryClient } from './query-client';
 import { getRouter } from './router';
 
@@ -17,7 +18,9 @@ function Layout( { config }: { config: AppConfig } ) {
 		<AppProvider config={ config }>
 			<QueryClientProvider client={ queryClient }>
 				<AuthProvider>
-					<RouterProviderWithAuth config={ config } />
+					<I18nProvider>
+						<RouterProviderWithAuth config={ config } />
+					</I18nProvider>
 				</AuthProvider>
 			</QueryClientProvider>
 		</AppProvider>

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -13,6 +13,8 @@ export interface User {
 	username: string;
 	display_name: string;
 	avatar_URL?: string;
+	language: string;
+	locale_variant: string;
 }
 
 export interface SiteDomain {


### PR DESCRIPTION
Adds i18n to the Hosting Dashboard. Implemented from scratch, no dependencies on existing Calypso code. Loads the language JSON from a `widgets.wp.com` URL and sets the data on an `i18n` object from `@wordpress/i18n`.

This is the basic setup, main Calypso does more. Here are the next steps how to evolve this:
- bootstrap the i18n data on the server: send it in the initial HTML document so that the browser app doesn't need to wait for an extra network roundtrip before booting up.
- implement the `use-translation-chunk` feature where we don't read the language file for entire Calypso (the size is in the order of hundreds of kilobytes), but hook into webpack to load i18n data together with an async chunk's JS and CSS.
- set `lang` and `rtl` attributes in DOM when language changes (mimic the `setLocaleInDOM` function).
- switch CSS stylesheets from LTR to RTL versions and vice versa when language changes.

Fixes DOTCOM-10589.