### PR TITLE
Reader: Fix subitems with 2 lines

### DIFF
--- a/client/reader/sidebar/reader-sidebar-organizations/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list-item.jsx
@@ -39,7 +39,7 @@ export class ReaderSidebarOrganizationsListItem extends Component {
 					href={ `/reader/feeds/${ site.feed_ID }` }
 					onClick={ this.handleSidebarClick }
 				>
-					<Favicon site={ site } className="sidebar__menu-item-siteicon" size={ 18 } />
+					<Favicon site={ site } className="sidebar__menu-item-siteicon" size={ 16 } />
 
 					<span className="sidebar__menu-item-sitename">
 						{ site.name }

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -182,7 +182,7 @@ body.is-section-reader {
 		margin-right: 15px;
 		position: relative;
 		flex-shrink: 0;
-		border-radius: 50%;
+		border-radius: 4px;
 	}
 
 	.sidebar__menu-item-last-updated {

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -182,6 +182,7 @@ body.is-section-reader {
 		margin-right: 15px;
 		position: relative;
 		flex-shrink: 0;
+		border-radius: 50%;
 	}
 
 	.sidebar__menu-item-last-updated {
@@ -245,7 +246,8 @@ body.is-section-reader {
 			align-items: center;
 			gap: 4px;
 			line-height: 1.5;
-			padding: 12px 10px 18px 18px;
+			padding: 12px 10px 12px 18px;
+			box-sizing: content-box;
 
 			&.view-more-link {
 				color: var(--color-link);


### PR DESCRIPTION
Part of  DOTCOM-55 and https://github.com/Automattic/wp-calypso/pull/103428#pullrequestreview-2858689174



## Proposed Changes
* Fix sizing with the menu text that has 2 lines
* Apply border-radius on the site icon following the ' recent` accordion items. 

Before vs After
| Before | After |
|--------|--------|
| ![CleanShot 2025-05-22 at 16 43 24@2x](https://github.com/user-attachments/assets/e33cea50-4746-4e83-8e02-0cb3bf6994ee) | ![CleanShot 2025-05-22 at 16 42 37@2x](https://github.com/user-attachments/assets/b2a4ce0a-6ae8-4bd7-9704-6bb1e5510f24)| 


## Testing Instructions
* Go to /reader
*  Open the Automattic menu

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
