### PR TITLE
Courses: Update blogging-quick-start

### DIFF
--- a/client/data/courses/constants.ts
+++ b/client/data/courses/constants.ts
@@ -1,5 +1,5 @@
 export const COURSE_SLUGS = {
-	BLOGGING_QUICK_START: 'create-your-blog',
+	BLOGGING_QUICK_START: 'blogging-quick-start',
 	PAYMENTS_FEATURES: 'payments-features',
 	SITE_EDITOR_QUICK_START: 'site-editor-quick-start',
 } as const;

--- a/client/data/courses/constants.ts
+++ b/client/data/courses/constants.ts
@@ -1,5 +1,5 @@
 export const COURSE_SLUGS = {
-	BLOGGING_QUICK_START: 'blogging-quick-start',
+	BLOGGING_QUICK_START: 'create-your-blog',
 	PAYMENTS_FEATURES: 'payments-features',
 	SITE_EDITOR_QUICK_START: 'site-editor-quick-start',
 } as const;

--- a/client/data/courses/use-course-details.ts
+++ b/client/data/courses/use-course-details.ts
@@ -19,13 +19,13 @@ const useCourseDetails = ( courseSlug: CourseSlug ): CourseDetails | undefined =
 
 	if ( courseSlug === COURSE_SLUGS.BLOGGING_QUICK_START ) {
 		return {
-			headerTitle: translate( 'Watch five videos.' ),
-			headerSubtitle: translate( 'Save yourself hours.' ),
+			headerTitle: translate( 'Start your blog.' ),
+			headerSubtitle: translate( 'Share your voice.' ),
 			headerSummary: [
-				translate( 'Learn the basics of blogging' ),
-				translate( 'Familiarize yourself with WordPress' ),
-				translate( 'Upskill and save hours' ),
-				translate( 'Set yourself up for blogging success' ),
+				translate( 'Find the perfect look for your blog' ),
+				translate( 'Craft posts that express your ideas' ),
+				translate( 'Keep your content clear and organized' ),
+				translate( 'Grow your audience and engage readers' ),
 			],
 		};
 	} else if ( courseSlug === COURSE_SLUGS.PAYMENTS_FEATURES ) {

--- a/client/my-sites/customer-home/cards/education/blogging-quick-start/index.jsx
+++ b/client/my-sites/customer-home/cards/education/blogging-quick-start/index.jsx
@@ -15,9 +15,9 @@ const BloggingQuickStart = () => {
 
 	return (
 		<EducationalContent
-			title={ translate( 'Blog like an expert from day one' ) }
+			title={ translate( 'Course: Create your blog' ) }
 			description={ translate(
-				"Learn the fundamentals from our bite-sized video course — you'll be up and running in just nine minutes."
+				'Follow along as we show you how to start your blog, publish posts, and connect with your audience.'
 			) }
 			modalLinks={ [
 				{
@@ -31,7 +31,7 @@ const BloggingQuickStart = () => {
 						courseSlug: COURSE_SLUGS.BLOGGING_QUICK_START,
 					},
 					onClick: openModal,
-					text: translate( 'Start learning' ),
+					text: translate( 'Start course' ),
 				},
 			] }
 			illustration={ startLearningPrompt }


### PR DESCRIPTION
Ref DOTCOM-13302

## Proposed Changes

This PR updates the blogging-quick-start course. The updated course has the slug create-your-blog. Before merging, the deprecate course slug needs to be updated to blogging-quick-start-old, so that the updated course can use blogging-quick-start as slug.

| Before | After |
| --- | --- |
| ![Screenshot 2025-05-27 at 5 31 37 PM](https://github.com/user-attachments/assets/cdb5df6d-1be3-4866-a9b0-8301bac865e1) | ![Screenshot 2025-05-27 at 5 31 19 PM](https://github.com/user-attachments/assets/1a210984-26ff-462a-8b1b-3ec0e9cb4b31) |

| Before | After |
| --- | --- |
| ![Screenshot 2025-05-27 at 5 31 42 PM](https://github.com/user-attachments/assets/2830af17-d980-4ae1-939f-7a8a927c985d) | ![Screenshot 2025-05-27 at 5 31 25 PM](https://github.com/user-attachments/assets/6953ee48-f83b-4cbb-a29f-6948a3319e5b) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

New course.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /home/:siteSlug.
* Ensure that the course card is updated as shown above.
* Click on the card.
* Ensure that the course is updated as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
