### PR TITLE
Disable the onboarding experiment by merging treatment

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -5,7 +5,7 @@ import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs, removeQueryArgs } from '@wordpress/url';
 import { useState, useEffect } from 'react';
-import { isMvpOnboardingExperiment } from 'calypso/landing/stepper/hooks/use-mvp-onboarding-experiment';
+import { isSimplifiedOnboarding } from 'calypso/landing/stepper/hooks/use-simplified-onboarding';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { pathToUrl } from 'calypso/lib/url';
 import {
@@ -126,7 +126,7 @@ const onboarding: FlowV2< typeof initialize > = {
 				];
 			}
 
-			if ( await isMvpOnboardingExperiment() ) {
+			if ( await isSimplifiedOnboarding() ) {
 				return [
 					addQueryArgs( `/home/${ providedDependencies.siteSlug }`, { ref: flowName } ),
 					addQueryArgs( withLocale( `/setup/${ flowName }/plans`, locale ), {

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
@@ -9,7 +9,7 @@ import recordStepComplete, {
 } from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-step-complete';
 import recordStepStart from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-step-start';
 import { useIntent } from 'calypso/landing/stepper/hooks/use-intent';
-import { isMvpOnboardingExperiment } from 'calypso/landing/stepper/hooks/use-mvp-onboarding-experiment';
+import { isSimplifiedOnboarding } from 'calypso/landing/stepper/hooks/use-simplified-onboarding';
 import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
 import kebabCase from 'calypso/landing/stepper/utils/kebabCase';
 import useSnakeCasedKeys from 'calypso/landing/stepper/utils/use-snake-cased-keys';
@@ -132,9 +132,7 @@ export const useStepRouteTracking = ( { flow, stepSlug, skipStepRender }: Props 
 			const params = {
 				flow: flowName,
 				is_simplified_onboarding:
-					flowName === 'onboarding' &&
-					stepSlug === 'plans' &&
-					( await isMvpOnboardingExperiment() ),
+					flowName === 'onboarding' && stepSlug === 'plans' && ( await isSimplifiedOnboarding() ),
 				skip_step_render: skipStepRender,
 				...reenteringStepAfterSignupCompleteProps,
 			};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -34,7 +34,7 @@ import {
 import { useSelector } from 'calypso/state';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
 import { getUrlData } from 'calypso/state/imports/url-analyzer/selectors';
-import { useMvpOnboardingExperiment } from '../../../../hooks/use-mvp-onboarding-experiment';
+import { useSimplifiedOnboarding } from '../../../../hooks/use-simplified-onboarding';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import type { Step as StepType } from '../../types';
 import type { OnboardSelect } from '@automattic/data-stores';
@@ -146,7 +146,7 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 		! isNewHostedSiteCreationFlow( flow ) &&
 		! isNewSiteMigrationFlow( flow );
 	const shouldGoToCheckout = Boolean( planCartItem );
-	const [ , isMvpOnboarding ] = useMvpOnboardingExperiment();
+	const [ , isSimplifiedOnboarding ] = useSimplifiedOnboarding();
 
 	async function createSite() {
 		if ( isManageSiteFlow ) {
@@ -170,7 +170,7 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 		// eslint-disable-next-line no-nested-ternary
 		const siteIntent = isNewSiteMigrationFlow( flow )
 			? 'migration'
-			: isMvpOnboarding
+			: isSimplifiedOnboarding
 			? // For the simplified onboarding flow, we'll use the build intent since user can't choose the intent.
 			  Onboard.SiteIntent.Build
 			: '';

--- a/client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
@@ -22,8 +22,8 @@ jest.mock( '../../hooks/use-marketplace-theme-products', () => ( {
 	} ),
 } ) );
 
-jest.mock( '../../hooks/use-mvp-onboarding-experiment', () => ( {
-	isMvpOnboardingExperiment: () => Promise.resolve( false ),
+jest.mock( '../../hooks/use-simplified-onboarding', () => ( {
+	isSimplifiedOnboarding: () => Promise.resolve( false ),
 } ) );
 
 describe( 'Onboarding Flow', () => {

--- a/client/landing/stepper/hooks/use-mvp-onboarding-experiment.ts
+++ b/client/landing/stepper/hooks/use-mvp-onboarding-experiment.ts
@@ -1,16 +1,9 @@
-import { useExperiment, loadExperimentAssignment } from 'calypso/lib/explat';
 import { useQuery } from './use-query';
-
-const HOSTING_ONBOARDING_EXPERIMENT_NAME = 'calypso_signup_onboarding_simplified_hosting_flow_v3';
 
 export function useMvpOnboardingExperiment() {
 	const hasPlaygroundId = useQuery().has( 'playground' );
 
-	const [ isLoading, assignment ] = useExperiment( HOSTING_ONBOARDING_EXPERIMENT_NAME, {
-		isEligible: ! hasPlaygroundId,
-	} );
-
-	return [ isLoading, assignment?.variationName === 'treatment' ];
+	return [ false, ! hasPlaygroundId ];
 }
 
 export async function isMvpOnboardingExperiment() {
@@ -21,6 +14,5 @@ export async function isMvpOnboardingExperiment() {
 		return false;
 	}
 
-	const assignment = await loadExperimentAssignment( HOSTING_ONBOARDING_EXPERIMENT_NAME );
-	return assignment.variationName === 'treatment';
+	return true;
 }

--- a/client/landing/stepper/hooks/use-simplified-onboarding.ts
+++ b/client/landing/stepper/hooks/use-simplified-onboarding.ts
@@ -1,12 +1,12 @@
 import { useQuery } from './use-query';
 
-export function useMvpOnboardingExperiment() {
+export function useSimplifiedOnboarding() {
 	const hasPlaygroundId = useQuery().has( 'playground' );
 
 	return [ false, ! hasPlaygroundId ];
 }
 
-export async function isMvpOnboardingExperiment() {
+export async function isSimplifiedOnboarding() {
 	const params = new URLSearchParams( window.location.search );
 	const hasPlaygroundId = params.has( 'playground' );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

[Linear project](https://linear.app/a8c/project/onboarding-simplify-flows-ab-tests-917de0dff4f8/overview).

## Proposed Changes

* Since treatment is simplifying onboarding and not reducing sales, we'll set it as the new default.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is part of our simplifying onboarding project

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that when going to [/setup/onboarding](http://calypso.localhost:3000/setup/onboarding) you won't see Goals and Themes selection anymore.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
