### PR TITLE
Connect Refresh: Update log-in layout for Studio clients to use white-signup/two-column

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -29,6 +29,7 @@ import {
 	isGravPoweredOAuth2Client,
 	isBlazeProOAuth2Client,
 	isPartnerPortalOAuth2Client,
+	isStudioAppOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { createAccountUrl } from 'calypso/lib/paths';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
@@ -162,7 +163,7 @@ const LayoutLoggedOut = ( {
 
 	if ( useOAuth2Layout && ( isGravatar || isGravPoweredClient ) ) {
 		masterbar = null;
-	} else if ( useOAuth2Layout && oauth2Client && oauth2Client.name ) {
+	} else if ( useOAuth2Layout && oauth2Client && oauth2Client.name && ! masterbarIsHidden ) {
 		classes.dops = true;
 		classes[ oauth2Client.name ] = true;
 
@@ -335,7 +336,9 @@ export default withCurrentRoute(
 			const isPartnerPortal = isPartnerPortalOAuth2Client( oauth2Client );
 			const isWooJPC = isWooJPCFlow( state );
 
+			const isStudioClient = isStudioAppOAuth2Client( oauth2Client );
 			const isWhiteLogin =
+				isStudioClient ||
 				( currentRoute.startsWith( '/log-in' ) &&
 					! isJetpackLogin &&
 					Boolean( currentQuery?.client_id ) === false &&
@@ -356,6 +359,7 @@ export default withCurrentRoute(
 				[ 'signup', 'jetpack-connect' ].includes( sectionName );
 			const wccomFrom = getWccomFrom( state );
 			const masterbarIsHidden =
+				isStudioClient ||
 				! ( currentSection || currentRoute ) ||
 				! masterbarIsVisible( state ) ||
 				noMasterbarForSection ||

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -5,6 +5,7 @@ import {
 	isGravPoweredOAuth2Client,
 	isWooOAuth2Client,
 	isPartnerPortalOAuth2Client,
+	isStudioAppOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { DesktopLoginStart, DesktopLoginFinalize } from 'calypso/login/desktop-login';
 import { SOCIAL_HANDOFF_CONNECT_ACCOUNT } from 'calypso/state/action-types';
@@ -64,6 +65,7 @@ const enhanceContextWithLogin = ( context ) => {
 	const isPartnerPortalClient = isPartnerPortalOAuth2Client( oauth2Client );
 	const isWooJPC = isWooJPCFlow( currentState );
 	const isBlazePro = getIsBlazePro( currentState );
+	const isStudioLogin = isStudioAppOAuth2Client( oauth2Client );
 
 	const isWhiteLogin =
 		( ! isJetpackLogin &&
@@ -71,7 +73,8 @@ const enhanceContextWithLogin = ( context ) => {
 			Boolean( oauth2ClientId ) === false &&
 			! isBlazePro &&
 			! isWooJPC ) ||
-		isPartnerPortalClient;
+		isPartnerPortalClient ||
+		isStudioLogin; // Force two-column layout for Studio
 
 	context.primary = (
 		<WPLogin


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13216/calypso-enable-the-two-column-layout-for-studio-extract-the-layout

## Proposed Changes

The forces the two-column/white layout for the log-in screen when accessed through Studio client redirect. 

| Before | After |
|--------|--------|
| <img width="1066" alt="Screenshot 2025-05-23 at 12 29 35 PM" src="https://github.com/user-attachments/assets/0564d98a-a451-44e6-a497-2ed237528f66" /> | <img width="1062" alt="Screenshot 2025-05-23 at 12 29 23 PM" src="https://github.com/user-attachments/assets/cdbc0627-8d4e-4e6c-8ad8-f9be1fcad749" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13216/calypso-enable-the-two-column-layout-for-studio-extract-the-layout

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- In Studio app, attempt to log-in to WP

<img width="500" alt="Screenshot 2025-05-23 at 12 32 18 PM" src="https://github.com/user-attachments/assets/d21e7e08-cc5a-44ee-92f8-073a2f875966" />

- Grab the path with the params (it will be something like `/log-in?client_id=123&redirect_to=xyz` and visit via Calypso Live or localhost
- Confirm the layout changes and that no additional CTAs are present
- Confirm that the various links work as before with paths/params being identical

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
