### PR TITLE
Help Center: Fix blockquote in chat

### DIFF
--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -104,15 +104,16 @@ $blueberry-color: #3858e9;
 				margin-top: 0;
 			}
 
-			> *:not(:first-child) {
+			> *:not( :first-child ) {
 				padding-top: 8px;
 			}
 
-			> *:not(:last-child) {
+			> *:not( :last-child ) {
 				padding-bottom: 8px;
 			}
 
-			ol, ul {
+			ol,
+			ul {
 				padding-left: 20px;
 				padding-right: 20px;
 			}
@@ -157,7 +158,7 @@ $blueberry-color: #3858e9;
 						outline: none;
 					}
 					.gridicon {
-						fill: #1E1E1E;
+						fill: #1e1e1e;
 					}
 				}
 			}
@@ -182,7 +183,6 @@ $blueberry-color: #3858e9;
 					}
 				}
 			}
-
 		}
 
 		.disclaimer {
@@ -193,7 +193,8 @@ $blueberry-color: #3858e9;
 			text-align: start;
 			margin: 16px 0;
 
-			.odie-button-link, .components-external-link {
+			.odie-button-link,
+			.components-external-link {
 				color: $blueberry-color;
 			}
 		}
@@ -221,8 +222,8 @@ $blueberry-color: #3858e9;
 		}
 		.message-feedback-submit {
 			margin-left: 46px;
-			align-items: start ;
-	
+			align-items: start;
+
 			a {
 				gap: 4px;
 			}
@@ -297,19 +298,25 @@ $blueberry-color: #3858e9;
 
 	blockquote {
 		background-color: transparent;
-		border-left: 2px solid var(--color-neutral-0);
+		border-left: 2px solid var( --color-neutral-0 );
 		margin: 8px 0 16px;
 		padding: 8px 16px;
 	}
 }
 
 .odie-chatbox-message.odie-chatbox-message-business {
-	p {
-		/* remove important */
+	.odie-chatbox-message__content {
+		background-color: #f7f8fe;
 		/* stylelint-disable-next-line scales/radii */
-		border-radius: 8px 8px 8px 0 !important;
-		background-color: #f7f8fe !important;
+		border-radius: 8px 8px 8px 0;
 		padding: 16px;
+	}
+
+	blockquote {
+		background-color: transparent;
+		border-left: 2px solid var( --studio-gray-10 );
+		margin: 8px 0 16px;
+		padding: 8px 16px;
 	}
 }
 
@@ -784,7 +791,7 @@ $custom-border-corner-size: 16px;
 }
 
 .odie__transfer-chat {
-	width: calc(100% - 80px)!important;
+	width: calc( 100% - 80px ) !important;
 	margin-top: 16px;
 	margin-left: 46px;
 }

--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -294,6 +294,13 @@ $blueberry-color: #3858e9;
 			height: auto;
 		}
 	}
+
+	blockquote {
+		background-color: transparent;
+		border-left: 2px solid var(--color-neutral-0);
+		margin: 8px 0 16px;
+		padding: 8px 16px;
+	}
 }
 
 .odie-chatbox-message.odie-chatbox-message-business {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-13320/help-center-quoted-text-appears-obscured
Fixes https://linear.app/a8c/issue/DOTCOM-13321/help-center-text-quoted-by-hes-doesnt-appear-as-quoted

## Proposed Changes

Fix the style of quotes in comments sent by the users and by HEs:

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/11e8fb07-ff21-4f98-af91-8785f26cbd62) | ![image](https://github.com/user-attachments/assets/5d5fce56-ce49-447e-b171-f56ef0d6c215) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open a chat with an Happiness Engineer and send a message starting with `<`



