### PR TITLE
Calendar components: simplify types, forward all `onChange` arguments

### DIFF
--- a/packages/components/src/calendar/date-calendar.tsx
+++ b/packages/components/src/calendar/date-calendar.tsx
@@ -4,7 +4,7 @@ import { COMMON_PROPS } from './utils/constants';
 import { clampNumberOfMonths } from './utils/misc';
 import { useControlledValue } from './utils/use-controlled-value';
 import { useLocalizationProps } from './utils/use-localization-props';
-import type { DateCalendarProps, OnSelectHandler } from './types';
+import type { DateCalendarProps } from './types';
 import './styles.scss';
 
 export const DateCalendar = ( {
@@ -25,7 +25,7 @@ export const DateCalendar = ( {
 	const [ selected, setSelected ] = useControlledValue< Date | undefined >( {
 		defaultValue: defaultSelected,
 		value: selectedProp,
-		onChange: onSelect as OnSelectHandler< Date | undefined >,
+		onChange: onSelect,
 	} );
 
 	return (

--- a/packages/components/src/calendar/date-range-calendar.tsx
+++ b/packages/components/src/calendar/date-range-calendar.tsx
@@ -5,7 +5,7 @@ import { COMMON_PROPS, MODIFIER_CLASSNAMES } from './utils/constants';
 import { clampNumberOfMonths } from './utils/misc';
 import { useControlledValue } from './utils/use-controlled-value';
 import { useLocalizationProps } from './utils/use-localization-props';
-import type { DateRangeCalendarProps, DateRange, OnSelectHandler } from './types';
+import type { DateRangeCalendarProps, DateRange } from './types';
 import './styles.scss';
 
 export const DateRangeCalendar = ( {
@@ -25,7 +25,7 @@ export const DateRangeCalendar = ( {
 	const [ selected, setSelected ] = useControlledValue< DateRange | undefined >( {
 		defaultValue: defaultSelected,
 		value: selectedProp,
-		onChange: onSelect as OnSelectHandler< DateRange | undefined >,
+		onChange: onSelect,
 	} );
 
 	const [ hoveredDate, setHoveredDate ] = useState< Date | undefined >( undefined );

--- a/packages/components/src/calendar/stories/date-calendar.stories.tsx
+++ b/packages/components/src/calendar/stories/date-calendar.stories.tsx
@@ -146,13 +146,7 @@ export const ControlledWithInputField: Story = {
 					selected={ selected }
 					onSelect={ ( selectedDate, ...rest ) => {
 						setSelected( selectedDate ?? null );
-						// TS is strict about `onSelect` expecting a non-undefined date
-						// when the selection is required.
-						if ( ! args.required ) {
-							args.onSelect?.( selectedDate, ...rest );
-						} else if ( selectedDate ) {
-							args.onSelect?.( selectedDate, ...rest );
-						}
+						args.onSelect?.( selectedDate, ...rest );
 					} }
 				/>
 			</div>
@@ -229,13 +223,7 @@ export const WithTimeZone: Story = {
 					selected={ selected }
 					onSelect={ ( selectedDate, ...rest ) => {
 						setSelected( selectedDate ? new TZDate( selectedDate, args.timeZone ) : null );
-						// TS is strict about `onSelect` expecting a non-undefined date
-						// when the selection is required.
-						if ( ! args.required ) {
-							args.onSelect?.( selectedDate, ...rest );
-						} else if ( selectedDate ) {
-							args.onSelect?.( selectedDate, ...rest );
-						}
+						args.onSelect?.( selectedDate, ...rest );
 					} }
 					disabled={ [
 						{
@@ -360,13 +348,7 @@ export const WithPresets: Story = {
 					selected={ selected }
 					onSelect={ ( selectedDate, ...rest ) => {
 						setSelected( selectedDate ?? null );
-						// TS is strict about `onSelect` expecting a non-undefined date
-						// when the selection is required.
-						if ( ! args.required ) {
-							args.onSelect?.( selectedDate, ...rest );
-						} else if ( selectedDate ) {
-							args.onSelect?.( selectedDate, ...rest );
-						}
+						args.onSelect?.( selectedDate, ...rest );
 					} }
 					month={ month }
 					onMonthChange={ setMonth }

--- a/packages/components/src/calendar/stories/date-range-calendar.stories.tsx
+++ b/packages/components/src/calendar/stories/date-range-calendar.stories.tsx
@@ -173,13 +173,7 @@ export const ControlledWithInputFields: Story = {
 								? null
 								: selectedDate
 						);
-						// TS is strict about `onSelect` expecting a non-undefined date
-						// when the selection is required.
-						if ( ! args.required ) {
-							args.onSelect?.( selectedDate, ...rest );
-						} else if ( selectedDate ) {
-							args.onSelect?.( selectedDate, ...rest );
-						}
+						args.onSelect?.( selectedDate, ...rest );
 					} }
 				/>
 			</div>
@@ -254,13 +248,7 @@ export const WithTimeZone: Story = {
 								? null
 								: selectedDate
 						);
-						// TS is strict about `onSelect` expecting a non-undefined date
-						// when the selection is required.
-						if ( ! args.required ) {
-							args.onSelect?.( selectedDate, ...rest );
-						} else if ( selectedDate ) {
-							args.onSelect?.( selectedDate, ...rest );
-						}
+						args.onSelect?.( selectedDate, ...rest );
 					} }
 					disabled={ [
 						{
@@ -399,13 +387,7 @@ export const WithPresets: Story = {
 								? null
 								: selectedDate
 						);
-						// TS is strict about `onSelect` expecting a non-undefined date
-						// when the selection is required.
-						if ( ! args.required ) {
-							args.onSelect?.( selectedDate, ...rest );
-						} else if ( selectedDate ) {
-							args.onSelect?.( selectedDate, ...rest );
-						}
+						args.onSelect?.( selectedDate, ...rest );
 					} }
 					month={ month }
 					onMonthChange={ setMonth }

--- a/packages/components/src/calendar/types.ts
+++ b/packages/components/src/calendar/types.ts
@@ -157,7 +157,8 @@ export type OnSelectHandler< T > = (
 	e: React.MouseEvent | React.KeyboardEvent
 ) => void;
 
-export interface BaseProps extends Omit< React.HTMLAttributes< HTMLDivElement >, 'onSelect' > {
+export interface BaseProps
+	extends Omit< React.HTMLAttributes< HTMLDivElement >, 'onSelect' | 'defaultValue' > {
 	/**
 	 * Whether the selection is required.
 	 * When `true`, there always needs to be a date selected.

--- a/packages/components/src/calendar/types.ts
+++ b/packages/components/src/calendar/types.ts
@@ -132,11 +132,30 @@ type DayOfWeek = {
 
 /**
  * Shared handler type for `onSelect` callback when a selection mode is set.
+ * @example
+ *   const handleSelect: OnSelectHandler<Date> = (
+ *     selected,
+ *     triggerDate,
+ *     modifiers,
+ *     e
+ *   ) => {
+ *     console.log("Selected:", selected);
+ *     console.log("Triggered by:", triggerDate);
+ *   };
  * @template T - The type of the selected item.
  * @callback OnSelectHandler
  * @param {T} selected - The selected item after the event.
+ * @param {Date} triggerDate - The date when the event was triggered. This is
+ *   typically the day clicked or interacted with.
+ * @param {Modifiers} modifiers - The modifiers associated with the event.
+ * @param {React.MouseEvent | React.KeyboardEvent} e - The event object.
  */
-type OnSelectHandler< T > = ( selected: T ) => void;
+export type OnSelectHandler< T > = (
+	selected: T,
+	triggerDate: Date,
+	modifiers: Modifiers,
+	e: React.MouseEvent | React.KeyboardEvent
+) => void;
 
 export interface BaseProps extends Omit< React.HTMLAttributes< HTMLDivElement >, 'onSelect' > {
 	/**

--- a/packages/components/src/calendar/types.ts
+++ b/packages/components/src/calendar/types.ts
@@ -136,11 +136,13 @@ type DayOfWeek = {
  * @callback OnSelectHandler
  * @param {T} selected - The selected item after the event.
  */
-export type OnSelectHandler< T > = ( selected: T ) => void;
+type OnSelectHandler< T > = ( selected: T ) => void;
 
 export interface BaseProps extends Omit< React.HTMLAttributes< HTMLDivElement >, 'onSelect' > {
 	/**
 	 * Whether the selection is required.
+	 * When `true`, there always needs to be a date selected.
+	 * @default false
 	 */
 	required?: boolean;
 
@@ -266,22 +268,7 @@ export interface BaseProps extends Omit< React.HTMLAttributes< HTMLDivElement >,
 	role?: 'application' | 'dialog' | undefined;
 }
 
-interface SinglePropsRequired {
-	required: true;
-	/** The selected date. */
-	selected: Date | undefined | null;
-	/**
-	 * Event handler when a day is selected. When the selection is required,
-	 * user can not deselect the date, and therefore the callback always
-	 * has a defined date argument.
-	 */
-	onSelect?: OnSelectHandler< Date >;
-	/** The default selected date (for uncontrolled usage). */
-	defaultSelected?: Date;
-}
-
-interface SinglePropsOptional {
-	required?: false | undefined;
+interface SingleProps {
 	/** The selected date. */
 	selected?: Date | undefined | null;
 	/** Event handler when a day is selected. */
@@ -299,24 +286,6 @@ interface RangeProps {
 	min?: number;
 	/** The maximum number of days to include in the range. */
 	max?: number;
-}
-
-interface RangePropsRequired {
-	required: true;
-	/** The selected range. */
-	selected: DateRange | undefined | null;
-	/**
-	 * Event handler when a range is selected. When the selection is required,
-	 * user can not deselect the range, and therefore the callback always
-	 * has a defined range argument.
-	 */
-	onSelect?: OnSelectHandler< DateRange >;
-	/** The default selected range (for uncontrolled usage). */
-	defaultSelected?: DateRange;
-}
-
-interface RangePropsOptional {
-	required?: false | undefined;
 	/** The selected range. */
 	selected?: DateRange | undefined | null;
 	/** Event handler when the selection changes. */
@@ -325,7 +294,5 @@ interface RangePropsOptional {
 	defaultSelected?: DateRange;
 }
 
-export type DateCalendarProps = BaseProps & ( SinglePropsRequired | SinglePropsOptional );
-export type DateRangeCalendarProps = BaseProps &
-	RangeProps &
-	( RangePropsRequired | RangePropsOptional );
+export type DateCalendarProps = BaseProps & SingleProps;
+export type DateRangeCalendarProps = BaseProps & RangeProps;

--- a/packages/components/src/calendar/types.ts
+++ b/packages/components/src/calendar/types.ts
@@ -139,8 +139,8 @@ type DayOfWeek = {
  *     modifiers,
  *     e
  *   ) => {
- *     console.log("Selected:", selected);
- *     console.log("Triggered by:", triggerDate);
+ *     console.log( "Selected:", selected );
+ *     console.log( "Triggered by:", triggerDate );
  *   };
  * @template T - The type of the selected item.
  * @callback OnSelectHandler

--- a/packages/components/src/calendar/utils/use-controlled-value.ts
+++ b/packages/components/src/calendar/utils/use-controlled-value.ts
@@ -6,7 +6,7 @@ import { useState, useCallback } from 'react';
 type Props< T > = {
 	defaultValue?: T;
 	value?: T | null | undefined;
-	onChange?: ( newValue: T ) => void;
+	onChange?: ( newValue: T, ...args: any[] ) => void;
 };
 
 /**
@@ -33,9 +33,9 @@ export function useControlledValue< T >( {
 
 	let setValue: typeof onChange;
 	const uncontrolledSetValue: NonNullable< typeof onChange > = useCallback(
-		( nextValue ) => {
+		( nextValue, ...args ) => {
 			setState( nextValue );
-			onChange?.( nextValue );
+			onChange?.( nextValue, ...args );
 		},
 		[ setState, onChange ]
 	);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes DS-232

## Proposed Changes

- Remove type unions around the `required` prop.
- Forward `onChange` arguments in the `useControlledValue` hook

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The current type unions complicate the code without necessarily bringing better DX. Removing them allows us to simplify the code, and generalize the `useControlledValue` hook.

The arguments forwarding for the `onChange` callback in `useControlledValue` also fixes an inconsistency, where the `onSelect` callback prop would return extra arguments only in uncontrolled mode.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- No TS errors
- `DateCalendar` and `DateRangeCalendar` works as expected in Storybook

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
