### PR TITLE
Revert "Remove the migration-flow/cancel-difm feature flag"

### DIFF
--- a/client/sites/overview/components/migration-overview/components/cancel-difm-migration/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/cancel-difm-migration/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Modal, Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
@@ -105,6 +106,10 @@ const CancelDifmMigrationForm = ( { siteId }: { siteId: number } ) => {
 	const [ cancellationStatus, setCancellationStatus ] = useState<
 		'pending' | 'error' | 'success' | null
 	>( null );
+
+	if ( ! isEnabled( 'migration-flow/cancel-difm' ) ) {
+		return null;
+	}
 
 	const isMigrationInProgress = stickers.includes( 'migration-in-progress' );
 	const isMigationCompleted =

--- a/client/sites/overview/components/migration-overview/components/cancel-difm-migration/test/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/cancel-difm-migration/test/index.tsx
@@ -41,6 +41,12 @@ describe( 'CancelDifmMigrationForm', () => {
 		useBlogStickersQuery.mockReturnValue( { data: [] } );
 	} );
 
+	it( 'renders nothing if feature flag is disabled', () => {
+		isEnabled.mockReturnValue( false );
+		renderWithProvider( <CancelDifmMigrationForm siteId={ siteId } /> );
+		expect( screen.queryByRole( 'button', { name: /cancel migration/i } ) ).toBeNull();
+	} );
+
 	describe( 'when migration is not in progress', () => {
 		beforeEach( () => {
 			useBlogStickersQuery.mockReturnValue( { data: [] } );

--- a/config/development.json
+++ b/config/development.json
@@ -124,6 +124,7 @@
 		"me/account/color-scheme-picker": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
+		"migration-flow/cancel-difm": true,
 		"oauth": false,
 		"onboarding/create-course": false,
 		"onboarding/import": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -81,6 +81,7 @@
 		"me/account/color-scheme-picker": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
+		"migration-flow/cancel-difm": true,
 		"onboarding/create-course": false,
 		"onboarding/step-container-v2-import-flow": true,
 		"onboarding/step-container-v2-migration-flow": true,

--- a/config/production.json
+++ b/config/production.json
@@ -98,6 +98,7 @@
 		"me/account/color-scheme-picker": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
+		"migration-flow/cancel-difm": false,
 		"onboarding/create-course": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -96,6 +96,7 @@
 		"me/account/color-scheme-picker": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
+		"migration-flow/cancel-difm": false,
 		"onboarding/create-course": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,

--- a/config/test.json
+++ b/config/test.json
@@ -77,6 +77,7 @@
 		"me/account-close": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
+		"migration-flow/cancel-difm": false,
 		"onboarding/create-course": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -99,6 +99,7 @@
 		"me/account/color-scheme-picker": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
+		"migration-flow/cancel-difm": false,
 		"onboarding/create-course": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#103548

We're going to hide this from users again. The current method we're using to check blog stickers is limited to a12s so end users are _always_ seeing the cancel button.