### PR TITLE
Dashboard v2: preview iframes: disable autoplay + remove scrollbars

### DIFF
--- a/client/dashboard/sites/site-preview/index.tsx
+++ b/client/dashboard/sites/site-preview/index.tsx
@@ -18,6 +18,10 @@ export default function SitePreview( {
 	const secureUrl = url.replace( /^http:\/\//, 'https://' );
 	return (
 		<iframe
+			sandbox="allow-scripts allow-same-origin"
+			// Officially deprecated, but still widely supported. Hides
+			// scrollbars in case they are set to always visible.
+			scrolling="no"
 			loading="lazy"
 			// @ts-expect-error For some reason there's no inert type.
 			inert="true"

--- a/client/dashboard/sites/site-preview/index.tsx
+++ b/client/dashboard/sites/site-preview/index.tsx
@@ -18,6 +18,8 @@ export default function SitePreview( {
 	const secureUrl = url.replace( /^http:\/\//, 'https://' );
 	return (
 		<iframe
+			// Enabling sandbox disables most features, such as autoplay,
+			// alerts, popups, fullscreen, etc.
 			sandbox="allow-scripts allow-same-origin"
 			// Officially deprecated, but still widely supported. Hides
 			// scrollbars in case they are set to always visible.


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* The iframe previews should not autoplay audio/video, also most other capabilities can be disabled.
* Disable scrolling with the `scrolling` attribute, for when the OS forces scrollbars to be shown all the time. Note that scrolling is also disabled through `inert`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
