### PR TITLE
Match button styling on the 100y plan confirmation modal

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-site-picker/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-site-picker/styles.scss
@@ -79,4 +79,19 @@
 	.components-button.is-primary {
 		@include primary-button-black-theme;
 	}
+
+	.components-button.is-secondary:not( .is-destructive ) {
+		--wp-components-color-accent: var( --studio-gray-100 );
+		--wp-components-color-accent-darker-20: var( --studio-gray-100 );
+		background: none;
+		border: 1px solid var( --studio-gray-30 );
+	}
+
+	.components-button {
+		&.is-primary:not( .is-destructive ),
+		&.is-secondary:not( .is-destructive ) {
+			font-weight: 500;
+			box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 );
+		}
+	}
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://github.com/Automattic/wp-calypso/issues/101962

## Proposed Changes

* updates the styling of the `Cancel` button to match the previous step
* updates the font weight of both buttons to match the previous step

<img width="480" src="https://github.com/user-attachments/assets/2b18c047-4362-499c-b970-6f991d24382d"/>
<img width="480" alt="427583405-0f76cbe9-66d3-471d-9184-04e1202378db" src="https://github.com/user-attachments/assets/9a0d0088-f097-4919-99db-224a92810ec4" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We want to match the button styling between the previous step and the confirmation modal.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/setup/hundred-year-plan/new-or-existing-site?ref=100-year-lp`
* Pick Existing site
* Pick a site
* Ensure the `Cancel` and `Confirm` button styling match the styling on the previou step

<img width="480" alt="Screenshot 2025-05-23 at 14 01 57" src="https://github.com/user-attachments/assets/0a720e05-b144-4f21-b3ed-5248c24f5756" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
