### PR TITLE
Callout: Rename prop from imageSrc to image

### DIFF
--- a/client/dashboard/components/callout-overlay/index.stories.tsx
+++ b/client/dashboard/components/callout-overlay/index.stories.tsx
@@ -46,7 +46,7 @@ export const Default: Story = {
 						Get started
 					</Button>
 				}
-				imageSrc="https://live.staticflickr.com/3277/2938134470_c807dc3e47_b.jpg"
+				image="https://live.staticflickr.com/3277/2938134470_c807dc3e47_b.jpg"
 				imageAlt="Sweet eyed kitty"
 			/>
 		),

--- a/client/dashboard/components/callout/index.stories.tsx
+++ b/client/dashboard/components/callout/index.stories.tsx
@@ -25,7 +25,7 @@ export const Default: Story = {
 				Get started
 			</Button>
 		),
-		imageSrc: 'https://live.staticflickr.com/3277/2938134470_c807dc3e47_b.jpg',
+		image: 'https://live.staticflickr.com/3277/2938134470_c807dc3e47_b.jpg',
 		imageAlt: 'Sweet eyed kitty',
 	},
 };

--- a/client/dashboard/components/callout/index.tsx
+++ b/client/dashboard/components/callout/index.tsx
@@ -13,7 +13,7 @@ function UnforwardedCallout(
 	{
 		title,
 		icon,
-		imageSrc,
+		image,
 		imageAlt,
 		description,
 		actions,
@@ -39,9 +39,9 @@ function UnforwardedCallout(
 					{ description }
 					{ actions }
 				</VStack>
-				{ imageSrc && (
+				{ image && (
 					<VStack justify="stretch" alignment="stretch" className="dashboard-callout__image">
-						<img src={ imageSrc } alt={ imageAlt } />
+						<img src={ image } alt={ imageAlt } />
 					</VStack>
 				) }
 			</HStack>

--- a/client/dashboard/components/callout/test/index.tsx
+++ b/client/dashboard/components/callout/test/index.tsx
@@ -16,12 +16,12 @@ describe( 'Callout', () => {
 		expect( screen.getByRole( 'paragraph' ) ).toHaveTextContent( 'Helpful content' );
 	} );
 
-	test( 'renders img element using imageSrc', () => {
+	test( 'renders img element using image', () => {
 		render(
 			<Callout
 				title="Test Title"
 				description={ <p>Helpful content</p> }
-				imageSrc="https://example.com/illustration.png"
+				image="https://example.com/illustration.png"
 				imageAlt="Illustration"
 			/>
 		);

--- a/client/dashboard/components/callout/types.ts
+++ b/client/dashboard/components/callout/types.ts
@@ -30,7 +30,7 @@ export interface CalloutProps {
 	/**
 	 * An optional larger visual or graphic that enhances the Callout’s impact and draws attention.
 	 */
-	imageSrc?: string;
+	image?: string;
 	/**
 	 * Alt text to accompany the image.
 	 */

--- a/client/dashboard/sites/deployments/index.tsx
+++ b/client/dashboard/sites/deployments/index.tsx
@@ -31,7 +31,7 @@ function SiteDeployments() {
 					<Callout
 						icon={ <img src={ ghIconUrl } alt={ __( 'GitHub logo' ) } /> }
 						title={ __( 'Deploy from GitHub' ) }
-						imageSrc={ illustrationUrl }
+						image={ illustrationUrl }
 						description={
 							<>
 								<Text as="p" variant="muted">

--- a/client/dashboard/sites/settings-callout/index.tsx
+++ b/client/dashboard/sites/settings-callout/index.tsx
@@ -16,7 +16,7 @@ interface SettingsCalloutProps extends Omit< CalloutProps, 'title' | 'descriptio
 export default function SettingsCallout( {
 	siteSlug,
 	icon,
-	imageSrc,
+	image,
 	title,
 	description,
 }: SettingsCalloutProps ) {
@@ -31,7 +31,7 @@ export default function SettingsCallout( {
 
 	const defaultProps = {
 		icon: settings,
-		imageSrc: calloutIllustrationUrl,
+		image: calloutIllustrationUrl,
 		title: __( 'Fine-tune your WordPress site' ),
 		description: __(
 			'Get under the hood—control caching, choose your PHP version, and test out upcoming WordPress releases.'
@@ -41,7 +41,7 @@ export default function SettingsCallout( {
 	return (
 		<Callout
 			icon={ icon ?? defaultProps.icon }
-			imageSrc={ imageSrc ?? defaultProps.imageSrc }
+			image={ image ?? defaultProps.image }
 			title={ title ?? defaultProps.title }
 			description={
 				<>

--- a/client/dashboard/sites/settings-database/index.tsx
+++ b/client/dashboard/sites/settings-database/index.tsx
@@ -54,7 +54,7 @@ export default function SiteDatabaseSettings( { siteSlug }: { siteSlug: string }
 				<SettingsCallout
 					siteSlug={ siteSlug }
 					icon={ blockTable }
-					imageSrc={ calloutIllustrationUrl }
+					image={ calloutIllustrationUrl }
 					title={ __( 'Fast, familiar database access' ) }
 					description={ __(
 						'Access your site’s database with phpMyAdmin—perfect for inspecting data, running queries, and quick debugging.'


### PR DESCRIPTION
See https://github.com/Automattic/wp-calypso/pull/103702#discussion_r2107069808
See https://github.com/Automattic/wp-calypso/pull/103414#discussion_r2107567679

## Proposed Changes

This PR renames the Callout prop "imageSrc" to "image".

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Callout should work as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
