### PR TITLE
A4A > Referrals: Show Estimated Commissions

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -48,7 +48,12 @@ export default function ReferralsOverview( {
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
 		...initialDataViewsState,
-		fields: [ 'completed-orders', 'pending-orders', 'commissions', 'subscription-status' ],
+		fields: [
+			'completed-orders',
+			'pending-orders',
+			'estimated-commissions',
+			'subscription-status',
+		],
 		titleField: 'client',
 	} );
 

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -76,6 +76,10 @@ $data-view-border-color: #f1f1f1;
 		.dataviews-view-table tr td:first-child {
 			padding-inline-start: 64px;
 		}
+
+		.dataviews-view-table__row .a4a-text-placeholder {
+			width: 50px;
+		}
 	}
 
 	&:not(.full-width-layout-with-table) .hosting-dashboard-layout__body-wrapper {


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-949/referrals-estimated-commissions-column-is-not-shown-anymore

## Proposed Changes

This PR fixes an issue with the Referrals not showing the `Estimated Commissions` column for each client. This could be a problem with rebase that happened with this PR: https://github.com/Automattic/wp-calypso/pull/96470/files#diff-6646a1e3c6f610240aff130e0c464870b9cb27a01f186fbe75e12a9b0e4a9825R56

## Why are these changes being made?

* To show the `Estimated Commissions` column on the Referrals.

## Testing Instructions

* Open the A4A live link
* Go to Referrals: Dashboard > Verify the `Estimated Commissions` column is now showing up.

| Before | After |
|--------|--------|
| <img width="1728" alt="Screenshot 2025-05-23 at 12 16 48 PM" src="https://github.com/user-attachments/assets/cac04c12-3135-4afa-8b8e-77129eaa446e" />| <img width="1728" alt="Screenshot 2025-05-23 at 12 17 37 PM" src="https://github.com/user-attachments/assets/10d10733-22e6-41f9-aec6-1a553cff7712" />  | 



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
