### PR TITLE
A4A: Fix signup sanitizer omitting 'plus' symbol in the number of sites and agency size.

### DIFF
--- a/client/a8c-for-agencies/sections/signup/lib/signup-data-from-reqest-parameters.ts
+++ b/client/a8c-for-agencies/sections/signup/lib/signup-data-from-reqest-parameters.ts
@@ -9,7 +9,7 @@ const sanitizeString = ( value: string | null ): string => {
 	if ( ! value ) {
 		return '';
 	}
-	return value.trim().replace( /[^\p{L}\p{N}\s._-]/gu, '' );
+	return value.trim().replace( /[^\p{L}\p{N}\s._+-]/gu, '' );
 };
 
 const sanitizePlansToOfferProducts = ( value: string | null ): 'Yes' | 'No' | undefined => {


### PR DESCRIPTION
When selecting the agency size to '251+' or the number of sites to '500+', the finish logic tries to omit the + symbol when parsing the value from the redirect URL. This PR fixes this issue.


## Proposed Changes

* Update the regex for parsing the value so that it excludes the '+' symbol from being omitted.

## Why are these changes being made?

* This prevent user from completing the signup when selecting the values stated above.

## Testing Instructions

* Spin up this branch locally.
* Use the A4A live link and navigate to http://agencies.localhost:3000/signup/finish?address_line1&address_line2&address_city&address_state&address_postal_code&work_with_clients_other&approach_and_challenges&first_name=James&last_name=Guidaven&email=james.kenneth.guidaven+testagency109120@automattic.com&agency_name=JK%20Test%20Agency&agency_url=http://jkguidaven.github.io&initial_source=Signup%20V2%20Flow&agency_size=251%2B&number_sites=500%2B&user_type=agency_owner&services_offered%5B0%5D=ecommerce_development&products_offered%5B0%5D=WordPress.com&&address_country=PH&phone_number&client_id=95932
* Try to sign-in with account and confirm that the signup completes.


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
