### PR TITLE
Dashboard: Replace decentralized feature functions with centralized object.

### DIFF
--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -6,11 +6,13 @@ import {
 	createLazyRoute,
 } from '@tanstack/react-router';
 import { fetchTwoStep } from '../data';
-import { canUpdateDefensiveMode } from '../sites/settings-defensive-mode';
-import { canUpdatePHPVersion } from '../sites/settings-php/utils';
-import { canGetPrimaryDataCenter } from '../sites/settings-primary-data-center';
-import { canSetStaticFile404Handling } from '../sites/settings-static-file-404';
-import { canUpdateWordPressVersion } from '../sites/settings-wordpress/utils';
+import {
+	canUpdatePHPVersion,
+	canUpdateDefensiveMode,
+	canUpdateWordPressVersion,
+	canGetPrimaryDataCenter,
+	canSetStaticFile404Handling,
+} from '../utils/site-features';
 import NotFound from './404';
 import UnknownError from './500';
 import {

--- a/client/dashboard/sites/settings-database/index.tsx
+++ b/client/dashboard/sites/settings-database/index.tsx
@@ -18,15 +18,11 @@ import { useState } from 'react';
 import { siteQuery } from '../../app/queries';
 import PageLayout from '../../components/page-layout';
 import { fetchPhpMyAdminToken } from '../../data';
+import { canAccessPhpMyAdmin } from '../../utils/site-features';
 import SettingsCallout from '../settings-callout';
 import SettingsPageHeader from '../settings-page-header';
 import calloutIllustrationUrl from './callout-illustration.svg';
 import ResetPasswordModal from './reset-password-modal';
-import type { Site } from '../../data/types';
-
-export function canOpenPhpMyAdmin( site: Site ) {
-	return site.is_wpcom_atomic;
-}
 
 export default function SiteDatabaseSettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useQuery( siteQuery( siteSlug ) );
@@ -38,7 +34,7 @@ export default function SiteDatabaseSettings( { siteSlug }: { siteSlug: string }
 		return null;
 	}
 
-	if ( ! canOpenPhpMyAdmin( site ) ) {
+	if ( ! canAccessPhpMyAdmin( site ) ) {
 		return (
 			<PageLayout
 				size="small"

--- a/client/dashboard/sites/settings-defensive-mode/index.tsx
+++ b/client/dashboard/sites/settings-defensive-mode/index.tsx
@@ -18,13 +18,10 @@ import { useState } from 'react';
 import { siteQuery, siteDefensiveModeQuery, siteDefensiveModeMutation } from '../../app/queries';
 import Notice from '../../components/notice';
 import PageLayout from '../../components/page-layout';
+import { canUpdateDefensiveMode } from '../../utils/site-features';
 import SettingsPageHeader from '../settings-page-header';
-import type { DefensiveModeSettingsUpdate, Site } from '../../data/types';
+import type { DefensiveModeSettingsUpdate } from '../../data/types';
 import type { Field } from '@automattic/dataviews';
-
-export function canUpdateDefensiveMode( site: Site ) {
-	return site.is_wpcom_atomic;
-}
 
 const availableTtls = [
 	{

--- a/client/dashboard/sites/settings-defensive-mode/summary.tsx
+++ b/client/dashboard/sites/settings-defensive-mode/summary.tsx
@@ -4,7 +4,7 @@ import { __ } from '@wordpress/i18n';
 import { shield } from '@wordpress/icons';
 import { siteDefensiveModeQuery } from '../../app/queries';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
-import { canUpdateDefensiveMode } from '.';
+import { canUpdateDefensiveMode } from '../../utils/site-features';
 import type { Site } from '../../data/types';
 import type { Density } from '@automattic/components/src/summary-button/types';
 

--- a/client/dashboard/sites/settings-php/index.tsx
+++ b/client/dashboard/sites/settings-php/index.tsx
@@ -14,9 +14,9 @@ import { useState } from 'react';
 import { getPHPVersions } from 'calypso/data/php-versions';
 import { siteQuery, sitePHPVersionQuery, sitePHPVersionMutation } from '../../app/queries';
 import PageLayout from '../../components/page-layout';
+import { canUpdatePHPVersion } from '../../utils/site-features';
 import SettingsCallout from '../settings-callout';
 import SettingsPageHeader from '../settings-page-header';
-import { canUpdatePHPVersion } from './utils';
 import type { Field } from '@automattic/dataviews';
 
 export default function PHPVersionSettings( { siteSlug }: { siteSlug: string } ) {

--- a/client/dashboard/sites/settings-php/summary.tsx
+++ b/client/dashboard/sites/settings-php/summary.tsx
@@ -5,7 +5,7 @@ import { code } from '@wordpress/icons';
 import { getPHPVersions } from 'calypso/data/php-versions';
 import { sitePHPVersionQuery } from '../../app/queries';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
-import { canUpdatePHPVersion } from './utils';
+import { canUpdatePHPVersion } from '../../utils/site-features';
 import type { Site } from '../../data/types';
 import type { Density } from '@automattic/components/src/summary-button/types';
 

--- a/client/dashboard/sites/settings-php/utils.tsx
+++ b/client/dashboard/sites/settings-php/utils.tsx
@@ -1,5 +1,0 @@
-import { Site } from '../../data/types';
-
-export function canUpdatePHPVersion( site: Site ) {
-	return site.is_wpcom_atomic;
-}

--- a/client/dashboard/sites/settings-primary-data-center/index.tsx
+++ b/client/dashboard/sites/settings-primary-data-center/index.tsx
@@ -7,12 +7,8 @@ import { cloud } from '@wordpress/icons';
 import { getDataCenterOptions } from 'calypso/data/data-center';
 import { siteQuery, sitePrimaryDataCenterQuery } from '../../app/queries';
 import PageLayout from '../../components/page-layout';
+import { canGetPrimaryDataCenter } from '../../utils/site-features';
 import SettingsPageHeader from '../settings-page-header';
-import type { Site } from '../../data/types';
-
-export function canGetPrimaryDataCenter( site: Site ) {
-	return site.is_wpcom_atomic;
-}
 
 export default function PrimaryDataCenterSettings( { siteSlug }: { siteSlug: string } ) {
 	const router = useRouter();

--- a/client/dashboard/sites/settings-primary-data-center/summary.tsx
+++ b/client/dashboard/sites/settings-primary-data-center/summary.tsx
@@ -5,7 +5,7 @@ import { cloud } from '@wordpress/icons';
 import { getDataCenterOptions } from 'calypso/data/data-center';
 import { sitePrimaryDataCenterQuery } from '../../app/queries';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
-import { canGetPrimaryDataCenter } from './index';
+import { canGetPrimaryDataCenter } from '../../utils/site-features';
 import type { Site } from '../../data/types';
 import type { Density } from '@automattic/components/src/summary-button/types';
 

--- a/client/dashboard/sites/settings-static-file-404/index.tsx
+++ b/client/dashboard/sites/settings-static-file-404/index.tsx
@@ -13,14 +13,10 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { siteQuery, siteStaticFile404Query, siteStaticFile404Mutation } from '../../app/queries';
 import PageLayout from '../../components/page-layout';
+import { canSetStaticFile404Handling } from '../../utils/site-features';
 import SettingsCallout from '../settings-callout';
 import SettingsPageHeader from '../settings-page-header';
-import type { Site } from '../../data/types';
 import type { Field } from '@automattic/dataviews';
-
-export function canSetStaticFile404Handling( site: Site ) {
-	return site.is_wpcom_atomic;
-}
 
 const fields: Field< { setting: string } >[] = [
 	{

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -20,9 +20,9 @@ import {
 	siteWordPressVersionMutation,
 } from '../../app/queries';
 import PageLayout from '../../components/page-layout';
+import { canUpdateWordPressVersion } from '../../utils/site-features';
 import { getFormattedWordPressVersion } from '../../utils/wp-version';
 import SettingsPageHeader from '../settings-page-header';
-import { canUpdateWordPressVersion } from './utils';
 import type { Field } from '@automattic/dataviews';
 
 export default function WordPressVersionSettings( { siteSlug }: { siteSlug: string } ) {

--- a/client/dashboard/sites/settings-wordpress/summary.tsx
+++ b/client/dashboard/sites/settings-wordpress/summary.tsx
@@ -3,8 +3,8 @@ import { Icon } from '@wordpress/components';
 import { wordpress } from '@wordpress/icons';
 import { siteWordPressVersionQuery } from '../../app/queries';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import { canUpdateWordPressVersion } from '../../utils/site-features';
 import { getFormattedWordPressVersion } from '../../utils/wp-version';
-import { canUpdateWordPressVersion } from './utils';
 import type { Site } from '../../data/types';
 import type { Density } from '@automattic/components/src/summary-button/types';
 

--- a/client/dashboard/sites/settings-wordpress/utils.ts
+++ b/client/dashboard/sites/settings-wordpress/utils.ts
@@ -1,5 +1,0 @@
-import { Site } from '../../data/types';
-
-export function canUpdateWordPressVersion( site: Site ) {
-	return site.is_wpcom_staging_site;
-}

--- a/client/dashboard/utils/site-features.ts
+++ b/client/dashboard/utils/site-features.ts
@@ -1,0 +1,13 @@
+import type { Site } from '../data/types';
+
+export const canUpdatePHPVersion = ( site: Site ): boolean => site.is_wpcom_atomic;
+
+export const canUpdateDefensiveMode = ( site: Site ): boolean => site.is_wpcom_atomic;
+
+export const canAccessPhpMyAdmin = ( site: Site ): boolean => site.is_wpcom_atomic;
+
+export const canUpdateWordPressVersion = ( site: Site ): boolean => site.is_wpcom_staging_site;
+
+export const canSetStaticFile404Handling = ( site: Site ): boolean => site.is_wpcom_atomic;
+
+export const canGetPrimaryDataCenter = ( site: Site ): boolean => site.is_wpcom_atomic;

--- a/client/sites/settings/v2/router.tsx
+++ b/client/sites/settings/v2/router.tsx
@@ -18,11 +18,13 @@ import {
 	siteWordPressVersionQuery,
 } from 'calypso/dashboard/app/queries';
 import { queryClient } from 'calypso/dashboard/app/query-client';
-import { canUpdateDefensiveMode } from 'calypso/dashboard/sites/settings-defensive-mode';
-import { canUpdatePHPVersion } from 'calypso/dashboard/sites/settings-php/utils';
-import { canGetPrimaryDataCenter } from 'calypso/dashboard/sites/settings-primary-data-center';
-import { canSetStaticFile404Handling } from 'calypso/dashboard/sites/settings-static-file-404';
-import { canUpdateWordPressVersion } from 'calypso/dashboard/sites/settings-wordpress/utils';
+import {
+	canGetPrimaryDataCenter,
+	canSetStaticFile404Handling,
+	canUpdatePHPVersion,
+	canUpdateDefensiveMode,
+	canUpdateWordPressVersion,
+} from 'calypso/dashboard/utils/site-features';
 import Root from './root';
 
 const rootRoute = createRootRoute( { component: Root } );


### PR DESCRIPTION
## Proposed Changes

This presents an option for centralizing feature checks for sites.

## Why are these changes being made?

We currently check the object directly like so `site.is_wpcom_atomic`. 

Since we don't have an agreed-upon strategy, we're starting to see [local functions](https://github.com/Automattic/wp-calypso/blob/91c029eac7653d7e1b88ebaa69b47600bd0213de/client/dashboard/sites/settings-php/utils.tsx#L4) wrapping that call and being exported.

[Example](https://github.com/Automattic/wp-calypso/blob/91c029eac7653d7e1b88ebaa69b47600bd0213de/client/dashboard/app/router.tsx#L9-L13):

```js
import { canUpdateDefensiveMode } from '../sites/settings-defensive-mode';
import { canUpdatePHPVersion } from '../sites/settings-php/utils';
import { canGetPrimaryDataCenter } from '../sites/settings-primary-data-center';
import { canSetStaticFile404Handling } from '../sites/settings-static-file-404';
import { canUpdateWordPressVersion } from '../sites/settings-wordpress/utils';
```

## Testing Instructions

N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
