### PR TITLE
Reader - logged out show post to navigate to full post view / signup

### DIFF
--- a/client/reader/utils.ts
+++ b/client/reader/utils.ts
@@ -3,7 +3,6 @@ import { safeImageUrl, getUrlParts } from '@automattic/calypso-url';
 import { addQueryArgs, getQueryArgs, removeQueryArgs } from '@wordpress/url';
 import { Dispatch } from 'redux';
 import XPostHelper, { isXPost } from 'calypso/reader/xpost-helper';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 import { AppState } from 'calypso/types';
 
@@ -29,12 +28,6 @@ export function showSelectedPost( { postKey, comments }: ShowSelectedPostArgs ) 
 		}
 
 		const post = getPostByKey( getState(), postKey );
-
-		const isLoggedIn = isUserLoggedIn( getState() );
-
-		if ( ! isLoggedIn ) {
-			return window.open( post.URL + ( comments ? '#comments' : '' ), '_blank' );
-		}
 
 		if ( isXPost( post ) ) {
 			return showFullXPost( XPostHelper.getXPostMetadata( post ) as ShowFullXPostArgs );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/CML-459/reader-discover-page-logged-out-users-are-directed-out-of-reader-when /  https://github.com/Automattic/wp-calypso/issues/101686

## Proposed Changes

* Removes logged out check from `showSelectedPost` util, so we will no longer redirect out to the external blog when not logged in.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Prompt logged out users to signup/login and use the full reader features.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the reader logged out
* Click a post in a stream, verify you are not directed to the blog but signup/signin
* after signup/signin, verify you are on the full post view of the post you clicked
* Test clicking cards logged in, verify no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
