### PR TITLE
A4A: Change 'Digital strategy & marketing' to 'Digital marketing' services.

### DIFF
--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
@@ -82,7 +82,7 @@ export default function PersonalizationForm( {
 			{ value: 'strategy_consulting', label: translate( 'Strategy consulting' ) },
 			{ value: 'website_design_development', label: translate( 'Website design & development' ) },
 			{ value: 'performance_optimization', label: translate( 'Performance optimization' ) },
-			{ value: 'digital_strategy_marketing', label: translate( 'Digital strategy & marketing' ) },
+			{ value: 'digital_strategy_marketing', label: translate( 'Digital marketing' ) },
 			{ value: 'ecommerce_development', label: translate( 'eCommerce Development' ) },
 			{ value: 'maintenance_support_plans', label: translate( 'Maintenance & support plans' ) },
 			{ value: 'other', label: translate( 'Other' ) },


### PR DESCRIPTION

## Proposed Changes
The terms **'Digital strategy & marketing'** and **'Strategy consulting'** can be confusing, so this PR changes **'Digital strategy & marketing'** to **'Digital marketing'** to avoid confusing Services offered options.

| Before | After |
|--------|--------|
| <img width="588" alt="Screenshot 2025-05-23 at 6 34 17 PM" src="https://github.com/user-attachments/assets/6217ed8e-c981-4f82-9778-1d246dc8ca8d" /> | <img width="605" alt="Screenshot 2025-05-23 at 6 35 48 PM" src="https://github.com/user-attachments/assets/a340bd12-4f5b-4abb-adc8-44e8587c1be7" /> | 


Context pgjTho-xO-p2#comment-530


## Why are these changes being made?

This is part of the Improved A4A Onboarding project that enhances the conversion rate.

## Testing Instructions

* Use the A4A live link and navigate to `/signup`.
* Confirm that the Services offered option matches the screenshot above.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?