### PR TITLE
Try: Validated form controls with DataForm

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -88,6 +88,7 @@
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-storybook": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
+		"@automattic/dataviews": "workspace:^",
 		"@storybook/react": "^8.6.12",
 		"@storybook/test": "^8.6.12",
 		"@testing-library/dom": "^10.4.0",

--- a/packages/components/src/validated-form-controls/overview.stories.tsx
+++ b/packages/components/src/validated-form-controls/overview.stories.tsx
@@ -1,8 +1,12 @@
+import { DataForm } from '@automattic/dataviews';
 import { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 import { ValidatedInputControl } from './components/input-control';
 import { formDecorator } from './components/story-utils';
+import { ValidatedTextControl } from './components/text-control';
+import { ValidatedTextareaControl } from './components/textarea-control';
 import { ControlWithError } from './control-with-error';
+import type { Field, Form, DataFormControlProps, NormalizedField } from '@automattic/dataviews';
 
 const meta: Meta< typeof ControlWithError > = {
 	title: 'Validated Form Controls/Overview',
@@ -76,6 +80,101 @@ export const WithHelpTextReplacement: Story = {
 					setHasCustomError( false );
 				} }
 				onChange={ ( value ) => setText( value ?? '' ) }
+			/>
+		);
+	},
+};
+
+interface FormData {
+	title: string;
+	subtitle: string;
+	description: string;
+}
+
+const createCustomValidator = ( field: NormalizedField< FormData > ) => ( value: any ) => {
+	if ( field.id === 'title' && ! value ) {
+		return 'Title is required';
+	}
+	if ( typeof value === 'string' && value.toLowerCase().includes( 'error' ) ) {
+		return 'The word "error" is not allowed';
+	}
+};
+
+// Custom Edit component that uses ValidatedTextControl
+const CustomTextEdit = ( { data, field, onChange }: DataFormControlProps< FormData > ) => {
+	const value = field.getValue( { item: data } );
+	return (
+		<ValidatedTextControl
+			label={ field.label }
+			value={ value }
+			required={ field.id === 'title' }
+			help="The word 'error' will trigger an error."
+			customValidator={ createCustomValidator( field ) }
+			onChange={ ( newValue ) => onChange( { [ field.id ]: newValue } ) }
+		/>
+	);
+};
+
+// Custom Edit component that uses ValidatedTextareaControl
+const CustomTextareaEdit = ( { data, field, onChange }: DataFormControlProps< FormData > ) => {
+	const value = field.getValue( { item: data } );
+	return (
+		<ValidatedTextareaControl
+			label={ field.label }
+			value={ value }
+			help="The word 'error' will trigger an error."
+			customValidator={ createCustomValidator( field ) }
+			onChange={ ( newValue ) => onChange( { [ field.id ]: newValue } ) }
+		/>
+	);
+};
+
+/**
+ * Example of using DataForm with custom validated form controls
+ */
+export const WithDataForm: Story = {
+	render: function Template() {
+		const [ data, setData ] = useState< FormData >( {
+			title: '',
+			subtitle: '',
+			description: '',
+		} );
+
+		const fields: Field< FormData >[] = [
+			{
+				id: 'title',
+				label: 'Title',
+				type: 'text',
+				getValue: ( { item }: { item: FormData } ) => item.title,
+				Edit: CustomTextEdit,
+			},
+			{
+				id: 'subtitle',
+				label: 'Subtitle',
+				type: 'text',
+				getValue: ( { item }: { item: FormData } ) => item.subtitle,
+				Edit: CustomTextEdit,
+			},
+			{
+				id: 'description',
+				label: 'Description',
+				type: 'text',
+				getValue: ( { item }: { item: FormData } ) => item.description,
+				Edit: CustomTextareaEdit,
+			},
+		];
+
+		const form: Form = {
+			type: 'regular',
+			fields,
+		};
+
+		return (
+			<DataForm< FormData >
+				data={ data }
+				form={ form }
+				fields={ fields }
+				onChange={ ( newData: Partial< FormData > ) => setData( { ...data, ...newData } ) }
 			/>
 		);
 	},

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -12,6 +12,7 @@
 	"references": [
 		{ "path": "../calypso-analytics" },
 		{ "path": "../calypso-url" },
+		{ "path": "../dataviews" },
 		{ "path": "../i18n-utils" }
 	]
 }

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -22,6 +22,7 @@
 		{ "path": "./composite-checkout" },
 		{ "path": "./create-calypso-config" },
 		{ "path": "./data-stores" },
+		{ "path": "./dataviews" },
 		{ "path": "./design-picker" },
 		{ "path": "./design-preview" },
 		{ "path": "./domain-picker" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -840,6 +840,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/calypso-url": "workspace:^"
     "@automattic/color-studio": "npm:^4.1.0"
+    "@automattic/dataviews": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/load-script": "workspace:^"
     "@automattic/material-design-icons": "workspace:^"


### PR DESCRIPTION
## Proposed Changes

This PR does a quick and dirty demo of how the current validated form fields in `@automattic/components` work with custom orchestration or external libraries.

In this rough example, we're using `DataForm` with custom validation.

## Why are these changes being made?

For demo purposes. Not intended to be merged.

cc @youknowriad 

## Testing Instructions

* Run `yarn components:storybook:start`
* Open the Validated Form Controls overview page: http://localhost:56833/?path=/docs/validated-form-controls-overview--docs#with-data-form
* Play with the form fields and verify validation works as expected.

## Preview


https://github.com/user-attachments/assets/397e77a0-a566-42ac-bbce-e79cfae3c96f

