### PR TITLE
Update to get migration status from site details

### DIFF
--- a/client/sites/overview/components/migration-overview/components/cancel-difm-migration/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/cancel-difm-migration/index.tsx
@@ -3,10 +3,10 @@ import { Modal, Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { useBlogStickersQuery } from 'calypso/blocks/blog-stickers/use-blog-stickers-query';
 import { LoadingBar } from 'calypso/components/loading-bar';
 import wp from 'calypso/lib/wp';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import { useSiteMigrationStatus } from './use-site-migration-status';
 
 type CancelMigrationButtonProps = {
 	isMigrationInProgress: boolean;
@@ -99,7 +99,6 @@ const CancelMigrationModal = ( {
 const CancelDifmMigrationForm = ( { siteId }: { siteId: number } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const { data: stickers = [] } = useBlogStickersQuery( siteId );
 	const [ isOpen, setOpen ] = useState( false );
 	const openModal = () => setOpen( true );
 	const closeModal = () => setOpen( false );
@@ -107,14 +106,15 @@ const CancelDifmMigrationForm = ( { siteId }: { siteId: number } ) => {
 		'pending' | 'error' | 'success' | null
 	>( null );
 
+	const { site, isMigrationCompleted, isMigrationInProgress } = useSiteMigrationStatus( siteId );
+
 	if ( ! isEnabled( 'migration-flow/cancel-difm' ) ) {
 		return null;
 	}
 
-	const isMigrationInProgress = stickers.includes( 'migration-in-progress' );
-	const isMigationCompleted =
-		stickers.includes( 'site-migration-complete' ) ||
-		stickers.includes( 'migration-completed-difm' );
+	if ( ! site ) {
+		return null;
+	}
 
 	const handleSendCancellationRequest = async ( siteId: number ) => {
 		try {
@@ -162,7 +162,7 @@ const CancelDifmMigrationForm = ( { siteId }: { siteId: number } ) => {
 			{ cancellationStatus === 'pending' && (
 				<LoadingBar className="migration-started-difm__cancel-loading-bar" progress={ 0.5 } />
 			) }
-			{ ! isMigationCompleted && cancellationStatus === null && (
+			{ ! isMigrationCompleted && cancellationStatus === null && (
 				<CancelMigrationButton
 					isMigrationInProgress={ isMigrationInProgress }
 					onClick={ openModal }

--- a/client/sites/overview/components/migration-overview/components/cancel-difm-migration/test/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/cancel-difm-migration/test/index.tsx
@@ -23,22 +23,26 @@ jest.mock( 'calypso/lib/wp', () => ( {
 	},
 } ) );
 
-jest.mock( 'calypso/blocks/blog-stickers/use-blog-stickers-query', () => ( {
-	useBlogStickersQuery: jest.fn(),
+jest.mock( '../use-site-migration-status', () => ( {
+	useSiteMigrationStatus: jest.fn(),
 } ) );
 
 describe( 'CancelDifmMigrationForm', () => {
 	const siteId = 123;
 	const isEnabled = jest.requireMock( '@automattic/calypso-config' ).isEnabled;
-	const useBlogStickersQuery = jest.requireMock(
-		'calypso/blocks/blog-stickers/use-blog-stickers-query'
-	).useBlogStickersQuery;
+	const useSiteMigrationStatus = jest.requireMock(
+		'../use-site-migration-status'
+	).useSiteMigrationStatus;
 
 	beforeEach( () => {
 		nock.cleanAll();
 		jest.clearAllMocks();
 		isEnabled.mockReturnValue( true );
-		useBlogStickersQuery.mockReturnValue( { data: [] } );
+		useSiteMigrationStatus.mockReturnValue( {
+			site: { ID: siteId },
+			isMigrationCompleted: false,
+			isMigrationInProgress: false,
+		} );
 	} );
 
 	it( 'renders nothing if feature flag is disabled', () => {
@@ -49,7 +53,11 @@ describe( 'CancelDifmMigrationForm', () => {
 
 	describe( 'when migration is not in progress', () => {
 		beforeEach( () => {
-			useBlogStickersQuery.mockReturnValue( { data: [] } );
+			useSiteMigrationStatus.mockReturnValue( {
+				site: { ID: siteId },
+				isMigrationCompleted: false,
+				isMigrationInProgress: false,
+			} );
 		} );
 
 		it( 'shows cancel migration button', () => {
@@ -68,7 +76,11 @@ describe( 'CancelDifmMigrationForm', () => {
 
 	describe( 'when migration is in progress', () => {
 		beforeEach( () => {
-			useBlogStickersQuery.mockReturnValue( { data: [ 'migration-in-progress' ] } );
+			useSiteMigrationStatus.mockReturnValue( {
+				site: { ID: siteId },
+				isMigrationCompleted: false,
+				isMigrationInProgress: true,
+			} );
 		} );
 
 		it( 'shows request cancellation button', () => {

--- a/client/sites/overview/components/migration-overview/components/cancel-difm-migration/test/use-site-migration-status.ts
+++ b/client/sites/overview/components/migration-overview/components/cancel-difm-migration/test/use-site-migration-status.ts
@@ -1,0 +1,97 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
+import { useSiteMigrationStatus } from '../use-site-migration-status';
+
+// Mock the SITE_STORE
+jest.mock( 'calypso/landing/stepper/stores', () => ( {
+	SITE_STORE: 'site-store',
+} ) );
+
+// Mock the WordPress data store with combineReducers
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	combineReducers: jest.fn( ( reducers ) => reducers ),
+	createReduxStore: jest.fn(),
+	register: jest.fn(),
+} ) );
+
+describe( 'useSiteMigrationStatus', () => {
+	const mockSite = {
+		ID: 123,
+		site_migration: {
+			is_complete: false,
+			in_progress: true,
+		},
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should return site data and migration status', () => {
+		( useSelect as jest.Mock ).mockImplementation( ( selector ) => {
+			return selector( ( storeName: string ) => {
+				if ( storeName === 'site-store' ) {
+					return {
+						getSite: () => mockSite,
+					};
+				}
+				return {};
+			} );
+		} );
+
+		const { result } = renderHook( () => useSiteMigrationStatus( 123 ) );
+
+		expect( result.current ).toEqual( {
+			site: mockSite,
+			isMigrationCompleted: false,
+			isMigrationInProgress: true,
+		} );
+	} );
+
+	it( 'should handle undefined site data', () => {
+		( useSelect as jest.Mock ).mockImplementation( ( selector ) => {
+			return selector( ( storeName: string ) => {
+				if ( storeName === 'site-store' ) {
+					return {
+						getSite: () => undefined,
+					};
+				}
+				return {};
+			} );
+		} );
+
+		const { result } = renderHook( () => useSiteMigrationStatus( 123 ) );
+
+		expect( result.current ).toEqual( {
+			site: undefined,
+			isMigrationCompleted: false,
+			isMigrationInProgress: false,
+		} );
+	} );
+
+	it( 'should handle site without migration data', () => {
+		( useSelect as jest.Mock ).mockImplementation( ( selector ) => {
+			return selector( ( storeName: string ) => {
+				if ( storeName === 'site-store' ) {
+					return {
+						getSite: () => ( { ID: 123 } ),
+					};
+				}
+				return {};
+			} );
+		} );
+
+		const { result } = renderHook( () => useSiteMigrationStatus( 123 ) );
+
+		expect( result.current ).toEqual( {
+			site: { ID: 123 },
+			isMigrationCompleted: false,
+			isMigrationInProgress: false,
+		} );
+	} );
+} );

--- a/client/sites/overview/components/migration-overview/components/cancel-difm-migration/use-site-migration-status.ts
+++ b/client/sites/overview/components/migration-overview/components/cancel-difm-migration/use-site-migration-status.ts
@@ -1,0 +1,22 @@
+import { useSelect } from '@wordpress/data';
+import { SITE_STORE } from 'calypso/landing/stepper/stores';
+import type { SiteSelect } from '@automattic/data-stores';
+
+/**
+ * Custom hook to get site migration status.
+ * @param siteId The ID of the site to check.
+ * @returns Object containing site data and migration status.
+ */
+export function useSiteMigrationStatus( siteId: number ) {
+	return useSelect(
+		( select ) => {
+			const site = ( select( SITE_STORE ) as SiteSelect ).getSite( siteId );
+			return {
+				isMigrationCompleted: site?.site_migration?.is_complete ?? false,
+				isMigrationInProgress: site?.site_migration?.in_progress ?? false,
+				site,
+			};
+		},
+		[ siteId ]
+	);
+}

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -631,6 +631,8 @@ export interface SourceSiteMigrationBase {
 	recent_migration?: boolean;
 	failed_backup_source?: boolean;
 	migration_status?: string;
+	is_complete?: boolean;
+	in_progress?: boolean;
 }
 
 export interface Page {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCON-26

**NOTE: This PR requires 183697-ghe-Automattic/wpcom. If the wpcom PR hasn't been merged yet, you'll need to apply it to your sandbox and sandbox the public-api.**

## Proposed Changes

Previously, we used blog stickers which turned out to only be accessible to a12s. Now we use the site details which includes status fields for the two pieces we're interested in.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the calypso.live url or run this locally. NOTE: If you run it locally, you'll need to share credentials instead of authorizing the application password once you reach that step.
* Go to `/setup/site-migration`
* Continue with the migration flow and select a DIFM migration.
* When you reach the site overview, there should be a new 'Cancel migration' button. 
  * If you don't see the button, try enabling the `migration-flow/cancel-difm` flag.
![image](https://github.com/user-attachments/assets/06422364-af22-441b-8a6f-ad160a8cf3a6)
* Now add the `migration-in-progress` sticker to the blog. The button should change to 'Request migration cancellation'. 
![image](https://github.com/user-attachments/assets/d82525b8-4e6e-47d2-a6cd-e60c8ce29b80)
* Now add the `migration-completed-difm` or `site-migration-complete` sticker. The cancellation button should be hidden.
![image](https://github.com/user-attachments/assets/776a78e3-8b43-478e-a5c2-91a9b420a1af)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?