### PR TITLE
Make site.site_migration.migration_status optional

### DIFF
--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -93,7 +93,9 @@ export interface Site {
 	launch_status: string | boolean;
 	site_migration: {
 		migration_status?: string;
-	} | null;
+		in_progress: boolean;
+		is_complete: boolean;
+	};
 	site_owner: number;
 	jetpack: boolean;
 	jetpack_modules: string[] | null;

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -92,7 +92,7 @@ export interface Site {
 	is_wpcom_staging_site: boolean;
 	launch_status: string | boolean;
 	site_migration: {
-		migration_status: string;
+		migration_status?: string;
 	} | null;
 	site_owner: number;
 	jetpack: boolean;

--- a/client/dashboard/utils/site-status.ts
+++ b/client/dashboard/utils/site-status.ts
@@ -12,11 +12,11 @@ export const STATUS_LABELS = {
 };
 
 export function getSiteStatus( item: Site ) {
-	if ( item.site_migration?.migration_status.startsWith( 'migration-pending' ) ) {
+	if ( item.site_migration?.migration_status?.startsWith( 'migration-pending' ) ) {
 		return 'migration_pending';
 	}
 
-	if ( item.site_migration?.migration_status.startsWith( 'migration-started' ) ) {
+	if ( item.site_migration?.migration_status?.startsWith( 'migration-started' ) ) {
 		return 'migration_started';
 	}
 


### PR DESCRIPTION
## Proposed Changes

Currently, the Site Overview tab returns the following error:

![Screenshot 2025-05-25 at 10 07 10 PM](https://github.com/user-attachments/assets/b5fff2a7-ea46-4518-a1e2-882a7d8b1245)

This is due to the assumption that whenever site_migration is defined, it will have the property migration_status as well. However, a recent change 183697-ghe-Automattic/wpcom introduced new properties is_complete and in_progress, which means that the original assumption is no longer true.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2/sites/:siteSlug
* Ensure that the error is no longer reproducible

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?