### PR TITLE
DataForms: Add help text to `text` and `email` control.

### DIFF
--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -6,7 +6,7 @@
 
 ## 0.2.0
 
-- `text`, `email` Edit control: add `help` support from the field `description` prop.
+- `text` Edit control: add `help` support from the field `description` prop.
 - Bring changes from `@wordpress/dataviews 4.19.0` (no updates in this version).
 - `select` Edit control: add `help` support from the field `description` prop.
 - Add new Edit controls: `checkbox`, `toggleGroup`. In the `toggleGroup`, if the field elements (options) have a `description`, then the selected option's description will be also rendered.

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -2,11 +2,11 @@
 
 ## Next
 
+- `text`, `email` Edit control: add `help` support from the field `description` prop.
 - Add `align` to the `layout.styles` properties, for use in the DataViews table layout. Options are: `start`, `center`, and `end`.
 
 ## 0.2.0
 
-- `text` Edit control: add `help` support from the field `description` prop.
 - Bring changes from `@wordpress/dataviews 4.19.0` (no updates in this version).
 - `select` Edit control: add `help` support from the field `description` prop.
 - Add new Edit controls: `checkbox`, `toggleGroup`. In the `toggleGroup`, if the field elements (options) have a `description`, then the selected option's description will be also rendered.

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -6,7 +6,7 @@
 
 ## 0.2.0
 
-- `text` Edit control: add `help` support from the field `description` prop.
+- `text`, `email` Edit control: add `help` support from the field `description` prop.
 - Bring changes from `@wordpress/dataviews 4.19.0` (no updates in this version).
 - `select` Edit control: add `help` support from the field `description` prop.
 - Add new Edit controls: `checkbox`, `toggleGroup`. In the `toggleGroup`, if the field elements (options) have a `description`, then the selected option's description will be also rendered.

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -6,6 +6,7 @@
 
 ## 0.2.0
 
+- `text` Edit control: add `help` support from the field `description` prop.
 - Bring changes from `@wordpress/dataviews 4.19.0` (no updates in this version).
 - `select` Edit control: add `help` support from the field `description` prop.
 - Add new Edit controls: `checkbox`, `toggleGroup`. In the `toggleGroup`, if the field elements (options) have a `description`, then the selected option's description will be also rendered.

--- a/packages/dataviews/src/dataform-controls/email.tsx
+++ b/packages/dataviews/src/dataform-controls/email.tsx
@@ -15,7 +15,7 @@ export default function Email< Item >( {
 	onChange,
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
-	const { id, label, placeholder } = field;
+	const { id, label, placeholder, description } = field;
 	const value = field.getValue( { item: data } );
 
 	const onChangeControl = useCallback(
@@ -32,6 +32,7 @@ export default function Email< Item >( {
 			label={ label }
 			placeholder={ placeholder }
 			value={ value ?? '' }
+			help={ description }
 			onChange={ onChangeControl }
 			__next40pxDefaultSize
 			__nextHasNoMarginBottom

--- a/packages/dataviews/src/dataform-controls/text.tsx
+++ b/packages/dataviews/src/dataform-controls/text.tsx
@@ -15,7 +15,7 @@ export default function Text< Item >( {
 	onChange,
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
-	const { id, label, placeholder } = field;
+	const { id, label, placeholder, description } = field;
 	const value = field.getValue( { item: data } );
 
 	const onChangeControl = useCallback(
@@ -31,6 +31,7 @@ export default function Text< Item >( {
 			label={ label }
 			placeholder={ placeholder }
 			value={ value ?? '' }
+			help={ description }
 			onChange={ onChangeControl }
 			__next40pxDefaultSize
 			__nextHasNoMarginBottom


### PR DESCRIPTION
## Proposed Change

We'll need the help text for the `text` and `email` controls for use in the new dashboard.

Example: QOBjujZah0UlGDDdLKZhzi-fi-3801_169281

## Testing Instructions

When creating a `<DataForm`, add the `description` property to your field. Expect to see it appear under your field.