### PR TITLE
Help Center: Fix mixup of conversations

### DIFF
--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -21,12 +21,6 @@ export function setCurrentSupportInteraction( supportInteraction: SupportInterac
 	} as const;
 }
 
-export const setOdieChatId = ( odieChatId: number | undefined ) =>
-	( {
-		type: 'HELP_CENTER_SET_ODIE_ID',
-		odieChatId,
-	} ) as const;
-
 export const setLastMessageReceivedAt = ( lastMessageReceivedAt: number ) =>
 	( {
 		type: 'HELP_CENTER_SET_LAST_MESSAGE_RECEIVED_AT',
@@ -255,7 +249,6 @@ export type HelpCenterAction =
 			| typeof setCurrentSupportInteraction
 			| typeof setAllowPremiumSupport
 			| typeof setHelpCenterOptions
-			| typeof setOdieChatId
 			| typeof setLastMessageReceivedAt
 	  >
 	| GeneratorReturnType< typeof setShowHelpCenter >;

--- a/packages/data-stores/src/help-center/reducer.ts
+++ b/packages/data-stores/src/help-center/reducer.ts
@@ -42,10 +42,6 @@ const currentSupportInteraction: Reducer< SupportInteraction | undefined, HelpCe
 	return state;
 };
 
-const odieChatId: Reducer< number | undefined, HelpCenterAction > = ( state, action ) => {
-	return action.type === 'HELP_CENTER_SET_ODIE_ID' ? action.odieChatId : state;
-};
-
 const isMinimized: Reducer< boolean, HelpCenterAction > = ( state = false, action ) => {
 	switch ( action.type ) {
 		case 'HELP_CENTER_SET_MINIMIZED':
@@ -202,7 +198,6 @@ const reducer = combineReducers( {
 	zendeskClientId,
 	unreadCount,
 	navigateToRoute,
-	odieChatId,
 	lastMessageReceivedAt,
 	odieInitialPromptText,
 	odieBotNameSlug,

--- a/packages/data-stores/src/help-center/selectors.ts
+++ b/packages/data-stores/src/help-center/selectors.ts
@@ -19,6 +19,5 @@ export const getOdieBotNameSlug = ( state: State ) => state.odieBotNameSlug;
 export const getCurrentSupportInteraction = ( state: State ) => state.currentSupportInteraction;
 export const getAllowPremiumSupport = ( state: State ) => state.allowPremiumSupport;
 export const getHelpCenterOptions = ( state: State ) => state.helpCenterOptions;
-export const getOdieChatId = ( state: State ) => state.odieChatId;
 export const getLastMessageReceivedAt = ( state: State ) => state.lastMessageReceivedAt;
 export const getContextTerm = ( state: State ) => state.contextTerm;

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -85,10 +85,9 @@ const ChatEllipsisMenu = () => {
 			areSoundNotificationsEnabled: helpCenterSelect.getAreSoundNotificationsEnabled(),
 		};
 	}, [] );
-	const { setAreSoundNotificationsEnabled, setOdieChatId } = useDispatch( HELP_CENTER_STORE );
+	const { setAreSoundNotificationsEnabled } = useDispatch( HELP_CENTER_STORE );
 
 	const clearChat = async () => {
-		setOdieChatId( undefined );
 		await resetSupportInteraction();
 		clearHelpCenterZendeskConversationStarted();
 		recordTracksEvent( 'calypso_inlinehelp_clear_conversation' );

--- a/packages/help-center/src/components/help-center-support-chat-message.tsx
+++ b/packages/help-center/src/components/help-center-support-chat-message.tsx
@@ -45,26 +45,11 @@ export const HelpCenterSupportChatMessage = ( {
 	const helpCenterContext = useHelpCenterContext();
 	const helpCenterContextSectionName = helpCenterContext.sectionName;
 	const { supportInteractions } = useGetHistoryChats();
-	const { setCurrentSupportInteraction, setOdieChatId } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const { setCurrentSupportInteraction } = useDataStoreDispatch( HELP_CENTER_STORE );
 
-	const isZendeskConversation = (
-		conversation: OdieConversation | ZendeskConversation
-	): conversation is ZendeskConversation =>
-		'metadata' in conversation && 'participants' in conversation;
-
-	let odieChatId = undefined;
-	let conversationStatus: string = '';
-	let supportInteraction = undefined;
-
-	if ( isZendeskConversation( conversation ) ) {
-		conversationStatus = conversation.metadata.status;
-
-		supportInteraction = supportInteractions.find(
-			( interaction ) => interaction.uuid === conversation.metadata.supportInteractionId
-		);
-	} else {
-		odieChatId = parseInt( conversation.id );
-	}
+	const supportInteraction = supportInteractions.find(
+		( interaction ) => interaction.uuid === conversation.metadata.supportInteractionId
+	);
 
 	const messageDisplayName =
 		role === 'business' ? __( 'Happiness Engineer', __i18n_text_domain__ ) : displayName;
@@ -96,17 +81,11 @@ export const HelpCenterSupportChatMessage = ( {
 			to="/odie"
 			onClick={ () => {
 				trackContactButtonClicked( sectionName || helpCenterContextSectionName );
-
-				if ( odieChatId ) {
-					setOdieChatId( odieChatId );
-				} else if ( supportInteraction ) {
-					setOdieChatId( undefined );
-					setCurrentSupportInteraction( supportInteraction );
-				}
+				setCurrentSupportInteraction( supportInteraction );
 			} }
 			className={ clsx( 'help-center-support-chat__conversation-container', {
 				'is-unread-message': hasUnreadMessages,
-				[ `is-${ conversationStatus }` ]: conversationStatus,
+				[ `is-${ supportInteraction?.status }` ]: supportInteraction?.status,
 			} ) }
 		>
 			<div

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -17,7 +17,6 @@ export const useGetCombinedChat = ( canConnectToZendesk: boolean ) => {
 		( select ) => {
 			const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
 			const currentSupportInteraction = store.getCurrentSupportInteraction();
-			const odieChatIdFromConversationHistory = store.getOdieChatId();
 
 			const odieId = getOdieIdFromInteraction( currentSupportInteraction );
 			const conversationId = getConversationIdFromInteraction( currentSupportInteraction );
@@ -25,7 +24,7 @@ export const useGetCombinedChat = ( canConnectToZendesk: boolean ) => {
 			return {
 				currentSupportInteraction,
 				conversationId,
-				odieId: odieChatIdFromConversationHistory ?? odieId,
+				odieId,
 				isChatLoaded: store.getIsChatLoaded(),
 			};
 		},

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -247,6 +247,7 @@ export type OdieConversation = {
 	id: string;
 	createdAt: number;
 	messages: OdieMessage[];
+	metadata: Metadata;
 };
 
 export type ZendeskConversation = {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes a bug introduced in https://github.com/Automattic/wp-calypso/pull/102667
Fixes https://linear.app/a8c/issue/DOTCOM-13357/help-center-mixup-of-chats

## Proposed Changes

- Fixes a bug where multiple Odie chats, when accessed in History, had the same last zendesk conversation that the user has seen. 
- Refactor the code to not need some additional components that were introduced.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix problems with chats in History

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

How to reproduce on production:
- Open Help Center and go to History
- Open a Odie chat, it should be fine (probably)
- Open a Zendesk chat
- Return to the Odie chat: you should see the Zendesk chat after AI
- Open a different Zendesk chat
- Return to the same Odie chat: you should see the latest Zendesk chat that you just saw

Test the fix:
- Same steps as above, but AI chats should only be AI chats

