### PR TITLE
Experiment streamlining the plans grid + checkout: Fix unchanging variation list on checkout

### DIFF
--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -35,7 +35,7 @@ import { getAffiliateCouponLabel } from '../../utils';
 import { AkismetProQuantityDropDown } from './akismet-pro-quantity-dropdown';
 import { ItemVariationPicker } from './item-variation-picker';
 import type { OnChangeAkProQuantity } from './akismet-pro-quantity-dropdown';
-import type { OnChangeItemVariant } from './item-variation-picker';
+import type { OnChangeItemVariant, WPCOMProductVariant } from './item-variation-picker';
 import type {
 	ResponseCart,
 	RemoveProductFromCart,
@@ -387,8 +387,7 @@ function LineItemWrapper( {
 	const isJetpack = responseCart.products.some( ( product ) =>
 		isJetpackPurchasableItem( product.product_slug )
 	);
-
-	const variants = useGetProductVariants( product, ( variant ) => {
+	const variantsFilterCallback = ( variant: WPCOMProductVariant ) => {
 		// Only show term variants which are equal to or longer than the variant that
 		// was in the cart when checkout finished loading (not necessarily the
 		// current variant). For WordPress.com only, not Jetpack, Akismet or Marketplace.
@@ -403,12 +402,12 @@ function LineItemWrapper( {
 			return true;
 		}
 
-		if ( isStreamlinedPrice ) {
-			return true;
-		}
-
 		return variant.termIntervalInMonths >= initialVariantTerm;
-	} );
+	};
+	const variants = useGetProductVariants(
+		product,
+		! isStreamlinedPrice ? variantsFilterCallback : undefined
+	);
 
 	const areThereVariants = variants.length > 1;
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

This changes the term variation filtering by not passing any filter for checkout treatment variations of the `calypso_streamlined_plans_checkout` experiment.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The radio component for the experiment should show lower plan term than the currently selected one. Sometimes, the assignment doesn't stabilize by the time the filtering is done and relies on incorrect conditions.
Subsequent changes are ignored as the filter callback is [memoized](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/checkout/src/hooks/product-variants.tsx#L84).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I couldn't find the exact conditions when this is happening but changing the stored assignment and triggering layout updates should cover them.
* Go through the `onboarding` flow with the `plans_3y_checkout_radio` variation of the `calypso_streamlined_plans_checkout` experiment
* On `Checkout` you should see all variants
<img width="480" alt="Screenshot 2025-05-27 at 16 21 35" src="https://github.com/user-attachments/assets/a019863c-b55f-40f1-bd74-24799c13ce59" />


* Edit the `explat-experiment--calypso_streamlined_plans_checkout` localStorage item so that `"variationName":null`
* Refresh the page
* You should see the control version
<img width="480" alt="Screenshot 2025-05-27 at 16 22 23" src="https://github.com/user-attachments/assets/5588b727-cd65-45f7-8e57-f477d847545a" />


* Edit back the `explat-experiment--calypso_streamlined_plans_checkout` localStorage item so that `"variationName": "plans_3y_checkout_radio"`
* Don't refresh, just change the `Country` from the dropdown so a re-render is triggered
* You should see all variants

|Before|After|
|------|-----|
|<img width="700" alt="Screenshot 2025-05-27 at 16 29 57" src="https://github.com/user-attachments/assets/0e590a69-225e-4ef8-8789-5cbdeac74062" />|<img width="710" alt="Screenshot 2025-05-27 at 16 26 38" src="https://github.com/user-attachments/assets/71337f06-474e-40dc-89a2-5a19154fc13e" />|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
