### PR TITLE
DOTCON-64: fix migration flow when selecting an existing site

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -199,7 +199,7 @@ const siteMigration: FlowV2< typeof initialize > = {
 								);
 							}
 
-							if ( platformQueryParam !== 'unknown' && platformQueryParam !== 'wordpress' ) {
+							if ( platformQueryParam !== 'wordpress' ) {
 								if ( isPlatformImportable( platformQueryParam ) && fromQueryParam ) {
 									return exitFlow(
 										getFullImporterUrl( platformQueryParam, siteSlug, fromQueryParam )

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/test/site-migration-flow.tsx
@@ -610,8 +610,8 @@ describe( 'Site Migration Flow', () => {
 				} );
 			} );
 
-			it( 'redirects to IMPORT_OR_MIGRATE when a site is selected and the platform is not identified', () => {
-				const destination = runNavigation( {
+			it( 'redirects to IMPORT_LIST when a site is selected and the platform is not identified', () => {
+				runNavigation( {
 					from: STEPS.PICK_SITE,
 					dependencies: {
 						action: 'select-site',
@@ -622,11 +622,13 @@ describe( 'Site Migration Flow', () => {
 					},
 				} );
 
-				expect( destination ).toMatchDestination( {
-					step: STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE,
+				expect( window.location.assign ).toMatchURL( {
+					path: '/setup/site-setup/importList',
 					query: {
-						siteSlug: 'example.wordpress.com',
+						backToFlow: '/site-migration/sitePicker',
+						sessionId: 123,
 						siteId: 123,
+						siteSlug: 'example.wordpress.com',
 					},
 				} );
 			} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCON-64

This is already deployed: ~**Should be merged once this is deployed 184180-ghe-Automattic/wpcom**~
## Proposed Changes

Redirect to the import list after selecting a site in the site picker with no source site set.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

So the flow works as expected.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the calypso.live link in this PR
* Navigate to `/setup/site-migration`
* Select "pick your current platform from a list"
* Select an existing site in the site picker
* Verify you are redirected to the import list: <img width="622" alt="image" src="https://github.com/user-attachments/assets/6323ed94-5b8a-47c4-8057-32f9a4ac92aa" />

* Go to wordpress.com/move
* Enter a WordPress site URL (not .com)
* In the URL that you are redirected to replace `https://wordpress.com` by the calypso.live URL
* Verify you are redirected to the import vs migrate screen after selecting a site
* 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?