### PR TITLE
Making promoted-post reply disclaimer always shown

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -821,27 +821,27 @@ export default function CampaignItemDetails( props: Props ) {
 								{ showAllReplies ? __( 'Show Less' ) : __( 'Show More' ) }
 							</button>
 						) }
-
-						<div className="campaign-items-details__reply-disclaimer">
-							&#42;&nbsp;
-							{ translate(
-								'Some replies may have been hidden, blocked, or removed due to {{tumblrGuideline}}Tumblr guidelines {{externalIcon/}}{{/tumblrGuideline}} violation',
-								{
-									components: {
-										tumblrGuideline: (
-											<a
-												href="https://www.tumblr.com/policy/en/user-guidelines"
-												target="_blank"
-												rel="noopener noreferrer"
-											/>
-										),
-										externalIcon: <Gridicon icon="external" size={ 16 } />,
-									},
-								}
-							) }
-						</div>
 					</div>
 				) }
+
+				<div className="campaign-items-details__reply-disclaimer">
+					&#42;&nbsp;
+					{ translate(
+						'Some replies may have been hidden, blocked, or removed due to {{tumblrGuideline}}Tumblr guidelines {{externalIcon/}}{{/tumblrGuideline}} violation',
+						{
+							components: {
+								tumblrGuideline: (
+									<a
+										href="https://www.tumblr.com/policy/en/user-guidelines"
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+								externalIcon: <Gridicon icon="external" size={ 16 } />,
+							},
+						}
+					) }
+				</div>
 			</div>
 		</>
 	);

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -363,6 +363,7 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 				cursor: pointer;
 			}
 			.campaign-items-details__reply-disclaimer {
+				grid-column: 1 / -1;
 				margin-top: 10px;
 			}
 		}


### PR DESCRIPTION
* https://github.tumblr.net/Tumblr/a8c-dsp/issues/3257
* https://github.com/Automattic/wp-calypso/pull/103267

## Proposed Changes

* Making the reply disclaimer always shown even if there's no replies. This was previously added into a block with replies length check. https://github.com/Automattic/wp-calypso/blob/46281630e3d0eb97e75eaa6293aba2e56730589b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx#L801

![image](https://github.com/user-attachments/assets/9ec50e90-301e-492a-bcb2-192f5d6a9f9b)


## Testing Instructions

* Visit the detail page of a completed super-native tumblr blaze campaign.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
