### PR TITLE
Add GitHub Actions workflow for publishing design system preview

### DIFF
--- a/.github/workflows/calypso-live.yml
+++ b/.github/workflows/calypso-live.yml
@@ -3,11 +3,6 @@ name: Calypso Live
 on:
   pull_request:
     types: ['opened']
-    # Ignore paths that trigger the design-system-docs workflow, which manages preview link comment
-    paths-ignore:
-      - apps/design-system-docs/**
-      - .github/workflows/design-system-docs.yml
-      - packages/components/**
 
 jobs:
   calypso-live:

--- a/.github/workflows/calypso-live.yml
+++ b/.github/workflows/calypso-live.yml
@@ -3,6 +3,11 @@ name: Calypso Live
 on:
   pull_request:
     types: ['opened']
+    # Ignore paths that trigger the design-system-docs workflow, which manages preview link comment
+    paths-ignore:
+      - apps/design-system-docs/**
+      - .github/workflows/design-system-docs.yml
+      - packages/components/**
 
 jobs:
   calypso-live:

--- a/.github/workflows/design-system-docs.yml
+++ b/.github/workflows/design-system-docs.yml
@@ -3,6 +3,9 @@ name: Publish Design System Docs PR Preview
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - 'apps/design-system-docs/**'
+      - .github/workflows/design-system-docs.yml
 
 # Ensure only one preview build runs per-PR at a time
 concurrency:

--- a/.github/workflows/design-system-docs.yml
+++ b/.github/workflows/design-system-docs.yml
@@ -4,9 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
-      - apps/design-system-docs/**
+      - 'apps/design-system-docs/**'
       - .github/workflows/design-system-docs.yml
-      - packages/components/**
 
 # Ensure only one preview build runs per-PR at a time
 concurrency:
@@ -76,9 +75,8 @@ jobs:
           edit-mode: replace
           body: |
             <!-- cf-preview-comment -->
-            **Live Preview:**
+            **Design System Reference Site Preview:**
 
-            - [Calypso](https://calypso.live?image=registry.a8c.com/calypso/app:commit-${{ github.event.pull_request.head.sha }})
-            - [Jetpack Cloud](https://calypso.live?image=registry.a8c.com/calypso/app:commit-${{ github.event.pull_request.head.sha }}&env=jetpack)
-            - [Automattic for Agencies](https://calypso.live?image=registry.a8c.com/calypso/app:commit-${{ github.event.pull_request.head.sha }}&env=a8c-for-agencies)
-            - [Design System Reference Site](${{ steps.upload.outputs.url }}) (Commit ${{ github.event.pull_request.head.sha }})
+            ${{ steps.upload.outputs.url }}
+
+            (Latest commit: `${{ github.sha }}`)

--- a/.github/workflows/design-system-docs.yml
+++ b/.github/workflows/design-system-docs.yml
@@ -4,8 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
-      - 'apps/design-system-docs/**'
+      - apps/design-system-docs/**
       - .github/workflows/design-system-docs.yml
+      - packages/components/**
 
 # Ensure only one preview build runs per-PR at a time
 concurrency:
@@ -75,8 +76,9 @@ jobs:
           edit-mode: replace
           body: |
             <!-- cf-preview-comment -->
-            **Design System Reference Site Preview:**
+            **Live Preview:**
 
-            ${{ steps.upload.outputs.url }}
-
-            (Latest commit: `${{ github.sha }}`)
+            - [Calypso](https://calypso.live?image=registry.a8c.com/calypso/app:commit-${{ github.event.pull_request.head.sha }})
+            - [Jetpack Cloud](https://calypso.live?image=registry.a8c.com/calypso/app:commit-${{ github.event.pull_request.head.sha }}&env=jetpack)
+            - [Automattic for Agencies](https://calypso.live?image=registry.a8c.com/calypso/app:commit-${{ github.event.pull_request.head.sha }}&env=a8c-for-agencies)
+            - [Design System Reference Site](${{ steps.upload.outputs.url }}) (Commit ${{ github.event.pull_request.head.sha }})

--- a/.github/workflows/design-system-docs.yml
+++ b/.github/workflows/design-system-docs.yml
@@ -50,7 +50,7 @@ jobs:
           URL=$(echo "$OUT" | grep -oE 'https://[a-z0-9-]+-preview\.a8cds\.workers\.dev/?')
 
           # Expose it to later steps
-          echo 'url=$URL' >> "$GITHUB_OUTPUT"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
 
       # 7. Try to find an existing comment with our marker
       - name: Find preview comment

--- a/.github/workflows/design-system-docs.yml
+++ b/.github/workflows/design-system-docs.yml
@@ -49,6 +49,9 @@ jobs:
           # Extract the preview URL from the output
           URL=$(echo "$OUT" | grep -oE 'https://[a-z0-9-]+-preview\.a8cds\.workers\.dev/?')
 
+          # Output the URL to the GitHub Actions log for debugging
+          echo "URL: $URL"
+
           # Expose it to later steps
           echo "url=$URL" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/design-system-docs.yml
+++ b/.github/workflows/design-system-docs.yml
@@ -1,0 +1,73 @@
+name: Publish Design System Docs PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Ensure only one preview build runs per-PR at a time
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}-preview
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1. Checkout the PR code
+      - uses: actions/checkout@v4
+
+      # 2. Set up Node
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+
+      # 3. Install dependencies for just the design-system-docs package
+      - run: yarn workspaces focus --production @automattic/design-system-docs
+
+      # 4. Build the design-system-docs workspace
+      - name: Build design system docs
+        run: yarn workspace @automattic/design-system-docs build
+
+      # 5. Install Wrangler
+      - run: npm install -g wrangler
+
+      # 6. Upload a new Worker version and capture the preview URL
+      - name: Upload Worker version
+        id: upload
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.DESIGN_SYSTEM_PREVIEW_CLOUDFLARE_ACCOUNT }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.DESIGN_SYSTEM_PREVIEW_CLOUDFLARE_TOKEN }}
+        run: |
+          # Run the upload and tee output so it's visible in the GitHub Actions log
+          OUT=$(wrangler versions upload --cwd apps/design-system-docs 2>&1 | tee /dev/stderr)
+
+          # Extract the preview URL from the output
+          URL=$(echo "$OUT" | grep -oE 'https://[a-z0-9-]+-preview\.a8cds\.workers\.dev/?')
+
+          # Expose it to later steps
+          echo 'url=$URL' >> "$GITHUB_OUTPUT"
+
+      # 7. Try to find an existing comment with our marker
+      - name: Find preview comment
+        id: find_comment
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: '<!-- cf-preview-comment -->'
+
+      # 8. Create or update a comment that shows the preview URL
+      - name: Comment (create or update)
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          edit-mode: replace
+          body: |
+            <!-- cf-preview-comment -->
+            **Design System Reference Site Preview:**
+
+            ${{ steps.upload.outputs.url }}
+
+            (Latest commit: `${{ github.sha }}`)

--- a/.github/workflows/design-system-docs.yml
+++ b/.github/workflows/design-system-docs.yml
@@ -79,4 +79,4 @@ jobs:
 
             ${{ steps.upload.outputs.url }}
 
-            (Latest commit: `${{ github.sha }}`)
+            (Latest commit: ${{ github.event.pull_request.head.sha }})

--- a/.github/workflows/design-system-docs.yml
+++ b/.github/workflows/design-system-docs.yml
@@ -14,6 +14,9 @@ concurrency:
 
 jobs:
   preview:
+    # Avoid running this workflow for pull requests from forks, which would fail due to missing secrets
+    if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+
     runs-on: ubuntu-latest
 
     steps:

--- a/apps/design-system-docs/package.json
+++ b/apps/design-system-docs/package.json
@@ -26,20 +26,20 @@
 		"@docusaurus/core": "^3.7.0",
 		"@docusaurus/preset-classic": "^3.7.0",
 		"@mdx-js/react": "^3.1.0",
+		"@wordpress/base-styles": "^5.23.0",
+		"@wordpress/browserslist-config": "^6.23.0",
 		"@wordpress/components": "^29.9.0",
+		"docusaurus-plugin-sass": "^0.2.6",
 		"prism-react-renderer": "^2.4.1",
 		"react": "^18.3.1",
-		"react-dom": "^18.3.1"
+		"react-dom": "^18.3.1",
+		"sass": "^1.54.0"
 	},
 	"devDependencies": {
 		"@docusaurus/module-type-aliases": "^3.7.0",
 		"@docusaurus/tsconfig": "^3.7.0",
 		"@docusaurus/types": "^3.7.0",
 		"@types/react": "^18.3.21",
-		"@wordpress/base-styles": "^5.23.0",
-		"@wordpress/browserslist-config": "^6.23.0",
-		"docusaurus-plugin-sass": "^0.2.6",
-		"sass": "^1.54.0",
 		"typescript": "^5.8.3"
 	},
 	"optionalDependencies": {

--- a/apps/design-system-docs/wrangler.jsonc
+++ b/apps/design-system-docs/wrangler.jsonc
@@ -1,0 +1,8 @@
+{
+	"name": "preview",
+	"compatibility_date": "2025-05-28",
+	"assets": {
+		"directory": "./dist/",
+		"not_found_handling": "404-page"
+	}
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DS-151

Closes DS-162

## Proposed Changes

* Adds GitHub Actions workflow to publish Automattic Design System reference site preview on pull request changes 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Make it easier to preview changes, particularly for non-engineer stakeholders

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The pull request should have a comment linking to a functioning preview site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
