### PR TITLE
Substack import - Updated steps and copy

### DIFF
--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -4,6 +4,7 @@ import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { external } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
+import { fixMe } from 'i18n-calypso';
 import { useEffect } from 'react';
 import exportSubstackDataImg from 'calypso/assets/images/importer/export-substack-content.png';
 import importerConfig from 'calypso/lib/importer/importer-config';
@@ -95,9 +96,15 @@ export default function Content( {
 					<h2>{ __( 'Step 1: Export your content from Substack' ) }</h2>
 					<p>
 						{ createInterpolateElement(
-							__(
-								'Generate a ZIP file of all your Substack posts. On Substack, go to Settings > Import/Export, click <strong>New export</strong>, and upload the downloaded ZIP file in the next step.'
-							),
+							( fixMe( {
+								text: 'Generate a ZIP file of all your Substack posts. On Substack, go to Settings > Import/Export, click <strong>New export</strong>, and upload the downloaded ZIP file in the next step.',
+								newCopy: __(
+									'Generate a ZIP file of all your Substack posts. On Substack, go to Settings > Import/Export, click <strong>New export</strong>, and upload the downloaded ZIP file in the next step.'
+								),
+								oldCopy: __(
+									'Generate a ZIP file of all your Substack posts. On Substack, go to Settings > Exports, click <strong>New export</strong>, and upload the downloaded ZIP file in the next step.'
+								),
+							} ) || '' ) as string,
 							{
 								strong: <strong />,
 							}

--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -96,7 +96,7 @@ export default function Content( {
 					<p>
 						{ createInterpolateElement(
 							__(
-								'Generate a ZIP file of all your Substack posts. On Substack, go to Settings > Imports/Exports, click <strong>New export</strong>, and upload the downloaded ZIP file in the next step.'
+								'Generate a ZIP file of all your Substack posts. On Substack, go to Settings > Import/Export, click <strong>New export</strong>, and upload the downloaded ZIP file in the next step.'
 							),
 							{
 								strong: <strong />,

--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -96,7 +96,7 @@ export default function Content( {
 					<p>
 						{ createInterpolateElement(
 							__(
-								'Generate a ZIP file of all your Substack posts. On Substack, go to Settings > Exports, click <strong>New export</strong>, and upload the downloaded ZIP file in the next step.'
+								'Generate a ZIP file of all your Substack posts. On Substack, go to Settings > Imports/Exports, click <strong>New export</strong>, and upload the downloaded ZIP file in the next step.'
 							),
 							{
 								strong: <strong />,

--- a/client/my-sites/importer/newsletter/subscribers/step-initial.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-initial.tsx
@@ -4,7 +4,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { external } from '@wordpress/icons';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, fixMe } from 'i18n-calypso';
 import { useEffect, useRef } from 'react';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useSelector } from 'calypso/state';
@@ -44,34 +44,59 @@ export default function StepInitial( {
 		<Card>
 			<h2>{ translate( 'Step 1: Export your subscribers from Substack' ) }</h2>
 			<p>
-				{ translate(
-					'In Substack, go to {{strong}}Subscribers{{/strong}}, scroll down to the "All subscribers" table, click the … menu on the right and select Export. Choose the "Export all columns" option and download the CSV file. Then upload the CSV below.',
-					{
-						components: {
-							strong: <strong />,
-						},
-					}
-				) }
-			</p>
-			{ isOnFreePlan && (
-				<p>
-					{ translate(
-						'Note: On the free plan, {{supportLink}}you can import up to 100 subscribers.{{/supportLink}}',
+				{ fixMe( {
+					text: 'In Substack, go to {{strong}}Subscribers{{/strong}}, scroll down to the "All subscribers" table, click the {{strong}}…{{/strong}} menu on the right and select {{strong}}Export{{/strong}}. Choose the "Export all columns" option and download the CSV file. Then upload the CSV below.',
+					newCopy: translate(
+						'In Substack, go to {{strong}}Subscribers{{/strong}}, scroll down to the "All subscribers" table, click the {{strong}}…{{/strong}} menu on the right and select {{strong}}Export{{/strong}}. Choose the "Export all columns" option and download the CSV file. Then upload the CSV below.',
 						{
 							components: {
+								strong: <strong />,
+							},
+						}
+					),
+					oldCopy: translate(
+						'Generate a CSV of your Substack subscribers. In Substack, go to {{strong}}Subscribers{{/strong}}, click {{strong}}Export{{/strong}} under "All subscribers," then upload the CSV in the next step. On the free plan, {{supportLink}}you can import up to 100 subscribers.{{/supportLink}}',
+						{
+							components: {
+								strong: <strong />,
 								supportLink: (
 									<InlineSupportLink
 										noWrap={ false }
 										showIcon={ false }
 										supportLink={ localizeUrl(
-											'https://wordpress.com/support/import-subscribers-to-a-newsletter/#import-limits'
+											'https://wordpress.com/support/import-subscribers-to-a-newsletter/#troubleshooting-subscriber-imports'
 										) }
 										supportPostId={ 220199 }
 									/>
 								),
 							},
 						}
-					) }
+					),
+				} ) }
+			</p>
+			{ isOnFreePlan && (
+				<p>
+					{ fixMe( {
+						text: 'Note: On the free plan, you can import up to 100 subscribers.',
+						newCopy: translate(
+							'Note: On the free plan, {{supportLink}}you can import up to 100 subscribers.{{/supportLink}}',
+							{
+								components: {
+									supportLink: (
+										<InlineSupportLink
+											noWrap={ false }
+											showIcon={ false }
+											supportLink={ localizeUrl(
+												'https://wordpress.com/support/import-subscribers-to-a-newsletter/#import-limits'
+											) }
+											supportPostId={ 220199 }
+										/>
+									),
+								},
+							}
+						),
+						oldCopy: '',
+					} ) }
 				</p>
 			) }
 			<Button

--- a/client/my-sites/importer/newsletter/subscribers/step-initial.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-initial.tsx
@@ -6,8 +6,9 @@ import { useSelect } from '@wordpress/data';
 import { external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useRef } from 'react';
-import exportSubstackSubscribersImg from 'calypso/assets/images/importer/export-substack-subscribers.png';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import { useSelector } from 'calypso/state';
+import isSiteOnFreePlan from 'calypso/state/selectors/is-site-on-free-plan';
 import { SubscribersStepProps } from '../types';
 import { normalizeFromSite } from '../utils';
 import SubscriberUploadForm from './upload-form';
@@ -37,34 +38,42 @@ export default function StepInitial( {
 		prevInProgress.current = importSelector?.inProgress;
 	}, [ importSelector?.inProgress, setAutoFetchData ] );
 
+	const isOnFreePlan = useSelector( ( state ) => isSiteOnFreePlan( state, selectedSite.ID ) );
+
 	return (
 		<Card>
 			<h2>{ translate( 'Step 1: Export your subscribers from Substack' ) }</h2>
 			<p>
 				{ translate(
-					'Generate a CSV of your Substack subscribers. In Substack, go to {{strong}}Subscribers{{/strong}}, click {{strong}}Export{{/strong}} under "All subscribers," then upload the CSV in the next step. On the free plan, {{supportLink}}you can import up to 100 subscribers.{{/supportLink}}',
+					'In Substack, go to {{strong}}Subscribers{{/strong}}, scroll down to the "All subscribers" table, click the … menu on the right and select Export. Choose the "Export all columns" option and download the CSV file. Then upload the CSV below.',
 					{
 						components: {
 							strong: <strong />,
-							supportLink: (
-								<InlineSupportLink
-									noWrap={ false }
-									showIcon={ false }
-									supportLink={ localizeUrl(
-										'https://wordpress.com/support/import-subscribers-to-a-newsletter/#troubleshooting-subscriber-imports'
-									) }
-									supportPostId={ 220199 }
-								/>
-							),
 						},
 					}
 				) }
 			</p>
-			<img
-				src={ exportSubstackSubscribersImg }
-				alt={ translate( 'Export Substack subscribers' ) }
-				className="export-subscribers"
-			/>
+			{ isOnFreePlan && (
+				<p>
+					{ translate(
+						'Note: On the free plan, {{supportLink}}you can import up to 100 subscribers.{{/supportLink}}',
+						{
+							components: {
+								supportLink: (
+									<InlineSupportLink
+										noWrap={ false }
+										showIcon={ false }
+										supportLink={ localizeUrl(
+											'https://wordpress.com/support/import-subscribers-to-a-newsletter/#troubleshooting-subscriber-imports'
+										) }
+										supportPostId={ 220199 }
+									/>
+								),
+							},
+						}
+					) }
+				</p>
+			) }
 			<Button
 				href={ `https://${ normalizeFromSite( fromSite ) }/publish/subscribers` }
 				target="_blank"

--- a/client/my-sites/importer/newsletter/subscribers/step-initial.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-initial.tsx
@@ -64,7 +64,7 @@ export default function StepInitial( {
 										noWrap={ false }
 										showIcon={ false }
 										supportLink={ localizeUrl(
-											'https://wordpress.com/support/import-subscribers-to-a-newsletter/#troubleshooting-subscriber-imports'
+											'https://wordpress.com/support/import-subscribers-to-a-newsletter/#import-limits'
 										) }
 										supportPostId={ 220199 }
 									/>


### PR DESCRIPTION
## Description

Resolves https://github.com/Automattic/loop/issues/654

In this PR I made a couple of changes.

1. On the import content screen I updated the link text to match what's in Substack these days:

![copy](https://github.com/user-attachments/assets/e17d08c8-c1e4-48b2-84fd-1d58ac9a9aaf)

2. On the subscriber import screen I updated the copy that instructs you on how to export subscribers, then also pulled the 100 subscribers line out and made it conditional on if you're on the free plan. I removed the screenshot from this screen because there's not a clear single screen that would be helpful to show:

![subscriber](https://github.com/user-attachments/assets/5858a1bd-c321-4f21-89dd-5e45a5de2938)

## How to replicate

- Pull down this PR
- On a simple free plan site go to wp-admin -> Users -> Subscribers
- Click "Add subscribers" in the top right corner and select the import from Substack option
- Enter "https://rick289.substack.com/" as the URL
- Upload [Yxsu4a0WSw_xlwDFbNCI2A.zip](https://github.com/user-attachments/files/20484821/Yxsu4a0WSw_xlwDFbNCI2A.zip)
- Proceed to the next step and preview the subscribers import page