### PR TITLE
Purchase Management: Add pagination and search to purchases DataViews

### DIFF
--- a/client/me/purchases/purchases-list-in-dataviews/hooks/use-field-definitions.ts
+++ b/client/me/purchases/purchases-list-in-dataviews/hooks/use-field-definitions.ts
@@ -1,4 +1,3 @@
-import { SiteDetails } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
@@ -13,9 +12,7 @@ export function usePurchasesFieldDefinitions( fieldIds?: string[] ) {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 	const paymentMethods = useStoredPaymentMethods().paymentMethods;
-	const sites: Record< number | string, SiteDetails > = useSelector(
-		( state: any ) => state.sites?.items
-	);
+	const sites = useSelector( ( state ) => state.sites?.items );
 
 	return useMemo( () => {
 		const fieldDefinitions = getPurchasesFieldDefinitions( {

--- a/client/me/purchases/purchases-list-in-dataviews/hooks/use-field-definitions.ts
+++ b/client/me/purchases/purchases-list-in-dataviews/hooks/use-field-definitions.ts
@@ -7,7 +7,7 @@ import {
 	getMembershipsFieldDefinitions,
 } from '../purchases-data-field';
 
-export function usePurchasesFieldDefinitions() {
+export function usePurchasesFieldDefinitions( fieldIds?: string[] ) {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 	const paymentMethods = useStoredPaymentMethods().paymentMethods;
@@ -17,9 +17,10 @@ export function usePurchasesFieldDefinitions() {
 			translate,
 			moment,
 			paymentMethods,
+			fieldIds,
 		} );
 		return fieldDefinitions;
-	}, [ translate, moment, paymentMethods ] );
+	}, [ translate, moment, paymentMethods, fieldIds ] );
 }
 
 export function useMembershipsFieldDefinitions() {

--- a/client/me/purchases/purchases-list-in-dataviews/hooks/use-field-definitions.ts
+++ b/client/me/purchases/purchases-list-in-dataviews/hooks/use-field-definitions.ts
@@ -1,7 +1,9 @@
+import { SiteDetails } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useStoredPaymentMethods } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
+import { useSelector } from 'calypso/state';
 import {
 	getPurchasesFieldDefinitions,
 	getMembershipsFieldDefinitions,
@@ -11,16 +13,20 @@ export function usePurchasesFieldDefinitions( fieldIds?: string[] ) {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 	const paymentMethods = useStoredPaymentMethods().paymentMethods;
+	const sites: Record< number | string, SiteDetails > = useSelector(
+		( state: any ) => state.sites?.items
+	);
 
 	return useMemo( () => {
 		const fieldDefinitions = getPurchasesFieldDefinitions( {
 			translate,
 			moment,
 			paymentMethods,
+			sites,
 			fieldIds,
 		} );
 		return fieldDefinitions;
-	}, [ translate, moment, paymentMethods, fieldIds ] );
+	}, [ translate, moment, paymentMethods, fieldIds, sites ] );
 }
 
 export function useMembershipsFieldDefinitions() {

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -1,4 +1,4 @@
-import { Purchases } from '@automattic/data-stores';
+import { Purchases, SiteDetails } from '@automattic/data-stores';
 import { Fields, Operator } from '@wordpress/dataviews';
 import { LocalizeProps } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
@@ -62,11 +62,13 @@ export function getPurchasesFieldDefinitions( {
 	translate,
 	moment,
 	paymentMethods,
+	sites,
 	fieldIds,
 }: {
 	translate: LocalizeProps[ 'translate' ];
 	moment: ReturnType< typeof useLocalizedMoment >;
 	paymentMethods: Array< StoredPaymentMethod >;
+	sites?: Record< number | string, SiteDetails >;
 	fieldIds?: string[];
 } ): Fields< Purchases.Purchase > {
 	const backupPaymentMethods = paymentMethods.filter(
@@ -104,7 +106,19 @@ export function getPurchasesFieldDefinitions( {
 				operators: [ 'is' as Operator ],
 			},
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
-				return getDisplayName( item ) + ' ' + purchaseType( item ) + ' ' + item.siteName;
+				// Render a bunch of things to make this easily searchable.
+				const site = sites?.[ item.siteId ];
+				return (
+					getDisplayName( item ) +
+					' ' +
+					purchaseType( item ) +
+					' ' +
+					item.siteName +
+					' ' +
+					item.domain +
+					' ' +
+					site?.URL
+				);
 			},
 			render: ( { item }: { item: Purchases.Purchase } ) => {
 				return (
@@ -193,9 +207,8 @@ export function getMembershipsFieldDefinitions( {
 			filterBy: {
 				operators: [ 'is' as Operator ],
 			},
-			// Filter by site ID
 			getValue: ( { item }: { item: MembershipSubscription } ) => {
-				return item.site_id;
+				return item.site_id + ' ' + item.site_title + ' ' + item.site_url;
 			},
 			// Render the site icon
 			render: ( { item }: { item: MembershipSubscription } ) => {

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -3,7 +3,7 @@ import { Fields, Operator } from '@wordpress/dataviews';
 import { LocalizeProps } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
-import { getDisplayName, isRenewing } from 'calypso/lib/purchases';
+import { getDisplayName, isRenewing, purchaseType } from 'calypso/lib/purchases';
 import { MembershipSubscription } from 'calypso/lib/purchases/types';
 import { useSelector } from 'calypso/state';
 import { getSite } from 'calypso/state/sites/selectors';
@@ -84,9 +84,8 @@ export function getPurchasesFieldDefinitions( {
 			filterBy: {
 				operators: [ 'is' as Operator ],
 			},
-			// Filter by site ID
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
-				return item.siteId;
+				return item.siteName;
 			},
 			// Render the site icon
 			render: ( { item }: { item: Purchases.Purchase } ) => {
@@ -105,7 +104,7 @@ export function getPurchasesFieldDefinitions( {
 				operators: [ 'is' as Operator ],
 			},
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
-				return item.productId;
+				return getDisplayName( item ) + ' ' + purchaseType( item ) + ' ' + item.siteName;
 			},
 			render: ( { item }: { item: Purchases.Purchase } ) => {
 				return (
@@ -218,7 +217,7 @@ export function getMembershipsFieldDefinitions( {
 				operators: [ 'is' as Operator ],
 			},
 			getValue: ( { item }: { item: MembershipSubscription } ) => {
-				return item.product_id;
+				return item.title;
 			},
 			render: ( { item }: { item: MembershipSubscription } ) => {
 				return (

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -62,16 +62,18 @@ export function getPurchasesFieldDefinitions( {
 	translate,
 	moment,
 	paymentMethods,
+	fieldIds,
 }: {
 	translate: LocalizeProps[ 'translate' ];
 	moment: ReturnType< typeof useLocalizedMoment >;
 	paymentMethods: Array< StoredPaymentMethod >;
+	fieldIds?: string[];
 } ): Fields< Purchases.Purchase > {
 	const backupPaymentMethods = paymentMethods.filter(
 		( paymentMethod ) => paymentMethod.is_backup === true
 	);
 
-	return [
+	const fields: Fields< Purchases.Purchase > = [
 		{
 			id: 'site',
 			label: 'Site',
@@ -150,7 +152,7 @@ export function getPurchasesFieldDefinitions( {
 				operators: [ 'is' as Operator ],
 			},
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
-				return item.payment.storedDetailsId;
+				return item.payment.storedDetailsId ?? '';
 			},
 			render: ( { item }: { item: Purchases.Purchase } ) => {
 				let isBackupMethodAvailable = false;
@@ -173,6 +175,7 @@ export function getPurchasesFieldDefinitions( {
 			},
 		},
 	];
+	return fields.filter( ( field ) => fieldIds?.includes( field.id ) ?? true );
 }
 
 export function getMembershipsFieldDefinitions( {
@@ -239,7 +242,7 @@ export function getMembershipsFieldDefinitions( {
 				operators: [ 'is' as Operator ],
 			},
 			getValue: ( { item }: { item: MembershipSubscription } ) => {
-				return item.end_date;
+				return item.end_date ?? '';
 			},
 			render: ( { item }: { item: MembershipSubscription } ) => {
 				return (

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -1,14 +1,15 @@
 import { Card } from '@automattic/components';
 import { Purchases } from '@automattic/data-stores';
-import { DataViews, View } from '@wordpress/dataviews';
+import { DataViews, View, filterSortAndPaginate } from '@wordpress/dataviews';
 import { LocalizeProps } from 'i18n-calypso';
+import { useMemo, useState } from 'react';
 import { MembershipSubscription } from 'calypso/lib/purchases/types';
 import {
 	usePurchasesFieldDefinitions,
 	useMembershipsFieldDefinitions,
 } from './hooks/use-field-definitions';
 
-export const purchasesDataView = {
+export const purchasesDataView: View = {
 	type: 'table',
 	page: 1,
 	perPage: 5,
@@ -19,38 +20,40 @@ export const purchasesDataView = {
 		direction: 'desc',
 	},
 	layout: {},
-} as View;
+};
 
 export function PurchasesDataViews( props: {
 	purchases: Purchases.Purchase[];
 	translate: LocalizeProps[ 'translate' ];
 } ) {
 	const { purchases } = props;
-	const onChangeView = () => {
-		return;
-	};
+	const [ currentView, setView ] = useState( purchasesDataView );
+	const purchasesDataFields = usePurchasesFieldDefinitions( purchasesDataView.fields );
+
+	const { data: adjustedPurchases, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( purchases, currentView, purchasesDataFields );
+	}, [ purchases, currentView, purchasesDataFields ] );
 
 	const getItemId = ( item: Purchases.Purchase ) => {
 		return item.id.toString();
 	};
-	const purchasesDataFields = usePurchasesFieldDefinitions();
 	return (
 		<Card id="purchases-list" className="section-content" tagName="section">
 			<DataViews
-				data={ purchases }
+				data={ adjustedPurchases }
 				fields={ purchasesDataFields }
-				view={ purchasesDataView }
-				onChangeView={ onChangeView }
+				view={ currentView }
+				onChangeView={ setView }
 				defaultLayouts={ { table: {} } }
 				actions={ undefined }
 				getItemId={ getItemId }
-				paginationInfo={ { totalItems: 100, totalPages: 10 } }
+				paginationInfo={ paginationInfo }
 			/>
 		</Card>
 	);
 }
 
-export const membershipDataView = {
+export const membershipDataView: View = {
 	type: 'table',
 	page: 1,
 	perPage: 5,
@@ -61,7 +64,7 @@ export const membershipDataView = {
 		direction: 'desc',
 	},
 	layout: {},
-} as View;
+};
 
 export function MembershipsDataViews( props: {
 	memberships: MembershipSubscription[];

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -71,25 +71,27 @@ export function MembershipsDataViews( props: {
 	translate: LocalizeProps[ 'translate' ];
 } ) {
 	const { memberships } = props;
-	const onChangeView = () => {
-		return;
-	};
+	const membershipsDataFields = useMembershipsFieldDefinitions();
+	const [ currentView, setView ] = useState( purchasesDataView );
+
+	const { data: adjustedMemberships, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( memberships, currentView, membershipsDataFields );
+	}, [ memberships, currentView, membershipsDataFields ] );
 
 	const getItemId = ( item: MembershipSubscription ) => {
 		return item.ID;
 	};
-	const membershipsDataFields = useMembershipsFieldDefinitions();
 	return (
 		<Card id="purchases-list" className="section-content" tagName="section">
 			<DataViews
-				data={ memberships }
+				data={ adjustedMemberships }
 				fields={ membershipsDataFields }
-				view={ membershipDataView }
-				onChangeView={ onChangeView }
+				view={ currentView }
+				onChangeView={ setView }
 				defaultLayouts={ { table: {} } }
 				actions={ undefined }
 				getItemId={ getItemId }
-				paginationInfo={ { totalItems: 100, totalPages: 10 } }
+				paginationInfo={ paginationInfo }
 			/>
 		</Card>
 	);

--- a/client/state/types.ts
+++ b/client/state/types.ts
@@ -1,3 +1,4 @@
+import { SiteDetails } from '@automattic/data-stores';
 import type { CountriesState } from './countries/types';
 import type { BillingTransactionsState } from 'calypso/state/billing-transactions/types';
 import type { IMarketplaceState } from 'calypso/state/marketplace/types';
@@ -22,6 +23,7 @@ export interface IAppState {
 	memberships?: IMembershipsState;
 	countries?: CountriesState;
 	billingTransactions?: BillingTransactionsState;
+	sites?: { items: Record< number | string, SiteDetails > };
 }
 
 /**


### PR DESCRIPTION
## Proposed Changes

This PR adds support for pagination and search to the DataViews version of the purchases list.

> [!NOTE]
> This version of the purchases list is still behind a feature flag. To test this you will need to manually enable the `purchases/purchase-list-dataview` flag in your local `development.json` config before starting calypso.

Part of https://linear.app/a8c/project/replace-calypsos-active-upgrades-subscriptions-with-dataviews-a7b39dea5417/overview / https://github.com/Automattic/wp-calypso/issues/86616
Tracked by https://linear.app/a8c/issue/CHE-152/implement-pagination-on-dataviews-subscription-list

## Screenshots

<img width="935" alt="Screenshot 2025-05-28 at 5 51 01 PM" src="https://github.com/user-attachments/assets/10e08e7b-8e2d-4fa0-afa5-1ba077edd588" />

<img width="941" alt="Screenshot 2025-05-28 at 5 51 14 PM" src="https://github.com/user-attachments/assets/99462c52-5428-4dee-85bd-0f3b1061f4d8" />


## Testing Instructions

- Use an account which has a number of purchases, the more the better.
- Visit `/me/purchases` with the DataView enabled (see above).
- Verify that entering text into the search field for the purchases list (and the memberships list, if you have any) filters the list by that text. You can use the product name and type (eg "Plan"), the site name, the site domain, and the site primary domain (if different).
- Verify that using the pagination controls (next, previous, and the page selector) works as expected.
