### PR TITLE
Hosting Dashboard: Implement Handling requests for nonexistent assets setting screen

### DIFF
--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -18,6 +18,8 @@ import {
 	restoreSitePlanSoftware,
 	fetchWordPressVersion,
 	updateWordPressVersion,
+	fetchStaticFile404,
+	updateStaticFile404,
 } from '../data';
 import { SITE_FIELDS, SITE_OPTIONS } from '../data/constants';
 import { queryClient } from './query-client';
@@ -180,6 +182,24 @@ export function performanceInsightsQuery( url: string, token: string ) {
 				return false;
 			}
 			return 5000;
+		},
+	};
+}
+
+export function siteStaticFile404Query( siteId: string ) {
+	return {
+		queryKey: [ 'site', siteId, 'static-file-404' ],
+		queryFn: () => {
+			return fetchStaticFile404( siteId );
+		},
+	};
+}
+
+export function siteStaticFile404Mutation( siteId: string ) {
+	return {
+		mutationFn: ( setting: string ) => updateStaticFile404( siteId, setting ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'site', siteId, 'static-file-404' ] } );
 		},
 	};
 }

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -396,11 +396,8 @@ const createRouteTree = ( config: AppConfig ) => {
 				siteSettingsSubscriptionGiftingRoute,
 				siteSettingsDatabaseRoute,
 				siteSettingsWordPressRoute,
-<<<<<<< HEAD
 				siteSettingsPHPRoute,
-=======
 				siteSettingsStaticFile404Route,
->>>>>>> 313bc547e75 (Implement Handling requests for nonexistent assets screen)
 				siteSettingsTransferSiteRoute,
 			] )
 		);

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -7,6 +7,7 @@ import {
 } from '@tanstack/react-router';
 import { fetchTwoStep } from '../data';
 import { canUpdatePHPVersion } from '../sites/settings-php/utils';
+import { canSetStaticFile404Handling } from '../sites/settings-static-file-404';
 import { canUpdateWordPressVersion } from '../sites/settings-wordpress/utils';
 import NotFound from './404';
 import UnknownError from './500';
@@ -19,6 +20,7 @@ import {
 	profileQuery,
 	siteCurrentPlanQuery,
 	siteEngagementStatsQuery,
+	siteStaticFile404Query,
 	siteWordPressVersionQuery,
 	sitePHPVersionQuery,
 } from './queries';
@@ -194,6 +196,23 @@ const siteSettingsPHPRoute = createRoute( {
 } ).lazy( () =>
 	import( '../sites/settings-php' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-php' )( {
+			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+const siteSettingsStaticFile404Route = createRoute( {
+	getParentRoute: () => siteRoute,
+	path: 'settings/static-file-404',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteQuery( siteSlug ) );
+		if ( canSetStaticFile404Handling( site ) ) {
+			return await queryClient.ensureQueryData( siteStaticFile404Query( siteSlug ) );
+		}
+	},
+} ).lazy( () =>
+	import( '../sites/settings-static-file-404' ).then( ( d ) =>
+		createLazyRoute( 'site-settings-static-file-404' )( {
 			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
 		} )
 	)
@@ -377,7 +396,11 @@ const createRouteTree = ( config: AppConfig ) => {
 				siteSettingsSubscriptionGiftingRoute,
 				siteSettingsDatabaseRoute,
 				siteSettingsWordPressRoute,
+<<<<<<< HEAD
 				siteSettingsPHPRoute,
+=======
+				siteSettingsStaticFile404Route,
+>>>>>>> 313bc547e75 (Implement Handling requests for nonexistent assets screen)
 				siteSettingsTransferSiteRoute,
 			] )
 		);

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -390,3 +390,23 @@ export const fetchPhpMyAdminToken = async ( siteIdOrSlug: string ): Promise< Php
 		apiNamespace: 'wpcom/v2',
 	} );
 };
+
+export const fetchStaticFile404 = async ( siteIdOrSlug: string ): Promise< string > => {
+	return wpcom.req.get( {
+		path: `/sites/${ siteIdOrSlug }/hosting/static-file-404`,
+		apiNamespace: 'wpcom/v2',
+	} );
+};
+
+export const updateStaticFile404 = async (
+	siteIdOrSlug: string,
+	setting: string
+): Promise< void > => {
+	return wpcom.req.post(
+		{
+			path: `/sites/${ siteIdOrSlug }/hosting/static-file-404`,
+			apiNamespace: 'wpcom/v2',
+		},
+		{ setting }
+	);
+};

