### PR TITLE
Dashboard: Add the ability to not persist query data to cache.

### DIFF
--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -4,7 +4,6 @@ import { fetchUser } from '../../data';
 import type { User } from '../../data/types';
 
 export const AUTH_QUERY_KEY = [ 'auth', 'user' ];
-export const TWO_STEP_QUERY_KEY = [ 'me', 'two-step' ];
 
 interface AuthContextType {
 	user: User;
@@ -28,6 +27,9 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 		queryFn: fetchUser,
 		staleTime: 30 * 60 * 1000, // Consider auth valid for 30 minutes
 		retry: false, // Don't retry on 401 errors
+		meta: {
+			persist: false,
+		},
 	} );
 
 	if ( userIsError ) {

--- a/client/dashboard/app/query-client.ts
+++ b/client/dashboard/app/query-client.ts
@@ -25,7 +25,6 @@ const [ , persistPromise ] = persistQueryClient( {
 			if ( meta?.persist === false ) {
 				return false;
 			}
-
 			return true;
 		},
 	},

--- a/client/dashboard/app/query-client.ts
+++ b/client/dashboard/app/query-client.ts
@@ -1,7 +1,6 @@
 import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister';
 import { QueryClient } from '@tanstack/react-query';
 import { persistQueryClient } from '@tanstack/react-query-persist-client';
-import { TWO_STEP_QUERY_KEY } from './auth';
 
 export const queryClient = new QueryClient( {
 	defaultOptions: {
@@ -22,11 +21,7 @@ const [ , persistPromise ] = persistQueryClient( {
 	buster: '2', // Bump when query data shape changes.
 	maxAge,
 	dehydrateOptions: {
-		shouldDehydrateQuery: ( { queryKey, meta } ) => {
-			if ( TWO_STEP_QUERY_KEY === queryKey ) {
-				return false;
-			}
-
+		shouldDehydrateQuery: ( { meta } ) => {
 			if ( meta?.persist === false ) {
 				return false;
 			}

--- a/client/dashboard/app/query-client.ts
+++ b/client/dashboard/app/query-client.ts
@@ -22,10 +22,15 @@ const [ , persistPromise ] = persistQueryClient( {
 	buster: '2', // Bump when query data shape changes.
 	maxAge,
 	dehydrateOptions: {
-		shouldDehydrateQuery: ( { queryKey } ) => {
+		shouldDehydrateQuery: ( { queryKey, meta } ) => {
 			if ( TWO_STEP_QUERY_KEY === queryKey ) {
 				return false;
 			}
+
+			if ( meta?.persist === false ) {
+				return false;
+			}
+
 			return true;
 		},
 	},


### PR DESCRIPTION
Relates to: #103723

## Proposed Changes

There are times when we don't want to add queries to the cache. 

Here are some examples of when we don't want to store to cache:
- Time-Sensitive Operations
  - Tokens 
- User-Specific Temporary States
  - Shopping Cart
  - Auto-saves 
- Large Datasets
  - Search results
  - Analytics data

We currently have this functionality in the [state query client](https://github.com/Automattic/wp-calypso/blob/976b10af7dfc9d094b0ec828a1944e702d89aef0/client/state/should-dehydrate-query.ts#L18), and exclude for `TWO_STEP_QUERY_KEY`. Let's standardize it.

## Testing Instructions
Add `{ meta: { persist: false } }` to any query. Inspect the localStorage cache (`REACT_QUERY_OFFLINE_CACHE`), expect to not see your query.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
