### PR TITLE
A4A: Fix the failing e2e test for the sign-in form

### DIFF
--- a/test/e2e/specs/a8c-for-agencies/signup__smoke.ts
+++ b/test/e2e/specs/a8c-for-agencies/signup__smoke.ts
@@ -32,11 +32,15 @@ describe( 'A4A > Signup: Smoke Test', function () {
 
 		// Enter first name
 		const firstName = 'John';
-		await page.getByLabel( 'First name' ).fill( firstName );
+		await page.getByLabel( 'Your first name' ).fill( firstName );
 
 		// Enter last name
 		const lastName = 'Doe';
 		await page.getByLabel( 'Last name' ).fill( lastName );
+
+		// Enter email address
+		const email = 'johndoe@example.com';
+		await page.getByLabel( 'Email' ).fill( email );
 
 		// Enter the agency name
 		const agencyName = 'Agency Name';
@@ -46,7 +50,31 @@ describe( 'A4A > Signup: Smoke Test', function () {
 		const businessURL = 'https://example.com';
 		await page.getByLabel( 'Business URL' ).fill( businessURL );
 
-		// Select the user type to site owner
+		// Phone number
+		const phoneNumber = '+1234567890';
+		await page.getByLabel( 'Phone number' ).fill( phoneNumber );
+
+		// Enter Country code combobox
+		await page
+			.getByRole( 'combobox', { name: 'Country code' } )
+			.selectOption( { label: 'United States (+1)' } );
+
+		// Verify the form values
+		expect( await page.getByLabel( 'Your first name' ).inputValue() ).toBe( firstName );
+		expect( await page.getByLabel( 'Last name' ).inputValue() ).toBe( lastName );
+		expect( await page.getByLabel( 'Email' ).inputValue() ).toBe( email );
+		expect( await page.getByLabel( 'Phone number' ).inputValue() ).toBe( phoneNumber );
+		expect( await page.getByLabel( 'Agency name' ).inputValue() ).toBe( agencyName );
+		expect( await page.getByLabel( 'Business URL' ).inputValue() ).toBe( businessURL );
+		expect( await page.getByRole( 'combobox', { name: 'Country code' } ).inputValue() ).toBe(
+			'+1'
+		);
+
+		// Click the "Continue for free" button
+		await page.getByRole( 'button', { name: 'Continue for free' } ).click();
+		await page.waitForURL( `${ A4A_URL }/signup/agency` );
+
+		/*	// Select the user type to site owner
 		await page
 			.getByRole( 'combobox', { name: 'How would you describe yourself?' } )
 			.selectOption( { label: "I do not work at an agency. I'm a site owner." } );
@@ -80,10 +108,7 @@ describe( 'A4A > Signup: Smoke Test', function () {
 		await page.getByLabel( 'Postal code' ).fill( '94105' );
 
 		// Verify the form values
-		expect( await page.getByLabel( 'First name' ).inputValue() ).toBe( firstName );
-		expect( await page.getByLabel( 'Last name' ).inputValue() ).toBe( lastName );
-		expect( await page.getByLabel( 'Agency name' ).inputValue() ).toBe( agencyName );
-		expect( await page.getByLabel( 'Business URL' ).inputValue() ).toBe( businessURL );
+
 		expect(
 			await page.getByRole( 'combobox', { name: 'How would you describe yourself?' } ).inputValue()
 		).toBe( 'agency_owner' );
@@ -104,5 +129,6 @@ describe( 'A4A > Signup: Smoke Test', function () {
 		).toBe( 'Suite 101' );
 		expect( await page.getByLabel( 'City' ).inputValue() ).toBe( 'San Francisco' );
 		expect( await page.getByLabel( 'Postal code' ).inputValue() ).toBe( '94105' );
+		*/
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

This PR fixes the E2E test for the new signup form recently added.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
