### PR TITLE
Update `postcss-custom-properties` from v11 to v12

### DIFF
--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -56,7 +56,7 @@
 		"@automattic/wp-babel-makepot": "workspace:^",
 		"html-webpack-plugin": "^5.6.3",
 		"postcss": "^8.5.3",
-		"postcss-custom-properties": "^11.0.0",
+		"postcss-custom-properties": "^12.0.0",
 		"webpack": "^5.97.1"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -300,7 +300,7 @@
 		"npm-run-all": "^4.1.5",
 		"postcss": "^8.5.3",
 		"postcss-cli": "^9.0.1",
-		"postcss-custom-properties": "^11.0.0",
+		"postcss-custom-properties": "^12.0.0",
 		"prettier": "npm:wp-prettier@3.0.3",
 		"react-refresh": "^0.17.0",
 		"readline-sync": "^1.4.10",

--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Dropped Babel presets. They have been moved to `@automattic/calypso-babel-config`. The new packge should be a drop in replacement, anywhere you were using `@automattic/calypso-build/babel/dependencies` you can use `@automattic/calypso-babel-config/presets/dependencies` (same for the other presets)
 - Dropped Jest presets. They have been moved to `@automattic/calypso-jest`. . The new packge should be a drop in replacement, you can use `preset: @automattic/calypso-jest` in your Jest config.
 - Added `build-app-languages` command that takes a `pot` file and builds translations file off of it based on `https://widgets.wp.com/languages/calypso`.
+- Updated dependencies:
+  - postcss-custom-properties to ^12.0.0
 
 ## 10.0.0
 

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -51,7 +51,7 @@
 		"duplicate-package-checker-webpack-plugin": "^3.0.0",
 		"lodash": "^4.17.21",
 		"mini-css-extract-plugin": "^1.6.2",
-		"postcss-custom-properties": "^11.0.0",
+		"postcss-custom-properties": "^12.0.0",
 		"postcss-loader": "^6.2.1",
 		"recursive-copy": "^2.0.14",
 		"sass": "1.54.0",

--- a/packages/calypso-color-schemes/CHANGELOG.md
+++ b/packages/calypso-color-schemes/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Clean up all definitions and usages of CSS variables ending with -rgb.
+- Updated dependencies:
+  - postcss-custom-properties to ^12.0.0
 
 ## 3.1.3
 

--- a/packages/calypso-color-schemes/package.json
+++ b/packages/calypso-color-schemes/package.json
@@ -31,7 +31,7 @@
 		"@automattic/color-studio": "^4.1.0",
 		"@types/node": "^22.10.10",
 		"postcss": "^8.5.3",
-		"postcss-custom-properties": "^11.0.0",
+		"postcss-custom-properties": "^12.0.0",
 		"sass": "1.54.0"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -485,7 +485,7 @@ __metadata:
     gettext-parser: "npm:^6.0.0"
     lodash: "npm:^4.17.21"
     mini-css-extract-plugin: "npm:^1.6.2"
-    postcss-custom-properties: "npm:^11.0.0"
+    postcss-custom-properties: "npm:^12.0.0"
     postcss-loader: "npm:^6.2.1"
     recursive-copy: "npm:^2.0.14"
     sass: "npm:1.54.0"
@@ -517,7 +517,7 @@ __metadata:
     "@automattic/color-studio": "npm:^4.1.0"
     "@types/node": "npm:^22.10.10"
     postcss: "npm:^8.5.3"
-    postcss-custom-properties: "npm:^11.0.0"
+    postcss-custom-properties: "npm:^12.0.0"
     sass: "npm:1.54.0"
   languageName: unknown
   linkType: soft
@@ -1671,7 +1671,7 @@ __metadata:
     html-webpack-plugin: "npm:^5.6.3"
     i18n-calypso: "workspace:^"
     postcss: "npm:^8.5.3"
-    postcss-custom-properties: "npm:^11.0.0"
+    postcss-custom-properties: "npm:^12.0.0"
     prop-types: "npm:^15.8.1"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
@@ -28604,14 +28604,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-custom-properties@npm:^11.0.0":
-  version: 11.0.0
-  resolution: "postcss-custom-properties@npm:11.0.0"
+"postcss-custom-properties@npm:^12.0.0":
+  version: 12.1.11
+  resolution: "postcss-custom-properties@npm:12.1.11"
   dependencies:
-    postcss-values-parser: "npm:^4.0.0"
+    postcss-value-parser: "npm:^4.2.0"
   peerDependencies:
-    postcss: ^8.1.0
-  checksum: de2be79d11269b1868515f54a3a2efc852b000edd17c19c877c9fc46afb5b8b1d80badc0f20ffcc39c407bce8de9c953ce9b1ce25845f15224354ad592f3e162
+    postcss: ^8.2
+  checksum: 99ad5a9f9a69590141157e447f48d9d6da74f0e83bf552cd5a4e74db7a03222f1e9e37df7ee442a7b97f5c6c824c1018667ee27ac64e0bc6ee7e67e89bc552c5
   languageName: node
   linkType: hard
 
@@ -29713,17 +29713,6 @@ __metadata:
   version: 4.2.0
   resolution: "postcss-value-parser@npm:4.2.0"
   checksum: f4142a4f56565f77c1831168e04e3effd9ffcc5aebaf0f538eee4b2d465adfd4b85a44257bb48418202a63806a7da7fe9f56c330aebb3cac898e46b4cbf49161
-  languageName: node
-  linkType: hard
-
-"postcss-values-parser@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "postcss-values-parser@npm:4.0.0"
-  dependencies:
-    color-name: "npm:^1.1.4"
-    is-url-superb: "npm:^4.0.0"
-    postcss: "npm:^7.0.5"
-  checksum: b06313eb1b90666cb695a6cda4837f6f690ce242e0f2c04de4e5114fe54456d5f73b924f67ac6018366c9f0c2decbd677f6dab4936335363c305b6a5076fe612
   languageName: node
   linkType: hard
 
@@ -37333,7 +37322,7 @@ __metadata:
     photon: "workspace:^"
     postcss: "npm:^8.5.3"
     postcss-cli: "npm:^9.0.1"
-    postcss-custom-properties: "npm:^11.0.0"
+    postcss-custom-properties: "npm:^12.0.0"
     prettier: "npm:wp-prettier@3.0.3"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Extracted from #103710

## Proposed Changes

Update `postcss-custom-properties` from v11 to v12 across the repository

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

While working on #103710, I started getting a `<css input> Unknown word` error in the ["Build Calypso Apps (WPCom Plugins)" CI task](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WPComPlugins_Build_Plugins/14976761?logView=flowAware).

It looks like the reason for error is the `postcss-custom-properties` dependency: https://github.com/tailwindlabs/tailwindcss/issues/5310

Updating from v11 to v12 seems to solve the issue. Also, I couldn't spot any breaking changes in [the CHANGELOG](https://github.com/csstools/postcss-plugins/blob/main/plugins/postcss-custom-properties/CHANGELOG.md) from v11 to v12.

I purposefully didn't update to the latest version (v14) since it would require a larger refactor, given that [the `importFrom` and `exportTo` config options were deprecated and removed](https://github.com/csstools/postcss-plugins/discussions/192) in v13.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure project builds as before (including apps), both in this PR and in https://github.com/Automattic/wp-calypso/pull/103710 (which is stacked on top of this PR)
* Smoke test calypso and apps

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
