### PR TITLE
Dashboard v2: Implement defensive mode settings

### DIFF
--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -21,10 +21,18 @@ import {
 	fetchPrimaryDataCenter,
 	fetchStaticFile404,
 	updateStaticFile404,
+	fetchEdgeCacheDefensiveMode,
+	updateEdgeCacheDefensiveMode,
 } from '../data';
 import { SITE_FIELDS, SITE_OPTIONS } from '../data/constants';
 import { queryClient } from './query-client';
-import type { Profile, SiteSettings, UrlPerformanceInsights } from '../data/types';
+import type {
+	Profile,
+	SiteSettings,
+	UrlPerformanceInsights,
+	DefensiveModeSettings,
+	DefensiveModeSettingsUpdate,
+} from '../data/types';
 import type { Query } from '@tanstack/react-query';
 
 export function sitesQuery() {
@@ -210,6 +218,25 @@ export function siteStaticFile404Mutation( siteId: string ) {
 		mutationFn: ( setting: string ) => updateStaticFile404( siteId, setting ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( { queryKey: [ 'site', siteId, 'static-file-404' ] } );
+		},
+	};
+}
+
+export function siteDefensiveModeQuery( siteSlug: string ) {
+	return {
+		queryKey: [ 'site', siteSlug, 'defensive-mode' ],
+		queryFn: () => {
+			return fetchEdgeCacheDefensiveMode( siteSlug );
+		},
+	};
+}
+
+export function siteDefensiveModeMutation( siteSlug: string ) {
+	return {
+		mutationFn: ( data: DefensiveModeSettingsUpdate ) =>
+			updateEdgeCacheDefensiveMode( siteSlug, data ),
+		onSuccess: ( data: DefensiveModeSettings ) => {
+			queryClient.setQueryData( [ 'site', siteSlug, 'defensive-mode' ], data );
 		},
 	};
 }

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -6,6 +6,7 @@ import {
 	createLazyRoute,
 } from '@tanstack/react-router';
 import { fetchTwoStep } from '../data';
+import { canUpdateDefensiveMode } from '../sites/settings-defensive-mode';
 import { canUpdatePHPVersion } from '../sites/settings-php/utils';
 import { canGetPrimaryDataCenter } from '../sites/settings-primary-data-center';
 import { canSetStaticFile404Handling } from '../sites/settings-static-file-404';
@@ -25,6 +26,7 @@ import {
 	siteWordPressVersionQuery,
 	sitePHPVersionQuery,
 	sitePrimaryDataCenterQuery,
+	siteDefensiveModeQuery,
 } from './queries';
 import { queryClient } from './query-client';
 import Root from './root';
@@ -237,6 +239,23 @@ const siteSettingsStaticFile404Route = createRoute( {
 	)
 );
 
