### PR TITLE
Dashboard v2: Add the ability to delete a site

### DIFF
--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -30,6 +30,7 @@ import {
 	fetchPurchases,
 	fetchSiteUserMe,
 	leaveSite,
+	fetchP2HubP2s,
 } from '../data';
 import { SITE_FIELDS, SITE_OPTIONS } from '../data/constants';
 import { queryClient } from './query-client';
@@ -319,5 +320,14 @@ export function siteUserMeQuery( siteId: string ) {
 export function leaveSiteMutation( siteId: string ) {
 	return {
 		mutationFn: ( userId: number ) => leaveSite( siteId, userId ),
+	};
+}
+
+export function p2HubP2sQuery( siteId: string, options: { limit?: number } = {} ) {
+	return {
+		queryKey: [ 'p2-hub-p2s', siteId, options ],
+		queryFn: () => {
+			return fetchP2HubP2s( siteId, options );
+		},
 	};
 }

--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -202,7 +202,7 @@ export function siteOwnerTransferConfirmMutation( siteId: string ) {
 				// Invalidate queries as the site has been transferred to new owner.
 				queryClient.invalidateQueries( { queryKey: [ 'site', siteId ] } );
 			}
-		}
+		},
 	};
 }
 

--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -19,6 +19,7 @@ import {
 	siteOwnerTransfer,
 	siteOwnerTransferEligibilityCheck,
 	siteOwnerTransferConfirm,
+	deleteSite,
 	fetchWordPressVersion,
 	updateWordPressVersion,
 	fetchPrimaryDataCenter,
@@ -200,6 +201,15 @@ export function siteOwnerTransferConfirmMutation( siteId: string ) {
 				// Invalidate queries as the site has been transferred to new owner.
 				queryClient.invalidateQueries( { queryKey: [ 'site', siteId ] } );
 			}
+		}
+	};
+}
+
+export function deleteSiteMutation( siteId: string ) {
+	return {
+		mutationFn: () => deleteSite( siteId ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'site', siteId ] } );
 		},
 	};
 }

--- a/client/dashboard/components/notice/style.scss
+++ b/client/dashboard/components/notice/style.scss
@@ -85,6 +85,7 @@
 
 .dashboard-notice__description {
 	@include body-medium;
+	text-wrap: pretty;
 }
 
 .dashboard-notice__actions {

--- a/client/dashboard/data/constants.ts
+++ b/client/dashboard/data/constants.ts
@@ -26,4 +26,10 @@ export const SITE_FIELDS = [
 	'jetpack_modules',
 ];
 
-export const SITE_OPTIONS = [ 'admin_url', 'software_version', 'is_redirect' ];
+export const SITE_OPTIONS = [
+	'admin_url',
+	'software_version',
+	'is_redirect',
+	'is_wpforteams_site',
+	'p2_hub_blog_id',
+];

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -525,3 +525,19 @@ export const leaveSite = async ( siteIdOrSlug: string, userId: number ) => {
 		path: `/sites/${ siteIdOrSlug }/users/${ userId }/delete`,
 	} );
 };
+
+export const fetchP2HubP2s = async (
+	siteIdOrSlug: string,
+	options: { limit?: number } = {}
+): Promise< { totalItems: number } > => {
+	return wpcom.req.get(
+		{
+			path: '/p2/workspace/sites/all',
+			apiNamespace: 'wpcom/v2',
+		},
+		{
+			hub_id: siteIdOrSlug,
+			...options,
+		}
+	);
+};

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -411,6 +411,13 @@ export const siteOwnerTransferConfirm = async (
 	);
 };
 
