### PR TITLE
Reader: Allow Jetpack paywall style attributes

### DIFF
--- a/client/lib/post-normalizer/rule-content-remove-styles.js
+++ b/client/lib/post-normalizer/rule-content-remove-styles.js
@@ -22,6 +22,8 @@ export default function removeContentStyles( post, dom ) {
 		'mark.has-inline-color, ' +
 		// Gallery
 		'.gallery, .gallery *, .gallery-row, .gallery-row *, .gallery-group, .gallery-group *, ' +
+		// Jetpack Paywall. These styles are coming from BE which keeps it consistent with the emails styles.
+		'.jetpack-paywall-simple *, ' +
 		// Instagram
 		'blockquote[class^="instagram-"], blockquote[class^="instagram-"] *, ' +
 		// Twitter

--- a/client/lib/post-normalizer/rule-content-remove-styles.js
+++ b/client/lib/post-normalizer/rule-content-remove-styles.js
@@ -22,8 +22,8 @@ export default function removeContentStyles( post, dom ) {
 		'mark.has-inline-color, ' +
 		// Gallery
 		'.gallery, .gallery *, .gallery-row, .gallery-row *, .gallery-group, .gallery-group *, ' +
-		// Jetpack Paywall. These styles are coming from BE which keeps it consistent with the emails styles.
-		'.jetpack-paywall-simple *, ' +
+		// Jetpack Paywall. These styles are coming from backend and we are keeping it so that it will be consistent with the email styles.
+		'.jetpack-paywall-simple, .jetpack-paywall-simple *, ' +
 		// Instagram
 		'blockquote[class^="instagram-"], blockquote[class^="instagram-"] *, ' +
 		// Twitter


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related: [CML-522](https://linear.app/a8c/issue/CML-522/reader-improve-layout-of-paywall-placeholder)

## Proposed Changes

Allow styles coming from Jetpack paywall blocks.

| Before | After |
| -------|------| 
| ![image](https://github.com/user-attachments/assets/e0b86dbe-afaf-46de-bb1d-1f88f2d82ae1) | ![image](https://github.com/user-attachments/assets/cd0b7d7d-f6b4-487d-839b-167304cad1c2) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To fix styling of Jetpack paywall.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply related Jetpack PR on sandbox (https://github.com/Automattic/jetpack/pull/43642).
- Use a normal subscriber account that doesn't have blog subscription (e.g. `266701797`).
- Visit `/reader/feeds/169371612/posts/5680625909`.
- Verify that the styling is fixed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
