### PR TITLE
JP Login: Create Jetpack version of QR code login page

### DIFF
--- a/client/blocks/qr-code-login/index.jsx
+++ b/client/blocks/qr-code-login/index.jsx
@@ -11,6 +11,7 @@ import qrCenter from 'calypso/assets/images/qr-login/app.png';
 import { setStoredItem, getStoredItem } from 'calypso/lib/browser-storage';
 import { useInterval } from 'calypso/lib/interval';
 import { postLoginRequest, getErrorFromHTTPError } from 'calypso/state/login/utils';
+import { JetpackQRCodeLogin } from './jetpack';
 
 import './style.scss';
 
@@ -41,7 +42,7 @@ const getLoginActionResponse = async ( action, args ) => {
 		} );
 };
 
-function TokenQRCode( { tokenData } ) {
+export function TokenQRCode( { tokenData } ) {
 	if ( ! tokenData ) {
 		return <QRCodePlaceholder />;
 	}
@@ -86,7 +87,7 @@ function QRCodeErrorCard() {
 	);
 }
 
-function QRCodeLogin( { redirectToAfterLoginUrl } ) {
+function QRCodeLogin( { redirectToAfterLoginUrl, isJetpack = false } ) {
 	const translate = useTranslate();
 	const [ tokenState, setTokenState ] = useState( null );
 	const [ authState, setAuthState ] = useState( false );
@@ -235,6 +236,10 @@ function QRCodeLogin( { redirectToAfterLoginUrl } ) {
 
 	if ( isErrorState ) {
 		return <QRCodeErrorCard />;
+	}
+
+	if ( isJetpack ) {
+		return <JetpackQRCodeLogin tokenState={ tokenState } />;
 	}
 
 	return (

--- a/client/blocks/qr-code-login/jetpack.jsx
+++ b/client/blocks/qr-code-login/jetpack.jsx
@@ -1,32 +1,36 @@
 import { ExternalLink } from '@automattic/components';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { TokenQRCode } from './index';
 
-const steps = [
-	// translation: Link to the Jetpack App.
-	translate( 'Open the {{link}}%(name)s App{{/link}} on your phone.', {
-		args: {
-			name: 'Jetpack',
-		},
-		components: {
-			link: <ExternalLink target="_blank" href="https://jetpack.com/app?campaign=login-qr-code" />,
-		},
-	} ),
-	translate( 'Tap the Me tab.' ),
-	translate( 'Tap the Scan Login Code option.' ),
-	translate( 'Point your phone to the following QR code to scan it.' ),
-];
-
-const notice = translate(
-	"Logging in via the Jetpack app is {{strong}}not available{{/strong}} if you've enabled two-step authentication on your WordPress.com account.",
-	{
-		components: {
-			strong: <strong />,
-		},
-	}
-);
-
 export const JetpackQRCodeLogin = ( { tokenState } ) => {
+	const translate = useTranslate();
+
+	const steps = [
+		// translation: Link to the Jetpack App.
+		translate( 'Open the {{link}}%(name)s App{{/link}} on your phone.', {
+			args: {
+				name: 'Jetpack',
+			},
+			components: {
+				link: (
+					<ExternalLink target="_blank" href="https://jetpack.com/app?campaign=login-qr-code" />
+				),
+			},
+		} ),
+		translate( 'Tap the Me tab.' ),
+		translate( 'Tap the Scan Login Code option.' ),
+		translate( 'Point your phone to the following QR code to scan it.' ),
+	];
+
+	const notice = translate(
+		"Logging in via the Jetpack app is {{strong}}not available{{/strong}} if you've enabled two-step authentication on your WordPress.com account.",
+		{
+			components: {
+				strong: <strong />,
+			},
+		}
+	);
+
 	return (
 		<div className="qr-code-login-jetpack">
 			<div className="qr-code-login-jetpack__instructions">

--- a/client/blocks/qr-code-login/jetpack.jsx
+++ b/client/blocks/qr-code-login/jetpack.jsx
@@ -1,0 +1,52 @@
+import { ExternalLink } from '@automattic/components';
+import { translate } from 'i18n-calypso';
+import { TokenQRCode } from './index';
+
+const steps = [
+	// translation: Link to the Jetpack App.
+	translate( 'Open the {{link}}%(name)s App{{/link}} on your phone.', {
+		args: {
+			name: 'Jetpack',
+		},
+		components: {
+			link: <ExternalLink target="_blank" href="https://jetpack.com/app?campaign=login-qr-code" />,
+		},
+	} ),
+	translate( 'Tap the Me tab.' ),
+	translate( 'Tap the Scan Login Code option.' ),
+	translate( 'Point your phone to the following QR code to scan it.' ),
+];
+
+const notice = translate(
+	"Logging in via the Jetpack app is {{strong}}not available{{/strong}} if you've enabled two-step authentication on your WordPress.com account.",
+	{
+		components: {
+			strong: <strong />,
+		},
+	}
+);
+
+export const JetpackQRCodeLogin = ( { tokenState } ) => {
+	return (
+		<div className="qr-code-login-jetpack">
+			<div className="qr-code-login-jetpack__instructions">
+				<h1 className="qr-code-login-jetpack__heading">
+					{ translate( 'Start with Jetpack app' ) }
+				</h1>
+				<ol className="qr-code-login-jetpack__steps">
+					{ steps.map( ( step, index ) => (
+						<li key={ 'step-' + index } className="qr-code-login-jetpack__step">
+							{ step }
+						</li>
+					) ) }
+				</ol>
+			</div>
+
+			<div className="qr-code-login-jetpack__token">
+				<TokenQRCode tokenData={ tokenState } />
+			</div>
+
+			<p className="qr-code-login-jetpack__notice">{ notice }</p>
+		</div>
+	);
+};

--- a/client/blocks/qr-code-login/style.scss
+++ b/client/blocks/qr-code-login/style.scss
@@ -131,7 +131,7 @@
 			line-height: 24px;
 
 			.qr-code-login-jetpack__step {
-				text-align: left;
+				text-align: start;
 			}
 		}
 

--- a/client/blocks/qr-code-login/style.scss
+++ b/client/blocks/qr-code-login/style.scss
@@ -126,7 +126,7 @@
 
 		.qr-code-login-jetpack__steps {
 			margin: 0;
-			padding-left: 20px;
+			padding-inline-start: 20px;
 			font-size: 15px;
 			line-height: 24px;
 

--- a/client/blocks/qr-code-login/style.scss
+++ b/client/blocks/qr-code-login/style.scss
@@ -1,4 +1,5 @@
 @import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/variables";
 @import "@wordpress/base-styles/mixins";
 
 .qr-code-login {
@@ -95,4 +96,74 @@
 	height: 16px;
 	top: 0;
 	left: 0;
+}
+
+.qr-code-login-jetpack {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+
+	padding: 0 16px;
+
+	@include break-small {
+		padding: 0;
+	}
+
+	&:not(.is-error) {
+		margin-bottom: 48px;
+	}
+
+	.qr-code-login-jetpack__instructions {
+		.qr-code-login-jetpack__heading {
+			margin-bottom: 16px;
+
+			font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+			font-size: 32px;
+			font-weight: 500;
+
+			text-align: initial;
+		}
+
+		.qr-code-login-jetpack__steps {
+			margin: 0;
+			padding-left: 20px;
+			font-size: 15px;
+			line-height: 24px;
+
+			.qr-code-login-jetpack__step {
+				text-align: left;
+			}
+		}
+
+		a {
+			color: var(--studio-jetpack-green-60, #007117);
+		}
+	}
+
+	.qr-code-login-jetpack__token {
+		width: 300px;
+		height: 300px;
+		max-width: 100%;
+		max-height: calc(100vw - 48px);
+		border: 1px solid var(--color-neutral-10);
+		border-radius: 4px;
+		padding: 16px;
+
+		svg {
+			max-width: 100%;
+			max-height: calc(100vw - 48px);
+		}
+
+		canvas {
+			max-width: 100%;
+			max-height: calc(100vw - 48px);
+		}
+	}
+
+	.qr-code-login-jetpack__notice {
+		text-align: initial;
+
+		color: var(--studio-jetpack-grey-50, #646970 );
+		@include body-medium;
+	}
 }

--- a/client/login/qr-code-login-page/index.jsx
+++ b/client/login/qr-code-login-page/index.jsx
@@ -1,4 +1,5 @@
 import { Card } from '@automattic/components';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import AsyncLoad from 'calypso/components/async-load';
 import Main from 'calypso/components/main';
@@ -15,7 +16,7 @@ function QrCodeLoginPage( { locale, redirectTo, isJetpack = false } ) {
 	const isWhiteLogin = true;
 
 	return (
-		<Main className="qr-code-login-page">
+		<Main className={ clsx( 'qr-code-login-page', { 'is-jetpack': isJetpack } ) }>
 			<div className="qr-code-login-page__form">
 				{ isJetpack ? (
 					<div className="magic-login__gutenboarding-wordpress-logo">
@@ -53,6 +54,7 @@ function QrCodeLoginPage( { locale, redirectTo, isJetpack = false } ) {
 					size={ 300 }
 					locale={ locale }
 					redirectToAfterLoginUrl={ redirectTo }
+					isJetpack={ isJetpack }
 				/>
 				<div className="qr-code-login-page__footer">
 					<a href={ login( { locale, redirectTo, isWhiteLogin, isJetpack } ) }>

--- a/client/login/qr-code-login-page/style.scss
+++ b/client/login/qr-code-login-page/style.scss
@@ -5,9 +5,13 @@
 	margin: 0 auto;
 	max-width: 700px;
 	text-align: center;
+
+	&.is-jetpack {
+		max-width: 450px;
+	}
 }
 
-.layout:has(.qr-code-login-page) {
+.layout:has(.qr-code-login-page:not(.is-jetpack)) {
 	display: flex;
 	align-items: center;
 	justify-content: center;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes MYJP-117

## Proposed Changes

* Added a variant of the QR code login page for Jetpack
* Passed down variables so the context is preserved
* Updated the layout so it matches the new designs

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To add new Jetpack version of the QR Code login page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/log-in/jetpack`.
* Click on the log in via Jetpack app button.
* Check the designs and see if it matches.
* Sanity check that on `/log-in`, clicking the button moves you to WP.com QR login that looks the same as before

![CleanShot 2025-05-28 at 15 50 33 png](https://github.com/user-attachments/assets/221eea00-ef94-421c-953a-5cad9d302e96)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
