### PR TITLE
Accessibility: Fix issues with the "Select domain" step buttons and domain name labels (with fixed test)

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -299,17 +299,17 @@ class DomainRegistrationSuggestion extends Component {
 		return (
 			<div className={ wrapperClassName }>
 				<div className={ titleWrapperClassName }>
-					<h3 className="domain-registration-suggestion__title">
+					<div className="domain-registration-suggestion__title">
 						<div className="domain-registration-suggestion__domain-title">
-							<span aria-label={ domain }>
+							<h3 aria-label={ domain }>
 								<span className="domain-registration-suggestion__domain-title-name">
 									{ this.getFormattedDomainName( name ) }
 								</span>
 								<span className="domain-registration-suggestion__domain-title-tld">{ tld }</span>
-							</span>
+							</h3>
 							{ ( showHstsNotice || showDotGayNotice ) && this.renderInfoBubble() }
 						</div>
-					</h3>
+					</div>
 				</div>
 			</div>
 		);

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -1,5 +1,6 @@
 import { Button, Gridicon } from '@automattic/components';
 import clsx from 'clsx';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import DomainProductPrice from 'calypso/components/domains/domain-product-price';
@@ -25,6 +26,65 @@ class DomainSuggestion extends Component {
 	static defaultProps = {
 		showChevron: false,
 	};
+
+	getAccessibleButtonLabel() {
+		const { buttonContent, domain, translate, price, salePrice, priceRule } = this.props;
+		let actionText = '';
+
+		if ( typeof buttonContent === 'string' ) {
+			actionText = buttonContent;
+		} else if ( typeof buttonContent?.props?.children === 'string' ) {
+			actionText = buttonContent.props.children;
+		} else if ( Array.isArray( buttonContent?.props?.children ) ) {
+			actionText = buttonContent.props.children.reduce( ( acc, item ) => {
+				return typeof item === 'string' ? acc + item : acc;
+			}, '' );
+		}
+
+		const baseLabel = translate( '%(action)s domain %(domain)s', {
+			args: {
+				action: actionText,
+				domain,
+			},
+			comment:
+				'Accessible label for domain selection button. %(action)s is the button action (Select, Selected, Upgrade, etc), %(domain)s is the domain name',
+		} );
+
+		if ( ( priceRule === 'FREE_DOMAIN' || priceRule === 'FREE_WITH_PLAN' ) && price ) {
+			return translate(
+				'%(baseLabel)s. Free for the first year with annual paid plans, then %(price)s per year',
+				{
+					args: {
+						baseLabel,
+						price,
+					},
+					comment: 'Accessible label for free domain with normal price',
+				}
+			);
+		} else if ( salePrice && price ) {
+			return translate(
+				'%(baseLabel)s. %(salePrice)s for the first year, then %(price)s per year',
+				{
+					args: {
+						baseLabel,
+						salePrice,
+						price,
+					},
+					comment: 'Accessible label for domain with sale price',
+				}
+			);
+		} else if ( price ) {
+			return translate( '%(baseLabel)s. %(price)s per year', {
+				args: {
+					baseLabel,
+					price,
+				},
+				comment: 'Accessible label for regularly priced domain',
+			} );
+		}
+
+		return baseLabel;
+	}
 
 	renderPrice() {
 		const {
@@ -96,6 +156,7 @@ class DomainSuggestion extends Component {
 								this.props.onButtonClick( isAdded );
 							} }
 							data-tracks-button-click-source={ this.props.tracksButtonClickSource }
+							aria-label={ this.getAccessibleButtonLabel() }
 							{ ...this.props.buttonStyles }
 						>
 							{ this.props.buttonContent }
@@ -111,7 +172,7 @@ class DomainSuggestion extends Component {
 	}
 }
 
-DomainSuggestion.Placeholder = function () {
+function DomainSuggestionPlaceholder() {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<div className="domain-suggestion card is-compact is-placeholder is-clickable">
@@ -123,7 +184,12 @@ DomainSuggestion.Placeholder = function () {
 		</div>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
-};
-DomainSuggestion.Placeholder.displayName = 'DomainSuggestion.Placeholder';
+}
 
-export default DomainSuggestion;
+DomainSuggestionPlaceholder.displayName = 'DomainSuggestionPlaceholder';
+DomainSuggestion.Placeholder = DomainSuggestionPlaceholder;
+
+const LocalizedDomainSuggestion = localize( DomainSuggestion );
+LocalizedDomainSuggestion.Placeholder = DomainSuggestionPlaceholder;
+
+export default LocalizedDomainSuggestion;

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -41,6 +41,10 @@ class DomainSuggestion extends Component {
 			}, '' );
 		}
 
+		if ( ! domain ) {
+			return actionText;
+		}
+
 		const baseLabel = translate( '%(action)s domain %(domain)s', {
 			args: {
 				action: actionText,

--- a/packages/calypso-e2e/src/lib/components/domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/domain-search-component.ts
@@ -83,7 +83,7 @@ export class DomainSearchComponent {
 		const target = targetRow.getByRole( 'button' );
 		await target.waitFor();
 
-		const selectedDomain = await targetRow.getByLabel( keyword ).getAttribute( 'aria-label' );
+		const selectedDomain = await targetRow.getByRole( 'heading' ).textContent();
 
 		if ( ! selectedDomain ) {
 			throw new Error( `No domain found for keyword: ${ keyword }` );

--- a/packages/calypso-e2e/src/lib/components/domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/domain-search-component.ts
@@ -83,7 +83,7 @@ export class DomainSearchComponent {
 		const target = targetRow.getByRole( 'button' );
 		await target.waitFor();
 
-		const selectedDomain = await targetRow.getByRole( 'heading' ).textContent();
+		const selectedDomain = await targetRow.getByRole( 'heading' ).getAttribute( 'aria-label' );
 
 		if ( ! selectedDomain ) {
 			throw new Error( `No domain found for keyword: ${ keyword }` );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

> [!NOTE]
>  This is a follow-up to the https://github.com/Automattic/wp-calypso/pull/103674 PR that had to be reverted due to failing pre-release E2E tests. Apart from the original changes, this PR also fixes the broken E2E test in `packages/calypso-e2e/src/lib/components/domain-search-component.ts` and ensures the aria-label for `Skip Purchase` button is correct (https://github.com/Automattic/wp-calypso/pull/103751/commits/e7a9473959b0c423e6cf7c9d6c51de1bcf3ddb18).

Resolves DOTCOM-13261
Related to https://github.com/Automattic/wp-calypso/pull/103674

## Proposed Changes

* ensure the domain name is read correctly together with "heading level 3"
* add accessible label for the `Select` button on the "Select Domain" step

![Markup on 2025-05-27 at 15:48:05](https://github.com/user-attachments/assets/e388de18-cf17-422b-ae40-612c17318707)

Each button will now read its action (e.g. `Select` / `Selected`), domain and price information, including sale.

I haven't included the badges like `Recommended` or `Best Alternative` as it made the whole read text quite long. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* a55edfa4e3bf-linear-project

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start` or use Calypso Live.
2. Head over to the Domain Select step at http://calypso.localhost:3000/start/domain/domain-only.
3. Enabled VoiceOver.
4. Try to search for a domain and then tab through the page. Focus on the `Select` buttons and listen to the announcements.
5. Try to select the domain by pressing `Control` + `Option` + `Space`. The announcement should be read again, but now with updated action, i.e.: `Select` → `Selected`.
6. Try to cycle through the elements on each domain card with <kbd>ctrl</kbd>+<kbd>option</kbd>+<kbd>→</kbd> or <kbd>ctrl</kbd>+<kbd>option</kbd>+<kbd>←</kbd>. The domain name should be read as well, not just "heading level 3". 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?