### PR TITLE
Help Center: Fix large images by HEs

### DIFF
--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -83,6 +83,11 @@ $blueberry-color: #3858e9;
 		list-style: initial;
 	}
 
+	img {
+		max-width: 100%;
+		height: auto;
+	}
+
 	&.odie-chatbox-message-no-avatar {
 		.odie-chatbox-message__content {
 			margin-left: 46px;
@@ -288,10 +293,6 @@ $blueberry-color: #3858e9;
 					color: var( --studio-blue-40 );
 				}
 			}
-		}
-		img {
-			max-width: 100%;
-			height: auto;
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-13322/help-center-screenshots-attached-by-hes-appear-oversized

## Proposed Changes

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/5308322e-6640-4f76-9e17-2fb4e2202110) | ![image](https://github.com/user-attachments/assets/e6cfd32e-ee34-4a19-bb2f-e681c673babc) | 



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open a chat with HEs (escalate from AI requiring to talk with a human)
* From Zendesk, upload a large image

