### PR TITLE
Stats: Clean up the Navigation Improvement feature flag

### DIFF
--- a/client/my-sites/google-my-business/stats/index.js
+++ b/client/my-sites/google-my-business/stats/index.js
@@ -1,6 +1,4 @@
-import config from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { CALYPSO_CONTACT } from '@automattic/urls';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
@@ -8,13 +6,11 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
-import { navItems } from 'calypso/blocks/stats-navigation/constants';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
 import QueryKeyringServices from 'calypso/components/data/query-keyring-services';
 import QuerySiteKeyrings from 'calypso/components/data/query-site-keyrings';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -196,7 +192,6 @@ class GoogleMyBusinessStats extends Component {
 
 	render() {
 		const { isLocationVerified, locationData, siteId, siteSlug, translate } = this.props;
-		const isStatsNavigationImprovementEnabled = config.isEnabled( 'stats/navigation-improvement' );
 
 		return (
 			<Main fullWidthLayout>
@@ -212,32 +207,7 @@ class GoogleMyBusinessStats extends Component {
 				<QueryKeyringServices />
 
 				<div className="stats">
-					{ ! isStatsNavigationImprovementEnabled ? (
-						<NavigationHeader
-							className="stats__section-header modernized-header"
-							title={ translate( 'Jetpack Stats' ) }
-							subtitle={ translate(
-								'Integrate your business with Google and get stats on your locations. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
-								{
-									components: {
-										learnMoreLink: (
-											<a
-												href={ localizeUrl(
-													'https://wordpress.com/support/google-my-business-integration/#checking-the-impact-of-your-google-my-business-connection'
-												) }
-												target="_blank"
-												rel="noreferrer noopener"
-											/>
-										),
-									},
-								}
-							) }
-							screenReader={ navItems.googleMyBusiness?.label }
-						></NavigationHeader>
-					) : (
-						<PageHeader />
-					) }
-
+					<PageHeader />
 					<StatsNavigation selectedItem="googleMyBusiness" siteId={ siteId } slug={ siteSlug } />
 
 					{ ! locationData && (

--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { StatsCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
@@ -20,7 +19,6 @@ import UTMBuilder from '../../../stats-module-utm-builder';
 import { StatsEmptyActionUTMBuilder } from '../shared';
 import StatsCardSkeleton from '../shared/stats-card-skeleton';
 import UTMDropdown from './stats-module-utm-dropdown';
-import UTMExportButton from './utm-export-button';
 import '../../../stats-module/style.scss';
 import '../../../stats-list/style.scss';
 
@@ -53,7 +51,6 @@ const StatsModuleUTM = ( {
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const isStatsNavigationImprovementEnabled = config.isEnabled( 'stats/navigation-improvement' );
 	const [ selectedOption, setSelectedOption ] = useState( () => {
 		const utmQueryParam = context.query[ UTM_QUERY_PARAM ];
 		return Object.values( OPTION_KEYS ).includes( utmQueryParam )
@@ -238,11 +235,6 @@ const StatsModuleUTM = ( {
 						titleNodes={ titleNodes }
 						emptyMessage={ <div>{ moduleStrings.empty }</div> }
 						metricLabel={ metricLabel }
-						downloadCsv={
-							! isStatsNavigationImprovementEnabled ? (
-								<UTMExportButton data={ data } path={ path } period={ period } />
-							) : null
-						}
 						showMore={
 							displaySummaryLink && ! summary
 								? {

--- a/client/my-sites/stats/pages/insights/index.jsx
+++ b/client/my-sites/stats/pages/insights/index.jsx
@@ -1,13 +1,10 @@
 import config from '@automattic/calypso-config';
 import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
-import { navItems } from 'calypso/blocks/stats-navigation/constants';
 import DocumentHead from 'calypso/components/data/document-head';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
-import NavigationHeader from 'calypso/components/navigation-header';
 import PageHeader from 'calypso/my-sites/stats/components/headers/page-header';
 import Main from 'calypso/my-sites/stats/components/stats-main';
 import { STATS_FEATURE_PAGE_INSIGHTS, STATS_PRODUCT_NAME } from 'calypso/my-sites/stats/constants';
@@ -34,7 +31,6 @@ function StatsInsights( { context } ) {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state, siteId ) );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
-	const translate = useTranslate();
 	const moduleStrings = statsStrings();
 	const { isPending, data: usageInfo } = usePlanUsageQuery( siteId );
 	const reduxDispatch = useDispatch();
@@ -52,7 +48,6 @@ function StatsInsights( { context } ) {
 
 	const shouldGateInsights = useShouldGateStats( STATS_FEATURE_PAGE_INSIGHTS );
 	const shouldRendeUpsell = config.isEnabled( 'stats/paid-wpcom-v3' ) && shouldGateInsights;
-	const isStatsNavigationImprovementEnabled = config.isEnabled( 'stats/navigation-improvement' );
 
 	useEffect(
 		() =>
@@ -83,17 +78,7 @@ function StatsInsights( { context } ) {
 			<DocumentHead title={ STATS_PRODUCT_NAME } />
 			<PageViewTracker path="/stats/insights/:site" title="Stats > Insights" />
 			<div className={ insightsPageClasses }>
-				{ ! isStatsNavigationImprovementEnabled ? (
-					<NavigationHeader
-						className="stats__section-header modernized-header"
-						title={ STATS_PRODUCT_NAME }
-						subtitle={ translate( "View your site's performance and learn from trends." ) }
-						screenReader={ navItems.insights?.label }
-						navigationItems={ [] }
-					></NavigationHeader>
-				) : (
-					<PageHeader />
-				) }
+				<PageHeader />
 				<StatsNavigation selectedItem="insights" siteId={ siteId } slug={ siteSlug } />
 				{ shouldRendeUpsell ? (
 					<div id="my-stats-content" className="stats-content">

--- a/client/my-sites/stats/pages/purchase/index.tsx
+++ b/client/my-sites/stats/pages/purchase/index.tsx
@@ -196,7 +196,6 @@ const StatsPurchasePage = ( {
 							siteId={ siteId }
 							slug={ siteSlug }
 							showLock
-							hideModuleSettings
 						/>
 					</>
 				) }

--- a/client/my-sites/stats/pages/realtime/index.jsx
+++ b/client/my-sites/stats/pages/realtime/index.jsx
@@ -1,14 +1,10 @@
-import config from '@automattic/calypso-config';
 import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
-import { navItems } from 'calypso/blocks/stats-navigation/constants';
 import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
-import NavigationHeader from 'calypso/components/navigation-header';
 import PageHeader from 'calypso/my-sites/stats/components/headers/page-header';
 import Main from 'calypso/my-sites/stats/components/stats-main';
 import { STATS_PRODUCT_NAME } from 'calypso/my-sites/stats/constants';
@@ -46,9 +42,7 @@ function StatsRealtime( { context } ) {
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state, siteId ) );
 	const momentSiteZone = useSelector( ( state ) => getMomentSiteZone( state, siteId ) );
 	const dispatch = useDispatch();
-	const translate = useTranslate();
 	const moduleStrings = statsStrings();
-	const isStatsNavigationImprovementEnabled = config.isEnabled( 'stats/navigation-improvement' );
 
 	const halfWidthModuleClasses = clsx(
 		'stats__flexible-grid-item--half',
@@ -120,17 +114,7 @@ function StatsRealtime( { context } ) {
 			<DocumentHead title={ STATS_PRODUCT_NAME } />
 			<PageViewTracker path="/stats/realtime/:site" title="Stats > Realtime" />
 			<div className="stats">
-				{ ! isStatsNavigationImprovementEnabled ? (
-					<NavigationHeader
-						className="stats__section-header modernized-header"
-						title={ STATS_PRODUCT_NAME }
-						subtitle={ translate( "[Experimental] View your site's traffic in real-time." ) }
-						screenReader={ navItems.realtime?.label }
-						navigationItems={ [] }
-					></NavigationHeader>
-				) : (
-					<PageHeader />
-				) }
+				<PageHeader />
 				<StatsNavigation selectedItem="realtime" siteId={ siteId } slug={ siteSlug } />
 				<StatsRealtimeHeader />
 				<AsyncLoad

--- a/client/my-sites/stats/pages/subscribers/index.tsx
+++ b/client/my-sites/stats/pages/subscribers/index.tsx
@@ -4,10 +4,8 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
-import { navItems } from 'calypso/blocks/stats-navigation/constants';
 import DocumentHead from 'calypso/components/data/document-head';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
-import NavigationHeader from 'calypso/components/navigation-header';
 import PageHeader from 'calypso/my-sites/stats/components/headers/page-header';
 import Main from 'calypso/my-sites/stats/components/stats-main';
 import { STATS_PRODUCT_NAME } from 'calypso/my-sites/stats/constants';
@@ -72,7 +70,6 @@ type TranslationStringType = {
 };
 
 const StatsSubscribersPage = ( { period, context }: StatsSubscribersPageProps ) => {
-	const translate = useTranslate();
 	// Use hooks for Redux pulls.
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
@@ -81,7 +78,6 @@ const StatsSubscribersPage = ( { period, context }: StatsSubscribersPageProps ) 
 	);
 	const today = new Date().toISOString().slice( 0, 10 );
 	const moduleStrings = statsStrings().emails as TranslationStringType;
-	const isStatsNavigationImprovementEnabled = config.isEnabled( 'stats/navigation-improvement' );
 
 	const className = clsx( 'subscribers-page', {
 		'is-email-stats-unavailable': ! supportsEmailStats,
@@ -143,17 +139,7 @@ const StatsSubscribersPage = ( { period, context }: StatsSubscribersPageProps ) 
 			<DocumentHead title={ STATS_PRODUCT_NAME } />
 			<PageViewTracker path="/stats/subscribers/:site" title="Stats > Subscribers" />
 			<div className={ subscribersPageClasses }>
-				{ ! isStatsNavigationImprovementEnabled ? (
-					<NavigationHeader
-						className="stats__section-header modernized-header"
-						title={ STATS_PRODUCT_NAME }
-						subtitle={ translate( 'Track your subscriber growth and engagement.' ) }
-						screenReader={ navItems.subscribers?.label }
-						navigationItems={ [] }
-					></NavigationHeader>
-				) : (
-					<PageHeader />
-				) }
+				<PageHeader />
 				<StatsNavigation selectedItem="subscribers" siteId={ siteId } slug={ siteSlug } />
 				{ isLoading && <StatsModulePlaceholder className="is-subscriber-page" isLoading /> }
 				{ isError && <StatsSubscribersPageError /> }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -11,7 +11,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import titlecase from 'to-title-case';
 import JetpackBackupCredsBanner from 'calypso/blocks/jetpack-backup-creds-banner';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
-import { AVAILABLE_PAGE_MODULES, navItems } from 'calypso/blocks/stats-navigation/constants';
+import { AVAILABLE_PAGE_MODULES } from 'calypso/blocks/stats-navigation/constants';
 import PageModuleToggler, {
 	getAvailablePageModules,
 } from 'calypso/blocks/stats-navigation/page-module-toggler';
@@ -22,9 +22,7 @@ import QueryKeyringConnections from 'calypso/components/data/query-keyring-conne
 import QuerySiteKeyrings from 'calypso/components/data/query-site-keyrings';
 import { useShortcuts } from 'calypso/components/date-range/use-shortcuts';
 import EmptyContent from 'calypso/components/empty-content';
-import InlineSupportLink from 'calypso/components/inline-support-link';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
-import NavigationHeader from 'calypso/components/navigation-header';
 import StickyPanel from 'calypso/components/sticky-panel';
 import version_compare from 'calypso/lib/version-compare';
 import Main from 'calypso/my-sites/stats/components/stats-main';
@@ -180,7 +178,6 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 	const isWPAdmin = config.isEnabled( 'is_odyssey' );
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
 	const isSitePrivate = useSelector( ( state ) => isPrivateSite( state, siteId ) );
-	const isStatsNavigationImprovementEnabled = config.isEnabled( 'stats/navigation-improvement' );
 	const slug = useSelector( getSelectedSiteSlug );
 	const moduleToggles = useSelector( ( state ) => getModuleToggles( state, siteId, 'traffic' ) );
 	const momentSiteZone = useSelector( ( state ) => getMomentSiteZone( state, siteId ) );
@@ -569,37 +566,20 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 					<JetpackBackupCredsBanner event="stats-backup-credentials" />
 				</div>
 			) }
-			{ isStatsNavigationImprovementEnabled ? (
-				<PageHeader
-					rightSection={
-						shouldRenderModuleToggler && (
-							<PageModuleToggler
-								selectedItem="traffic"
-								moduleToggles={ moduleToggles }
-								siteId={ siteId }
-								isTooltipShown={ showSettingsTooltip && ! isPageSettingsTooltipDismissed }
-								onTooltipDismiss={ onTooltipDismiss }
-								customToggleIcon={ <Icon className="gridicon" icon={ settings } /> }
-							/>
-						)
-					}
-				/>
-			) : (
-				<NavigationHeader
-					className="stats__section-header modernized-header"
-					title={ STATS_PRODUCT_NAME }
-					subtitle={ translate(
-						"Gain insights into the activity and behavior of your site's visitors. {{learnMoreLink}}Learn more{{/learnMoreLink}}",
-						{
-							components: {
-								learnMoreLink: <InlineSupportLink supportContext="stats" showIcon={ false } />,
-							},
-						}
-					) }
-					screenReader={ navItems.traffic?.label }
-					navigationItems={ [] }
-				/>
-			) }
+			<PageHeader
+				rightSection={
+					shouldRenderModuleToggler && (
+						<PageModuleToggler
+							selectedItem="traffic"
+							moduleToggles={ moduleToggles }
+							siteId={ siteId }
+							isTooltipShown={ showSettingsTooltip && ! isPageSettingsTooltipDismissed }
+							onTooltipDismiss={ onTooltipDismiss }
+							customToggleIcon={ <Icon className="gridicon" icon={ settings } /> }
+						/>
+					)
+				}
+			/>
 			<StatsNavigation selectedItem="traffic" interval={ period } siteId={ siteId } slug={ slug } />
 			<StatsNotices
 				siteId={ siteId }

--- a/client/my-sites/stats/stats-details-navigation/index.tsx
+++ b/client/my-sites/stats/stats-details-navigation/index.tsx
@@ -1,12 +1,8 @@
-import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { TabPanel } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { useCallback, useMemo } from 'react';
-import SectionNav from 'calypso/components/section-nav';
-import NavItem from 'calypso/components/section-nav/item';
-import NavTabs from 'calypso/components/section-nav/tabs';
+import { useMemo } from 'react';
 
 interface StatsDetailsNavigationProps {
 	postId: number;
@@ -69,60 +65,8 @@ function StatsDetailsNavigationImproved( {
 	);
 }
 
-function StatsDetailsNavigationLegacy( {
-	postId,
-	period,
-	statType,
-	givenSiteId,
-}: StatsDetailsNavigationProps ) {
-	const translate = useTranslate();
-	const tabs = useMemo(
-		() => ( {
-			highlights: translate( 'Post traffic' ),
-			opens: translate( 'Email opens' ),
-			clicks: translate( 'Email clicks' ),
-		} ),
-		[ translate ]
-	) as { [ key: string ]: string };
-
-	const selectedTab = statType ? statType : 'highlights';
-
-	const navItems = useCallback(
-		( postId: number, period: string | undefined = 'day', givenSiteId: string | number ) => {
-			return Object.keys( tabs ).map( ( item ) => {
-				const selected = selectedTab === item;
-				const pathParam = [ 'opens', 'clicks' ].includes( item )
-					? `email/${ item }/${ period }`
-					: 'post';
-				const attr = {
-					path: `/stats/${ pathParam }/${ postId }/${ givenSiteId }`,
-					selected,
-				};
-				const label = tabs[ item as keyof typeof tabs ];
-
-				// uppercase first character of item
-				return (
-					<NavItem key={ item } { ...attr }>
-						{ label }
-					</NavItem>
-				);
-			} );
-		},
-		[ tabs, selectedTab ]
-	);
-
-	return (
-		<SectionNav selectedText={ tabs[ selectedTab ] }>
-			<NavTabs label="Stats">{ navItems( postId, period, givenSiteId ) }</NavTabs>
-		</SectionNav>
-	);
-}
-
 function StatsDetailsNavigation( props: StatsDetailsNavigationProps ) {
-	if ( config.isEnabled( 'stats/navigation-improvement' ) ) {
-		return <StatsDetailsNavigationImproved { ...props } />;
-	}
-	return <StatsDetailsNavigationLegacy { ...props } />;
+	return <StatsDetailsNavigationImproved { ...props } />;
 }
 
 StatsDetailsNavigation.propTypes = {

--- a/client/my-sites/stats/stats-email-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-detail/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Spinner } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
@@ -18,7 +17,6 @@ import QueryEmailStats from 'calypso/components/data/query-email-stats';
 import QueryPostStats from 'calypso/components/data/query-post-stats';
 import QueryPosts from 'calypso/components/data/query-posts';
 import EmptyContent from 'calypso/components/empty-content';
-import NavigationHeader from 'calypso/components/navigation-header';
 import WebPreview from 'calypso/components/web-preview';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import memoizeLast from 'calypso/lib/memoize-last';
@@ -272,11 +270,7 @@ class StatsEmailDetail extends Component {
 
 		return (
 			<>
-				<Main
-					className={ clsx( 'stats', 'stats__email-detail', {
-						'has-fixed-nav': ! config.isEnabled( 'stats/navigation-improvement' ),
-					} ) }
-				>
+				<Main className={ clsx( 'stats', 'stats__email-detail' ) }>
 					<QueryPosts siteId={ siteId } postId={ postId } />
 					<QueryPostStats siteId={ siteId } postId={ postId } />
 					<QueryEmailStats
@@ -297,23 +291,17 @@ class StatsEmailDetail extends Component {
 						title="Stats > Single Email"
 					/>
 
-					{ config.isEnabled( 'stats/navigation-improvement' ) ? (
-						<PageHeader
-							backLinkProps={ backLinkProps }
-							titleProps={ titleProps }
-							rightSection={
-								showViewLink && (
-									<CoreButton onClick={ this.openPreview } variant="primary">
-										<span>{ actionLabel }</span>
-									</CoreButton>
-								)
-							}
-						/>
-					) : (
-						<NavigationHeader
-							navigationItems={ this.getNavigationItemsWithTitle( this.getNavigationTitle() ) }
-						/>
-					) }
+					<PageHeader
+						backLinkProps={ backLinkProps }
+						titleProps={ titleProps }
+						rightSection={
+							showViewLink && (
+								<CoreButton onClick={ this.openPreview } variant="primary">
+									<span>{ actionLabel }</span>
+								</CoreButton>
+							)
+						}
+					/>
 
 					{ ! isRequestingStats && ! countViews && post && (
 						<EmptyContent
@@ -329,9 +317,11 @@ class StatsEmailDetail extends Component {
 					{ post ? (
 						<>
 							<div
-								className={ clsx( 'stats-navigation', 'stats-navigation--modernized', {
-									'stats-navigation--improved': config.isEnabled( 'stats/navigation-improvement' ),
-								} ) }
+								className={ clsx(
+									'stats-navigation',
+									'stats-navigation--modernized',
+									'stats-navigation--improved'
+								) }
 							>
 								<StatsDetailsNavigation
 									postId={ postId }

--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -1,10 +1,7 @@
-import config from '@automattic/calypso-config';
 import { formatNumber } from '@automattic/number-formatters';
-import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useEffect } from 'react';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
-import NavigationHeader from 'calypso/components/navigation-header';
 import Main from 'calypso/my-sites/stats/components/stats-main';
 import { useShouldGateStats } from 'calypso/my-sites/stats/hooks/use-should-gate-stats';
 import { recordCurrentScreen } from 'calypso/my-sites/stats/hooks/use-stats-navigation-history';
@@ -72,8 +69,6 @@ const StatsEmailSummary = ( { period, query, context } ) => {
 		} );
 	}, [ context.query, period.period ] );
 
-	const isStatsNavigationImprovementEnabled = config.isEnabled( 'stats/navigation-improvement' );
-
 	const backLinkProps = {
 		text: navigationItems[ 0 ].label,
 		url: navigationItems[ 0 ].href,
@@ -105,28 +100,17 @@ const StatsEmailSummary = ( { period, query, context } ) => {
 	);
 
 	return (
-		<Main
-			className={ clsx( {
-				'has-fixed-nav': ! config.isEnabled( 'stats/navigation-improvement' ),
-			} ) }
-			fullWidthLayout
-		>
+		<Main fullWidthLayout>
 			<PageViewTracker path="/stats/emails/:site" title="Stats > Emails" />
 			<div className="stats stats-summary-view">
-				{ isStatsNavigationImprovementEnabled && (
-					<PageHeader
-						className="stats__section-header modernized-header"
-						titleProps={ titleProps }
-						backLinkProps={ backLinkProps }
-						rightSection={
-							<div className="stats-module__header-nav-button">{ downloadCsvElement }</div>
-						}
-					/>
-				) }
-
-				{ ! isStatsNavigationImprovementEnabled && (
-					<NavigationHeader className="stats-summary-view" navigationItems={ navigationItems } />
-				) }
+				<PageHeader
+					className="stats__section-header modernized-header"
+					titleProps={ titleProps }
+					backLinkProps={ backLinkProps }
+					rightSection={
+						<div className="stats-module__header-nav-button">{ downloadCsvElement }</div>
+					}
+				/>
 
 				<div id="my-stats-content" className="stats-summary-view stats-summary__positioned">
 					<div className="stats-summary-nav">

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { includes, isEqual } from 'lodash';
@@ -18,8 +17,6 @@ import Geochart from '../geochart';
 import { shouldGateStats } from '../hooks/use-should-gate-stats';
 import StatsCardUpsell from '../stats-card-upsell';
 import DatePicker from '../stats-date-picker';
-import DownloadCsv from '../stats-download-csv';
-import DownloadCsvUpsell from '../stats-download-csv-upsell';
 import ErrorPanel from '../stats-error';
 import StatsListCard from '../stats-list/stats-list-card';
 import StatsModulePlaceholder from './placeholder';
@@ -265,7 +262,6 @@ class StatsModule extends Component {
 			moduleStrings,
 			statType,
 			query,
-			period,
 			translate,
 			useShortLabel,
 			metricLabel,
@@ -273,7 +269,6 @@ class StatsModule extends Component {
 			mainItemLabel,
 			listItemClassName,
 			gateStats,
-			gateDownloads,
 			hasNoBackground,
 			skipQuery,
 			titleNodes,
@@ -292,35 +287,6 @@ class StatsModule extends Component {
 		const summaryLink = ! this.props.hideSummaryLink && this.getSummaryLink();
 		const displaySummaryLink = data && summaryLink;
 		const isAllTime = this.isAllTimeList();
-		const isStatsNavigationImprovementEnabled = config.isEnabled( 'stats/navigation-improvement' );
-
-		const renderDownloadCsv = () => {
-			// Disable the Download button for the new navigation.
-			if ( isStatsNavigationImprovementEnabled ) {
-				return null;
-			}
-
-			// Disable for the email module as it doesn't work correctly.
-			if ( statType === 'statsEmailsSummary' ) {
-				return null;
-			}
-
-			if ( gateDownloads ) {
-				return <DownloadCsvUpsell siteId={ siteId } borderless />;
-			}
-
-			return (
-				<DownloadCsv
-					statType={ statType }
-					query={ query }
-					path={ path }
-					period={ period }
-					skipQuery={ skipQuery }
-				/>
-			);
-		};
-
-		const downloadCsv = renderDownloadCsv();
 
 		const emptyMessage = isRealTime ? 'gathering info…' : moduleStrings.empty;
 		// TODO: Translate empty message
@@ -338,7 +304,6 @@ class StatsModule extends Component {
 					useShortLabel={ useShortLabel }
 					title={ this.props.moduleStrings?.title }
 					titleNodes={ titleNodes }
-					downloadCsv={ downloadCsv }
 					emptyMessage={ emptyMessage }
 					metricLabel={ metricLabel }
 					showMore={

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -14,7 +14,6 @@ import QueryPostStats from 'calypso/components/data/query-post-stats';
 import QueryPosts from 'calypso/components/data/query-posts';
 import EmptyContent from 'calypso/components/empty-content';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
-import NavigationHeader from 'calypso/components/navigation-header';
 import WebPreview from 'calypso/components/web-preview';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import PageHeader from 'calypso/my-sites/stats/components/headers/page-header';
@@ -229,7 +228,6 @@ class StatsPostDetail extends Component {
 		const isWPAdmin = config.isEnabled( 'is_odyssey' );
 		const postDetailPageClasses = clsx( 'stats', {
 			'is-odyssey-stats': isWPAdmin,
-			'has-fixed-nav': ! config.isEnabled( 'stats/navigation-improvement' ),
 		} );
 
 		// TODO: Refactor navigationItems to a single object with backLink and title attributes.
@@ -268,33 +266,25 @@ class StatsPostDetail extends Component {
 				{ siteId && <QueryJetpackModules siteId={ siteId } /> }
 
 				<div className={ postDetailPageClasses }>
-					{ config.isEnabled( 'stats/navigation-improvement' ) ? (
-						<PageHeader
-							backLinkProps={ backLinkProps }
-							titleProps={ titleProps }
-							rightSection={
-								showViewLink && (
-									<CoreButton onClick={ this.openPreview } variant="primary">
-										<span>{ actionLabel }</span>
-									</CoreButton>
-								)
-							}
-						/>
-					) : (
-						<NavigationHeader navigationItems={ navigationItems }>
-							{ showViewLink && (
-								<Button onClick={ this.openPreview }>
+					<PageHeader
+						backLinkProps={ backLinkProps }
+						titleProps={ titleProps }
+						rightSection={
+							showViewLink && (
+								<CoreButton onClick={ this.openPreview } variant="primary">
 									<span>{ actionLabel }</span>
-								</Button>
-							) }
-						</NavigationHeader>
-					) }
+								</CoreButton>
+							)
+						}
+					/>
 
 					{ isEmailTabsAvailable && (
 						<div
-							className={ clsx( 'stats-navigation', 'stats-navigation--modernized', {
-								'stats-navigation--improved': config.isEnabled( 'stats/navigation-improvement' ),
-							} ) }
+							className={ clsx(
+								'stats-navigation',
+								'stats-navigation--modernized',
+								'stats-navigation--improved'
+							) }
 						>
 							<StatsDetailsNavigation postId={ postId } givenSiteId={ siteId } />
 						</div>

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -1,4 +1,4 @@
-import config, { isEnabled } from '@automattic/calypso-config';
+import { isEnabled } from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import { isEqual, merge } from 'lodash';
 import { Component, Fragment } from 'react';
@@ -6,7 +6,6 @@ import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
 import QueryMedia from 'calypso/components/data/query-media';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
-import NavigationHeader from 'calypso/components/navigation-header';
 import AnnualSiteStats from 'calypso/my-sites/stats/annual-site-stats';
 import Main from 'calypso/my-sites/stats/components/stats-main';
 import StatsModuleAuthors from 'calypso/my-sites/stats/features/modules/stats-authors';
@@ -109,16 +108,6 @@ class StatsSummary extends Component {
 		let path;
 		let statType;
 
-		// Navigation settings. One of the following, depending on the summary view.
-		// Traffic => /stats/day/
-		// Insights => /stats/insights/
-		const localizedTabNames = {
-			traffic: translate( 'Traffic' ),
-			insights: translate( 'Insights' ),
-		};
-		let backLabel = localizedTabNames.traffic;
-		let backLink = `/stats/day/`;
-
 		const { period, endOf } = this.props.period;
 		const query = {
 			period: period,
@@ -140,7 +129,6 @@ class StatsSummary extends Component {
 		const moduleQuery = merge( {}, statsQueryOptions, query );
 		const urlParams = new URLSearchParams( this.props.context.querystring );
 		const listItemClassName = 'stats__summary--narrow-mobile';
-		const isStatsNavigationImprovementEnabled = config.isEnabled( 'stats/navigation-improvement' );
 
 		switch ( this.props.context.params.module ) {
 			case 'referrers':
@@ -368,14 +356,10 @@ class StatsSummary extends Component {
 				break;
 			case 'annualstats':
 				title = translate( 'Annual insights' );
-				backLabel = localizedTabNames.insights;
-				backLink = `/stats/insights/`;
 				summaryView = <AnnualSiteStats key="annualstats" />;
 				break;
 			case 'utm': {
 				title = translate( 'UTM insights' );
-				backLabel = localizedTabNames.traffic;
-				backLink = `/stats/traffic/`;
 				path = 'utm';
 				statType = 'statsUTM';
 				summaryView = <></>; // done inline to use context values
@@ -396,11 +380,6 @@ class StatsSummary extends Component {
 
 		const { module } = this.props.context.params;
 
-		const domain = this.props.siteSlug;
-		if ( domain?.length > 0 ) {
-			backLink += domain;
-		}
-		const navigationItems = [ { label: backLabel, href: backLink }, { label: title } ];
 		const geoMode = this.props.context.query.geoMode;
 		const geoModeLabel =
 			geoMode && Object.prototype.hasOwnProperty.call( GEO_MODES, geoMode )
@@ -414,49 +393,40 @@ class StatsSummary extends Component {
 					title={ `Stats > ${ titlecase( period ) } > ${ titlecase( module ) }` }
 				/>
 				<div className="stats stats-summary-view">
-					{ isStatsNavigationImprovementEnabled && (
-						<PageHeader
-							className="stats__section-header modernized-header"
-							titleProps={ { title, titleLogo: null } }
-							backLinkProps={ {
-								url: lastScreen.url,
-								text: lastScreen.text,
-							} }
-							rightSection={
-								<div className="stats-module__header-nav-button">
-									{ shouldGateStatsCsvDownload ? (
-										<DownloadCsvUpsell siteId={ siteId } borderless />
-									) : (
-										<DownloadCsv
-											statType={ statType }
-											query={ moduleQuery }
-											path={
-												statType === 'statsCountryViews' ? `${ path }-${ geoModeLabel }` : path
-											}
-											period={ this.props.period }
-											skipQuery
-											hideIfNoData
-										/>
-									) }
-								</div>
-							}
-						/>
-					) }
-
-					{ ! isStatsNavigationImprovementEnabled && (
-						<NavigationHeader className="stats-summary-view" navigationItems={ navigationItems } />
-					) }
-
-					{ isStatsNavigationImprovementEnabled &&
-						this.props.context.params.module === 'locations' && (
-							<div className="stats-navigation stats-navigation--improved">
-								<LocationsNavTabs
-									period={ this.props.period }
-									query={ moduleQuery }
-									givenSiteId={ siteId }
-								/>
+					<PageHeader
+						className="stats__section-header modernized-header"
+						titleProps={ { title, titleLogo: null } }
+						backLinkProps={ {
+							url: lastScreen.url,
+							text: lastScreen.text,
+						} }
+						rightSection={
+							<div className="stats-module__header-nav-button">
+								{ shouldGateStatsCsvDownload ? (
+									<DownloadCsvUpsell siteId={ siteId } borderless />
+								) : (
+									<DownloadCsv
+										statType={ statType }
+										query={ moduleQuery }
+										path={ statType === 'statsCountryViews' ? `${ path }-${ geoModeLabel }` : path }
+										period={ this.props.period }
+										skipQuery
+										hideIfNoData
+									/>
+								) }
 							</div>
-						) }
+						}
+					/>
+
+					{ this.props.context.params.module === 'locations' && (
+						<div className="stats-navigation stats-navigation--improved">
+							<LocationsNavTabs
+								period={ this.props.period }
+								query={ moduleQuery }
+								givenSiteId={ siteId }
+							/>
+						</div>
+					) }
 
 					<div id="my-stats-content" className="stats-summary-view stats-summary__positioned">
 						{ this.props.context.params.module === 'utm' ? (

--- a/client/my-sites/stats/videopress-stats-module/index.jsx
+++ b/client/my-sites/stats/videopress-stats-module/index.jsx
@@ -20,7 +20,6 @@ import {
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import EmptyModuleCardVideo from '../features/modules/shared/stats-empty-module-video';
 import DatePicker from '../stats-date-picker';
-import DownloadCsv from '../stats-download-csv';
 import ErrorPanel from '../stats-error';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import '../stats-module/style.scss';
@@ -129,7 +128,6 @@ class VideoPressStatsModule extends Component {
 				.flat();
 		}
 
-		const isStatsNavigationImprovementEnabled = config.isEnabled( 'stats/navigation-improvement' );
 		const noData = data && this.state.loaded && ! completeVideoStats.length;
 		// Only show loading indicators when nothing is in state tree, and request in-flight
 		const isLoading = ! this.state.loaded && ! ( data && data.length );
@@ -173,11 +171,6 @@ class VideoPressStatsModule extends Component {
 			page( url );
 		};
 
-		const csvData = [
-			[ 'post_id', 'title', 'views', 'impressions', 'watch_time', 'retention_rate' ],
-			...completeVideoStats,
-		];
-
 		// Calculate max views only
 		const maxViews = this.getMaxValue( completeVideoStats, 'views' );
 
@@ -213,18 +206,7 @@ class VideoPressStatsModule extends Component {
 							</div>
 						}
 						href={ ! summary ? summaryLink : null }
-					>
-						{ summary && ! isStatsNavigationImprovementEnabled && (
-							<DownloadCsv
-								statType={ statType }
-								data={ csvData }
-								query={ query }
-								path={ path }
-								period={ period }
-								skipQuery
-							/>
-						) }
-					</SectionHeader>
+					/>
 					<div className="videopress-stats-module__grid">
 						<div className="videopress-stats-module__header-row-wrapper">
 							<div className="videopress-stats-module__grid-header">{ translate( 'Title' ) }</div>

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -17,10 +17,8 @@ import Intervals from 'calypso/blocks/stats-navigation/intervals';
 import DocumentHead from 'calypso/components/data/document-head';
 import EmptyContent from 'calypso/components/empty-content';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
-import NavigationHeader from 'calypso/components/navigation-header';
 import PageHeader from 'calypso/my-sites/stats/components/headers/page-header';
 import Main from 'calypso/my-sites/stats/components/stats-main';
-import { STATS_PRODUCT_NAME } from 'calypso/my-sites/stats/constants';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { canAccessWordAds } from 'calypso/state/sites/selectors';
@@ -145,7 +143,6 @@ class WordAds extends Component {
 			this.props;
 
 		const { period, endOf } = this.props.period;
-		const isStatsNavigationImprovementEnabled = config.isEnabled( 'stats/navigation-improvement' );
 
 		const yesterday = moment.utc().subtract( 1, 'days' ).format( 'YYYY-MM-DD' );
 
@@ -178,16 +175,7 @@ class WordAds extends Component {
 				/>
 
 				<div className={ wordAdsPageClasses }>
-					{ ! isStatsNavigationImprovementEnabled ? (
-						<NavigationHeader
-							className="stats__section-header modernized-header"
-							title={ STATS_PRODUCT_NAME }
-							subtitle={ translate( 'See how ads are performing on your site.' ) }
-							screenReader={ navItems.wordads?.label }
-						></NavigationHeader>
-					) : (
-						<PageHeader />
-					) }
+					<PageHeader />
 
 					{ ! canAccessAds && (
 						<EmptyContent

--- a/client/my-sites/store/app/store-stats/index.js
+++ b/client/my-sites/store/app/store-stats/index.js
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import moment from 'moment';
@@ -7,12 +6,10 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
-import { navItems } from 'calypso/blocks/stats-navigation/constants';
 import Intervals from 'calypso/blocks/stats-navigation/intervals';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import SectionHeader from 'calypso/components/section-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import PageHeader from 'calypso/my-sites/stats/components/headers/page-header';
@@ -44,7 +41,6 @@ class StoreStats extends Component {
 		const { topListQuery } = getQueries( unit, selectedDate );
 		const topWidgets = [ topProducts, topCategories, topCoupons ];
 		const widgetPath = getWidgetPath( unit, slug, queryParams );
-		const isStatsNavigationImprovementEnabled = config.isEnabled( 'stats/navigation-improvement' );
 
 		// For period option links
 		const store = {
@@ -70,19 +66,7 @@ class StoreStats extends Component {
 				) }
 
 				<div className="stats">
-					{ ! isStatsNavigationImprovementEnabled ? (
-						<NavigationHeader
-							className="stats__section-header modernized-header"
-							title={ translate( 'Jetpack Stats' ) }
-							subtitle={ translate(
-								'Learn valuable insights about the purchases made on your store.'
-							) }
-							screenReader={ navItems.store?.label }
-						></NavigationHeader>
-					) : (
-						<PageHeader />
-					) }
-
+					<PageHeader />
 					<StatsNavigation selectedItem="store" siteId={ siteId } slug={ slug } interval={ unit } />
 
 					<div id="my-stats-content" className={ statsWrapperClass }>

--- a/config/development.json
+++ b/config/development.json
@@ -186,7 +186,6 @@
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
 		"stats/real-time-tab": true,
-		"stats/navigation-improvement": true,
 		"subscriber-importer": true,
 		"subscribers-helper-library": true,
 		"themes/block-theme-previews-premium-and-woo": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -122,7 +122,6 @@
 		"stats/empty-module-traffic": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/real-time-tab": false,
-		"stats/navigation-improvement": true,
 		"subscriber-importer": true,
 		"subscribers-helper-library": true,
 		"themes/block-theme-previews-premium-and-woo": true,

--- a/config/production.json
+++ b/config/production.json
@@ -158,7 +158,6 @@
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
 		"stats/real-time-tab": false,
-		"stats/navigation-improvement": true,
 		"subscriber-importer": true,
 		"subscribers-helper-library": true,
 		"themes/block-theme-previews-premium-and-woo": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -154,7 +154,6 @@
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
 		"stats/real-time-tab": false,
-		"stats/navigation-improvement": true,
 		"subscriber-importer": true,
 		"subscribers-helper-library": true,
 		"themes/block-theme-previews-premium-and-woo": true,

--- a/config/test.json
+++ b/config/test.json
@@ -114,7 +114,6 @@
 		"ssr/prefetch-timebox": true,
 		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
-		"stats/navigation-improvement": true,
 		"subscribers-helper-library": true,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -157,7 +157,6 @@
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
 		"stats/real-time-tab": false,
-		"stats/navigation-improvement": true,
 		"subscriber-importer": true,
 		"subscribers-helper-library": true,
 		"themes/block-theme-previews-premium-and-woo": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixed STATS-66.

## Proposed Changes

* Remove feature flag `stats/navigation-improvement` usage from the released Navigation Improvement project.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Clean up legacy feature flag usages.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Ensure the improved Navigation across pages works well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
