### PR TITLE
DataForm: Support spacing to control the gap between each field

### DIFF
--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -18,6 +18,7 @@
 - Add `className` prop to the `DataViews.Layout` component to allow customizing the layout styles.
 - Clean up --wp-components-color-* variables.
 - Add `checkbox` type to the fields of the form.
+- Add `spacing` to allow user to control the spacing of each field.
 
 ## 0.1.1
 

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -35,6 +35,9 @@ const meta = {
 			description: 'Chooses the label position of the layout.',
 			options: [ 'default', 'top', 'side', 'none' ],
 		},
+		spacing: {
+			control: { type: 'number' },
+		},
 	},
 };
 export default meta;
@@ -124,9 +127,11 @@ const fields = [
 export const Default = ( {
 	type,
 	labelPosition,
+	spacing,
 }: {
 	type: 'default' | 'regular' | 'panel';
 	labelPosition: 'default' | 'top' | 'side' | 'none';
+	spacing: number;
 } ) => {
 	const [ post, setPost ] = useState( {
 		title: 'Hello, World!',
@@ -145,6 +150,7 @@ export const Default = ( {
 		() => ( {
 			type,
 			labelPosition,
+			spacing,
 			fields: [
 				'title',
 				'order',
@@ -159,7 +165,7 @@ export const Default = ( {
 				'can_comment',
 			],
 		} ),
-		[ type, labelPosition ]
+		[ type, labelPosition, spacing ]
 	) as Form;
 
 	return (
@@ -180,9 +186,11 @@ export const Default = ( {
 const CombinedFieldsComponent = ( {
 	type,
 	labelPosition,
+	spacing,
 }: {
 	type: 'default' | 'regular' | 'panel';
 	labelPosition: 'default' | 'top' | 'side' | 'none';
+	spacing: number;
 } ) => {
 	const [ post, setPost ] = useState< SamplePost >( {
 		title: 'Hello, World!',
@@ -198,6 +206,7 @@ const CombinedFieldsComponent = ( {
 		() => ( {
 			type,
 			labelPosition,
+			spacing,
 			fields: [
 				'title',
 				{
@@ -209,7 +218,7 @@ const CombinedFieldsComponent = ( {
 				'author',
 			],
 		} ),
-		[ type, labelPosition ]
+		[ type, labelPosition, spacing ]
 	) as Form;
 
 	return (

--- a/packages/dataviews/src/dataforms-layouts/data-form-layout.tsx
+++ b/packages/dataviews/src/dataforms-layouts/data-form-layout.tsx
@@ -48,7 +48,7 @@ export function DataFormLayout< Item >( {
 	);
 
 	return (
-		<VStack spacing={ 2 }>
+		<VStack spacing={ form.spacing ?? 2 }>
 			{ normalizedFormFields.map( ( formField ) => {
 				const FieldLayout = getFormFieldLayout( formField.layout )
 					?.component;

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -596,6 +596,7 @@ export type Form = {
 	type?: 'regular' | 'panel';
 	fields?: Array< FormField | string >;
 	labelPosition?: 'side' | 'top' | 'none';
+	spacing?: number;
 };
 
 export interface DataFormProps< Item > {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DES-113

## Proposed Changes

* Allow developers to control the gap between each field to fit design

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run the storybook
* Adjust the spacing to ensure it works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
