### PR TITLE
Tag Stream: Use capitalPDangit to prevent a flash of the wrong capitalization.

### DIFF
--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -3,6 +3,7 @@ import { trim } from 'lodash';
 import titlecase from 'to-title-case';
 import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
+import { capitalPDangit } from 'calypso/lib/formatting';
 import {
 	trackPageLoad,
 	trackUpdatesLoaded,
@@ -26,7 +27,8 @@ export const tagListing = ( context, next ) => {
 	);
 	const state = context.store.getState();
 	const tag = getReaderTagBySlug( state, tagSlug );
-	const tagTitle = tag?.title || titlecase( trim( context.params.tag ) ).replace( /[-_]/g, ' ' );
+	const tagTitle =
+		tag?.title || capitalPDangit( titlecase( trim( context.params.tag ) ).replace( /[-_]/g, ' ' ) );
 
 	const encodedTag = encodeURIComponent( tagSlug ).toLowerCase();
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/CML-473/can-we-have-wordpress-as-a-tag-instead-of-wordpress

## Proposed Changes

* Wrap the tag title with `capitalPDangit` to prevent a flash of incorrect WordPress capitalization.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Follow up to https://github.com/Automattic/wp-calypso/pull/103302

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /tag/wordpress
* Verify that WordPress is correctly capitalized and that you don't see a flash of lowercase p on reload.
* Regression test other tags to make sure their titles load.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