--- a/client/dashboard/sites/settings-static-file-404/callout-illustration.svg
+++ b/client/dashboard/sites/settings-static-file-404/callout-illustration.svg
@@ -1,0 +1,51 @@
+<svg width="286" height="244" viewBox="0 0 286 244" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g clip-path="url(#clip0_4468_50763)">
+<path d="M0 4C0 1.79086 1.79086 0 4 0H282C284.209 0 286 1.79086 286 4V240C286 242.209 284.209 244 282 244H3.99999C1.79085 244 0 242.209 0 240V4Z" fill="#101517"/>
+<rect opacity="0.1" width="286" height="244" fill="url(#pattern0_4468_50763)"/>
+<ellipse cx="143.146" cy="121.793" rx="75.6176" ry="75.4105" transform="rotate(45 143.146 121.793)" fill="#101517"/>
+<circle cx="143.293" cy="122.586" r="27" transform="rotate(45 143.293 122.586)" stroke="url(#paint0_linear_4468_50763)"/>
+<circle cx="143.293" cy="122.586" r="39" transform="rotate(45 143.293 122.586)" stroke="url(#paint1_linear_4468_50763)"/>
+<circle cx="143.293" cy="122.586" r="51" transform="rotate(45 143.293 122.586)" stroke="url(#paint2_linear_4468_50763)"/>
+<circle cx="143.293" cy="122.586" r="63" transform="rotate(45 143.293 122.586)" stroke="url(#paint3_linear_4468_50763)"/>
+<circle cx="143.293" cy="122.586" r="75" transform="rotate(45 143.293 122.586)" stroke="url(#paint4_linear_4468_50763)"/>
+<path d="M143 118V47.0001C143 47.0001 158.5 45.9574 175 53.5C192.5 61.4999 198.452 69.595 206.5 81.5001C215.217 94.3951 217 118 217 118L143 118Z" fill="url(#paint5_linear_4468_50763)"/>
+<path d="M246.5 18.5V225.5H39.5V18.5H246.5Z" stroke="#3858E9"/>
+<circle cx="246" cy="20" r="4.25" fill="white" stroke="#3858E9" stroke-width="1.5"/>
+<circle cx="246" cy="226" r="4.25" fill="white" stroke="#3858E9" stroke-width="1.5"/>
+<circle cx="40" cy="19" r="4.25" fill="white" stroke="#3858E9" stroke-width="1.5"/>
+<circle cx="40" cy="225" r="4.25" fill="white" stroke="#3858E9" stroke-width="1.5"/>
+</g>
+<defs>
+<pattern id="pattern0_4468_50763" patternContentUnits="objectBoundingBox" width="0.020979" height="0.0245902">
+<use xlink:href="#image0_4468_50763" transform="scale(0.00174825 0.00204918)"/>
+</pattern>
+<linearGradient id="paint0_linear_4468_50763" x1="163.452" y1="122.586" x2="121.857" y2="122.637" gradientUnits="userSpaceOnUse">
+<stop stop-color="#3858E9"/>
+<stop offset="1" stop-color="#069E08"/>
+</linearGradient>
+<linearGradient id="paint1_linear_4468_50763" x1="172.411" y1="122.585" x2="112.33" y2="122.66" gradientUnits="userSpaceOnUse">
+<stop stop-color="#3858E9"/>
+<stop offset="1" stop-color="#069E08"/>
+</linearGradient>
+<linearGradient id="paint2_linear_4468_50763" x1="181.371" y1="122.585" x2="102.803" y2="122.682" gradientUnits="userSpaceOnUse">
+<stop stop-color="#3858E9"/>
+<stop offset="1" stop-color="#069E08"/>
+</linearGradient>
+<linearGradient id="paint3_linear_4468_50763" x1="190.33" y1="122.584" x2="93.2762" y2="122.705" gradientUnits="userSpaceOnUse">
+<stop stop-color="#3858E9"/>
+<stop offset="1" stop-color="#069E08"/>
+</linearGradient>
+<linearGradient id="paint4_linear_4468_50763" x1="199.29" y1="122.584" x2="83.7492" y2="122.727" gradientUnits="userSpaceOnUse">
+<stop stop-color="#3858E9"/>
+<stop offset="1" stop-color="#069E08"/>
+</linearGradient>
+<linearGradient id="paint5_linear_4468_50763" x1="180.267" y1="117.019" x2="163.235" y2="95.6324" gradientUnits="userSpaceOnUse">
+<stop stop-color="#101517" stop-opacity="0"/>
+<stop offset="1" stop-color="#101517"/>
+</linearGradient>
+<clipPath id="clip0_4468_50763">
+<path d="M0 4C0 1.79086 1.79086 0 4 0H282C284.209 0 286 1.79086 286 4V240C286 242.209 284.209 244 282 244H3.99999C1.79085 244 0 242.209 0 240V4Z" fill="white"/>
+</clipPath>
+<image id="image0_4468_50763" width="12" height="12" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAAHklEQVR4nGNgGAUI8P/////YxJnwKcaliSQbhgMAAKzQD/NUeFzJAAAAAElFTkSuQmCC"/>
+</defs>
+</svg>

