### PR TITLE
Adjust "What's included" text in the emails to have better contrast

### DIFF
--- a/client/my-sites/email/email-providers-comparison/stacked/email-provider-stacked-card/style.scss
+++ b/client/my-sites/email/email-providers-comparison/stacked/email-provider-stacked-card/style.scss
@@ -7,7 +7,7 @@ $width-right-panel-card-expanded:  45%;
 $width-left-panel-card: 55%;
 
 .email-provider-stacked-features__whats-included {
-	color: var(--studio-gray-20);
+	color: var(--studio-gray-50);
 	display: block;
 	font-size: 0.75rem;
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-13251

## Proposed Changes

This PR adjusts contrast on `What's included` text in the email purchase flow. Before:

<img width="1053" alt="Screenshot 2025-05-23 at 3 25 21 PM" src="https://github.com/user-attachments/assets/0eb578b3-65aa-47c8-ad50-e9fdd468bd53" />

After:

<img width="1637" alt="Screenshot 2025-05-23 at 3 27 07 PM" src="https://github.com/user-attachments/assets/84a14974-c1a7-4f2f-9138-919dcda7750f" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This issue was identified as a part of testing with axe DevTools.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch or navigate to Calypso Live link
* Ensure that you have a site with a custom domain
* Navigate to `email/{siteWithCustomDomain}/purchase/{customDomain}`
* Confirm that the contrast looks good for `What's included` text
* Run axe DevTools and confirm that no issue is raised over that area

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
