### PR TITLE
Dashboard v2: fix header breadcrumb view transition

### DIFF
--- a/client/dashboard/app/view-transitions.scss
+++ b/client/dashboard/app/view-transitions.scss
@@ -31,11 +31,23 @@ main div.dashboard-header-bar {
 }
 
 // Large and small must be separate so they don't cross-animate.
-.dashboard-page-layout.is-large .client-dashboard-components-page-header {
-	view-transition-name: page-layout-header-large;
+.dashboard-page-layout.is-large .client-dashboard-components-page-header .client-dashboard-components-page-header__breadcrumbs {
+	view-transition-name: page-layout-header-breadcrumbs-large;
 }
-.dashboard-page-layout.is-small .client-dashboard-components-page-header {
-	view-transition-name: page-layout-header-small;
+.dashboard-page-layout.is-small .client-dashboard-components-page-header .client-dashboard-components-page-header__breadcrumbs {
+	view-transition-name: page-layout-header-breadcrumbs-small;
+}
+.dashboard-page-layout.is-large .client-dashboard-components-page-header .client-dashboard-components-page-header__heading-row {
+	view-transition-name: page-layout-header-heading-row-large;
+}
+.dashboard-page-layout.is-small .client-dashboard-components-page-header .client-dashboard-components-page-header__heading-row {
+	view-transition-name: page-layout-header-heading-row-small;
+}
+.dashboard-page-layout.is-large .client-dashboard-components-page-header .client-dashboard-components-page-header__description {
+	view-transition-name: page-layout-header-description-large;
+}
+.dashboard-page-layout.is-small .client-dashboard-components-page-header .client-dashboard-components-page-header__description {
+	view-transition-name: page-layout-header-description-small;
 }
 
 .dashboard-page-layout.is-large .client-dashboard-components-page-header .components-button.is-primary {

--- a/client/dashboard/components/page-header/index.tsx
+++ b/client/dashboard/components/page-header/index.tsx
@@ -40,8 +40,15 @@ export const PageHeader = ( {
 }: PageHeaderProps ) => {
 	return (
 		<VStack spacing={ 2 } className="client-dashboard-components-page-header">
-			{ breadcrumbs }
-			<HStack spacing={ 4 } justify="flex-start" alignment="flex-start">
+			{ breadcrumbs && (
+				<div className="client-dashboard-components-page-header__breadcrumbs">{ breadcrumbs }</div>
+			) }
+			<HStack
+				spacing={ 4 }
+				justify="flex-start"
+				alignment="flex-start"
+				className="client-dashboard-components-page-header__heading-row"
+			>
 				{ decoration && (
 					<span className="client-dashboard-components-page-header__decoration">
 						{ decoration }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #103278 

## Proposed Changes

* The breadcrumbs, header row and description should animate separately.
* It's not perfect, because the cards are used differently in both screens so the cross animate weirdly. In one screen there's heading with multiple cards and the other is one card.

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/0afeeda5-d412-467d-9bf4-cb64bcc977f5">|<video src="https://github.com/user-attachments/assets/83c941fb-a7a8-4c86-9a46-4dfc96ddda9b">|



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

