### PR TITLE
Experiment streamlining the plans grid + checkout: Undo change to the checkout coupon field

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -405,9 +405,6 @@ export default function CheckoutMainContent( {
 
 	const [ isStreamlinedPriceExperimentLoading, streamlinedPriceExperimentAssignment ] =
 		useStreamlinedPriceExperiment();
-	const isStreamlinedPrice =
-		! isStreamlinedPriceExperimentLoading &&
-		isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment );
 
 	const searchParams = new URLSearchParams( window.location.search );
 	const isDIFMInCart = hasDIFMProduct( responseCart );
@@ -704,16 +701,6 @@ export default function CheckoutMainContent( {
 					formStatus={ formStatus }
 				/>
 
-				{ isStreamlinedPrice && (
-					<CouponFieldArea
-						isCouponFieldVisible={ isCouponFieldVisible }
-						setCouponFieldVisible={ setCouponFieldVisible }
-						isPurchaseFree={ isPurchaseFree }
-						couponStatus={ couponStatus }
-						couponFieldStateProps={ couponFieldStateProps }
-					/>
-				) }
-
 				{ contactDetailsType !== 'none' && (
 					<CheckoutStep
 						className="checkout-contact-form-step"
@@ -851,15 +838,13 @@ export default function CheckoutMainContent( {
 					} }
 				/>
 
-				{ ! isStreamlinedPrice && (
-					<CouponFieldArea
-						isCouponFieldVisible={ isCouponFieldVisible }
-						setCouponFieldVisible={ setCouponFieldVisible }
-						isPurchaseFree={ isPurchaseFree }
-						couponStatus={ couponStatus }
-						couponFieldStateProps={ couponFieldStateProps }
-					/>
-				) }
+				<CouponFieldArea
+					isCouponFieldVisible={ isCouponFieldVisible }
+					setCouponFieldVisible={ setCouponFieldVisible }
+					isPurchaseFree={ isPurchaseFree }
+					couponStatus={ couponStatus }
+					couponFieldStateProps={ couponFieldStateProps }
+				/>
 
 				<CheckoutTermsAndCheckboxes
 					is3PDAccountConsentAccepted={ is3PDAccountConsentAccepted }
@@ -1573,8 +1558,7 @@ const WPCheckoutMainContent = styled.div< {
 			.checkout-line-item .checkout-line-item__remove-product {
 				font-size: 14px;
 			}
-			.form-fieldset.contact-details-form-fields .form__hidden-input a,
-			.checkout__content .wp-checkout-order-review__show-coupon-field-button {
+			.form-fieldset.contact-details-form-fields .form__hidden-input a {
 				font-weight: 500;
 				text-decoration: none;
 				color: ${ props.theme.colors.textColorDark };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of pdtkmj-3DM-p2#comment-6996

## Proposed Changes

* Removes order and styling changes to the coupon are.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We're undoing changes to this area as they might skew the results of the experiment.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Assign treatment variation of the `calypso_streamlined_plans_checkout` experiment 
* Go through the `onboarding` flow to get assigned
* The `Have a coupon` link should be underlined and positioned before the fine print

|Before|After|
|------|-----|
|<img width="480" alt="Screenshot 2025-05-26 at 14 25 26" src="https://github.com/user-attachments/assets/1c06d623-1b39-4cc2-bffe-98e85687f2a5" />|<img width="480" alt="Screenshot 2025-05-26 at 14 24 31" src="https://github.com/user-attachments/assets/04038d9d-f746-44cc-b0b2-93c0187d6712" />|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?