### PR TITLE
i18n: Add context to several category names

### DIFF
--- a/client/blocks/login/social.scss
+++ b/client/blocks/login/social.scss
@@ -15,7 +15,6 @@
 
 .auth-form__social.is-login {
 	margin-bottom: 0;
-	flex-shrink: 0;
 
 	/**
 	* Social First Logins

--- a/client/blocks/login/social.scss
+++ b/client/blocks/login/social.scss
@@ -15,6 +15,7 @@
 
 .auth-form__social.is-login {
 	margin-bottom: 0;
+	flex-shrink: 0;
 
 	/**
 	* Social First Logins

--- a/client/my-sites/plugins/categories/use-categories.tsx
+++ b/client/my-sites/plugins/categories/use-categories.tsx
@@ -183,7 +183,7 @@ export const getCategories: () => Record< string, Category > = () => ( {
 		preview: [],
 	},
 	social: {
-		menu: __( 'Social' ),
+		menu: _x( 'Social', 'category name' ),
 		title: __( 'Social' ),
 		description: __( 'Connect to your audience and amplify your content on social.' ),
 		icon: 'grid',
@@ -493,7 +493,7 @@ export const getCategories: () => Record< string, Category > = () => ( {
 		preview: [],
 	},
 	comments: {
-		menu: __( 'Comment' ),
+		menu: _x( 'Comment', 'category name' ),
 		title: __( 'Comments & commenting' ),
 		slug: 'comments',
 		tags: [ 'comment', 'comments', 'comment fields', 'delete comments' ],
@@ -558,7 +558,7 @@ export const getCategories: () => Record< string, Category > = () => ( {
 		preview: [],
 	},
 	search: {
-		menu: __( 'Search' ),
+		menu: _x( 'Search', 'category name' ),
 		title: __( 'Search' ),
 		slug: 'search',
 		tags: [ 'ajax search', 'image search', 'search and replace', 'search', 'google' ],


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of I18N-226

## Proposed Changes

* Add context to several plugin category names.

<img width="1370" alt="Screenshot 2025-05-25 at 22 20 36" src="https://github.com/user-attachments/assets/54435ef1-6a05-45ef-a4e2-94f72c3e2c1c" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This would allow us to translate them more accurately.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
