### PR TITLE
Hosting Dashboard v2: Add the ability to leave a site

### DIFF
--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -255,7 +255,7 @@ export function siteHasPurchasesCancelableQuery( siteId: string, userId: number 
 			const cancelables = purchases
 				.filter( ( purchase ) => {
 					// Exclude inactive purchases and legacy premium theme purchases.
-					if ( ! purchase.active || purchase.productSlug === 'premium_theme' ) {
+					if ( ! purchase.active || purchase.product_slug === 'premium_theme' ) {
 						return false;
 					}
 
@@ -277,8 +277,8 @@ export function siteUserMeQuery( siteId: string ) {
 	};
 }
 
-export function leaveSiteMutation( siteId: string, userId: number ) {
+export function leaveSiteMutation( siteId: string ) {
 	return {
-		mutationFn: () => leaveSite( siteId, userId ),
+		mutationFn: ( userId: number ) => leaveSite( siteId, userId ),
 	};
 }

--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -23,6 +23,9 @@ import {
 	updateStaticFile404,
 	fetchEdgeCacheDefensiveMode,
 	updateEdgeCacheDefensiveMode,
+	fetchPurchases,
+	fetchSiteUserMe,
+	leaveSite,
 } from '../data';
 import { SITE_FIELDS, SITE_OPTIONS } from '../data/constants';
 import { queryClient } from './query-client';
@@ -238,5 +241,43 @@ export function siteDefensiveModeMutation( siteSlug: string ) {
 		onSuccess: ( data: DefensiveModeSettings ) => {
 			queryClient.setQueryData( [ 'site', siteSlug, 'defensive-mode' ], data );
 		},
+	};
+}
+
+export function siteHasPurchasesCancelableQuery( siteId: string, userId: number ) {
+	return {
+		queryKey: [ 'site', siteId, 'purchases-cancelable' ],
+		queryFn: () => {
+			return fetchPurchases( siteId );
+		},
+		select: ( purchases: Purchase[] ) => {
+			const cancelables = purchases
+				.filter( ( purchase ) => {
+					// Exclude inactive purchases and legacy premium theme purchases.
+					if ( ! purchase.active || purchase.productSlug === 'premium_theme' ) {
+						return false;
+					}
+
+					return purchase.is_cancelable;
+				} )
+				.filter( ( purchase ) => Number( purchase.user_id ) === userId );
+
+			return cancelables.length > 0;
+		},
+	};
+}
+
+export function siteUserMeQuery( siteId: string ) {
+	return {
+		queryKey: [ 'site', siteId, 'user-me' ],
+		queryFn: () => {
+			return fetchSiteUserMe( siteId );
+		},
+	};
+}
+
+export function leaveSiteMutation( siteId: string, userId: number ) {
+	return {
+		mutationFn: () => leaveSite( siteId, userId ),
 	};
 }

--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -31,6 +31,7 @@ import { SITE_FIELDS, SITE_OPTIONS } from '../data/constants';
 import { queryClient } from './query-client';
 import type {
 	Profile,
+	Purchase,
 	SiteSettings,
 	UrlPerformanceInsights,
 	DefensiveModeSettings,

--- a/client/dashboard/data/constants.ts
+++ b/client/dashboard/data/constants.ts
@@ -26,4 +26,9 @@ export const SITE_FIELDS = [
 	'jetpack_modules',
 ];
 
-export const SITE_OPTIONS = [ 'admin_url', 'software_version', 'is_redirect' ];
+export const SITE_OPTIONS = [
+	'admin_url',
+	'software_version',
+	'is_redirect',
+	'is_wpforteams_site',
+];

--- a/client/dashboard/data/constants.ts
+++ b/client/dashboard/data/constants.ts
@@ -26,9 +26,4 @@ export const SITE_FIELDS = [
 	'jetpack_modules',
 ];
 
-export const SITE_OPTIONS = [
-	'admin_url',
-	'software_version',
-	'is_redirect',
-	'is_wpforteams_site',
-];
+export const SITE_OPTIONS = [ 'admin_url', 'software_version', 'is_redirect' ];

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -9,6 +9,7 @@ import type {
 	Site,
 	Purchase,
 	User,
+	SiteUser,
 	Profile,
 	TwoStep,
 	EngagementStatsDataPoint,
@@ -459,7 +460,7 @@ export const fetchPurchases = async ( siteIdOrSlug: string ): Promise< Purchase[
 	} );
 };
 
-export const fetchSiteUserMe = async ( siteIdOrSlug: string ): Promise< Me > => {
+export const fetchSiteUserMe = async ( siteIdOrSlug: string ): Promise< SiteUser > => {
 	return wpcom.req.get( {
 		path: `/sites/${ siteIdOrSlug }/users/me`,
 		apiNamespace: 'wp/v2',

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -7,6 +7,7 @@ import type {
 	MonitorUptime,
 	Plan,
 	Site,
+	Purchase,
 	User,
 	Profile,
 	TwoStep,
@@ -450,4 +451,23 @@ export const updateEdgeCacheDefensiveMode = async (
 		},
 		data
 	);
+};
+
+export const fetchPurchases = async ( siteIdOrSlug: string ): Promise< Purchase[] > => {
+	return wpcom.req.get( {
+		path: `/sites/${ siteIdOrSlug }/purchases`,
+	} );
+};
+
+export const fetchSiteUserMe = async ( siteIdOrSlug: string ): Promise< Me > => {
+	return wpcom.req.get( {
+		path: `/sites/${ siteIdOrSlug }/users/me`,
+		apiNamespace: 'wp/v2',
+	} );
+};
+
+export const leaveSite = async ( siteIdOrSlug: string, userId: number ) => {
+	return wpcom.req.post( {
+		path: `/sites/${ siteIdOrSlug }/users/${ userId }/delete`,
+	} );
 };

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -17,6 +17,16 @@ export interface User {
 	locale_variant: string;
 }
 
+export interface SiteUser {
+	id: number;
+	id_wpcom: number;
+	description: string;
+	name: string;
+	slug: string;
+	url: string;
+	link: string;
+}
+
 export interface SiteDomain {
 	id: number;
 	domain: string;
@@ -71,6 +81,8 @@ export interface SiteOptions {
 	software_version: string;
 	admin_url: string;
 	is_redirect?: boolean;
+	// True for P2 sites.
+	is_wpforteams_site?: boolean;
 }
 
 export interface Site {
@@ -101,6 +113,14 @@ export interface Site {
 	site_owner: number;
 	jetpack: boolean;
 	jetpack_modules: string[] | null;
+}
+
+export interface Purchase {
+	ID: number | string;
+	active: boolean;
+	is_cancelable: boolean;
+	product_slug: string;
+	user_id: number | string;
 }
 
 export type EmailProvider = 'titan' | 'google-workspace' | 'forwarding';

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -19,12 +19,6 @@ export interface User {
 
 export interface SiteUser {
 	id: number;
-	id_wpcom: number;
-	description: string;
-	name: string;
-	slug: string;
-	url: string;
-	link: string;
 }
 
 export interface SiteDomain {

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -81,8 +81,6 @@ export interface SiteOptions {
 	software_version: string;
 	admin_url: string;
 	is_redirect?: boolean;
-	// True for P2 sites.
-	is_wpforteams_site?: boolean;
 }
 
 export interface Site {

--- a/client/dashboard/sites/settings/danger-zone.tsx
+++ b/client/dashboard/sites/settings/danger-zone.tsx
@@ -7,10 +7,6 @@ import { useCanTransferSite } from '../hooks/use-can-transfer-site';
 import SiteLeaveModal from '../site-leave-modal';
 import type { Site } from '../../data/types';
 
-function canLeaveSite( site: Site ) {
-	return ! site.options?.is_wpforteams_site;
-}
-
 const SiteTransferAction = ( { site }: { site: Site } ) => {
 	const { slug } = site;
 
@@ -57,7 +53,7 @@ export default function DangerZone( { site }: { site: Site } ) {
 
 	const actions = [
 		canTransferSite && <SiteTransferAction key="transfer-site" site={ site } />,
-		canLeaveSite( site ) && <SiteLeaveAction key="leave-site" site={ site } />,
+		<SiteLeaveAction key="leave-site" site={ site } />,
 	].filter( Boolean );
 
 	if ( ! actions.length ) {

--- a/client/dashboard/sites/settings/danger-zone.tsx
+++ b/client/dashboard/sites/settings/danger-zone.tsx
@@ -31,20 +31,18 @@ const SiteLeaveAction = ( { site }: { site: Site } ) => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
 	return (
-		<ActionList.ActionItem
-			title={ __( 'Leave site' ) }
-			description={ __( 'Leave this site and remove your access.' ) }
-			actions={
-				<>
+		<>
+			<ActionList.ActionItem
+				title={ __( 'Leave site' ) }
+				description={ __( 'Leave this site and remove your access.' ) }
+				actions={
 					<Button variant="secondary" size="compact" onClick={ () => setIsModalOpen( true ) }>
 						{ __( 'Leave' ) }
 					</Button>
-					{ isModalOpen && (
-						<SiteLeaveModal site={ site } onClose={ () => setIsModalOpen( false ) } />
-					) }
-				</>
-			}
-		/>
+				}
+			/>
+			{ isModalOpen && <SiteLeaveModal site={ site } onClose={ () => setIsModalOpen( false ) } /> }
+		</>
 	);
 };
 

--- a/client/dashboard/sites/settings/danger-zone.tsx
+++ b/client/dashboard/sites/settings/danger-zone.tsx
@@ -1,11 +1,17 @@
-import { __experimentalHeading as Heading } from '@wordpress/components';
+import { __experimentalHeading as Heading, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
 import { ActionList } from '../../components/action-list';
 import RouterLinkButton from '../../components/router-link-button';
 import { useCanTransferSite } from '../hooks/use-can-transfer-site';
+import SiteLeaveModal from '../site-leave-modal';
 import type { Site } from '../../data/types';
 
-const TransferSite = ( { site }: { site: Site } ) => {
+function canLeaveSite( site: Site ) {
+	return ! site.options?.is_wpforteams_site;
+}
+
+const SiteTransferAction = ( { site }: { site: Site } ) => {
 	const { slug } = site;
 
 	return (
@@ -25,11 +31,34 @@ const TransferSite = ( { site }: { site: Site } ) => {
 	);
 };
 
+const SiteLeaveAction = ( { site }: { site: Site } ) => {
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+
+	return (
+		<ActionList.ActionItem
+			title={ __( 'Leave site' ) }
+			description={ __( 'Leave this site and remove your access.' ) }
+			actions={
+				<>
+					<Button variant="secondary" size="compact" onClick={ () => setIsModalOpen( true ) }>
+						{ __( 'Leave' ) }
+					</Button>
+					{ isModalOpen && (
+						<SiteLeaveModal site={ site } onClose={ () => setIsModalOpen( false ) } />
+					) }
+				</>
+			}
+		/>
+	);
+};
+
 export default function DangerZone( { site }: { site: Site } ) {
 	const canTransferSite = useCanTransferSite( { site } );
-	const actions = [ canTransferSite && <TransferSite key="transfer-site" site={ site } /> ].filter(
-		Boolean
-	);
+
+	const actions = [
+		canTransferSite && <SiteTransferAction key="transfer-site" site={ site } />,
+		canLeaveSite( site ) && <SiteLeaveAction key="leave-site" site={ site } />,
+	].filter( Boolean );
 
 	if ( ! actions.length ) {
 		return null;

--- a/client/dashboard/sites/site-leave-modal/index.tsx
+++ b/client/dashboard/sites/site-leave-modal/index.tsx
@@ -94,7 +94,7 @@ function ContentLeaveSite( { site, onClose }: ContentProps ) {
 	const router = useRouter();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
-	// Fetch "me" as a site user entity.
+	// It gets external user ID (ID of user entity from site connected via Jetpack) from provided WPCOM user ID.
 	const { data: me } = useQuery( siteUserMeQuery( site.slug ) );
 	const mutation = useMutation( leaveSiteMutation( site.slug ) );
 
@@ -196,19 +196,21 @@ export default function SiteLeaveModal( { site, onClose }: SiteLeaveModalProps )
 		siteHasPurchasesCancelableQuery( site.slug, user.ID )
 	);
 
-	const showContentHasPurchasesCancelable = hasPurchasesCancelable;
-	const showContentSiteOwner = ! showContentHasPurchasesCancelable && isSiteOwner( user, site );
-	const showContentLeaveSite = ! showContentHasPurchasesCancelable && ! showContentSiteOwner;
+	const renderContent = () => {
+		if ( hasPurchasesCancelable ) {
+			return <ContentHasPurchasesCancelable site={ site } onClose={ onClose } />;
+		}
+
+		if ( isSiteOwner( user, site ) ) {
+			return <ContentSiteOwner site={ site } onClose={ onClose } />;
+		}
+
+		return <ContentLeaveSite site={ site } onClose={ onClose } />;
+	};
 
 	return (
 		<Modal title={ __( 'Leave site' ) } size="medium" onRequestClose={ onClose }>
-			<VStack spacing={ 6 }>
-				{ showContentHasPurchasesCancelable && (
-					<ContentHasPurchasesCancelable site={ site } onClose={ onClose } />
-				) }
-				{ showContentSiteOwner && <ContentSiteOwner site={ site } onClose={ onClose } /> }
-				{ showContentLeaveSite && <ContentLeaveSite site={ site } onClose={ onClose } /> }
-			</VStack>
+			<VStack spacing={ 6 }>{ renderContent() }</VStack>
 		</Modal>
 	);
 }

--- a/client/dashboard/sites/site-leave-modal/index.tsx
+++ b/client/dashboard/sites/site-leave-modal/index.tsx
@@ -1,0 +1,216 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { DataForm } from '@automattic/dataviews';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import {
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	Button,
+	Modal,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useState } from 'react';
+import { useAuth } from '../../app/auth';
+import {
+	leaveSiteMutation,
+	siteHasPurchasesCancelableQuery,
+	siteUserMeQuery,
+} from '../../app/queries';
+import RouterLinkButton from '../../components/router-link-button';
+import type { Site, User } from '../../data/types';
+
+interface SiteLeaveModalProps {
+	site: Site;
+	onClose: () => void;
+}
+
+type ContentProps = SiteLeaveModalProps;
+
+function isSiteOwner( user: User, site: Site ) {
+	return user.ID === site.site_owner;
+}
+
+function ContentHasPurchasesCancelable( { site, onClose }: ContentProps ) {
+	return (
+		<>
+			<VStack spacing={ 0 }>
+				<Text>
+					{ __(
+						'You have active subscriptions associated with this site. These must be cancelled before you can leave the site.'
+					) }
+				</Text>
+			</VStack>
+			<HStack spacing={ 4 } justify="flex-end" expanded={ false }>
+				<Button variant="tertiary" onClick={ onClose }>
+					{ __( 'Cancel' ) }
+				</Button>
+				<Button
+					variant="primary"
+					href={ `/purchases/subscriptions/${ site.slug }` }
+					onClick={ () =>
+						recordTracksEvent( 'calypso_sites_dashboard_site_leave_modal_manage_purchases_click' )
+					}
+				>
+					{ __( 'Manage purchases' ) }
+				</Button>
+			</HStack>
+		</>
+	);
+}
+
+function ContentSiteOwner( { site, onClose }: ContentProps ) {
+	return (
+		<>
+			<VStack spacing={ 0 }>
+				<Text>
+					{ __(
+						'You are the owner of this site. To leave you must first transfer ownership to another account.'
+					) }
+				</Text>
+			</VStack>
+			<HStack spacing={ 4 } justify="flex-end" expanded={ false }>
+				<Button variant="tertiary" onClick={ onClose }>
+					{ __( 'Cancel' ) }
+				</Button>
+				<RouterLinkButton
+					variant="primary"
+					to={ `/sites/${ site.slug }/settings/transfer-site` }
+					onClick={ () =>
+						recordTracksEvent( 'calypso_sites_dashboard_site_leave_modal_transfer_ownership_click' )
+					}
+				>
+					{ __( 'Transfer ownership' ) }
+				</RouterLinkButton>
+			</HStack>
+		</>
+	);
+}
+
+function ContentLeaveSite( { site, onClose }: ContentProps ) {
+	const router = useRouter();
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	// Fetch "me" as a site user entity.
+	const { data: me } = useQuery( siteUserMeQuery( site.slug ) );
+	const mutation = useMutation( leaveSiteMutation( site.slug, me?.id ) );
+
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
+	const [ formData, setFormData ] = useState< { confirmed: boolean } >( {
+		confirmed: false,
+	} );
+
+	const isConfirmed = formData.confirmed;
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		if ( ! isConfirmed ) {
+			return;
+		}
+
+		setIsSubmitting( true );
+		recordTracksEvent( 'calypso_sites_dashboard_site_leave_modal_leave_site_click' );
+
+		mutation.mutate( undefined, {
+			onSuccess: () => {
+				recordTracksEvent( 'calypso_sites_dashboard_site_leave_modal_leave_site_success' );
+				createSuccessNotice(
+					/* translators: %s: site domain */
+					sprintf( __( 'You have left %s successfully.' ), site.slug ),
+					{ type: 'snackbar' }
+				);
+
+				router.navigate( { to: '/sites' } );
+				onClose();
+			},
+			onError: ( error: Error ) => {
+				recordTracksEvent( 'calypso_sites_dashboard_site_leave_modal_leave_site_error', {
+					site_id: site.ID,
+					error: error.name,
+				} );
+
+				createErrorNotice( error.message, { type: 'snackbar' } );
+				onClose();
+			},
+		} );
+	};
+
+	return (
+		<form onSubmit={ handleSubmit }>
+			<VStack spacing={ 6 }>
+				<Text as="p">
+					{ createInterpolateElement(
+						/* translators: %s: site domain */
+						__( 'Are you sure to leave the site <siteDomain />?' ),
+						{
+							siteDomain: <strong>{ site.slug }</strong>,
+						}
+					) }
+				</Text>
+				<Text as="p">
+					{ __(
+						'Leaving will remove your access to the site, including all content, users, domains, upgrades, and anything else you have access to.'
+					) }
+				</Text>
+				<Text as="p">
+					{ __(
+						'To regain access, a current administrator must re-invite you. Please confirm this is your intent before proceeding.'
+					) }
+				</Text>
+				<DataForm< { confirmed: boolean } >
+					data={ formData }
+					fields={ [
+						{
+							id: 'confirmed',
+							label: __( 'I understand the consequences of leaving' ),
+							Edit: 'checkbox',
+						},
+					] }
+					form={ { type: 'regular' as const, fields: [ 'confirmed' ] } }
+					onChange={ ( edits: { confirmed?: boolean } ) => {
+						setFormData( ( data ) => ( { ...data, ...edits } ) );
+					} }
+				/>
+				<HStack spacing={ 4 } justify="flex-end" expanded={ false }>
+					<Button variant="tertiary" onClick={ onClose }>
+						{ __( 'Cancel' ) }
+					</Button>
+					<Button
+						variant="primary"
+						type="submit"
+						disabled={ ! isConfirmed }
+						isBusy={ isSubmitting }
+					>
+						{ __( 'Leave site' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		</form>
+	);
+}
+
+export default function SiteLeaveModal( { site, onClose }: SiteLeaveModalProps ) {
+	const { user } = useAuth();
+	const { data: hasPurchasesCancelable } = useQuery(
+		siteHasPurchasesCancelableQuery( site.slug, user.ID )
+	);
+
+	const showContentHasPurchasesCancelable = hasPurchasesCancelable;
+	const showContentSiteOwner = ! showContentHasPurchasesCancelable && isSiteOwner( user, site );
+	const showContentLeaveSite = ! showContentHasPurchasesCancelable && ! showContentSiteOwner;
+
+	return (
+		<Modal title={ __( 'Leave site' ) } size="medium" onRequestClose={ onClose }>
+			<VStack spacing={ 6 }>
+				{ showContentHasPurchasesCancelable && (
+					<ContentHasPurchasesCancelable site={ site } onClose={ onClose } />
+				) }
+				{ showContentSiteOwner && <ContentSiteOwner site={ site } onClose={ onClose } /> }
+				{ showContentLeaveSite && <ContentLeaveSite site={ site } onClose={ onClose } /> }
+			</VStack>
+		</Modal>
+	);
+}

--- a/client/dashboard/sites/site-leave-modal/index.tsx
+++ b/client/dashboard/sites/site-leave-modal/index.tsx
@@ -96,9 +96,8 @@ function ContentLeaveSite( { site, onClose }: ContentProps ) {
 
 	// Fetch "me" as a site user entity.
 	const { data: me } = useQuery( siteUserMeQuery( site.slug ) );
-	const mutation = useMutation( leaveSiteMutation( site.slug, me?.id ) );
+	const mutation = useMutation( leaveSiteMutation( site.slug ) );
 
-	const [ isSubmitting, setIsSubmitting ] = useState( false );
 	const [ formData, setFormData ] = useState< { confirmed: boolean } >( {
 		confirmed: false,
 	} );
@@ -107,14 +106,13 @@ function ContentLeaveSite( { site, onClose }: ContentProps ) {
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
-		if ( ! isConfirmed ) {
+		if ( ! me || ! isConfirmed ) {
 			return;
 		}
 
-		setIsSubmitting( true );
 		recordTracksEvent( 'calypso_sites_dashboard_site_leave_modal_leave_site_click' );
 
-		mutation.mutate( undefined, {
+		mutation.mutate( me.id, {
 			onSuccess: () => {
 				recordTracksEvent( 'calypso_sites_dashboard_site_leave_modal_leave_site_success' );
 				createSuccessNotice(
@@ -182,7 +180,7 @@ function ContentLeaveSite( { site, onClose }: ContentProps ) {
 						variant="primary"
 						type="submit"
 						disabled={ ! isConfirmed }
-						isBusy={ isSubmitting }
+						isBusy={ mutation.isPending }
 					>
 						{ __( 'Leave site' ) }
 					</Button>

--- a/client/dashboard/sites/site-leave-modal/index.tsx
+++ b/client/dashboard/sites/site-leave-modal/index.tsx
@@ -30,6 +30,10 @@ interface SiteLeaveModalProps {
 
 type ContentProps = SiteLeaveModalProps;
 
+type SiteLeaveFormData = {
+	confirmed: boolean;
+};
+
 function isSiteOwner( user: User, site: Site ) {
 	return user.ID === site.site_owner;
 }
@@ -98,7 +102,7 @@ function ContentLeaveSite( { site, onClose }: ContentProps ) {
 	const { data: me } = useQuery( siteUserMeQuery( site.slug ) );
 	const mutation = useMutation( leaveSiteMutation( site.slug ) );
 
-	const [ formData, setFormData ] = useState< { confirmed: boolean } >( {
+	const [ formData, setFormData ] = useState< SiteLeaveFormData >( {
 		confirmed: false,
 	} );
 
@@ -158,7 +162,7 @@ function ContentLeaveSite( { site, onClose }: ContentProps ) {
 						'To regain access, a current administrator must re-invite you. Please confirm this is your intent before proceeding.'
 					) }
 				</Text>
-				<DataForm< { confirmed: boolean } >
+				<DataForm< SiteLeaveFormData >
 					data={ formData }
 					fields={ [
 						{
@@ -168,7 +172,7 @@ function ContentLeaveSite( { site, onClose }: ContentProps ) {
 						},
 					] }
 					form={ { type: 'regular' as const, fields: [ 'confirmed' ] } }
-					onChange={ ( edits: { confirmed?: boolean } ) => {
+					onChange={ ( edits: Partial< SiteLeaveFormData > ) => {
 						setFormData( ( data ) => ( { ...data, ...edits } ) );
 					} }
 				/>


### PR DESCRIPTION
Ref DOTCOM-13259

## Proposed Changes

This PR implements the option to leave a site via the modal component SiteLeaveModal.

![Screenshot 2025-05-28 at 4 20 31 PM](https://github.com/user-attachments/assets/7443f238-3005-43bb-a045-dbfbe92c4f4d)

SiteLeaveModal has three states. When it comes to priority, scenario 1 will be shown if it's applicable, then scenario 2 will be shown if scenario 1 is not applicable. Scenario 3 will be shown when 1 and 2 are not applicable.

1. When the site has active cancelable subscriptions, the modal will prompt to remove them first. To test this, use a WoA site.

![Screenshot 2025-05-28 at 4 23 50 PM](https://github.com/user-attachments/assets/86204954-b55f-4cb8-8a6f-d61ff1696a52)

2. When the user is the site owner, the modal will prompt to transfer the site. To test this, use a free site.

![Screenshot 2025-05-28 at 4 22 58 PM](https://github.com/user-attachments/assets/2a7c5ad0-9e2a-4831-b53b-a0b8e03b78c2)

3. Otherwise, the option to leave the site is available. To test this, use a P2 site.

![SCR-20250528-oote](https://github.com/user-attachments/assets/effc1873-036b-4ab8-9209-50db9cafe26b)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Hosting Dashboard v2 implementation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2/sites/:siteSlug/settings
* Ensure that the Leave Site action is available, and it works as described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
