### PR TITLE
Dashboard v2: Implement PHP version settings

### DIFF
--- a/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
@@ -13,7 +13,7 @@ import useCreateWPCOMSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-
 import FormSelect from 'calypso/components/forms/form-select';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import { useDataCenterOptions } from 'calypso/data/data-center/use-data-center-options';
-import { usePhpVersions } from 'calypso/data/php-versions/use-php-versions';
+import { getPHPVersions } from 'calypso/data/php-versions';
 import { useDispatch } from 'calypso/state';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { useSiteName } from './use-site-name';
@@ -42,7 +42,7 @@ export default function SiteConfigurationsModal( {
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
 	const translate = useTranslate();
 	const dataCenterOptions = useDataCenterOptions();
-	const { phpVersions } = usePhpVersions();
+	const { phpVersions } = getPHPVersions();
 	const siteName = useSiteName( randomSiteName, isRandomSiteNameLoading );
 	const { mutate: createWPCOMSite } = useCreateWPCOMSiteMutation();
 	const { mutate: createWPCOMDevSite } = useCreateWPCOMDevSiteMutation();

--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -7,6 +7,10 @@ module.exports = {
 					{
 						group: [
 							'calypso/*',
+							// Allowed: calypso/data/php-versions
+							'!calypso/data',
+							'calypso/data/*',
+							'!calypso/data/php-versions',
 							// Allowed: calypso/lib/wp
 							'!calypso/lib',
 							'calypso/lib/*',

--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -4,6 +4,7 @@ import {
 	fetchSiteMediaStorage,
 	fetchSiteMonitorUptime,
 	fetchPHPVersion,
+	updatePHPVersion,
 	fetchCurrentPlan,
 	fetchSiteEngagementStats,
 	fetchDomains,
@@ -69,6 +70,15 @@ export function sitePHPVersionQuery( siteIdOrSlug: string ) {
 	return {
 		queryKey: [ 'site', siteIdOrSlug, 'php-version' ],
 		queryFn: () => fetchPHPVersion( siteIdOrSlug ),
+	};
+}
+
+export function sitePHPVersionMutation( siteSlug: string ) {
+	return {
+		mutationFn: ( version: string ) => updatePHPVersion( siteSlug, version ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'site', siteSlug, 'php-version' ] } );
+		},
 	};
 }
 

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -80,12 +80,23 @@ export const fetchSiteMonitorUptime = async (
 };
 
 export const fetchPHPVersion = async ( id: string ): Promise< string | undefined > => {
-	// TODO: check request in different contexts.. Also do we show this only for atomic sites?
-	// TODO: find out what check is needed before this request to avoid 403 errors.
 	return wpcom.req.get( {
 		path: `/sites/${ id }/hosting/php-version`,
 		apiNamespace: 'wpcom/v2',
 	} );
+};
+
+export const updatePHPVersion = async (
+	siteIdOrSlug: string,
+	version: string
+): Promise< void > => {
+	return wpcom.req.post(
+		{
+			path: `/sites/${ siteIdOrSlug }/hosting/php-version`,
+			apiNamespace: 'wpcom/v2',
+		},
+		{ version }
+	);
 };
 
 export const fetchWordPressVersion = async ( siteIdOrSlug: string ): Promise< string > => {

--- a/client/dashboard/sites/settings-php/index.tsx
+++ b/client/dashboard/sites/settings-php/index.tsx
@@ -1,0 +1,120 @@
+import { DataForm } from '@automattic/dataviews';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import {
+	Card,
+	CardBody,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Button,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useState } from 'react';
+import { getPHPVersions } from 'calypso/data/php-versions';
+import { siteQuery, sitePHPVersionQuery, sitePHPVersionMutation } from '../../app/queries';
+import PageLayout from '../../components/page-layout';
+import SettingsPageHeader from '../settings-page-header';
+import { canUpdatePHPVersion } from './utils';
+import type { Field } from '@automattic/dataviews';
+
+export default function PHPVersionSettings( { siteSlug }: { siteSlug: string } ) {
+	const { data: site } = useQuery( siteQuery( siteSlug ) );
+	const canUpdate = site && canUpdatePHPVersion( site );
+
+	const { data: version } = useQuery( {
+		...sitePHPVersionQuery( siteSlug ),
+		enabled: canUpdate,
+	} );
+	const mutation = useMutation( sitePHPVersionMutation( siteSlug ) );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const [ formData, setFormData ] = useState< { version: string } >( {
+		version: version ?? '',
+	} );
+
+	if ( ! site ) {
+		return null;
+	}
+
+	const { phpVersions } = getPHPVersions();
+
+	const fields: Field< { version: string } >[] = [
+		{
+			id: 'version',
+			label: __( 'PHP version' ),
+			Edit: 'select',
+			elements: phpVersions.filter( ( option ) => {
+				// Show disabled PHP version only if the site is still using it.
+				if ( option.disabled && option.value !== version ) {
+					return false;
+				}
+				return true;
+			} ),
+		},
+	];
+
+	const form = {
+		type: 'regular' as const,
+		fields: [ 'version' ],
+	};
+
+	const isDirty = formData.version !== version;
+	const { isPending } = mutation;
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		mutation.mutate( formData.version, {
+			onSuccess: () => {
+				createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
+			},
+			onError: () => {
+				createErrorNotice( __( 'Failed to save settings.' ), {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
+
+	const renderForm = () => {
+		return (
+			<Card>
+				<CardBody>
+					<form onSubmit={ handleSubmit }>
+						<VStack spacing={ 4 }>
+							<DataForm< { version: string } >
+								data={ formData }
+								fields={ fields }
+								form={ form }
+								onChange={ ( edits: { version?: string } ) => {
+									setFormData( ( data ) => ( { ...data, ...edits } ) );
+								} }
+							/>
+							<HStack justify="flex-start">
+								<Button
+									variant="primary"
+									type="submit"
+									isBusy={ isPending }
+									disabled={ isPending || ! isDirty }
+								>
+									{ __( 'Save' ) }
+								</Button>
+							</HStack>
+						</VStack>
+					</form>
+				</CardBody>
+			</Card>
+		);
+	};
+
+	const renderCallout = () => {
+		return <p>TODO: callout</p>;
+	};
+
+	return (
+		<PageLayout size="small">
+			<SettingsPageHeader title="PHP" />
+			{ canUpdate ? renderForm() : renderCallout() }
+		</PageLayout>
+	);
+}

--- a/client/dashboard/sites/settings-php/index.tsx
+++ b/client/dashboard/sites/settings-php/index.tsx
@@ -22,7 +22,7 @@ export default function PHPVersionSettings( { siteSlug }: { siteSlug: string } )
 	const { data: site } = useQuery( siteQuery( siteSlug ) );
 	const canUpdate = site && canUpdatePHPVersion( site );
 
-	const { data: version } = useQuery( {
+	const { data: currentVersion } = useQuery( {
 		...sitePHPVersionQuery( siteSlug ),
 		enabled: canUpdate,
 	} );
@@ -30,7 +30,7 @@ export default function PHPVersionSettings( { siteSlug }: { siteSlug: string } )
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
 	const [ formData, setFormData ] = useState< { version: string } >( {
-		version: version ?? '',
+		version: currentVersion ?? '',
 	} );
 
 	if ( ! site ) {
@@ -46,7 +46,7 @@ export default function PHPVersionSettings( { siteSlug }: { siteSlug: string } )
 			Edit: 'select',
 			elements: phpVersions.filter( ( option ) => {
 				// Show disabled PHP version only if the site is still using it.
-				if ( option.disabled && option.value !== version ) {
+				if ( option.disabled && option.value !== currentVersion ) {
 					return false;
 				}
 				return true;
@@ -59,7 +59,7 @@ export default function PHPVersionSettings( { siteSlug }: { siteSlug: string } )
 		fields: [ 'version' ],
 	};
 
-	const isDirty = formData.version !== version;
+	const isDirty = formData.version !== currentVersion;
 	const { isPending } = mutation;
 
 	const handleSubmit = ( e: React.FormEvent ) => {

--- a/client/dashboard/sites/settings-php/summary.tsx
+++ b/client/dashboard/sites/settings-php/summary.tsx
@@ -1,0 +1,34 @@
+import { useQuery } from '@tanstack/react-query';
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { code } from '@wordpress/icons';
+import { getPHPVersions } from 'calypso/data/php-versions';
+import { sitePHPVersionQuery } from '../../app/queries';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import { canUpdatePHPVersion } from './utils';
+import type { Site } from '../../data/types';
+
+export default function PHPSettingsSummary( { site }: { site: Site } ) {
+	const { data: version } = useQuery( {
+		...sitePHPVersionQuery( site.slug ),
+		enabled: canUpdatePHPVersion( site ),
+	} );
+
+	const { recommendedValue } = getPHPVersions();
+
+	const badge = {
+		text: version ?? __( 'Managed' ),
+		intent:
+			version && version !== recommendedValue ? ( 'warning' as const ) : ( 'success' as const ),
+	};
+
+	return (
+		<RouterLinkSummaryButton
+			to={ `/sites/${ site.slug }/settings/php` }
+			title="PHP"
+			density="medium"
+			decoration={ <Icon icon={ code } /> }
+			badges={ [ badge ] }
+		/>
+	);
+}

--- a/client/dashboard/sites/settings-php/utils.tsx
+++ b/client/dashboard/sites/settings-php/utils.tsx
@@ -1,0 +1,5 @@
+import { Site } from '../../data/types';
+
+export function canUpdatePHPVersion( site: Site ) {
+	return site.is_wpcom_atomic;
+}

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -29,7 +29,7 @@ export default function WordPressVersionSettings( { siteSlug }: { siteSlug: stri
 	const { data: site } = useQuery( siteQuery( siteSlug ) );
 	const canUpdate = site && canUpdateWordPressVersion( site );
 
-	const { data: version } = useQuery( {
+	const { data: currentVersion } = useQuery( {
 		...siteWordPressVersionQuery( siteSlug ),
 		enabled: canUpdate,
 	} );
@@ -37,7 +37,7 @@ export default function WordPressVersionSettings( { siteSlug }: { siteSlug: stri
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
 	const [ formData, setFormData ] = useState< { version: string } >( {
-		version: version ?? '',
+		version: currentVersion ?? '',
 	} );
 
 	if ( ! site ) {
@@ -61,7 +61,7 @@ export default function WordPressVersionSettings( { siteSlug }: { siteSlug: stri
 		fields: [ 'version' ],
 	};
 
-	const isDirty = formData.version !== version;
+	const isDirty = formData.version !== currentVersion;
 	const { isPending } = mutation;
 
 	const handleSubmit = ( e: React.FormEvent ) => {

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -9,6 +9,7 @@ import { siteQuery, siteSettingsQuery } from '../../app/queries';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import DatabaseSettingsSummary from '../settings-database/summary';
+import PHPSettingsSummary from '../settings-php/summary';
 import SiteVisibilitySettingsSummary from '../settings-site-visibility/summary';
 import SubscriptionGiftingSettingsSummary from '../settings-subscription-gifting/summary';
 import WordPressSettingsSummary from '../settings-wordpress/summary';
@@ -37,6 +38,7 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 				<VStack>
 					<DatabaseSettingsSummary site={ site } />
 					<WordPressSettingsSummary site={ site } />
+					<PHPSettingsSummary site={ site } />
 				</VStack>
 			</Card>
 			<SiteActions site={ site } />

--- a/client/data/php-versions/index.jsx
+++ b/client/data/php-versions/index.jsx
@@ -1,14 +1,10 @@
-import { useTranslate } from 'i18n-calypso';
+import { __, sprintf } from '@wordpress/i18n';
 
-export const usePhpVersions = () => {
-	const translate = useTranslate();
-
+export const getPHPVersions = () => {
 	// PHP 8.3 is now the default recommended version
 	const recommendedValue = '8.3';
-	const recommendedLabel = translate( '%s (recommended)', {
-		args: recommendedValue,
-		comment: 'PHP Version for a version switcher',
-	} );
+	// translators: PHP Version for a version switcher
+	const recommendedLabel = sprintf( __( '%s (recommended)' ), recommendedValue );
 
 	const phpVersions = [
 		{
@@ -17,10 +13,8 @@ export const usePhpVersions = () => {
 			disabled: true, // EOL 6th December, 2021
 		},
 		{
-			label: translate( '%s (deprecated)', {
-				args: '7.4',
-				comment: 'PHP Version for a version switcher',
-			} ),
+			// translators: PHP Version for a version switcher
+			label: sprintf( __( '%s (deprecated)' ), '7.4' ),
 			value: '7.4',
 			disabled: true, // EOL 1st July, 2024
 		},
@@ -30,10 +24,8 @@ export const usePhpVersions = () => {
 			disabled: true, // EOL 26th November, 2023
 		},
 		{
-			label: translate( '%s (deprecated)', {
-				args: '8.1',
-				comment: 'PHP Version for a version switcher',
-			} ),
+			// translators: PHP Version for a version switcher
+			label: sprintf( __( '%s (deprecated)' ), '8.1' ),
 			value: '8.1',
 			disabled: false, // EOL 31st December, 2025
 		},

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-iframe/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-iframe/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { usePhpVersions } from 'calypso/data/php-versions/use-php-versions';
+import { getPHPVersions } from 'calypso/data/php-versions';
 import { initializeWordPressPlayground } from '../../lib/initialize-playground';
 import { PlaygroundError } from '../playground-error';
 import type { PlaygroundClient } from '@wp-playground/client';
@@ -15,7 +15,7 @@ export function PlaygroundIframe( {
 	setPlaygroundClient: ( client: PlaygroundClient ) => void;
 } ) {
 	const iframeRef = useRef< HTMLIFrameElement >( null );
-	const recommendedPHPVersion = usePhpVersions().recommendedValue;
+	const recommendedPHPVersion = getPHPVersions().recommendedValue;
 	const [ searchParams, setSearchParams ] = useSearchParams();
 	const [ playgroundError, setPlaygroundError ] = useState< string | null >( null );
 

--- a/client/sites/settings/server/server-configuration-form.tsx
+++ b/client/sites/settings/server/server-configuration-form.tsx
@@ -13,7 +13,7 @@ import FormSettingExplanation from 'calypso/components/forms/form-setting-explan
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import { useDataCenterOptions } from 'calypso/data/data-center/use-data-center-options';
-import { usePhpVersions } from 'calypso/data/php-versions/use-php-versions';
+import { getPHPVersions } from 'calypso/data/php-versions';
 import { useSelector } from 'calypso/state';
 import {
 	updateAtomicPhpVersion,
@@ -93,7 +93,7 @@ export default function ServerConfigurationForm( { disabled }: ServerConfigurati
 	const isPhpVersionChanged = selectedPhpVersion && selectedPhpVersion !== phpVersion;
 	const isStaticFile404Changed = selectedStaticFile404 && selectedStaticFile404 !== staticFile404;
 
-	const { recommendedValue, phpVersions } = usePhpVersions();
+	const { recommendedValue, phpVersions } = getPHPVersions();
 	const dataCenterOptions = useDataCenterOptions();
 
 	const wpVersionRef = useRef< HTMLLabelElement >( null );


### PR DESCRIPTION
Part of DOTCOM-13239

## Proposed Changes

This PR implements Settings -> PHP as follows.

### Simple sites

In simple sites, we don't know the PHP version, and we don't advertise it. See discussion: p1747972441625309-slack-C08JZTRS6NA

The upsell will be handled separately as DOTCOM-13292.

|||
|-|-|
|<img width="500" src="https://github.com/user-attachments/assets/a333e811-88b9-4586-a108-8b4ad13e9beb">|<img width="350" alt="image" src="https://github.com/user-attachments/assets/3197e81a-5dbe-47c1-b6cd-8c65d9394af8" />|

### Atomic sites

We show a warning badge if the version is not the recommended one.

|||
|-|-|
|<img width="500" src="https://github.com/user-attachments/assets/03ab7323-bc6d-48ff-b572-8f8572e8069e"><br><br><img width="500" src="https://github.com/user-attachments/assets/2dd99ce0-57c1-4b5f-8556-defc6e2836f3">|<img width="350" alt="image" src="https://github.com/user-attachments/assets/0ee32d71-87e4-4218-9f58-b36b9cdd2270" />

While working on it, I found that the "Select item" placeholder option in the `<select>` is still selectable... filed DOTCOM-13298.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?