### PR TITLE
BACKUP-142 | Show the "Backups scheduler" component only when the plan is purchased

### DIFF
--- a/client/jetpack-cloud/sections/settings/controller.tsx
+++ b/client/jetpack-cloud/sections/settings/controller.tsx
@@ -76,7 +76,14 @@ export const advancedCredentials: Callback = ( context, next ) => {
 				falseComponent={ null }
 				loadingComponent={ <AdvancedCredentialsLoadingPlaceholder /> }
 			/>
-			{ config.isEnabled( 'jetpack/backup-schedule-setting' ) ? <BackupScheduleSetting /> : null }
+			{ config.isEnabled( 'jetpack/backup-schedule-setting' ) ? (
+				<HasSitePurchasesSwitch
+					siteId={ siteId }
+					trueComponent={ <BackupScheduleSetting /> }
+					falseComponent={ null }
+					loadingComponent={ <AdvancedCredentialsLoadingPlaceholder /> }
+				/>
+			) : null }
 		</Main>
 	);
 


### PR DESCRIPTION
Resolves BACKUP-142

## Proposed Changes

This PR improves the way we render the "Backups scheduler" component. From now on we're only rendering it when the site has the backup plan.

### Before

https://cloud.jetpack.com/settings/hector-of-hectors.jurassic.ninja

<img width="1464" alt="Screenshot 2025-05-28 at 14 03 26" src="https://github.com/user-attachments/assets/bde751eb-4602-4a92-b693-c3d7928dbe2c" />

### After

http://jetpack.cloud.localhost:3000/settings/hector-of-hectors.jurassic.ninja

<img width="1464" alt="Screenshot 2025-05-28 at 14 42 42" src="https://github.com/user-attachments/assets/8dcb7eee-9ae3-41c2-8de2-fb46668a0094" />

## Testing Instructions

1. Create a Jurassic Ninja site.
2. Connect it to Jetpack.
3. Visit the Settings in the Jetpack Cloud, e.g. https://cloud.jetpack.com/settings/hector-of-hectors.jurassic.ninja
4. Now, start your local Jetpack Cloud instance of wp-calypso:
```
wp-calypso$ yarn start-jetpack-cloud
```
5. Visit [the local instance of the Jetpack Cloud](http://jetpack.cloud.localhost:3000/settings/hector-of-hectors.jurassic.ninja) and verify the backups scheduler is gone for the test site (but [still present](http://jetpack.cloud.localhost:3000/settings/wptest.macbre.net) for the sites with the active plan).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
