### PR TITLE
Experiment streamlining the plans grid + checkout: Extract first year intro offers from wpcom plan pricing

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -418,7 +418,8 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 			isSmallestUnit: true,
 			stripZeros: true,
 		} );
-		const itemSubtotalInteger = product.item_subtotal_integer;
+		const itemSubtotalInteger =
+			product.item_subtotal_integer + ( product.coupon_savings_integer ?? 0 );
 		streamlinedActualAmountDisplay = formatCurrency( itemSubtotalInteger, product.currency, {
 			isSmallestUnit: true,
 			stripZeros: true,
@@ -427,6 +428,8 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 			itemSubtotalInteger < originalAmountInteger && originalAmountDisplay
 		);
 
+		// For WPCOM plans always show the renewal amount for legal reasons.
+		// Introductory offer discount would be shown in LineItemCostOverrides.
 		if ( ! isDiscounted || isWpComPlan( product.product_slug ) ) {
 			streamlinedActualAmountDisplay = actualAmountDisplay;
 		}

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -253,7 +253,6 @@ function LineItemCostOverride( {
 	product: ResponseCartProduct;
 } ) {
 	const isPriceIncrease = doesIntroductoryOfferHavePriceIncrease( product );
-	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
 	if ( isPriceIncrease ) {
 		return (
 			<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
@@ -268,7 +267,6 @@ function LineItemCostOverride( {
 			</span>
 			<span className="cost-overrides-list-item__discount">
 				{ costOverride.discountAmount &&
-					! isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment ) &&
 					formatCurrency( -costOverride.discountAmount, product.currency, {
 						isSmallestUnit: true,
 						signForPositive: true, // TODO clk numberFormatCurrency signForPositive only usage
@@ -404,26 +402,17 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
 	const monthlyPrices = useEquivalentMonthlyTotals( [ product ] );
 	if ( isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment ) ) {
-		let streamlinedActualAmountDisplay;
-
 		const originalAmountInteger =
 			monthlyPrices[ product.product_slug as PlanSlug ] || product.item_original_subtotal_integer;
 		const originalAmountDisplay = formatCurrency( originalAmountInteger, product.currency, {
 			isSmallestUnit: true,
 			stripZeros: true,
 		} );
-		const itemSubtotalInteger = product.item_subtotal_integer;
-		streamlinedActualAmountDisplay = formatCurrency( itemSubtotalInteger, product.currency, {
-			isSmallestUnit: true,
-			stripZeros: true,
-		} );
+		const itemSubtotalInteger = product.item_original_subtotal_integer;
+
 		const isDiscounted = Boolean(
 			itemSubtotalInteger < originalAmountInteger && originalAmountDisplay
 		);
-
-		if ( ! isDiscounted ) {
-			streamlinedActualAmountDisplay = actualAmountDisplay;
-		}
 
 		return (
 			<StreamlinedSingleProductAndCostOverridesListWrapper>
@@ -431,7 +420,7 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 				<ProductTitleAreaForCostOverridesList>
 					<span className="cost-overrides-list-product__title">{ label }</span>
 					<StreamlinedLineItemPrice
-						actualAmount={ streamlinedActualAmountDisplay }
+						actualAmount={ actualAmountDisplay }
 						crossedOutAmount={ isDiscounted ? originalAmountDisplay : undefined }
 					/>
 				</ProductTitleAreaForCostOverridesList>

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -3,6 +3,7 @@ import {
 	isDIFMProduct,
 	isMonthlyProduct,
 	isTriennially,
+	isWpComPlan,
 	isYearly,
 	type PlanSlug,
 } from '@automattic/calypso-products';
@@ -253,6 +254,7 @@ function LineItemCostOverride( {
 	product: ResponseCartProduct;
 } ) {
 	const isPriceIncrease = doesIntroductoryOfferHavePriceIncrease( product );
+	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
 	if ( isPriceIncrease ) {
 		return (
 			<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
@@ -260,6 +262,11 @@ function LineItemCostOverride( {
 			</div>
 		);
 	}
+
+	const shouldShowDiscount =
+		! isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment ) ||
+		isWpComPlan( product.product_slug );
+
 	return (
 		<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
 			<span className="cost-overrides-list-item__reason cost-overrides-list-item__reason--is-discount">
@@ -267,6 +274,7 @@ function LineItemCostOverride( {
 			</span>
 			<span className="cost-overrides-list-item__discount">
 				{ costOverride.discountAmount &&
+					shouldShowDiscount &&
 					formatCurrency( -costOverride.discountAmount, product.currency, {
 						isSmallestUnit: true,
 						signForPositive: true, // TODO clk numberFormatCurrency signForPositive only usage
@@ -402,17 +410,26 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
 	const monthlyPrices = useEquivalentMonthlyTotals( [ product ] );
 	if ( isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment ) ) {
+		let streamlinedActualAmountDisplay;
+
 		const originalAmountInteger =
 			monthlyPrices[ product.product_slug as PlanSlug ] || product.item_original_subtotal_integer;
 		const originalAmountDisplay = formatCurrency( originalAmountInteger, product.currency, {
 			isSmallestUnit: true,
 			stripZeros: true,
 		} );
-		const itemSubtotalInteger = product.item_original_subtotal_integer;
-
+		const itemSubtotalInteger = product.item_subtotal_integer;
+		streamlinedActualAmountDisplay = formatCurrency( itemSubtotalInteger, product.currency, {
+			isSmallestUnit: true,
+			stripZeros: true,
+		} );
 		const isDiscounted = Boolean(
 			itemSubtotalInteger < originalAmountInteger && originalAmountDisplay
 		);
+
+		if ( ! isDiscounted || isWpComPlan( product.product_slug ) ) {
+			streamlinedActualAmountDisplay = actualAmountDisplay;
+		}
 
 		return (
 			<StreamlinedSingleProductAndCostOverridesListWrapper>
@@ -420,7 +437,7 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 				<ProductTitleAreaForCostOverridesList>
 					<span className="cost-overrides-list-product__title">{ label }</span>
 					<StreamlinedLineItemPrice
-						actualAmount={ actualAmountDisplay }
+						actualAmount={ streamlinedActualAmountDisplay }
 						crossedOutAmount={ isDiscounted ? originalAmountDisplay : undefined }
 					/>
 				</ProductTitleAreaForCostOverridesList>

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -93,6 +93,12 @@ export const LineItem = styled( CheckoutLineItem )< {
 
 	.checkout-line-item__price {
 		position: relative;
+
+		${ ( { shouldShowComparison } ) =>
+			shouldShowComparison &&
+			`
+				display: flex;
+			` }
 	}
 `;
 
@@ -806,7 +812,8 @@ export function LineItemSublabelAndPrice( {
 			stripZeros: true,
 		} );
 		const showCrossedOutPrice =
-			product.item_subtotal_integer / ( product.months_per_bill_period ?? 1 ) !== compareToPrice;
+			product.item_original_subtotal_integer / ( product.months_per_bill_period ?? 1 ) !==
+			compareToPrice;
 		if ( isMonthlyProduct( product ) ) {
 			return (
 				<>
@@ -1333,13 +1340,19 @@ function CheckoutLineItem( {
 	} );
 
 	let pricePerMonth = 0;
+	let originalPricePerMonth = 0;
 	if ( shouldShowComparison ) {
 		pricePerMonth = Math.round(
 			product.item_subtotal_integer / ( product.months_per_bill_period ?? 1 )
 		);
+		originalPricePerMonth = product.item_original_monthly_cost_integer;
 	}
 
 	const monthlyAmountDisplay = formatCurrency( pricePerMonth, product.currency, {
+		isSmallestUnit: true,
+		stripZeros: true,
+	} );
+	const originalMonthlyAmountDisplay = formatCurrency( originalPricePerMonth, product.currency, {
 		isSmallestUnit: true,
 		stripZeros: true,
 	} );
@@ -1380,7 +1393,11 @@ function CheckoutLineItem( {
 			<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">
 				{ shouldShowComparison ? (
 					<>
-						{ monthlyAmountDisplay } { translate( '/month' ) }
+						<LineItemPrice
+							actualAmount={ monthlyAmountDisplay }
+							crossedOutAmount={ isDiscounted ? originalMonthlyAmountDisplay : undefined }
+						/>{ ' ' }
+						{ translate( '/month' ) }
 					</>
 				) : (
 					<>

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1360,7 +1360,6 @@ function CheckoutLineItem( {
 	const isDiscounted = Boolean(
 		itemSubtotalInteger < originalAmountInteger && originalAmountDisplay
 	);
-	const hasIntroOffer = Boolean( product.introductory_offer_terms?.enabled );
 
 	const isEmail =
 		isGoogleWorkspaceProductSlug( productSlug ) ||
@@ -1396,7 +1395,7 @@ function CheckoutLineItem( {
 					<>
 						<LineItemPrice
 							actualAmount={ monthlyAmountDisplay }
-							crossedOutAmount={ hasIntroOffer ? originalMonthlyAmountDisplay : undefined }
+							crossedOutAmount={ isDiscounted ? originalMonthlyAmountDisplay : undefined }
 						/>{ ' ' }
 						{ translate( '/month' ) }
 					</>

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1360,6 +1360,7 @@ function CheckoutLineItem( {
 	const isDiscounted = Boolean(
 		itemSubtotalInteger < originalAmountInteger && originalAmountDisplay
 	);
+	const hasIntroOffer = Boolean( product.introductory_offer_terms?.enabled );
 
 	const isEmail =
 		isGoogleWorkspaceProductSlug( productSlug ) ||
@@ -1395,7 +1396,7 @@ function CheckoutLineItem( {
 					<>
 						<LineItemPrice
 							actualAmount={ monthlyAmountDisplay }
-							crossedOutAmount={ isDiscounted ? originalMonthlyAmountDisplay : undefined }
+							crossedOutAmount={ hasIntroOffer ? originalMonthlyAmountDisplay : undefined }
 						/>{ ' ' }
 						{ translate( '/month' ) }
 					</>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of p58i-kUT-p2#comment-68251

## Proposed Changes

This covers the situation where there are intro offers that include a temporary discount.
* main order list: add the original (crossed) price next to the **introductory + term** discounted price
* side order summary list: show the **term discount** price and add the introductory discount amount below (only for wpcom plans)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We and to address any potential legal issues and confusion around how much the user will be paying each time.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use an account with a intro offer discount currency (such as MXN)
* To test this feature, you'll need to be assigned to any checkout treatment variation of the `calypso_streamlined_plans_checkout` experiment
* Go through the `onboarding` flow to get assigned
* You should see the updated prices on the page

|Before|After|
|------|-----|
|<img width="480" alt="Screenshot 2025-05-28 at 16 00 36" src="https://github.com/user-attachments/assets/200afc93-d0e4-4f0b-87ba-433e197b25db" />|<img width="480" alt="Screenshot 2025-05-30 at 11 52 49" src="https://github.com/user-attachments/assets/83a0b687-c6ed-4767-8a33-a04d06a39f48" />|


* Switch to a `control` variation
* The checkout should be unchanged

<img width="480" alt="Screenshot 2025-05-28 at 16 01 03" src="https://github.com/user-attachments/assets/51c7ec43-ebeb-4cb2-a5f6-ab2dda7fc6b0" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?