### PR TITLE
Connect Refresh: fixMe the new header strings in Login

### DIFF
--- a/client/blocks/login/login-header.tsx
+++ b/client/blocks/login/login-header.tsx
@@ -1,4 +1,4 @@
-import { useTranslate, TranslateResult } from 'i18n-calypso';
+import { useTranslate, TranslateResult, fixMe } from 'i18n-calypso';
 import { capitalize } from 'lodash';
 import A4APlusWpComLogo from 'calypso/a8c-for-agencies/components/a4a-plus-wpcom-logo';
 import VisitSite from 'calypso/blocks/visit-site';
@@ -79,10 +79,14 @@ export function getHeaderText(
 	if ( isSocialFirst ) {
 		headerText =
 			oauth2Client && isStudioAppOAuth2Client( oauth2Client )
-				? translate( 'Log in to {{span}}%(client)s{{/span}} with WordPress.com', {
-						args: { client: oauth2Client.name },
-						components: { span: <span className="login-header-text__client-name" /> },
-				  } )
+				? ( fixMe( {
+						text: 'Log in to {{span}}%(client)s{{/span}} with WordPress.com',
+						newCopy: translate( 'Log in to {{span}}%(client)s{{/span}} with WordPress.com', {
+							args: { client: oauth2Client.name },
+							components: { span: <span className="login-header-text__client-name" /> },
+						} ),
+						oldCopy: translate( 'Log in to WordPress.com' ),
+				  } ) as TranslateResult )
 				: translate( 'Log in to WordPress.com' );
 	}
 

--- a/client/login/wp-login/components/heading-subtext.tsx
+++ b/client/login/wp-login/components/heading-subtext.tsx
@@ -1,5 +1,5 @@
 import { localizeUrl } from '@automattic/i18n-utils';
-import { translate } from 'i18n-calypso';
+import { fixMe, useTranslate } from 'i18n-calypso';
 
 interface Props {
 	isSocialFirst: boolean;
@@ -7,31 +7,57 @@ interface Props {
 }
 
 const HeadingSubText = ( { isSocialFirst, twoFactorAuthType }: Props ) => {
+	const translate = useTranslate();
+
 	if ( ! isSocialFirst || twoFactorAuthType ) {
 		return null;
 	}
 
-	const tos = translate(
-		'Just a little reminder that by continuing with any of the options below, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and {{privacyLink}}Privacy Policy{{/privacyLink}}.',
-		{
-			components: {
-				tosLink: (
-					<a
-						href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-						target="_blank"
-						rel="noopener noreferrer"
-					/>
-				),
-				privacyLink: (
-					<a
-						href={ localizeUrl( 'https://automattic.com/privacy/' ) }
-						target="_blank"
-						rel="noopener noreferrer"
-					/>
-				),
-			},
-		}
-	);
+	const tos = fixMe( {
+		text: 'Just a little reminder that by continuing with any of the options below, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+		newCopy: translate(
+			'Just a little reminder that by continuing with any of the options below, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+			{
+				components: {
+					tosLink: (
+						<a
+							href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+					privacyLink: (
+						<a
+							href={ localizeUrl( 'https://automattic.com/privacy/' ) }
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+				},
+			}
+		),
+		oldCopy: translate(
+			'By continuing you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+			{
+				components: {
+					tosLink: (
+						<a
+							href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+					privacyLink: (
+						<a
+							href={ localizeUrl( 'https://automattic.com/privacy/' ) }
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+				},
+			}
+		),
+	} );
 
 	/**
 	 * Return a span here because the Step.Heading renders subtext as a p tag.


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of 
- project https://linear.app/a8c/project/log-in-screen-unify-design-and-layout-16a857e58712/overview
- issue https://linear.app/a8c/issue/DOTCOM-13271/calypso-update-and-move-tos-under-the-header

## Proposed Changes

- We recently shipped a couple of PRs with untranslated text for the updated headings in Login
  - These affected the new subheading (TOS), and the heading used for oauth clients (albeit only enabled for Studio app)
- We now wrap these strings with `fixMe` method with fallback to the original TOS and the generic "Log in to WordPress.com" header text

## Media

| When translated | When not (el) |
|--------|--------|
| <img width="832" alt="Screenshot 2025-05-29 at 10 22 46 AM" src="https://github.com/user-attachments/assets/078cef03-e1ec-4618-a1f6-b3e8515f1751" /> | <img width="835" alt="Screenshot 2025-05-29 at 10 22 34 AM" src="https://github.com/user-attachments/assets/85bbac40-d303-486c-9e52-765856c82702" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fallback on missing translations

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [Studio Login](http://calypso.localhost:3000/log-in?client_id=95109&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dtoken%26client_id%3D95109%26redirect_uri%3Dwpcom-local-dev%253A%252F%252Fauth%26scope%3Dglobal%26client_source%26jetpack-code%26jetpack-user-id%3D0%26action%3Doauth2-login%26from-calypso%3D1)
* Switch locale and confirm the original translated strings render instead for header/subheader

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
