### PR TITLE
Revert "Accessibility: Fix issues with the "Select domain" step buttons and domain name labels"

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -299,17 +299,17 @@ class DomainRegistrationSuggestion extends Component {
 		return (
 			<div className={ wrapperClassName }>
 				<div className={ titleWrapperClassName }>
-					<div className="domain-registration-suggestion__title">
+					<h3 className="domain-registration-suggestion__title">
 						<div className="domain-registration-suggestion__domain-title">
-							<h3 aria-label={ domain }>
+							<span aria-label={ domain }>
 								<span className="domain-registration-suggestion__domain-title-name">
 									{ this.getFormattedDomainName( name ) }
 								</span>
 								<span className="domain-registration-suggestion__domain-title-tld">{ tld }</span>
-							</h3>
+							</span>
 							{ ( showHstsNotice || showDotGayNotice ) && this.renderInfoBubble() }
 						</div>
-					</div>
+					</h3>
 				</div>
 			</div>
 		);

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -1,6 +1,5 @@
 import { Button, Gridicon } from '@automattic/components';
 import clsx from 'clsx';
-import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import DomainProductPrice from 'calypso/components/domains/domain-product-price';
@@ -26,65 +25,6 @@ class DomainSuggestion extends Component {
 	static defaultProps = {
 		showChevron: false,
 	};
-
-	getAccessibleButtonLabel() {
-		const { buttonContent, domain, translate, price, salePrice, priceRule } = this.props;
-		let actionText = '';
-
-		if ( typeof buttonContent === 'string' ) {
-			actionText = buttonContent;
-		} else if ( typeof buttonContent?.props?.children === 'string' ) {
-			actionText = buttonContent.props.children;
-		} else if ( Array.isArray( buttonContent?.props?.children ) ) {
-			actionText = buttonContent.props.children.reduce( ( acc, item ) => {
-				return typeof item === 'string' ? acc + item : acc;
-			}, '' );
-		}
-
-		const baseLabel = translate( '%(action)s domain %(domain)s', {
-			args: {
-				action: actionText,
-				domain,
-			},
-			comment:
-				'Accessible label for domain selection button. %(action)s is the button action (Select, Selected, Upgrade, etc), %(domain)s is the domain name',
-		} );
-
-		if ( ( priceRule === 'FREE_DOMAIN' || priceRule === 'FREE_WITH_PLAN' ) && price ) {
-			return translate(
-				'%(baseLabel)s. Free for the first year with annual paid plans, then %(price)s per year',
-				{
-					args: {
-						baseLabel,
-						price,
-					},
-					comment: 'Accessible label for free domain with normal price',
-				}
-			);
-		} else if ( salePrice && price ) {
-			return translate(
-				'%(baseLabel)s. %(salePrice)s for the first year, then %(price)s per year',
-				{
-					args: {
-						baseLabel,
-						salePrice,
-						price,
-					},
-					comment: 'Accessible label for domain with sale price',
-				}
-			);
-		} else if ( price ) {
-			return translate( '%(baseLabel)s. %(price)s per year', {
-				args: {
-					baseLabel,
-					price,
-				},
-				comment: 'Accessible label for regularly priced domain',
-			} );
-		}
-
-		return baseLabel;
-	}
 
 	renderPrice() {
 		const {
@@ -156,7 +96,6 @@ class DomainSuggestion extends Component {
 								this.props.onButtonClick( isAdded );
 							} }
 							data-tracks-button-click-source={ this.props.tracksButtonClickSource }
-							aria-label={ this.getAccessibleButtonLabel() }
 							{ ...this.props.buttonStyles }
 						>
 							{ this.props.buttonContent }
@@ -172,7 +111,7 @@ class DomainSuggestion extends Component {
 	}
 }
 
-function DomainSuggestionPlaceholder() {
+DomainSuggestion.Placeholder = function () {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<div className="domain-suggestion card is-compact is-placeholder is-clickable">
@@ -184,12 +123,6 @@ function DomainSuggestionPlaceholder() {
 		</div>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
-}
+};
 
-DomainSuggestionPlaceholder.displayName = 'DomainSuggestionPlaceholder';
-DomainSuggestion.Placeholder = DomainSuggestionPlaceholder;
-
-const LocalizedDomainSuggestion = localize( DomainSuggestion );
-LocalizedDomainSuggestion.Placeholder = DomainSuggestionPlaceholder;
-
-export default LocalizedDomainSuggestion;
+export default DomainSuggestion;

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -124,5 +124,6 @@ DomainSuggestion.Placeholder = function () {
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 };
+DomainSuggestion.Placeholder.displayName = 'DomainSuggestion.Placeholder';
 
 export default DomainSuggestion;


### PR DESCRIPTION
Reverts Automattic/wp-calypso#103674 which is likely causing pre-release tests to fail