### PR TITLE
Revert "Forcing triggering e2ePreReleaseBuildType on trunk merges"

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -1165,13 +1165,6 @@ fun e2ePreReleaseBuildType( targetDevice: String, buildUuid: String ): E2EBuildT
 				buildProbablyHanging = true
 			}
 		},
-		buildTriggers = {
-			vcs {
-				branchFilter = """
-					+:trunk
-				""".trimIndent()
-			}
-		},
 		enableCommitStatusPublisher = true,
 	)
 }


### PR DESCRIPTION
Just in case.
Reverts Automattic/wp-calypso#103647