### PR TITLE
Fix: Update signup URL formatting logic

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -12,7 +12,7 @@ import Notice from 'calypso/components/notice';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import isAkismetRedirect from 'calypso/lib/akismet/is-akismet-redirect';
 import getGravatarOAuth2Flow from 'calypso/lib/get-gravatar-oauth2-flow';
-import { getSignupUrl } from 'calypso/lib/login';
+import { getSignupUrl, pathWithLeadingSlash } from 'calypso/lib/login';
 import {
 	isJetpackCloudOAuth2Client,
 	isA4AOAuth2Client,
@@ -314,7 +314,11 @@ class Login extends Component {
 		} = this.props;
 
 		if ( signupUrl ) {
-			return signupUrl;
+			const cleanUrl = String( signupUrl )
+				.replace( /<\/?[^>]+(>|$)/g, '' )
+				.replace( /^[a-zA-Z][a-zA-Z\d+\-.]*:/, '' )
+				.replace( /\s/g, '' );
+			return window.location.origin + pathWithLeadingSlash( cleanUrl );
 		}
 
 		if ( isWCCOM && isEmpty( currentQuery ) ) {

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -314,11 +314,7 @@ class Login extends Component {
 		} = this.props;
 
 		if ( signupUrl ) {
-			const cleanUrl = String( signupUrl )
-				.replace( /<\/?[^>]+(>|$)/g, '' )
-				.replace( /^[a-zA-Z][a-zA-Z\d+\-.]*:/, '' )
-				.replace( /\s/g, '' );
-			return window.location.origin + pathWithLeadingSlash( cleanUrl );
+			return window.location.origin + pathWithLeadingSlash( signupUrl );
 		}
 
 		if ( isWCCOM && isEmpty( currentQuery ) ) {

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -46,7 +46,11 @@ export function pathWithLeadingSlash( path ) {
 		return '';
 	}
 
-	return path ? `/${ path.replace( /^\/+/, '' ) }` : '';
+	const cleanPath = path
+		.replace( /<\/?[^>]+(>|$)/g, '' )
+		.replace( /^[a-zA-Z][a-zA-Z\d+\-.]*:/, '' )
+		.replace( /\s/g, '' );
+	return cleanPath ? `/${ cleanPath.replace( /^\/+/, '' ) }` : '';
 }
 
 export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, pathname ) {


### PR DESCRIPTION
* Related to # p1748086048991459-slack-CRA4UEQQ3


## Proposed Changes

* signupUrl was not handling some characters properly on the page where an account already exists.

## Why are these changes being made?

* Improve handling of signupurl path/characters

## Testing Instructions

* Check Slack for detailed instructions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
