### PR TITLE
Accessibility: Add informative `aria-label` to the `PremiumBadge` domain component

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -405,7 +405,11 @@ class DomainRegistrationSuggestion extends Component {
 
 		if ( isPremium ) {
 			badges.push(
-				<PremiumBadge key="premium" restrictedPremium={ premiumDomain?.is_price_limit_exceeded } />
+				<PremiumBadge
+					key="premium"
+					restrictedPremium={ premiumDomain?.is_price_limit_exceeded }
+					domainName={ this.props.suggestion.domain_name }
+				/>
 			);
 		}
 

--- a/client/components/domains/domain-registration-suggestion/premium-badge/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/premium-badge/index.jsx
@@ -26,15 +26,30 @@ class PremiumBadge extends Component {
 	}
 
 	render() {
-		const { restrictedPremium } = this.props;
+		const { restrictedPremium, domainName, translate } = this.props;
 		const { text, description } = this.getPopoverText( restrictedPremium );
 		const badgeClassNames = clsx( 'premium-badge', {
 			'restricted-premium': restrictedPremium,
 		} );
+
+		const popoverAriaLabel = restrictedPremium
+			? translate( '%(domainName)s is a restricted premium domain. Learn more', {
+					args: { domainName },
+					comment:
+						'Accessible label for premium badge when a domain is restricted. %(domainName)s is the domain name',
+			  } )
+			: translate( '%(domainName)s is a premium domain. Learn more', {
+					args: { domainName },
+					comment:
+						'Accessible label for premium badge when a domain is not restricted. %(domainName)s is the domain name',
+			  } );
+
 		return (
 			<Badge className={ badgeClassNames }>
 				{ text }
-				<InfoPopover iconSize={ 16 }>{ description }</InfoPopover>
+				<InfoPopover iconSize={ 16 } aria-label={ popoverAriaLabel }>
+					{ description }
+				</InfoPopover>
 			</Badge>
 		);
 	}

--- a/client/components/info-popover/index.jsx
+++ b/client/components/info-popover/index.jsx
@@ -33,6 +33,7 @@ export default class InfoPopover extends Component {
 		] ),
 		showOnHover: PropTypes.bool,
 		children: PropTypes.node,
+		'aria-label': PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -125,7 +126,7 @@ export default class InfoPopover extends Component {
 					type="button"
 					aria-haspopup
 					aria-expanded={ this.state.showPopover }
-					aria-label={ translate( 'More information' ) }
+					aria-label={ this.props[ 'aria-label' ] || translate( 'More information' ) }
 					onClick={ this.handleClick }
 					onMouseEnter={ this.handleOnMouseEnterButton }
 					onMouseLeave={ this.handleOnMouseLeave }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DOTCOM-13261
Related to https://github.com/Automattic/wp-calypso/pull/103674

## Proposed Changes

* add `aria-label` for the `PremiumBadge` domain component used on the "Select Domain" step

![Markup on 2025-05-27 at 15:38:25](https://github.com/user-attachments/assets/ae86a524-06f7-4134-90f4-44dfe2982733)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* a55edfa4e3bf-linear-project

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start` (or use Calypso Live).
2. Head over to the Domain Select step at http://calypso.localhost:3000/start/domain/domain-only.
3. Enable VoiceOver.
4. Try to search for a **_premium_** domains and then tab through the page. Focus on the `Premium domain` badges and listen to the announcements.
5. The announced message should be clear and inform the user which domain it is related to.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?