### PR TITLE
Backup: fix translated buttons

### DIFF
--- a/client/components/jetpack/backup-actions-toolbar/style.scss
+++ b/client/components/jetpack/backup-actions-toolbar/style.scss
@@ -5,6 +5,7 @@
 	display: flex;
 	gap: 10px;
 	flex-direction: column-reverse;
+	float: right;
 
 	@include break-small {
 		flex-direction: row;

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -87,11 +87,8 @@
 .backup__header-right {
 	text-align: right;
 	margin-top: 8px;
-
-	.backup__clone-button {
-		white-space: nowrap;
-
-	}
+	margin-left: 8px;
+	width: 50%;
 }
 
 .backup__header-title {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/BACKUP-76.

## Proposed Changes

Fixes the `Copy site`/`Back up now` buttons for languages other than English.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Translations should also have their buttons presented in a clear, well-aligned way.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check out this branch and start the local Jetpack Cloud environment:
  - `$ yarn start-jetpack-cloud`
- Access http://jetpack.cloud.localhost:3000/ and log in with your Jetpack Cloud credentials.
- Select a site.
- Go to `VaultPress Backup` in the left menu. The buttons are shown in this page.
- Try different languages at https://wordpress.com/me/account and check how they look like.

### Before

These screenshots illustrate the current form, before the fixes are applied:

#### English

<img width="757" alt="image" src="https://github.com/user-attachments/assets/22bf9784-7d94-4a06-b156-b832a6c83ddc" />

#### Spanish

<img width="754" alt="before-spanish" src="https://github.com/user-attachments/assets/1d706ee0-c6d7-4739-bbe9-482999fb9e1e" />

---

### After

These screenshots show how it will look like, with different terms, after the fixes are applied:

#### Spanish

<img width="757" alt="after-spanish" src="https://github.com/user-attachments/assets/dd053650-2c09-4c19-8ec2-7da8cfd5faef" />

#### Spanish, short term

<img width="770" alt="after-spanish-short" src="https://github.com/user-attachments/assets/6ac77d55-fece-4892-87ce-e2f299017674" />

#### Spanish, even shorter term

<img width="763" alt="after-spanish-shorter" src="https://github.com/user-attachments/assets/88969fd2-d1af-4e2f-9d2b-1ea43732208e" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
