### PR TITLE
Accessibility: Fix colour contrast ratio issue with installed sites on plugin page

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -149,7 +149,7 @@
 
 
 	.plugin-details-cta__installed-text-quantity {
-		color: var(--studio-green-50);
+		color: var(--studio-green-60);
 	}
 
 	.plugin-details-cta__installed-text-active {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13332

## Proposed Changes

* Update colour contrast ratio issue with installed sites on the plugin page


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Axe DevTool complained about the contrast ratio issue. We need to ensure that the pages comply with EAA. 

![CleanShot 2025-05-27 at 13 14 16@2x](https://github.com/user-attachments/assets/3fa35d6b-2bee-47fb-b8be-2fe1ec41e3a5)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR
* Log in to WordPress.com
* Visit any plugin page. The plugin should be installed on one of your sites. In my case it is `all-in-one-seo-pack`. 
```
http://calypso.localhost:3000/plugins/[PLUGIN_SLUG]
http://calypso.localhost:3000/plugins/all-in-one-seo-pack
```
* Run Axe DevTools accessibility test
* Ensure there is no error related to contrast ratio. 



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
