### PR TITLE
Hosting Dashboard v2: Backport router sync 

### DIFF
--- a/client/sites/settings/v2/router.tsx
+++ b/client/sites/settings/v2/router.tsx
@@ -9,11 +9,19 @@ import {
 	type AnyRouter,
 } from '@tanstack/react-router';
 import {
+	siteDefensiveModeQuery,
+	sitePHPVersionQuery,
+	sitePrimaryDataCenterQuery,
 	siteQuery,
 	siteSettingsQuery,
+	siteStaticFile404Query,
 	siteWordPressVersionQuery,
 } from 'calypso/dashboard/app/queries';
 import { queryClient } from 'calypso/dashboard/app/query-client';
+import { canUpdateDefensiveMode } from 'calypso/dashboard/sites/settings-defensive-mode';
+import { canUpdatePHPVersion } from 'calypso/dashboard/sites/settings-php/utils';
+import { canGetPrimaryDataCenter } from 'calypso/dashboard/sites/settings-primary-data-center';
+import { canSetStaticFile404Handling } from 'calypso/dashboard/sites/settings-static-file-404';
 import { canUpdateWordPressVersion } from 'calypso/dashboard/sites/settings-wordpress/utils';
 import Root from './root';
 
@@ -108,6 +116,74 @@ const wordpressRoute = createRoute( {
 	)
 );
 
+const phpRoute = createRoute( {
+	getParentRoute: () => siteRoute,
+	path: 'php',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteQuery( siteSlug ) );
+		if ( canUpdatePHPVersion( site ) ) {
+			await queryClient.ensureQueryData( sitePHPVersionQuery( siteSlug ) );
+		}
+	},
+} ).lazy( () =>
+	import( 'calypso/dashboard/sites/settings-php' ).then( ( d ) =>
+		createLazyRoute( 'php' )( {
+			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+const primaryDataCenterRoute = createRoute( {
+	getParentRoute: () => siteRoute,
+	path: 'primary-data-center',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteQuery( siteSlug ) );
+		if ( canGetPrimaryDataCenter( site ) ) {
+			await queryClient.ensureQueryData( sitePrimaryDataCenterQuery( siteSlug ) );
+		}
+	},
+} ).lazy( () =>
+	import( 'calypso/dashboard/sites/settings-primary-data-center' ).then( ( d ) =>
+		createLazyRoute( 'primary-data-center' )( {
+			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+const staticFile404Route = createRoute( {
+	getParentRoute: () => siteRoute,
+	path: 'static-file-404',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteQuery( siteSlug ) );
+		if ( canSetStaticFile404Handling( site ) ) {
+			await queryClient.ensureQueryData( siteStaticFile404Query( siteSlug ) );
+		}
+	},
+} ).lazy( () =>
+	import( 'calypso/dashboard/sites/settings-static-file-404' ).then( ( d ) =>
+		createLazyRoute( 'static-file-404' )( {
+			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+const defensiveModeRoute = createRoute( {
+	getParentRoute: () => siteRoute,
+	path: 'defensive-mode',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteQuery( siteSlug ) );
+		if ( canUpdateDefensiveMode( site ) ) {
+			await queryClient.ensureQueryData( siteDefensiveModeQuery( siteSlug ) );
+		}
+	},
+} ).lazy( () =>
+	import( 'calypso/dashboard/sites/settings-defensive-mode' ).then( ( d ) =>
+		createLazyRoute( 'defensive-mode' )( {
+			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
 const transferSiteRoute = createRoute( {
 	getParentRoute: () => siteRoute,
 	path: 'transfer-site',
@@ -127,6 +203,10 @@ const createRouteTree = () =>
 			subscriptionGiftingRoute,
 			databaseRoute,
 			wordpressRoute,
+			phpRoute,
+			primaryDataCenterRoute,
+			staticFile404Route,
+			defensiveModeRoute,
 			transferSiteRoute,
 		] ),
 		dashboardSiteSettingsCompatibilityRouteRoot,


### PR DESCRIPTION
## Proposed Changes

Sync more routes.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Hosting Dashboard v2 backport.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /sites/settings/v2/:siteSlug
* Ensure settings still work as intended

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
