### PR TITLE
Fix Calypso Cannot read properties of null reading 'domain' error

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -317,7 +317,7 @@ class RegisterDomainStep extends Component {
 	// created a site by skipping the domain step. In these cases, fire the initial search
 	// with the subdomain name.
 	getInitialQueryInLaunchFlow() {
-		if ( ! this.props.isInLaunchFlow ) {
+		if ( ! this.props.isInLaunchFlow || this.props.selectedSite === null ) {
 			return;
 		}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Task related: https://linear.app/a8c/issue/DOTCOM-13243/fix-calypso-cannot-read-properties-of-null-reading-domain-error

## Proposed Changes

* We're checking if we do have a `selectedSite` before trying to use it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We're fixing a bug on treating an invalid state from users, caught here: p1747924156914929-slack-C04H4NY6STW

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open this Calyspo launch site URL [using an invalid site](http://calypso.localhost:3000/start/launch-site/domains-launch?siteSlug=aaaaaaaaaaaaaaaaaaaaa.wordpress.com) and you should see the Choose a domain screen:

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/b85cc54c-7b37-42b6-b267-f47c96ed57ed) | ![image](https://github.com/user-attachments/assets/73092deb-d17f-4ddd-aa92-df91ff7dc5f3) | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?