### PR TITLE
Reader - likes popover - fix broken loading state

### DIFF
--- a/client/blocks/post-likes/index.jsx
+++ b/client/blocks/post-likes/index.jsx
@@ -97,7 +97,7 @@ class PostLikes extends PureComponent {
 		}
 
 		// Prevent loading for postId `0`
-		const isLoading = !! postId && ! sortedLikes;
+		const isLoading = !! postId && ! likes;
 
 		const classes = clsx( 'post-likes', {
 			'has-display-names': showDisplayNames,

--- a/client/blocks/post-likes/index.jsx
+++ b/client/blocks/post-likes/index.jsx
@@ -95,9 +95,14 @@ class PostLikes extends PureComponent {
 		} else {
 			noLikesLabel = translate( 'There are no likes on this post yet.' );
 		}
+		// Previously we only checked for sortedLikes, but this was always an array and thus truthy
+		// => bypassed the loading state. We can check for likes instead, which is falsy until
+		// loaded as an array. However, for future proofing I am treating this as if it may be
+		// initialized as an empty array and checking its length vs the count.
+		const areLikesLoading = ! likes || ( likeCount && likes?.length === 0 );
 
 		// Prevent loading for postId `0`
-		const isLoading = !! postId && ! likes;
+		const isLoading = !! postId && areLikesLoading;
 
 		const classes = clsx( 'post-likes', {
 			'has-display-names': showDisplayNames,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/CML-454/reader-like-button-shows-an-arrow-down 

## Proposed Changes

Fixes the broken loading state noted in linked issue
* the `isLoading` check was not being marked true due to the check on `sortedLikes`. `sortedLikes` is always an array thus always truthy. Instead lets look at the likes being sorted to tell if they are present yet.

BEFORE (awkward loading state)
![likes-popover-before](https://github.com/user-attachments/assets/91e11ff1-a9cf-4345-8be4-8827159b6e86)


AFTER (full popover with loading indicator)
![likes-popover-after](https://github.com/user-attachments/assets/feb2a7ce-4f3b-43be-ade4-17cd543afd96)




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Broken looking loading state

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to discover /recommended (just because this is a place with a lot of likes with good amounts).
* Hover over the like icon on a post for the first time since loading (loading state shows once per post).
* Verify we have a loading style instead of the broken looking arrow.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
