### PR TITLE
[DataViews]: bump to 0.2.0

### DIFF
--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -9,7 +9,6 @@
 - Implement the `media` field type definition and allow type definitions to provide a new default: `enableSorting`.
 - Add new `boolean` field type definition and edit control. Field type definitions are able to define a default render function that will be used if the field doesn't define one.
 - Pin the actions column on the table view when the width is insufficient.
-- Bring changes from @wordpress/dataviews 4.19.0 (no updates in this version).
 - Add `renderItemLink` prop support in the `DataViews` component. It replaces `onClickItem`prop and allows integration with router libraries.
 - Enhance filter component styles.
 - Add user input filter support based on the `Edit` property of the field type definitions.

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -9,16 +9,13 @@
 - Implement the `media` field type definition and allow type definitions to provide a new default: `enableSorting`.
 - Add new `boolean` field type definition and edit control. Field type definitions are able to define a default render function that will be used if the field doesn't define one.
 - Pin the actions column on the table view when the width is insufficient.
-- Bring changes from @wordpress/dataviews 4.19.0 (no updates in this version).$
+- Bring changes from @wordpress/dataviews 4.19.0 (no updates in this version).
 - Add `renderItemLink` prop support in the `DataViews` component. It replaces `onClickItem`prop and allows integration with router libraries.
 - Enhance filter component styles.
-- Adds new story that combines DataViews and DataForm.
 - Add user input filter support based on the `Edit` property of the field type definitions.
-- Add new filter operators: `lessThan`, `greaterThan`, `lessThanOrEqual`, and `greaterThanOrEqual` for numeric and comparable fields.
-- Add new filter operators: `contains`, `notContains`, `startsWith` for text fields.
+- Add new filter operators: `lessThan`, `greaterThan`, `lessThanOrEqual`, `greaterThanOrEqual`, `contains`, `notContains`, and `startsWith`.
 - Add `email` type to the fields of the form.
 - Add `className` prop to the `DataViews.Layout` component to allow customizing the layout styles.
-- Clean up --wp-components-color-* variables.
 - Add `checkbox` type to the fields of the form.
 
 ## 0.1.1

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-## 0.1.2
+## 0.2.0
 
 - Bring changes from `@wordpress/dataviews 4.19.0` (no updates in this version).
 - `select` Edit control: add `help` support from the field `description` prop.

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -9,6 +9,7 @@
 - Implement the `media` field type definition and allow type definitions to provide a new default: `enableSorting`.
 - Add new `boolean` field type definition and edit control. Field type definitions are able to define a default render function that will be used if the field doesn't define one.
 - Pin the actions column on the table view when the width is insufficient.
+- Bring changes from @wordpress/dataviews 4.19.0 (no updates in this version).
 - Add `renderItemLink` prop support in the `DataViews` component. It replaces `onClickItem`prop and allows integration with router libraries.
 - Enhance filter component styles.
 - Add user input filter support based on the `Edit` property of the field type definitions.

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -4,19 +4,18 @@
 
 ## 0.1.2
 
-- Add `help` prop support for `SelectControl` used in the `select` DataForm control, via the DataForm field `description` prop.
-- Add a new DataForm Edit control: `toggleGroup`, which renders a `<ToggleGroupControl />`. If the field elements (options) have a `description`, then the selected option's description will be also rendered.
-- Implement the `media` field type definition and allow type definitions to provide a new default: `enableSorting`.
-- Add new `boolean` field type definition and edit control. Field type definitions are able to define a default render function that will be used if the field doesn't define one.
+- Bring changes from `@wordpress/dataviews 4.19.0` (no updates in this version).
+- `select` Edit control: add `help` support from the field `description` prop.
+- Add new Edit controls: `checkbox`, `toggleGroup`. In the `toggleGroup`, if the field elements (options) have a `description`, then the selected option's description will be also rendered.
+- Add new `media`, `boolean`, and `email` field type definitions.
+- Field type definitions are now able to define a default `enableSorting` and `render` function.
 - Pin the actions column on the table view when the width is insufficient.
-- Bring changes from @wordpress/dataviews 4.19.0 (no updates in this version).
 - Add `renderItemLink` prop support in the `DataViews` component. It replaces `onClickItem`prop and allows integration with router libraries.
+- Adds new story that combines DataViews and DataForm.
+- Add `className` prop to the `DataViews.Layout` component to allow customizing the layout styles.
 - Enhance filter component styles.
 - Add user input filter support based on the `Edit` property of the field type definitions.
-- Add new filter operators: `lessThan`, `greaterThan`, `lessThanOrEqual`, `greaterThanOrEqual`, `contains`, `notContains`, and `startsWith`.
-- Add `email` type to the fields of the form.
-- Add `className` prop to the `DataViews.Layout` component to allow customizing the layout styles.
-- Add `checkbox` type to the fields of the form.
+- Add new filter operators: `lessThan`, `greaterThan`, `lessThanOrEqual`, `greaterThanOrEqual`, `contains`, `notContains`, `startsWith`.
 
 ## 0.1.1
 

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+## 0.1.2
+
 - Add `help` prop support for `SelectControl` used in the `select` DataForm control, via the DataForm field `description` prop.
 - Add a new DataForm Edit control: `toggleGroup`, which renders a `<ToggleGroupControl />`. If the field elements (options) have a `description`, then the selected option's description will be also rendered.
 - Implement the `media` field type definition and allow type definitions to provide a new default: `enableSorting`.

--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/dataviews",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "DataViews is a component that provides an API to render datasets using different types of layouts (table, grid, list, etc.).",
 	"author": "Automattic Inc.",
 	"license": "GPL-2.0-or-later",

--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/dataviews",
-	"version": "0.1.2",
+	"version": "0.2.0",
 	"description": "DataViews is a component that provides an API to render datasets using different types of layouts (table, grid, list, etc.).",
 	"author": "Automattic Inc.",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## Proposed Changes

* Bumped the version of `@automattic/dataviews` to `0.2.0`.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This version bump so we can use the latest version of `@automattic/dataviews` in Woo Analytics and remove the local copy of the package.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm the new version is correctly published in `package.json`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
