### PR TITLE
Hosting Dashboard: Add Settings Database

### DIFF
--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -152,6 +152,17 @@ const siteSettingsSubscriptionGiftingRoute = createRoute( {
 	)
 );
 
+const siteSettingsDatabaseRoute = createRoute( {
+	getParentRoute: () => siteRoute,
+	path: 'settings/database',
+} ).lazy( () =>
+	import( '../sites/settings-database' ).then( ( d ) =>
+		createLazyRoute( 'site-settings-database' )( {
+			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
 const siteSettingsWordPressRoute = createRoute( {
 	getParentRoute: () => siteRoute,
 	path: 'settings/wordpress',
@@ -345,6 +356,7 @@ const createRouteTree = ( config: AppConfig ) => {
 				siteSettingsRoute,
 				siteSettingsSiteVisibilityRoute,
 				siteSettingsSubscriptionGiftingRoute,
+				siteSettingsDatabaseRoute,
 				siteSettingsWordPressRoute,
 				siteSettingsTransferSiteRoute,
 			] )

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -14,6 +14,7 @@ import type {
 	BasicMetricsData,
 	SiteSettings,
 	UrlPerformanceInsights,
+	PhpMyAdminToken,
 } from './types';
 
 export const fetchProfile = async (): Promise< Profile > => {
@@ -370,4 +371,11 @@ export const fetchPerformanceInsights = async (
 		},
 		{ url, advance: '1', hash: token }
 	);
+};
+
+export const fetchPhpMyAdminToken = async ( siteIdOrSlug: string ): Promise< PhpMyAdminToken > => {
+	return wpcom.req.post( {
+		path: `/sites/${ siteIdOrSlug }/hosting/pma/token`,
+		apiNamespace: 'wpcom/v2',
+	} );
 };

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -169,3 +169,7 @@ export interface UrlPerformanceInsights {
 		status: string;
 	};
 }
+
+export interface PhpMyAdminToken {
+	token: string;
+}

--- a/client/dashboard/sites/settings-database/index.tsx
+++ b/client/dashboard/sites/settings-database/index.tsx
@@ -1,0 +1,55 @@
+import {
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	Button,
+	Card,
+	CardBody,
+	Notice,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import PageLayout from '../../components/page-layout';
+import SettingsPageHeader from '../settings-page-header';
+
+export default function SiteDatabaseSettings() {
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<SettingsPageHeader
+					title={ __( 'Database' ) }
+					description={ __(
+						'For the tech-savvy, manage your database with phpMyAdmin and run a wide range of operations with MySQL.'
+					) }
+				/>
+			}
+		>
+			<Card>
+				<CardBody>
+					<VStack spacing={ 4 }>
+						<VStack spacing={ 2 }>
+							<Text size="15px" weight={ 500 } lineHeight="20px">
+								phpMyAdmin
+							</Text>
+							<Text variant="muted" lineHeight="20px">
+								{ __(
+									'phpMyAdmin is a free open source software tool that allows you to administer your site’s MySQL database over the Web.'
+								) }
+							</Text>
+						</VStack>
+						<VStack>
+							<Notice isDismissible={ false }>
+								{ __(
+									'Managing a database can be tricky and it’s not necessary for your site to function.'
+								) }
+							</Notice>
+						</VStack>
+						<HStack justify="flex-start" expanded={ false } as="span">
+							<Button variant="primary">{ __( 'Open phpMyAdmin' ) }</Button>
+						</HStack>
+					</VStack>
+				</CardBody>
+			</Card>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/sites/settings-database/index.tsx
+++ b/client/dashboard/sites/settings-database/index.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from '@tanstack/react-query';
 import {
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
@@ -11,13 +12,24 @@ import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
+import { siteQuery } from '../../app/queries';
 import PageLayout from '../../components/page-layout';
 import { fetchPhpMyAdminToken } from '../../data';
 import SettingsPageHeader from '../settings-page-header';
+import type { Site } from '../../data/types';
+
+export function canOpenPhpMyAdmin( site: Site ) {
+	return site.is_wpcom_atomic;
+}
 
 export default function SiteDatabaseSettings( { siteSlug }: { siteSlug: string } ) {
+	const { data: site } = useQuery( siteQuery( siteSlug ) );
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const [ isFetchingToken, setIsFetchingToken ] = useState( false );
+
+	if ( ! site || ! canOpenPhpMyAdmin( site ) ) {
+		return null;
+	}
 
 	const handleOpenPhpMyAdmin = async () => {
 		setIsFetchingToken( true );

--- a/client/dashboard/sites/settings-database/index.tsx
+++ b/client/dashboard/sites/settings-database/index.tsx
@@ -7,11 +7,35 @@ import {
 	CardBody,
 	Notice,
 } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useState } from 'react';
 import PageLayout from '../../components/page-layout';
+import { fetchPhpMyAdminToken } from '../../data';
 import SettingsPageHeader from '../settings-page-header';
 
-export default function SiteDatabaseSettings() {
+export default function SiteDatabaseSettings( { siteSlug }: { siteSlug: string } ) {
+	const { createErrorNotice } = useDispatch( noticesStore );
+	const [ isFetchingToken, setIsFetchingToken ] = useState( false );
+
+	const handleOpenPhpMyAdmin = async () => {
+		setIsFetchingToken( true );
+
+		try {
+			const { token } = await fetchPhpMyAdminToken( siteSlug );
+			if ( ! token ) {
+				throw new Error( 'No token found' );
+			}
+
+			window.open( `https://wordpress.com/pma-login?token=${ token }` );
+		} catch {
+			createErrorNotice( __( 'Failed to fetch phpMyAdmin token.' ), { type: 'snackbar' } );
+		}
+
+		setIsFetchingToken( false );
+	};
+
 	return (
 		<PageLayout
 			size="small"
@@ -45,7 +69,9 @@ export default function SiteDatabaseSettings() {
 							</Notice>
 						</VStack>
 						<HStack justify="flex-start" expanded={ false } as="span">
-							<Button variant="primary">{ __( 'Open phpMyAdmin' ) }</Button>
+							<Button variant="primary" isBusy={ isFetchingToken } onClick={ handleOpenPhpMyAdmin }>
+								{ __( 'Open phpMyAdmin ↗' ) }
+							</Button>
 						</HStack>
 					</VStack>
 				</CardBody>

--- a/client/dashboard/sites/settings-database/summary.tsx
+++ b/client/dashboard/sites/settings-database/summary.tsx
@@ -2,9 +2,14 @@ import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { blockTable } from '@wordpress/icons';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import { canOpenPhpMyAdmin } from './index';
 import type { Site } from '../../data/types';
 
 export default function DatabaseSettingsSummary( { site }: { site: Site } ) {
+	if ( ! canOpenPhpMyAdmin( site ) ) {
+		return null;
+	}
+
 	return (
 		<RouterLinkSummaryButton
 			to={ `/sites/${ site.slug }/settings/database` }

--- a/client/dashboard/sites/settings-database/summary.tsx
+++ b/client/dashboard/sites/settings-database/summary.tsx
@@ -1,0 +1,16 @@
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { blockTable } from '@wordpress/icons';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import type { Site } from '../../data/types';
+
+export default function DatabaseSettingsSummary( { site }: { site: Site } ) {
+	return (
+		<RouterLinkSummaryButton
+			to={ `/sites/${ site.slug }/settings/database` }
+			title={ __( 'Database' ) }
+			density="medium"
+			decoration={ <Icon icon={ blockTable } /> }
+		/>
+	);
+}

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -8,6 +8,7 @@ import { __ } from '@wordpress/i18n';
 import { siteQuery, siteSettingsQuery } from '../../app/queries';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import DatabaseSettingsSummary from '../settings-database/summary';
 import SiteVisibilitySettingsSummary from '../settings-site-visibility/summary';
 import SubscriptionGiftingSettingsSummary from '../settings-subscription-gifting/summary';
 import WordPressSettingsSummary from '../settings-wordpress/summary';
@@ -34,6 +35,7 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 			<Heading>{ __( 'Server' ) }</Heading>
 			<Card>
 				<VStack>
+					<DatabaseSettingsSummary site={ site } />
 					<WordPressSettingsSummary site={ site } />
 				</VStack>
 			</Card>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Ref DOTCOM-13253

## Proposed Changes

This PR implements the Settings Database screen.

![Screenshot 2025-05-23 at 6 21 23 PM](https://github.com/user-attachments/assets/66750beb-feb8-489c-8099-c5494f53e9ea)

Follow-ups:
- Reset phpMyAdmin password flow.

## Why are these changes being made?

<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Hosting Dashboard v2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2/sites/:siteSlug.
* Ensure you see the Database SummaryButton.
* Ensure that clicking the button takes you to the Database screen.
* Ensure that the "Open phpMyAdmin" button works as intended.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
