### PR TITLE
Fix misaligned card in 'Use your domain' page

### DIFF
--- a/client/components/domains/use-my-domain/style.scss
+++ b/client/components/domains/use-my-domain/style.scss
@@ -11,6 +11,9 @@
 	background-color: inherit;
 	& .card {
 		box-shadow: none;
+	}
+
+	&.card {
 		display: flex; // NOTE: To increase specificity
 	}
 

--- a/client/components/domains/use-my-domain/style.scss
+++ b/client/components/domains/use-my-domain/style.scss
@@ -11,6 +11,7 @@
 	background-color: inherit;
 	& .card {
 		box-shadow: none;
+		display: flex; // NOTE: To increase specificity
 	}
 
 	& &__page-heading {


### PR DESCRIPTION
This PR fixes: https://linear.app/a8c/issue/DOTCOM-13339/use-your-domain-layout-seems-misplaced-stepper

## Proposed Changes

Currently, the css property display: block of the .card class is overriding the display: flex property in .use-my-domain, causing a misalignment of the layout. To fix this, a display: flex with higher specificity was added.

### Before:
![Screenshot 2025-05-27 at 18 34 31](https://github.com/user-attachments/assets/1332b43f-f3ff-4357-bc30-3531b28718a6)

### After:
![Screenshot 2025-05-27 at 18 34 43](https://github.com/user-attachments/assets/ba49ebb2-4afd-4153-960b-869363fcac13)


## Testing Instructions
1. Start local environment
2. Go to http://calypso.localhost:3000/sites
4. Select any site that hasn't been launched yet
7. Click `Launch site` button from the master bar
8. Select `Use a domain I own` in Domains page

Current result: The form is misaligned to the left. (screenshot 1)
Expected result: The form should be centred. (screenshot 2)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