+const siteSettingsDefensiveModeRoute = createRoute( {
+	getParentRoute: () => siteRoute,
+	path: 'settings/defensive-mode',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteQuery( siteSlug ) );
+		if ( canUpdateDefensiveMode( site ) ) {
+			await queryClient.ensureQueryData( siteDefensiveModeQuery( siteSlug ) );
+		}
+	},
+} ).lazy( () =>
+	import( '../sites/settings-defensive-mode' ).then( ( d ) =>
+		createLazyRoute( 'site-settings-defensive-mode' )( {
+			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
 const siteSettingsTransferSiteRoute = createRoute( {
 	getParentRoute: () => siteRoute,
 	path: 'settings/transfer-site',
@@ -418,6 +437,7 @@ const createRouteTree = ( config: AppConfig ) => {
 				siteSettingsPHPRoute,
 				siteSettingsPrimaryDataCenterRoute,
 				siteSettingsStaticFile404Route,
+				siteSettingsDefensiveModeRoute,
 				siteSettingsTransferSiteRoute,
 			] )
 		);

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -15,6 +15,8 @@ import type {
 	SiteSettings,
 	UrlPerformanceInsights,
 	PhpMyAdminToken,
+	DefensiveModeSettings,
+	DefensiveModeSettingsUpdate,
 } from './types';
 import type { DataCenterOption } from 'calypso/data/data-center/types';
 
@@ -425,5 +427,27 @@ export const updateStaticFile404 = async (
 			apiNamespace: 'wpcom/v2',
 		},
 		{ setting }
+	);
+};
+
+export const fetchEdgeCacheDefensiveMode = async (
+	siteIdOrSlug: string
+): Promise< DefensiveModeSettings > => {
+	return wpcom.req.get( {
+		path: `/sites/${ siteIdOrSlug }/hosting/edge-cache/defensive-mode`,
+		apiNamespace: 'wpcom/v2',
+	} );
+};
+
+export const updateEdgeCacheDefensiveMode = async (
+	siteIdOrSlug: string,
+	data: DefensiveModeSettingsUpdate
+): Promise< DefensiveModeSettings > => {
+	return wpcom.req.post(
+		{
+			path: `/sites/${ siteIdOrSlug }/hosting/edge-cache/defensive-mode`,
+			apiNamespace: 'wpcom/v2',
+		},
+		data
 	);
 };

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -177,3 +177,13 @@ export interface UrlPerformanceInsights {
 export interface PhpMyAdminToken {
 	token: string;
 }
+
+export interface DefensiveModeSettings {
+	enabled: boolean;
+	enabled_by_a11n: boolean;
+	enabled_until: number;
+}
+export interface DefensiveModeSettingsUpdate {
+	active: boolean;
+	ttl?: number;
+}

--- a/client/dashboard/sites/settings-defensive-mode/index.tsx
+++ b/client/dashboard/sites/settings-defensive-mode/index.tsx
@@ -15,7 +15,6 @@ import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import moment from 'moment';
 import { useState } from 'react';
 import { siteQuery, siteDefensiveModeQuery, siteDefensiveModeMutation } from '../../app/queries';
 import PageLayout from '../../components/page-layout';
@@ -105,7 +104,14 @@ export default function DefensiveModeSettings( { siteSlug }: { siteSlug: string 
 	const { enabled, enabled_by_a11n, enabled_until } = data;
 
 	const renderEnabled = () => {
-		const enabledUntil = moment.unix( enabled_until ?? 0 ).local();
+		const date = new Date( enabled_until * 1000 );
+		const enabledUntil = date.toLocaleString( undefined, {
+			year: 'numeric',
+			month: 'long',
+			day: 'numeric',
+			hour: 'numeric',
+			minute: '2-digit',
+		} );
 
 		const handleDisable = () => {
 			handleSubmit( {
@@ -135,7 +141,7 @@ export default function DefensiveModeSettings( { siteSlug }: { siteSlug: string 
 					{ sprintf(
 						// translators: %s: timestamp, e.g. May 27, 2025 11:02 AM
 						__( 'This will be automatically disabled on %s.' ),
-						enabledUntil.format( 'LLL' )
+						enabledUntil
 					) }
 				</Text>
 

--- a/client/dashboard/sites/settings-defensive-mode/index.tsx
+++ b/client/dashboard/sites/settings-defensive-mode/index.tsx
@@ -1,0 +1,212 @@
+import { DataForm } from '@automattic/dataviews';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { notFound } from '@tanstack/react-router';
+import {
+	Card,
+	CardBody,
+	ExternalLink,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	Button,
+	Notice,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import moment from 'moment';
+import { useState } from 'react';
+import { siteQuery, siteDefensiveModeQuery, siteDefensiveModeMutation } from '../../app/queries';
+import PageLayout from '../../components/page-layout';
+import SettingsPageHeader from '../settings-page-header';
+import type { DefensiveModeSettingsUpdate, Site } from '../../data/types';
+import type { Field } from '@automattic/dataviews';
+
+export function canUpdateDefensiveMode( site: Site ) {
+	return site.is_wpcom_atomic;
+}
+
+const availableTtls = [
+	{
+		label: __( '1 hour' ),
+		value: '3600',
+	},
+	{
+		label: __( '12 hours' ),
+		value: '43200',
+	},
+	{
+		label: __( '24 hours' ),
+		value: '86400',
+	},
+	{
+		label: __( '2 days' ),
+		value: '172800',
+	},
+	{
+		label: __( '7 days' ),
+		value: '604800',
+	},
+];
+
+const fields: Field< { ttl: string } >[] = [
+	{
+		id: 'ttl',
+		label: __( 'Duration' ),
+		Edit: 'select',
+		elements: availableTtls,
+	},
+];
+
+const form = {
+	type: 'regular' as const,
+	fields: [ 'ttl' ],
+};
+
+export default function DefensiveModeSettings( { siteSlug }: { siteSlug: string } ) {
+	const { data: site } = useQuery( siteQuery( siteSlug ) );
+	const canUpdate = site && canUpdateDefensiveMode( site );
+
+	const { data } = useQuery( {
+		...siteDefensiveModeQuery( siteSlug ),
+		enabled: canUpdate,
+	} );
+	const mutation = useMutation( siteDefensiveModeMutation( siteSlug ) );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const [ formData, setFormData ] = useState< { ttl: string } >( {
+		ttl: availableTtls[ 0 ].value,
+	} );
+
+	if ( ! canUpdate ) {
+		throw notFound();
+	}
+
+	if ( ! data ) {
+		return null;
+	}
+
+	const { isPending } = mutation;
+
+	const handleSubmit = ( data: DefensiveModeSettingsUpdate ) => {
+		mutation.mutate( data, {
+			onSuccess: () => {
+				createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
+			},
+			onError: () => {
+				createErrorNotice( __( 'Failed to save settings.' ), {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
+
+	const { enabled, enabled_by_a11n, enabled_until } = data;
+
+	const renderEnabled = () => {
+		const enabledUntil = moment.unix( enabled_until ?? 0 ).local();
+
+		const handleDisable = () => {
+			handleSubmit( {
+				active: false,
+			} );
+		};
+
+		return (
+			<Notice status="success" isDismissible={ false }>
+				<Text as="p">{ __( 'Defensive mode is enabled' ) }</Text>
+
+				{ enabled_by_a11n && (
+					<Text as="p">
+						{ createInterpolateElement(
+							__(
+								'We’ve enabled defensive mode to protect your site. <link>Contact a Happiness Engineer</link> if you need assistance.'
+							),
+							{
+								// @ts-expect-error children prop is injected by createInterpolateElement
+								link: <ExternalLink href="/help/contact" />,
+							}
+						) }
+					</Text>
+				) }
+
+				<Text as="p">
+					{ sprintf(
+						// translators: %s: timestamp, e.g. May 27, 2025 11:02 AM
+						__( 'This will be automatically disabled on %s.' ),
+						enabledUntil.format( 'LLL' )
+					) }
+				</Text>
+
+				{ ! enabled_by_a11n && (
+					<Button
+						variant="primary"
+						type="submit"
+						isBusy={ isPending }
+						disabled={ isPending }
+						onClick={ handleDisable }
+					>
+						{ __( 'Disable' ) }
+					</Button>
+				) }
+			</Notice>
+		);
+	};
+
+	const renderDisabled = () => {
+		const handleEnable = ( event: React.FormEvent ) => {
+			event.preventDefault();
+			handleSubmit( {
+				active: true,
+				ttl: Number( formData.ttl ),
+			} );
+		};
+
+		return (
+			<VStack spacing={ 8 }>
+				<Notice status="info" isDismissible={ false }>
+					<Text>{ __( 'Defensive mode is disabled' ) }</Text>
+				</Notice>
+				<Card>
+					<CardBody>
+						<VStack spacing={ 8 } style={ { padding: '8px 0' } }>
+							<Text size="15px" weight={ 500 } lineHeight="20px">
+								{ __( 'Enable defensive mode' ) }
+							</Text>
+
+							<form onSubmit={ handleEnable }>
+								<VStack spacing={ 4 }>
+									<DataForm< { ttl: string } >
+										data={ formData }
+										fields={ fields }
+										form={ form }
+										onChange={ ( edits: { ttl?: string } ) => {
+											setFormData( ( data ) => ( { ...data, ...edits } ) );
+										} }
+									/>
+									<HStack justify="flex-start">
+										<Button
+											variant="primary"
+											type="submit"
+											isBusy={ isPending }
+											disabled={ isPending }
+										>
+											{ __( 'Enable' ) }
+										</Button>
+									</HStack>
+								</VStack>
+							</form>
+						</VStack>
+					</CardBody>
+				</Card>
+			</VStack>
+		);
+	};
+
+	return (
+		<PageLayout size="small" header={ <SettingsPageHeader title={ __( 'Defensive mode' ) } /> }>
+			{ enabled ? renderEnabled() : renderDisabled() }
+		</PageLayout>
+	);
+}

--- a/client/dashboard/sites/settings-defensive-mode/summary.tsx
+++ b/client/dashboard/sites/settings-defensive-mode/summary.tsx
@@ -15,9 +15,16 @@ export default function DefensiveModeSettingsSummary( { site }: { site: Site } )
 
 	let badge;
 	if ( data ) {
-		badge = {
-			text: data.enabled ? __( 'Enabled' ) : __( 'Disabled' ),
-		};
+		if ( data.enabled ) {
+			badge = {
+				text: __( 'Enabled' ),
+				intent: 'info' as const,
+			};
+		} else {
+			badge = {
+				text: __( 'Disabled' ),
+			};
+		}
 	} else {
 		badge = { text: __( 'Managed' ) };
 	}

--- a/client/dashboard/sites/settings-defensive-mode/summary.tsx
+++ b/client/dashboard/sites/settings-defensive-mode/summary.tsx
@@ -8,10 +8,16 @@ import { canUpdateDefensiveMode } from '.';
 import type { Site } from '../../data/types';
 
 export default function DefensiveModeSettingsSummary( { site }: { site: Site } ) {
+	const canUpdate = canUpdateDefensiveMode( site );
+
 	const { data } = useQuery( {
 		...siteDefensiveModeQuery( site.slug ),
-		enabled: canUpdateDefensiveMode( site ),
+		enabled: canUpdate,
 	} );
+
+	if ( ! canUpdate ) {
+		return null;
+	}
 
 	let badge;
 	if ( data ) {

--- a/client/dashboard/sites/settings-defensive-mode/summary.tsx
+++ b/client/dashboard/sites/settings-defensive-mode/summary.tsx
@@ -1,0 +1,34 @@
+import { useQuery } from '@tanstack/react-query';
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { shield } from '@wordpress/icons';
+import { siteDefensiveModeQuery } from '../../app/queries';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import { canUpdateDefensiveMode } from '.';
+import type { Site } from '../../data/types';
+
+export default function DefensiveModeSettingsSummary( { site }: { site: Site } ) {
+	const { data } = useQuery( {
+		...siteDefensiveModeQuery( site.slug ),
+		enabled: canUpdateDefensiveMode( site ),
+	} );
+
+	let badge;
+	if ( data ) {
+		badge = {
+			text: data.enabled ? __( 'Enabled' ) : __( 'Disabled' ),
+		};
+	} else {
+		badge = { text: __( 'Managed' ) };
+	}
+
+	return (
+		<RouterLinkSummaryButton
+			to={ `/sites/${ site.slug }/settings/defensive-mode` }
+			title={ __( 'Defensive mode' ) }
+			density="medium"
+			decoration={ <Icon icon={ shield } /> }
+			badges={ [ badge ] }
+		/>
+	);
+}

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -9,6 +9,7 @@ import { siteQuery, siteSettingsQuery } from '../../app/queries';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import DatabaseSettingsSummary from '../settings-database/summary';
+import DefensiveModeSettingsSummary from '../settings-defensive-mode/summary';
 import PHPSettingsSummary from '../settings-php/summary';
 import PrimaryDataCenterSettingsSummary from '../settings-primary-data-center/summary';
 import SiteVisibilitySettingsSummary from '../settings-site-visibility/summary';
@@ -43,6 +44,7 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 					<PHPSettingsSummary site={ site } />
 					<PrimaryDataCenterSettingsSummary site={ site } />
 					<StaticFile404SettingsSummary site={ site } />
+					<DefensiveModeSettingsSummary site={ site } />
 				</VStack>
 			</Card>
 			<SiteActions site={ site } />


### PR DESCRIPTION
Fixes DOTCOM-13258

## Proposed Changes

This PR implements the defensive mode settings in v2.

> [!WARNING]  
> Please don't review the notice design; we'll follow up later.


|Disabled|Enabled|Enabled by a11n|
|-|-|-|
|<img width="618" alt="image" src="https://github.com/user-attachments/assets/21cf343f-b017-43f0-a3eb-346cd2b6b77e" /><br><br><img width="633" alt="image" src="https://github.com/user-attachments/assets/dc4c88fb-7192-495c-8424-56e08a8511d8" />|<img width="614" alt="image" src="https://github.com/user-attachments/assets/7c0d02ce-b892-48cf-b89d-6df93010715f" /><br><br><img width="648" alt="image" src="https://github.com/user-attachments/assets/a4206327-fb01-4a70-88e7-2b6e53d10ba9" />|<img width="614" alt="image" src="https://github.com/user-attachments/assets/7c0d02ce-b892-48cf-b89d-6df93010715f" /><br><br><img width="632" alt="image" src="https://github.com/user-attachments/assets/3d7406e3-3313-49f5-acf4-3e72ece29b2f" />|


## Testing Instructions

1. Go to Simple site's settings; verify you can't see the summary button for defensive mode.
2. Go to Atomic site's settings; verify you can play around with defensive mode settings.
   - To test the "Enabled by a11n" case, you can go to the site's BRC and enable it there.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
