### PR TITLE
Help Center: add external link icons for links opening in new tabs

### DIFF
--- a/packages/help-center/src/components/help-center-article.scss
+++ b/packages/help-center/src/components/help-center-article.scss
@@ -557,6 +557,26 @@
 						}
 					}
 				}
+
+				// External link icon styles
+				.help-center-external-link-icon {
+					display: inline-block;
+					color: var(--color-neutral-60);
+					font-size: 0.75em;
+					margin-left: 3px;
+					vertical-align: top;
+					line-height: 1;
+					text-decoration: none;
+				}
+
+				// Screen reader text for accessibility
+				.screen-reader-text {
+					clip: rect(1px, 1px, 1px, 1px);
+					position: absolute !important;
+					height: 1px;
+					width: 1px;
+					overflow: hidden;
+				}
 			}
 		}
 	}

--- a/packages/help-center/src/components/help-center-article.scss
+++ b/packages/help-center/src/components/help-center-article.scss
@@ -563,10 +563,8 @@
 			.help-center-external-link-icon {
 				color: currentColor;
 				fill: currentColor;
-				margin-left: 3px;
-				margin-right: 0;
-				top: 2px;
 				position: relative;
+				vertical-align: sub;
 			}
 
 			// Screen reader text for accessibility

--- a/packages/help-center/src/components/help-center-article.scss
+++ b/packages/help-center/src/components/help-center-article.scss
@@ -557,26 +557,24 @@
 						}
 					}
 				}
+			}
 
-				// External link icon styles
-				.help-center-external-link-icon {
-					display: inline-block;
-					color: var(--color-neutral-60);
-					font-size: 0.75em;
-					margin-left: 3px;
-					vertical-align: top;
-					line-height: 1;
-					text-decoration: none;
-				}
+			// External link icon styles
+			.help-center-external-link-icon {
+				color: currentColor;
+				margin-left: 3px;
+				margin-right: 0;
+				top: 2px;
+				position: relative;
+			}
 
-				// Screen reader text for accessibility
-				.screen-reader-text {
-					clip: rect(1px, 1px, 1px, 1px);
-					position: absolute !important;
-					height: 1px;
-					width: 1px;
-					overflow: hidden;
-				}
+			// Screen reader text for accessibility
+			.screen-reader-text {
+				clip: rect(1px, 1px, 1px, 1px);
+				position: absolute !important;
+				height: 1px;
+				width: 1px;
+				overflow: hidden;
 			}
 		}
 	}

--- a/packages/help-center/src/components/help-center-article.scss
+++ b/packages/help-center/src/components/help-center-article.scss
@@ -562,6 +562,7 @@
 			// External link icon styles
 			.help-center-external-link-icon {
 				color: currentColor;
+				fill: currentColor;
 				margin-left: 3px;
 				margin-right: 0;
 				top: 2px;

--- a/packages/help-center/src/hooks/use-content-filter.ts
+++ b/packages/help-center/src/hooks/use-content-filter.ts
@@ -112,8 +112,8 @@ export const useContentFilter = ( node: HTMLDivElement | null ) => {
 					// Create external link icon SVG
 					const icon = document.createElementNS( 'http://www.w3.org/2000/svg', 'svg' );
 					icon.setAttribute( 'class', 'help-center-external-link-icon' );
-					icon.setAttribute( 'width', '18' );
-					icon.setAttribute( 'height', '18' );
+					icon.setAttribute( 'width', '16' );
+					icon.setAttribute( 'height', '16' );
 					icon.setAttribute( 'viewBox', '0 0 24 24' );
 					icon.setAttribute( 'aria-hidden', 'true' );
 

--- a/packages/help-center/src/hooks/use-content-filter.ts
+++ b/packages/help-center/src/hooks/use-content-filter.ts
@@ -1,4 +1,5 @@
 import { useEffect, useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 
@@ -101,21 +102,32 @@ export const useContentFilter = ( node: HTMLDivElement | null ) => {
 			{
 				pattern: 'a[target="_blank"]',
 				action: ( element: HTMLAnchorElement ) => {
-					// Skip if already has an external icon
-					if ( element.querySelector( '.help-center-external-link-icon' ) ) {
+					const href = element.getAttribute( 'href' ) as string;
+
+					// Skip support articles
+					if ( href && isThisASupportArticleLink( href ) ) {
 						return;
 					}
 
-					// Create external link icon
-					const icon = document.createElement( 'span' );
-					icon.className = 'help-center-external-link-icon';
+					// Create external link icon SVG
+					const icon = document.createElementNS( 'http://www.w3.org/2000/svg', 'svg' );
+					icon.setAttribute( 'class', 'help-center-external-link-icon' );
+					icon.setAttribute( 'width', '18' );
+					icon.setAttribute( 'height', '18' );
+					icon.setAttribute( 'viewBox', '0 0 24 24' );
 					icon.setAttribute( 'aria-hidden', 'true' );
-					icon.innerHTML = '↗';
+
+					const path = document.createElementNS( 'http://www.w3.org/2000/svg', 'path' );
+					path.setAttribute(
+						'd',
+						'M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z'
+					);
+					icon.appendChild( path );
 
 					// Add screen reader text for accessibility
 					const srText = document.createElement( 'span' );
 					srText.className = 'screen-reader-text';
-					srText.textContent = ' (opens in a new tab)';
+					srText.textContent = ` (${ __( 'opens in a new tab', 'help-center' ) })`;
 
 					// Append icon and screen reader text to the link
 					element.appendChild( icon );

--- a/packages/help-center/src/hooks/use-content-filter.ts
+++ b/packages/help-center/src/hooks/use-content-filter.ts
@@ -95,6 +95,33 @@ export const useContentFilter = ( node: HTMLDivElement | null ) => {
 					}
 				},
 			},
+			/**
+			 * Add external link icons to links that open in new tabs.
+			 */
+			{
+				pattern: 'a[target="_blank"]',
+				action: ( element: HTMLAnchorElement ) => {
+					// Skip if already has an external icon
+					if ( element.querySelector( '.help-center-external-link-icon' ) ) {
+						return;
+					}
+
+					// Create external link icon
+					const icon = document.createElement( 'span' );
+					icon.className = 'help-center-external-link-icon';
+					icon.setAttribute( 'aria-hidden', 'true' );
+					icon.innerHTML = '↗';
+
+					// Add screen reader text for accessibility
+					const srText = document.createElement( 'span' );
+					srText.className = 'screen-reader-text';
+					srText.textContent = ' (opens in a new tab)';
+
+					// Append icon and screen reader text to the link
+					element.appendChild( icon );
+					element.appendChild( srText );
+				},
+			},
 		],
 		[ navigate, link, node ]
 	);


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-10695/help-center-articles-linkto-new-tab-should-include-an-external-link

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

  1. Added external link detection logic in packages/help-center/src/hooks/use-content-filter.ts that identifies links with target="_blank" and adds a visual icon
  (↗) and screen reader text
  2. Added CSS styles in packages/help-center/src/components/help-center-article.scss for the external link icon with proper spacing, color, and accessibility support

  - Automatically detects links that open in new tabs (target="_blank")
  - Adds a ↗ symbol next to these links
  - Includes screen reader text "(opens in a new tab)" for accessibility
  - Uses design system colors (--color-neutral-60)
  - Prevents duplicate icons on already-processed link

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Help Center and check an article for external links

