### PR TITLE
Accessibility: Add informative aria-label to the Select button component in choose your domain screen

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -474,6 +474,7 @@ class DomainRegistrationSuggestion extends Component {
 				isFeatured={ isFeatured }
 				showStrikedOutPrice={ showStrikedOutPrice }
 				hideMatchReasons={ hideMatchReasons }
+				translate={ this.props.translate }
 			>
 				{ badges }
 				{ this.renderDomain( !! badges ) }

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -20,6 +20,7 @@ class DomainSuggestion extends Component {
 		hidePrice: PropTypes.bool,
 		showChevron: PropTypes.bool,
 		isAdded: PropTypes.bool,
+		translate: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -79,6 +80,8 @@ class DomainSuggestion extends Component {
 			? children
 			: [];
 
+		const { translate } = this.props;
+
 		return (
 			<div className={ classes } data-e2e-domain={ this.props.domain }>
 				{ badges }
@@ -97,6 +100,11 @@ class DomainSuggestion extends Component {
 							} }
 							data-tracks-button-click-source={ this.props.tracksButtonClickSource }
 							{ ...this.props.buttonStyles }
+							aria-label={ translate( 'Select %(domainName)s', {
+								args: { domainName: this.props.domain },
+								context:
+									'Accessibility label for domain suggestion button, %(domainName)s is the domain name',
+							} ) }
 						>
 							{ this.props.buttonContent }
 						</Button>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13356

## Proposed Changes

Added accessibility label information to domain suggestion components with translation support.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When navigating through domains on the domain selection page, the select button doesn't announce which domain is being selected. This makes it very difficult to know which domain is selected.

![CleanShot 2025-05-29 at 11 29 33@2x](https://github.com/user-attachments/assets/5a699153-f279-413e-bdf4-f6ade78e32e4)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Props to @ivan-ottinger as I borrowed instructions from their PR #103742

- Check out the PR branch and build the app with yarn start (or use Calypso Live).
- Head over to the Domain Select step at http://calypso.localhost:3000/start/domain/domain-only.
- Enable VoiceOver.
- Try to search for the domain and then tab through the page. Focus on the domain suggestions and listen to the announcements.
- The announced message should be clear and inform the user which domain it is selected & related to.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
