### PR TITLE
Remove always-on jetpack/social-plans-v1 feature flag

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
@@ -1,9 +1,4 @@
-import { isEnabled } from '@automattic/calypso-config';
-import {
-	isJetpackPlanSlug,
-	isJetpackSocialSlug,
-	isJetpackStatsPaidProductSlug,
-} from '@automattic/calypso-products';
+import { isJetpackPlanSlug, isJetpackStatsPaidProductSlug } from '@automattic/calypso-products';
 import clsx from 'clsx';
 import { useStoreItemInfoContext } from '../context/store-item-info-context';
 import { ItemPrice } from '../item-price';
@@ -101,10 +96,7 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 						isSuperseded
 					);
 
-					const isMultiPlanSelectProduct =
-						( isJetpackSocialSlug( item.productSlug ) &&
-							! isEnabled( 'jetpack/social-plans-v1' ) ) ||
-						isJetpackStatsPaidProductSlug( item.productSlug );
+					const isMultiPlanSelectProduct = isJetpackStatsPaidProductSlug( item.productSlug );
 
 					let ctaHref = getCheckoutURL( item );
 					if ( isMultiPlanSelectProduct && ! isIncludedInPlanOrSuperseded ) {

--- a/client/my-sites/plans/jetpack-plans/use-get-plans-grid-products.ts
+++ b/client/my-sites/plans/jetpack-plans/use-get-plans-grid-products.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	JETPACK_ANTI_SPAM_PRODUCTS,
 	PRODUCT_JETPACK_BACKUP_T0_YEARLY,
@@ -7,12 +6,6 @@ import {
 	PRODUCT_JETPACK_BACKUP_T1_MONTHLY,
 	PRODUCT_JETPACK_BACKUP_T2_YEARLY,
 	PRODUCT_JETPACK_BACKUP_T2_MONTHLY,
-	PRODUCT_JETPACK_SOCIAL_BASIC_BI_YEARLY,
-	PRODUCT_JETPACK_SOCIAL_BASIC,
-	PRODUCT_JETPACK_SOCIAL_BASIC_MONTHLY,
-	PRODUCT_JETPACK_SOCIAL_ADVANCED_BI_YEARLY,
-	PRODUCT_JETPACK_SOCIAL_ADVANCED,
-	PRODUCT_JETPACK_SOCIAL_ADVANCED_MONTHLY,
 	PRODUCT_JETPACK_SCAN,
 	PRODUCT_JETPACK_SCAN_MONTHLY,
 	JETPACK_AI_PRODUCTS,
@@ -139,38 +132,13 @@ const useSelectorPageProducts = ( siteId: number | null ): PlanGridProducts => {
 		availableProducts = [ ...availableProducts, ...JETPACK_STATS_PRODUCTS ];
 	}
 
-	if ( isEnabled( 'jetpack/social-plans-v1' ) ) {
-		// If Jetpack Social is directly or indirectly owned, continue, otherwise make it available.
-		if (
-			! ownedProducts.some( ( ownedProduct ) =>
-				( JETPACK_SOCIAL_V1_PRODUCTS as ReadonlyArray< string > ).includes( ownedProduct )
-			)
-		) {
-			availableProducts = [ ...availableProducts, ...JETPACK_SOCIAL_V1_PRODUCTS ];
-		}
-	} else {
-		const socialProductsToShow: string[] = [];
-
-		const ownsSocialBasic =
-			ownedProducts.includes( PRODUCT_JETPACK_SOCIAL_BASIC_BI_YEARLY ) ||
-			ownedProducts.includes( PRODUCT_JETPACK_SOCIAL_BASIC ) ||
-			ownedProducts.includes( PRODUCT_JETPACK_SOCIAL_BASIC_MONTHLY );
-		const ownsSocialAdvanced =
-			ownedProducts.includes( PRODUCT_JETPACK_SOCIAL_ADVANCED_BI_YEARLY ) ||
-			ownedProducts.includes( PRODUCT_JETPACK_SOCIAL_ADVANCED ) ||
-			ownedProducts.includes( PRODUCT_JETPACK_SOCIAL_ADVANCED_MONTHLY );
-
-		// If neither Social Basic or Social Advanced backups are owned, then show Social Basic Plan.
-		// Otherwise the one owned will be displayed via purchasedProducts.
-		if ( ! ownsSocialBasic && ! ownsSocialAdvanced ) {
-			socialProductsToShow.push(
-				PRODUCT_JETPACK_SOCIAL_ADVANCED_BI_YEARLY,
-				PRODUCT_JETPACK_SOCIAL_ADVANCED,
-				PRODUCT_JETPACK_SOCIAL_ADVANCED_MONTHLY
-			);
-		}
-
-		availableProducts = [ ...availableProducts, ...socialProductsToShow ];
+	// If Jetpack Social is directly or indirectly owned, continue, otherwise make it available.
+	if (
+		! ownedProducts.some( ( ownedProduct ) =>
+			( JETPACK_SOCIAL_V1_PRODUCTS as ReadonlyArray< string > ).includes( ownedProduct )
+		)
+	) {
+		availableProducts = [ ...availableProducts, ...JETPACK_SOCIAL_V1_PRODUCTS ];
 	}
 
 	// If the user does not own the AI product, include it in available products

--- a/config/development.json
+++ b/config/development.json
@@ -96,7 +96,6 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/sharing-buttons-block-enabled": true,
 		"jetpack/simplify-pricing-structure": false,
-		"jetpack/social-plans-v1": true,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/zendesk-chat-for-logged-in-users": true,
 		"jetpack/crm-downloads": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -58,7 +58,6 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/sharing-buttons-block-enabled": false,
 		"jetpack/simplify-pricing-structure": false,
-		"jetpack/social-plans-v1": true,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/crm-downloads": true,
 		"jitms": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -62,7 +62,6 @@
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
-		"jetpack/social-plans-v1": true,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/url-only-connection": true,
 		"jetpack/streamline-license-purchases": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -56,7 +56,6 @@
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
-		"jetpack/social-plans-v1": true,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/streamline-license-purchases": false,
 		"layout/app-banner": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -59,7 +59,6 @@
 		"jetpack/manage-sites-v2-menu": false,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
-		"jetpack/social-plans-v1": true,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/streamline-license-purchases": false,
 		"jetpack/crm-downloads": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -59,7 +59,6 @@
 		"jetpack/manage-simple-sites": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
-		"jetpack/social-plans-v1": true,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/url-only-connection": true,
 		"jetpack/streamline-license-purchases": false,

--- a/config/production.json
+++ b/config/production.json
@@ -73,7 +73,6 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/sharing-buttons-block-enabled": false,
 		"jetpack/simplify-pricing-structure": false,
-		"jetpack/social-plans-v1": true,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/zendesk-chat-for-logged-in-users": true,
 		"jetpack/crm-downloads": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -70,7 +70,6 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/sharing-buttons-block-enabled": false,
 		"jetpack/simplify-pricing-structure": false,
-		"jetpack/social-plans-v1": true,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/zendesk-chat-for-logged-in-users": true,
 		"jetpack/crm-downloads": true,


### PR DESCRIPTION
Removes a feature flag that is always-on in all environments. Both Calypso Blue and Calypso Green.
