### PR TITLE
Connect Refresh: Centralise login header and top-bar

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -56,7 +56,6 @@ import isWooJPCFlow from 'calypso/state/selectors/is-woo-jpc-flow';
 import ContinueAsUser from './continue-as-user';
 import ErrorNotice from './error-notice';
 import LoginForm from './login-form';
-import { LoginHeader } from './login-header';
 
 import './style.scss';
 
@@ -446,7 +445,7 @@ class Login extends Component {
 					{ ! isWooJPC && ! isBlazePro && (
 						<div className="login__lost-password-footer">
 							<p className="login__lost-password-no-account">
-								{ translate( 'Don’t have an account? {{signupLink}}Sign up{{/signupLink}}', {
+								{ translate( "Don't have an account? {{signupLink}}Sign up{{/signupLink}}", {
 									components: {
 										signupLink,
 									},
@@ -457,7 +456,7 @@ class Login extends Component {
 					{ isBlazePro && (
 						<div className="login__lost-password-footer">
 							<p className="login__lost-password-no-account">
-								<span>{ translate( 'Don’t have an account?' ) }&nbsp;</span>
+								<span>{ translate( "Don't have an account?" ) }&nbsp;</span>
 								{ translate( '{{signupLink}}Sign up{{/signupLink}}', {
 									components: {
 										signupLink,
@@ -488,7 +487,7 @@ class Login extends Component {
 					{ isWoo && (
 						<div className="login__two-factor-footer">
 							<p className="login__two-factor-no-account">
-								{ translate( 'Don’t have an account? {{signupLink}}Sign up{{/signupLink}}', {
+								{ translate( "Don't have an account? {{signupLink}}Sign up{{/signupLink}}", {
 									components: {
 										signupLink,
 									},
@@ -496,7 +495,7 @@ class Login extends Component {
 							</p>
 							<p className="login__two-factor-cannot-access-phone">
 								{ translate(
-									'Can’t access your phone? {{contactUsLink}}Contact us{{/contactUsLink}}',
+									"Can't access your phone? {{contactUsLink}}Contact us{{/contactUsLink}}",
 									{
 										components: {
 											contactUsLink: (
@@ -594,27 +593,9 @@ class Login extends Component {
 			locale,
 			isWCCOM,
 			isFromAutomatticForAgenciesPlugin,
-			action,
-			currentQuery,
-			fromSite,
-			isFromMigrationPlugin,
-			isGravPoweredClient,
-			isGravPoweredLoginPage,
-			isManualRenewalImmediateLoginAttempt,
 			isSignupExistingAccount,
 			isSocialFirst,
 			isWhiteLogin,
-			isBlazePro,
-			linkingSocialService,
-			socialConnect,
-			translate,
-			twoStepNonce,
-			wccomFrom,
-			isWooJPC,
-			twoFactorAuthType,
-			twoFactorEnabled,
-			initialQuery,
-			partnerSlug,
 		} = this.props;
 
 		const content = (
@@ -629,38 +610,6 @@ class Login extends Component {
 					'is-social-first': isSocialFirst,
 				} ) }
 			>
-				{ ! isWhiteLogin && (
-					<LoginHeader
-						action={ action }
-						currentQuery={ currentQuery }
-						fromSite={ fromSite }
-						isFromAkismet={ isFromAkismet }
-						isFromMigrationPlugin={ isFromMigrationPlugin }
-						isFromAutomatticForAgenciesPlugin={ isFromAutomatticForAgenciesPlugin }
-						isGravPoweredClient={ isGravPoweredClient }
-						isGravPoweredLoginPage={ isGravPoweredLoginPage }
-						isJetpack={ isJetpack }
-						isManualRenewalImmediateLoginAttempt={ isManualRenewalImmediateLoginAttempt }
-						isSocialFirst={ isSocialFirst }
-						isWhiteLogin={ isWhiteLogin }
-						isWCCOM={ isWCCOM }
-						isBlazePro={ isBlazePro }
-						linkingSocialService={ linkingSocialService }
-						oauth2Client={ oauth2Client }
-						socialConnect={ socialConnect }
-						translate={ translate }
-						twoStepNonce={ twoStepNonce }
-						wccomFrom={ wccomFrom }
-						isWooJPC={ isWooJPC }
-						twoFactorAuthType={ twoFactorAuthType }
-						twoFactorEnabled={ twoFactorEnabled }
-						initialQuery={ initialQuery }
-						partnerSlug={ partnerSlug }
-						getSignupLinkComponent={ this.getSignupLinkComponent }
-						showContinueAsUser={ this.showContinueAsUser() }
-					/>
-				) }
-
 				{ isSignupExistingAccount && this.renderLoginFormSignupNotice() }
 
 				{ /* For Woo, we render the ErrrorNotice component in login-form.jsx */ }

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -617,7 +617,7 @@ class Login extends Component {
 			partnerSlug,
 		} = this.props;
 
-		return (
+		const content = (
 			<div
 				className={ clsx( 'login', {
 					'is-akismet': isFromAkismet,
@@ -625,6 +625,8 @@ class Login extends Component {
 					'is-jetpack-cloud': isJetpackCloudOAuth2Client( oauth2Client ),
 					'is-automattic-for-agencies-flow': isFromAutomatticForAgenciesPlugin,
 					'is-a4a': isA4AOAuth2Client( oauth2Client ),
+					'is-white-login': isWhiteLogin,
+					'is-social-first': isSocialFirst,
 				} ) }
 			>
 				{ ! isWhiteLogin && (
@@ -675,6 +677,8 @@ class Login extends Component {
 				{ isWhiteLogin && this.renderToS() }
 			</div>
 		);
+
+		return content;
 	}
 }
 

--- a/client/blocks/login/login-header.tsx
+++ b/client/blocks/login/login-header.tsx
@@ -197,7 +197,6 @@ export function getHeaderText(
 
 	return headerText;
 }
-
 export function LoginHeader( {
 	action,
 	currentQuery,

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -29,6 +29,7 @@ import {
 	isGravPoweredOAuth2Client,
 	isBlazeProOAuth2Client,
 	isPartnerPortalOAuth2Client,
+	isStudioAppOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { createAccountUrl } from 'calypso/lib/paths';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
@@ -162,7 +163,7 @@ const LayoutLoggedOut = ( {
 
 	if ( useOAuth2Layout && ( isGravatar || isGravPoweredClient ) ) {
 		masterbar = null;
-	} else if ( useOAuth2Layout && oauth2Client && oauth2Client.name ) {
+	} else if ( useOAuth2Layout && oauth2Client && oauth2Client.name && ! masterbarIsHidden ) {
 		classes.dops = true;
 		classes[ oauth2Client.name ] = true;
 
@@ -335,7 +336,9 @@ export default withCurrentRoute(
 			const isPartnerPortal = isPartnerPortalOAuth2Client( oauth2Client );
 			const isWooJPC = isWooJPCFlow( state );
 
+			const isStudioClient = isStudioAppOAuth2Client( oauth2Client );
 			const isWhiteLogin =
+				isStudioClient ||
 				( currentRoute.startsWith( '/log-in' ) &&
 					! isJetpackLogin &&
 					Boolean( currentQuery?.client_id ) === false &&
@@ -356,6 +359,7 @@ export default withCurrentRoute(
 				[ 'signup', 'jetpack-connect' ].includes( sectionName );
 			const wccomFrom = getWccomFrom( state );
 			const masterbarIsHidden =
+				isStudioClient ||
 				! ( currentSection || currentRoute ) ||
 				! masterbarIsVisible( state ) ||
 				noMasterbarForSection ||

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -5,6 +5,7 @@ import {
 	isGravPoweredOAuth2Client,
 	isWooOAuth2Client,
 	isPartnerPortalOAuth2Client,
+	isStudioAppOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { DesktopLoginStart, DesktopLoginFinalize } from 'calypso/login/desktop-login';
 import { SOCIAL_HANDOFF_CONNECT_ACCOUNT } from 'calypso/state/action-types';
@@ -64,6 +65,7 @@ const enhanceContextWithLogin = ( context ) => {
 	const isPartnerPortalClient = isPartnerPortalOAuth2Client( oauth2Client );
 	const isWooJPC = isWooJPCFlow( currentState );
 	const isBlazePro = getIsBlazePro( currentState );
+	const isStudioLogin = isStudioAppOAuth2Client( oauth2Client );
 
 	const isWhiteLogin =
 		( ! isJetpackLogin &&
@@ -71,7 +73,8 @@ const enhanceContextWithLogin = ( context ) => {
 			Boolean( oauth2ClientId ) === false &&
 			! isBlazePro &&
 			! isWooJPC ) ||
-		isPartnerPortalClient;
+		isPartnerPortalClient ||
+		isStudioLogin; // Force two-column layout for Studio
 
 	context.primary = (
 		<WPLogin

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -640,7 +640,7 @@ export class Login extends Component {
 
 		return (
 			<>
-				{ isWhiteLogin && (
+				{ isWhiteLogin ? (
 					<Step.CenteredColumnLayout
 						columnWidth={ 6 }
 						topBar={
@@ -651,10 +651,16 @@ export class Login extends Component {
 					>
 						{ mainContent }
 					</Step.CenteredColumnLayout>
+				) : (
+					<>
+						{ ! isWooJPC &&
+							isJetpack &&
+							! this.props.isFromAutomatticForAgenciesPlugin &&
+							jetpackLogo }
+						{ mainContent }
+						{ this.renderFooter() }
+					</>
 				) }
-				{ ! isWooJPC && isJetpack && ! this.props.isFromAutomatticForAgenciesPlugin && jetpackLogo }
-				{ ! isWhiteLogin && mainContent }
-				{ this.renderFooter() }
 			</>
 		);
 	}

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -8,10 +8,13 @@ import { get, startsWith } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import A4APlusWpComLogo from 'calypso/a8c-for-agencies/components/a4a-plus-wpcom-logo';
 import LoginBlock from 'calypso/blocks/login';
 import { getHeaderText } from 'calypso/blocks/login/login-header';
 import AutomatticLogo from 'calypso/components/automattic-logo';
 import DocumentHead from 'calypso/components/data/document-head';
+import GravatarLoginLogo from 'calypso/components/gravatar-login-logo';
+import JetpackPlusWpComLogo from 'calypso/components/jetpack-plus-wpcom-logo';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import LoggedOutFormBackLink from 'calypso/components/logged-out-form/back-link';
 import Main from 'calypso/components/main';
@@ -635,33 +638,59 @@ export class Login extends Component {
 			isPartnerPortalOAuth2Client( oauth2Client ) &&
 			document.location.search?.includes( 'wpcloud' )
 		) {
-			brandLogo = <WPCloudLogo className="login__wpcloud-logo" size={ 120 } />;
+			brandLogo = <WPCloudLogo size={ 120 } />;
+		}
+
+		let logo = null;
+		if ( isJetpackCloudOAuth2Client( oauth2Client ) ) {
+			logo = <JetpackPlusWpComLogo size={ 24 } />;
+		} else if ( isA4AOAuth2Client( oauth2Client ) ) {
+			logo = <A4APlusWpComLogo size={ 32 } />;
+		} else if ( isPartnerPortalOAuth2Client( oauth2Client ) ) {
+			if ( document.location.search?.includes( 'wpcloud' ) ) {
+				logo = <WPCloudLogo size={ 256 } />;
+			} else if ( document.location.search?.includes( 'jetpack' ) ) {
+				logo = <JetpackPlusWpComLogo size={ 24 } />;
+			}
+		} else if ( isGravPoweredClient ) {
+			logo = (
+				<GravatarLoginLogo
+					iconUrl={ oauth2Client?.icon }
+					alt={ oauth2Client?.title || '' }
+					isCoBrand={ isGravatarFlowOAuth2Client( oauth2Client ) }
+				/>
+			);
 		}
 
 		return (
-			<>
-				{ isWhiteLogin ? (
-					<Step.CenteredColumnLayout
-						columnWidth={ 6 }
-						topBar={
-							<Step.TopBar rightElement={ this.renderLoginHeaderNavigation() } logo={ brandLogo } />
+			<Step.CenteredColumnLayout
+				columnWidth={ 6 }
+				topBar={
+					<Step.TopBar
+						rightElement={ this.renderLoginHeaderNavigation() }
+						logo={
+							brandLogo ||
+							( ! isWooJPC && isJetpack && ! this.props.isFromAutomatticForAgenciesPlugin
+								? jetpackLogo
+								: null )
 						}
-						heading={ <Step.Heading text={ headerText } /> }
-						verticalAlign="center"
-					>
-						{ mainContent }
-					</Step.CenteredColumnLayout>
-				) : (
-					<>
-						{ ! isWooJPC &&
-							isJetpack &&
-							! this.props.isFromAutomatticForAgenciesPlugin &&
-							jetpackLogo }
-						{ mainContent }
-						{ this.renderFooter() }
-					</>
-				) }
-			</>
+					/>
+				}
+				heading={
+					<Step.Heading
+						text={
+							<>
+								<div>{ logo }</div>
+								{ headerText }
+							</>
+						}
+					/>
+				}
+				verticalAlign="center"
+			>
+				{ mainContent }
+				{ ! isWhiteLogin && this.renderFooter() }
+			</Step.CenteredColumnLayout>
 		);
 	}
 }

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -19,7 +19,7 @@ $image-height: 47px;
 		padding-bottom: $image-height;
 		min-height: calc(100% - #{$image-height});
 	}
-	
+
 	.layout__content {
 		position: static;
 	}
@@ -35,6 +35,14 @@ $image-height: 47px;
 		.masterbar {
 			display: none;
 		}
+	}
+
+	.gravatar-login-logo {
+		display: block;
+	}
+
+	.step-container-v2__heading {
+		text-align: center;
 	}
 }
 
@@ -927,4 +935,3 @@ $image-height: 47px;
 :root {
 	--login-form-column-max-width: 327px;
 }
-


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13334/centralise-log-in-header-and-top-bar

## Proposed Changes

WIP

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13334/centralise-log-in-header-and-top-bar


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

WIP

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
