### PR TITLE
Experiment streamlining the plans grid + checkout: Remove price from the pay button for treatment variations

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-submit-button-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-submit-button-content.tsx
@@ -5,6 +5,10 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled } from '@automattic/wpcom-checkout';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
+import {
+	useStreamlinedPriceExperiment,
+	isStreamlinedPriceCheckoutTreatment,
+} from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import useCartKey from '../../use-cart-key';
 
 const CreditCardPayButtonWrapper = styled.span`
@@ -33,6 +37,7 @@ const StyledMaterialIcon = styled( MaterialIcon )`
 export function CheckoutSubmitButtonContent() {
 	const { __ } = useI18n();
 	const cartKey = useCartKey();
+	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
 	const { responseCart } = useShoppingCart( cartKey );
 	const isPurchaseFree = responseCart.total_cost_integer === 0;
 	const { formStatus } = useFormStatus();
@@ -56,11 +61,13 @@ export function CheckoutSubmitButtonContent() {
 	return (
 		<CreditCardPayButtonWrapper>
 			<StyledMaterialIcon icon="credit_card" />
-			{ sprintf(
-				/* translators: %s is the total to be paid in localized currency */
-				__( 'Pay %s now' ),
-				total
-			) }
+			{ isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment )
+				? __( 'Pay now' )
+				: sprintf(
+						/* translators: %s is the total to be paid in localized currency */
+						__( 'Pay %s now' ),
+						total
+				  ) }
 		</CreditCardPayButtonWrapper>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to p58i-kUT-p2

## Proposed Changes

* removes the total amount value from the bottom `Pay now` button (via credit card)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We're experimenting with streamlining the plans and checkout user experience

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To test this feature, you'll need to be assigned to any checkout treatment variation of the `calypso_streamlined_plans_checkout` experiment 
* Go through the `onboarding` flow to get assigned
* The `Pay now` button on the button should not show the cost

|Before|After|
|------|-----|
|<img width="480" alt="Screenshot 2025-05-28 at 14 35 41" src="https://github.com/user-attachments/assets/e5438d99-4a56-4e5e-abd3-73cd6c5d2758" />|<img width="480" alt="Screenshot 2025-05-28 at 14 25 49" src="https://github.com/user-attachments/assets/334cdcae-ab3a-4141-b042-f6051cf71493" />|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
