### PR TITLE
Skip domain step if launch-site triggered from wp-admin

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -1070,7 +1070,7 @@ function excludeDomainStep( stepName, tracksEventValue, submitSignupStep ) {
 	submitSignupStep( { stepName, domainItem }, { domainItem, domainCart } );
 	recordExcludeStepEvent( stepName, tracksEventValue );
 
-	fulfilledDependencies = [ 'domainItem', 'domainCart' ];
+	fulfilledDependencies = [ 'domainItem', 'domainCart', 'siteId', 'siteSlug', 'themeItem' ];
 
 	if ( shouldExcludeStep( stepName, fulfilledDependencies ) ) {
 		flows.excludeStep( stepName );

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -1065,11 +1065,12 @@ function shouldExcludeStep( stepName, fulfilledDependencies ) {
 function excludeDomainStep( stepName, tracksEventValue, submitSignupStep ) {
 	let fulfilledDependencies = [];
 	const domainItem = undefined;
+	const domainCart = undefined;
 
-	submitSignupStep( { stepName, domainItem }, { domainItem } );
+	submitSignupStep( { stepName, domainItem }, { domainItem, domainCart } );
 	recordExcludeStepEvent( stepName, tracksEventValue );
 
-	fulfilledDependencies = [ 'domainItem', 'siteId', 'siteSlug', 'themeItem' ];
+	fulfilledDependencies = [ 'domainItem', 'domainCart' ];
 
 	if ( shouldExcludeStep( stepName, fulfilledDependencies ) ) {
 		flows.excludeStep( stepName );

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -119,17 +119,21 @@ describe( 'createSiteWithCart()', () => {
 
 describe( 'isDomainFulfilled', () => {
 	const submitSignupStep = jest.fn();
-	const oneDomain = [ { domain: 'example.wordpress.com' } ];
-	const twoDomains = [ { domain: 'example.wordpress.com' }, { domain: 'example.com' } ];
+	const wpcomDomain = [ { domain: 'example.wordpress.com', isWPCOMDomain: true } ];
+	const customDomain = { domain: 'example.com', isWPCOMDomain: false };
+	const wpcomAndCustomDomains = [
+		{ domain: 'example.wordpress.com', isWPCOMDomain: true },
+		customDomain,
+	];
 
 	beforeEach( () => {
 		flows.excludeStep.mockClear();
 		submitSignupStep.mockClear();
 	} );
 
-	test( 'should call `submitSignupStep` with empty domainItem', () => {
+	test( 'should call `submitSignupStep` with empty domainItem when site has custom domains', () => {
 		const stepName = 'domains-launch';
-		const nextProps = { siteDomains: twoDomains, submitSignupStep };
+		const nextProps = { siteDomains: wpcomAndCustomDomains, submitSignupStep };
 
 		expect( submitSignupStep ).not.toHaveBeenCalled();
 
@@ -141,9 +145,9 @@ describe( 'isDomainFulfilled', () => {
 		);
 	} );
 
-	test( 'should call `flows.excludeStep` with the stepName', () => {
+	test( 'should call `flows.excludeStep` with the stepName when site has custom domains', () => {
 		const stepName = 'domains-launch';
-		const nextProps = { siteDomains: twoDomains, submitSignupStep };
+		const nextProps = { siteDomains: wpcomAndCustomDomains, submitSignupStep };
 
 		expect( flows.excludeStep ).not.toHaveBeenCalled();
 
@@ -152,9 +156,35 @@ describe( 'isDomainFulfilled', () => {
 		expect( flows.excludeStep ).toHaveBeenCalledWith( stepName );
 	} );
 
-	test( 'should not remove unfulfilled step', () => {
+	test( 'should not remove step when site only has WordPress.com domains', () => {
 		const stepName = 'domains-launch';
-		const nextProps = { siteDomains: oneDomain, submitSignupStep };
+		const nextProps = { siteDomains: wpcomDomain, submitSignupStep };
+
+		expect( flows.excludeStep ).not.toHaveBeenCalled();
+		expect( submitSignupStep ).not.toHaveBeenCalled();
+
+		isDomainFulfilled( stepName, undefined, nextProps );
+
+		expect( submitSignupStep ).not.toHaveBeenCalled();
+		expect( flows.excludeStep ).not.toHaveBeenCalled();
+	} );
+
+	test( 'should not remove step when domains are still loading (siteId exists but no siteDomains)', () => {
+		const stepName = 'domains-launch';
+		const nextProps = { siteId: 123, siteDomains: [], submitSignupStep };
+
+		expect( flows.excludeStep ).not.toHaveBeenCalled();
+		expect( submitSignupStep ).not.toHaveBeenCalled();
+
+		isDomainFulfilled( stepName, undefined, nextProps );
+
+		expect( submitSignupStep ).not.toHaveBeenCalled();
+		expect( flows.excludeStep ).not.toHaveBeenCalled();
+	} );
+
+	test( 'should not remove step when domains are still loading (siteId exists but siteDomains is undefined)', () => {
+		const stepName = 'domains-launch';
+		const nextProps = { siteId: 123, siteDomains: undefined, submitSignupStep };
 
 		expect( flows.excludeStep ).not.toHaveBeenCalled();
 		expect( submitSignupStep ).not.toHaveBeenCalled();

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -32,13 +32,19 @@ function getCheckoutUrl( dependencies, localeSlug, flowName, destination ) {
 		? destination
 		: pathToUrl( isDomainOnly ? `/start/${ flowName }/domain-only` : destination );
 
+	// Add celebrateLaunch=true for launch-site flow so the celebration modal shows after checkout
+	const isLaunchSiteFlow = flowName === 'launch-site';
+	const finalCheckoutBackUrl = isLaunchSiteFlow
+		? addQueryArgs( { skippedCheckout: 1, celebrateLaunch: 'true' }, checkoutBackUrl )
+		: addQueryArgs( { skippedCheckout: 1 }, checkoutBackUrl );
+
 	return addQueryArgs(
 		{
 			signup: 1,
 			ref: getQueryArgs()?.ref,
 			...( dependencies.coupon && { coupon: dependencies.coupon } ),
 			...( isDomainOnly && { isDomainOnly: 1 } ),
-			checkoutBackUrl: addQueryArgs( { skippedCheckout: 1 }, checkoutBackUrl ),
+			checkoutBackUrl: finalCheckoutBackUrl,
 		},
 		checkoutURL
 	);

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -90,7 +90,7 @@ function getSignupDestination( { domainItem, siteId, siteSlug, refParameter } ) 
 }
 
 function getLaunchDestination( dependencies ) {
-	return `/home/${ dependencies.siteSlug }`;
+	return addQueryArgs( { celebrateLaunch: 'true' }, `/home/${ dependencies.siteSlug }` );
 }
 
 function getDomainSignupFlowDestination( { domainItem, cartItem, siteId, designType, siteSlug } ) {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -240,7 +240,8 @@ class Signup extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { flowName, stepName, sitePlanName, sitePlanSlug, signupDependencies } = this.props;
+		const { flowName, stepName, sitePlanName, sitePlanSlug, signupDependencies, siteDomains } =
+			this.props;
 
 		if (
 			( flowName !== prevProps.flowName || stepName !== prevProps.stepName ) &&
@@ -277,6 +278,12 @@ class Signup extends Component {
 			signupDependencies.domainItem !== prevProps.signupDependencies.domainItem
 		) {
 			clearDomainsDependencies();
+		}
+
+		// Re-check fulfilled steps when siteDomains data changes
+		// This ensures that isDomainFulfilled is called again when domain data loads
+		if ( siteDomains !== prevProps.siteDomains ) {
+			this.removeFulfilledSteps( this.props );
 		}
 	}
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -282,7 +282,7 @@ class Signup extends Component {
 
 		// Re-check fulfilled steps when siteDomains data changes
 		// This ensures that isDomainFulfilled is called again when domain data loads
-		if ( siteDomains !== prevProps.siteDomains ) {
+		if ( flowName === 'launch-site' && siteDomains !== prevProps.siteDomains ) {
 			this.removeFulfilledSteps( this.props );
 		}
 	}

--- a/client/signup/test/flows.js
+++ b/client/signup/test/flows.js
@@ -54,4 +54,60 @@ describe( 'Signup Flows Configuration', () => {
 			expect( destination ).toBe( '/home/test-site?celebrateLaunch=true' );
 		} );
 	} );
+
+	describe( 'filterDestination with checkout URLs', () => {
+		// Mock the required modules
+		beforeAll( () => {
+			// Mock getQueryArgs to return empty object
+			jest.doMock( 'calypso/lib/query-args', () => ( {
+				getQueryArgs: () => ( {} ),
+			} ) );
+
+			// Mock pathToUrl to return the path as-is
+			jest.doMock( 'calypso/lib/url', () => ( {
+				addQueryArgs: jest.requireActual( 'calypso/lib/url' ).addQueryArgs,
+				pathToUrl: ( path ) => `https://wordpress.com${ path }`,
+			} ) );
+		} );
+
+		test( 'should add celebrateLaunch=true to checkout back URL when flow is launch-site', () => {
+			// Import the actual filterDestination function
+			const flowsModule = require( 'calypso/signup/config/flows' );
+			const { filterDestination } = flowsModule.default;
+
+			const dependencies = {
+				siteSlug: 'test-site',
+				cartItem: 'premium_plan', // This will trigger checkout redirect
+			};
+			const destination = '/home/test-site';
+			const flowName = 'launch-site';
+			const localeSlug = 'en';
+
+			const result = filterDestination( destination, dependencies, flowName, localeSlug );
+
+			// The result should be a checkout URL with celebrateLaunch in the checkoutBackUrl
+			expect( result ).toContain( '/checkout/test-site' );
+			expect( result ).toContain( 'checkoutBackUrl=' );
+			expect( result ).toContain( 'celebrateLaunch%3Dtrue' ); // URL encoded celebrateLaunch=true
+		} );
+
+		test( 'should not add celebrateLaunch=true to non-launch-site flows', () => {
+			const flowsModule = require( 'calypso/signup/config/flows' );
+			const { filterDestination } = flowsModule.default;
+
+			const dependencies = {
+				siteSlug: 'test-site',
+				cartItem: 'premium_plan',
+			};
+			const destination = '/home/test-site';
+			const flowName = 'onboarding';
+			const localeSlug = 'en';
+
+			const result = filterDestination( destination, dependencies, flowName, localeSlug );
+
+			expect( result ).toContain( '/checkout/test-site' );
+			expect( result ).toContain( 'checkoutBackUrl=' );
+			expect( result ).not.toContain( 'celebrateLaunch%3Dtrue' );
+		} );
+	} );
 } );

--- a/client/signup/test/flows.js
+++ b/client/signup/test/flows.js
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import flows from 'calypso/signup/config/flows';
+import { generateFlows } from 'calypso/signup/config/flows-pure';
 import mockedFlows from './fixtures/flows';
 
 describe( 'Signup Flows Configuration', () => {
@@ -31,6 +32,26 @@ describe( 'Signup Flows Configuration', () => {
 		test( 'should exclude site step from getFlow', () => {
 			flows.excludeStep( 'site' );
 			expect( flows.getFlow( 'main', false ).steps ).toEqual( [ 'user' ] );
+		} );
+	} );
+
+	describe( 'getLaunchDestination', () => {
+		test( 'should add celebrateLaunch=true query parameter to the destination URL', () => {
+			const mockGetLaunchDestination = jest.fn( ( dependencies ) => {
+				// Import the actual function from flows.js
+				const { addQueryArgs } = require( 'calypso/lib/url' );
+				return addQueryArgs( { celebrateLaunch: 'true' }, `/home/${ dependencies.siteSlug }` );
+			} );
+
+			const testFlows = generateFlows( {
+				getLaunchDestination: mockGetLaunchDestination,
+			} );
+
+			const launchSiteFlow = testFlows[ 'launch-site' ];
+			const dependencies = { siteSlug: 'test-site' };
+			const destination = launchSiteFlow.destination( dependencies );
+
+			expect( destination ).toBe( '/home/test-site?celebrateLaunch=true' );
 		} );
 	} );
 } );


### PR DESCRIPTION

Part of DOTCOM-13180

## Proposed Changes

* wp-admin links to start/launch-site for unlaunched sites
* When a site already has a domain, we should skip the domain step
* When a site completes the flow with or without a purchase of some kind, we should display a message that the site was launched

## Why are these changes being made?

* wp-admin triggered launch-site doesn't match the one from Calypso

## Testing Instructions

1. Unlaunching a site requires a sandbox - use your site instead of dzver13d
```
wp option --url=dzver13d.wordpress.com set launch-status unlaunched
```
2. Enable the store sandbox
3. Get a plan AND domain
4. Go to wp-admin > Settings > Reading and click the button.
5. Change the wordpress.com address with calypso.localhost:3000
6. Complete the flow, domain step should be skipped, modal should be displayed
7. Get a domain but make sure you're on FREE
8. Repeat steps 4-6, this time you'll be asked to get a plan. No matter which plan you select, completing the flow should display the celebratory modal
9. You can try the case with plan but no domain just in case

These are the launch buttons in the settings page, they are two and do the same:
<img width="818" alt="Screenshot 2025-05-27 at 17 21 13" src="https://github.com/user-attachments/assets/df343028-fa39-4d2b-b8d6-e67b554d0491" />

This is the modal that's currently only displayed if we launch from Calypso:
<img width="1397" alt="Screenshot 2025-05-27 at 16 00 07" src="https://github.com/user-attachments/assets/9f34124e-7434-4818-967a-386e8610787a" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
