### PR TITLE
Hosting Dashboard: Add settings for robots and 3rd party sharing

### DIFF
--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -360,7 +360,6 @@ function toRawSiteSettings( settings: Partial< SiteSettings > ): any {
 	const rawSettings = rest as any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
 	if ( wpcom_site_visibility !== undefined ) {
-		// The high-level visibility of the site has changed.
 		if ( wpcom_site_visibility === 'coming-soon' ) {
 			rawSettings.blog_public = 0;
 			rawSettings.wpcom_public_coming_soon = 1;
@@ -377,17 +376,6 @@ function toRawSiteSettings( settings: Partial< SiteSettings > ): any {
 
 		// Take opportunity, while the user is switching visibility settings, to disable the legacy coming soon setting.
 		rawSettings.wpcom_coming_soon = 0;
-	} else {
-		// High-level visibility of the site has not changed, but the sub settings may have.
-		// If they have then we must be a "public" site.
-		if ( wpcom_discourage_search_engines !== undefined ) {
-			rawSettings.blog_public = wpcom_discourage_search_engines ? 0 : 1;
-			rawSettings.wpcom_coming_soon = 0;
-		}
-		if ( wpcom_prevent_third_party_sharing !== undefined ) {
-			rawSettings.wpcom_data_sharing_opt_out = wpcom_prevent_third_party_sharing;
-			rawSettings.wpcom_coming_soon = 0;
-		}
 	}
 
 	return rawSettings;

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -341,7 +341,7 @@ function fromRawSiteSettings( settings: any ): SiteSettings {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function toRawSiteSettings( settings: Partial< SiteSettings > ): any {
-	const rawSettings = settings as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+	const rawSettings = {} as any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
 	const {
 		wpcom_site_visibility,

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -349,13 +349,8 @@ function toRawSiteSettings( settings: Partial< SiteSettings > ): any {
 		wpcom_prevent_third_party_sharing,
 	} = settings;
 
-	if ( wpcom_discourage_search_engines !== undefined ) {
-		rawSettings.blog_public = wpcom_discourage_search_engines ? 0 : 1;
-	}
-	if ( wpcom_prevent_third_party_sharing !== undefined ) {
-		rawSettings.wpcom_data_sharing_opt_out = wpcom_prevent_third_party_sharing;
-	}
 	if ( wpcom_site_visibility !== undefined ) {
+		// The high-level visibility of the site has changed.
 		if ( wpcom_site_visibility === 'coming-soon' ) {
 			rawSettings.blog_public = 0;
 			rawSettings.wpcom_public_coming_soon = 1;
@@ -365,10 +360,18 @@ function toRawSiteSettings( settings: Partial< SiteSettings > ): any {
 			rawSettings.wpcom_public_coming_soon = 0;
 			rawSettings.wpcom_data_sharing_opt_out = false;
 		} else {
-			if ( wpcom_discourage_search_engines === undefined ) {
-				rawSettings.blog_public = 1;
-			}
+			rawSettings.blog_public = wpcom_discourage_search_engines ? 0 : 1;
 			rawSettings.wpcom_public_coming_soon = 0;
+			rawSettings.wpcom_data_sharing_opt_out = wpcom_prevent_third_party_sharing;
+		}
+	} else {
+		// High-level visibility of the site has not changed, but the sub settings may have.
+		// If they have then we must be a "public" site.
+		if ( wpcom_discourage_search_engines !== undefined ) {
+			rawSettings.blog_public = wpcom_discourage_search_engines ? 0 : 1;
+		}
+		if ( wpcom_prevent_third_party_sharing !== undefined ) {
+			rawSettings.wpcom_data_sharing_opt_out = wpcom_prevent_third_party_sharing;
 		}
 	}
 

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -317,11 +317,20 @@ export const updateSiteSettings = async ( siteIdOrSlug: string, data: Partial< S
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function fromRawSiteSettings( settings: any ): SiteSettings {
-	const blog_public = Number( settings.blog_public );
-	const wpcom_coming_soon = Number( settings.wpcom_coming_soon );
-	const wpcom_public_coming_soon = Number( settings.wpcom_public_coming_soon );
-	const wpcom_data_sharing_opt_out = Boolean( settings.wpcom_data_sharing_opt_out );
+function fromRawSiteSettings( rawSettings: any ): SiteSettings {
+	// Pluck out raw settings which don't map directly to a field in SiteSettings.
+	const {
+		blog_public: blogPublicRaw,
+		wpcom_coming_soon: wpcomComingSoonRaw,
+		wpcom_public_coming_soon: wpcomPublicComingSoonRaw,
+		wpcom_data_sharing_opt_out: wpcomDataSharingOptOutRaw,
+		...settings
+	} = rawSettings;
+
+	const blog_public = Number( blogPublicRaw );
+	const wpcom_coming_soon = Number( wpcomComingSoonRaw );
+	const wpcom_public_coming_soon = Number( wpcomPublicComingSoonRaw );
+	const wpcom_data_sharing_opt_out = Boolean( wpcomDataSharingOptOutRaw );
 
 	if ( wpcom_coming_soon === 1 || wpcom_public_coming_soon === 1 ) {
 		settings.wpcom_site_visibility = 'coming-soon';
@@ -341,13 +350,14 @@ function fromRawSiteSettings( settings: any ): SiteSettings {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function toRawSiteSettings( settings: Partial< SiteSettings > ): any {
-	const rawSettings = {} as any; // eslint-disable-line @typescript-eslint/no-explicit-any
-
+	// Pluck out settings which don't map directly to a field in the raw settings.
 	const {
 		wpcom_site_visibility,
 		wpcom_discourage_search_engines,
 		wpcom_prevent_third_party_sharing,
+		...rest
 	} = settings;
+	const rawSettings = rest as any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
 	if ( wpcom_site_visibility !== undefined ) {
 		// The high-level visibility of the site has changed.
@@ -364,14 +374,19 @@ function toRawSiteSettings( settings: Partial< SiteSettings > ): any {
 			rawSettings.wpcom_public_coming_soon = 0;
 			rawSettings.wpcom_data_sharing_opt_out = wpcom_prevent_third_party_sharing;
 		}
+
+		// Take opportunity, while the user is switching visibility settings, to disable the legacy coming soon setting.
+		rawSettings.wpcom_coming_soon = 0;
 	} else {
 		// High-level visibility of the site has not changed, but the sub settings may have.
 		// If they have then we must be a "public" site.
 		if ( wpcom_discourage_search_engines !== undefined ) {
 			rawSettings.blog_public = wpcom_discourage_search_engines ? 0 : 1;
+			rawSettings.wpcom_coming_soon = 0;
 		}
 		if ( wpcom_prevent_third_party_sharing !== undefined ) {
 			rawSettings.wpcom_data_sharing_opt_out = wpcom_prevent_third_party_sharing;
+			rawSettings.wpcom_coming_soon = 0;
 		}
 	}
 

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -319,16 +319,23 @@ export const updateSiteSettings = async ( siteIdOrSlug: string, data: Partial< S
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function fromRawSiteSettings( settings: any ): SiteSettings {
 	const blog_public = Number( settings.blog_public );
-	const wpcom_coming_soon = Number( settings.wpcom_public_coming_soon );
+	const wpcom_coming_soon = Number( settings.wpcom_coming_soon );
 	const wpcom_public_coming_soon = Number( settings.wpcom_public_coming_soon );
+	const wpcom_data_sharing_opt_out = Boolean( settings.wpcom_data_sharing_opt_out );
 
 	if ( wpcom_coming_soon === 1 || wpcom_public_coming_soon === 1 ) {
 		settings.wpcom_site_visibility = 'coming-soon';
+		settings.wpcom_discourage_search_engines = false;
 	} else if ( blog_public === -1 ) {
 		settings.wpcom_site_visibility = 'private';
+		settings.wpcom_discourage_search_engines = false;
 	} else {
 		settings.wpcom_site_visibility = 'public';
+		settings.wpcom_discourage_search_engines = blog_public === 0;
 	}
+
+	settings.wpcom_prevent_third_party_sharing = wpcom_data_sharing_opt_out;
+
 	return settings;
 }
 
@@ -336,20 +343,35 @@ function fromRawSiteSettings( settings: any ): SiteSettings {
 function toRawSiteSettings( settings: Partial< SiteSettings > ): any {
 	const rawSettings = settings as any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
-	const { wpcom_site_visibility } = settings;
+	const {
+		wpcom_site_visibility,
+		wpcom_discourage_search_engines,
+		wpcom_prevent_third_party_sharing,
+	} = settings;
 
+	if ( wpcom_discourage_search_engines !== undefined ) {
+		rawSettings.blog_public = wpcom_discourage_search_engines ? 0 : 1;
+	}
+	if ( wpcom_prevent_third_party_sharing !== undefined ) {
+		rawSettings.wpcom_data_sharing_opt_out = wpcom_prevent_third_party_sharing;
+	}
 	if ( wpcom_site_visibility !== undefined ) {
 		if ( wpcom_site_visibility === 'coming-soon' ) {
 			rawSettings.blog_public = 0;
 			rawSettings.wpcom_public_coming_soon = 1;
+			rawSettings.wpcom_data_sharing_opt_out = false;
 		} else if ( wpcom_site_visibility === 'private' ) {
 			rawSettings.blog_public = -1;
 			rawSettings.wpcom_public_coming_soon = 0;
+			rawSettings.wpcom_data_sharing_opt_out = false;
 		} else {
-			rawSettings.blog_public = 1;
+			if ( wpcom_discourage_search_engines === undefined ) {
+				rawSettings.blog_public = 1;
+			}
 			rawSettings.wpcom_public_coming_soon = 0;
 		}
 	}
+
 	return rawSettings;
 }
 

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -149,6 +149,8 @@ export interface EngagementStats {
 
 export interface SiteSettings {
 	wpcom_site_visibility?: 'coming-soon' | 'public' | 'private';
+	wpcom_discourage_search_engines?: boolean;
+	wpcom_prevent_third_party_sharing?: boolean;
 	wpcom_gifting_subscription?: boolean;
 	wpcom_performance_report_url?: string;
 }

--- a/client/dashboard/sites/settings-site-visibility/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/index.tsx
@@ -31,7 +31,7 @@ export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string
 					{ site.launch_status === 'unlaunched' ? (
 						<LaunchForm site={ site } />
 					) : (
-						<PrivacyForm settings={ settings } mutation={ mutation } />
+						<PrivacyForm site={ site } settings={ settings } mutation={ mutation } />
 					) }
 				</CardBody>
 			</Card>

--- a/client/dashboard/sites/settings-site-visibility/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/index.tsx
@@ -6,6 +6,7 @@ import PageLayout from '../../components/page-layout';
 import SettingsPageHeader from '../settings-page-header';
 import { LaunchForm } from './launch-form';
 import { PrivacyForm } from './privacy-form';
+import './style.scss';
 
 export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useQuery( siteQuery( siteSlug ) );
@@ -31,7 +32,7 @@ export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string
 					{ site.launch_status === 'unlaunched' ? (
 						<LaunchForm site={ site } />
 					) : (
-						<PrivacyForm site={ site } settings={ settings } mutation={ mutation } />
+						<PrivacyForm settings={ settings } mutation={ mutation } />
 					) }
 				</CardBody>
 			</Card>

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -61,17 +61,7 @@ export function PrivacyForm( {
 			},
 			{
 				id: 'wpcom_discourage_search_engines',
-				Edit: ( { field, onChange, data, hideLabelFromVision } ) => (
-					<CheckboxControl
-						__nextHasNoMarginBottom
-						label={ hideLabelFromVision ? '' : field.label }
-						checked={ field.getValue( { item: data } ) }
-						onChange={ () => {
-							onChange( { [ field.id ]: ! field.getValue( { item: data } ) } );
-						} }
-						help={ field.description }
-					/>
-				),
+				Edit: 'checkbox',
 				label: __( 'Discourage search engines from indexing this site' ),
 				description: __(
 					'This does not block access to your site — it is up to search engines to honor your request.'

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -83,6 +83,15 @@ const fields: Field< SiteSettings >[] = [
 	},
 ];
 
+const form = {
+	type: 'regular',
+	fields: [
+		{ id: 'wpcom_site_visibility', labelPosition: 'none' },
+		'wpcom_discourage_search_engines',
+		'wpcom_prevent_third_party_sharing',
+	],
+} satisfies Form;
+
 export function PrivacyForm( {
 	settings,
 	mutation,
@@ -117,15 +126,6 @@ export function PrivacyForm( {
 			}
 		);
 	};
-
-	const form = {
-		type: 'regular',
-		fields: [
-			{ id: 'wpcom_site_visibility', labelPosition: 'none' },
-			'wpcom_discourage_search_engines',
-			'wpcom_prevent_third_party_sharing',
-		],
-	} satisfies Form;
 
 	return (
 		<form onSubmit={ handleSubmit } className="dashboard-site-settings-privacy-form">

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -3,59 +3,117 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	Button,
+	CheckboxControl,
+	ExternalLink,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { useState } from 'react';
-import type { SiteSettings } from '../../data/types';
-import type { Field, SimpleFormField } from '@automattic/dataviews';
+import { useState, useMemo } from 'react';
+import type { SiteSettings, Site } from '../../data/types';
+import type { Field, Form, FormField } from '@automattic/dataviews';
 import type { UseMutationResult } from '@tanstack/react-query';
 
-const fields: Field< SiteSettings >[] = [
-	{
-		id: 'wpcom_site_visibility',
-		Edit: 'toggleGroup',
-		elements: [
-			{
-				label: __( 'Coming soon' ),
-				value: 'coming-soon',
-				description: __(
-					'Your site is hidden from visitors behind a "Coming Soon" notice until it is ready for viewing.'
-				),
-			},
-			{
-				label: __( 'Public' ),
-				value: 'public',
-				description: __( 'Your site is visible to everyone.' ),
-			},
-			{
-				label: __( 'Private' ),
-				value: 'private',
-				description: __(
-					'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
-				),
-			},
-		],
-	},
-];
-
-const form = {
-	type: 'regular' as const,
-	fields: [ { id: 'wpcom_site_visibility', labelPosition: 'none' } as SimpleFormField ],
-};
-
 export function PrivacyForm( {
+	site,
 	settings,
 	mutation,
 }: {
+	site: Site;
 	settings: SiteSettings;
 	mutation: UseMutationResult< Partial< SiteSettings >, Error, Partial< SiteSettings >, unknown >;
 } ) {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const [ formData, setFormData ] = useState( {
 		wpcom_site_visibility: settings.wpcom_site_visibility,
+		wpcom_discourage_search_engines: settings.wpcom_discourage_search_engines,
+		wpcom_prevent_third_party_sharing:
+			settings.wpcom_discourage_search_engines || settings.wpcom_prevent_third_party_sharing,
 	} );
+
+	const fields: Field< SiteSettings >[] = useMemo(
+		() => [
+			{
+				id: 'wpcom_site_visibility',
+				Edit: 'toggleGroup',
+				elements: [
+					{
+						label: __( 'Coming soon' ),
+						value: 'coming-soon',
+						description: __(
+							'Your site is hidden from visitors behind a "Coming Soon" notice until it is ready for viewing.'
+						),
+					},
+					{
+						label: __( 'Public' ),
+						value: 'public',
+						description: __( 'Your site is visible to everyone.' ),
+					},
+					{
+						label: __( 'Private' ),
+						value: 'private',
+						description: __(
+							'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
+						),
+					},
+				],
+			},
+			{
+				id: 'wpcom_discourage_search_engines',
+				Edit: ( { field, onChange, data, hideLabelFromVision } ) => (
+					<CheckboxControl
+						__nextHasNoMarginBottom
+						label={ hideLabelFromVision ? '' : field.label }
+						checked={ field.getValue( { item: data } ) }
+						onChange={ () => {
+							onChange( { [ field.id ]: ! field.getValue( { item: data } ) } );
+						} }
+						help={ field.description }
+					/>
+				),
+				label: __( 'Discourage search engines from indexing this site' ),
+				description: __(
+					'This does not block access to your site — it is up to search engines to honor your request.'
+				),
+			},
+			{
+				id: 'wpcom_prevent_third_party_sharing',
+				Edit: ( { field, onChange, data, hideLabelFromVision } ) => (
+					<CheckboxControl
+						__nextHasNoMarginBottom
+						label={ hideLabelFromVision ? '' : field.label }
+						checked={ field.getValue( { item: data } ) }
+						disabled={ data.wpcom_discourage_search_engines }
+						onChange={ () => {
+							onChange( { [ field.id ]: ! field.getValue( { item: data } ) } );
+						} }
+						help={ createInterpolateElement(
+							__(
+								'This will present this site’s content from being shared with our licensed network of content and research partners, including those that train AI models. <a>Learn more</a>'
+							),
+							{
+								a: (
+									// TODO investigate whether localizeUrl() is safe to import into dashboard
+									<ExternalLink
+										/* eslint-disable-next-line wpcalypso/i18n-unlocalized-url */
+										href="https://wordpress.com/support/privacy-settings/make-your-website-public/#prevent-third-party-sharing"
+										children={ null } // ExternalLink's children prop is marked as required
+									/>
+								),
+							}
+						) }
+					/>
+				),
+				label: sprintf(
+					/* translators: domain will be a site's domain name e.g. example.com */
+					__( 'Prevent third-party sharing for %(domain)s' ),
+					{ domain: new URL( site.URL ).hostname }
+				),
+			},
+		],
+		[ site.URL ]
+	);
 
 	const isDirty = Object.entries( formData ).some(
 		( [ key, value ] ) => settings[ key as keyof SiteSettings ] !== value
@@ -77,6 +135,18 @@ export function PrivacyForm( {
 		);
 	};
 
+	const form = {
+		type: 'regular',
+		fields: [ { id: 'wpcom_site_visibility', labelPosition: 'none' } ] as Array<
+			FormField | string
+		>,
+	} satisfies Form;
+
+	if ( formData.wpcom_site_visibility === 'public' ) {
+		form.fields.push( 'wpcom_discourage_search_engines' );
+		form.fields.push( 'wpcom_prevent_third_party_sharing' );
+	}
+
 	return (
 		<form onSubmit={ handleSubmit }>
 			<VStack spacing={ 4 }>
@@ -85,12 +155,31 @@ export function PrivacyForm( {
 					fields={ fields }
 					form={ form }
 					onChange={ ( edits: Partial< SiteSettings > ) => {
-						setFormData( ( data ) => ( { ...data, ...edits } ) );
+						setFormData( ( data ) => {
+							const newFormData = { ...data, ...edits };
+
+							if ( edits.wpcom_site_visibility !== undefined ) {
+								// Forget any previous edits to the discoverability controls when the visibility changes.
+								newFormData.wpcom_discourage_search_engines =
+									settings.wpcom_discourage_search_engines;
+								newFormData.wpcom_prevent_third_party_sharing =
+									settings.wpcom_discourage_search_engines ||
+									settings.wpcom_prevent_third_party_sharing;
+							}
+
+							if ( edits.wpcom_discourage_search_engines === true ) {
+								// Checking the search engine box forces the third party checkbox too.
+								newFormData.wpcom_prevent_third_party_sharing = true;
+							}
+
+							return newFormData;
+						} );
 					} }
 				/>
 				<HStack justify="flex-start">
 					<Button
 						variant="primary"
+						__next40pxDefaultSize
 						type="submit"
 						isBusy={ isPending }
 						disabled={ isPending || ! isDirty }

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -8,19 +8,85 @@ import {
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { useState, useMemo } from 'react';
-import type { SiteSettings, Site } from '../../data/types';
-import type { Field, Form, FormField } from '@automattic/dataviews';
+import { useState } from 'react';
+import type { SiteSettings } from '../../data/types';
+import type { Field, Form } from '@automattic/dataviews';
 import type { UseMutationResult } from '@tanstack/react-query';
 
+const fields: Field< SiteSettings >[] = [
+	{
+		id: 'wpcom_site_visibility',
+		Edit: 'toggleGroup',
+		elements: [
+			{
+				label: __( 'Coming soon' ),
+				value: 'coming-soon',
+				description: __(
+					'Your site is hidden from visitors behind a "Coming Soon" notice until it is ready for viewing.'
+				),
+			},
+			{
+				label: __( 'Public' ),
+				value: 'public',
+				description: __( 'Your site is visible to everyone.' ),
+			},
+			{
+				label: __( 'Private' ),
+				value: 'private',
+				description: __(
+					'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
+				),
+			},
+		],
+	},
+	{
+		id: 'wpcom_discourage_search_engines',
+		Edit: 'checkbox',
+		label: __( 'Discourage search engines from indexing this site' ),
+		description: __(
+			'This does not block access to your site — it is up to search engines to honor your request.'
+		),
+		isVisible: ( { wpcom_site_visibility }: SiteSettings ) => wpcom_site_visibility === 'public',
+	},
+	{
+		id: 'wpcom_prevent_third_party_sharing',
+		Edit: ( { field, onChange, data, hideLabelFromVision } ) => (
+			<CheckboxControl
+				__nextHasNoMarginBottom
+				label={ hideLabelFromVision ? '' : field.label }
+				checked={ field.getValue( { item: data } ) }
+				disabled={ data.wpcom_discourage_search_engines }
+				onChange={ () => {
+					onChange( { [ field.id ]: ! field.getValue( { item: data } ) } );
+				} }
+				help={ createInterpolateElement(
+					__(
+						'This will present this site’s content from being shared with our licensed network of content and research partners, including those that train AI models. <a>Learn more</a>'
+					),
+					{
+						a: (
+							// TODO investigate whether localizeUrl() is safe to import into dashboard
+							<ExternalLink
+								/* eslint-disable-next-line wpcalypso/i18n-unlocalized-url */
+								href="https://wordpress.com/support/privacy-settings/make-your-website-public/#prevent-third-party-sharing"
+								children={ null } // ExternalLink's children prop is marked as required
+							/>
+						),
+					}
+				) }
+			/>
+		),
+		label: __( 'Prevent third-party sharing for this site' ),
+		isVisible: ( { wpcom_site_visibility }: SiteSettings ) => wpcom_site_visibility === 'public',
+	},
+];
+
 export function PrivacyForm( {
-	site,
 	settings,
 	mutation,
 }: {
-	site: Site;
 	settings: SiteSettings;
 	mutation: UseMutationResult< Partial< SiteSettings >, Error, Partial< SiteSettings >, unknown >;
 } ) {
@@ -31,79 +97,6 @@ export function PrivacyForm( {
 		wpcom_prevent_third_party_sharing:
 			settings.wpcom_discourage_search_engines || settings.wpcom_prevent_third_party_sharing,
 	} );
-
-	const fields: Field< SiteSettings >[] = useMemo(
-		() => [
-			{
-				id: 'wpcom_site_visibility',
-				Edit: 'toggleGroup',
-				elements: [
-					{
-						label: __( 'Coming soon' ),
-						value: 'coming-soon',
-						description: __(
-							'Your site is hidden from visitors behind a "Coming Soon" notice until it is ready for viewing.'
-						),
-					},
-					{
-						label: __( 'Public' ),
-						value: 'public',
-						description: __( 'Your site is visible to everyone.' ),
-					},
-					{
-						label: __( 'Private' ),
-						value: 'private',
-						description: __(
-							'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
-						),
-					},
-				],
-			},
-			{
-				id: 'wpcom_discourage_search_engines',
-				Edit: 'checkbox',
-				label: __( 'Discourage search engines from indexing this site' ),
-				description: __(
-					'This does not block access to your site — it is up to search engines to honor your request.'
-				),
-			},
-			{
-				id: 'wpcom_prevent_third_party_sharing',
-				Edit: ( { field, onChange, data, hideLabelFromVision } ) => (
-					<CheckboxControl
-						__nextHasNoMarginBottom
-						label={ hideLabelFromVision ? '' : field.label }
-						checked={ field.getValue( { item: data } ) }
-						disabled={ data.wpcom_discourage_search_engines }
-						onChange={ () => {
-							onChange( { [ field.id ]: ! field.getValue( { item: data } ) } );
-						} }
-						help={ createInterpolateElement(
-							__(
-								'This will present this site’s content from being shared with our licensed network of content and research partners, including those that train AI models. <a>Learn more</a>'
-							),
-							{
-								a: (
-									// TODO investigate whether localizeUrl() is safe to import into dashboard
-									<ExternalLink
-										/* eslint-disable-next-line wpcalypso/i18n-unlocalized-url */
-										href="https://wordpress.com/support/privacy-settings/make-your-website-public/#prevent-third-party-sharing"
-										children={ null } // ExternalLink's children prop is marked as required
-									/>
-								),
-							}
-						) }
-					/>
-				),
-				label: sprintf(
-					/* translators: domain will be a site's domain name e.g. example.com */
-					__( 'Prevent third-party sharing for %(domain)s' ),
-					{ domain: new URL( site.URL ).hostname }
-				),
-			},
-		],
-		[ site.URL ]
-	);
 
 	const isDirty = Object.entries( formData ).some(
 		( [ key, value ] ) => settings[ key as keyof SiteSettings ] !== value
@@ -127,18 +120,15 @@ export function PrivacyForm( {
 
 	const form = {
 		type: 'regular',
-		fields: [ { id: 'wpcom_site_visibility', labelPosition: 'none' } ] as Array<
-			FormField | string
-		>,
+		fields: [
+			{ id: 'wpcom_site_visibility', labelPosition: 'none' },
+			'wpcom_discourage_search_engines',
+			'wpcom_prevent_third_party_sharing',
+		],
 	} satisfies Form;
 
-	if ( formData.wpcom_site_visibility === 'public' ) {
-		form.fields.push( 'wpcom_discourage_search_engines' );
-		form.fields.push( 'wpcom_prevent_third_party_sharing' );
-	}
-
 	return (
-		<form onSubmit={ handleSubmit }>
+		<form onSubmit={ handleSubmit } className="dashboard-site-settings-privacy-form">
 			<VStack spacing={ 4 }>
 				<DataForm< SiteSettings >
 					data={ formData }

--- a/client/dashboard/sites/settings-site-visibility/style.scss
+++ b/client/dashboard/sites/settings-site-visibility/style.scss
@@ -1,0 +1,16 @@
+.dashboard-site-settings-privacy-form .components-checkbox-control:has(input[type="checkbox"]:disabled:checked) {
+	label {
+		cursor: default;
+	}
+
+	input[type="checkbox"] {
+		background: #f0f0f0;
+		border-color: #ddd;
+		cursor: default;
+		opacity: 1;
+	}
+
+	svg {
+		fill: var( --dashboard__text-color );
+	}
+}

--- a/client/dashboard/sites/settings-site-visibility/test/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/test/index.tsx
@@ -1,0 +1,379 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { RouterProvider, createRouter, createRootRoute } from '@tanstack/react-router';
+import { render as testingLibraryRender, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import SiteVisibilitySettings from '../index';
+
+function render( ui: React.ReactElement ) {
+	const queryClient = new QueryClient();
+	const router = createRouter( {
+		routeTree: createRootRoute( {
+			component: () => ui,
+		} ),
+	} );
+	return testingLibraryRender(
+		<QueryClientProvider client={ queryClient }>
+			<RouterProvider router={ router } />
+		</QueryClientProvider>
+	);
+}
+
+interface TestSiteOptions {
+	slug: string;
+	visibility: 'public' | 'private' | 'coming-soon';
+	notCrawlable?: boolean;
+	dataSharingOptOut?: boolean;
+}
+
+// Only mocks site and settings fields that are necessary for the tests.
+// Feel free to add more feilds as they are needed.
+function mockTestSite( options: TestSiteOptions ) {
+	const site = {
+		slug: options.slug,
+		URL: `https://${ options.slug }`,
+		is_coming_soon: options.visibility === 'coming-soon',
+		is_private: options.visibility === 'private',
+		launch_status: 'launched',
+	};
+
+	let blog_public = 0;
+	if ( options.visibility === 'private' ) {
+		blog_public = -1;
+	} else if ( options.visibility === 'public' && ! options.notCrawlable ) {
+		blog_public = 1;
+	} else {
+		blog_public = 0;
+	}
+
+	const settings = {
+		URL: site.URL,
+		settings: {
+			blog_public,
+			wpcom_public_coming_soon: options.visibility === 'coming-soon' ? 1 : 0,
+			wpcom_data_sharing_opt_out: options.dataSharingOptOut ?? false,
+		},
+	};
+
+	const scope = nock( 'https://public-api.wordpress.com' )
+		.get( `/rest/v1.1/sites/${ site.slug }` )
+		.query( true )
+		.reply( 200, site )
+		.get( `/rest/v1.4/sites/${ site.slug }/settings` )
+		.query( true )
+		.reply( 200, settings );
+
+	return { site, settings, scope };
+}
+
+function mockSettingsSaved( siteSlug: string, settings: nock.DataMatcherMap ) {
+	return nock( 'https://public-api.wordpress.com' )
+		.post( `/rest/v1.4/sites/${ siteSlug }/settings`, ( body ) => {
+			expect( body ).toMatchObject( settings );
+			return true;
+		} )
+		.reply( 200 );
+}
+
+describe( '<SiteVisibilitySettings>', () => {
+	describe( 'Launched site', () => {
+		test( 'hides search engine and 3rd party checkboxes when private', async () => {
+			mockTestSite( {
+				slug: 'test-site',
+				visibility: 'private',
+			} );
+
+			render( <SiteVisibilitySettings siteSlug="test-site" /> );
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'radio', { name: 'Private' } ) ).toBeChecked();
+			} );
+
+			expect( screen.queryByRole( 'checkbox' ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'hides search engine and 3rd party checkboxes when coming soon', async () => {
+			mockTestSite( {
+				slug: 'test-site',
+				visibility: 'coming-soon',
+			} );
+
+			render( <SiteVisibilitySettings siteSlug="test-site" /> );
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'radio', { name: 'Coming soon' } ) ).toBeChecked();
+			} );
+
+			expect( screen.queryByRole( 'checkbox' ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'data sharing opt-out is disabled and force checked when site is not crawlable', async () => {
+			const user = userEvent.setup();
+
+			mockTestSite( {
+				slug: 'test-site',
+				visibility: 'public',
+				notCrawlable: true,
+				dataSharingOptOut: false,
+			} );
+
+			render( <SiteVisibilitySettings siteSlug="test-site" /> );
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'radio', { name: 'Public' } ) ).toBeChecked();
+			} );
+			const notCrawlable = screen.getByRole( 'checkbox', { name: /Discourage search engines/ } );
+			const preventThirdParty = screen.getByRole( 'checkbox', { name: /Prevent third-party/ } );
+
+			expect( notCrawlable ).toBeChecked();
+			expect( preventThirdParty ).toBeChecked();
+			expect( preventThirdParty ).toBeDisabled();
+
+			await user.click( notCrawlable );
+
+			expect( notCrawlable ).not.toBeChecked();
+			expect( preventThirdParty ).toBeChecked();
+			expect( preventThirdParty ).toBeEnabled();
+
+			await user.click( preventThirdParty );
+			await user.click( notCrawlable );
+
+			expect( notCrawlable ).toBeChecked();
+			expect( preventThirdParty ).toBeChecked();
+			expect( preventThirdParty ).toBeDisabled();
+		} );
+
+		test( 'switching away from public resets data sharing and crawlable settings', async () => {
+			const user = userEvent.setup();
+
+			mockTestSite( {
+				slug: 'test-site',
+				visibility: 'public',
+				notCrawlable: false,
+				dataSharingOptOut: true,
+			} );
+
+			render( <SiteVisibilitySettings siteSlug="test-site" /> );
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'radio', { name: 'Public' } ) ).toBeChecked();
+			} );
+
+			const notCrawlable = screen.getByRole( 'checkbox', { name: /Discourage search engines/ } );
+			const preventThirdParty = screen.getByRole( 'checkbox', { name: /Prevent third-party/ } );
+
+			expect( notCrawlable ).not.toBeChecked();
+			expect( preventThirdParty ).toBeChecked();
+
+			await user.click( notCrawlable );
+
+			expect( notCrawlable ).toBeChecked();
+			expect( preventThirdParty ).toBeChecked();
+
+			await user.click( screen.getByRole( 'radio', { name: 'Private' } ) );
+			await user.click( screen.getByRole( 'radio', { name: 'Public' } ) );
+
+			// Reselect checkbox elements because we expect them to have re-rendered.
+			expect(
+				screen.getByRole( 'checkbox', { name: /Discourage search engines/ } )
+			).not.toBeChecked();
+			expect( screen.getByRole( 'checkbox', { name: /Prevent third-party/ } ) ).toBeChecked();
+		} );
+
+		test( 'save site settings to make a public site private', async () => {
+			const user = userEvent.setup();
+
+			mockTestSite( {
+				slug: 'test-site',
+				visibility: 'public',
+				notCrawlable: false,
+				dataSharingOptOut: true,
+			} );
+			const scope = mockSettingsSaved( 'test-site', {
+				blog_public: -1,
+				wpcom_data_sharing_opt_out: false,
+			} );
+
+			render( <SiteVisibilitySettings siteSlug="test-site" /> );
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'radio', { name: 'Public' } ) ).toBeChecked();
+			} );
+
+			const saveButton = screen.getByRole( 'button', { name: 'Save' } );
+
+			await user.click( screen.getByRole( 'radio', { name: 'Private' } ) );
+			await user.click( saveButton );
+
+			expect( saveButton ).toBeDisabled();
+
+			await waitFor( () => {
+				expect( scope.pendingMocks() ).toHaveLength( 0 );
+				expect( saveButton ).toBeEnabled();
+			} );
+		} );
+
+		test( 'save site settings to make a public site coming soon', async () => {
+			const user = userEvent.setup();
+
+			mockTestSite( {
+				slug: 'test-site',
+				visibility: 'public',
+				notCrawlable: false,
+				dataSharingOptOut: true,
+			} );
+			const scope = mockSettingsSaved( 'test-site', {
+				blog_public: 0,
+				wpcom_public_coming_soon: 1,
+			} );
+
+			render( <SiteVisibilitySettings siteSlug="test-site" /> );
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'radio', { name: 'Public' } ) ).toBeChecked();
+			} );
+
+			await user.click( screen.getByRole( 'radio', { name: 'Coming soon' } ) );
+
+			const saveButton = screen.getByRole( 'button', { name: 'Save' } );
+
+			await user.click( saveButton );
+
+			expect( saveButton ).toBeDisabled();
+
+			await waitFor( () => {
+				expect( scope.pendingMocks() ).toHaveLength( 0 );
+				expect( saveButton ).toBeEnabled();
+			} );
+		} );
+
+		test( 'save site settings to make a coming soon site public (crawlable, allow data sharing)', async () => {
+			const user = userEvent.setup();
+
+			mockTestSite( {
+				slug: 'test-site',
+				visibility: 'coming-soon',
+			} );
+			const scope = mockSettingsSaved( 'test-site', {
+				blog_public: 1,
+				wpcom_public_coming_soon: 0,
+				wpcom_data_sharing_opt_out: false,
+			} );
+
+			render( <SiteVisibilitySettings siteSlug="test-site" /> );
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'radio', { name: 'Coming soon' } ) ).toBeChecked();
+			} );
+
+			await user.click( screen.getByRole( 'radio', { name: 'Public' } ) );
+
+			const notCrawlableCheckbox = screen.getByRole( 'checkbox', {
+				name: /Discourage search engines/,
+			} );
+			const preventThirdPartyCheckbox = screen.getByRole( 'checkbox', {
+				name: /Prevent third-party/,
+			} );
+			const saveButton = screen.getByRole( 'button', { name: 'Save' } );
+
+			expect( notCrawlableCheckbox ).not.toBeChecked();
+			expect( preventThirdPartyCheckbox ).not.toBeChecked();
+
+			await user.click( saveButton );
+
+			expect( saveButton ).toBeDisabled();
+
+			await waitFor( () => {
+				expect( scope.pendingMocks() ).toHaveLength( 0 );
+				expect( saveButton ).toBeEnabled();
+			} );
+		} );
+
+		test( 'save site settings to make a private site public (not crawlable, prevent data sharing)', async () => {
+			const user = userEvent.setup();
+
+			mockTestSite( {
+				slug: 'test-site',
+				visibility: 'private',
+			} );
+			const scope = mockSettingsSaved( 'test-site', {
+				blog_public: 0,
+				wpcom_data_sharing_opt_out: true,
+			} );
+
+			render( <SiteVisibilitySettings siteSlug="test-site" /> );
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'radio', { name: 'Private' } ) ).toBeChecked();
+			} );
+
+			await user.click( screen.getByRole( 'radio', { name: 'Public' } ) );
+
+			const notCrawlableCheckbox = screen.getByRole( 'checkbox', {
+				name: /Discourage search engines/,
+			} );
+			const preventThirdPartyCheckbox = screen.getByRole( 'checkbox', {
+				name: /Prevent third-party/,
+			} );
+			const saveButton = screen.getByRole( 'button', { name: 'Save' } );
+
+			expect( notCrawlableCheckbox ).not.toBeChecked();
+			expect( preventThirdPartyCheckbox ).not.toBeChecked();
+
+			await user.click( notCrawlableCheckbox );
+			await user.click( saveButton );
+
+			expect( saveButton ).toBeDisabled();
+
+			await waitFor( () => {
+				expect( scope.pendingMocks() ).toHaveLength( 0 );
+				expect( saveButton ).toBeEnabled();
+			} );
+		} );
+
+		test( 'save site settings to make a public site crawlable but prevent data sharing', async () => {
+			const user = userEvent.setup();
+
+			mockTestSite( {
+				slug: 'test-site',
+				visibility: 'public',
+				notCrawlable: true,
+				dataSharingOptOut: true,
+			} );
+			const scope = mockSettingsSaved( 'test-site', {
+				blog_public: 1,
+				wpcom_data_sharing_opt_out: true,
+			} );
+
+			render( <SiteVisibilitySettings siteSlug="test-site" /> );
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'radio', { name: 'Public' } ) ).toBeChecked();
+			} );
+
+			const notCrawlableCheckbox = screen.getByRole( 'checkbox', {
+				name: /Discourage search engines/,
+			} );
+			const preventThirdPartyCheckbox = screen.getByRole( 'checkbox', {
+				name: /Prevent third-party/,
+			} );
+			const saveButton = screen.getByRole( 'button', { name: 'Save' } );
+
+			expect( notCrawlableCheckbox ).toBeChecked();
+			expect( preventThirdPartyCheckbox ).toBeChecked();
+
+			await user.click( notCrawlableCheckbox );
+			await user.click( saveButton );
+
+			expect( saveButton ).toBeDisabled();
+
+			await waitFor( () => {
+				expect( scope.pendingMocks() ).toHaveLength( 0 );
+				expect( saveButton ).toBeEnabled();
+			} );
+		} );
+	} );
+} );

--- a/client/dashboard/sites/settings-site-visibility/test/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/test/index.tsx
@@ -23,38 +23,24 @@ function render( ui: React.ReactElement ) {
 }
 
 interface TestSiteOptions {
-	slug: string;
-	visibility: 'public' | 'private' | 'coming-soon';
-	notCrawlable?: boolean;
-	dataSharingOptOut?: boolean;
+	blog_public: 0 | 1 | -1;
+	wpcom_public_coming_soon: 0 | 1;
+	wpcom_data_sharing_opt_out: boolean;
 }
 
 // Only mocks site and settings fields that are necessary for the tests.
 // Feel free to add more fields as they are needed.
-function mockTestSite( options: TestSiteOptions ) {
+function mockTestSite( slug: string, options: TestSiteOptions ) {
 	const site = {
-		slug: options.slug,
-		URL: `https://${ options.slug }`,
-		is_coming_soon: options.visibility === 'coming-soon',
-		is_private: options.visibility === 'private',
+		slug,
 		launch_status: 'launched',
 	};
 
-	let blog_public = 0;
-	if ( options.visibility === 'private' ) {
-		blog_public = -1;
-	} else if ( options.visibility === 'public' && ! options.notCrawlable ) {
-		blog_public = 1;
-	} else {
-		blog_public = 0;
-	}
-
 	const settings = {
-		URL: site.URL,
 		settings: {
-			blog_public,
-			wpcom_public_coming_soon: options.visibility === 'coming-soon' ? 1 : 0,
-			wpcom_data_sharing_opt_out: options.dataSharingOptOut ?? false,
+			blog_public: options.blog_public,
+			wpcom_public_coming_soon: options.wpcom_public_coming_soon,
+			wpcom_data_sharing_opt_out: options.wpcom_data_sharing_opt_out,
 		},
 	};
 
@@ -81,9 +67,10 @@ function mockSettingsSaved( siteSlug: string, settings: nock.DataMatcherMap ) {
 describe( '<SiteVisibilitySettings>', () => {
 	describe( 'Launched site', () => {
 		test( 'hides search engine and 3rd party checkboxes when private', async () => {
-			mockTestSite( {
-				slug: 'test-site',
-				visibility: 'private',
+			mockTestSite( 'test-site', {
+				blog_public: -1,
+				wpcom_public_coming_soon: 0,
+				wpcom_data_sharing_opt_out: false,
 			} );
 
 			render( <SiteVisibilitySettings siteSlug="test-site" /> );
@@ -96,9 +83,10 @@ describe( '<SiteVisibilitySettings>', () => {
 		} );
 
 		test( 'hides search engine and 3rd party checkboxes when coming soon', async () => {
-			mockTestSite( {
-				slug: 'test-site',
-				visibility: 'coming-soon',
+			mockTestSite( 'test-site', {
+				blog_public: 0,
+				wpcom_public_coming_soon: 1,
+				wpcom_data_sharing_opt_out: false,
 			} );
 
 			render( <SiteVisibilitySettings siteSlug="test-site" /> );
@@ -113,11 +101,10 @@ describe( '<SiteVisibilitySettings>', () => {
 		test( 'data sharing opt-out is disabled and force checked when site is not crawlable', async () => {
 			const user = userEvent.setup();
 
-			mockTestSite( {
-				slug: 'test-site',
-				visibility: 'public',
-				notCrawlable: true,
-				dataSharingOptOut: false,
+			mockTestSite( 'test-site', {
+				blog_public: 0,
+				wpcom_public_coming_soon: 0,
+				wpcom_data_sharing_opt_out: false,
 			} );
 
 			render( <SiteVisibilitySettings siteSlug="test-site" /> );
@@ -149,11 +136,10 @@ describe( '<SiteVisibilitySettings>', () => {
 		test( 'switching away from public resets data sharing and crawlable settings', async () => {
 			const user = userEvent.setup();
 
-			mockTestSite( {
-				slug: 'test-site',
-				visibility: 'public',
-				notCrawlable: false,
-				dataSharingOptOut: true,
+			mockTestSite( 'test-site', {
+				blog_public: 1,
+				wpcom_public_coming_soon: 0,
+				wpcom_data_sharing_opt_out: true,
 			} );
 
 			render( <SiteVisibilitySettings siteSlug="test-site" /> );
@@ -186,11 +172,10 @@ describe( '<SiteVisibilitySettings>', () => {
 		test( 'save site settings to make a public site private', async () => {
 			const user = userEvent.setup();
 
-			mockTestSite( {
-				slug: 'test-site',
-				visibility: 'public',
-				notCrawlable: false,
-				dataSharingOptOut: true,
+			mockTestSite( 'test-site', {
+				blog_public: 1,
+				wpcom_public_coming_soon: 0,
+				wpcom_data_sharing_opt_out: true,
 			} );
 			const scope = mockSettingsSaved( 'test-site', {
 				blog_public: -1,
@@ -219,11 +204,10 @@ describe( '<SiteVisibilitySettings>', () => {
 		test( 'save site settings to make a public site coming soon', async () => {
 			const user = userEvent.setup();
 
-			mockTestSite( {
-				slug: 'test-site',
-				visibility: 'public',
-				notCrawlable: false,
-				dataSharingOptOut: true,
+			mockTestSite( 'test-site', {
+				blog_public: 1,
+				wpcom_public_coming_soon: 0,
+				wpcom_data_sharing_opt_out: true,
 			} );
 			const scope = mockSettingsSaved( 'test-site', {
 				blog_public: 0,
@@ -253,9 +237,10 @@ describe( '<SiteVisibilitySettings>', () => {
 		test( 'save site settings to make a coming soon site public (crawlable, allow data sharing)', async () => {
 			const user = userEvent.setup();
 
-			mockTestSite( {
-				slug: 'test-site',
-				visibility: 'coming-soon',
+			mockTestSite( 'test-site', {
+				blog_public: 0,
+				wpcom_public_coming_soon: 1,
+				wpcom_data_sharing_opt_out: false,
 			} );
 			const scope = mockSettingsSaved( 'test-site', {
 				blog_public: 1,
@@ -295,9 +280,10 @@ describe( '<SiteVisibilitySettings>', () => {
 		test( 'save site settings to make a private site public (not crawlable, prevent data sharing)', async () => {
 			const user = userEvent.setup();
 
-			mockTestSite( {
-				slug: 'test-site',
-				visibility: 'private',
+			mockTestSite( 'test-site', {
+				blog_public: -1,
+				wpcom_public_coming_soon: 0,
+				wpcom_data_sharing_opt_out: false,
 			} );
 			const scope = mockSettingsSaved( 'test-site', {
 				blog_public: 0,
@@ -337,11 +323,10 @@ describe( '<SiteVisibilitySettings>', () => {
 		test( 'save site settings to make a public site crawlable but prevent data sharing', async () => {
 			const user = userEvent.setup();
 
-			mockTestSite( {
-				slug: 'test-site',
-				visibility: 'public',
-				notCrawlable: true,
-				dataSharingOptOut: true,
+			mockTestSite( 'test-site', {
+				blog_public: 0,
+				wpcom_public_coming_soon: 0,
+				wpcom_data_sharing_opt_out: true,
 			} );
 			const scope = mockSettingsSaved( 'test-site', {
 				blog_public: 1,

--- a/client/dashboard/sites/settings-site-visibility/test/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/test/index.tsx
@@ -30,7 +30,7 @@ interface TestSiteOptions {
 }
 
 // Only mocks site and settings fields that are necessary for the tests.
-// Feel free to add more feilds as they are needed.
+// Feel free to add more fields as they are needed.
 function mockTestSite( options: TestSiteOptions ) {
 	const site = {
 		slug: options.slug,

--- a/client/dashboard/sites/settings-site-visibility/test/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/test/index.tsx
@@ -58,7 +58,7 @@ function mockTestSite( slug: string, options: TestSiteOptions ) {
 function mockSettingsSaved( siteSlug: string, settings: nock.DataMatcherMap ) {
 	return nock( 'https://public-api.wordpress.com' )
 		.post( `/rest/v1.4/sites/${ siteSlug }/settings`, ( body ) => {
-			expect( body ).toMatchObject( settings );
+			expect( body ).toEqual( settings );
 			return true;
 		} )
 		.reply( 200 );
@@ -180,6 +180,8 @@ describe( '<SiteVisibilitySettings>', () => {
 			const scope = mockSettingsSaved( 'test-site', {
 				blog_public: -1,
 				wpcom_data_sharing_opt_out: false,
+				wpcom_public_coming_soon: 0,
+				wpcom_coming_soon: 0,
 			} );
 
 			render( <SiteVisibilitySettings siteSlug="test-site" /> );
@@ -211,7 +213,9 @@ describe( '<SiteVisibilitySettings>', () => {
 			} );
 			const scope = mockSettingsSaved( 'test-site', {
 				blog_public: 0,
+				wpcom_data_sharing_opt_out: false,
 				wpcom_public_coming_soon: 1,
+				wpcom_coming_soon: 0, // Legacy coming soon should always be set to 0
 			} );
 
 			render( <SiteVisibilitySettings siteSlug="test-site" /> );
@@ -244,8 +248,9 @@ describe( '<SiteVisibilitySettings>', () => {
 			} );
 			const scope = mockSettingsSaved( 'test-site', {
 				blog_public: 1,
-				wpcom_public_coming_soon: 0,
 				wpcom_data_sharing_opt_out: false,
+				wpcom_public_coming_soon: 0,
+				wpcom_coming_soon: 0,
 			} );
 
 			render( <SiteVisibilitySettings siteSlug="test-site" /> );
@@ -288,6 +293,8 @@ describe( '<SiteVisibilitySettings>', () => {
 			const scope = mockSettingsSaved( 'test-site', {
 				blog_public: 0,
 				wpcom_data_sharing_opt_out: true,
+				wpcom_public_coming_soon: 0,
+				wpcom_coming_soon: 0,
 			} );
 
 			render( <SiteVisibilitySettings siteSlug="test-site" /> );
@@ -331,6 +338,8 @@ describe( '<SiteVisibilitySettings>', () => {
 			const scope = mockSettingsSaved( 'test-site', {
 				blog_public: 1,
 				wpcom_data_sharing_opt_out: true,
+				wpcom_public_coming_soon: 0,
+				wpcom_coming_soon: 0,
 			} );
 
 			render( <SiteVisibilitySettings siteSlug="test-site" /> );

--- a/test/e2e/specs/dashboard/settings__site-visibility.ts
+++ b/test/e2e/specs/dashboard/settings__site-visibility.ts
@@ -72,7 +72,7 @@ describe( 'Dashboard: Site Visibility Settings', function () {
 		await page.getByRole( 'radio', { name: 'Coming soon' } ).click();
 		await saveChanges( page );
 
-		// Open the site in a new incognito browser context to verify it's private
+		// Open the site in a new incognito browser context to verify it's coming soon
 		const incognitoPage = await browser.newPage();
 		await incognitoPage.goto( site.blog_details.url );
 		const pageContent = await incognitoPage.content();
@@ -84,13 +84,26 @@ describe( 'Dashboard: Site Visibility Settings', function () {
 		await page.getByRole( 'radio', { name: 'Public' } ).click();
 		await saveChanges( page );
 
-		// Open the site in a new incognito browser context to verify it's private
+		// Open the site in a new incognito browser context to verify it's public
 		const incognitoPage = await browser.newPage();
 		await incognitoPage.goto( site.blog_details.url );
 		const pageContent = await incognitoPage.content();
 		expect( pageContent ).not.toContain( 'Private Site' );
 		expect( pageContent ).not.toContain( 'coming soon' );
 		await incognitoPage.close();
+	} );
+
+	it( 'Can discourage search engines from indexing site', async function () {
+		await page
+			.getByRole( 'checkbox', { name: 'Discourage search engines from indexing this site' } )
+			.click();
+		await saveChanges( page );
+
+		const robotsPage = await browser.newPage();
+		await robotsPage.goto( site.blog_details.url + '/robots.txt' );
+		const pageContent = await robotsPage.content();
+		expect( pageContent ).toContain( 'User-agent: *\nDisallow: /' );
+		await robotsPage.close();
 	} );
 } );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13139

## Proposed Changes

Check out the figma QOBjujZah0UlGDDdLKZhzi-fi-3703_149132

![CleanShot 2025-05-23 at 21 27 08@2x](https://github.com/user-attachments/assets/3bcae010-7ad6-4ef0-bc06-5678e007e981)

Note:
- Discouraging search engines forces "prevent 3rd party sharing" to be enabled
- The core checkbox component does not have a good disabled UI. It still looks enabled even when it is disabled
- The "Learn more" link is not localised yet, it always points at the English support docs

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Required settings to fill out the new hosting dashboard

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test using any site at: `/v2/sites/{{ site slug }}/settings/site-visibility`
These settings are available to all sites, free -> business, simple or atomic.

Use an incognito window to ensure the settings are correctly reflected on the front end.

Feel free to compare the settings side by side with the existing Calypso controls and ensure they sync up correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?