### PR TITLE
Hosting Dashboard: Add reset password in Settings Database

### DIFF
--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -35,8 +35,3 @@ a {
 #wpcom {
 	font-size: $font-size-medium;
 }
-
-h1 {
-	font-family: var( --dashboard-h1__font-family );
-	font-weight: var( --dashboard-h1__font-weight ) !important;
-}

--- a/client/dashboard/components/page-header/style.scss
+++ b/client/dashboard/components/page-header/style.scss
@@ -6,7 +6,9 @@ client-dashboard-components-page-header {
 }
 
 .client-dashboard-components-page-header__heading {
+	font-family: var( --dashboard-h1__font-family );
 	font-size: $font-size-2x-large;
+	font-weight: var( --dashboard-h1__font-weight ) !important;
 	line-height: $font-line-height-2x-large;
 	margin-block: 0;
 }

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -391,6 +391,13 @@ export const fetchPhpMyAdminToken = async ( siteIdOrSlug: string ): Promise< Php
 	} );
 };
 
+export const resetPhpMyAdminPassword = async ( siteIdOrSlug: string ): Promise< void > => {
+	return wpcom.req.post( {
+		path: `/sites/${ siteIdOrSlug }/hosting/restore-database-password`,
+		apiNamespace: 'wpcom/v2',
+	} );
+};
+
 export const fetchStaticFile404 = async ( siteIdOrSlug: string ): Promise< string > => {
 	return wpcom.req.get( {
 		path: `/sites/${ siteIdOrSlug }/hosting/static-file-404`,
@@ -410,3 +417,4 @@ export const updateStaticFile404 = async (
 		{ setting }
 	);
 };
+

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -417,4 +417,3 @@ export const updateStaticFile404 = async (
 		{ setting }
 	);
 };
-

--- a/client/dashboard/sites/settings-database/reset-password-modal.tsx
+++ b/client/dashboard/sites/settings-database/reset-password-modal.tsx
@@ -1,0 +1,55 @@
+import {
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	Button,
+	Modal,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import { resetPhpMyAdminPassword } from '../../data';
+
+interface ResetPasswordModalProps {
+	siteSlug: string;
+	onClose: () => void;
+	onSuccess: () => void;
+	onError: () => void;
+}
+
+export default function ResetPasswordModal( {
+	siteSlug,
+	onClose,
+	onSuccess,
+	onError,
+}: ResetPasswordModalProps ) {
+	const [ isRestoring, setIsRestoring ] = useState( false );
+
+	const handleRestore = () => {
+		setIsRestoring( true );
+		resetPhpMyAdminPassword( siteSlug )
+			.then( () => {
+				setIsRestoring( false );
+				onSuccess();
+			} )
+			.catch( () => {
+				setIsRestoring( false );
+				onError();
+			} );
+	};
+
+	return (
+		<Modal title={ __( 'Restore database password' ) } onRequestClose={ onClose }>
+			<VStack spacing={ 6 }>
+				<Text>
+					{ __( 'Are you sure you want to restore the default password of your database?' ) }
+				</Text>
+				<HStack justify="flex-end" spacing={ 2 }>
+					<Button onClick={ onClose }>{ __( 'Cancel' ) }</Button>
+					<Button variant="primary" isBusy={ isRestoring } onClick={ handleRestore }>
+						{ __( 'Restore' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		</Modal>
+	);
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Ref DOTCOM-13253

## Proposed Changes

This PR implements the reset database password functionality.

![Screenshot 2025-05-24 at 11 32 27 PM](https://github.com/user-attachments/assets/e8ad641e-a644-464f-95d8-f4e52295ed46)

## Why are these changes being made?

<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Hosting Dashboard.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2/sites/:siteSlug/settings/database
* Ensure that the "resetting the password" link opens the confirmation modal.
* Ensure that the Restore button in the confirmation modal works as intended. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
