### PR TITLE
Calendar: fix SVG attribute casing to camelCase

### DIFF
--- a/packages/components/src/calendar/utils/day-cell.tsx
+++ b/packages/components/src/calendar/utils/day-cell.tsx
@@ -13,9 +13,9 @@ const PreviewDashStart = () => {
 			xmlns="http://www.w3.org/2000/svg"
 			fill="none"
 			stroke="currentColor"
-			stroke-dasharray="3.84516"
-			stroke-dashoffset="1.9226"
-			stroke-width="1"
+			strokeDasharray="3.84516"
+			strokeDashoffset="1.9226"
+			strokeWidth="1"
 		>
 			<path d="M32,0.5 h-29.5 a2,2 0 0 0 -2,2 v27 a2,2 0 0 0 2,2 h30" />
 		</svg>
@@ -32,9 +32,9 @@ const PreviewDashMiddle = () => {
 			xmlns="http://www.w3.org/2000/svg"
 			fill="none"
 			stroke="currentColor"
-			stroke-dasharray="3.9 4"
-			stroke-dashoffset="2"
-			stroke-width="1"
+			strokeDasharray="3.9 4"
+			strokeDashoffset="2"
+			strokeWidth="1"
 		>
 			<line x1="0" y1="0.5" x2="100" y2="0.5" />
 			<line x1="0" y1="31.5" x2="100" y2="31.5" />
@@ -53,9 +53,9 @@ const PreviewDashEnd = () => {
 			xmlns="http://www.w3.org/2000/svg"
 			fill="none"
 			stroke="currentColor"
-			stroke-dasharray="3.84516"
-			stroke-dashoffset="1.9226"
-			stroke-width="1"
+			strokeDasharray="3.84516"
+			strokeDashoffset="1.9226"
+			strokeWidth="1"
 		>
 			<path d="M0,0.5 h29.5 a2,2 0 0 1 2,2 v27 a2,2 0 0 1 -2,2 h-29.5" />
 		</svg>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Follow up to #102989

## Proposed Changes

Apply the correct camelCase to the SVG attributes in the Calendar components

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To fully adhere to JSX syntax

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load `DateRangeCalendar` in Storybook
* Select at least one date, and hover with your cursor to show the range selection preview
* Check the console output and make sure there are not warnings against ill-formatted SVG attributes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
