### PR TITLE
Hosting Dashboard: Use checkbox for subscription gifting instead of toggle

### DIFF
--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -4,7 +4,9 @@ import {
 	__experimentalVStack as VStack,
 	Button,
 } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import type { SiteSettings } from '../../data/types';
 import type { Field, SimpleFormField } from '@automattic/dataviews';
@@ -50,6 +52,7 @@ export function PrivacyForm( {
 	settings: SiteSettings;
 	mutation: UseMutationResult< Partial< SiteSettings >, Error, Partial< SiteSettings >, unknown >;
 } ) {
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const [ formData, setFormData ] = useState( {
 		wpcom_site_visibility: settings.wpcom_site_visibility,
 	} );
@@ -61,7 +64,17 @@ export function PrivacyForm( {
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
-		mutation.mutate( { ...formData } );
+		mutation.mutate(
+			{ ...formData },
+			{
+				onSuccess: () => {
+					createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
+				},
+				onError: () => {
+					createErrorNotice( __( 'Failed to save settings.' ), { type: 'snackbar' } );
+				},
+			}
+		);
 	};
 
 	return (

--- a/client/dashboard/sites/settings-subscription-gifting/index.tsx
+++ b/client/dashboard/sites/settings-subscription-gifting/index.tsx
@@ -99,7 +99,7 @@ export default function SubscriptionGiftingSettings( { siteSlug }: { siteSlug: s
 			<Card>
 				<CardBody>
 					<form onSubmit={ handleSubmit }>
-						<VStack spacing={ 4 }>
+						<VStack spacing={ 4 } style={ { padding: '8px 0' } }>
 							<DataForm< SiteSettings >
 								data={ formData }
 								fields={ fields }

--- a/client/dashboard/sites/settings-subscription-gifting/index.tsx
+++ b/client/dashboard/sites/settings-subscription-gifting/index.tsx
@@ -1,14 +1,24 @@
 import { DataForm } from '@automattic/dataviews';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { notFound } from '@tanstack/react-router';
-import { Card, CardBody, ToggleControl } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Button,
+	Card,
+	CardBody,
+	CheckboxControl,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useState } from 'react';
 import { siteQuery, siteSettingsMutation, siteSettingsQuery } from '../../app/queries';
 import PageLayout from '../../components/page-layout';
 import SettingsPageHeader from '../settings-page-header';
 import { hasSubscriptionGiftingFeature } from './utils';
 import type { SiteSettings } from '../../data/types';
-import type { Field } from '@automattic/dataviews';
+import type { Field, SimpleFormField } from '@automattic/dataviews';
 
 const fields: Field< SiteSettings >[] = [
 	{
@@ -17,7 +27,7 @@ const fields: Field< SiteSettings >[] = [
 		Edit: ( { field, onChange, data, hideLabelFromVision } ) => {
 			const { id, getValue } = field;
 			return (
-				<ToggleControl
+				<CheckboxControl
 					__nextHasNoMarginBottom
 					label={ hideLabelFromVision ? '' : field.label }
 					checked={ getValue( { item: data } ) }
@@ -32,13 +42,18 @@ const fields: Field< SiteSettings >[] = [
 
 const form = {
 	type: 'regular' as const,
-	fields,
+	fields: [ { id: 'wpcom_gifting_subscription' } as SimpleFormField ],
 };
 
 export default function SubscriptionGiftingSettings( { siteSlug }: { siteSlug: string } ) {
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { data: site } = useQuery( siteQuery( siteSlug ) );
 	const { data } = useQuery( siteSettingsQuery( siteSlug ) );
 	const mutation = useMutation( siteSettingsMutation( siteSlug ) );
+
+	const [ formData, setFormData ] = useState( {
+		wpcom_gifting_subscription: data?.wpcom_gifting_subscription,
+	} );
 
 	if ( ! data || ! site ) {
 		return null;
@@ -48,8 +63,25 @@ export default function SubscriptionGiftingSettings( { siteSlug }: { siteSlug: s
 		throw notFound();
 	}
 
-	const handleSubmit = ( edits: Partial< SiteSettings > ) => {
-		return mutation.mutate( edits );
+	const isDirty = Object.entries( formData ).some(
+		( [ key, value ] ) => data[ key as keyof SiteSettings ] !== value
+	);
+
+	const { isPending } = mutation;
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		mutation.mutate(
+			{ ...formData },
+			{
+				onSuccess: () => {
+					createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
+				},
+				onError: () => {
+					createErrorNotice( __( 'Failed to save settings.' ), { type: 'snackbar' } );
+				},
+			}
+		);
 	};
 
 	return (
@@ -66,12 +98,28 @@ export default function SubscriptionGiftingSettings( { siteSlug }: { siteSlug: s
 		>
 			<Card>
 				<CardBody>
-					<DataForm< SiteSettings >
-						data={ data }
-						fields={ fields }
-						form={ form }
-						onChange={ handleSubmit }
-					/>
+					<form onSubmit={ handleSubmit }>
+						<VStack spacing={ 4 }>
+							<DataForm< SiteSettings >
+								data={ formData }
+								fields={ fields }
+								form={ form }
+								onChange={ ( edits: Partial< SiteSettings > ) => {
+									setFormData( ( data ) => ( { ...data, ...edits } ) );
+								} }
+							/>
+							<HStack justify="flex-start">
+								<Button
+									variant="primary"
+									type="submit"
+									isBusy={ isPending }
+									disabled={ isPending || ! isDirty }
+								>
+									{ __( 'Save' ) }
+								</Button>
+							</HStack>
+						</VStack>
+					</form>
 				</CardBody>
 			</Card>
 		</PageLayout>


### PR DESCRIPTION
## Proposed Changes

This PR updates the Subscription Gifting setting to use a checkbox instead of a toggle. This is due to toggles auto-save and thus removing the need for the Save button. This might create confusion where the Subscription Gifting screen is just a single toggle, and users might expect a Save button coming from other settings pages.

| Before | After |
| --- | --- |
| ![Screenshot 2025-05-23 at 1 20 15 PM](https://github.com/user-attachments/assets/78353335-0eeb-4850-ab9b-24c48f51fd2a) | ![Screenshot 2025-05-23 at 1 20 20 PM](https://github.com/user-attachments/assets/a0c86e81-54fc-4109-b429-e438b49593a5) |

This PR also adds a snackbar notice to indicate that the setting has been saved or otherwise.

## Why are these changes being made?

<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

UX improvement.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2/sites/:siteSlug/settings/subscription-gifting
* Ensure that the checkbox and the Save button works as intended
* Ensure that the notice shows as intended

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
