### PR TITLE
Remove the jetpack/onboarding-user-connection-redesign feature flag

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	PRODUCT_JETPACK_BACKUP_T1_YEARLY,
 	WPCOM_FEATURES_BACKUPS,
@@ -806,10 +805,7 @@ export class JetpackAuthorize extends Component {
 			return translate( 'Connect to WordPress.com' );
 		}
 
-		if (
-			config.isEnabled( 'jetpack/onboarding-user-connection-redesign' ) &&
-			this.isFromJetpackOnboarding()
-		) {
+		if ( this.isFromJetpackOnboarding() ) {
 			return translate( 'Connect my site' );
 		}
 
@@ -886,10 +882,7 @@ export class JetpackAuthorize extends Component {
 			);
 		}
 
-		if (
-			config.isEnabled( 'jetpack/onboarding-user-connection-redesign' ) &&
-			this.isFromJetpackOnboarding()
-		) {
+		if ( this.isFromJetpackOnboarding() ) {
 			return (
 				<>
 					<div className="jetpack-connect__logged-in-user-text-name">
@@ -1067,10 +1060,7 @@ export class JetpackAuthorize extends Component {
 		const { from } = authQuery;
 		const loginURL = login( { isJetpack: true, redirectTo: window.location.href, from } );
 
-		if (
-			config.isEnabled( 'jetpack/onboarding-user-connection-redesign' ) &&
-			this.isFromJetpackOnboarding()
-		) {
+		if ( this.isFromJetpackOnboarding() ) {
 			return (
 				<>
 					<div className="jetpack-connect__logged-in-user-card">
@@ -1280,10 +1270,7 @@ export class JetpackAuthorize extends Component {
 			/>
 		);
 
-		if (
-			config.isEnabled( 'jetpack/onboarding-user-connection-redesign' ) &&
-			this.isFromJetpackOnboarding()
-		) {
+		if ( this.isFromJetpackOnboarding() ) {
 			return (
 				<LoggedOutFormFooter className="jetpack-connect__action--onboarding">
 					{ actionButton }
@@ -1304,9 +1291,7 @@ export class JetpackAuthorize extends Component {
 		const wooDna = this.getWooDnaConfig();
 		const authSiteId = this.props.authQuery.clientId;
 		const { authorizeSuccess, isAuthorizing } = this.props.authorizationData;
-		const isFromJetpackOnboarding =
-			config.isEnabled( 'jetpack/onboarding-user-connection-redesign' ) &&
-			this.isFromJetpackOnboarding();
+		const isFromJetpackOnboarding = this.isFromJetpackOnboarding();
 
 		if ( this.isWooJPC() && ( isAuthorizing || authorizeSuccess ) ) {
 			return (

--- a/config/development.json
+++ b/config/development.json
@@ -91,7 +91,6 @@
 		"jetpack/features-section/simple": true,
 		"jetpack/golden-token": true,
 		"jetpack/manage-simple-sites": true,
-		"jetpack/onboarding-user-connection-redesign": true,
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/sharing-buttons-block-enabled": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -53,7 +53,6 @@
 		"jetpack/features-section/jetpack": true,
 		"jetpack/features-section/simple": true,
 		"jetpack/manage-simple-sites": true,
-		"jetpack/onboarding-user-connection-redesign": true,
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/sharing-buttons-block-enabled": false,

--- a/config/production.json
+++ b/config/production.json
@@ -68,7 +68,6 @@
 		"jetpack/features-section/jetpack": true,
 		"jetpack/features-section/simple": true,
 		"jetpack/manage-simple-sites": false,
-		"jetpack/onboarding-user-connection-redesign": true,
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/sharing-buttons-block-enabled": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -65,7 +65,6 @@
 		"jetpack/features-section/jetpack": true,
 		"jetpack/features-section/simple": true,
 		"jetpack/manage-simple-sites": true,
-		"jetpack/onboarding-user-connection-redesign": true,
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/sharing-buttons-block-enabled": false,

--- a/config/test.json
+++ b/config/test.json
@@ -56,7 +56,6 @@
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
 		"jetpack/features-section/simple": true,
-		"jetpack/onboarding-user-connection-redesign": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/sharing-buttons-block-enabled": false,
 		"jetpack/simplify-pricing-structure": false,


### PR DESCRIPTION
Removes the feature flag that was shipped to production in #103145. I noticed this opportunity when working on #103766.

Comparison of `/jetpack/connect/authorize` before and after the redesign:

| Before | After (with `from=jetpack-onboarding`) |
|--------|--------|
| <img width="535" alt="Screenshot 2025-05-28 at 10 45 08" src="https://github.com/user-attachments/assets/293df7f3-8836-4aa3-9f40-aabd0961f8bc" /> | <img width="529" alt="Screenshot 2025-05-28 at 14 01 37" src="https://github.com/user-attachments/assets/36a1bf84-8f48-411d-b2bc-6099f6ba8941" /> | 




