### PR TITLE
Tweak spacing of import support link

### DIFF
--- a/client/blocks/importer/components/uploading-pane/uploading-pane.scss
+++ b/client/blocks/importer/components/uploading-pane/uploading-pane.scss
@@ -66,10 +66,6 @@
 	color: var(--studio-gray-50);
 
 	.inline-support-link {
-		&::before {
-			content: "\A";
-		}
-
 		&:hover {
 			color: var(--studio-gray-100);
 		}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCON-35

## Proposed Changes

This tweaks the import stepper steps so the 'Need help' link is on the same line as the rest of the copy. We're showing the Squarespace importer as an example but this applies to all stepper importers

**Before**
![image](https://github.com/user-attachments/assets/853acf80-639b-4373-8d71-14d941610dbc)



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the calypso.live link or run this locally.
* Go to `/setup/site-migration`
* Choose 'pick your current platform from a list'
* Create a new site.
* Pick Squarespace.
* Verify the screen looks like this
![image](https://github.com/user-attachments/assets/f9752f66-36f8-47ec-9226-6300da5fc716)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
