### PR TITLE
Dashboard v2: Handle transfer site

### DIFF
--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -177,20 +177,20 @@ export function restoreSitePlanSoftwareMutation( siteId: string ) {
 
 export function siteOwnerTransferMutation( siteId: string ) {
 	return {
-		mutationFn: ( newData: { new_site_owner: string } ) => siteOwnerTransfer( siteId, newData ),
+		mutationFn: ( data: { new_site_owner: string } ) => siteOwnerTransfer( siteId, data ),
 	};
 }
 
 export function siteOwnerTransferEligibilityCheckMutation( siteId: string ) {
 	return {
-		mutationFn: ( newData: { new_site_owner: string } ) =>
-			siteOwnerTransferEligibilityCheck( siteId, newData ),
+		mutationFn: ( data: { new_site_owner: string } ) =>
+			siteOwnerTransferEligibilityCheck( siteId, data ),
 	};
 }
 
 export function siteOwnerTransferConfirmMutation( siteId: string ) {
 	return {
-		mutationFn: ( newData: { hash: string } ) => siteOwnerTransferConfirm( siteId, newData ),
+		mutationFn: ( data: { hash: string } ) => siteOwnerTransferConfirm( siteId, data ),
 		onSuccess: ( { transfer }: SiteTransferConfirmation ) => {
 			if ( transfer ) {
 				// Invalidate queries as the site has been transferred to new owner.

--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -17,6 +17,7 @@ import {
 	updateSiteSettings,
 	restoreSitePlanSoftware,
 	siteOwnerTransfer,
+	siteOwnerTransferConfirm,
 	fetchWordPressVersion,
 	updateWordPressVersion,
 	fetchPrimaryDataCenter,
@@ -175,9 +176,12 @@ export function restoreSitePlanSoftwareMutation( siteId: string ) {
 export function siteOwnerTransferMutation( siteId: string ) {
 	return {
 		mutationFn: ( newData: { new_site_owner: string } ) => siteOwnerTransfer( siteId, newData ),
-		onSuccess: () => {
-			queryClient.invalidateQueries( { queryKey: [ 'site', siteId ] } );
-		},
+	};
+}
+
+export function siteOwnerTransferConfirmMutation( siteId: string ) {
+	return {
+		mutationFn: ( newData: { hash: string } ) => siteOwnerTransferConfirm( siteId, newData ),
 	};
 }
 

--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -34,6 +34,7 @@ import type {
 	UrlPerformanceInsights,
 	DefensiveModeSettings,
 	DefensiveModeSettingsUpdate,
+	SiteTransferConfirmation,
 } from '../data/types';
 import type { Query } from '@tanstack/react-query';
 
@@ -182,6 +183,12 @@ export function siteOwnerTransferMutation( siteId: string ) {
 export function siteOwnerTransferConfirmMutation( siteId: string ) {
 	return {
 		mutationFn: ( newData: { hash: string } ) => siteOwnerTransferConfirm( siteId, newData ),
+		onSuccess: ( { transfer }: SiteTransferConfirmation ) => {
+			if ( transfer ) {
+				// Invalidate queries as the site has been transferred to new owner.
+				queryClient.invalidateQueries( { queryKey: [ 'site', siteId ] } );
+			}
+		},
 	};
 }
 

--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -17,6 +17,7 @@ import {
 	updateSiteSettings,
 	restoreSitePlanSoftware,
 	siteOwnerTransfer,
+	siteOwnerTransferEligibilityCheck,
 	siteOwnerTransferConfirm,
 	fetchWordPressVersion,
 	updateWordPressVersion,
@@ -177,6 +178,13 @@ export function restoreSitePlanSoftwareMutation( siteId: string ) {
 export function siteOwnerTransferMutation( siteId: string ) {
 	return {
 		mutationFn: ( newData: { new_site_owner: string } ) => siteOwnerTransfer( siteId, newData ),
+	};
+}
+
+export function siteOwnerTransferEligibilityCheckMutation( siteId: string ) {
+	return {
+		mutationFn: ( newData: { new_site_owner: string } ) =>
+			siteOwnerTransferEligibilityCheck( siteId, newData ),
 	};
 }
 

--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -16,6 +16,7 @@ import {
 	fetchPerformanceInsights,
 	updateSiteSettings,
 	restoreSitePlanSoftware,
+	siteOwnerTransfer,
 	fetchWordPressVersion,
 	updateWordPressVersion,
 	fetchPrimaryDataCenter,
@@ -168,6 +169,15 @@ export function siteSettingsMutation( siteId: string ) {
 export function restoreSitePlanSoftwareMutation( siteId: string ) {
 	return {
 		mutationFn: () => restoreSitePlanSoftware( siteId ),
+	};
+}
+
+export function siteOwnerTransferMutation( siteId: string ) {
+	return {
+		mutationFn: ( newData: { new_site_owner: string } ) => siteOwnerTransfer( siteId, newData ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'site', siteId ] } );
+		},
 	};
 }
 

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -380,6 +380,19 @@ export const siteOwnerTransfer = async (
 	);
 };
 
+export const siteOwnerTransferEligibilityCheck = async (
+	siteIdOrSlug: string,
+	data: { new_site_owner: string }
+) => {
+	return wpcom.req.post(
+		{
+			path: `/sites/${ siteIdOrSlug }/site-owner-transfer/eligibility`,
+			apiNamespace: 'wpcom/v2',
+		},
+		data
+	);
+};
+
 export const siteOwnerTransferConfirm = async (
 	siteIdOrSlug: string,
 	data: { hash: string }

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -370,8 +370,11 @@ export const siteOwnerTransfer = async (
 ) => {
 	return wpcom.req.post(
 		{
-			path: `/sites/${ siteIdOrSlug }/site-owner-transfer?calypso_origin=${ window.location.origin }`,
+			path: `/sites/${ siteIdOrSlug }/site-owner-transfer`,
 			apiNamespace: 'wpcom/v2',
+		},
+		{
+			calypso_origin: window.location.origin,
 		},
 		{
 			context: 'dashboard_v2',

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -370,10 +370,13 @@ export const siteOwnerTransfer = async (
 ) => {
 	return wpcom.req.post(
 		{
-			path: `/sites/${ siteIdOrSlug }/site-owner-transfer?v2`,
+			path: `/sites/${ siteIdOrSlug }/site-owner-transfer?calypso_origin=${ window.location.origin }`,
 			apiNamespace: 'wpcom/v2',
 		},
-		data
+		{
+			context: 'dashboard_v2',
+			...data,
+		}
 	);
 };
 

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -17,6 +17,7 @@ import type {
 	PhpMyAdminToken,
 	DefensiveModeSettings,
 	DefensiveModeSettingsUpdate,
+	SiteTransferResponse,
 } from './types';
 import type { DataCenterOption } from 'calypso/data/data-center/types';
 
@@ -370,6 +371,19 @@ export const siteOwnerTransfer = async (
 	return wpcom.req.post(
 		{
 			path: `/sites/${ siteIdOrSlug }/site-owner-transfer?v2`,
+			apiNamespace: 'wpcom/v2',
+		},
+		data
+	);
+};
+
+export const siteOwnerTransferConfirm = async (
+	siteIdOrSlug: string,
+	data: { hash: string }
+): Promise< SiteTransferResponse > => {
+	return wpcom.req.post(
+		{
+			path: `/sites/${ siteIdOrSlug }/site-owner-transfer/confirm`,
 			apiNamespace: 'wpcom/v2',
 		},
 		data

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -363,6 +363,19 @@ export const restoreSitePlanSoftware = async ( siteIdOrSlug: string ) => {
 	} );
 };
 
+export const siteOwnerTransfer = async (
+	siteIdOrSlug: string,
+	data: { new_site_owner: string }
+) => {
+	return wpcom.req.post(
+		{
+			path: `/sites/${ siteIdOrSlug }/site-owner-transfer?v2`,
+			apiNamespace: 'wpcom/v2',
+		},
+		data
+	);
+};
+
 export const fetchBasicMetrics = async ( url: string ): Promise< BasicMetricsData > => {
 	return wpcom.req.get(
 		{

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -17,7 +17,7 @@ import type {
 	PhpMyAdminToken,
 	DefensiveModeSettings,
 	DefensiveModeSettingsUpdate,
-	SiteTransferResponse,
+	SiteTransferConfirmation,
 } from './types';
 import type { DataCenterOption } from 'calypso/data/data-center/types';
 
@@ -380,7 +380,7 @@ export const siteOwnerTransfer = async (
 export const siteOwnerTransferConfirm = async (
 	siteIdOrSlug: string,
 	data: { hash: string }
-): Promise< SiteTransferResponse > => {
+): Promise< SiteTransferConfirmation > => {
 	return wpcom.req.post(
 		{
 			path: `/sites/${ siteIdOrSlug }/site-owner-transfer/confirm`,

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -15,6 +15,7 @@ export interface User {
 	avatar_URL?: string;
 	language: string;
 	locale_variant: string;
+	email: string;
 }
 
 export interface SiteDomain {

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -188,3 +188,8 @@ export interface DefensiveModeSettingsUpdate {
 	active: boolean;
 	ttl?: number;
 }
+
+export interface SiteTransferResponse {
+	transfer: boolean;
+	email_sent_to: string;
+}

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -191,5 +191,6 @@ export interface DefensiveModeSettingsUpdate {
 
 export interface SiteTransferConfirmation {
 	transfer: boolean;
-	email_sent_to: string;
+	email_sent: boolean;
+	new_owner_email: string;
 }

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -189,7 +189,7 @@ export interface DefensiveModeSettingsUpdate {
 	ttl?: number;
 }
 
-export interface SiteTransferResponse {
+export interface SiteTransferConfirmation {
 	transfer: boolean;
 	email_sent_to: string;
 }

--- a/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
@@ -32,11 +32,11 @@ const form = {
 export function ConfirmNewOwnerForm( {
 	siteSlug,
 	newOwnerEmail,
-	handleSubmit,
+	onSubmit,
 }: {
 	siteSlug: string;
 	newOwnerEmail: string;
-	handleSubmit: ( data: ConfirmNewOwnerFormData ) => void;
+	onSubmit: ( data: ConfirmNewOwnerFormData ) => void;
 } ) {
 	const [ formData, setFormData ] = useState( {
 		email: newOwnerEmail,
@@ -46,14 +46,14 @@ export function ConfirmNewOwnerForm( {
 
 	const isSaveDisabled = ! isItemValid( formData, fields, form );
 
-	const onSubmit = ( event: React.FormEvent ) => {
+	const handleSubmit = ( event: React.FormEvent ) => {
 		event.preventDefault();
 
 		mutation.mutate(
 			{ new_site_owner: formData.email },
 			{
 				onSuccess: () => {
-					handleSubmit( formData );
+					onSubmit( formData );
 				},
 				onError: () => {
 					// TODO: Display error message below the field.
@@ -79,7 +79,7 @@ export function ConfirmNewOwnerForm( {
 					) }
 				</Text>
 			</VStack>
-			<form onSubmit={ onSubmit }>
+			<form onSubmit={ handleSubmit }>
 				<VStack spacing={ 4 } style={ { padding: '8px 0' } }>
 					{ /* TODO: Update the gap between each field */ }
 					<DataForm< ConfirmNewOwnerFormData >

--- a/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
@@ -10,7 +10,7 @@ import { sprintf, __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import type { Field } from '@automattic/dataviews';
 
-type ConfirmNewOwnerFormData = {
+export type ConfirmNewOwnerFormData = {
 	email: string;
 };
 
@@ -34,7 +34,7 @@ export function ConfirmNewOwnerForm( {
 }: {
 	initialData?: Partial< ConfirmNewOwnerFormData >;
 	siteSlug: string;
-	handleSubmit: ( event: React.FormEvent ) => void;
+	handleSubmit: ( data: ConfirmNewOwnerFormData ) => void;
 } ) {
 	const [ formData, setFormData ] = useState( {
 		email: '',
@@ -42,6 +42,11 @@ export function ConfirmNewOwnerForm( {
 	} );
 
 	const isSaveDisabled = ! isItemValid( formData, fields, form );
+
+	const onSubmit = ( event: React.FormEvent ) => {
+		event.preventDefault();
+		handleSubmit( formData );
+	};
 
 	return (
 		<VStack spacing={ 1 }>
@@ -66,7 +71,7 @@ export function ConfirmNewOwnerForm( {
 					) }
 				</Text>
 			</VStack>
-			<form onSubmit={ handleSubmit }>
+			<form onSubmit={ onSubmit }>
 				<VStack spacing={ 4 } style={ { padding: '8px 0' } }>
 					<DataForm< ConfirmNewOwnerFormData >
 						data={ formData }

--- a/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
@@ -28,14 +28,17 @@ const form = {
 };
 
 export function ConfirmNewOwnerForm( {
+	initialData = {},
 	siteSlug,
 	handleSubmit,
 }: {
+	initialData?: Partial< ConfirmNewOwnerFormData >;
 	siteSlug: string;
 	handleSubmit: ( event: React.FormEvent ) => void;
 } ) {
 	const [ formData, setFormData ] = useState( {
 		email: '',
+		...initialData,
 	} );
 
 	const isSaveDisabled = ! isItemValid( formData, fields, form );

--- a/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
@@ -1,4 +1,5 @@
 import { DataForm, isItemValid } from '@automattic/dataviews';
+import { useMutation } from '@tanstack/react-query';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -8,6 +9,7 @@ import {
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import { useState } from 'react';
+import { siteOwnerTransferEligibilityCheckMutation } from '../../app/queries';
 import type { Field } from '@automattic/dataviews';
 
 export type ConfirmNewOwnerFormData = {
@@ -40,11 +42,24 @@ export function ConfirmNewOwnerForm( {
 		email: newOwnerEmail,
 	} );
 
+	const mutation = useMutation( siteOwnerTransferEligibilityCheckMutation( siteSlug ) );
+
 	const isSaveDisabled = ! isItemValid( formData, fields, form );
 
 	const onSubmit = ( event: React.FormEvent ) => {
 		event.preventDefault();
-		handleSubmit( formData );
+
+		mutation.mutate(
+			{ new_site_owner: newOwnerEmail },
+			{
+				onSuccess: () => {
+					handleSubmit( formData );
+				},
+				onError: () => {
+					// TODO: Display error message below the field.
+				},
+			}
+		);
 	};
 
 	return (
@@ -82,7 +97,12 @@ export function ConfirmNewOwnerForm( {
 						} }
 					/>
 					<HStack justify="flex-start">
-						<Button variant="primary" type="submit" disabled={ isSaveDisabled }>
+						<Button
+							variant="primary"
+							type="submit"
+							isBusy={ mutation.isPending }
+							disabled={ isSaveDisabled }
+						>
 							{ __( 'Continue' ) }
 						</Button>
 					</HStack>

--- a/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
@@ -28,17 +28,16 @@ const form = {
 };
 
 export function ConfirmNewOwnerForm( {
-	initialData = {},
 	siteSlug,
+	newOwnerEmail,
 	handleSubmit,
 }: {
-	initialData?: Partial< ConfirmNewOwnerFormData >;
 	siteSlug: string;
+	newOwnerEmail: string;
 	handleSubmit: ( data: ConfirmNewOwnerFormData ) => void;
 } ) {
 	const [ formData, setFormData ] = useState( {
-		email: '',
-		...initialData,
+		email: newOwnerEmail,
 	} );
 
 	const isSaveDisabled = ! isItemValid( formData, fields, form );
@@ -73,6 +72,7 @@ export function ConfirmNewOwnerForm( {
 			</VStack>
 			<form onSubmit={ onSubmit }>
 				<VStack spacing={ 4 } style={ { padding: '8px 0' } }>
+					{ /* TODO: Update the gap between each field */ }
 					<DataForm< ConfirmNewOwnerFormData >
 						data={ formData }
 						fields={ fields }

--- a/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
@@ -65,7 +65,8 @@ export function ConfirmNewOwnerForm( {
 	return (
 		<VStack spacing={ 1 }>
 			<VStack style={ { padding: '8px 0' } }>
-				<Text size="15px" weight={ 500 } lineHeight="32px">
+				{ /* TODO: Think about the better way of using <Heading /> as the font size doesn't match now */ }
+				<Text size="15px" weight={ 500 } lineHeight="32px" as="h2">
 					{ __( 'Confirm new owner' ) }
 				</Text>
 				<Text lineHeight="20px">

--- a/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
@@ -50,7 +50,7 @@ export function ConfirmNewOwnerForm( {
 		event.preventDefault();
 
 		mutation.mutate(
-			{ new_site_owner: newOwnerEmail },
+			{ new_site_owner: formData.email },
 			{
 				onSuccess: () => {
 					handleSubmit( formData );

--- a/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
@@ -7,7 +7,7 @@ import {
 	Button,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { sprintf, __ } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import { siteOwnerTransferEligibilityCheckMutation } from '../../app/queries';
 import type { Field } from '@automattic/dataviews';
@@ -70,17 +70,11 @@ export function ConfirmNewOwnerForm( {
 				</Text>
 				<Text lineHeight="20px">
 					{ createInterpolateElement(
-						sprintf(
-							/* translators: %(siteSlug)s - the current site slug */
-							__(
-								"Ready to transfer <strong>%(siteSlug)s</strong> and its associated purchases? Simply enter the new owner's email below, or choose an existing user to start the transfer process."
-							),
-							{
-								siteSlug,
-							}
+						__(
+							"Ready to transfer <siteSlug /> and its associated purchases? Simply enter the new owner's email below, or choose an existing user to start the transfer process."
 						),
 						{
-							strong: <strong />,
+							siteSlug: <strong>{ siteSlug }</strong>,
 						}
 					) }
 				</Text>

--- a/client/dashboard/sites/settings-transfer-site/email-confirmation.tsx
+++ b/client/dashboard/sites/settings-transfer-site/email-confirmation.tsx
@@ -1,0 +1,35 @@
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+} from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { sprintf, __ } from '@wordpress/i18n';
+import { Icon, inbox } from '@wordpress/icons';
+
+export function EmailConfirmation( { userEmail }: { userEmail: string } ) {
+	return (
+		<VStack style={ { padding: '8px 0 12px' } }>
+			<HStack>
+				<Icon icon={ inbox } />
+				<Text size="15px" weight={ 500 } lineHeight="32px">
+					{ __( 'Check your inbox' ) }
+				</Text>
+			</HStack>
+			<Text>
+				{ createInterpolateElement(
+					sprintf(
+						/* translators: %(userEmail)s - the current user's email */
+						'We’ve sent a transfer confirmation email to <strong>%(userEmail)s</strong>. Please check your inbox and spam folder. The transfer will not proceed unless you authorize it using the link in the email.',
+						{
+							userEmail,
+						}
+					),
+					{
+						strong: <strong />,
+					}
+				) }
+			</Text>
+		</VStack>
+	);
+}

--- a/client/dashboard/sites/settings-transfer-site/email-confirmation.tsx
+++ b/client/dashboard/sites/settings-transfer-site/email-confirmation.tsx
@@ -12,7 +12,7 @@ export function EmailConfirmation( { userEmail }: { userEmail: string } ) {
 		<VStack style={ { padding: '8px 0 12px' } }>
 			<HStack justify="flex-start">
 				<Icon icon={ inbox } />
-				<Text size="15px" weight={ 500 } lineHeight="32px">
+				<Text size="15px" weight={ 500 } lineHeight="32px" as="h2">
 					{ __( 'Check your inbox' ) }
 				</Text>
 			</HStack>

--- a/client/dashboard/sites/settings-transfer-site/email-confirmation.tsx
+++ b/client/dashboard/sites/settings-transfer-site/email-confirmation.tsx
@@ -10,7 +10,7 @@ import { Icon, inbox } from '@wordpress/icons';
 export function EmailConfirmation( { userEmail }: { userEmail: string } ) {
 	return (
 		<VStack style={ { padding: '8px 0 12px' } }>
-			<HStack>
+			<HStack justify="flex-start">
 				<Icon icon={ inbox } />
 				<Text size="15px" weight={ 500 } lineHeight="32px">
 					{ __( 'Check your inbox' ) }

--- a/client/dashboard/sites/settings-transfer-site/email-confirmation.tsx
+++ b/client/dashboard/sites/settings-transfer-site/email-confirmation.tsx
@@ -4,7 +4,7 @@ import {
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { sprintf, __ } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Icon, inbox } from '@wordpress/icons';
 
 export function EmailConfirmation( { userEmail }: { userEmail: string } ) {
@@ -18,15 +18,11 @@ export function EmailConfirmation( { userEmail }: { userEmail: string } ) {
 			</HStack>
 			<Text>
 				{ createInterpolateElement(
-					sprintf(
-						/* translators: %(userEmail)s - the current user's email */
-						'We’ve sent a transfer confirmation email to <strong>%(userEmail)s</strong>. Please check your inbox and spam folder. The transfer will not proceed unless you authorize it using the link in the email.',
-						{
-							userEmail,
-						}
+					__(
+						'We’ve sent a transfer confirmation email to <userEmail />. Please check your inbox and spam folder. The transfer will not proceed unless you authorize it using the link in the email.'
 					),
 					{
-						strong: <strong />,
+						userEmail: <strong>{ userEmail }</strong>,
 					}
 				) }
 			</Text>

--- a/client/dashboard/sites/settings-transfer-site/index.tsx
+++ b/client/dashboard/sites/settings-transfer-site/index.tsx
@@ -1,14 +1,12 @@
-import { useQuery, useMutation } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { notFound } from '@tanstack/react-router';
 import { Card, CardBody, ExternalLink } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { getQueryArg } from '@wordpress/url';
 import React, { useState } from 'react';
 import { useAuth } from '../../app/auth';
-import { siteQuery, siteOwnerTransferMutation } from '../../app/queries';
+import { siteQuery } from '../../app/queries';
 import PageLayout from '../../components/page-layout';
 import { useCanTransferSite } from '../hooks/use-can-transfer-site';
 import SettingsPageHeader from '../settings-page-header';
@@ -46,13 +44,11 @@ const SettingsTransferSitePageLayout = ( { children }: { children: React.ReactNo
 
 // TODO: Use Stepper component when the design is ready.
 export default function SettingsTransferSite( { siteSlug }: { siteSlug: string } ) {
-	const { createErrorNotice } = useDispatch( noticesStore );
 	const { user } = useAuth();
 	const { data: site } = useQuery( siteQuery( siteSlug ) );
 	const canTransferSite = useCanTransferSite( { site } );
 	const [ newOwnerEmail, setNewOwnerEmail ] = useState( '' );
 	const [ currentStep, setCurrentStep ] = useState( 0 );
-	const mutation = useMutation( siteOwnerTransferMutation( siteSlug ) );
 	const confirmationHash = getQueryArg( window.location.search, 'site-transfer-confirm' );
 
 	const handleBack = () => setCurrentStep( ( step ) => Math.max( step - 1, MIN_STEP ) );
@@ -65,19 +61,7 @@ export default function SettingsTransferSite( { siteSlug }: { siteSlug: string }
 	};
 
 	const handleStartSiteTransfer = () => {
-		mutation.mutate(
-			{ new_site_owner: newOwnerEmail },
-			{
-				onSuccess: () => {
-					handleForward();
-				},
-				onError: ( error: Error ) => {
-					createErrorNotice( error.message ?? __( 'Failed to transfer site.' ), {
-						type: 'snackbar',
-					} );
-				},
-			}
-		);
+		handleForward();
 	};
 
 	if ( ! site ) {
@@ -115,7 +99,6 @@ export default function SettingsTransferSite( { siteSlug }: { siteSlug: string }
 							siteSlug={ siteSlug }
 							newOwnerEmail={ newOwnerEmail }
 							site={ site }
-							isTransferring={ mutation.isPending }
 							handleSubmit={ handleStartSiteTransfer }
 							handleBack={ handleBack }
 						/>

--- a/client/dashboard/sites/settings-transfer-site/index.tsx
+++ b/client/dashboard/sites/settings-transfer-site/index.tsx
@@ -6,15 +6,18 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
+import { useAuth } from '../../app/auth';
 import { siteQuery, siteOwnerTransferMutation } from '../../app/queries';
 import PageLayout from '../../components/page-layout';
 import { useCanTransferSite } from '../hooks/use-can-transfer-site';
 import SettingsPageHeader from '../settings-page-header';
 import { ConfirmNewOwnerForm } from './confirm-new-owner-form';
+import { EmailConfirmation } from './email-confirmation';
 import { StartSiteTransferForm } from './start-site-transfer-form';
 
 export default function SettingsTransferSite( { siteSlug }: { siteSlug: string } ) {
 	const { createErrorNotice } = useDispatch( noticesStore );
+	const { user } = useAuth();
 	const { data: site } = useQuery( siteQuery( siteSlug ) );
 	const canTransferSite = useCanTransferSite( { site } );
 	const [ currentStep, setCurrentStep ] = useState( 0 );
@@ -98,6 +101,7 @@ export default function SettingsTransferSite( { siteSlug }: { siteSlug: string }
 							handleBack={ handleBack }
 						/>
 					) }
+					{ currentStep === 2 && <EmailConfirmation userEmail={ user.email } /> }
 				</CardBody>
 			</Card>
 		</PageLayout>

--- a/client/dashboard/sites/settings-transfer-site/index.tsx
+++ b/client/dashboard/sites/settings-transfer-site/index.tsx
@@ -3,19 +3,37 @@ import { notFound } from '@tanstack/react-router';
 import { Card, CardBody, ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
 import { siteQuery } from '../../app/queries';
 import PageLayout from '../../components/page-layout';
 import { useCanTransferSite } from '../hooks/use-can-transfer-site';
 import SettingsPageHeader from '../settings-page-header';
 import { ConfirmNewOwnerForm } from './confirm-new-owner-form';
+import { StartSiteTransferForm } from './start-site-transfer-form';
 
 export default function SettingsTransferSite( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useQuery( siteQuery( siteSlug ) );
 	const canTransferSite = useCanTransferSite( { site } );
+	const [ currentStep, setCurrentStep ] = useState( 0 );
+	const [ stepsData, setStepsData ] = useState( [] );
+	const [ newOwnerEmail, setNewOwnerEmail ] = useState( '' );
+
+	const handleBack = () => setCurrentStep( ( step ) => Math.max( step - 1, 0 ) );
+
+	const handleForward = () => setCurrentStep( ( step ) => step + 1 );
 
 	// TODO: Integrate with the API.
 	const handleConfirmNewOwner = ( event: React.FormEvent ) => {
 		event.preventDefault();
+		setNewOwnerEmail( '' );
+		setStepsData( [] );
+		handleForward();
+	};
+
+	const handleStartSiteTransfer = ( event: React.FormEvent ) => {
+		event.preventDefault();
+		setStepsData( [] );
+		handleForward();
 	};
 
 	if ( ! site ) {
@@ -45,7 +63,22 @@ export default function SettingsTransferSite( { siteSlug }: { siteSlug: string }
 		>
 			<Card>
 				<CardBody>
-					<ConfirmNewOwnerForm siteSlug={ siteSlug } handleSubmit={ handleConfirmNewOwner } />
+					{ currentStep === 0 && (
+						<ConfirmNewOwnerForm
+							initialData={ stepsData[ 0 ] }
+							siteSlug={ siteSlug }
+							handleSubmit={ handleConfirmNewOwner }
+						/>
+					) }
+					{ currentStep === 1 && (
+						<StartSiteTransferForm
+							initialData={ stepsData[ 1 ] }
+							siteSlug={ siteSlug }
+							newOwnerEmail={ newOwnerEmail }
+							handleSubmit={ handleStartSiteTransfer }
+							handleBack={ handleBack }
+						/>
+					) }
 				</CardBody>
 			</Card>
 		</PageLayout>

--- a/client/dashboard/sites/settings-transfer-site/index.tsx
+++ b/client/dashboard/sites/settings-transfer-site/index.tsx
@@ -28,10 +28,11 @@ const SettingsTransferSitePageLayout = ( { children }: { children: React.ReactNo
 					title={ __( 'Transfer site' ) }
 					description={ createInterpolateElement(
 						__(
-							'Transfer this site to a new or existing site member with just a few clicks. <learnMoreLink />.'
+							'Transfer this site to a new or existing site member with just a few clicks. <link>Learn more</link>.'
 						),
 						{
-							learnMoreLink: <ExternalLink href="#learn-more">{ __( 'Learn more' ) }</ExternalLink>,
+							// @ts-expect-error children prop is injected by createInterpolateElement
+							link: <ExternalLink href="#learn-more" />,
 						}
 					) }
 				/>

--- a/client/dashboard/sites/settings-transfer-site/index.tsx
+++ b/client/dashboard/sites/settings-transfer-site/index.tsx
@@ -15,9 +15,7 @@ import SettingsPageHeader from '../settings-page-header';
 import { ConfirmNewOwnerForm, ConfirmNewOwnerFormData } from './confirm-new-owner-form';
 import { EmailConfirmation } from './email-confirmation';
 import { InvitationEmailSent } from './invitation-email-sent';
-import { StartSiteTransferForm, StartSiteTransferFormData } from './start-site-transfer-form';
-
-type StepsData = [ ConfirmNewOwnerFormData?, StartSiteTransferFormData? ];
+import { StartSiteTransferForm } from './start-site-transfer-form';
 
 const MIN_STEP = 0;
 
@@ -46,30 +44,27 @@ const SettingsTransferSitePageLayout = ( { children }: { children: React.ReactNo
 	);
 };
 
+// TODO: Use Stepper component when the design is ready.
 export default function SettingsTransferSite( { siteSlug }: { siteSlug: string } ) {
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { user } = useAuth();
 	const { data: site } = useQuery( siteQuery( siteSlug ) );
 	const canTransferSite = useCanTransferSite( { site } );
+	const [ newOwnerEmail, setNewOwnerEmail ] = useState( '' );
 	const [ currentStep, setCurrentStep ] = useState( 0 );
-	const [ stepsData, setStepsData ] = useState< StepsData >( [] );
 	const mutation = useMutation( siteOwnerTransferMutation( siteSlug ) );
 	const confirmationHash = getQueryArg( window.location.search, 'site-transfer-confirm' );
-
-	const newOwnerEmail = stepsData[ 0 ]?.email ?? '';
 
 	const handleBack = () => setCurrentStep( ( step ) => Math.max( step - 1, MIN_STEP ) );
 
 	const handleForward = () => setCurrentStep( ( step ) => Math.min( step + 1, MAX_STEP ) );
 
 	const handleConfirmNewOwner = ( data: ConfirmNewOwnerFormData ) => {
-		setStepsData( ( currentStepData: StepsData ) => [ data, currentStepData.slice( 1, 1 ) ] );
+		setNewOwnerEmail( data.email );
 		handleForward();
 	};
 
-	const handleStartSiteTransfer = ( data: StartSiteTransferFormData ) => {
-		setStepsData( ( currentStepData: StepsData ) => [ currentStepData.slice( 0, 1 ), data ] );
-
+	const handleStartSiteTransfer = () => {
 		mutation.mutate(
 			{ new_site_owner: newOwnerEmail },
 			{
@@ -107,17 +102,16 @@ export default function SettingsTransferSite( { siteSlug }: { siteSlug: string }
 				<CardBody>
 					{ currentStep === 0 && (
 						<ConfirmNewOwnerForm
-							initialData={ stepsData[ 0 ] }
 							siteSlug={ siteSlug }
+							newOwnerEmail={ newOwnerEmail }
 							handleSubmit={ handleConfirmNewOwner }
 						/>
 					) }
 					{ currentStep === 1 && (
 						<StartSiteTransferForm
-							initialData={ stepsData[ 1 ] }
 							siteSlug={ siteSlug }
-							site={ site }
 							newOwnerEmail={ newOwnerEmail }
+							site={ site }
 							isTransferring={ mutation.isPending }
 							handleSubmit={ handleStartSiteTransfer }
 							handleBack={ handleBack }

--- a/client/dashboard/sites/settings-transfer-site/index.tsx
+++ b/client/dashboard/sites/settings-transfer-site/index.tsx
@@ -69,7 +69,7 @@ export default function SettingsTransferSite( { siteSlug }: { siteSlug: string }
 		return null;
 	}
 
-	if ( ! canTransferSite ) {
+	if ( ! canTransferSite && ! confirmationHash ) {
 		throw notFound();
 	}
 

--- a/client/dashboard/sites/settings-transfer-site/index.tsx
+++ b/client/dashboard/sites/settings-transfer-site/index.tsx
@@ -92,7 +92,7 @@ export default function SettingsTransferSite( { siteSlug }: { siteSlug: string }
 						<ConfirmNewOwnerForm
 							siteSlug={ siteSlug }
 							newOwnerEmail={ newOwnerEmail }
-							handleSubmit={ handleConfirmNewOwner }
+							onSubmit={ handleConfirmNewOwner }
 						/>
 					) }
 					{ currentStep === 1 && (
@@ -100,8 +100,8 @@ export default function SettingsTransferSite( { siteSlug }: { siteSlug: string }
 							siteSlug={ siteSlug }
 							newOwnerEmail={ newOwnerEmail }
 							site={ site }
-							handleSubmit={ handleStartSiteTransfer }
-							handleBack={ handleBack }
+							onSubmit={ handleStartSiteTransfer }
+							onBack={ handleBack }
 						/>
 					) }
 					{ currentStep === 2 && <EmailConfirmation userEmail={ user.email } /> }

--- a/client/dashboard/sites/settings-transfer-site/index.tsx
+++ b/client/dashboard/sites/settings-transfer-site/index.tsx
@@ -1,10 +1,12 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import { notFound } from '@tanstack/react-router';
 import { Card, CardBody, ExternalLink } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
-import { siteQuery } from '../../app/queries';
+import { siteQuery, siteOwnerTransferMutation } from '../../app/queries';
 import PageLayout from '../../components/page-layout';
 import { useCanTransferSite } from '../hooks/use-can-transfer-site';
 import SettingsPageHeader from '../settings-page-header';
@@ -12,11 +14,13 @@ import { ConfirmNewOwnerForm } from './confirm-new-owner-form';
 import { StartSiteTransferForm } from './start-site-transfer-form';
 
 export default function SettingsTransferSite( { siteSlug }: { siteSlug: string } ) {
+	const { createErrorNotice } = useDispatch( noticesStore );
 	const { data: site } = useQuery( siteQuery( siteSlug ) );
 	const canTransferSite = useCanTransferSite( { site } );
 	const [ currentStep, setCurrentStep ] = useState( 0 );
 	const [ stepsData, setStepsData ] = useState( [] );
 	const [ newOwnerEmail, setNewOwnerEmail ] = useState( '' );
+	const mutation = useMutation( siteOwnerTransferMutation( siteSlug ) );
 
 	const handleBack = () => setCurrentStep( ( step ) => Math.max( step - 1, 0 ) );
 
@@ -33,7 +37,20 @@ export default function SettingsTransferSite( { siteSlug }: { siteSlug: string }
 	const handleStartSiteTransfer = ( event: React.FormEvent ) => {
 		event.preventDefault();
 		setStepsData( [] );
-		handleForward();
+
+		mutation.mutate(
+			{ new_site_owner: newOwnerEmail },
+			{
+				onSuccess: () => {
+					handleForward();
+				},
+				onError: ( error: Error ) => {
+					createErrorNotice( error.message ?? __( 'Failed to transfer site.' ), {
+						type: 'snackbar',
+					} );
+				},
+			}
+		);
 	};
 
 	if ( ! site ) {
@@ -74,7 +91,9 @@ export default function SettingsTransferSite( { siteSlug }: { siteSlug: string }
 						<StartSiteTransferForm
 							initialData={ stepsData[ 1 ] }
 							siteSlug={ siteSlug }
+							site={ site }
 							newOwnerEmail={ newOwnerEmail }
+							isTransferring={ mutation.isPending }
 							handleSubmit={ handleStartSiteTransfer }
 							handleBack={ handleBack }
 						/>

--- a/client/dashboard/sites/settings-transfer-site/index.tsx
+++ b/client/dashboard/sites/settings-transfer-site/index.tsx
@@ -5,15 +5,46 @@ import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { useState } from 'react';
+import { getQueryArg } from '@wordpress/url';
+import React, { useState } from 'react';
 import { useAuth } from '../../app/auth';
 import { siteQuery, siteOwnerTransferMutation } from '../../app/queries';
 import PageLayout from '../../components/page-layout';
 import { useCanTransferSite } from '../hooks/use-can-transfer-site';
 import SettingsPageHeader from '../settings-page-header';
-import { ConfirmNewOwnerForm } from './confirm-new-owner-form';
+import { ConfirmNewOwnerForm, ConfirmNewOwnerFormData } from './confirm-new-owner-form';
 import { EmailConfirmation } from './email-confirmation';
-import { StartSiteTransferForm } from './start-site-transfer-form';
+import { InvitationEmailSent } from './invitation-email-sent';
+import { StartSiteTransferForm, StartSiteTransferFormData } from './start-site-transfer-form';
+
+type StepsData = [ ConfirmNewOwnerFormData?, StartSiteTransferFormData? ];
+
+const MIN_STEP = 0;
+
+const MAX_STEP = 2;
+
+const SettingsTransferSitePageLayout = ( { children }: { children: React.ReactNode } ) => {
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<SettingsPageHeader
+					title={ __( 'Transfer site' ) }
+					description={ createInterpolateElement(
+						__(
+							'Transfer this site to a new or existing site member with just a few clicks. <learnMoreLink />.'
+						),
+						{
+							learnMoreLink: <ExternalLink href="#learn-more">{ __( 'Learn more' ) }</ExternalLink>,
+						}
+					) }
+				/>
+			}
+		>
+			{ children }
+		</PageLayout>
+	);
+};
 
 export default function SettingsTransferSite( { siteSlug }: { siteSlug: string } ) {
 	const { createErrorNotice } = useDispatch( noticesStore );
@@ -21,25 +52,23 @@ export default function SettingsTransferSite( { siteSlug }: { siteSlug: string }
 	const { data: site } = useQuery( siteQuery( siteSlug ) );
 	const canTransferSite = useCanTransferSite( { site } );
 	const [ currentStep, setCurrentStep ] = useState( 0 );
-	const [ stepsData, setStepsData ] = useState( [] );
-	const [ newOwnerEmail, setNewOwnerEmail ] = useState( '' );
+	const [ stepsData, setStepsData ] = useState< StepsData >( [] );
 	const mutation = useMutation( siteOwnerTransferMutation( siteSlug ) );
+	const confirmationHash = getQueryArg( window.location.search, 'site-transfer-confirm' );
 
-	const handleBack = () => setCurrentStep( ( step ) => Math.max( step - 1, 0 ) );
+	const newOwnerEmail = stepsData[ 0 ]?.email ?? '';
 
-	const handleForward = () => setCurrentStep( ( step ) => step + 1 );
+	const handleBack = () => setCurrentStep( ( step ) => Math.max( step - 1, MIN_STEP ) );
 
-	// TODO: Integrate with the API.
-	const handleConfirmNewOwner = ( event: React.FormEvent ) => {
-		event.preventDefault();
-		setNewOwnerEmail( '' );
-		setStepsData( [] );
+	const handleForward = () => setCurrentStep( ( step ) => Math.min( step + 1, MAX_STEP ) );
+
+	const handleConfirmNewOwner = ( data: ConfirmNewOwnerFormData ) => {
+		setStepsData( ( currentStepData: StepsData ) => [ data, currentStepData.slice( 1, 1 ) ] );
 		handleForward();
 	};
 
-	const handleStartSiteTransfer = ( event: React.FormEvent ) => {
-		event.preventDefault();
-		setStepsData( [] );
+	const handleStartSiteTransfer = ( data: StartSiteTransferFormData ) => {
+		setStepsData( ( currentStepData: StepsData ) => [ currentStepData.slice( 0, 1 ), data ] );
 
 		mutation.mutate(
 			{ new_site_owner: newOwnerEmail },
@@ -64,23 +93,16 @@ export default function SettingsTransferSite( { siteSlug }: { siteSlug: string }
 		throw notFound();
 	}
 
+	if ( confirmationHash ) {
+		return (
+			<SettingsTransferSitePageLayout>
+				<InvitationEmailSent siteSlug={ siteSlug } confirmationHash={ confirmationHash } />
+			</SettingsTransferSitePageLayout>
+		);
+	}
+
 	return (
-		<PageLayout
-			size="small"
-			header={
-				<SettingsPageHeader
-					title={ __( 'Transfer site' ) }
-					description={ createInterpolateElement(
-						__(
-							'Transfer this site to a new or existing site member with just a few clicks. <learnMoreLink />.'
-						),
-						{
-							learnMoreLink: <ExternalLink href="#learn-more">{ __( 'Learn more' ) }</ExternalLink>,
-						}
-					) }
-				/>
-			}
-		>
+		<SettingsTransferSitePageLayout>
 			<Card>
 				<CardBody>
 					{ currentStep === 0 && (
@@ -104,6 +126,6 @@ export default function SettingsTransferSite( { siteSlug }: { siteSlug: string }
 					{ currentStep === 2 && <EmailConfirmation userEmail={ user.email } /> }
 				</CardBody>
 			</Card>
-		</PageLayout>
+		</SettingsTransferSitePageLayout>
 	);
 }

--- a/client/dashboard/sites/settings-transfer-site/index.tsx
+++ b/client/dashboard/sites/settings-transfer-site/index.tsx
@@ -69,7 +69,7 @@ export default function SettingsTransferSite( { siteSlug }: { siteSlug: string }
 		return null;
 	}
 
-	if ( ! canTransferSite && ! confirmationHash ) {
+	if ( ! canTransferSite ) {
 		throw notFound();
 	}
 

--- a/client/dashboard/sites/settings-transfer-site/index.tsx
+++ b/client/dashboard/sites/settings-transfer-site/index.tsx
@@ -91,7 +91,10 @@ export default function SettingsTransferSite( { siteSlug }: { siteSlug: string }
 	if ( confirmationHash ) {
 		return (
 			<SettingsTransferSitePageLayout>
-				<InvitationEmailSent siteSlug={ siteSlug } confirmationHash={ confirmationHash } />
+				<InvitationEmailSent
+					siteSlug={ siteSlug }
+					confirmationHash={ confirmationHash as string }
+				/>
 			</SettingsTransferSitePageLayout>
 		);
 	}

--- a/client/dashboard/sites/settings-transfer-site/invitation-email-sent.tsx
+++ b/client/dashboard/sites/settings-transfer-site/invitation-email-sent.tsx
@@ -56,10 +56,6 @@ export function InvitationEmailSent( {
 		);
 	}, [ confirmationHash ] );
 
-	if ( ! newOwnerEmail || mutation.isPending ) {
-		return <Spinner />;
-	}
-
 	if ( hasError ) {
 		return (
 			<Notice variant="error">
@@ -76,6 +72,10 @@ export function InvitationEmailSent( {
 				) }
 			</Notice>
 		);
+	}
+
+	if ( ! newOwnerEmail || mutation.isPending ) {
+		return <Spinner />;
 	}
 
 	return (

--- a/client/dashboard/sites/settings-transfer-site/invitation-email-sent.tsx
+++ b/client/dashboard/sites/settings-transfer-site/invitation-email-sent.tsx
@@ -44,10 +44,13 @@ export function InvitationEmailSent( {
 		return (
 			<Notice variant="error">
 				{ createInterpolateElement(
-					__( 'There was an error confirming the site transfer. Please <supportLink /> for help.' ),
+					__(
+						'There was an error confirming the site transfer. Please <link>contact our support team</link> for help.'
+					),
 					{
-						supportLink: (
-							<ExternalLink href="/help">{ __( 'contact our support team' ) }</ExternalLink>
+						link: (
+							// @ts-expect-error children prop is injected by createInterpolateElement
+							<ExternalLink href="/help" />
 						),
 					}
 				) }

--- a/client/dashboard/sites/settings-transfer-site/invitation-email-sent.tsx
+++ b/client/dashboard/sites/settings-transfer-site/invitation-email-sent.tsx
@@ -18,6 +18,10 @@ export function InvitationEmailSent( {
 	const [ hasError, setHasError ] = useState( false );
 	const mutation = useMutation( siteOwnerTransferConfirmMutation( siteSlug ) );
 
+	// The page is accessed via the confirmation email, so this is the only place where the request can be triggered.
+	// It would be better if
+	// * we have the server trigger the mutation before rendering the page
+	// * we first show a page, clarifying what is going to happen with an "accept" button or something.
 	useEffect( () => {
 		mutation.mutate(
 			{ hash: confirmationHash },

--- a/client/dashboard/sites/settings-transfer-site/invitation-email-sent.tsx
+++ b/client/dashboard/sites/settings-transfer-site/invitation-email-sent.tsx
@@ -81,18 +81,9 @@ export function InvitationEmailSent( {
 	return (
 		<Notice
 			variant="success"
-			title={ createInterpolateElement(
-				sprintf(
-					/* translators: %(newOwnerEmail)s - the new owner's email */
-					__( 'Invitation sent to <strong>%(newOwnerEmail)s</strong>' ),
-					{
-						newOwnerEmail,
-					}
-				),
-				{
-					strong: <strong />,
-				}
-			) }
+			title={ createInterpolateElement( __( 'Invitation sent to <newOwnerEmail />' ), {
+				newOwnerEmail: <strong>{ newOwnerEmail }</strong>,
+			} ) }
 		>
 			{ __(
 				'They will need to visit the link included in the email invitation for the site transfer to complete. The invitation will expire in 7 days.'

--- a/client/dashboard/sites/settings-transfer-site/invitation-email-sent.tsx
+++ b/client/dashboard/sites/settings-transfer-site/invitation-email-sent.tsx
@@ -43,7 +43,7 @@ export function InvitationEmailSent( {
 							),
 							{ type: 'snackbar' }
 						);
-						router.navigate( { to: '/sites' } );
+						router.navigate( { to: '/sites', replace: true } );
 						return;
 					}
 

--- a/client/dashboard/sites/settings-transfer-site/invitation-email-sent.tsx
+++ b/client/dashboard/sites/settings-transfer-site/invitation-email-sent.tsx
@@ -1,0 +1,75 @@
+import { useMutation } from '@tanstack/react-query';
+import { ExternalLink, Spinner } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { sprintf, __ } from '@wordpress/i18n';
+import { useEffect, useState } from 'react';
+import { siteOwnerTransferConfirmMutation } from '../../app/queries';
+import Notice from '../../components/notice';
+import type { SiteTransferResponse } from '../../data/types';
+
+export function InvitationEmailSent( {
+	siteSlug,
+	confirmationHash,
+}: {
+	siteSlug: string;
+	confirmationHash: string;
+} ) {
+	const [ newOwnerEmail, setNewOwnerEmail ] = useState( '' );
+	const [ hasError, setHasError ] = useState( false );
+	const mutation = useMutation( siteOwnerTransferConfirmMutation( siteSlug ) );
+
+	useEffect( () => {
+		mutation.mutate(
+			{ hash: confirmationHash },
+			{
+				onSuccess: ( { email_sent_to }: SiteTransferResponse ) => {
+					setNewOwnerEmail( email_sent_to );
+				},
+				onError: () => {
+					setHasError( true );
+				},
+			}
+		);
+	}, [ confirmationHash ] );
+
+	if ( ! newOwnerEmail || mutation.isPending ) {
+		return <Spinner />;
+	}
+
+	if ( hasError ) {
+		return (
+			<Notice
+				variant="error"
+				content={ createInterpolateElement(
+					__( 'There was an error confirming the site transfer. Please <supportLink /> for help.' ),
+					{
+						supportLink: (
+							<ExternalLink href="/help">{ __( 'contact our support team' ) }</ExternalLink>
+						),
+					}
+				) }
+			/>
+		);
+	}
+
+	return (
+		<Notice
+			variant="success"
+			title={ createInterpolateElement(
+				sprintf(
+					/* translators: %(newOwnerEmail)s - the current user's email */
+					__( 'Invitation sent to <strong>%(newOwnerEmail)s</strong>' ),
+					{
+						newOwnerEmail,
+					}
+				),
+				{
+					strong: <strong />,
+				}
+			) }
+			content={ __(
+				'They will need to visit the link included in the email invitation for the site transfer to complete. The invitation will expire in 7 days.'
+			) }
+		/>
+	);
+}

--- a/client/dashboard/sites/settings-transfer-site/invitation-email-sent.tsx
+++ b/client/dashboard/sites/settings-transfer-site/invitation-email-sent.tsx
@@ -5,7 +5,7 @@ import { sprintf, __ } from '@wordpress/i18n';
 import { useEffect, useState } from 'react';
 import { siteOwnerTransferConfirmMutation } from '../../app/queries';
 import Notice from '../../components/notice';
-import type { SiteTransferResponse } from '../../data/types';
+import type { SiteTransferConfirmation } from '../../data/types';
 
 export function InvitationEmailSent( {
 	siteSlug,
@@ -22,7 +22,7 @@ export function InvitationEmailSent( {
 		mutation.mutate(
 			{ hash: confirmationHash },
 			{
-				onSuccess: ( { email_sent_to }: SiteTransferResponse ) => {
+				onSuccess: ( { email_sent_to }: SiteTransferConfirmation ) => {
 					setNewOwnerEmail( email_sent_to );
 				},
 				onError: () => {

--- a/client/dashboard/sites/settings-transfer-site/invitation-email-sent.tsx
+++ b/client/dashboard/sites/settings-transfer-site/invitation-email-sent.tsx
@@ -22,8 +22,8 @@ export function InvitationEmailSent( {
 		mutation.mutate(
 			{ hash: confirmationHash },
 			{
-				onSuccess: ( { email_sent_to }: SiteTransferConfirmation ) => {
-					setNewOwnerEmail( email_sent_to );
+				onSuccess: ( { new_owner_email }: SiteTransferConfirmation ) => {
+					setNewOwnerEmail( new_owner_email );
 				},
 				onError: () => {
 					setHasError( true );

--- a/client/dashboard/sites/settings-transfer-site/invitation-email-sent.tsx
+++ b/client/dashboard/sites/settings-transfer-site/invitation-email-sent.tsx
@@ -38,9 +38,8 @@ export function InvitationEmailSent( {
 
 	if ( hasError ) {
 		return (
-			<Notice
-				variant="error"
-				content={ createInterpolateElement(
+			<Notice variant="error">
+				{ createInterpolateElement(
 					__( 'There was an error confirming the site transfer. Please <supportLink /> for help.' ),
 					{
 						supportLink: (
@@ -48,7 +47,7 @@ export function InvitationEmailSent( {
 						),
 					}
 				) }
-			/>
+			</Notice>
 		);
 	}
 
@@ -67,9 +66,10 @@ export function InvitationEmailSent( {
 					strong: <strong />,
 				}
 			) }
-			content={ __(
+		>
+			{ __(
 				'They will need to visit the link included in the email invitation for the site transfer to complete. The invitation will expire in 7 days.'
 			) }
-		/>
+		</Notice>
 	);
 }

--- a/client/dashboard/sites/settings-transfer-site/invitation-email-sent.tsx
+++ b/client/dashboard/sites/settings-transfer-site/invitation-email-sent.tsx
@@ -1,7 +1,10 @@
 import { useMutation } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
 import { ExternalLink, Spinner } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { useEffect, useState } from 'react';
 import { siteOwnerTransferConfirmMutation } from '../../app/queries';
 import Notice from '../../components/notice';
@@ -17,6 +20,8 @@ export function InvitationEmailSent( {
 	const [ newOwnerEmail, setNewOwnerEmail ] = useState( '' );
 	const [ hasError, setHasError ] = useState( false );
 	const mutation = useMutation( siteOwnerTransferConfirmMutation( siteSlug ) );
+	const { createSuccessNotice } = useDispatch( noticesStore );
+	const router = useRouter();
 
 	// The page is accessed via the confirmation email, so this is the only place where the request can be triggered.
 	// It would be better if
@@ -26,7 +31,22 @@ export function InvitationEmailSent( {
 		mutation.mutate(
 			{ hash: confirmationHash },
 			{
-				onSuccess: ( { new_owner_email }: SiteTransferConfirmation ) => {
+				onSuccess: ( { transfer, new_owner_email }: SiteTransferConfirmation ) => {
+					if ( transfer ) {
+						createSuccessNotice(
+							sprintf(
+								/* translators: %(newOwnerEmail)s - the new owner's email */
+								__( 'The site has been successfully transferred to %(newOwnerEmail)s.' ),
+								{
+									newOwnerEmail: new_owner_email,
+								}
+							),
+							{ type: 'snackbar' }
+						);
+						router.navigate( { to: '/sites' } );
+						return;
+					}
+
 					setNewOwnerEmail( new_owner_email );
 				},
 				onError: () => {
@@ -63,7 +83,7 @@ export function InvitationEmailSent( {
 			variant="success"
 			title={ createInterpolateElement(
 				sprintf(
-					/* translators: %(newOwnerEmail)s - the current user's email */
+					/* translators: %(newOwnerEmail)s - the new owner's email */
 					__( 'Invitation sent to <strong>%(newOwnerEmail)s</strong>' ),
 					{
 						newOwnerEmail,

--- a/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
@@ -164,7 +164,7 @@ export function StartSiteTransferForm( {
 								sprintf(
 									/* translators: %(siteSlug)s - the current site slug, %(newOwnerEmail)s - the new owner's email */
 									__(
-										'Your paid upgrades on <strong>%(siteSlug)s</strong> will be transferred to <strong>%(siteOwner)s</strong> and will remain with the site.'
+										'Your paid upgrades on <strong>%(siteSlug)s</strong> will be transferred to <strong>%(newOwnerEmail)s</strong> and will remain with the site.'
 									),
 									{ siteSlug, newOwnerEmail }
 								),

--- a/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
@@ -89,13 +89,9 @@ export function StartSiteTransferForm( {
 				</Text>
 			</VStack>
 			<VStack spacing={ 5 } style={ { padding: '8px 0' } }>
-				<Notice
-					variant="warning"
-					density="medium"
-					content={ __(
-						'Please read the following carefully. Transferring a site cannot be undone.'
-					) }
-				/>
+				<Notice variant="warning" density="medium">
+					{ __( 'Please read the following carefully. Transferring a site cannot be undone.' ) }
+				</Notice>
 				<VStack spacing={ 6 } style={ { padding: '8px 0' } }>
 					<List title={ __( 'Content and ownership' ) }>
 						<li>

--- a/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
@@ -5,6 +5,7 @@ import {
 	__experimentalText as Text,
 	Button,
 } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import React, { useState } from 'react';
 import type { Field } from '@automattic/dataviews';
@@ -20,16 +21,19 @@ const fields: Field< StartSiteTransferFormData >[] = [
 		id: 'accept_authorization',
 		label: __( 'I understand the changes that will be made once I authorize this transfer.' ),
 		type: 'boolean' as const,
+		Edit: 'checkbox',
 	},
 	{
 		id: 'accept_transfer',
 		label: __( 'I want to transfer the ownership of the site.' ),
 		type: 'boolean' as const,
+		Edit: 'checkbox',
 	},
 	{
 		id: 'accept_undone',
 		label: __( 'I understand that transferring a site cannot be undone.' ),
 		type: 'boolean' as const,
+		Edit: 'checkbox',
 	},
 ];
 
@@ -61,74 +65,106 @@ export function StartSiteTransferForm( {
 	const isSaveDisabled = Object.values( formData ).some( ( value ) => ! value );
 
 	return (
-		<VStack spacing={ 5 }>
-			<VStack style={ { padding: '8px 0' } }>
+		<VStack spacing={ 0 }>
+			<VStack style={ { padding: '8px 0 12px' } }>
 				<Text size="15px" weight={ 500 } lineHeight="32px">
 					{ __( 'Start site transfer' ) }
 				</Text>
 			</VStack>
-			{ /* TODO: Add notice when the component is ready */ }
-			<ul>
-				{ __( 'Content and ownership' ) }
-				<li>
-					{ sprintf(
-						/* translators: %(siteSlug)s - the current site slug, %(newOwnerEmail)s - the new owner's email */
-						__(
-							'You’ll be removed as owner of %(siteSlug)s and %(newOwnerEmail)s will the new owner from now on.'
-						),
-						{ siteSlug, newOwnerEmail }
-					) }
-				</li>
-				<li>
-					{ sprintf(
-						/* translators: %(newOwnerEmail)s - the new owner's email */
-						__( 'You will keep your admin access unless %(newOwnerEmail)s removes you.' ),
-						{ newOwnerEmail }
-					) }
-				</li>
-				<li>
-					{ sprintf(
-						/* translators: %(siteSlug)s - the current site slug */
-						__( 'Your posts on %(siteSlug)s will remain authored by your account.' ),
-						{ siteSlug }
-					) }
-				</li>
-			</ul>
-			<ul>
-				{ __( 'Domains' ) }
-				<li>
-					{ sprintf(
-						/* translators: %(siteSlug)s - the current site slug, %(newOwnerEmail)s - the new owner's email */
-						__(
-							'The domain name %(siteSlug)s will be transferred to %(newOwnerEmail)s and will remain working on the site.'
-						),
-						{ siteSlug, newOwnerEmail }
-					) }
-				</li>
-			</ul>
-			<form onSubmit={ handleSubmit }>
-				<VStack spacing={ 4 } style={ { padding: '8px 0' } }>
-					<span>
-						{ __( 'To transfer your site, review and accept the following statements:' ) }
-					</span>
-					<DataForm< StartSiteTransferFormData >
-						data={ formData }
-						fields={ fields }
-						form={ form }
-						onChange={ ( edits: Partial< StartSiteTransferFormData > ) => {
-							setFormData( ( data ) => ( { ...data, ...edits } ) );
-						} }
-					/>
-					<HStack justify="flex-start">
-						<Button variant="primary" type="submit" disabled={ isSaveDisabled }>
-							{ __( 'Start transfer' ) }
-						</Button>
-						<Button variant="tertiary" onClick={ handleBack }>
-							{ __( 'Back' ) }
-						</Button>
-					</HStack>
+			<VStack spacing={ 5 } style={ { padding: '8px 0' } }>
+				{ /* TODO: Add notice when the component is ready */ }
+				<VStack spacing={ 6 } style={ { padding: '8px 0' } }>
+					<VStack>
+						<Text weight={ 500 }>{ __( 'Content and ownership' ) }</Text>
+						<ul style={ { paddingInlineStart: '20px', margin: 0 } }>
+							<li>
+								{ createInterpolateElement(
+									sprintf(
+										/* translators: %(siteSlug)s - the current site slug, %(newOwnerEmail)s - the new owner's email */
+										__(
+											'You’ll be removed as owner of <strong>%(siteSlug)s</strong> and <strong>%(newOwnerEmail)s</strong> will the new owner from now on.'
+										),
+										{ siteSlug, newOwnerEmail }
+									),
+									{
+										strong: <strong />,
+									}
+								) }
+							</li>
+							<li>
+								{ createInterpolateElement(
+									sprintf(
+										/* translators: %(newOwnerEmail)s - the new owner's email */
+										__(
+											'You will keep your admin access unless <strong>%(newOwnerEmail)s</strong> removes you.'
+										),
+										{ newOwnerEmail }
+									),
+									{
+										strong: <strong />,
+									}
+								) }
+							</li>
+							<li>
+								{ createInterpolateElement(
+									sprintf(
+										/* translators: %(siteSlug)s - the current site slug */
+										__(
+											'Your posts on <strong>%(siteSlug)s</strong> will remain authored by your account.'
+										),
+										{ siteSlug }
+									),
+									{
+										strong: <strong />,
+									}
+								) }
+							</li>
+						</ul>
+					</VStack>
+					<VStack>
+						<Text weight={ 500 }>{ __( 'Domains' ) }</Text>
+						<ul style={ { paddingInlineStart: '20px', margin: 0 } }>
+							<li>
+								{ createInterpolateElement(
+									sprintf(
+										/* translators: %(siteSlug)s - the current site slug, %(newOwnerEmail)s - the new owner's email */
+										__(
+											'The domain name <strong>%(siteSlug)s</strong> will be transferred to <strong>%(newOwnerEmail)s</strong> and will remain working on the site.'
+										),
+										{ siteSlug, newOwnerEmail }
+									),
+									{
+										strong: <strong />,
+									}
+								) }
+							</li>
+						</ul>
+					</VStack>
 				</VStack>
-			</form>
+				<form onSubmit={ handleSubmit }>
+					<VStack>
+						<span style={ { textTransform: 'uppercase' } }>
+							{ __( 'To transfer your site, review and accept the following statements:' ) }
+						</span>
+						<DataForm< StartSiteTransferFormData >
+							data={ formData }
+							fields={ fields }
+							form={ form }
+							onChange={ ( edits: Partial< StartSiteTransferFormData > ) => {
+								setFormData( ( data ) => ( { ...data, ...edits } ) );
+							} }
+						/>
+						<HStack justify="flex-start" style={ { paddingTop: '8px' } }>
+							<Button variant="primary" type="submit" disabled={ isSaveDisabled }>
+								{ __( 'Start transfer' ) }
+							</Button>
+							<Button variant="tertiary" onClick={ handleBack }>
+								{ __( 'Back' ) }
+							</Button>
+						</HStack>
+					</VStack>
+				</form>
+			</VStack>
 		</VStack>
 	);
 }

--- a/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
@@ -49,7 +49,9 @@ const form = {
 const List = ( { title, children }: { title: string; children: React.ReactNode } ) => {
 	return (
 		<VStack>
-			<Text weight={ 500 }>{ title }</Text>
+			<Text weight={ 500 } as="h3">
+				{ title }
+			</Text>
 			<ul style={ { paddingInlineStart: '20px', margin: 0 } }>{ children }</ul>
 		</VStack>
 	);
@@ -101,7 +103,7 @@ export function StartSiteTransferForm( {
 	return (
 		<VStack spacing={ 0 }>
 			<VStack style={ { padding: '8px 0 12px' } }>
-				<Text size="15px" weight={ 500 } lineHeight="32px">
+				<Text size="15px" weight={ 500 } lineHeight="32px" as="h2">
 					{ __( 'Start site transfer' ) }
 				</Text>
 			</VStack>

--- a/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
@@ -8,6 +8,7 @@ import {
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import React, { useState } from 'react';
+import type { Site } from '../../data/types';
 import type { Field } from '@automattic/dataviews';
 
 type StartSiteTransferFormData = {
@@ -42,16 +43,29 @@ const form = {
 	fields: [ 'accept_authorization', 'accept_transfer', 'accept_undone' ],
 };
 
+const List = ( { title, children }: { title: string; children: React.ReactNode } ) => {
+	return (
+		<VStack>
+			<Text weight={ 500 }>{ title }</Text>
+			<ul style={ { paddingInlineStart: '20px', margin: 0 } }>{ children }</ul>
+		</VStack>
+	);
+};
+
 export function StartSiteTransferForm( {
 	initialData = {},
 	siteSlug,
+	site,
 	newOwnerEmail,
+	isTransferring,
 	handleSubmit,
 	handleBack,
 }: {
 	initialData?: Partial< StartSiteTransferFormData >;
 	siteSlug: string;
+	site: Site;
 	newOwnerEmail: string;
+	isTransferring: boolean;
 	handleSubmit: ( event: React.FormEvent ) => void;
 	handleBack: () => void;
 } ) {
@@ -74,15 +88,56 @@ export function StartSiteTransferForm( {
 			<VStack spacing={ 5 } style={ { padding: '8px 0' } }>
 				{ /* TODO: Add notice when the component is ready */ }
 				<VStack spacing={ 6 } style={ { padding: '8px 0' } }>
-					<VStack>
-						<Text weight={ 500 }>{ __( 'Content and ownership' ) }</Text>
-						<ul style={ { paddingInlineStart: '20px', margin: 0 } }>
+					<List title={ __( 'Content and ownership' ) }>
+						<li>
+							{ createInterpolateElement(
+								sprintf(
+									/* translators: %(siteSlug)s - the current site slug, %(newOwnerEmail)s - the new owner's email */
+									__(
+										'You’ll be removed as owner of <strong>%(siteSlug)s</strong> and <strong>%(newOwnerEmail)s</strong> will the new owner from now on.'
+									),
+									{ siteSlug, newOwnerEmail }
+								),
+								{
+									strong: <strong />,
+								}
+							) }
+						</li>
+						<li>
+							{ createInterpolateElement(
+								sprintf(
+									/* translators: %(newOwnerEmail)s - the new owner's email */
+									__(
+										'You will keep your admin access unless <strong>%(newOwnerEmail)s</strong> removes you.'
+									),
+									{ newOwnerEmail }
+								),
+								{
+									strong: <strong />,
+								}
+							) }
+						</li>
+						<li>
+							{ createInterpolateElement(
+								sprintf(
+									/* translators: %(siteSlug)s - the current site slug */
+									__(
+										'Your posts on <strong>%(siteSlug)s</strong> will remain authored by your account.'
+									),
+									{ siteSlug }
+								),
+								{
+									strong: <strong />,
+								}
+							) }
+						</li>
+						{ site.is_wpcom_atomic && ! site.is_wpcom_staging_site && (
 							<li>
 								{ createInterpolateElement(
 									sprintf(
 										/* translators: %(siteSlug)s - the current site slug, %(newOwnerEmail)s - the new owner's email */
 										__(
-											'You’ll be removed as owner of <strong>%(siteSlug)s</strong> and <strong>%(newOwnerEmail)s</strong> will the new owner from now on.'
+											'If your site <strong>%(siteSlug)s</strong> has a staging site, it will be transferred to <strong>%(newOwnerEmail)s</strong>.'
 										),
 										{ siteSlug, newOwnerEmail }
 									),
@@ -91,55 +146,39 @@ export function StartSiteTransferForm( {
 									}
 								) }
 							</li>
-							<li>
-								{ createInterpolateElement(
-									sprintf(
-										/* translators: %(newOwnerEmail)s - the new owner's email */
-										__(
-											'You will keep your admin access unless <strong>%(newOwnerEmail)s</strong> removes you.'
-										),
-										{ newOwnerEmail }
+						) }
+					</List>
+					{ /* TODO: Check there is any active purchase on current user. */ }
+					<List title={ __( 'Upgrades' ) }>
+						<li>
+							{ createInterpolateElement(
+								sprintf(
+									/* translators: %(siteSlug)s - the current site slug, %(newOwnerEmail)s - the new owner's email */
+									__(
+										'Your paid upgrades on <strong>%(siteSlug)s</strong> will be transferred to <strong>%(siteOwner)s</strong> and will remain with the site.'
 									),
-									{
-										strong: <strong />,
-									}
-								) }
-							</li>
-							<li>
-								{ createInterpolateElement(
-									sprintf(
-										/* translators: %(siteSlug)s - the current site slug */
-										__(
-											'Your posts on <strong>%(siteSlug)s</strong> will remain authored by your account.'
-										),
-										{ siteSlug }
+									{ siteSlug, newOwnerEmail }
+								),
+								{ strong: <strong /> }
+							) }
+						</li>
+					</List>
+					<List title={ __( 'Domains' ) }>
+						<li>
+							{ createInterpolateElement(
+								sprintf(
+									/* translators: %(siteSlug)s - the current site slug, %(newOwnerEmail)s - the new owner's email */
+									__(
+										'The domain name <strong>%(siteSlug)s</strong> will be transferred to <strong>%(newOwnerEmail)s</strong> and will remain working on the site.'
 									),
-									{
-										strong: <strong />,
-									}
-								) }
-							</li>
-						</ul>
-					</VStack>
-					<VStack>
-						<Text weight={ 500 }>{ __( 'Domains' ) }</Text>
-						<ul style={ { paddingInlineStart: '20px', margin: 0 } }>
-							<li>
-								{ createInterpolateElement(
-									sprintf(
-										/* translators: %(siteSlug)s - the current site slug, %(newOwnerEmail)s - the new owner's email */
-										__(
-											'The domain name <strong>%(siteSlug)s</strong> will be transferred to <strong>%(newOwnerEmail)s</strong> and will remain working on the site.'
-										),
-										{ siteSlug, newOwnerEmail }
-									),
-									{
-										strong: <strong />,
-									}
-								) }
-							</li>
-						</ul>
-					</VStack>
+									{ siteSlug, newOwnerEmail }
+								),
+								{
+									strong: <strong />,
+								}
+							) }
+						</li>
+					</List>
 				</VStack>
 				<form onSubmit={ handleSubmit }>
 					<VStack>
@@ -155,10 +194,15 @@ export function StartSiteTransferForm( {
 							} }
 						/>
 						<HStack justify="flex-start" style={ { paddingTop: '8px' } }>
-							<Button variant="primary" type="submit" disabled={ isSaveDisabled }>
+							<Button
+								variant="primary"
+								type="submit"
+								isBusy={ isTransferring }
+								disabled={ isSaveDisabled }
+							>
 								{ __( 'Start transfer' ) }
 							</Button>
-							<Button variant="tertiary" onClick={ handleBack }>
+							<Button variant="tertiary" onClick={ handleBack } disabled={ isTransferring }>
 								{ __( 'Back' ) }
 							</Button>
 						</HStack>

--- a/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
@@ -8,6 +8,7 @@ import {
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import React, { useState } from 'react';
+import Notice from '../../components/notice';
 import type { Site } from '../../data/types';
 import type { Field } from '@automattic/dataviews';
 
@@ -86,7 +87,13 @@ export function StartSiteTransferForm( {
 				</Text>
 			</VStack>
 			<VStack spacing={ 5 } style={ { padding: '8px 0' } }>
-				{ /* TODO: Add notice when the component is ready */ }
+				<Notice
+					variant="warning"
+					density="medium"
+					content={ __(
+						'Please read the following carefully. Transferring a site cannot be undone.'
+					) }
+				/>
 				<VStack spacing={ 6 } style={ { padding: '8px 0' } }>
 					<List title={ __( 'Content and ownership' ) }>
 						<li>

--- a/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
@@ -1,4 +1,5 @@
 import { DataForm } from '@automattic/dataviews';
+import { useMutation } from '@tanstack/react-query';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -8,6 +9,7 @@ import {
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import React, { useState } from 'react';
+import { siteOwnerTransferMutation } from '../../app/queries';
 import Notice from '../../components/notice';
 import type { Site } from '../../data/types';
 import type { Field } from '@automattic/dataviews';
@@ -57,14 +59,12 @@ export function StartSiteTransferForm( {
 	siteSlug,
 	site,
 	newOwnerEmail,
-	isTransferring,
 	handleSubmit,
 	handleBack,
 }: {
 	siteSlug: string;
 	site: Site;
 	newOwnerEmail: string;
-	isTransferring: boolean;
 	handleSubmit: () => void;
 	handleBack: () => void;
 } ) {
@@ -74,11 +74,24 @@ export function StartSiteTransferForm( {
 		accept_undone: false,
 	} );
 
+	const mutation = useMutation( siteOwnerTransferMutation( siteSlug ) );
+
 	const isSaveDisabled = Object.values( formData ).some( ( value ) => ! value );
 
 	const onSubmit = ( event: React.FormEvent ) => {
 		event.preventDefault();
-		handleSubmit();
+
+		mutation.mutate(
+			{ new_site_owner: newOwnerEmail },
+			{
+				onSuccess: () => {
+					handleSubmit();
+				},
+				onError: () => {
+					// TODO: Display error message
+				},
+			}
+		);
 	};
 
 	return (
@@ -202,12 +215,12 @@ export function StartSiteTransferForm( {
 							<Button
 								variant="primary"
 								type="submit"
-								isBusy={ isTransferring }
+								isBusy={ mutation.isPending }
 								disabled={ isSaveDisabled }
 							>
 								{ __( 'Start transfer' ) }
 							</Button>
-							<Button variant="tertiary" onClick={ handleBack } disabled={ isTransferring }>
+							<Button variant="tertiary" onClick={ handleBack } disabled={ mutation.isPending }>
 								{ __( 'Back' ) }
 							</Button>
 						</HStack>

--- a/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
@@ -59,14 +59,14 @@ export function StartSiteTransferForm( {
 	siteSlug,
 	site,
 	newOwnerEmail,
-	handleSubmit,
-	handleBack,
+	onSubmit,
+	onBack,
 }: {
 	siteSlug: string;
 	site: Site;
 	newOwnerEmail: string;
-	handleSubmit: () => void;
-	handleBack: () => void;
+	onSubmit: () => void;
+	onBack: () => void;
 } ) {
 	const [ formData, setFormData ] = useState( {
 		accept_authorization: false,
@@ -82,14 +82,14 @@ export function StartSiteTransferForm( {
 
 	const renderNewOwnerEmail = () => <strong>{ newOwnerEmail }</strong>;
 
-	const onSubmit = ( event: React.FormEvent ) => {
+	const handleSubmit = ( event: React.FormEvent ) => {
 		event.preventDefault();
 
 		mutation.mutate(
 			{ new_site_owner: newOwnerEmail },
 			{
 				onSuccess: () => {
-					handleSubmit();
+					onSubmit();
 				},
 				onError: () => {
 					// TODO: Display error message
@@ -180,9 +180,9 @@ export function StartSiteTransferForm( {
 						</li>
 					</List>
 				</VStack>
-				<form onSubmit={ onSubmit }>
+				<form onSubmit={ handleSubmit }>
 					<VStack>
-						<span style={ { textTransform: 'uppercase' } }>
+						<span style={ { textTransform: 'uppercase', fontSize: '11px', fontWeight: 500 } }>
 							{ __( 'To transfer your site, review and accept the following statements:' ) }
 						</span>
 						<DataForm< StartSiteTransferFormData >
@@ -202,7 +202,7 @@ export function StartSiteTransferForm( {
 							>
 								{ __( 'Start transfer' ) }
 							</Button>
-							<Button variant="tertiary" onClick={ handleBack } disabled={ mutation.isPending }>
+							<Button variant="tertiary" onClick={ onBack } disabled={ mutation.isPending }>
 								{ __( 'Back' ) }
 							</Button>
 						</HStack>

--- a/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
@@ -54,7 +54,6 @@ const List = ( { title, children }: { title: string; children: React.ReactNode }
 };
 
 export function StartSiteTransferForm( {
-	initialData = {},
 	siteSlug,
 	site,
 	newOwnerEmail,
@@ -62,26 +61,24 @@ export function StartSiteTransferForm( {
 	handleSubmit,
 	handleBack,
 }: {
-	initialData?: Partial< StartSiteTransferFormData >;
 	siteSlug: string;
 	site: Site;
 	newOwnerEmail: string;
 	isTransferring: boolean;
-	handleSubmit: ( data: StartSiteTransferFormData ) => void;
+	handleSubmit: () => void;
 	handleBack: () => void;
 } ) {
 	const [ formData, setFormData ] = useState( {
 		accept_authorization: false,
 		accept_transfer: false,
 		accept_undone: false,
-		...initialData,
 	} );
 
 	const isSaveDisabled = Object.values( formData ).some( ( value ) => ! value );
 
 	const onSubmit = ( event: React.FormEvent ) => {
 		event.preventDefault();
-		handleSubmit( formData );
+		handleSubmit();
 	};
 
 	return (

--- a/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
@@ -12,7 +12,7 @@ import Notice from '../../components/notice';
 import type { Site } from '../../data/types';
 import type { Field } from '@automattic/dataviews';
 
-type StartSiteTransferFormData = {
+export type StartSiteTransferFormData = {
 	accept_authorization: boolean;
 	accept_transfer: boolean;
 	accept_undone: boolean;
@@ -67,7 +67,7 @@ export function StartSiteTransferForm( {
 	site: Site;
 	newOwnerEmail: string;
 	isTransferring: boolean;
-	handleSubmit: ( event: React.FormEvent ) => void;
+	handleSubmit: ( data: StartSiteTransferFormData ) => void;
 	handleBack: () => void;
 } ) {
 	const [ formData, setFormData ] = useState( {
@@ -78,6 +78,11 @@ export function StartSiteTransferForm( {
 	} );
 
 	const isSaveDisabled = Object.values( formData ).some( ( value ) => ! value );
+
+	const onSubmit = ( event: React.FormEvent ) => {
+		event.preventDefault();
+		handleSubmit( formData );
+	};
 
 	return (
 		<VStack spacing={ 0 }>
@@ -187,7 +192,7 @@ export function StartSiteTransferForm( {
 						</li>
 					</List>
 				</VStack>
-				<form onSubmit={ handleSubmit }>
+				<form onSubmit={ onSubmit }>
 					<VStack>
 						<span style={ { textTransform: 'uppercase' } }>
 							{ __( 'To transfer your site, review and accept the following statements:' ) }

--- a/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
@@ -7,7 +7,7 @@ import {
 	Button,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { sprintf, __ } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import React, { useState } from 'react';
 import { siteOwnerTransferMutation } from '../../app/queries';
 import Notice from '../../components/notice';
@@ -78,6 +78,10 @@ export function StartSiteTransferForm( {
 
 	const isSaveDisabled = Object.values( formData ).some( ( value ) => ! value );
 
+	const renderSiteSlug = () => <strong>{ siteSlug }</strong>;
+
+	const renderNewOwnerEmail = () => <strong>{ newOwnerEmail }</strong>;
+
 	const onSubmit = ( event: React.FormEvent ) => {
 		event.preventDefault();
 
@@ -109,58 +113,40 @@ export function StartSiteTransferForm( {
 					<List title={ __( 'Content and ownership' ) }>
 						<li>
 							{ createInterpolateElement(
-								sprintf(
-									/* translators: %(siteSlug)s - the current site slug, %(newOwnerEmail)s - the new owner's email */
-									__(
-										'You’ll be removed as owner of <strong>%(siteSlug)s</strong> and <strong>%(newOwnerEmail)s</strong> will the new owner from now on.'
-									),
-									{ siteSlug, newOwnerEmail }
+								__(
+									'You’ll be removed as owner of <siteSlug /> and <newOwnerEmail /> will the new owner from now on.'
 								),
 								{
-									strong: <strong />,
+									siteSlug: renderSiteSlug(),
+									newOwnerEmail: renderNewOwnerEmail(),
 								}
 							) }
 						</li>
 						<li>
 							{ createInterpolateElement(
-								sprintf(
-									/* translators: %(newOwnerEmail)s - the new owner's email */
-									__(
-										'You will keep your admin access unless <strong>%(newOwnerEmail)s</strong> removes you.'
-									),
-									{ newOwnerEmail }
-								),
+								__( 'You will keep your admin access unless <newOwnerEmail /> removes you.' ),
 								{
-									strong: <strong />,
+									newOwnerEmail: renderNewOwnerEmail(),
 								}
 							) }
 						</li>
 						<li>
 							{ createInterpolateElement(
-								sprintf(
-									/* translators: %(siteSlug)s - the current site slug */
-									__(
-										'Your posts on <strong>%(siteSlug)s</strong> will remain authored by your account.'
-									),
-									{ siteSlug }
-								),
+								__( 'Your posts on <siteSlug /> will remain authored by your account.' ),
 								{
-									strong: <strong />,
+									siteSlug: renderSiteSlug(),
 								}
 							) }
 						</li>
 						{ site.is_wpcom_atomic && ! site.is_wpcom_staging_site && (
 							<li>
 								{ createInterpolateElement(
-									sprintf(
-										/* translators: %(siteSlug)s - the current site slug, %(newOwnerEmail)s - the new owner's email */
-										__(
-											'If your site <strong>%(siteSlug)s</strong> has a staging site, it will be transferred to <strong>%(newOwnerEmail)s</strong>.'
-										),
-										{ siteSlug, newOwnerEmail }
+									__(
+										'If your site <siteSlug /> has a staging site, it will be transferred to <newOwnerEmail />.'
 									),
 									{
-										strong: <strong />,
+										siteSlug: renderSiteSlug(),
+										newOwnerEmail: renderNewOwnerEmail(),
 									}
 								) }
 							</li>
@@ -170,29 +156,25 @@ export function StartSiteTransferForm( {
 					<List title={ __( 'Upgrades' ) }>
 						<li>
 							{ createInterpolateElement(
-								sprintf(
-									/* translators: %(siteSlug)s - the current site slug, %(newOwnerEmail)s - the new owner's email */
-									__(
-										'Your paid upgrades on <strong>%(siteSlug)s</strong> will be transferred to <strong>%(newOwnerEmail)s</strong> and will remain with the site.'
-									),
-									{ siteSlug, newOwnerEmail }
+								__(
+									'Your paid upgrades on <siteSlug /> will be transferred to <newOwnerEmail /> and will remain with the site.'
 								),
-								{ strong: <strong /> }
+								{
+									siteSlug: renderSiteSlug(),
+									newOwnerEmail: renderNewOwnerEmail(),
+								}
 							) }
 						</li>
 					</List>
 					<List title={ __( 'Domains' ) }>
 						<li>
 							{ createInterpolateElement(
-								sprintf(
-									/* translators: %(siteSlug)s - the current site slug, %(newOwnerEmail)s - the new owner's email */
-									__(
-										'The domain name <strong>%(siteSlug)s</strong> will be transferred to <strong>%(newOwnerEmail)s</strong> and will remain working on the site.'
-									),
-									{ siteSlug, newOwnerEmail }
+								__(
+									'The domain name <siteSlug /> will be transferred to <newOwnerEmail /> and will remain working on the site.'
 								),
 								{
-									strong: <strong />,
+									siteSlug: renderSiteSlug(),
+									newOwnerEmail: renderNewOwnerEmail(),
 								}
 							) }
 						</li>

--- a/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
@@ -1,0 +1,134 @@
+import { DataForm } from '@automattic/dataviews';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	Button,
+} from '@wordpress/components';
+import { sprintf, __ } from '@wordpress/i18n';
+import React, { useState } from 'react';
+import type { Field } from '@automattic/dataviews';
+
+type StartSiteTransferFormData = {
+	accept_authorization: boolean;
+	accept_transfer: boolean;
+	accept_undone: boolean;
+};
+
+const fields: Field< StartSiteTransferFormData >[] = [
+	{
+		id: 'accept_authorization',
+		label: __( 'I understand the changes that will be made once I authorize this transfer.' ),
+		type: 'boolean' as const,
+	},
+	{
+		id: 'accept_transfer',
+		label: __( 'I want to transfer the ownership of the site.' ),
+		type: 'boolean' as const,
+	},
+	{
+		id: 'accept_undone',
+		label: __( 'I understand that transferring a site cannot be undone.' ),
+		type: 'boolean' as const,
+	},
+];
+
+const form = {
+	type: 'regular' as const,
+	fields: [ 'accept_authorization', 'accept_transfer', 'accept_undone' ],
+};
+
+export function StartSiteTransferForm( {
+	initialData = {},
+	siteSlug,
+	newOwnerEmail,
+	handleSubmit,
+	handleBack,
+}: {
+	initialData?: Partial< StartSiteTransferFormData >;
+	siteSlug: string;
+	newOwnerEmail: string;
+	handleSubmit: ( event: React.FormEvent ) => void;
+	handleBack: () => void;
+} ) {
+	const [ formData, setFormData ] = useState( {
+		accept_authorization: false,
+		accept_transfer: false,
+		accept_undone: false,
+		...initialData,
+	} );
+
+	const isSaveDisabled = Object.values( formData ).some( ( value ) => ! value );
+
+	return (
+		<VStack spacing={ 5 }>
+			<VStack style={ { padding: '8px 0' } }>
+				<Text size="15px" weight={ 500 } lineHeight="32px">
+					{ __( 'Start site transfer' ) }
+				</Text>
+			</VStack>
+			{ /* TODO: Add notice when the component is ready */ }
+			<ul>
+				{ __( 'Content and ownership' ) }
+				<li>
+					{ sprintf(
+						/* translators: %(siteSlug)s - the current site slug, %(newOwnerEmail)s - the new owner's email */
+						__(
+							'You’ll be removed as owner of %(siteSlug)s and %(newOwnerEmail)s will the new owner from now on.'
+						),
+						{ siteSlug, newOwnerEmail }
+					) }
+				</li>
+				<li>
+					{ sprintf(
+						/* translators: %(newOwnerEmail)s - the new owner's email */
+						__( 'You will keep your admin access unless %(newOwnerEmail)s removes you.' ),
+						{ newOwnerEmail }
+					) }
+				</li>
+				<li>
+					{ sprintf(
+						/* translators: %(siteSlug)s - the current site slug */
+						__( 'Your posts on %(siteSlug)s will remain authored by your account.' ),
+						{ siteSlug }
+					) }
+				</li>
+			</ul>
+			<ul>
+				{ __( 'Domains' ) }
+				<li>
+					{ sprintf(
+						/* translators: %(siteSlug)s - the current site slug, %(newOwnerEmail)s - the new owner's email */
+						__(
+							'The domain name %(siteSlug)s will be transferred to %(newOwnerEmail)s and will remain working on the site.'
+						),
+						{ siteSlug, newOwnerEmail }
+					) }
+				</li>
+			</ul>
+			<form onSubmit={ handleSubmit }>
+				<VStack spacing={ 4 } style={ { padding: '8px 0' } }>
+					<span>
+						{ __( 'To transfer your site, review and accept the following statements:' ) }
+					</span>
+					<DataForm< StartSiteTransferFormData >
+						data={ formData }
+						fields={ fields }
+						form={ form }
+						onChange={ ( edits: Partial< StartSiteTransferFormData > ) => {
+							setFormData( ( data ) => ( { ...data, ...edits } ) );
+						} }
+					/>
+					<HStack justify="flex-start">
+						<Button variant="primary" type="submit" disabled={ isSaveDisabled }>
+							{ __( 'Start transfer' ) }
+						</Button>
+						<Button variant="tertiary" onClick={ handleBack }>
+							{ __( 'Back' ) }
+						</Button>
+					</HStack>
+				</VStack>
+			</form>
+		</VStack>
+	);
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13175

## Proposed Changes

* Implement the "Start site transfer" screen and integrate with the `/site-owner-transfer` endpoint
* Implement the "Check your inbox" screen
* Implement the "Invitation sent" screen and  integrate with the `/site-owner-transfer/confirm` endpoint

### Start site transfer

<img width="600" src="https://github.com/user-attachments/assets/d7073bb1-4515-4b5d-a489-655503e54215" />

#### Check your inbox

<img width="600" src="https://github.com/user-attachments/assets/a6e35fd9-e478-4a9d-8d0c-5cbe78934279" />

#### Invitation sent

<img width="600" src="https://github.com/user-attachments/assets/87934ad6-d284-4d1f-b2f5-b5adec5037cb" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Select any of your site
* Go to Settings
* Transfer your site
* Enter email and continue
* Check all checkbox and start transfer
* Ensure you can see the "Check your inbox" screen
* Go to your email to verify the request
* Ensure you can see the "Invitation sent to xxx" screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?