### PR TITLE
Connect Refresh: Login - Refactor heading to accept client name and logo. Fix for Studio

### DIFF
--- a/client/blocks/login/login-header.scss
+++ b/client/blocks/login/login-header.scss
@@ -1,0 +1,3 @@
+.login-header-text__client-name {
+	text-transform: capitalize;
+}

--- a/client/blocks/login/login-header.tsx
+++ b/client/blocks/login/login-header.tsx
@@ -8,6 +8,7 @@ import WooCommerceConnectCartHeader from 'calypso/components/woocommerce-connect
 import WPCloudLogo from 'calypso/components/wp-cloud-logo';
 import { getPluginTitle } from 'calypso/lib/login';
 import {
+	isStudioAppOAuth2Client,
 	isCrowdsignalOAuth2Client,
 	isJetpackCloudOAuth2Client,
 	isA4AOAuth2Client,
@@ -16,6 +17,7 @@ import {
 	isGravatarOAuth2Client,
 	isPartnerPortalOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
+import './login-header.scss';
 
 interface LoginHeaderProps {
 	action: string;
@@ -37,6 +39,7 @@ interface LoginHeaderProps {
 	oauth2Client: {
 		title: string;
 		icon: string;
+		name: string;
 	} | null;
 	socialConnect: boolean;
 	twoStepNonce: string | null;
@@ -56,7 +59,7 @@ export function getHeaderText(
 	socialConnect: boolean,
 	linkingSocialService: string,
 	action: string,
-	oauth2Client: { title: string; icon: string } | null,
+	oauth2Client: { title: string; icon: string; name: string } | null,
 	isWooJPC: boolean,
 	isFromMigrationPlugin: boolean,
 	isJetpack: boolean,
@@ -74,7 +77,13 @@ export function getHeaderText(
 	let headerText = translate( 'Log in to your account' );
 
 	if ( isSocialFirst ) {
-		headerText = translate( 'Log in to WordPress.com' );
+		headerText =
+			oauth2Client && isStudioAppOAuth2Client( oauth2Client )
+				? translate( 'Log in to {{span}}%(client)s{{/span}} with WordPress.com', {
+						args: { client: oauth2Client.name },
+						components: { span: <span className="login-header-text__client-name" /> },
+				  } )
+				: translate( 'Log in to WordPress.com' );
 	}
 
 	if ( twoFactorAuthType === 'authenticator' ) {
@@ -260,12 +269,12 @@ export function LoginHeader( {
 		postHeader = (
 			<p className="login__header-subtitle login__lostpassword-subtitle">
 				{ translate(
-					'It happens to the best of us. Enter the email address associated with your WordPress.com account and we’ll send you a link to reset your password.'
+					"It happens to the best of us. Enter the email address associated with your WordPress.com account and we'll send you a link to reset your password."
 				) }
 				{ isWooJPC && (
 					<span>
 						<br />
-						{ translate( 'Don’t have an account? {{signupLink}}Sign up{{/signupLink}}', {
+						{ translate( "Don't have an account? {{signupLink}}Sign up{{/signupLink}}", {
 							components: {
 								signupLink,
 							},
@@ -278,7 +287,7 @@ export function LoginHeader( {
 			postHeader = (
 				<p className="login__header-subtitle login__lostpassword-subtitle">
 					{ translate(
-						'It happens to the best of us. Enter the email address associated with your Blaze Pro account and we’ll send you a link to reset your password.'
+						"It happens to the best of us. Enter the email address associated with your Blaze Pro account and we'll send you a link to reset your password."
 					) }
 				</p>
 			);
@@ -310,8 +319,8 @@ export function LoginHeader( {
 				postHeader = (
 					<p className="login__header-subtitle">
 						{ wccomFrom === 'nux'
-							? translate( 'First, select the account you’d like to use.' )
-							: translate( 'Select the account you’d like to use.' ) }
+							? translate( "First, select the account you'd like to use." )
+							: translate( "Select the account you'd like to use." ) }
 					</p>
 				);
 			} else {
@@ -416,7 +425,7 @@ export function LoginHeader( {
 			if ( showContinueAsUser ) {
 				postHeader = (
 					<p className="login__header-subtitle">
-						{ translate( 'Select the account you’d like to use' ) }
+						{ translate( "Select the account you'd like to use" ) }
 					</p>
 				);
 			}
@@ -438,7 +447,7 @@ export function LoginHeader( {
 		} else if ( ! isTwoFactorAuthFlow ) {
 			header = <h3>{ headerText }</h3>;
 			subtitle = translate(
-				'To access all of the features and functionality %(pluginName)s, you’ll first need to connect your store to a WordPress.com account. Log in now, or {{signupLink}}create a new account{{/signupLink}}. For more information, please {{doc}}review our documentation{{/doc}}.',
+				"To access all of the features and functionality %(pluginName)s, you'll first need to connect your store to a WordPress.com account. Log in now, or {{signupLink}}create a new account{{/signupLink}}. For more information, please {{doc}}review our documentation{{/doc}}.",
 				{
 					components: {
 						signupLink,

--- a/client/login/wp-login/components/login-heading-logo.tsx
+++ b/client/login/wp-login/components/login-heading-logo.tsx
@@ -1,0 +1,16 @@
+import studioAppLogo from 'calypso/assets/images/icons/studio-app-logo.svg';
+import { isStudioAppOAuth2Client } from 'calypso/lib/oauth2-clients';
+import { useSelector } from 'calypso/state';
+import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+
+const HeadingLogo = () => {
+	const oauth2Client = useSelector( getCurrentOAuth2Client );
+
+	const logo = isStudioAppOAuth2Client( oauth2Client ) ? (
+		<img className="wp-login__heading-logo-studio" src={ studioAppLogo } alt="Studio App Logo" />
+	) : null;
+
+	return logo ? <div className="wp-login__heading-logo">{ logo }</div> : null;
+};
+
+export default HeadingLogo;

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -28,6 +28,7 @@ import {
 	isBlazeProOAuth2Client,
 	isWooOAuth2Client,
 	isPartnerPortalOAuth2Client,
+	isStudioAppOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login, lostPassword } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -48,6 +49,7 @@ import getIsWCCOM from 'calypso/state/selectors/get-is-wccom';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
 import isWooJPCFlow from 'calypso/state/selectors/is-woo-jpc-flow';
 import { withEnhancers } from 'calypso/state/utils';
+import HeadingLogo from './components/login-heading-logo';
 import LoginFooter from './login-footer';
 import LoginLinks from './login-links';
 
@@ -651,10 +653,20 @@ export class Login extends Component {
 				{ isWhiteLogin && (
 					<Step.CenteredColumnLayout
 						columnWidth={ 6 }
+						{ ...( isStudioAppOAuth2Client( oauth2Client ) && { columnWidthHeading: 8 } ) }
 						topBar={
 							<Step.TopBar rightElement={ this.renderLoginHeaderNavigation() } logo={ brandLogo } />
 						}
-						heading={ <Step.Heading text={ headerText } /> }
+						heading={
+							<Step.Heading
+								text={
+									<>
+										<HeadingLogo />
+										<div className="wp-login__heading-text">{ headerText }</div>
+									</>
+								}
+							/>
+						}
 						verticalAlign="center"
 					>
 						{ mainContent }

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -36,6 +36,20 @@ $image-height: 47px;
 			display: none;
 		}
 	}
+
+	.step-container-v2__heading {
+		text-align: center;
+	}
+}
+
+.wp-login__heading-logo {
+	text-align: center;
+	margin-bottom: 16px;
+
+	.wp-login__heading-logo-studio {
+		width: 64px;
+		height: 64px;
+	}
 }
 
 .wp-login__main.main {
@@ -912,4 +926,3 @@ $image-height: 47px;
 :root {
 	--login-form-column-max-width: 327px;
 }
-

--- a/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/CenteredColumnLayout.tsx
+++ b/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/CenteredColumnLayout.tsx
@@ -13,11 +13,13 @@ interface CenteredColumnLayoutProps {
 	children?: ContentProp;
 	stickyBottomBar?: ContentProp;
 	columnWidth: 4 | 5 | 6 | 8 | 10;
+	columnWidthHeading?: 4 | 5 | 6 | 8 | 10;
 	verticalAlign?: 'center';
 }
 
 export const CenteredColumnLayout = ( {
 	columnWidth,
+	columnWidthHeading,
 	topBar,
 	heading,
 	className,
@@ -34,7 +36,9 @@ export const CenteredColumnLayout = ( {
 					<>
 						<TopBarRenderer topBar={ topBar } />
 						<ContentWrapper centerAligned={ context.isSmallViewport && verticalAlign === 'center' }>
-							{ heading && <ContentRow columns={ 6 }>{ heading }</ContentRow> }
+							{ heading && (
+								<ContentRow columns={ columnWidthHeading ?? 6 }>{ heading }</ContentRow>
+							) }
 							<ContentRow columns={ columnWidth } className={ className }>
 								{ content }
 							</ContentRow>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13216/calypso-enable-the-two-column-layout-for-studio

## Proposed Changes

- We update the login heading to include the correct wording and a logo above the text
- No other client/login variations affected

## Media

### Studio Login

<img width="600" alt="Screenshot 2025-05-27 at 8 14 27 PM" src="https://github.com/user-attachments/assets/3ffd5ee5-b2f5-47ba-ba91-49104864df13" />

### WordPress Login

<img width="600" alt="Screenshot 2025-05-27 at 8 14 44 PM" src="https://github.com/user-attachments/assets/363040c9-3919-464d-bd28-cc69704b07bf" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13216/calypso-enable-the-two-column-layout-for-studio

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On calypso.localhost use the following:
    * [Studio login](http://calypso.localhost:3000/log-in?client_id=95109&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dtoken%26client_id%3D95109%26redirect_uri%3Dwpcom-local-dev%253A%252F%252Fauth%26scope%3Dglobal%26client_source%26jetpack-code%26jetpack-user-id%3D0%26action%3Doauth2-login%26from-calypso%3D1) 
    * [WordPress login](http://calypso/localhost:3000/log-in)
* Other client/login variations should stay the same / no change. Confirm that other variant implementations are not affected. See [Linear issue](https://linear.app/a8c/issue/DOTCOM-13220/calypso-make-the-two-column-layout-and-unified-design-the-default) for a list

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
