### PR TITLE
Hosting Dashboard: Site Settings backport route parity

### DIFF
--- a/client/sites/settings/v2/index.tsx
+++ b/client/sites/settings/v2/index.tsx
@@ -1,9 +1,7 @@
-import { QueryClientProvider } from '@tanstack/react-query';
-import { RouterProvider } from '@tanstack/react-router';
 import { useEffect, useRef } from 'react';
 import { createRoot } from 'react-dom/client';
-import { persistPromise, queryClient } from 'calypso/dashboard/app/query-client';
-import { getRouter } from './router';
+import { persistPromise } from 'calypso/dashboard/app/query-client';
+import Layout from './layout';
 
 export default function DashboardBackportSiteSettingsRenderer() {
 	const rootInstanceRef = useRef< ReturnType< typeof createRoot > | null >( null );
@@ -14,17 +12,12 @@ export default function DashboardBackportSiteSettingsRenderer() {
 			return;
 		}
 
-		const router = getRouter();
 		if ( ! rootInstanceRef.current ) {
 			rootInstanceRef.current = createRoot( containerRef.current );
 		}
 
 		persistPromise.then( () => {
-			rootInstanceRef.current?.render(
-				<QueryClientProvider client={ queryClient }>
-					<RouterProvider router={ router } />
-				</QueryClientProvider>
-			);
+			rootInstanceRef.current?.render( <Layout /> );
 		} );
 
 		return () => {

--- a/client/sites/settings/v2/layout.tsx
+++ b/client/sites/settings/v2/layout.tsx
@@ -1,0 +1,23 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { RouterProvider } from '@tanstack/react-router';
+import { AuthProvider, useAuth } from 'calypso/dashboard/app/auth';
+import { queryClient } from 'calypso/dashboard/app/query-client';
+import { getRouter } from './router';
+
+function RouterProviderWithAuth() {
+	const auth = useAuth();
+	const router = getRouter();
+	return <RouterProvider router={ router } context={ { auth } } />;
+}
+
+function Layout() {
+	return (
+		<QueryClientProvider client={ queryClient }>
+			<AuthProvider>
+				<RouterProviderWithAuth />
+			</AuthProvider>
+		</QueryClientProvider>
+	);
+}
+
+export default Layout;


### PR DESCRIPTION
## Proposed Changes

This PR brings newly added routes to the Site Settings backport. In addition, this PR also introduces AuthProvider to the backport since useAuth is used in some of the components. This might have cause some interoperatibility issues but doing some smoke testing things work as intended.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Hosting Dashboard Site Settings backport.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /sites/settings/v2/:siteSlug
* Ensure the settings work as intended

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
