### PR TITLE
fix display error in pricing grid for migration plan selection

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/migration-plan-feature-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/migration-plan-feature-list.tsx
@@ -25,10 +25,16 @@ export const MigrationPlanFeatureList = ( {
 	}
 
 	const selectedPlanPricing = pricing.originalPrice?.monthly;
+	const selectedPlanDiscountedPrice = pricing.introOffer?.rawPrice?.monthly;
 
-	const savingsDecimal =
+	const annualSavingsDecimal =
 		fullMonthlyPrice && selectedPlanPricing
 			? ( fullMonthlyPrice - selectedPlanPricing ) / fullMonthlyPrice
+			: 0;
+
+	const discountedPriceDecimal =
+		selectedPlanPricing && selectedPlanDiscountedPrice
+			? ( selectedPlanPricing - selectedPlanDiscountedPrice ) / selectedPlanPricing
 			: 0;
 
 	const jetpackFeatures = [
@@ -48,7 +54,7 @@ export const MigrationPlanFeatureList = ( {
 		// translators: %(percentage)s is the percentage of annual savings formatted like '50%'
 		translate( '{{strong}}%(percentage)s{{/strong}} annual savings', {
 			args: {
-				percentage: formatNumber( savingsDecimal, {
+				percentage: formatNumber( annualSavingsDecimal, {
 					numberFormatOptions: { style: 'percent' },
 				} ),
 			},
@@ -71,15 +77,17 @@ export const MigrationPlanFeatureList = ( {
 	} = {
 		wpcomFeatures: {
 			[ PLAN_BUSINESS ]: [
-				translate( '{{strong}}%(percentage)s off{{/strong}} your first year', {
-					args: {
-						percentage: formatNumber( 0.5, {
-							numberFormatOptions: { style: 'percent' },
-						} ),
-						comment: 'percentage like 50% off',
-					},
-					components: { strong: <strong /> },
-				} ),
+				discountedPriceDecimal
+					? translate( '{{strong}}%(percentage)s off{{/strong}} your first year', {
+							args: {
+								percentage: formatNumber( discountedPriceDecimal, {
+									numberFormatOptions: { style: 'percent' },
+								} ),
+								comment: 'percentage like 50% off',
+							},
+							components: { strong: <strong /> },
+					  } )
+					: translate( 'No first year discount' ),
 				...commonDiscountedFeatures,
 				...businessFeatures,
 			],
@@ -96,15 +104,17 @@ export const MigrationPlanFeatureList = ( {
 				...businessFeatures,
 			],
 			[ PLAN_BUSINESS_2_YEARS ]: [
-				translate( '{{strong}}%(percentage)s off{{/strong}} your first two years', {
-					args: {
-						percentage: formatNumber( 0.5, {
-							numberFormatOptions: { style: 'percent' },
-						} ),
-						comment: 'percentage like 50% off',
-					},
-					components: { strong: <strong /> },
-				} ),
+				discountedPriceDecimal
+					? translate( '{{strong}}%(percentage)s off{{/strong}} your first two years', {
+							args: {
+								percentage: formatNumber( discountedPriceDecimal, {
+									numberFormatOptions: { style: 'percent' },
+								} ),
+								comment: 'percentage like 50% off',
+							},
+							components: { strong: <strong /> },
+					  } )
+					: translate( 'No discount on your first two years' ),
 				...commonDiscountedFeatures,
 				...businessFeatures,
 			],


### PR DESCRIPTION
## Proposed Changes

* This PR calculates the discount percentage provided by intro offers in the pricing grid shown in the migrations flow. Previously, these discount percentages were set in the code at 50%.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->
* To show the correct % discount in the pricing grid, matching the discount offered in checkout

Reference for correct pricing and discounts: pdxWSz-1Mt-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* While logged in, test with the migration flow: /setup/site-migration/
* Choose to migrate to an existing wordpress.com site
* Select to purchase a plan
* You should be presented with the pricing grid
* Testing in production, you will notice that the discount listed on the card for the 2 year business plan is 50%. This is incorrect.
![Screenshot 2025-05-28 at 4 41 16 PM](https://github.com/user-attachments/assets/e2df5a54-17bb-4898-822e-77bb87808a06)

* With this PR applied, the discount on the pricing grid for two years should be correct at 25%
![Screenshot 2025-05-28 at 5 14 51 PM](https://github.com/user-attachments/assets/f7a9f88a-d441-4ddc-99ce-9fd0f01c019f)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?