--- a/client/dashboard/sites/settings-static-file-404/index.tsx
+++ b/client/dashboard/sites/settings-static-file-404/index.tsx
@@ -114,10 +114,6 @@ export default function SiteStaticFile404Settings( { siteSlug }: { siteSlug: str
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
-		if ( ! canSetStaticFile404Handling( site ) ) {
-			return;
-		}
-
 		mutation.mutate( formData.setting, {
 			onSuccess: () => {
 				createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );

--- a/client/dashboard/sites/settings-static-file-404/index.tsx
+++ b/client/dashboard/sites/settings-static-file-404/index.tsx
@@ -1,0 +1,166 @@
+import { DataForm } from '@automattic/dataviews';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import {
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	Card,
+	CardBody,
+	Button,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { settings } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
+import { addQueryArgs } from '@wordpress/url';
+import { useState } from 'react';
+import { siteQuery, siteStaticFile404Query, siteStaticFile404Mutation } from '../../app/queries';
+import { Callout } from '../../components/callout';
+import PageLayout from '../../components/page-layout';
+import SettingsPageHeader from '../settings-page-header';
+import calloutIllustrationUrl from './callout-illustration.svg';
+import type { Site } from '../../data/types';
+import type { Field } from '@automattic/dataviews';
+
+export function canSetStaticFile404Handling( site: Site ) {
+	return site.is_wpcom_atomic;
+}
+
+const fields: Field< { setting: string } >[] = [
+	{
+		id: 'setting',
+		label: __( 'Server response' ),
+		Edit: 'select',
+		description: __(
+			'Assets are images, fonts, JavaScript, and CSS files that web browsers request as part of loading a web page. This setting controls how the web server handles requests for missing asset files.'
+		),
+		elements: [
+			{ value: 'default', label: __( 'Default' ) },
+			{ value: 'lightweight', label: __( 'Send a lightweight File-Not-Found page' ) },
+			{ value: 'wordpress', label: __( 'Delegate request to WordPress' ) },
+		],
+	},
+];
+
+const form = {
+	type: 'regular' as const,
+	fields: [ 'setting' ],
+};
+
+export default function SiteStaticFile404Settings( { siteSlug }: { siteSlug: string } ) {
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const { data: site } = useQuery( siteQuery( siteSlug ) );
+	const { data: currentSetting } = useQuery( {
+		...siteStaticFile404Query( siteSlug ),
+		enabled: site && canSetStaticFile404Handling( site ),
+	} );
+	const mutation = useMutation( siteStaticFile404Mutation( siteSlug ) );
+
+	const [ formData, setFormData ] = useState< { setting: string } >( {
+		setting: currentSetting ?? 'default',
+	} );
+
+	if ( ! site ) {
+		return null;
+	}
+
+	if ( ! canSetStaticFile404Handling( site ) ) {
+		const handleUpgradePlan = () => {
+			const backUrl = window.location.href.replace( window.location.origin, '' );
+
+			window.location.href = addQueryArgs(
+				`/checkout/${ encodeURIComponent( siteSlug ) }/business`,
+				{
+					cancel_to: backUrl,
+					redirect_to: backUrl,
+				}
+			);
+		};
+
+		return (
+			<PageLayout
+				size="small"
+				header={ <SettingsPageHeader title={ __( 'Handling requests for nonexistent assets' ) } /> }
+			>
+				<Callout
+					icon={ settings }
+					headingLevel={ 4 }
+					imageSrc={ calloutIllustrationUrl }
+					title={ __( 'Fine-tune your WordPress site' ) }
+					description={
+						<>
+							<Text variant="muted">
+								{ __(
+									'Get under the hood—control caching, choose your PHP version, and test out upcoming WordPress releases.'
+								) }
+							</Text>
+							<Text variant="muted">
+								{ __( 'Available on the WordPress.com Business and Commerce plans.' ) }
+							</Text>
+						</>
+					}
+					actions={
+						<Button variant="primary" size="compact" onClick={ handleUpgradePlan }>
+							{ __( 'Upgrade plan' ) }
+						</Button>
+					}
+				/>
+			</PageLayout>
+		);
+	}
+
+	const isDirty = formData.setting !== currentSetting;
+	const { isPending } = mutation;
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		if ( ! canSetStaticFile404Handling( site ) ) {
+			return;
+		}
+
+		mutation.mutate( formData.setting, {
+			onSuccess: () => {
+				createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
+			},
+			onError: () => {
+				createErrorNotice( __( 'Failed to save settings.' ), {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
+
+	return (
+		<PageLayout
+			size="small"
+			header={ <SettingsPageHeader title={ __( 'Handling requests for nonexistent assets' ) } /> }
+		>
+			<Card>
+				<CardBody>
+					<form onSubmit={ handleSubmit }>
+						<VStack spacing={ 4 }>
+							<DataForm< { setting: string } >
+								data={ formData }
+								fields={ fields }
+								form={ form }
+								onChange={ ( edits: { setting?: string } ) => {
+									setFormData( ( data ) => ( { ...data, ...edits } ) );
+								} }
+							/>
+							<HStack justify="flex-start">
+								<Button
+									variant="primary"
+									type="submit"
+									isBusy={ isPending }
+									disabled={ isPending || ! isDirty }
+								>
+									{ __( 'Save' ) }
+								</Button>
+							</HStack>
+						</VStack>
+					</form>
+				</CardBody>
+			</Card>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/sites/settings-static-file-404/summary.tsx
+++ b/client/dashboard/sites/settings-static-file-404/summary.tsx
@@ -1,0 +1,16 @@
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { notFound } from '@wordpress/icons';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import type { Site } from '../../data/types';
+
+export default function StaticFile404SettingsSummary( { site }: { site: Site } ) {
+	return (
+		<RouterLinkSummaryButton
+			to={ `/sites/${ site.slug }/settings/static-file-404` }
+			title={ __( 'Handling requests for nonexistent assets' ) }
+			density="medium"
+			decoration={ <Icon icon={ notFound } /> }
+		/>
+	);
+}

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -11,6 +11,7 @@ import PageLayout from '../../components/page-layout';
 import DatabaseSettingsSummary from '../settings-database/summary';
 import PHPSettingsSummary from '../settings-php/summary';
 import SiteVisibilitySettingsSummary from '../settings-site-visibility/summary';
+import StaticFile404SettingsSummary from '../settings-static-file-404/summary';
 import SubscriptionGiftingSettingsSummary from '../settings-subscription-gifting/summary';
 import WordPressSettingsSummary from '../settings-wordpress/summary';
 import DangerZone from './danger-zone';
@@ -39,6 +40,7 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 					<DatabaseSettingsSummary site={ site } />
 					<WordPressSettingsSummary site={ site } />
 					<PHPSettingsSummary site={ site } />
+					<StaticFile404SettingsSummary site={ site } />
 				</VStack>
 			</Card>
 			<SiteActions site={ site } />

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+- Add `help` prop support for `SelectControl` used in the `select` DataForm control, via the DataForm field `description` prop.
 - Add a new DataForm Edit control: `toggleGroup`, which renders a `<ToggleGroupControl />`. If the field elements (options) have a `description`, then the selected option's description will be also rendered.
 - Implement the `media` field type definition and allow type definitions to provide a new default: `enableSorting`.
 - Add new `boolean` field type definition and edit control. Field type definitions are able to define a default render function that will be used if the field doesn't define one.

--- a/packages/dataviews/src/dataform-controls/select.tsx
+++ b/packages/dataviews/src/dataform-controls/select.tsx
@@ -42,6 +42,7 @@ export default function Select< Item >( {
 		<SelectControl
 			label={ label }
 			value={ value }
+			help={ field.description }
 			options={ elements }
 			onChange={ onChangeControl }
 			__next40pxDefaultSize


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

DOTCOM-13256

## Proposed Changes

This PR implements the "Handling requests for nonexistent assets" screen. See screenshots for reference:

| Callout | Default |
| --- | --- |
| ![Screenshot 2025-05-25 at 3 54 17 PM](https://github.com/user-attachments/assets/ac9b4c36-e20c-411a-b3c8-000eaf04e4e0) | ![Screenshot 2025-05-25 at 3 11 24 PM](https://github.com/user-attachments/assets/6bf89b2d-b092-4821-82e5-b93f8b2fd9ab) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of the Hosting Dashboard project.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2/sites/:siteSlug/settings/static-file-404.
* For WoA sites, ensure the setting saves as intended.
* For simple sites, ensure the Callout is shown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
