### PR TITLE
Dashboard: Add reset site to settings.

### DIFF
--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -31,6 +31,9 @@ import {
 	fetchSiteUserMe,
 	leaveSite,
 	fetchP2HubP2s,
+	fetchSiteResetContentSummary,
+	resetSite,
+	fetchSiteResetStatus,
 } from '../data';
 import { SITE_FIELDS, SITE_OPTIONS } from '../data/constants';
 import { queryClient } from './query-client';
@@ -118,6 +121,26 @@ export function siteWordPressVersionMutation( siteSlug: string ) {
 		onSuccess: () => {
 			queryClient.invalidateQueries( { queryKey: [ 'site', siteSlug, 'wp-version' ] } );
 		},
+	};
+}
+
+export function siteResetContentSummaryQuery( siteIdOrSlug: string ) {
+	return {
+		queryKey: [ 'site-reset-content', siteIdOrSlug ],
+		queryFn: () => fetchSiteResetContentSummary( siteIdOrSlug ),
+	};
+}
+
+export function resetSiteMutation( siteIdOrSlug: string ) {
+	return {
+		mutationFn: () => resetSite( siteIdOrSlug ),
+	};
+}
+
+export function siteResetStatusQuery( siteIdOrSlug: string ) {
+	return {
+		queryKey: [ 'site-reset-status', siteIdOrSlug ],
+		queryFn: () => fetchSiteResetStatus( siteIdOrSlug ),
 	};
 }
 

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -16,7 +16,7 @@ import type {
 	BasicMetricsData,
 	SiteSettings,
 	UrlPerformanceInsights,
-	SiteContent,
+	SiteResetContentSummary,
 	SiteResetStatus,
 	PhpMyAdminToken,
 	DefensiveModeSettings,
@@ -573,7 +573,7 @@ export const fetchP2HubP2s = async (
 
 export const fetchSiteResetContentSummary = async (
 	siteIdOrSlug: string
-): Promise< SiteContent > => {
+): Promise< SiteResetContentSummary > => {
 	return wpcom.req.get( {
 		path: `/sites/${ siteIdOrSlug }/reset-site/content-summary`,
 		apiNamespace: 'wpcom/v2',

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -16,6 +16,8 @@ import type {
 	BasicMetricsData,
 	SiteSettings,
 	UrlPerformanceInsights,
+	SiteContent,
+	SiteResetStatus,
 	PhpMyAdminToken,
 	DefensiveModeSettings,
 	DefensiveModeSettingsUpdate,
@@ -567,4 +569,27 @@ export const fetchP2HubP2s = async (
 			...options,
 		}
 	);
+};
+
+export const fetchSiteResetContentSummary = async (
+	siteIdOrSlug: string
+): Promise< SiteContent > => {
+	return wpcom.req.get( {
+		path: `/sites/${ siteIdOrSlug }/reset-site/content-summary`,
+		apiNamespace: 'wpcom/v2',
+	} );
+};
+
+export const resetSite = async ( siteIdOrSlug: string ): Promise< void > => {
+	return wpcom.req.post( {
+		path: `/sites/${ siteIdOrSlug }/reset-site`,
+		apiNamespace: 'wpcom/v2',
+	} );
+};
+
+export const fetchSiteResetStatus = async ( siteIdOrSlug: string ): Promise< SiteResetStatus > => {
+	return wpcom.req.get( {
+		path: `/sites/${ siteIdOrSlug }/reset-site/status`,
+		apiNamespace: 'wpcom/v2',
+	} );
 };

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -212,3 +212,15 @@ export interface SiteTransferConfirmation {
 	email_sent: boolean;
 	new_owner_email: string;
 }
+
+export type SiteContent = {
+	post_count: number;
+	page_count: number;
+	media_count: number;
+	plugin_count: number;
+};
+
+export type SiteResetStatus = {
+	status: 'in-progress' | 'ready' | 'completed';
+	progress: number;
+};

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -213,7 +213,7 @@ export interface SiteTransferConfirmation {
 	new_owner_email: string;
 }
 
-export type SiteContent = {
+export type SiteResetContentSummary = {
 	post_count: number;
 	page_count: number;
 	media_count: number;

--- a/client/dashboard/sites/settings/danger-zone.tsx
+++ b/client/dashboard/sites/settings/danger-zone.tsx
@@ -30,7 +30,7 @@ const SiteTransferAction = ( { site }: { site: Site } ) => {
 	);
 };
 
-const SiteReset = ( { site }: { site: Site } ) => {
+const SiteResetAction = ( { site }: { site: Site } ) => {
 	const [ isOpen, setIsOpen ] = useState( false );
 	return (
 		<>
@@ -97,11 +97,12 @@ const SiteDeleteAction = ( { site }: { site: Site } ) => {
 
 export default function DangerZone( { site }: { site: Site } ) {
 	const canTransferSite = useCanTransferSite( { site } );
+	const canResetSite = ! site.is_wpcom_staging_site;
 
 	const actions = [
 		canTransferSite && <SiteTransferAction key="transfer-site" site={ site } />,
 		<SiteLeaveAction key="leave-site" site={ site } />,
-		! site.is_wpcom_staging_site && <SiteReset key="reset-site" site={ site } />,
+		canResetSite && <SiteResetAction key="reset-site" site={ site } />,
 		showSiteDeleteAction( site ) && <SiteDeleteAction key="delete-site" site={ site } />,
 	].filter( Boolean );
 

--- a/client/dashboard/sites/settings/danger-zone.tsx
+++ b/client/dashboard/sites/settings/danger-zone.tsx
@@ -7,6 +7,7 @@ import { SectionHeader } from '../../components/section-header';
 import { useCanTransferSite } from '../hooks/use-can-transfer-site';
 import SiteDeleteModal from '../site-delete-modal';
 import SiteLeaveModal from '../site-leave-modal';
+import SiteResetModal from '../site-reset-modal';
 import type { Site } from '../../data/types';
 
 const SiteTransferAction = ( { site }: { site: Site } ) => {
@@ -26,6 +27,24 @@ const SiteTransferAction = ( { site }: { site: Site } ) => {
 				</RouterLinkButton>
 			}
 		/>
+	);
+};
+
+const SiteReset = ( { site }: { site: Site } ) => {
+	const [ isOpen, setIsOpen ] = useState( false );
+	return (
+		<>
+			<ActionList.ActionItem
+				title={ __( 'Reset site' ) }
+				description={ __( 'Restore this site to its original state.' ) }
+				actions={
+					<Button variant="secondary" size="compact" onClick={ () => setIsOpen( true ) }>
+						{ __( 'Reset' ) }
+					</Button>
+				}
+			/>
+			{ isOpen && <SiteResetModal site={ site } onClose={ () => setIsOpen( false ) } /> }
+		</>
 	);
 };
 
@@ -82,6 +101,7 @@ export default function DangerZone( { site }: { site: Site } ) {
 	const actions = [
 		canTransferSite && <SiteTransferAction key="transfer-site" site={ site } />,
 		<SiteLeaveAction key="leave-site" site={ site } />,
+		! site.is_wpcom_staging_site && <SiteReset key="reset-site" site={ site } />,
 		showSiteDeleteAction( site ) && <SiteDeleteAction key="delete-site" site={ site } />,
 	].filter( Boolean );
 

--- a/client/dashboard/sites/site-reset-modal/content-info.tsx
+++ b/client/dashboard/sites/site-reset-modal/content-info.tsx
@@ -1,0 +1,64 @@
+import { __experimentalText as Text } from '@wordpress/components';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { SiteContent } from '../../data/types';
+
+interface ContentItem {
+	text: string;
+	url?: string;
+}
+
+type ContentType = [ keyof SiteContent, string, string ];
+
+export default function ContentInfo( {
+	siteContent,
+	siteDomain,
+}: {
+	siteContent: SiteContent;
+	siteDomain: string;
+} ) {
+	const types: ContentType[] = [
+		[ 'post_count', 'post', `/posts/${ siteDomain }` ],
+		[ 'page_count', 'page', `/pages/${ siteDomain }` ],
+		[ 'media_count', 'media item', `/media/${ siteDomain }` ],
+		[ 'plugin_count', 'plugin', `https://${ siteDomain }/wp-admin/plugins.php` ],
+	];
+
+	const content: ContentItem[] = types
+		.filter( ( [ key ]: ContentType ) => siteContent[ key ] > 0 )
+		.map( ( [ key, label, url ]: ContentType ): ContentItem => {
+			const count: number = siteContent[ key ];
+			const text: string = sprintf(
+				/* translators: %(count)d: number of items, %(label)s: content type label (post, page) */
+				_n( '%(count)d %(label)s', '%(count)d %(label)ss', count ),
+				{
+					count,
+					label,
+				}
+			);
+			return { text, url };
+		} );
+
+	if ( ! content.length ) {
+		return null;
+	}
+
+	return (
+		<>
+			<Text>{ __( 'The following content will be removed:' ) }</Text>
+			<ul style={ { margin: 0, paddingLeft: '24px' } }>
+				{ content.map( ( { text, url } ) => {
+					if ( url ) {
+						return (
+							<li key={ text }>
+								<a style={ { fontSize: '13px' } } href={ url }>
+									{ text }
+								</a>
+							</li>
+						);
+					}
+					return <li key={ text }>{ text }</li>;
+				} ) }
+			</ul>
+		</>
+	);
+}

--- a/client/dashboard/sites/site-reset-modal/content-info.tsx
+++ b/client/dashboard/sites/site-reset-modal/content-info.tsx
@@ -1,19 +1,19 @@
 import { __experimentalText as Text } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { SiteContent } from '../../data/types';
+import { SiteResetContentSummary } from '../../data/types';
 
 interface ContentItem {
 	text: string;
 	url?: string;
 }
 
-type ContentType = [ keyof SiteContent, string, string ];
+type ContentType = [ keyof SiteResetContentSummary, string, string ];
 
 export default function ContentInfo( {
 	siteContent,
 	siteDomain,
 }: {
-	siteContent: SiteContent;
+	siteContent: SiteResetContentSummary;
 	siteDomain: string;
 } ) {
 	const types: ContentType[] = [

--- a/client/dashboard/sites/site-reset-modal/index.tsx
+++ b/client/dashboard/sites/site-reset-modal/index.tsx
@@ -21,7 +21,7 @@ import {
 } from '../../app/queries';
 import Notice from '../../components/notice';
 import ContentInfo from './content-info';
-import type { Site, SiteContent, SiteResetStatus } from '../../data/types';
+import type { Site, SiteResetContentSummary, SiteResetStatus } from '../../data/types';
 import type { Field } from '@automattic/dataviews';
 
 import './style.scss';
@@ -61,7 +61,7 @@ function SiteResetContent( {
 	onClose,
 }: {
 	site: Site;
-	siteContent: SiteContent;
+	siteContent: SiteResetContentSummary;
 	siteDomain: string;
 	isBusy: boolean;
 	onSubmit: () => void;
@@ -154,7 +154,9 @@ export default function SiteResetModal( { site, onClose }: { site: Site; onClose
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const [ error, setError ] = useState< string | null >( null );
 
-	const { data: siteContent } = useQuery< SiteContent >( siteResetContentSummaryQuery( site.ID ) );
+	const { data: siteContentSummary } = useQuery< SiteResetContentSummary >(
+		siteResetContentSummaryQuery( site.ID )
+	);
 
 	const statusQuery = {
 		...siteResetStatusQuery( site.ID ),
@@ -196,7 +198,7 @@ export default function SiteResetModal( { site, onClose }: { site: Site; onClose
 		}
 	}, [ resetStatus?.status, showSuccessNotice, onClose ] );
 
-	if ( ! siteContent || ! resetStatus ) {
+	if ( ! siteContentSummary || ! resetStatus ) {
 		return null;
 	}
 
@@ -243,7 +245,7 @@ export default function SiteResetModal( { site, onClose }: { site: Site; onClose
 			content: (
 				<SiteResetContent
 					site={ site }
-					siteContent={ siteContent }
+					siteContent={ siteContentSummary }
 					siteDomain={ site.slug }
 					isBusy={ isMutationPending }
 					onSubmit={ handleReset }

--- a/client/dashboard/sites/site-reset-modal/index.tsx
+++ b/client/dashboard/sites/site-reset-modal/index.tsx
@@ -1,0 +1,267 @@
+import { DataForm } from '@automattic/dataviews';
+import { useQuery, useMutation, Query } from '@tanstack/react-query';
+import {
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	Button,
+	ExternalLink,
+	Modal,
+	ProgressBar,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useEffect, useState, useCallback } from 'react';
+import {
+	siteResetContentSummaryQuery,
+	resetSiteMutation,
+	siteResetStatusQuery,
+} from '../../app/queries';
+import Notice from '../../components/notice';
+import ContentInfo from './content-info';
+import type { Site, SiteContent, SiteResetStatus } from '../../data/types';
+import type { Field } from '@automattic/dataviews';
+
+import './style.scss';
+
+type SiteResetFormData = {
+	domain: string;
+};
+
+function ErrorContent( { message, onClose }: { message: string; onClose: () => void } ) {
+	return (
+		<VStack spacing={ 6 }>
+			<Text>{ message }</Text>
+			<HStack justify="flex-end">
+				<Button variant="primary" onClick={ onClose }>
+					{ __( 'OK' ) }
+				</Button>
+			</HStack>
+		</VStack>
+	);
+}
+
+function InProgressContent( { progress }: { progress: number | undefined } ) {
+	const progressValue = progress ? progress * 100 : 10;
+	return (
+		<VStack spacing={ 4 }>
+			<ProgressBar className="reset-site-modal-progress-bar" value={ progressValue } />
+			<Text>{ __( "We're resetting your site. We'll email you once it's ready." ) }</Text>
+		</VStack>
+	);
+}
+
+function SiteResetContent( {
+	siteContent,
+	siteDomain,
+	isBusy,
+	onSubmit,
+	onClose,
+}: {
+	site: Site;
+	siteContent: SiteContent;
+	siteDomain: string;
+	isBusy: boolean;
+	onSubmit: () => void;
+	onClose: () => void;
+} ) {
+	const [ formData, setFormData ] = useState< SiteResetFormData >( {
+		domain: '',
+	} );
+
+	const fields: Field< SiteResetFormData >[] = [
+		{
+			id: 'domain',
+			label: __( 'Type the site domain to confirm' ),
+			type: 'text' as const,
+			description: sprintf(
+				/* translators: %s: site domain */
+				__( 'The site domain is: %s' ),
+				siteDomain
+			),
+		},
+	];
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		onSubmit();
+	};
+
+	return (
+		<VStack spacing={ 6 }>
+			<Notice variant="warning" density="medium">
+				<Text>
+					{ createInterpolateElement(
+						__(
+							'Before resetting your site, consider <link>exporting your content as a backup</link>.'
+						),
+						{
+							// @ts-expect-error children prop is injected by createInterpolateElement
+							link: <ExternalLink href={ `/export/${ siteDomain }` } />,
+						}
+					) }
+				</Text>
+			</Notice>
+			<Text as="p">
+				{ createInterpolateElement(
+					/* translators: <siteDomain />: site domain */
+					__(
+						"Resetting <siteDomain /> will remove all of its content but keep the site and its URL up and running. You'll also lose any modifications you've made to your current theme. This cannot be undone."
+					),
+					{
+						siteDomain: <strong>{ siteDomain }</strong>,
+					}
+				) }
+			</Text>
+			<ContentInfo siteContent={ siteContent } siteDomain={ siteDomain } />
+
+			<form onSubmit={ handleSubmit }>
+				<VStack spacing={ 4 }>
+					<DataForm< SiteResetFormData >
+						data={ formData }
+						fields={ fields }
+						form={ { type: 'regular', fields } }
+						onChange={ ( edits: { domain?: string } ) => {
+							setFormData( ( data ) => ( {
+								...data,
+								...edits,
+								domain: edits.domain?.trim() ?? data.domain,
+							} ) );
+						} }
+					/>
+					<HStack spacing={ 4 } justify="flex-end">
+						<Button variant="tertiary" onClick={ onClose }>
+							{ __( 'Cancel' ) }
+						</Button>
+						<Button
+							variant="primary"
+							type="submit"
+							isBusy={ isBusy }
+							disabled={ formData.domain !== siteDomain }
+						>
+							{ __( 'Reset site' ) }
+						</Button>
+					</HStack>
+				</VStack>
+			</form>
+		</VStack>
+	);
+}
+
+export default function SiteResetModal( { site, onClose }: { site: Site; onClose: () => void } ) {
+	const { createSuccessNotice } = useDispatch( noticesStore );
+	const [ error, setError ] = useState< string | null >( null );
+
+	const { data: siteContent } = useQuery< SiteContent >( siteResetContentSummaryQuery( site.ID ) );
+
+	const statusQuery = {
+		...siteResetStatusQuery( site.ID ),
+		...( site.is_wpcom_atomic && {
+			refetchInterval: ( query: Query< SiteResetStatus > ) => {
+				const { data } = query.state;
+
+				if ( data?.status === 'ready' || data?.status === 'completed' ) {
+					return false;
+				}
+				return 5000;
+			},
+			gcTime: 0,
+			meta: {
+				persist: false,
+			},
+		} ),
+	};
+
+	const { data: resetStatus, refetch: refetchResetStatus } =
+		useQuery< SiteResetStatus >( statusQuery );
+	const { mutate, isPending: isMutationPending } = useMutation( resetSiteMutation( site.ID ) );
+
+	const showSuccessNotice = useCallback( () => {
+		createSuccessNotice(
+			sprintf(
+				/* translators: %s: site domain */
+				__( '%s has been reset.' ),
+				site.slug
+			),
+			{ type: 'snackbar' }
+		);
+	}, [ createSuccessNotice, site.slug ] );
+
+	useEffect( () => {
+		if ( resetStatus?.status === 'completed' ) {
+			showSuccessNotice();
+			onClose();
+		}
+	}, [ resetStatus?.status, showSuccessNotice, onClose ] );
+
+	if ( ! siteContent || ! resetStatus ) {
+		return null;
+	}
+
+	const handleReset = () => {
+		if ( isMutationPending ) {
+			return;
+		}
+
+		mutate( undefined, {
+			onSuccess: () => {
+				if ( site.is_wpcom_atomic ) {
+					refetchResetStatus();
+				} else {
+					showSuccessNotice();
+					onClose();
+				}
+			},
+			onError: ( error: Error ) => {
+				setError(
+					error.message || __( 'The site could not be reset due to an error. Please try again.' )
+				);
+			},
+		} );
+	};
+
+	let modalConfig;
+
+	if ( error ) {
+		modalConfig = {
+			title: __( 'Error resetting site' ),
+			size: 'small' as const,
+			content: <ErrorContent message={ error } onClose={ onClose } />,
+		};
+	} else if ( resetStatus?.status === 'in-progress' ) {
+		modalConfig = {
+			title: __( 'Resetting site' ),
+			size: 'small' as const,
+			content: <InProgressContent progress={ resetStatus?.progress } />,
+		};
+	} else {
+		modalConfig = {
+			title: __( 'Reset site' ),
+			size: 'medium' as const,
+			content: (
+				<SiteResetContent
+					site={ site }
+					siteContent={ siteContent }
+					siteDomain={ site.slug }
+					isBusy={ isMutationPending }
+					onSubmit={ handleReset }
+					onClose={ onClose }
+				/>
+			),
+		};
+	}
+
+	return (
+		<Modal
+			title={ modalConfig.title }
+			onRequestClose={ onClose }
+			size={ modalConfig.size }
+			isDismissible={ ! error && ! isMutationPending }
+			shouldCloseOnClickOutside={ ! isMutationPending }
+		>
+			{ modalConfig.content }
+		</Modal>
+	);
+}

--- a/client/dashboard/sites/site-reset-modal/style.scss
+++ b/client/dashboard/sites/site-reset-modal/style.scss
@@ -1,0 +1,3 @@
+.reset-site-modal-progress-bar {
+    width: 100% !important;
+}


### PR DESCRIPTION
Fixes: DOTCOM-13248

## Proposed Changes

This PR adds the reset site functionality to the settings page.


## Screenshots:

### Default

<img width="400" alt="Screenshot 2025-06-02 at 9 21 52 AM" src="https://github.com/user-attachments/assets/fe02a5af-1fbb-4da2-8871-a590e14a965f" />


### Progress

<img width="400" alt="Screenshot 2025-06-02 at 9 18 48 AM" src="https://github.com/user-attachments/assets/91b1d330-b471-4ca9-b822-f10d2e943879" />


### Success confirmation

<img width="200" alt="Screenshot 2025-06-02 at 9 19 36 AM" src="https://github.com/user-attachments/assets/7422e3f4-669a-467d-8a48-f3f8a3c440d5" />

### Error: Staging site error

Staging sites shouldn't be able to queue a reset, but if they do they will see:

<img width="992" alt="Screenshot 2025-05-27 at 3 01 41 PM" src="https://github.com/user-attachments/assets/cf178a3e-8f9e-4160-b878-9e16f62f1ae6" />


### Error: Random error

We display a generic message if the request fails.

<img width="993" alt="Screenshot 2025-05-27 at 3 00 59 PM" src="https://github.com/user-attachments/assets/d5e9493d-93c8-4e6a-b3e8-a6d8c934f96f" />


## Todo

- Handle errors when reset status query fails.


## Ad-Hoc changes
- Add a title to the error modal.
  - The `@wordpress` Modal component doesn't handle the lack of a title gracefully
- Add a progress window (See Atomic video)
  - The original designs don't have this, but Atomic resets take a while. We need to show the user something.  

## Considerations

The API for resetting a site isn't great. We don't get a job-like ID, and we need to re-request the site's endpoint to determine the outcome, which finally returns 'completed'. However, that result doesn't last long and resets. So if the user leaves the reset view and comes back, we can't show them the final state of their last reset. We show them a brand new state. 

It's also possible to get the Snackbar added again when you click 'Reset site' quickly after it has completed, before the backend has cleared its cache, and `completed` is still the status for that site.

## Testing Instructions

**Atomic Site**
- Trigger a reset
- Expect to see a progress window
- Close progress window
- Click 'Reset site'
- Expect to see the progress window again
- Waiting until complete
- Expect to see a Snackbar

**Simple**
- Trigger a reset
- Expect to see a Snackbar

**Staging**
- Visit settings for staging site
- Expect to not see reset site Action item.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
