### PR TITLE
A4A: Fix label accessibility in the A4A signup form.

### DIFF
--- a/client/a8c-for-agencies/components/form/field/index.tsx
+++ b/client/a8c-for-agencies/components/form/field/index.tsx
@@ -7,6 +7,7 @@ import './style.scss';
 
 type Props = {
 	label: string;
+	labelFor?: string;
 	sub?: string;
 	description?: string | ReactNode;
 	showOptionalLabel?: boolean;
@@ -17,6 +18,7 @@ type Props = {
 
 function FormField( {
 	label,
+	labelFor,
 	sub,
 	children,
 	description,
@@ -29,12 +31,12 @@ function FormField( {
 	return (
 		<div className="a4a-form__section-field">
 			<div className="a4a-form__section-field-heading">
-				<h3 className="a4a-form__section-field-label">
+				<label className="a4a-form__section-field-label" htmlFor={ labelFor }>
 					{ label } { isRequired && <span className="a4a-form__section-field-required">*</span> }
 					{ ! isRequired && showOptionalLabel && (
 						<span className="a4a-form__section-field-optional">({ translate( 'optional' ) })</span>
 					) }
-				</h3>
+				</label>
 				{ sub && <p className="a4a-form__section-field-sub">{ sub }</p> }
 			</div>
 

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form-2/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form-2/index.tsx
@@ -19,10 +19,12 @@ type Props = {
 };
 
 const BlueprintFormRadio = ( {
+	id,
 	label,
 	checked,
 	onChange,
 }: {
+	id?: string;
 	label: string;
 	checked: boolean;
 	onChange: () => void;
@@ -39,7 +41,13 @@ const BlueprintFormRadio = ( {
 				}
 			} }
 		>
-			<FormRadio label={ label } checked={ checked } onChange={ onChange } />
+			<FormRadio
+				id={ id }
+				htmlFor={ id }
+				label={ label }
+				checked={ checked }
+				onChange={ onChange }
+			/>
 		</div>
 	);
 };
@@ -98,6 +106,7 @@ const BlueprintForm2: React.FC< Props > = ( { onContinue, initialFormData, goBac
 					{ workModelOptions.map( ( option ) => (
 						<BlueprintFormRadio
 							key={ `work-model-option-${ option.value }` }
+							id={ `work-model-option-${ option.value }` }
 							label={ option.label }
 							checked={ formData.workWithClients === option.value }
 							onChange={ () => {

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form/index.tsx
@@ -17,10 +17,12 @@ type Props = {
 };
 
 const BlueprintFormRadio = ( {
+	id,
 	label,
 	checked,
 	onChange,
 }: {
+	id?: string;
 	label: string;
 	checked: boolean;
 	onChange: () => void;
@@ -37,7 +39,13 @@ const BlueprintFormRadio = ( {
 				}
 			} }
 		>
-			<FormRadio label={ label } checked={ checked } onChange={ onChange } />
+			<FormRadio
+				id={ id }
+				htmlFor={ id }
+				label={ label }
+				checked={ checked }
+				onChange={ onChange }
+			/>
 		</div>
 	);
 };
@@ -111,6 +119,7 @@ const BlueprintForm: React.FC< Props > = ( { onContinue, initialFormData, goBack
 					{ topGoalOptions.map( ( option ) => (
 						<BlueprintFormRadio
 							key={ `goal-option-${ option.value }` }
+							id={ `goal-option-${ option.value }` }
 							label={ option.label }
 							checked={ formData.topPartneringGoal === option.value }
 							onChange={ () => {
@@ -131,6 +140,7 @@ const BlueprintForm: React.FC< Props > = ( { onContinue, initialFormData, goBack
 					{ mainGoal2025Options.map( ( option ) => (
 						<BlueprintFormRadio
 							key={ `main-goal-2025-option-${ option.value }` }
+							id={ `main-goal-2025-option-${ option.value }` }
 							label={ option.label }
 							checked={ formData.topYearlyGoal === option.value }
 							onChange={ () => {

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
@@ -92,9 +92,11 @@ const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: 
 				<FormField
 					error={ validationError.firstName }
 					label={ translate( 'Your first name' ) }
+					labelFor="firstName"
 					isRequired
 				>
 					<FormTextInput
+						id="firstName"
 						name="firstName"
 						value={ formData.firstName }
 						onChange={ handleInputChange( 'firstName' ) }
@@ -102,8 +104,14 @@ const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: 
 					/>
 				</FormField>
 
-				<FormField error={ validationError.lastName } label={ translate( 'Last name' ) } isRequired>
+				<FormField
+					error={ validationError.lastName }
+					label={ translate( 'Last name' ) }
+					labelFor="lastName"
+					isRequired
+				>
 					<FormTextInput
+						id="lastName"
 						name="lastName"
 						value={ formData.lastName }
 						onChange={ handleInputChange( 'lastName' ) }
@@ -113,8 +121,14 @@ const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: 
 			</div>
 
 			{ withEmail && (
-				<FormField error={ validationError.email } label={ translate( 'Email' ) } isRequired>
+				<FormField
+					error={ validationError.email }
+					label={ translate( 'Email' ) }
+					labelFor="email"
+					isRequired
+				>
 					<FormTextInput
+						id="email"
 						name="email"
 						type="email"
 						value={ formData.email }
@@ -127,9 +141,11 @@ const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: 
 			<FormField
 				error={ validationError.agencyName }
 				label={ translate( 'Agency name' ) }
+				labelFor="agencyName"
 				isRequired
 			>
 				<FormTextInput
+					id="agencyName"
 					name="agencyName"
 					value={ formData.agencyName }
 					onChange={ handleInputChange( 'agencyName' ) }
@@ -140,9 +156,11 @@ const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: 
 			<FormField
 				error={ validationError.agencyUrl }
 				label={ translate( 'Business URL' ) }
+				labelFor="agencyUrl"
 				isRequired
 			>
 				<FormTextInput
+					id="agencyUrl"
 					name="agencyUrl"
 					value={ formData.agencyUrl }
 					onChange={ handleInputChange( 'agencyUrl' ) }
@@ -158,7 +176,11 @@ const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: 
 				onChange={ handlePhoneInputChange }
 				className="contact-form__phone-input"
 				phoneInputProps={ {
+					id: 'phone_number',
 					placeholder: translate( 'Phone number' ),
+				} }
+				countrySelectProps={ {
+					id: 'country_code',
 				} }
 				initialCountryCode="US"
 			/>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
@@ -28,10 +28,12 @@ interface Props {
 }
 
 const PersonalizationFormRadio = ( {
+	id,
 	label,
 	checked,
 	onChange,
 }: {
+	id?: string;
 	label: string;
 	checked?: boolean;
 	onChange: () => void;
@@ -48,7 +50,13 @@ const PersonalizationFormRadio = ( {
 				}
 			} }
 		>
-			<FormRadio label={ label } checked={ checked } onChange={ onChange } />
+			<FormRadio
+				id={ id }
+				htmlFor={ id }
+				label={ label }
+				checked={ checked }
+				onChange={ onChange }
+			/>
 		</div>
 	);
 };
@@ -226,6 +234,7 @@ export default function PersonalizationForm( {
 					<FormField
 						error={ validationError.country }
 						label={ translate( 'Where is your agency located?' ) }
+						labelFor="country"
 						isRequired
 					>
 						<SearchableDropdown
@@ -238,7 +247,11 @@ export default function PersonalizationForm( {
 				</FormFieldset>
 
 				<FormFieldset>
-					<FormField label={ translate( 'How would you describe yourself?' ) } isRequired>
+					<FormField
+						label={ translate( 'How would you describe yourself?' ) }
+						labelFor="user_type"
+						isRequired
+					>
 						<FormSelect
 							id="user_type"
 							value={ formData.userType }
@@ -260,6 +273,7 @@ export default function PersonalizationForm( {
 						<FormFieldset>
 							<FormField
 								label={ translate( 'What is the size of your agency (number of employees)?' ) }
+								labelFor="agency_size"
 								isRequired
 							>
 								<FormSelect
@@ -279,7 +293,11 @@ export default function PersonalizationForm( {
 						</FormFieldset>
 
 						<FormFieldset>
-							<FormField label={ translate( 'How many sites do you manage?' ) } isRequired>
+							<FormField
+								label={ translate( 'How many sites do you manage?' ) }
+								labelFor="managed_sites"
+								isRequired
+							>
 								<FormSelect
 									id="managed_sites"
 									value={ formData.managedSites }
@@ -299,6 +317,7 @@ export default function PersonalizationForm( {
 							<FormField
 								error={ validationError.servicesOffered }
 								label={ translate( 'What services do you offer?' ) }
+								labelFor="services_offered"
 								sub={ translate(
 									'Understanding your strategy helps us tailor the program to your needs'
 								) }
@@ -320,6 +339,7 @@ export default function PersonalizationForm( {
 								label={ translate(
 									'What Automattic products do you currently offer your clients?'
 								) }
+								labelFor="products_offered"
 								sub={ translate(
 									"We'll help you deliver more value to your clients with our products"
 								) }
@@ -340,12 +360,14 @@ export default function PersonalizationForm( {
 								<FormFieldset className="signup-personalization-form__checkbox is-horizontal">
 									<FormField label={ translate( 'Do you plan to offer more products?' ) }>
 										<PersonalizationFormRadio
+											id="plans_to_offer_products_yes"
 											label={ translate( 'Yes' ) }
 											checked={ formData.plansToOfferProducts === 'Yes' }
 											onChange={ () => handleSetPlansToOfferProducts( 'Yes' ) }
 										/>
 
 										<PersonalizationFormRadio
+											id="plans_to_offer_products_no"
 											label={ translate( 'No' ) }
 											checked={ formData.plansToOfferProducts === 'No' }
 											onChange={ () => handleSetPlansToOfferProducts( 'No' ) }
@@ -358,6 +380,7 @@ export default function PersonalizationForm( {
 										<FormField
 											error={ validationError.productsToOffer }
 											label={ translate( 'Select the products you plan to offer your clients.' ) }
+											labelFor="products_to_offer"
 											isRequired
 										>
 											<MultiCheckbox

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
@@ -234,7 +234,6 @@ export default function PersonalizationForm( {
 					<FormField
 						error={ validationError.country }
 						label={ translate( 'Where is your agency located?' ) }
-						labelFor="country"
 						isRequired
 					>
 						<SearchableDropdown


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/A4A-1010/website-signup-form-missing-basic-accessibility-eg-form-labels

## Proposed Changes

* This PR modifies the markup of the A4A Form field component to use the correct `label` element and incorporates the `htmlFor` property to meet basic accessibility standards. It's important to note that this form component is also utilized in the PD form. 

## Why are these changes being made?

* Ensuring our UI meets accessibility standards is essential to our dedication to quality products and services.

## Testing Instructions

* Use the A4A live link and navigate to `/signup/wc-asia`.
* Inspect the html source and verify that the labels now are using the correct markup.
* Verify that clicking the label will auto focus the component.
<img width="663" alt="Screenshot 2025-05-27 at 9 35 44 PM" src="https://github.com/user-attachments/assets/32a14775-e98e-421a-a130-47f4335cf8ff" />

**NOTE: Certain components are not addressed in this PR, such as the country search dropdown and the multi-checkboxes. Modifying their structure could potentially break other parts of Calypso that depend on them. I recommend we handle these in a separate PR specifically for those components.**

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
