### PR TITLE
Login: Set the social links container to expand with the text

### DIFF
--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -43,25 +43,12 @@ form {
 				margin: 0;
 			}
 
-/*			.card.login__form:lang(ar),
-			.card.login__form:lang(he),
-			.card.login__form:lang(id),
-			.card.login__form:lang(it),
-			.card.login__form:lang(ja),
-			.card.login__form:lang(pt-br),
-			.card.login__form:lang(tr),
-			.card.auth-form__social:lang(ar),
-			.card.auth-form__social:lang(he),
-			.card.auth-form__social:lang(id),
-			.card.auth-form__social:lang(it),
-			.card.auth-form__social:lang(ja),
-			.card.auth-form__social:lang(pt-br),
-			.card.auth-form__social:lang(tr) {
-				flex-shrink: 0;
-			}*/
-
 			.card.login__form:not(:lang(en)),
-			.card.auth-form__social:not(:lang(en)) {
+			.card.auth-form__social:not(:lang(en)),
+			.card.login__form:not(:lang(ko)),
+			.card.auth-form__social:not(:lang(ko)),
+			.card.login__form:not(:lang(zh)),
+			.card.auth-form__social:not(:lang(zh)) {
 				flex-shrink: 0;
 			}
 

--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -43,6 +43,28 @@ form {
 				margin: 0;
 			}
 
+/*			.card.login__form:lang(ar),
+			.card.login__form:lang(he),
+			.card.login__form:lang(id),
+			.card.login__form:lang(it),
+			.card.login__form:lang(ja),
+			.card.login__form:lang(pt-br),
+			.card.login__form:lang(tr),
+			.card.auth-form__social:lang(ar),
+			.card.auth-form__social:lang(he),
+			.card.auth-form__social:lang(id),
+			.card.auth-form__social:lang(it),
+			.card.auth-form__social:lang(ja),
+			.card.auth-form__social:lang(pt-br),
+			.card.auth-form__social:lang(tr) {
+				flex-shrink: 0;
+			}*/
+
+			.card.login__form:not(:lang(en)),
+			.card.auth-form__social:not(:lang(en)) {
+				flex-shrink: 0;
+			}
+
 			.card.login__form {
 				display: flex;
 				flex-direction: column;

--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -43,12 +43,8 @@ form {
 				margin: 0;
 			}
 
-			.card.login__form:not(:lang(en)),
-			.card.auth-form__social:not(:lang(en)),
-			.card.login__form:not(:lang(ko)),
-			.card.auth-form__social:not(:lang(ko)),
-			.card.login__form:not(:lang(zh)),
-			.card.auth-form__social:not(:lang(zh)) {
+			.card.login__form:not(:lang(en)):not(:lang(ko)):not(:lang(zh)),
+			.card.auth-form__social:not(:lang(en)):not(:lang(ko)):not(:lang(zh)) {
 				flex-shrink: 0;
 			}
 

--- a/client/blocks/login/social.scss
+++ b/client/blocks/login/social.scss
@@ -15,7 +15,6 @@
 
 .auth-form__social.is-login {
 	margin-bottom: 0;
-	flex-shrink: 0;
 
 	/**
 	* Social First Logins

--- a/client/blocks/login/social.scss
+++ b/client/blocks/login/social.scss
@@ -15,6 +15,7 @@
 
 .auth-form__social.is-login {
 	margin-bottom: 0;
+	flex-shrink: 0;
 
 	/**
 	* Social First Logins


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of I18N-221

## Proposed Changes

* Set the social links container on login page to always fit the text content and not shrink below that.

Before|After
-----|-----|
<img width="857" alt="wpcom-before" src="https://github.com/user-attachments/assets/7aaa065b-32c2-4123-83ee-245e5e215ee5" />|<img width="857" alt="wpcom-after" src="https://github.com/user-attachments/assets/c9a49eb9-4b85-48be-a1f1-08ac29a3cb93" />
<img width="668" alt="crowdsignal-before" src="https://github.com/user-attachments/assets/b270288b-3e65-408a-b557-44eafc735de7" />|<img width="668" alt="crowdsignal-after" src="https://github.com/user-attachments/assets/52ed553d-c91b-4954-8e97-9722d1eb6fae" />
<img width="678" alt="jetpack-before" src="https://github.com/user-attachments/assets/b86bee60-18e6-4861-b9be-170ecdf15e0f" />|<img width="678" alt="jetpack-after" src="https://github.com/user-attachments/assets/3633db38-13c8-45ac-b708-ce8f2591fdc2" />
<img width="790" alt="woo-before" src="https://github.com/user-attachments/assets/9982748e-6e95-4810-aeb3-aaa13647bd0e" />|<img width="790" alt="woo-after" src="https://github.com/user-attachments/assets/b2185ae0-762b-4d4f-a401-e3daa6734772" />
<img width="797" alt="blazepro-before" src="https://github.com/user-attachments/assets/3e1c6f68-44b7-4403-8886-882f00f3210c" />|<img width="797" alt="blazepro-after" src="https://github.com/user-attachments/assets/669607d5-a251-4cd1-b422-6a0a9c7aa50d" />
<img width="797" alt="akismet-before" src="https://github.com/user-attachments/assets/8402c389-6c45-4883-9ec1-e1b258e8dc04" />|<img width="797" alt="akismet-after" src="https://github.com/user-attachments/assets/e2df01a5-fd38-4654-9223-d99d61164314" />
<img width="688" alt="a4a-before" src="https://github.com/user-attachments/assets/64ee8bb2-9d29-4691-ac41-59df8e4ffc5e" />|<img width="688" alt="a4a-after" src="https://github.com/user-attachments/assets/0b42ab5d-ee98-4b0c-b094-446cfa0cd476" />
<img width="509" alt="gravatar-before" src="https://github.com/user-attachments/assets/2242bd4a-5551-4fb8-9595-58abeeeb9356" />|<img width="509" alt="gravatar-after" src="https://github.com/user-attachments/assets/a4a88e37-154b-410f-b2c5-25167d14912c" />
<img width="509" alt="wpjm-before" src="https://github.com/user-attachments/assets/35cbbb4d-1b6c-4796-a19c-113fcb40cbb4" />|<img width="509" alt="wpjm-after" src="https://github.com/user-attachments/assets/f9180282-01e5-4f22-9717-270436b3069d" />
<img width="509" alt="vip-before" src="https://github.com/user-attachments/assets/f55b0849-2913-4e96-9872-9661152701c9" />|<img width="509" alt="vip-after" src="https://github.com/user-attachments/assets/c1810636-654e-4115-9237-1697dda82d25" />
<img width="688" alt="p2-before" src="https://github.com/user-attachments/assets/00fb070d-864a-459c-8e81-3a588991d68e" />|<img width="688" alt="p2-after" src="https://github.com/user-attachments/assets/7ae71147-04e0-44d1-97ea-32ee0024b0d1" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* On many languages the translations for "Email me a login link" and "Log in via Jetpack app" are considerably longer than in English, which causes the texts to overflow the buttons.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

On calypso.localhost use the following links to test in Turkish (you can check other languages by changing the locale slug in the URL):
[WordPress.com](http://calypso.localhost:3000/log-in/tr)
[Crowdsignal](http://calypso.localhost:3000/log-in/tr?client_id=978&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3Df5da55616562ed1b1ef36c8e88328853efcc0167150831e59437c3330ec11509%26redirect_uri%3Dhttps%253A%252F%252Fapp.crowdsignal.com%252Fconnect%253Fsource%253Dlogin%2526action%253Drequest_access_token%26wpcom_connect%3D1%26from-calypso%3D1)
[Jetpack Cloud](http://calypso.localhost:3000/log-in/tr?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D69040%26redirect_uri%3Dhttps%253A%252F%252Fcloud.jetpack.com%252Fconnect%252Foauth%252Ftoken%253Fnext%253D%25252F%26scope%3Dglobal%26blog_id%3D0%26from-calypso%3D1&client_id=69040&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D69040%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%253Fresponse_type%253Dtoken%2526client_id%253D69040%2526redirect_uri%253Dhttps%25253A%25252F%25252Fcloud.jetpack.com%25252Fconnect%25252Foauth%25252Ftoken%25253Fnext%25253D%2525252F%2526scope%253Dglobal%2526blog_id%253D0%2526from-calypso%253D1)
[Woo](http://calypso.localhost:3000/log-in/tr?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Db30d4e6a81f72b803c873f517f4189601c46a1bc8b9bfdb9ed27cf3d17ad5601%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26from-calypso%3D1&client_id=50916&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D50916%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%252F%253Fresponse_type%253Dcode%2526client_id%253D50916%2526state%253Db30d4e6a81f72b803c873f517f4189601c46a1bc8b9bfdb9ed27cf3d17ad5601%2526redirect_uri%253Dhttps%25253A%25252F%25252Fwoocommerce.com%25252Fwc-api%25252Fwpcom-signin%25253Fnext%25253D%2525252F%2526blog_id%253D0%2526wpcom_connect%253D1%2526wccom-from%2526calypso_env%253Dproduction%2526from-calypso%253D1) - on Woo the container width is set to 327px, so a simple solution would be to source shorter translations for a single string in French, Italian and Brazilian Portuguese.
[Blaze Pro](http://calypso.localhost:3000/log-in/tr?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D99370%26state%3D0f0d1f16975b65cf8e9e924461b7c892f78eabeeb190dc03654cef0465786da0%26redirect_uri%3Dhttps%253A%252F%252Fblazepro.tumblr.com%252Fauth%252Fconnected%26blog_id%3D0%26wpcom_connect%3D1%26calypso_env%3Dproduction%26scope%3Dglobal%26from-calypso%3D1&client_id=99370&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D99370%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%253Fresponse_type%253Dcode%2526client_id%253D99370%2526state%253D0f0d1f16975b65cf8e9e924461b7c892f78eabeeb190dc03654cef0465786da0%2526redirect_uri%253Dhttps%25253A%25252F%25252Fblazepro.tumblr.com%25252Fauth%25252Fconnected%2526blog_id%253D0%2526wpcom_connect%253D1%2526calypso_env%253Dproduction%2526scope%253Dglobal%2526from-calypso%253D1)
[Akismet](http://calypso.localhost:3000/log-in/tr?redirect_to=https%3A%2F%2Fr-login.wordpress.com%2Fremote-login.php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet.com%252Faccount%252F&signup_url=%2Fstart%2Faccount%2Fuser-social%3Fredirect_to%3Dhttps%253A%252F%252Fr-login.wordpress.com%252Fremote-login.php%253Faction%253Dlink%2526back%253Dhttps%25253A%25252F%25252Fakismet.com%25252Faccount%25252F)
A4A - Can't link due to GitHub OSS scan rules: go to the A4A site and click login. Edit the URL and change the host to calypso.localhost:3000 and the locale to tr.
[Gravatar](http://calypso.localhost:3000/log-in/tr?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D4a5153e30a28e2ef24ca7e599abd80f3969340cd1f88327c1f5d2fbc88593fa1%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1&client_id=1854)
[WP Job Manager](http://calypso.localhost:3000/log-in/tr?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fclient_id%3D90057%26response_type%3Dcode%26state%3DeyJyZWRpcmVjdF90byI6Imh0dHBzOlwvXC93cGpvYm1hbmFnZXIuY29tXC9teS1hY2NvdW50In0%26redirect_uri%3Dhttps%253A%252F%252Fwpjobmanager.com%252Fwp-json%252Fwpjmcom-auth%252Fv1%252Fcallback%26blog_id%3D0%26from-calypso%3D1&client_id=90057)
[VIP](http://calypso.localhost:3000/log-in/tr?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fstate%3Dd01a004590fc4017316cef309b1e213de0cf6c1fd4b68d3152d9f9acbf9c%26scope%3Dauth%26response_type%3Dcode%26approval_prompt%3Dauto%26redirect_uri%3Dhttps%253A%252F%252Fid.wpvip.com%252Fwp-json%252Foauth%252Fv1%252Fcallback%252Fwpcom%26client_id%3D76596%26from-calypso%3D1&client_id=76596&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D76596%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%253Fstate%253Dd01a004590fc4017316cef309b1e213de0cf6c1fd4b68d3152d9f9acbf9c%2526scope%253Dauth%2526response_type%253Dcode%2526approval_prompt%253Dauto%2526redirect_uri%253Dhttps%25253A%25252F%25252Fid.wpvip.com%25252Fwp-json%25252Foauth%25252Fv1%25252Fcallback%25252Fwpcom%2526client_id%253D76596%2526from-calypso%253D1)
[P2](http://calypso.localhost:3000/log-in/tr?from=p2)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
