### PR TITLE
Connect Refresh: Update the WP logo in default login to just logo / no watermark

### DIFF
--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { Gridicon } from '@automattic/components';
+import { Gridicon, WordPressLogo } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Step } from '@automattic/onboarding';
 import clsx from 'clsx';
@@ -636,6 +636,14 @@ export class Login extends Component {
 			document.location.search?.includes( 'wpcloud' )
 		) {
 			brandLogo = <WPCloudLogo className="login__wpcloud-logo" size={ 120 } />;
+		} else {
+			brandLogo = (
+				<WordPressLogo
+					size={ 21 }
+					className="step-container-v2__top-bar-wordpress-logo"
+					color="currentColor"
+				/>
+			);
 		}
 
 		return (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DS-230/design-system-calypso-enable-and-unify-the-master-bar-and-wp-logo

## Proposed Changes

- Updates the default login top-bar to match the [Figma (DS Pass)](https://www.figma.com/proto/QwLWndRBggFq0keb79EZM7/WordPress.com-OAuth-Flow?page-id=800%3A14498&node-id=1995-9289&node-type=frame&viewport=1808%2C493%2C0.09&t=uenVMHgzLlybRnMn-1&scaling=min-zoom&content-scaling=fixed&starting-point-node-id=1995%3A9715&show-proto-sidebar=1).
  - Effectively removes the WordPress wording/watermark
- This should only affect the default WP brand i.e. cases where client/variant does not override

## Media

| Before | After |
|--------|--------|
| <img width="1021" alt="Screenshot 2025-05-27 at 8 34 04 PM" src="https://github.com/user-attachments/assets/dd0a3e53-b26a-42d2-b7f6-8bb870a2dcad" /> | <img width="1022" alt="Screenshot 2025-05-27 at 8 33 38 PM" src="https://github.com/user-attachments/assets/75328d42-8a7a-4a8b-ac0f-77413a341975" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DS-230/design-system-calypso-enable-and-unify-the-master-bar-and-wp-logo


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/log-in` and confirm
- Go to any of the other client/variant login screens and confirm not affected. See a full list with quick links in https://github.com/Automattic/wp-calypso/pull/103650

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
