### PR TITLE
Hosting Dashboard: Revert moving h1 styles to PageHeader

### DIFF
--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -35,3 +35,8 @@ a {
 #wpcom {
 	font-size: $font-size-medium;
 }
+
+h1 {
+	font-family: var( --dashboard-h1__font-family );
+	font-weight: var( --dashboard-h1__font-weight ) !important;
+}

--- a/client/dashboard/components/page-header/style.scss
+++ b/client/dashboard/components/page-header/style.scss
@@ -6,9 +6,7 @@ client-dashboard-components-page-header {
 }
 
 .client-dashboard-components-page-header__heading {
-	font-family: var( --dashboard-h1__font-family );
 	font-size: $font-size-2x-large;
-	font-weight: var( --dashboard-h1__font-weight ) !important;
 	line-height: $font-line-height-2x-large;
 	margin-block: 0;
 }

--- a/client/dashboard/utils/site-status.ts
+++ b/client/dashboard/utils/site-status.ts
@@ -12,11 +12,11 @@ export const STATUS_LABELS = {
 };
 
 export function getSiteStatus( item: Site ) {
-	if ( item.site_migration?.migration_status?.startsWith( 'migration-pending' ) ) {
+	if ( item.site_migration.migration_status?.startsWith( 'migration-pending' ) ) {
 		return 'migration_pending';
 	}
 
-	if ( item.site_migration?.migration_status?.startsWith( 'migration-started' ) ) {
+	if ( item.site_migration.migration_status?.startsWith( 'migration-started' ) ) {
 		return 'migration_started';
 	}
 


### PR DESCRIPTION
## Proposed Changes

As discussed in https://github.com/Automattic/wp-calypso/pull/103691#discussion_r2106780629, `dashboard` css vars should not be used in the PageHeader. Thus, this PR reverts the change and we'll follow up with designers whether we want a special handling for h1 in Modal components.

This PR also addresses the feedback from https://github.com/Automattic/wp-calypso/pull/103696#discussion_r2106795003, where the Site prop site_migration is no longer optional so shouldn't be optionally chained.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Code improvements.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that all h1 uses the branding font.
* Ensure that the Site Overview tab renders without an 500 error caused by site_migration being undefined. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
