### PR TITLE
Calendar: add README

### DIFF
--- a/packages/components/src/calendar/date-calendar/README.md
+++ b/packages/components/src/calendar/date-calendar/README.md
@@ -107,13 +107,6 @@ Specify which days are disabled. Using `true` will disable all dates. See the [M
 
 Disable the navigation buttons.
 
-### `modifiers`
-
-- Type: `Record<string, Matcher | Matcher[] | undefined> | undefined`
-- Required: No
-
-Add modifiers to the matching days. See the [Matcher Types](#matcher-types) section for more details.
-
 ### `labels`
 
 - Type: `object`

--- a/packages/components/src/calendar/date-calendar/README.md
+++ b/packages/components/src/calendar/date-calendar/README.md
@@ -1,0 +1,243 @@
+# `DateCalendar`
+
+`DateCalendar` is a React component that provides a customizable calendar interface for **single date** selection.
+
+The component is built with accessibility in mind and follows ARIA best practices for calendar widgets. It provides keyboard navigation, screen reader support, and customizable labels for internationalization.
+
+## Usage example
+
+```tsx
+import { DateCalendar } from '@automattic/components';
+
+function MyComponent() {
+	const [ selected, setSelected ] = useState< Date >( new Date() );
+
+	return <DateCalendar selected={ selected } onSelect={ setSelected } />;
+}
+```
+
+## Props
+
+These props are shared between both single date and date range calendar modes.
+
+### `required`
+
+- Type: `boolean`
+- Required: No
+- Default: `false`
+
+Whether the selection is required. When `true`, there always needs to be a date selected.
+
+### `selected`
+
+- Type: `Date | undefined | null`
+- Required: No
+
+The selected date.
+
+### `onSelect`
+
+- Type: `(selected: Date | undefined, triggerDate: Date, modifiers: Modifiers, e: React.MouseEvent | React.KeyboardEvent) => void`
+- Required: No
+
+Event handler when a day is selected.
+
+### `defaultSelected`
+
+- Type: `Date`
+- Required: No
+
+The default selected date (for uncontrolled usage).
+
+### `defaultMonth`
+
+- Type: `Date`
+- Required: No
+- Default: Current month
+
+The initial month to show in the calendar view (uncontrolled).
+
+### `month`
+
+- Type: `Date`
+- Required: No
+
+The month displayed in the calendar view (controlled). Use together with `onMonthChange` to change the month programmatically.
+
+### `numberOfMonths`
+
+- Type: `number`
+- Required: No
+- Default: `1`
+
+The number of months displayed at once.
+
+### `startMonth`
+
+- Type: `Date`
+- Required: No
+
+The earliest month to start the month navigation.
+
+### `endMonth`
+
+- Type: `Date`
+- Required: No
+
+The latest month to end the month navigation.
+
+### `autoFocus`
+
+- Type: `boolean`
+- Required: No
+
+Focus the first selected day (if set) or today's date (if not disabled). Use this prop when you need to focus the calendar after a user action (e.g. opening the dialog with the calendar).
+
+### `disabled`
+
+- Type: `Matcher | Matcher[] | undefined`
+- Required: No
+
+Specify which days are disabled. Using `true` will disable all dates. See the [Matcher Types](#matcher-types) section for more details.
+
+### `disableNavigation`
+
+- Type: `boolean`
+- Required: No
+
+Disable the navigation buttons.
+
+### `modifiers`
+
+- Type: `Record<string, Matcher | Matcher[] | undefined> | undefined`
+- Required: No
+
+Add modifiers to the matching days. See the [Matcher Types](#matcher-types) section for more details.
+
+### `labels`
+
+- Type: `object`
+- Required: No
+
+Use custom labels for internationalization. All labels are optional and have sensible defaults:
+
+```typescript
+{
+  labelNav?: () => string; // Navigation toolbar label
+  labelGrid?: (date: Date) => string; // Month grid label (default: "LLLL y")
+  labelGridcell?: (date: Date, modifiers?: Modifiers) => string; // Grid cell label
+  labelNext?: (month: Date | undefined) => string; // Next month button label
+  labelPrevious?: (month: Date | undefined) => string; // Previous month button label
+  labelDayButton?: (date: Date, modifiers?: Modifiers) => string; // Day button label
+  labelWeekday?: (date: Date) => string; // Weekday label
+}
+```
+
+**Important: For a correct localized experience, consumers should make sure the locale used for the translated labels and `locale` prop are consistent.**
+
+### `locale`
+
+- Type: `Locale`
+- Required: No
+- Default: `enUS` from `@date-fns/locale`
+
+The locale object used to localize dates. Pass a locale from `@date-fns/locale` to localize the calendar.
+
+**Important: For a correct localized experience, consumers should make sure the locale used for the translated labels and `locale` prop are consistent.**
+
+### `weekStartsOn`
+
+- Type: `0 | 1 | 2 | 3 | 4 | 5 | 6 | undefined`
+- Required: No
+- Default: Based on the `locale` prop
+
+The index of the first day of the week (0 - Sunday). Overrides the locale's setting.
+
+### `onMonthChange`
+
+- Type: `(month: Date) => void`
+- Required: No
+
+Event fired when the user navigates between months.
+
+### `timeZone`
+
+- Type: `string`
+- Required: No
+
+The time zone (IANA or UTC offset) to use in the calendar. See [Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for possible values.
+
+### `role`
+
+- Type: `'application' | 'dialog' | undefined`
+- Required: No
+- Default: `'application'`
+
+The role attribute to add to the container element.
+
+## Matcher Types
+
+The calendar component uses a flexible matching system to determine which days should be disabled or have specific modifiers. Here are the available matcher types:
+
+### Boolean Matcher
+
+```typescript
+const booleanMatcher: Matcher = true; // Will always match the day
+```
+
+### Date Matcher
+
+```typescript
+const dateMatcher: Matcher = new Date(); // Will match today's date
+```
+
+### Array Matcher
+
+```typescript
+const arrayMatcher: Matcher = [ new Date( 2019, 1, 2 ), new Date( 2019, 1, 4 ) ]; // Will match the days in the array
+```
+
+### Date After Matcher
+
+```typescript
+const afterMatcher: DateAfter = { after: new Date( 2019, 1, 2 ) }; // Will match days after the 2nd of February 2019
+```
+
+### Date Before Matcher
+
+```typescript
+const beforeMatcher: DateBefore = { before: new Date( 2019, 1, 2 ) }; // Will match days before the 2nd of February 2019
+```
+
+### Date Interval Matcher
+
+```typescript
+const intervalMatcher: DateInterval = {
+	after: new Date( 2019, 1, 2 ),
+	before: new Date( 2019, 1, 5 ),
+}; // Will match the days between the 2nd and the 5th of February 2019 (exclusive)
+```
+
+### Date Range Matcher
+
+```typescript
+const rangeMatcher: DateRange = {
+	from: new Date( 2019, 1, 2 ),
+	to: new Date( 2019, 1, 5 ),
+}; // Will match the days between the 2nd and the 5th of February 2019 (inclusive)
+```
+
+### Day of Week Matcher
+
+```typescript
+const dayOfWeekMatcher: DayOfWeek = { dayOfWeek: 0 }; // Will match Sundays
+const weekendMatcher: DayOfWeek = { dayOfWeek: [ 0, 6 ] }; // Will match weekends
+```
+
+### Function Matcher
+
+```typescript
+const functionMatcher: Matcher = ( day: Date ) => {
+	return day.getMonth() === 2; // Will match when month is March
+};
+```

--- a/packages/components/src/calendar/date-calendar/index.stories.tsx
+++ b/packages/components/src/calendar/date-calendar/index.stories.tsx
@@ -19,12 +19,12 @@ import {
 	sv,
 } from 'date-fns/locale';
 import { useState, useEffect } from 'react';
-import { DateRangeCalendar, TZDate } from '../index';
+import { DateCalendar, TZDate } from '../';
 import type { Meta, StoryObj } from '@storybook/react';
 
-const meta: Meta< typeof DateRangeCalendar > = {
-	title: 'Components/DateRangeCalendar',
-	component: DateRangeCalendar,
+const meta: Meta< typeof DateCalendar > = {
+	title: 'Components/DateCalendar',
+	component: DateCalendar,
 	parameters: {
 		controls: { expanded: true },
 	},
@@ -83,8 +83,8 @@ const meta: Meta< typeof DateRangeCalendar > = {
 		labels: {
 			control: false,
 		},
-		defaultSelected: { control: false },
-		selected: { control: false },
+		defaultSelected: { control: 'date' },
+		selected: { control: 'date' },
 		onSelect: {
 			control: false,
 		},
@@ -103,7 +103,7 @@ const meta: Meta< typeof DateRangeCalendar > = {
 };
 export default meta;
 
-type Story = StoryObj< typeof DateRangeCalendar >;
+type Story = StoryObj< typeof DateCalendar >;
 
 export const Default: Story = {};
 
@@ -116,68 +116,52 @@ function dateToInputValue( date: Date ) {
 
 /**
  * The component can be used in controlled mode. This is useful, for example,
- * when in need of keeping the component in sync with external input fields.
+ * when in need of keeping the component in sync with an external input field.
  *
  * _Note: this example doesn't handle time zones_
  */
-export const ControlledWithInputFields: Story = {
-	render: function ControlledTemplate( args ) {
-		const [ range, setRange ] = useState< typeof args.selected | null >( null );
+export const ControlledWithInputField: Story = {
+	render: function ControlledDateCalendar( args ) {
+		const [ selected, setSelected ] = useState< Date | null >( null );
+
 		return (
 			<div style={ { display: 'flex', flexDirection: 'column', gap: 16 } }>
 				<label style={ { display: 'flex', flexDirection: 'column', gap: 4 } }>
-					Start date
+					Selected date
 					<input
 						type="date"
 						value={
 							// Note: the following code doesn't handle time zones.
-							range?.from ? dateToInputValue( range.from ) : ''
+							selected ? dateToInputValue( selected ) : ''
 						}
 						onChange={ ( e ) => {
 							// Note: the following code doesn't handle time zones.
-							setRange( {
-								to: new Date( e.target.value ),
-								...range,
-								from: new Date( e.target.value ),
-							} );
+							setSelected( new Date( e.target.value ) );
 						} }
 						style={ { width: 160 } }
 					/>
 				</label>
-				<label style={ { display: 'flex', flexDirection: 'column', gap: 4 } }>
-					End date
-					<input
-						type="date"
-						value={
-							// Note: the following code doesn't handle time zones.
-							range?.to ? dateToInputValue( range.to ) : ''
-						}
-						onChange={ ( e ) => {
-							// Note: the following code doesn't handle time zones.
-							setRange( {
-								from: new Date( e.target.value ),
-								...range,
-								to: new Date( e.target.value ),
-							} );
-						} }
-						style={ { width: 160 } }
-					/>
-				</label>
-				<DateRangeCalendar
+				<DateCalendar
 					{ ...args }
-					selected={ range }
+					selected={ selected }
 					onSelect={ ( selectedDate, ...rest ) => {
-						setRange(
-							// Set controlled state to null if there's no selection
-							! selectedDate || ( selectedDate.from === undefined && selectedDate.to === undefined )
-								? null
-								: selectedDate
-						);
+						setSelected( selectedDate ?? null );
 						args.onSelect?.( selectedDate, ...rest );
 					} }
 				/>
 			</div>
 		);
+	},
+	argTypes: {
+		defaultSelected: {
+			control: false,
+		},
+		selected: {
+			control: false,
+		},
+		timeZone: {
+			control: false,
+		},
 	},
 };
 
@@ -214,40 +198,31 @@ const nextMonth = new Date().getMonth() === 11 ? 0 : new Date().getMonth() + 1;
 const nextMonthYear =
 	new Date().getMonth() === 11 ? new Date().getFullYear() + 1 : new Date().getFullYear();
 const firstDayOfNextMonth = new Date( nextMonthYear, nextMonth, 1 );
-const fourthDayOfNextMonth = new Date( nextMonthYear, nextMonth, 4 );
-export const WithSelectedRangeAndMonth: Story = {
+export const WithSelectedDateAndMonth: Story = {
 	args: {
-		defaultSelected: { from: firstDayOfNextMonth, to: fourthDayOfNextMonth },
+		defaultSelected: firstDayOfNextMonth,
 		defaultMonth: firstDayOfNextMonth,
 	},
 };
 
 export const WithTimeZone: Story = {
 	render: function DateCalendarWithTimeZone( args ) {
-		const [ range, setRange ] = useState< typeof args.selected | null >( null );
+		const [ selected, setSelected ] = useState< TZDate | null >( null );
 
 		useEffect( () => {
-			setRange(
-				// Select from one week from today to two weeks from today 	every time the time zone changes.
-				{
-					from: new TZDate( new Date().setDate( new Date().getDate() + 7 ), args.timeZone ),
-					to: new TZDate( new Date().setDate( new Date().getDate() + 14 ), args.timeZone ),
-				}
+			setSelected(
+				// Select one week from today every time the time zone changes.
+				new TZDate( new Date().setDate( new Date().getDate() + 7 ), args.timeZone )
 			);
 		}, [ args.timeZone ] );
 
 		return (
 			<>
-				<DateRangeCalendar
+				<DateCalendar
 					{ ...args }
-					selected={ range }
+					selected={ selected }
 					onSelect={ ( selectedDate, ...rest ) => {
-						setRange(
-							// Set controlled state to null if there's no selection
-							! selectedDate || ( selectedDate.from === undefined && selectedDate.to === undefined )
-								? null
-								: selectedDate
-						);
+						setSelected( selectedDate ? new TZDate( selectedDate, args.timeZone ) : null );
 						args.onSelect?.( selectedDate, ...rest );
 					} }
 					disabled={ [
@@ -257,6 +232,7 @@ export const WithTimeZone: Story = {
 						},
 					] }
 				/>
+
 				<p>
 					Calendar set to { args.timeZone ?? 'current' } timezone, disabling selection for all dates
 					before today, and starting with a default date of 1 week from today`
@@ -268,6 +244,12 @@ export const WithTimeZone: Story = {
 		timeZone: 'Pacific/Auckland',
 	},
 	argTypes: {
+		selected: {
+			control: false,
+		},
+		defaultSelected: {
+			control: false,
+		},
 		disabled: {
 			control: false,
 		},
@@ -275,43 +257,27 @@ export const WithTimeZone: Story = {
 };
 
 const today = new Date();
-const lastSevenDays = ( date: Date ) => {
+const oneWeekBefore = ( date: Date ) => {
 	const toReturn = new Date( date );
-	toReturn.setDate( date.getDate() - 6 );
-	return {
-		from: toReturn,
-		to: date,
-	};
+	toReturn.setDate( date.getDate() - 7 );
+	return toReturn;
 };
-const monthToDate = ( date: Date ) => ( {
-	from: new Date( date.getFullYear(), date.getMonth(), 1 ),
-	to: date,
-} );
-const lastThirtyDays = ( date: Date ) => {
+const startOfMonth = ( date: Date ) => new Date( date.getFullYear(), date.getMonth(), 1 );
+const oneMonthBefore = ( date: Date ) => {
 	const toReturn = new Date( date );
-	toReturn.setDate( date.getDate() - 29 );
-	return {
-		from: toReturn,
-		to: date,
-	};
+	toReturn.setMonth( date.getMonth() - 1 );
+	return toReturn;
 };
-const yearToDate = ( date: Date ) => ( {
-	from: new Date( date.getFullYear(), 0, 1 ),
-	to: date,
-} );
-const lastTwelveMonths = ( date: Date ) => {
+const startOfYear = ( date: Date ) => new Date( date.getFullYear(), 0, 1 );
+const oneYearBefore = ( date: Date ) => {
 	const toReturn = new Date( date );
 	toReturn.setFullYear( date.getFullYear() - 1 );
-	toReturn.setDate( date.getDate() + 1 );
-	return {
-		from: toReturn,
-		to: date,
-	};
+	return toReturn;
 };
 
 export const WithPresets: Story = {
 	render: function ControlledDateCalendar( args ) {
-		const [ range, setRange ] = useState< typeof args.selected | null >( null );
+		const [ selected, setSelected ] = useState< Date | null >( null );
 		const [ month, setMonth ] = useState< Date >();
 
 		return (
@@ -320,7 +286,7 @@ export const WithPresets: Story = {
 					<button
 						type="button"
 						onClick={ () => {
-							setRange( { from: today, to: today } );
+							setSelected( today );
 							setMonth( today );
 						} }
 					>
@@ -329,64 +295,59 @@ export const WithPresets: Story = {
 					<button
 						type="button"
 						onClick={ () => {
-							const targetRange = lastSevenDays( today );
-							setRange( targetRange );
-							setMonth( targetRange.to );
+							const targetDate = oneWeekBefore( today );
+							setSelected( targetDate );
+							setMonth( targetDate );
 						} }
 					>
-						Last 7 days
+						One week ago
 					</button>
 					<button
 						type="button"
 						onClick={ () => {
-							const targetRange = lastThirtyDays( today );
-							setRange( targetRange );
-							setMonth( targetRange.to );
+							const targetDate = startOfMonth( today );
+							setSelected( targetDate );
+							setMonth( targetDate );
 						} }
 					>
-						Last 30 days
+						Start of this month
 					</button>
 					<button
 						type="button"
 						onClick={ () => {
-							const targetRange = monthToDate( today );
-							setRange( targetRange );
-							setMonth( targetRange.to );
+							const targetDate = oneMonthBefore( today );
+							setSelected( targetDate );
+							setMonth( targetDate );
 						} }
 					>
-						Month to date
+						One month ago
 					</button>
 					<button
 						type="button"
 						onClick={ () => {
-							const targetRange = lastTwelveMonths( today );
-							setRange( targetRange );
-							setMonth( targetRange.to );
+							const targetDate = startOfYear( today );
+							setSelected( targetDate );
+							setMonth( targetDate );
 						} }
 					>
-						Last 12 months
+						Start of the year
 					</button>
 					<button
 						type="button"
 						onClick={ () => {
-							const targetRange = yearToDate( today );
-							setRange( targetRange );
-							setMonth( targetRange.to );
+							const targetDate = oneYearBefore( today );
+							setSelected( targetDate );
+							setMonth( targetDate );
 						} }
 					>
-						Year to date
+						One year ago
 					</button>
 				</div>
-				<DateRangeCalendar
+				<DateCalendar
 					{ ...args }
-					selected={ range }
+					selected={ selected }
 					onSelect={ ( selectedDate, ...rest ) => {
-						setRange(
-							// Set controlled state to null if there's no selection
-							! selectedDate || ( selectedDate.from === undefined && selectedDate.to === undefined )
-								? null
-								: selectedDate
-						);
+						setSelected( selectedDate ?? null );
 						args.onSelect?.( selectedDate, ...rest );
 					} }
 					month={ month }
@@ -394,5 +355,13 @@ export const WithPresets: Story = {
 				/>
 			</>
 		);
+	},
+	argTypes: {
+		selected: {
+			control: false,
+		},
+		defaultSelected: {
+			control: false,
+		},
 	},
 };

--- a/packages/components/src/calendar/date-calendar/index.tsx
+++ b/packages/components/src/calendar/date-calendar/index.tsx
@@ -1,11 +1,11 @@
 import { DayPicker } from 'react-day-picker';
 import { enUS } from 'react-day-picker/locale';
-import { COMMON_PROPS } from './utils/constants';
-import { clampNumberOfMonths } from './utils/misc';
-import { useControlledValue } from './utils/use-controlled-value';
-import { useLocalizationProps } from './utils/use-localization-props';
-import type { DateCalendarProps } from './types';
-import './styles.scss';
+import { COMMON_PROPS } from '../utils/constants';
+import { clampNumberOfMonths } from '../utils/misc';
+import { useControlledValue } from '../utils/use-controlled-value';
+import { useLocalizationProps } from '../utils/use-localization-props';
+import type { DateCalendarProps } from '../types';
+import '../styles.scss';
 
 export const DateCalendar = ( {
 	defaultSelected,

--- a/packages/components/src/calendar/date-calendar/index.tsx
+++ b/packages/components/src/calendar/date-calendar/index.tsx
@@ -7,6 +7,14 @@ import { useLocalizationProps } from '../utils/use-localization-props';
 import type { DateCalendarProps } from '../types';
 import '../styles.scss';
 
+/**
+ * `DateCalendar` is a React component that provides a customizable calendar
+ * interface for **single date** selection.
+ *
+ * The component is built with accessibility in mind and follows ARIA best
+ * practices for calendar widgets. It provides keyboard navigation, screen reader
+ * support, and customizable labels for internationalization.
+ */
 export const DateCalendar = ( {
 	defaultSelected,
 	selected: selectedProp,

--- a/packages/components/src/calendar/date-calendar/test/index.tsx
+++ b/packages/components/src/calendar/date-calendar/test/index.tsx
@@ -20,9 +20,14 @@ import {
 import { ar } from 'date-fns/locale';
 import { useState, default as React } from 'react';
 import '@testing-library/jest-dom';
-import { DateCalendar, TZDate } from '..';
-import { getDateButton, getDateCell, queryDateCell, monthNameFormatter } from '../utils/test-utils';
-import type { DateCalendarProps } from '../types';
+import { DateCalendar, TZDate } from '../../';
+import {
+	getDateButton,
+	getDateCell,
+	queryDateCell,
+	monthNameFormatter,
+} from '../../utils/test-utils';
+import type { DateCalendarProps } from '../../types';
 
 const UncontrolledDateCalendar = (
 	props: DateCalendarProps & {

--- a/packages/components/src/calendar/date-range-calendar/README.md
+++ b/packages/components/src/calendar/date-range-calendar/README.md
@@ -143,13 +143,6 @@ Specify which days are disabled. Using `true` will disable all dates. See the [M
 
 Disable the navigation buttons.
 
-### `modifiers`
-
-- Type: `Record<string, Matcher | Matcher[] | undefined> | undefined`
-- Required: No
-
-Add modifiers to the matching days. See the [Matcher Types](#matcher-types) section for more details.
-
 ### `labels`
 
 - Type: `object`

--- a/packages/components/src/calendar/date-range-calendar/README.md
+++ b/packages/components/src/calendar/date-range-calendar/README.md
@@ -1,0 +1,279 @@
+# `DateRangeCalendar`
+
+`DateRangeCalendar` is a React component that provides a customizable calendar interface for **date range** selection.
+
+The component is built with accessibility in mind and follows ARIA best practices for calendar widgets. It provides keyboard navigation, screen reader support, and customizable labels for internationalization.
+
+## Usage example
+
+```tsx
+import { DateRangeCalendar } from '@automattic/components';
+
+type DateRange = {
+	from: Date | undefined;
+	to?: Date | undefined;
+};
+
+function MyComponent() {
+	const [ selected, setSelected ] = useState< DateRange >( {
+		from: new Date( date.getFullYear(), date.getMonth(), 1 ),
+		to: new Date(),
+	} );
+
+	return <DateRangeCalendar selected={ selected } onSelect={ setSelected } />;
+}
+```
+
+## Props
+
+These props are shared between both single date and date range calendar modes.
+
+### `required`
+
+- Type: `boolean`
+- Required: No
+- Default: `false`
+
+Whether the selection is required. When `true`, there always needs to be a date selected.
+
+### `selected`
+
+- Type: `DateRange | undefined | null`
+- Required: No
+
+The selected date range. A `DateRange` object has the following shape:
+
+```typescript
+{
+  from: Date | undefined;
+  to?: Date | undefined;
+}
+```
+
+### `onSelect`
+
+- Type: `(selected: DateRange | undefined, triggerDate: Date, modifiers: Modifiers, e: React.MouseEvent | React.KeyboardEvent) => void`
+- Required: No
+
+Event handler when the selection changes. The `selected` parameter will contain the new date range.
+
+### `defaultSelected`
+
+- Type: `DateRange`
+- Required: No
+
+The default selected range (for uncontrolled usage).
+
+### `excludeDisabled`
+
+- Type: `boolean`
+- Required: No
+
+When `true`, the range will reset when including a disabled day. This is useful to prevent users from selecting ranges that include unavailable dates.
+
+### `min`
+
+- Type: `number`
+- Required: No
+
+The minimum number of days to include in the range. If a user tries to select a range shorter than this, the selection will be adjusted to meet the minimum requirement.
+
+### `max`
+
+- Type: `number`
+- Required: No
+
+The maximum number of days to include in the range. If a user tries to select a range longer than this, the selection will be adjusted to meet the maximum requirement.
+
+### `defaultMonth`
+
+- Type: `Date`
+- Required: No
+- Default: Current month
+
+The initial month to show in the calendar view (uncontrolled).
+
+### `month`
+
+- Type: `Date`
+- Required: No
+
+The month displayed in the calendar view (controlled). Use together with `onMonthChange` to change the month programmatically.
+
+### `numberOfMonths`
+
+- Type: `number`
+- Required: No
+- Default: `1`
+
+The number of months displayed at once.
+
+### `startMonth`
+
+- Type: `Date`
+- Required: No
+
+The earliest month to start the month navigation.
+
+### `endMonth`
+
+- Type: `Date`
+- Required: No
+
+The latest month to end the month navigation.
+
+### `autoFocus`
+
+- Type: `boolean`
+- Required: No
+
+Focus the first selected day (if set) or today's date (if not disabled). Use this prop when you need to focus the calendar after a user action (e.g. opening the dialog with the calendar).
+
+### `disabled`
+
+- Type: `Matcher | Matcher[] | undefined`
+- Required: No
+
+Specify which days are disabled. Using `true` will disable all dates. See the [Matcher Types](#matcher-types) section for more details.
+
+### `disableNavigation`
+
+- Type: `boolean`
+- Required: No
+
+Disable the navigation buttons.
+
+### `modifiers`
+
+- Type: `Record<string, Matcher | Matcher[] | undefined> | undefined`
+- Required: No
+
+Add modifiers to the matching days. See the [Matcher Types](#matcher-types) section for more details.
+
+### `labels`
+
+- Type: `object`
+- Required: No
+
+Use custom labels for internationalization. All labels are optional and have sensible defaults:
+
+```typescript
+{
+  labelNav?: () => string; // Navigation toolbar label
+  labelGrid?: (date: Date) => string; // Month grid label (default: "LLLL y")
+  labelGridcell?: (date: Date, modifiers?: Modifiers) => string; // Grid cell label
+  labelNext?: (month: Date | undefined) => string; // Next month button label
+  labelPrevious?: (month: Date | undefined) => string; // Previous month button label
+  labelDayButton?: (date: Date, modifiers?: Modifiers) => string; // Day button label
+  labelWeekday?: (date: Date) => string; // Weekday label
+}
+```
+
+**Important: For a correct localized experience, consumers should make sure the locale used for the translated labels and `locale` prop are consistent.**
+
+### `locale`
+
+- Type: `Locale`
+- Required: No
+- Default: `enUS` from `@date-fns/locale`
+
+The locale object used to localize dates. Pass a locale from `@date-fns/locale` to localize the calendar.
+
+**Important: For a correct localized experience, consumers should make sure the locale used for the translated labels and `locale` prop are consistent.**
+
+### `weekStartsOn`
+
+- Type: `0 | 1 | 2 | 3 | 4 | 5 | 6 | undefined`
+- Required: No
+- Default: Based on the `locale` prop
+
+The index of the first day of the week (0 - Sunday). Overrides the locale's setting.
+
+### `onMonthChange`
+
+- Type: `(month: Date) => void`
+- Required: No
+
+Event fired when the user navigates between months.
+
+### `timeZone`
+
+- Type: `string`
+- Required: No
+
+The time zone (IANA or UTC offset) to use in the calendar. See [Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for possible values.
+
+### `role`
+
+- Type: `'application' | 'dialog' | undefined`
+- Required: No
+- Default: `'application'`
+
+The role attribute to add to the container element.
+
+## Matcher Types
+
+The calendar component uses a flexible matching system to determine which days should be disabled or have specific modifiers. Here are the available matcher types:
+
+### Boolean Matcher
+
+```typescript
+const booleanMatcher: Matcher = true; // Will always match the day
+```
+
+### Date Matcher
+
+```typescript
+const dateMatcher: Matcher = new Date(); // Will match today's date
+```
+
+### Array Matcher
+
+```typescript
+const arrayMatcher: Matcher = [ new Date( 2019, 1, 2 ), new Date( 2019, 1, 4 ) ]; // Will match the days in the array
+```
+
+### Date After Matcher
+
+```typescript
+const afterMatcher: DateAfter = { after: new Date( 2019, 1, 2 ) }; // Will match days after the 2nd of February 2019
+```
+
+### Date Before Matcher
+
+```typescript
+const beforeMatcher: DateBefore = { before: new Date( 2019, 1, 2 ) }; // Will match days before the 2nd of February 2019
+```
+
+### Date Interval Matcher
+
+```typescript
+const intervalMatcher: DateInterval = {
+	after: new Date( 2019, 1, 2 ),
+	before: new Date( 2019, 1, 5 ),
+}; // Will match the days between the 2nd and the 5th of February 2019 (exclusive)
+```
+
+### Date Range Matcher
+
+```typescript
+const rangeMatcher: DateRange = {
+	from: new Date( 2019, 1, 2 ),
+	to: new Date( 2019, 1, 5 ),
+}; // Will match the days between the 2nd and the 5th of February 2019 (inclusive)
+```
+
+### Day of Week Matcher
+
+```typescript
+const dayOfWeekMatcher: DayOfWeek = { dayOfWeek: 0 }; // Will match Sundays
+const weekendMatcher: DayOfWeek = { dayOfWeek: [ 0, 6 ] }; // Will match weekends
+```
+
+### Function Matcher
+
+```typescript
+const functionMatcher: Matcher = ( day: Date ) => {
+	return day.getMonth() === 2; // Will match when month is March
+};
+```

--- a/packages/components/src/calendar/date-range-calendar/index.tsx
+++ b/packages/components/src/calendar/date-range-calendar/index.tsx
@@ -1,12 +1,12 @@
 import { useMemo, useState } from 'react';
 import { DayPicker } from 'react-day-picker';
 import { enUS } from 'react-day-picker/locale';
-import { COMMON_PROPS, MODIFIER_CLASSNAMES } from './utils/constants';
-import { clampNumberOfMonths } from './utils/misc';
-import { useControlledValue } from './utils/use-controlled-value';
-import { useLocalizationProps } from './utils/use-localization-props';
-import type { DateRangeCalendarProps, DateRange } from './types';
-import './styles.scss';
+import { COMMON_PROPS, MODIFIER_CLASSNAMES } from '../utils/constants';
+import { clampNumberOfMonths } from '../utils/misc';
+import { useControlledValue } from '../utils/use-controlled-value';
+import { useLocalizationProps } from '../utils/use-localization-props';
+import type { DateRangeCalendarProps, DateRange } from '../types';
+import '../styles.scss';
 
 export const DateRangeCalendar = ( {
 	defaultSelected,

--- a/packages/components/src/calendar/date-range-calendar/index.tsx
+++ b/packages/components/src/calendar/date-range-calendar/index.tsx
@@ -8,6 +8,14 @@ import { useLocalizationProps } from '../utils/use-localization-props';
 import type { DateRangeCalendarProps, DateRange } from '../types';
 import '../styles.scss';
 
+/**
+ * `DateRangeCalendar` is a React component that provides a customizable calendar
+ * interface for **date range** selection.
+ *
+ * The component is built with accessibility in mind and follows ARIA best
+ * practices for calendar widgets. It provides keyboard navigation, screen reader
+ * support, and customizable labels for internationalization.
+ */
 export const DateRangeCalendar = ( {
 	defaultSelected,
 	selected: selectedProp,

--- a/packages/components/src/calendar/types.ts
+++ b/packages/components/src/calendar/types.ts
@@ -205,10 +205,6 @@ export interface BaseProps
 	 */
 	disableNavigation?: boolean;
 	/**
-	 * Add modifiers to the matching days.
-	 */
-	modifiers?: Record< string, Matcher | Matcher[] | undefined > | undefined;
-	/**
 	 * Use custom labels, useful for translating the component.
 	 *
 	 * For a correct localized experience, consumers should make sure the locale


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes DS-218

## Proposed Changes

Add README and JSDocs to `DateCalendar` and `DateRangeCalendar` components.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To document components for their future consumers.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Project builds
* Storybook builds
* Tests pass
* Check JSDocs in IDE
* Check README

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
