### PR TITLE
Remove the signup_url config flag

### DIFF
--- a/client/components/empty-content/README.md
+++ b/client/components/empty-content/README.md
@@ -66,7 +66,7 @@ The component also supports a secondary action. This should be used sparingly.
 	title="You don't have any WordPress sites yet."
 	line="Would you like to start one?"
 	action="Create Site"
-	actionURL={ config( 'signup_url' ) + '?ref=calypso-section' }
+	actionURL="/start?ref=calypso-section"
 />
 ```
 

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -389,12 +389,11 @@ export function signupForm( context, next ) {
 	const { query } = context;
 	const from = query.from;
 	if ( from && startsWith( from, 'wpcom-migration' ) ) {
-		const signupUrl = config( 'signup_url' );
 		const urlQueryArgs = {
 			redirect_to: context.path,
 			from,
 		};
-		return page( addQueryArgs( urlQueryArgs, `${ signupUrl }/account` ) );
+		return page( addQueryArgs( urlQueryArgs, '/start/account' ) );
 	}
 
 	if ( retrieveMobileRedirect() && ! isLoggedIn ) {

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { getLanguageRouteParam } from '@automattic/i18n-utils';
 import { makeLayout, render as clientRender } from 'calypso/controller';
@@ -118,7 +117,7 @@ export default function () {
 
 	// For some reason, the first redirection below redirects `/jetpack/connect` to `/jetpack/new` in Jetpack cloud.
 	if ( ! isJetpackCloud() ) {
-		page( '/jetpack/new', config( 'signup_url' ) );
+		page( '/jetpack/new', '/start' );
 		page( '/jetpack/new/*', '/jetpack/connect' );
 	}
 }

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { WordPressWordmark, WordPressLogo } from '@automattic/components';
 import {
 	isDefaultLocale,
@@ -147,7 +146,7 @@ class MasterbarLoggedOut extends Component {
 			return null;
 		}
 
-		let signupUrl = config( 'signup_url' );
+		let signupUrl = '/start';
 		const signupFlow = currentQuery?.signup_flow;
 		if (
 			// Match locales like `/log-in/jetpack/es`

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -54,8 +54,6 @@ export function pathWithLeadingSlash( path ) {
 }
 
 export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, pathname ) {
-	const signupUrl = config( 'signup_url' );
-
 	const redirectTo = get( currentQuery, 'redirect_to', '' );
 	const signupFlow = get( currentQuery, 'signup_flow' );
 	const wccomFrom = get( currentQuery, 'wccom-from' );
@@ -108,7 +106,7 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 			oauth2_client_id: oauth2Client.id,
 			oauth2_redirect: redirectTo,
 		} );
-		return `${ signupUrl }/${ oauth2Flow }?${ oauth2Params.toString() }`;
+		return `/start/${ oauth2Flow }?${ oauth2Params.toString() }`;
 	}
 
 	if ( isGravPoweredOAuth2Client( oauth2Client ) ) {
@@ -136,12 +134,11 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 	}
 
 	if ( isCrowdsignalOAuth2Client( oauth2Client ) ) {
-		const oauth2Flow = 'crowdsignal';
 		const oauth2Params = new URLSearchParams( {
 			oauth2_client_id: oauth2Client.id,
 			oauth2_redirect: redirectTo,
 		} );
-		return `${ signupUrl }/${ oauth2Flow }?${ oauth2Params.toString() }`;
+		return `/start/crowdsignal?${ oauth2Params.toString() }`;
 	}
 
 	if ( oauth2Client && isWooOAuth2Client( oauth2Client ) ) {
@@ -152,7 +149,7 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 		if ( wccomFrom ) {
 			oauth2Params.set( 'wccom-from', wccomFrom );
 		}
-		return `${ signupUrl }/wpcc?${ oauth2Params.toString() }`;
+		return `/start/wpcc?${ oauth2Params.toString() }`;
 	}
 
 	if ( oauth2Client ) {
@@ -160,7 +157,7 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 			oauth2_client_id: oauth2Client.id,
 			oauth2_redirect: redirectTo,
 		} );
-		return `${ signupUrl }/wpcc?${ oauth2Params.toString() }`;
+		return `/start/wpcc?${ oauth2Params.toString() }`;
 	}
 
 	if ( signupFlow ) {
@@ -168,9 +165,9 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 			const params = new URLSearchParams( {
 				redirect_to: redirectTo,
 			} );
-			return `${ signupUrl }/${ signupFlow }?${ params.toString() }`;
+			return `/start/${ signupFlow }?${ params.toString() }`;
 		}
-		return `${ signupUrl }/${ signupFlow }`;
+		return `/start/${ signupFlow }`;
 	}
 
 	if (
@@ -182,14 +179,14 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 		const params = new URLSearchParams( {
 			redirect_to: redirectTo,
 		} );
-		return `${ signupUrl }/account?${ params.toString() }`;
+		return `/start/account?${ params.toString() }`;
 	}
 
 	if ( ! isDefaultLocale( locale ) ) {
-		return addLocaleToPath( signupUrl, locale );
+		return addLocaleToPath( '/start', locale );
 	}
 
-	return signupUrl;
+	return '/start';
 }
 
 export const canDoMagicLogin = ( twoFactorAuthType, oauth2Client ) => {
@@ -224,7 +221,7 @@ export const getLoginLinkPageUrl = ( {
 	const loginParameters = {
 		locale: locale,
 		twoFactorAuthType: 'link',
-		signupUrl: signupUrl,
+		signupUrl,
 		oauth2ClientId,
 		...additionalParams,
 	};

--- a/client/lib/login/test/index.js
+++ b/client/lib/login/test/index.js
@@ -30,8 +30,6 @@ jest.mock( '@automattic/calypso-config', () => ( {
 	__esModule: true,
 	default: jest.fn( ( key ) => {
 		switch ( key ) {
-			case 'signup_url':
-				return '/start';
 			case 'i18n_default_locale_slug':
 				return 'en';
 			default:

--- a/client/lib/paths/onboarding-url.js
+++ b/client/lib/paths/onboarding-url.js
@@ -9,5 +9,5 @@ export function onboardingUrl() {
 	if ( isJetpackCloud() ) {
 		return config( 'jetpack_connect_url' );
 	}
-	return config( 'signup_url' );
+	return '/start';
 }

--- a/client/lib/paths/use-add-new-site-url.tsx
+++ b/client/lib/paths/use-add-new-site-url.tsx
@@ -15,6 +15,6 @@ export const useAddNewSiteUrl = ( queryParameters: Record< string, Primitive > )
 			? config( 'jetpack_connect_url' )
 			: isHostingFlow
 			? '/setup/new-hosted-site'
-			: config( 'signup_url' )
+			: '/start'
 	);
 };

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -148,7 +148,6 @@
 	"english_locales": [ "en", "en-gb" ],
 	"readerFollowingSource": "calypso",
 	"siftscience_key": false,
-	"signup_url": false,
 	"woocommerce_blog_id": 113771570,
 	"wpcom_concierge_schedule_id": 1,
 	"wpcom_signup_id": false,

--- a/config/client.json
+++ b/config/client.json
@@ -20,7 +20,6 @@
 	"oauth_url",
 	"readerFollowingSource",
 	"siftscience_key",
-	"signup_url",
 	"stats/chart-library",
 	"stats/empty-module-traffic",
 	"stats/real-time-tab",

--- a/config/development.json
+++ b/config/development.json
@@ -17,7 +17,6 @@
 	"boom_analytics_key": "development",
 	"theme_color": "#1D2327",
 	"hotjar_enabled": true,
-	"signup_url": "/start",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -5,7 +5,6 @@
 	"client_slug": "browser",
 	"hostname": "horizon.wordpress.com",
 	"i18n_default_locale_slug": "en",
-	"signup_url": "/start",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",

--- a/config/production.json
+++ b/config/production.json
@@ -5,7 +5,6 @@
 	"client_slug": "browser",
 	"hostname": "wordpress.com",
 	"i18n_default_locale_slug": "en",
-	"signup_url": "/start",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",

--- a/config/stage.json
+++ b/config/stage.json
@@ -5,7 +5,6 @@
 	"client_slug": "browser",
 	"hostname": "wordpress.com",
 	"i18n_default_locale_slug": "en",
-	"signup_url": "/start",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",

--- a/config/test.json
+++ b/config/test.json
@@ -17,7 +17,6 @@
 	"google_recaptcha_site_key": "",
 	"theme_color": "#1D2327",
 	"hotjar_enabled": true,
-	"signup_url": "/start",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -5,7 +5,6 @@
 	"client_slug": "browser",
 	"hostname": "wpcalypso.wordpress.com",
 	"i18n_default_locale_slug": "en",
-	"signup_url": "/start",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",

--- a/packages/calypso-config/src/desktop.ts
+++ b/packages/calypso-config/src/desktop.ts
@@ -1,7 +1,7 @@
 import type { ConfigData } from '@automattic/create-calypso-config';
 
 // TODO: Revisit whether it is useful for the Desktop app to override the following properties:
-// signup_url, login_url, logout_url and discover_logged_out_redirect_url
+// login_url, logout_url and discover_logged_out_redirect_url
 
 const config = {
 	env: 'production',


### PR DESCRIPTION
This patch removes the `config( 'signup_url' )` value and replaces it with a hardcoded `/start` string.

The `config` flags and values are intended for customization for different environments, but here no customization is going on: the value is always `'/start'`. There's no point abstracting it away, let's just hardcode it.

The `config( 'signup_url' )` value was added more than 10 years ago, you can find it in the `calypso-pre-oss` repo. At the time it was used to distinguish between the `/start` and `/start/desktop` (in the desktop app env) but that distinction is long gone.

The config also long predates Jetpack Cloud. There `/start` path won't work, so part of the testing instructions is to verify that the `/start` value is never used in Jetpack Cloud. Before this patch, `config( 'signup_url' )` returned `false` for Jetpack Cloud and A4A, so the URLs created using it were wrong anyway.
