### PR TITLE
Fix contrast on domains step

### DIFF
--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -47,10 +47,10 @@
 	}
 
 	.domain-product-price__sale-price {
-		color: var(--studio-orange-50);
+		color: var(--studio-orange-60);
 		font-weight: 600;
 		small {
-			color: var(--studio-orange-50);
+			color: var(--studio-orange-60);
 			font-size: $font-body-small;
 		}
 	}

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -410,10 +410,6 @@ body.is-section-signup {
 		.domain-product-price__price {
 			font-size: $font-body-small;
 			font-weight: initial;
-
-			&:not(.domain-product-price__free-price) {
-				color: var(--color-neutral-40);
-			}
 		}
 
 		&.is-clickable:hover {

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -129,7 +129,7 @@
 .register-domain-step__example-prompt {
 	font-size: 0.875rem;
 	line-height: 20px;
-	color: var(--studio-gray-40);
+	color: var(--studio-gray-50);
 	display: flex;
 	align-items: center;
 	margin: 0;

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -180,7 +180,7 @@ body.is-section-stepper .domains__step-content,
 			}
 
 			.domains__price-free {
-				color: var(--studio-green-50);
+				color: var(--studio-green-60);
 			}
 
 		}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-13193

## Proposed Changes

I propose fixing the contrast on the domain step.

<img width="932" alt="Screenshot 2025-05-23 at 09 14 28" src="https://github.com/user-attachments/assets/e26a6d0d-69bf-485e-946b-0065fa543c58" />

<img width="1235" alt="Screenshot 2025-05-23 at 09 11 39" src="https://github.com/user-attachments/assets/330e6ae5-61f7-4b4b-8888-a8315006702a" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To confirm accessibility guidelines:

> Elements must meet minimum color contrast ratio thresholds

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start new site flow
2. Using axe Dev Tools confirm there is no contrast issue
3. Search for the domain
4. Repeat step 2

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