+export const deleteSite = async ( siteIdOrSlug: string ) => {
+	return wpcom.req.post( {
+		path: `/sites/${ siteIdOrSlug }/delete`,
+		apiNamespace: 'wpcom/v2',
+	} );
+};
+
 export const fetchBasicMetrics = async ( url: string ): Promise< BasicMetricsData > => {
 	return wpcom.req.get(
 		{

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -526,7 +526,7 @@ export const leaveSite = async ( siteIdOrSlug: string, userId: number ) => {
 };
 
 export const fetchP2HubP2s = async (
-	siteIdOrSlug: string,
+	siteId: string,
 	options: { limit?: number } = {}
 ): Promise< { totalItems: number } > => {
 	return wpcom.req.get(
@@ -535,7 +535,7 @@ export const fetchP2HubP2s = async (
 			apiNamespace: 'wpcom/v2',
 		},
 		{
-			hub_id: siteIdOrSlug,
+			hub_id: siteId,
 			...options,
 		}
 	);

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -414,7 +414,6 @@ export const siteOwnerTransferConfirm = async (
 export const deleteSite = async ( siteIdOrSlug: string ) => {
 	return wpcom.req.post( {
 		path: `/sites/${ siteIdOrSlug }/delete`,
-		apiNamespace: 'wpcom/v2',
 	} );
 };
 

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -50,6 +50,7 @@ export interface Domain {
 }
 
 export interface SitePlan {
+	product_slug: string;
 	product_name: string;
 	product_name_short: string;
 	expired: boolean;
@@ -77,6 +78,7 @@ export interface SiteOptions {
 	admin_url: string;
 	is_redirect?: boolean;
 	p2_hub_blog_id?: number;
+	is_wpforteams_site?: boolean;
 }
 
 export interface Site {

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -76,6 +76,7 @@ export interface SiteOptions {
 	software_version: string;
 	admin_url: string;
 	is_redirect?: boolean;
+	p2_hub_blog_id?: number;
 }
 
 export interface Site {
@@ -97,6 +98,7 @@ export interface Site {
 	is_private: boolean;
 	is_wpcom_atomic: boolean;
 	is_wpcom_staging_site: boolean;
+	is_vip: boolean;
 	launch_status: string | boolean;
 	site_migration: {
 		migration_status?: string;

--- a/client/dashboard/sites/settings/danger-zone.tsx
+++ b/client/dashboard/sites/settings/danger-zone.tsx
@@ -47,9 +47,6 @@ const SiteLeaveAction = ( { site }: { site: Site } ) => {
 	);
 }
 
-const canDeleteSite = ( site: Site ) =>
-	( site.is_wpcom_atomic || ! site.jetpack ) && ! site.is_vip && ! site.options?.p2_hub_blog_id;
-
 const SiteDeleteAction = ( { site }: { site: Site } ) => {
 	const [ isOpen, setIsOpen ] = useState( false );
 
@@ -82,7 +79,7 @@ export default function DangerZone( { site }: { site: Site } ) {
 	const actions = [
 		canTransferSite && <SiteTransferAction key="transfer-site" site={ site } />,
 		<SiteLeaveAction key="leave-site" site={ site } />,
-		canDeleteSite( site ) && <SiteDeleteAction key="delete-site" site={ site } />,
+		<SiteDeleteAction key="delete-site" site={ site } />,
 	].filter( Boolean );
 
 	if ( ! actions.length ) {

--- a/client/dashboard/sites/settings/danger-zone.tsx
+++ b/client/dashboard/sites/settings/danger-zone.tsx
@@ -4,8 +4,8 @@ import { useState } from 'react';
 import { ActionList } from '../../components/action-list';
 import RouterLinkButton from '../../components/router-link-button';
 import { useCanTransferSite } from '../hooks/use-can-transfer-site';
-import SiteLeaveModal from '../site-leave-modal';
 import SiteDeleteModal from '../site-delete-modal';
+import SiteLeaveModal from '../site-leave-modal';
 import type { Site } from '../../data/types';
 
 const SiteTransferAction = ( { site }: { site: Site } ) => {
@@ -45,7 +45,9 @@ const SiteLeaveAction = ( { site }: { site: Site } ) => {
 			{ isModalOpen && <SiteLeaveModal site={ site } onClose={ () => setIsModalOpen( false ) } /> }
 		</>
 	);
-}
+};
+
+const showSiteDeleteAction = ( site: Site ) => ! site.is_wpcom_staging_site;
 
 const SiteDeleteAction = ( { site }: { site: Site } ) => {
 	const [ isOpen, setIsOpen ] = useState( false );
@@ -79,7 +81,7 @@ export default function DangerZone( { site }: { site: Site } ) {
 	const actions = [
 		canTransferSite && <SiteTransferAction key="transfer-site" site={ site } />,
 		<SiteLeaveAction key="leave-site" site={ site } />,
-		<SiteDeleteAction key="delete-site" site={ site } />,
+		showSiteDeleteAction( site ) && <SiteDeleteAction key="delete-site" site={ site } />,
 	].filter( Boolean );
 
 	if ( ! actions.length ) {

--- a/client/dashboard/sites/settings/danger-zone.tsx
+++ b/client/dashboard/sites/settings/danger-zone.tsx
@@ -5,6 +5,7 @@ import { ActionList } from '../../components/action-list';
 import RouterLinkButton from '../../components/router-link-button';
 import { useCanTransferSite } from '../hooks/use-can-transfer-site';
 import SiteLeaveModal from '../site-leave-modal';
+import SiteDeleteModal from '../site-delete-modal';
 import type { Site } from '../../data/types';
 
 const SiteTransferAction = ( { site }: { site: Site } ) => {
@@ -44,6 +45,35 @@ const SiteLeaveAction = ( { site }: { site: Site } ) => {
 			{ isModalOpen && <SiteLeaveModal site={ site } onClose={ () => setIsModalOpen( false ) } /> }
 		</>
 	);
+}
+
+const canDeleteSite = ( site: Site ) =>
+	( site.is_wpcom_atomic || ! site.jetpack ) && ! site.is_vip && ! site.options?.p2_hub_blog_id;
+
+const SiteDeleteAction = ( { site }: { site: Site } ) => {
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	return (
+		<>
+			<ActionList.ActionItem
+				title={ __( 'Delete site' ) }
+				description={ __(
+					"Delete all your posts, pages, media, and data, and give up your site's address."
+				) }
+				actions={
+					<Button
+						variant="secondary"
+						size="compact"
+						isDestructive
+						onClick={ () => setIsOpen( true ) }
+					>
+						{ __( 'Delete' ) }
+					</Button>
+				}
+			/>
+			{ isOpen && <SiteDeleteModal site={ site } onClose={ () => setIsOpen( false ) } /> }
+		</>
+	);
 };
 
 export default function DangerZone( { site }: { site: Site } ) {
@@ -52,6 +82,7 @@ export default function DangerZone( { site }: { site: Site } ) {
 	const actions = [
 		canTransferSite && <SiteTransferAction key="transfer-site" site={ site } />,
 		<SiteLeaveAction key="leave-site" site={ site } />,
+		canDeleteSite( site ) && <SiteDeleteAction key="delete-site" site={ site } />,
 	].filter( Boolean );
 
 	if ( ! actions.length ) {

--- a/client/dashboard/sites/site-delete-modal/index.tsx
+++ b/client/dashboard/sites/site-delete-modal/index.tsx
@@ -1,0 +1,133 @@
+import { DataForm } from '@automattic/dataviews';
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import {
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	Button,
+	ExternalLink,
+	Modal,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useState } from 'react';
+import { deleteSiteMutation } from '../../app/queries';
+import Notice from '../../components/notice';
+import type { Site } from '../../data/types';
+import type { Field } from '@automattic/dataviews';
+
+type SiteDeleteFormData = {
+	domain: string;
+};
+
+// TODO: Unable to delete site
+export default function SiteDeleteModal( { site, onClose }: { site: Site; onClose: () => void } ) {
+	const router = useRouter();
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const [ formData, setFormData ] = useState< SiteDeleteFormData >( { domain: '' } );
+	const mutation = useMutation( deleteSiteMutation( site.slug ) );
+
+	const fields: Field< SiteDeleteFormData >[] = [
+		{
+			id: 'domain',
+			label: __( 'Type the site domain to confirm' ),
+			type: 'text' as const,
+			description: sprintf(
+				/* translators: %s: site domain */
+				__( 'The site domain is: %s' ),
+				site.slug
+			),
+		},
+	];
+
+	const form = {
+		type: 'regular' as const,
+		fields: [ 'domain' ],
+	};
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+
+		mutation.mutate( undefined, {
+			onSuccess: () => {
+				router.navigate( { to: '/sites' } );
+				createSuccessNotice(
+					sprintf(
+						/* translators: %s: site name */
+						__( '%s has been deleted.' ),
+						site.name
+					),
+					{ type: 'snackbar' }
+				);
+			},
+			onError: ( error: { error: string } ) => {
+				let message = 'Failed to delete site';
+				if ( error.error === 'active-subscriptions' ) {
+					message = 'You must cancel any active subscriptions prior to deleting your site.';
+				}
+
+				if ( error.error === 'p2-hub-has-spaces' ) {
+					message =
+						'Your P2 Workspace has P2s. You must delete all P2s in this workspace before you can delete it.';
+				}
+
+				createErrorNotice( message, {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
+
+	return (
+		<Modal title={ __( 'Delete site' ) } size="medium" onRequestClose={ onClose }>
+			<VStack spacing={ 4 }>
+				<Notice variant="warning" density="medium">
+					<Text>
+						{ createInterpolateElement(
+							'Before deleting your site, consider <link>exporting your content as a backup</link>.',
+							{
+								// @ts-expect-error children prop is injected by createInterpolateElement
+								link: <ExternalLink href="#" />,
+							}
+						) }
+					</Text>
+				</Notice>
+				<Text as="p">
+					{ __(
+						'Deletion is irreversible and will permanently remove all site content — posts, pages, media, users, authors, domains, purchased upgrades, and premium themes.'
+					) }
+				</Text>
+				<Text as="p">
+					{ sprintf(
+						/* translators: %s: site domain */
+						__( 'Once deleted, your domain %s will also become unavailable.' ),
+						site.slug
+					) }
+				</Text>
+				<form onSubmit={ handleSubmit }>
+					<VStack spacing={ 4 } style={ { padding: '8px 0' } }>
+						<DataForm< SiteDeleteFormData >
+							data={ formData }
+							fields={ fields }
+							form={ form }
+							onChange={ ( edits: Partial< SiteDeleteFormData > ) => {
+								setFormData( ( data ) => ( { ...data, ...edits } ) );
+							} }
+						/>
+						<HStack justify="flex-end">
+							<Button variant="tertiary" disabled={ mutation.isPending } onClick={ onClose }>
+								{ __( 'Cancel' ) }
+							</Button>
+							<Button variant="primary" type="submit" isDestructive isBusy={ mutation.isPending }>
+								{ __( 'Delete site' ) }
+							</Button>
+						</HStack>
+					</VStack>
+				</form>
+			</VStack>
+		</Modal>
+	);
+}

--- a/client/dashboard/sites/site-delete-modal/index.tsx
+++ b/client/dashboard/sites/site-delete-modal/index.tsx
@@ -215,7 +215,13 @@ export function SiteDeleteConfirmModal( { site, onClose }: { site: Site; onClose
 							<Button variant="tertiary" disabled={ mutation.isPending } onClick={ onClose }>
 								{ __( 'Cancel' ) }
 							</Button>
-							<Button variant="primary" type="submit" isDestructive isBusy={ mutation.isPending }>
+							<Button
+								variant="primary"
+								type="submit"
+								isDestructive
+								isBusy={ mutation.isPending }
+								disabled={ formData.domain !== site.slug }
+							>
 								{ __( 'Delete site' ) }
 							</Button>
 						</HStack>

--- a/client/dashboard/sites/site-delete-modal/index.tsx
+++ b/client/dashboard/sites/site-delete-modal/index.tsx
@@ -40,7 +40,7 @@ const TRIAL_PRODUCT_SLUGS = [
 const isTrialSite = ( site: Site ) =>
 	site.plan?.product_slug && TRIAL_PRODUCT_SLUGS.includes( site.plan?.product_slug );
 
-export function SiteDeleteWarningModal( { site, onClose }: { site: Site; onClose: () => void } ) {
+function SiteDeleteWarningContent( { site, onClose }: { site: Site; onClose: () => void } ) {
 	const { data: p2HubP2s } = useQuery( {
 		...p2HubP2sQuery( site.ID, { limit: 1 } ),
 		enabled: !! site.options?.p2_hub_blog_id && site.options?.is_wpforteams_site,
@@ -110,23 +110,21 @@ export function SiteDeleteWarningModal( { site, onClose }: { site: Site; onClose
 	};
 
 	return (
-		<Modal title={ __( 'Unable to delete site' ) } size="medium" onRequestClose={ onClose }>
-			<VStack spacing={ 4 }>
-				<Text as="p">{ renderWarningContent() }</Text>
-				<HStack justify="flex-end">
-					{ ! isAtomicRemovalInProgress && (
-						<Button variant="tertiary" onClick={ onClose }>
-							{ __( 'Cancel' ) }
-						</Button>
-					) }
-					{ renderPrimaryButton() }
-				</HStack>
-			</VStack>
-		</Modal>
+		<>
+			<Text as="p">{ renderWarningContent() }</Text>
+			<HStack justify="flex-end">
+				{ ! isAtomicRemovalInProgress && (
+					<Button variant="tertiary" onClick={ onClose }>
+						{ __( 'Cancel' ) }
+					</Button>
+				) }
+				{ renderPrimaryButton() }
+			</HStack>
+		</>
 	);
 }
 
-export function SiteDeleteConfirmModal( { site, onClose }: { site: Site; onClose: () => void } ) {
+function SiteDeleteConfirmContent( { site, onClose }: { site: Site; onClose: () => void } ) {
 	const router = useRouter();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const [ formData, setFormData ] = useState< SiteDeleteFormData >( { domain: '' } );
@@ -174,59 +172,57 @@ export function SiteDeleteConfirmModal( { site, onClose }: { site: Site; onClose
 	};
 
 	return (
-		<Modal title={ __( 'Delete site' ) } size="medium" onRequestClose={ onClose }>
-			<VStack spacing={ 4 }>
-				<Notice variant="warning" density="medium">
-					<Text>
-						{ createInterpolateElement(
-							'Before deleting your site, consider <link>exporting your content as a backup</link>.',
-							{
-								// @ts-expect-error children prop is injected by createInterpolateElement
-								link: <ExternalLink href="#" />,
-							}
-						) }
-					</Text>
-				</Notice>
-				<Text as="p">
-					{ __(
-						'Deletion is irreversible and will permanently remove all site content — posts, pages, media, users, authors, domains, purchased upgrades, and premium themes.'
+		<>
+			<Notice variant="warning" density="medium">
+				<Text>
+					{ createInterpolateElement(
+						'Before deleting your site, consider <link>exporting your content as a backup</link>.',
+						{
+							// @ts-expect-error children prop is injected by createInterpolateElement
+							link: <ExternalLink href="#" />,
+						}
 					) }
 				</Text>
-				<Text as="p">
-					{ sprintf(
-						/* translators: %s: site domain */
-						__( 'Once deleted, your domain %s will also become unavailable.' ),
-						site.slug
-					) }
-				</Text>
-				<form onSubmit={ handleSubmit }>
-					<VStack spacing={ 4 } style={ { padding: '8px 0' } }>
-						<DataForm< SiteDeleteFormData >
-							data={ formData }
-							fields={ fields }
-							form={ form }
-							onChange={ ( edits: Partial< SiteDeleteFormData > ) => {
-								setFormData( ( data ) => ( { ...data, ...edits } ) );
-							} }
-						/>
-						<HStack justify="flex-end">
-							<Button variant="tertiary" disabled={ mutation.isPending } onClick={ onClose }>
-								{ __( 'Cancel' ) }
-							</Button>
-							<Button
-								variant="primary"
-								type="submit"
-								isDestructive
-								isBusy={ mutation.isPending }
-								disabled={ formData.domain !== site.slug }
-							>
-								{ __( 'Delete site' ) }
-							</Button>
-						</HStack>
-					</VStack>
-				</form>
-			</VStack>
-		</Modal>
+			</Notice>
+			<Text as="p">
+				{ __(
+					'Deletion is irreversible and will permanently remove all site content — posts, pages, media, users, authors, domains, purchased upgrades, and premium themes.'
+				) }
+			</Text>
+			<Text as="p">
+				{ sprintf(
+					/* translators: %s: site domain */
+					__( 'Once deleted, your domain %s will also become unavailable.' ),
+					site.slug
+				) }
+			</Text>
+			<form onSubmit={ handleSubmit }>
+				<VStack spacing={ 4 } style={ { padding: '8px 0' } }>
+					<DataForm< SiteDeleteFormData >
+						data={ formData }
+						fields={ fields }
+						form={ form }
+						onChange={ ( edits: Partial< SiteDeleteFormData > ) => {
+							setFormData( ( data ) => ( { ...data, ...edits } ) );
+						} }
+					/>
+					<HStack justify="flex-end">
+						<Button variant="tertiary" disabled={ mutation.isPending } onClick={ onClose }>
+							{ __( 'Cancel' ) }
+						</Button>
+						<Button
+							variant="primary"
+							type="submit"
+							isDestructive
+							isBusy={ mutation.isPending }
+							disabled={ formData.domain !== site.slug }
+						>
+							{ __( 'Delete site' ) }
+						</Button>
+					</HStack>
+				</VStack>
+			</form>
+		</>
 	);
 }
 
@@ -236,13 +232,22 @@ export default function SiteDeleteModal( { site, onClose }: { site: Site; onClos
 		siteHasPurchasesCancelableQuery( site.slug, user.ID )
 	);
 
+	const canBeDeleted = canDeleteSite( site ) && ! hasPurchasesCancelable;
+	const title = canBeDeleted ? __( 'Delete site' ) : __( 'Unable to delete site' );
+
 	if ( isLoading ) {
 		return null;
 	}
 
-	return canDeleteSite( site ) && ! hasPurchasesCancelable ? (
-		<SiteDeleteConfirmModal site={ site } onClose={ onClose } />
-	) : (
-		<SiteDeleteWarningModal site={ site } onClose={ onClose } />
+	return (
+		<Modal title={ title } size="medium" onRequestClose={ onClose }>
+			<VStack spacing={ 4 }>
+				{ canBeDeleted ? (
+					<SiteDeleteConfirmContent site={ site } onClose={ onClose } />
+				) : (
+					<SiteDeleteWarningContent site={ site } onClose={ onClose } />
+				) }
+			</VStack>
+		</Modal>
 	);
 }

--- a/client/dashboard/sites/site-delete-modal/index.tsx
+++ b/client/dashboard/sites/site-delete-modal/index.tsx
@@ -11,7 +11,7 @@ import {
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { deleteSiteMutation } from '../../app/queries';
@@ -23,8 +23,60 @@ type SiteDeleteFormData = {
 	domain: string;
 };
 
-// TODO: Unable to delete site
-export default function SiteDeleteModal( { site, onClose }: { site: Site; onClose: () => void } ) {
+const canDeleteSite = ( site: Site ) =>
+	( site.is_wpcom_atomic || ! site.jetpack ) && ! site.is_vip && ! site.options?.p2_hub_blog_id;
+
+export function SiteDeleteWarningModal( { onClose }: { site: Site; onClose: () => void } ) {
+	const isAtomicRemovalInProgress = false;
+	const p2HubP2Count = 0;
+	const isTrialSite = false;
+
+	const renderWarningContent = () => {
+		if ( isAtomicRemovalInProgress ) {
+			return __(
+				"We are still in the process of removing your previous plan. Please check back in a few minutes and you'll be able to delete your site."
+			);
+		} else if ( p2HubP2Count ) {
+			return sprintf(
+				/* translators: %d is the number of P2 in your workspace */
+				_n(
+					'There is %d P2 in your workspace. Please delete it prior to deleting your workspace.',
+					'There are %d P2s in your workspace. Please delete them prior to deleting your workspace.',
+					p2HubP2Count
+				),
+				p2HubP2Count
+			);
+		} else if ( isTrialSite ) {
+			return __(
+				'You have an active or expired free trial on your site. Please cancel this plan prior to deleting your site.'
+			);
+		}
+
+		return __(
+			'You have active paid upgrades on your site. Please cancel your upgrades prior to deleting your site.'
+		);
+	};
+
+	const renderPrimaryButton = () => {
+		<Button variant="primary">{ __( 'Delete site' ) }</Button>;
+	};
+
+	return (
+		<Modal title={ __( 'Unable to delete site' ) } size="medium" onRequestClose={ onClose }>
+			<VStack spacing={ 4 }>
+				<Text as="p">{ renderWarningContent() }</Text>
+				<HStack justify="flex-end">
+					<Button variant="tertiary" onClick={ onClose }>
+						{ __( 'Cancel' ) }
+					</Button>
+					{ renderPrimaryButton() }
+				</HStack>
+			</VStack>
+		</Modal>
+	);
+}
+
+export function SiteDeleteConfirmModal( { site, onClose }: { site: Site; onClose: () => void } ) {
 	const router = useRouter();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const [ formData, setFormData ] = useState< SiteDeleteFormData >( { domain: '' } );
@@ -129,5 +181,13 @@ export default function SiteDeleteModal( { site, onClose }: { site: Site; onClos
 				</form>
 			</VStack>
 		</Modal>
+	);
+}
+
+export default function SiteDeleteModal( { site, onClose }: { site: Site; onClose: () => void } ) {
+	return canDeleteSite( site ) ? (
+		<SiteDeleteConfirmModal site={ site } onClose={ onClose } />
+	) : (
+		<SiteDeleteWarningModal site={ site } onClose={ onClose } />
 	);
 }

--- a/client/dashboard/sites/site-delete-modal/index.tsx
+++ b/client/dashboard/sites/site-delete-modal/index.tsx
@@ -79,7 +79,11 @@ export function SiteDeleteWarningModal( { site, onClose }: { site: Site; onClose
 
 	const renderPrimaryButton = () => {
 		if ( isAtomicRemovalInProgress ) {
-			return null;
+			return (
+				<Button variant="primary" onClick={ onClose }>
+					{ __( 'OK' ) }
+				</Button>
+			);
 		}
 
 		if ( p2HubP2Count ) {
@@ -108,9 +112,11 @@ export function SiteDeleteWarningModal( { site, onClose }: { site: Site; onClose
 			<VStack spacing={ 4 }>
 				<Text as="p">{ renderWarningContent() }</Text>
 				<HStack justify="flex-end">
-					<Button variant="tertiary" onClick={ onClose }>
-						{ __( 'Cancel' ) }
-					</Button>
+					{ ! isAtomicRemovalInProgress && (
+						<Button variant="tertiary" onClick={ onClose }>
+							{ __( 'Cancel' ) }
+						</Button>
+					) }
 					{ renderPrimaryButton() }
 				</HStack>
 			</VStack>

--- a/client/dashboard/sites/site-delete-modal/index.tsx
+++ b/client/dashboard/sites/site-delete-modal/index.tsx
@@ -37,16 +37,17 @@ const TRIAL_PRODUCT_SLUGS = [
 	'ecommerce-trial-bundle-monthly',
 ];
 
+const isTrialSite = ( site: Site ) =>
+	site.plan?.product_slug && TRIAL_PRODUCT_SLUGS.includes( site.plan?.product_slug );
+
 export function SiteDeleteWarningModal( { site, onClose }: { site: Site; onClose: () => void } ) {
 	const { data: p2HubP2s } = useQuery( {
-		...p2HubP2sQuery( site.slug, { limit: 1 } ),
+		...p2HubP2sQuery( site.ID, { limit: 1 } ),
 		enabled: !! site.options?.p2_hub_blog_id && site.options?.is_wpforteams_site,
 	} );
 
 	const isAtomicRemovalInProgress = site.plan?.is_free && site.is_wpcom_atomic;
 	const p2HubP2Count = p2HubP2s?.totalItems ?? 0;
-	const isTrialSite =
-		site.plan?.product_slug && TRIAL_PRODUCT_SLUGS.includes( site.plan?.product_slug );
 
 	const renderWarningContent = () => {
 		if ( isAtomicRemovalInProgress ) {
@@ -67,7 +68,7 @@ export function SiteDeleteWarningModal( { site, onClose }: { site: Site; onClose
 			);
 		}
 
-		if ( isTrialSite ) {
+		if ( isTrialSite( site ) ) {
 			return __(
 				'You have an active or expired free trial on your site. Please cancel this plan prior to deleting your site.'
 			);
@@ -95,7 +96,7 @@ export function SiteDeleteWarningModal( { site, onClose }: { site: Site; onClose
 			);
 		}
 
-		if ( isTrialSite ) {
+		if ( isTrialSite( site ) ) {
 			<Button variant="primary" href={ `/purchases/subscriptions/${ site.slug }` }>
 				{ __( 'Cancel trial' ) }
 			</Button>;
@@ -159,7 +160,7 @@ export function SiteDeleteConfirmModal( { site, onClose }: { site: Site; onClose
 					sprintf(
 						/* translators: %s: site name */
 						__( '%s has been deleted.' ),
-						site.name
+						site.slug
 					),
 					{ type: 'snackbar' }
 				);

--- a/client/dashboard/sites/site-delete-modal/index.tsx
+++ b/client/dashboard/sites/site-delete-modal/index.tsx
@@ -90,8 +90,8 @@ function SiteDeleteWarningContent( { site, onClose }: { site: Site; onClose: () 
 
 		if ( p2HubP2Count ) {
 			return (
-				<Button variant="primary" href="/sites">
-					{ __( 'Manage sites' ) }
+				<Button variant="primary" href={ site.URL }>
+					{ __( 'Manage P2s' ) }
 				</Button>
 			);
 		}

--- a/client/dashboard/sites/site-delete-modal/index.tsx
+++ b/client/dashboard/sites/site-delete-modal/index.tsx
@@ -40,12 +40,13 @@ const TRIAL_PRODUCT_SLUGS = [
 export function SiteDeleteWarningModal( { site, onClose }: { site: Site; onClose: () => void } ) {
 	const { data: p2HubP2s } = useQuery( {
 		...p2HubP2sQuery( site.slug, { limit: 1 } ),
-		enabled: site.options?.p2_hub_blog_id && site.options?.is_wpforteams_site,
+		enabled: !! site.options?.p2_hub_blog_id && site.options?.is_wpforteams_site,
 	} );
 
 	const isAtomicRemovalInProgress = site.plan?.is_free && site.is_wpcom_atomic;
 	const p2HubP2Count = p2HubP2s?.totalItems ?? 0;
-	const isTrialSite = TRIAL_PRODUCT_SLUGS.includes( site.plan?.product_name );
+	const isTrialSite =
+		site.plan?.product_slug && TRIAL_PRODUCT_SLUGS.includes( site.plan?.product_slug );
 
 	const renderWarningContent = () => {
 		if ( isAtomicRemovalInProgress ) {
@@ -163,18 +164,8 @@ export function SiteDeleteConfirmModal( { site, onClose }: { site: Site; onClose
 					{ type: 'snackbar' }
 				);
 			},
-			onError: ( error: { error: string } ) => {
-				let message = 'Failed to delete site';
-				if ( error.error === 'active-subscriptions' ) {
-					message = 'You must cancel any active subscriptions prior to deleting your site.';
-				}
-
-				if ( error.error === 'p2-hub-has-spaces' ) {
-					message =
-						'Your P2 Workspace has P2s. You must delete all P2s in this workspace before you can delete it.';
-				}
-
-				createErrorNotice( message, {
+			onError: ( error: Error ) => {
+				createErrorNotice( error.message || __( 'Failed to delete site' ), {
 					type: 'snackbar',
 				} );
 			},

--- a/client/dashboard/sites/site-delete-modal/index.tsx
+++ b/client/dashboard/sites/site-delete-modal/index.tsx
@@ -1,5 +1,5 @@
 import { DataForm } from '@automattic/dataviews';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
@@ -14,7 +14,12 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
-import { deleteSiteMutation } from '../../app/queries';
+import { useAuth } from '../../app/auth';
+import {
+	deleteSiteMutation,
+	p2HubP2sQuery,
+	siteHasPurchasesCancelableQuery,
+} from '../../app/queries';
 import Notice from '../../components/notice';
 import type { Site } from '../../data/types';
 import type { Field } from '@automattic/dataviews';
@@ -26,17 +31,30 @@ type SiteDeleteFormData = {
 const canDeleteSite = ( site: Site ) =>
 	( site.is_wpcom_atomic || ! site.jetpack ) && ! site.is_vip && ! site.options?.p2_hub_blog_id;
 
-export function SiteDeleteWarningModal( { onClose }: { site: Site; onClose: () => void } ) {
-	const isAtomicRemovalInProgress = false;
-	const p2HubP2Count = 0;
-	const isTrialSite = false;
+const TRIAL_PRODUCT_SLUGS = [
+	'wp_bundle_migration_trial_monthly',
+	'wp_bundle_hosting_trial_monthly',
+	'ecommerce-trial-bundle-monthly',
+];
+
+export function SiteDeleteWarningModal( { site, onClose }: { site: Site; onClose: () => void } ) {
+	const { data: p2HubP2s } = useQuery( {
+		...p2HubP2sQuery( site.slug, { limit: 1 } ),
+		enabled: site.options?.p2_hub_blog_id && site.options?.is_wpforteams_site,
+	} );
+
+	const isAtomicRemovalInProgress = site.plan?.is_free && site.is_wpcom_atomic;
+	const p2HubP2Count = p2HubP2s?.totalItems ?? 0;
+	const isTrialSite = TRIAL_PRODUCT_SLUGS.includes( site.plan?.product_name );
 
 	const renderWarningContent = () => {
 		if ( isAtomicRemovalInProgress ) {
 			return __(
 				"We are still in the process of removing your previous plan. Please check back in a few minutes and you'll be able to delete your site."
 			);
-		} else if ( p2HubP2Count ) {
+		}
+
+		if ( p2HubP2Count ) {
 			return sprintf(
 				/* translators: %d is the number of P2 in your workspace */
 				_n(
@@ -46,7 +64,9 @@ export function SiteDeleteWarningModal( { onClose }: { site: Site; onClose: () =
 				),
 				p2HubP2Count
 			);
-		} else if ( isTrialSite ) {
+		}
+
+		if ( isTrialSite ) {
 			return __(
 				'You have an active or expired free trial on your site. Please cancel this plan prior to deleting your site.'
 			);
@@ -58,7 +78,29 @@ export function SiteDeleteWarningModal( { onClose }: { site: Site; onClose: () =
 	};
 
 	const renderPrimaryButton = () => {
-		<Button variant="primary">{ __( 'Delete site' ) }</Button>;
+		if ( isAtomicRemovalInProgress ) {
+			return null;
+		}
+
+		if ( p2HubP2Count ) {
+			return (
+				<Button variant="primary" href="/sites">
+					{ __( 'Manage sites' ) }
+				</Button>
+			);
+		}
+
+		if ( isTrialSite ) {
+			<Button variant="primary" href={ `/purchases/subscriptions/${ site.slug }` }>
+				{ __( 'Cancel trial' ) }
+			</Button>;
+		}
+
+		return (
+			<Button variant="primary" href={ `/purchases/subscriptions/${ site.slug }` }>
+				{ __( 'Manage purchases' ) }
+			</Button>
+		);
 	};
 
 	return (
@@ -185,7 +227,16 @@ export function SiteDeleteConfirmModal( { site, onClose }: { site: Site; onClose
 }
 
 export default function SiteDeleteModal( { site, onClose }: { site: Site; onClose: () => void } ) {
-	return canDeleteSite( site ) ? (
+	const { user } = useAuth();
+	const { isLoading, data: hasPurchasesCancelable } = useQuery(
+		siteHasPurchasesCancelableQuery( site.slug, user.ID )
+	);
+
+	if ( isLoading ) {
+		return null;
+	}
+
+	return canDeleteSite( site ) && ! hasPurchasesCancelable ? (
 		<SiteDeleteConfirmModal site={ site } onClose={ onClose } />
 	) : (
 		<SiteDeleteWarningModal site={ site } onClose={ onClose } />


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13249

## Proposed Changes

This PR implements the option to delete a site via the modal component SiteDeleteModal. The action is visible if the site is not a staging site.

![image](https://github.com/user-attachments/assets/5946ef03-a548-4dea-ba49-6df58f64d12e)

The SiteDeleteModal has following states:

1. You're able to delete the site
  ![image](https://github.com/user-attachments/assets/fa1ccd79-241e-4daa-aaeb-987408c5b242)
2. The site has active purchases
  ![image](https://github.com/user-attachments/assets/d8c6188a-03c7-4472-a0a0-043a1bb8bfd4)
3. The site is reverting to a simple site
  ![image](https://github.com/user-attachments/assets/3513f874-e967-49f0-abd1-e79172f0e7ef)
4. P2 Hub
  ![image](https://github.com/user-attachments/assets/453474f7-d4ce-4380-a8c0-d96fc15c1dcd)
5. Trial site
  ![image](https://github.com/user-attachments/assets/9bf97981-fe21-422a-a457-2233994431ae)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Hosting Dashboard v2 implementation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2/sites/:siteSlug/settings
* Ensure that the Delete Site action is available, and it works as described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
