### PR TITLE
Help center: Open deployment mode tooltip support link in help center modal

### DIFF
--- a/client/components/support-info/index.jsx
+++ b/client/components/support-info/index.jsx
@@ -1,9 +1,14 @@
 import { ExternalLink } from '@automattic/components';
+import { HelpCenter } from '@automattic/data-stores';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { dispatch as dataStoreDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import InfoPopover from 'calypso/components/info-popover';
 
 import './style.scss';
+
+const HELP_CENTER_STORE = HelpCenter.register();
 
 function makePrivacyLink( privacyLink = true, link = '' ) {
 	if ( privacyLink ) {
@@ -24,9 +29,22 @@ function SupportInfo( {
 	position = 'left',
 	privacyLink,
 	popoverClassName = '',
+	supportPostId,
+	supportBlogId,
 } ) {
 	const translate = useTranslate();
 	const filteredPrivacyLink = makePrivacyLink( privacyLink, link );
+
+	const handleLinkClick = ( event, url ) => {
+		if ( supportPostId ) {
+			event.preventDefault();
+			dataStoreDispatch( HELP_CENTER_STORE ).setShowSupportDoc( url, supportPostId, supportBlogId );
+		}
+		// If no supportPostId, let the link open normally in a new tab
+	};
+
+	const LinkComponent = supportPostId ? 'a' : ExternalLink;
+	const linkUrl = supportPostId ? localizeUrl( link ) : link;
 
 	return (
 		<div className="support-info">
@@ -40,9 +58,13 @@ function SupportInfo( {
 				{ link || filteredPrivacyLink ? ' ' : null }
 				{ link && (
 					<span className="support-info__learn-more">
-						<ExternalLink href={ link } target="_blank">
+						<LinkComponent
+							href={ linkUrl }
+							target={ supportPostId ? undefined : '_blank' }
+							onClick={ ( event ) => handleLinkClick( event, linkUrl ) }
+						>
 							{ translate( 'Learn more' ) }
-						</ExternalLink>
+						</LinkComponent>
 					</span>
 				) }
 				{ filteredPrivacyLink && (
@@ -63,6 +85,9 @@ SupportInfo.propTypes = {
 	link: PropTypes.string,
 	position: PropTypes.string,
 	privacyLink: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
+	popoverClassName: PropTypes.string,
+	supportPostId: PropTypes.number,
+	supportBlogId: PropTypes.number,
 };
 
 export default SupportInfo;

--- a/client/sites/deployments/components/deployment-style/index.tsx
+++ b/client/sites/deployments/components/deployment-style/index.tsx
@@ -62,6 +62,8 @@ export const DeploymentStyle = ( {
 					popoverClassName="github-deployments-deployments-style-popover"
 					// @todo Move to contextLinks
 					link="https://developer.wordpress.com/docs/developer-tools/github-deployments/github-deployments-workflow-recipes/"
+					supportPostId={ 99879 }
+					supportBlogId={ 33534099 }
 					privacyLink={ false }
 				>
 					{ supportMessage }


### PR DESCRIPTION
Updates the "Learn more" link in the deployment mode tooltip to open in the help center modal instead of a new tab, providing a better user experience by keeping users within the application.

- Enhanced SupportInfo component to support help center modal integration
- Added supportPostId and supportBlogId props to enable modal opening
- Applied help center modal to deployment mode tooltip using post ID 99879

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-1727/fix-support-link-on-deployments-page

## Proposed Changes

  Summary of changes:
  - ✅ Enhanced the SupportInfo component to support opening links in the help center modal
  - ✅ Added supportPostId and supportBlogId props for help center integration
  - ✅ Updated the deployment mode tooltip to use help center modal (post ID: 99879)
  - ✅ Maintained backward compatibility for external links when no supportPostId is provided
 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit /sites
- Click on a Business site
- Click the deployments tab
- Click on the (i) to open the tool tip
- Click more
