### PR TITLE
A4A > Log-in: Fix the empty log-in screen

### DIFF
--- a/client/a8c-for-agencies/sections/auth/controller.tsx
+++ b/client/a8c-for-agencies/sections/auth/controller.tsx
@@ -67,3 +67,8 @@ export const tokenRedirect: Callback = ( ctx, next ) => {
 		document.location.replace( DEFAULT_NEXT_LOCATION );
 	}
 };
+
+export const logIn: Callback = () => {
+	debug( 'log in' );
+	document.location.replace( DEFAULT_NEXT_LOCATION );
+};

--- a/client/a8c-for-agencies/sections/auth/index.ts
+++ b/client/a8c-for-agencies/sections/auth/index.ts
@@ -1,11 +1,12 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
-import { connect, tokenRedirect } from './controller';
+import { connect, logIn, tokenRedirect } from './controller';
 
 export default (): void => {
 	if ( isA8CForAgencies() ) {
 		page( '/connect', connect, makeLayout, clientRender );
 		page( '/connect/oauth/token', tokenRedirect, makeLayout, clientRender );
+		page( '/log-in', logIn, makeLayout, clientRender );
 	}
 };

--- a/client/sections.js
+++ b/client/sections.js
@@ -777,7 +777,7 @@ const sections = [
 	},
 	{
 		name: 'a8c-for-agencies-auth',
-		paths: [ '/connect', '/connect/oauth/token' ],
+		paths: [ '/log-in', '/connect', '/connect/oauth/token' ],
 		module: 'calypso/a8c-for-agencies/sections/auth',
 		group: 'a8c-for-agencies',
 		enableLoggedOut: true,


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-873/a4a-log-in-screen-shows-empty-screen-when-visited-manually

## Proposed Changes

This PR fixes an issue with the A4A log-in page showing an empty screen. 

## Why are these changes being made?

- To allow users to log-in to A4A if they manually visit `/log-in`

## Testing Instructions

* Switch to the branch locally and **restart the server**.
* Open http://agencies.localhost:3000/log-in in incognito > Verify you are redirected to the usual A4A log-in flow > Log in to your account and verify you are redirected to http://agencies.localhost:3000. It will next follow the A4A redirects, which is `/landing`, then `/overview`. **We don't have to handle any args here as of now since we don't support it**. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
