### PR TITLE
Account Settings: Update language picker buttons to justify-content: flex-start

### DIFF
--- a/packages/language-picker/src/style.scss
+++ b/packages/language-picker/src/style.scss
@@ -109,6 +109,7 @@
 	}
 
 	.language-picker-component__language-group {
+		justify-content: flex-start;
 		width: 230px;
 	}
 
@@ -173,7 +174,9 @@
 	}
 
 	.language-picker-component__language-button {
+		justify-content: flex-start;
 		width: 100%;
+
 		@include break-small() {
 			width: $language_button_width;
 		}


### PR DESCRIPTION
## Proposed Changes

There's been a recent change where the Button component is set to justify-content: center. As a result, some existing UIs might look odd. This PR updates the language picker buttons to use justify-content: flex-start.

Desktop

| Before | After |
| --- | --- |
| ![Screenshot 2025-05-26 at 10 49 33 AM](https://github.com/user-attachments/assets/45f05d76-4a45-41e8-9ca8-d8d07a7661ae) | ![Screenshot 2025-05-26 at 10 49 18 AM](https://github.com/user-attachments/assets/bad39c31-a349-4448-9aed-97f1ef60195f) |

Mobile

| Before | After |
| --- | --- |
| ![Screenshot 2025-05-26 at 10 49 41 AM](https://github.com/user-attachments/assets/27e0ebc3-b9cf-4ad4-bee5-319106a99db9) |  ![Screenshot 2025-05-26 at 10 49 47 AM](https://github.com/user-attachments/assets/6d5a5616-9308-4b34-97f5-314ececf52a8) |

## Why are these changes being made?

<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /me/account.
* Ensure that the UI is updated as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
