### PR TITLE
Banner: Fix Visual Regression on the Action Margin

### DIFF
--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -215,10 +215,6 @@
 	text-align: left;
 	width: 100%;
 
-	.is-primary {
-		margin-left: 8px;
-	}
-
 	.banner__prices {
 		display: flex;
 		justify-content: flex-start;

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -215,6 +215,10 @@
 	text-align: left;
 	width: 100%;
 
+	.button + .is-primary {
+		margin-left: 8px;
+	}
+
 	.banner__prices {
 		display: flex;
 		justify-content: flex-start;

--- a/client/me/email-verification-banner/style.scss
+++ b/client/me/email-verification-banner/style.scss
@@ -6,10 +6,6 @@
 
 	.banner__action {
 		display: flex;
-
-		& .is-primary {
-			margin-left: 8px;
-		}
 	}
 
 	@media (max-width: $break-xlarge) {

--- a/client/me/email-verification-banner/style.scss
+++ b/client/me/email-verification-banner/style.scss
@@ -6,6 +6,10 @@
 
 	.banner__action {
 		display: flex;
+
+		& .is-primary {
+			margin-left: 8px;
+		}
 	}
 
 	@media (max-width: $break-xlarge) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-13327

## Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/103171, we added a secondary button to the Banner component, requiring a new left margin for the primary action.

This caused a minor visual regression to some instances of Banner, with the primary button unpleasantly shifted to the side.

This PR ensures that the margin is only applied to the primary button if the banner has two buttons.

| Before | After |
|--------|--------|
| ![Screenshot 2025-05-26 at 18 51 27](https://github.com/user-attachments/assets/e353fd38-861c-4ffd-a9d9-01c9eff28000) | ![Screenshot 2025-05-26 at 18 51 45](https://github.com/user-attachments/assets/c52b0691-e157-4a51-95ca-9a1391682aa4) | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the site admin of any site without a domain.
* Switch to the Classic admin interface (aka wp-admin) from Settings -> General.
* Open any Calypso screen, e.g. My Home (Hosting -> My Home).
* Look at the domain upsell in the sidebar: the button is now aligned!

Also try the steps from https://github.com/Automattic/wp-calypso/pull/103171 and ensure there are no visual regressions on the email verification banner.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
