### PR TITLE
Add purchase amount for linkedin purchase event

### DIFF
--- a/client/lib/analytics/ad-tracking/record-order.ts
+++ b/client/lib/analytics/ad-tracking/record-order.ts
@@ -159,7 +159,11 @@ export async function recordOrder(
 	}
 
 	if ( mayWeTrackByTracker( 'linkedin' ) && wpcomJetpackCartInfo.containsWpcomProducts ) {
-		const params = { conversion_id: 19839620 };
+		const params = {
+			conversion_id: 19839620,
+			conversion_value: usdTotalCost,
+			conversion_currency: 'USD',
+		};
 
 		debug( 'recordOrder: [LinkedIn]', params );
 		window.lintrk( 'track', params );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Adds the conversion_value and conversion_currency to the linkedin conversion event call

## Why are these changes being made?

* Requested by @debbiengWP 

## Testing Instructions

* Open network tab
* Enable tracking - either by visiting checkout/personal?flags=ad-tracking or by modifying development.json
* Complete purchase and observe the event data being sent out

<img width="686" alt="Screenshot 2025-05-26 at 9 45 04" src="https://github.com/user-attachments/assets/f44db3db-a968-4302-9905-6911686c7b4e" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
