### PR TITLE
Improve voiceover navigation on the plan comparison step

### DIFF
--- a/packages/components/src/logos/woo-logo/index.tsx
+++ b/packages/components/src/logos/woo-logo/index.tsx
@@ -11,6 +11,7 @@ export const WooLogo = ( props: React.SVGProps< SVGSVGElement > ) => (
 		viewBox="0 0 183.6 47.5"
 		{ ...props }
 	>
+		<title>WooCommerce logo</title>
 		<style type="text/css">
 			{ `
 				.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#873EFF;}

--- a/packages/components/src/logos/woo-logo/index.tsx
+++ b/packages/components/src/logos/woo-logo/index.tsx
@@ -11,7 +11,7 @@ export const WooLogo = ( props: React.SVGProps< SVGSVGElement > ) => (
 		viewBox="0 0 183.6 47.5"
 		{ ...props }
 	>
-		<title>WooCommerce logo</title>
+		<title>WooCommerce</title>
 		<style type="text/css">
 			{ `
 				.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#873EFF;}

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -242,7 +242,27 @@ const Cell = styled.div< { textAlign?: 'start' | 'center' | 'end' } >`
 	` ) }
 `;
 
-const RowTitleCell = styled.div< {
+const RowTitleCell = styled.td< {
+	isPlaceholderHeaderCell?: boolean;
+	isFeatureGroupRowTitleCell?: boolean;
+} >`
+	display: none;
+	font-size: 14px;
+	padding-right: 10px;
+	${ plansGridMediumLarge( css`
+		display: block;
+		flex: 1;
+		min-width: 290px;
+	` ) }
+	max-width: ${ ( props ) => {
+		if ( props.isPlaceholderHeaderCell || props.isFeatureGroupRowTitleCell ) {
+			return `${ featureGroupRowTitleCellMaxWidth }px`;
+		}
+		return `${ rowCellMaxWidth }px`;
+	} };
+`;
+
+const RowHeaderCell = styled.th< {
 	isPlaceholderHeaderCell?: boolean;
 	isFeatureGroupRowTitleCell?: boolean;
 } >`
@@ -501,7 +521,6 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 		return (
 			<PlanRow as="tr" isHiddenInMobile={ isHiddenInMobile } ref={ ref }>
 				<RowTitleCell
-					as="td"
 					key="feature-name"
 					className="plan-comparison-grid__header-cell is-placeholder-header-cell"
 					isPlaceholderHeaderCell
@@ -735,6 +754,8 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	const featureSlug = feature?.getSlug() ?? '';
 	const footnote = planFeatureFootnotes?.footnotesByFeature?.[ featureSlug ];
 	const tooltipId = `${ feature?.getSlug() }-comparison-grid`;
+	const title = feature?.getTitle?.();
+	const headerAriaLabel: string = typeof title === 'string' ? title : '';
 
 	const { enableFeatureTooltips } = usePlansGridContext();
 
@@ -745,13 +766,12 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 			className={ rowClasses }
 			isHighlighted={ isHighlighted }
 		>
-			<RowTitleCell
-				as="th"
+			<RowHeaderCell
 				key="feature-name"
 				className="is-feature-group-row-title-cell"
 				isFeatureGroupRowTitleCell
-				{ ...{ scope: 'row' } }
-				aria-label={ ( feature?.getTitle?.() as string ) || '' }
+				scope="row"
+				aria-label={ headerAriaLabel }
 			>
 				{ isStorageFeature ? (
 					<Plans2023Tooltip
@@ -801,7 +821,7 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 						) }
 					</>
 				) }
-			</RowTitleCell>
+			</RowHeaderCell>
 			{ visibleGridPlans.map( ( { planSlug } ) => (
 				<ComparisonGridFeatureGroupRowCell
 					key={ planSlug }
@@ -915,7 +935,7 @@ const FeatureGroup = ( {
 				className="plan-comparison-grid__feature-group-title-row"
 				onClick={ handleFeatureGroupToggle }
 			>
-				<Title isHiddenInMobile={ isHiddenInMobile }>
+				<Title as="td" isHiddenInMobile={ isHiddenInMobile }>
 					<Gridicon icon="chevron-up" size={ 12 } color="#1E1E1E" />
 					<span>{ featureGroup.getTitle() }</span>
 				</Title>
@@ -1141,30 +1161,34 @@ const ComparisonGrid = ( {
 					plansLength={ visiblePlans.length }
 				/>
 			) ) }
-			<ComparisonGridHeader
-				displayedGridPlans={ gridPlans }
-				visibleGridPlans={ visibleGridPlans }
-				isInSignup={ isInSignup }
-				isFooter
-				onPlanChange={ onPlanChange }
-				currentSitePlanSlug={ currentSitePlanSlug }
-				planActionOverrides={ planActionOverrides }
-				selectedPlan={ selectedPlan }
-				showRefundPeriod={ showRefundPeriod }
-				isStuck={ false }
-				isHiddenInMobile
-				ref={ bottomHeaderRef }
-				planTypeSelectorProps={ planTypeSelectorProps }
-			/>
+			<tbody>
+				<ComparisonGridHeader
+					displayedGridPlans={ gridPlans }
+					visibleGridPlans={ visibleGridPlans }
+					isInSignup={ isInSignup }
+					isFooter
+					onPlanChange={ onPlanChange }
+					currentSitePlanSlug={ currentSitePlanSlug }
+					planActionOverrides={ planActionOverrides }
+					selectedPlan={ selectedPlan }
+					showRefundPeriod={ showRefundPeriod }
+					isStuck={ false }
+					isHiddenInMobile
+					ref={ bottomHeaderRef }
+					planTypeSelectorProps={ planTypeSelectorProps }
+				/>
+			</tbody>
 
 			<tfoot className="plan-comparison-grid__footer">
 				{ planFeatureFootnotes?.footnoteList && (
-					<FeatureFootnotes>
-						<ol>
-							{ planFeatureFootnotes?.footnoteList?.map( ( footnote, index ) => {
-								return <li key={ `${ footnote }-${ index }` }>{ footnote }</li>;
-							} ) }
-						</ol>
+					<FeatureFootnotes as="tr">
+						<td>
+							<ol>
+								{ planFeatureFootnotes?.footnoteList?.map( ( footnote, index ) => {
+									return <li key={ `${ footnote }-${ index }` }>{ footnote }</li>;
+								} ) }
+							</ol>
+						</td>
 					</FeatureFootnotes>
 				) }
 			</tfoot>

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -97,11 +97,10 @@ const Title = styled.div< { isHiddenInMobile?: boolean } >`
 	` ) }
 `;
 
-const Grid = styled.div< { visiblePlans: number } >`
+const StickyGrid = styled( StickyContainer )< { visiblePlans: number } >`
 	display: grid;
 	margin: 0 auto;
 	background: #fff;
-	border: solid 1px #e0e0e0;
 	${ ( props ) =>
 		props.visiblePlans &&
 		css`
@@ -111,11 +110,21 @@ const Grid = styled.div< { visiblePlans: number } >`
 	${ plansGridMediumLarge( css`
 		border-radius: 5px;
 	` ) }
+`;
 
-	> .is-sticky-header-row {
-		border-bottom: solid 1px #e0e0e0;
-		background: #fff;
-	}
+const Grid = styled.div< { visiblePlans: number; as?: string } >`
+	display: ${ ( props ) => ( props.as === 'tbody' ? 'table-row-group' : 'grid' ) };
+	margin: 0 auto;
+	background: #fff;
+	${ ( props ) =>
+		props.visiblePlans &&
+		css`
+			max-width: ${ rowCellMaxWidth * props.visiblePlans + featureGroupRowTitleCellMaxWidth }px;
+		` }
+
+	${ plansGridMediumLarge( css`
+		border-radius: 5px;
+	` ) }
 `;
 
 const Row = styled.div< {
@@ -389,7 +398,13 @@ const ComparisonGridHeaderCell = ( {
 	const showPlanSelect = ! allVisible && ! gridPlan.current;
 
 	return (
-		<Cell className={ headerClasses } textAlign="start">
+		<Cell
+			as="th"
+			className={ headerClasses }
+			textAlign="start"
+			{ ...{ scope: 'col' } }
+			aria-label={ gridPlan.planTitle as string }
+		>
 			<PopularBadge
 				isInSignup={ isInSignup }
 				planSlug={ planSlug }
@@ -484,8 +499,9 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 		const { coupon } = usePlansGridContext();
 
 		return (
-			<PlanRow isHiddenInMobile={ isHiddenInMobile } ref={ ref }>
+			<PlanRow as="tr" isHiddenInMobile={ isHiddenInMobile } ref={ ref }>
 				<RowTitleCell
+					as="td"
 					key="feature-name"
 					className="plan-comparison-grid__header-cell is-placeholder-header-cell"
 					isPlaceholderHeaderCell
@@ -596,7 +612,7 @@ const ComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 	);
 
 	return (
-		<Cell className={ cellClasses } textAlign="center">
+		<Cell as="td" className={ cellClasses } textAlign="center">
 			{ isStorageFeature ? (
 				<>
 					<span className="plan-comparison-grid__plan-title">{ translate( 'Storage' ) }</span>
@@ -664,9 +680,19 @@ const ComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 								</span>
 							) }
 							{ hasFeature && ! featureLabel && (
-								<Gridicon icon="checkmark" color="var(--studio-wordpress-blue-50)" />
+								<Gridicon
+									icon="checkmark"
+									color="var(--studio-wordpress-blue-50)"
+									aria-label={ translate( 'Feature available' ) }
+								/>
 							) }
-							{ ! hasFeature && ! featureLabel && <Gridicon icon="minus-small" color="#C3C4C7" /> }
+							{ ! hasFeature && ! featureLabel && (
+								<Gridicon
+									icon="minus-small"
+									color="#C3C4C7"
+									aria-label={ translate( 'Feature not available' ) }
+								/>
+							) }
 						</>
 					) }
 				</>
@@ -714,14 +740,18 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 
 	return (
 		<Row
+			as="tr"
 			isHiddenInMobile={ isHiddenInMobile }
 			className={ rowClasses }
 			isHighlighted={ isHighlighted }
 		>
 			<RowTitleCell
+				as="th"
 				key="feature-name"
 				className="is-feature-group-row-title-cell"
 				isFeatureGroupRowTitleCell
+				{ ...{ scope: 'row' } }
+				aria-label={ ( feature?.getTitle?.() as string ) || '' }
 			>
 				{ isStorageFeature ? (
 					<Plans2023Tooltip
@@ -802,6 +832,7 @@ const FeatureGroup = ( {
 	featureGroupMap,
 	visibleGridPlans,
 	planFeatureFootnotes,
+	plansLength,
 }: {
 	featureGroup: FeatureGroup;
 	selectedFeature?: string;
@@ -816,6 +847,7 @@ const FeatureGroup = ( {
 		footnoteList: string[];
 		footnotesByFeature: Record< string, number >;
 	};
+	plansLength: number;
 } ) => {
 	const { allFeaturesList } = usePlansGridContext();
 	const [ firstSetOfFeatures ] = Object.keys( featureGroupMap );
@@ -872,8 +904,14 @@ const FeatureGroup = ( {
 	}
 
 	return (
-		<div key={ featureGroup.slug } className="plan-comparison-grid__feature-group">
+		<Grid
+			as="tbody"
+			visiblePlans={ plansLength }
+			key={ featureGroup.slug }
+			className="plan-comparison-grid__feature-group"
+		>
 			<TitleRow
+				as="tr"
 				className="plan-comparison-grid__feature-group-title-row"
 				onClick={ handleFeatureGroupToggle }
 			>
@@ -915,7 +953,7 @@ const FeatureGroup = ( {
 					onStorageAddOnClick={ onStorageAddOnClick }
 				/>
 			) : null }
-		</div>
+		</Grid>
 	);
 };
 
@@ -1063,62 +1101,63 @@ const ComparisonGrid = ( {
 	} );
 
 	return (
-		<div className={ classes }>
-			<Grid visiblePlans={ visiblePlans.length }>
-				<StickyContainer
-					disabled={ isBottomHeaderInView }
-					stickyClass="is-sticky-header-row"
-					stickyOffset={ stickyRowOffset }
-					zIndex={ 1 }
-				>
-					{ ( isStuck: boolean ) => (
-						<ComparisonGridHeader
-							displayedGridPlans={ gridPlans }
-							visibleGridPlans={ visibleGridPlans }
-							isInSignup={ isInSignup }
-							onPlanChange={ onPlanChange }
-							currentSitePlanSlug={ currentSitePlanSlug }
-							planActionOverrides={ planActionOverrides }
-							selectedPlan={ selectedPlan }
-							showRefundPeriod={ showRefundPeriod }
-							isStuck={ isStuck }
-							planTypeSelectorProps={ planTypeSelectorProps }
-						/>
-					) }
-				</StickyContainer>
-				{ Object.values( featureGroupMap ).map( ( featureGroup: FeatureGroup ) => (
-					<FeatureGroup
-						key={ featureGroup.slug }
-						featureGroup={ featureGroup }
+		<table className={ classes }>
+			<StickyGrid
+				visiblePlans={ visiblePlans.length }
+				element="thead"
+				disabled={ isBottomHeaderInView }
+				stickyClass="is-sticky-header-row"
+				stickyOffset={ stickyRowOffset }
+				zIndex={ 1 }
+			>
+				{ ( isStuck: boolean ) => (
+					<ComparisonGridHeader
+						displayedGridPlans={ gridPlans }
 						visibleGridPlans={ visibleGridPlans }
-						featureGroupMap={ featureGroupMap }
-						selectedFeature={ selectedFeature }
-						intervalType={ intervalType }
-						activeTooltipId={ activeTooltipId }
-						setActiveTooltipId={ setActiveTooltipId }
-						showUpgradeableStorage={ showUpgradeableStorage }
-						onStorageAddOnClick={ onStorageAddOnClick }
-						planFeatureFootnotes={ planFeatureFootnotes }
+						isInSignup={ isInSignup }
+						onPlanChange={ onPlanChange }
+						currentSitePlanSlug={ currentSitePlanSlug }
+						planActionOverrides={ planActionOverrides }
+						selectedPlan={ selectedPlan }
+						showRefundPeriod={ showRefundPeriod }
+						isStuck={ isStuck }
+						planTypeSelectorProps={ planTypeSelectorProps }
 					/>
-				) ) }
-				<ComparisonGridHeader
-					displayedGridPlans={ gridPlans }
+				) }
+			</StickyGrid>
+			{ Object.values( featureGroupMap ).map( ( featureGroup: FeatureGroup ) => (
+				<FeatureGroup
+					key={ featureGroup.slug }
+					featureGroup={ featureGroup }
 					visibleGridPlans={ visibleGridPlans }
-					isInSignup={ isInSignup }
-					isFooter
-					onPlanChange={ onPlanChange }
-					currentSitePlanSlug={ currentSitePlanSlug }
-					planActionOverrides={ planActionOverrides }
-					selectedPlan={ selectedPlan }
-					showRefundPeriod={ showRefundPeriod }
-					isStuck={ false }
-					isHiddenInMobile
-					ref={ bottomHeaderRef }
-					planTypeSelectorProps={ planTypeSelectorProps }
+					featureGroupMap={ featureGroupMap }
+					selectedFeature={ selectedFeature }
+					intervalType={ intervalType }
+					activeTooltipId={ activeTooltipId }
+					setActiveTooltipId={ setActiveTooltipId }
+					showUpgradeableStorage={ showUpgradeableStorage }
+					onStorageAddOnClick={ onStorageAddOnClick }
+					planFeatureFootnotes={ planFeatureFootnotes }
+					plansLength={ visiblePlans.length }
 				/>
-			</Grid>
+			) ) }
+			<ComparisonGridHeader
+				displayedGridPlans={ gridPlans }
+				visibleGridPlans={ visibleGridPlans }
+				isInSignup={ isInSignup }
+				isFooter
+				onPlanChange={ onPlanChange }
+				currentSitePlanSlug={ currentSitePlanSlug }
+				planActionOverrides={ planActionOverrides }
+				selectedPlan={ selectedPlan }
+				showRefundPeriod={ showRefundPeriod }
+				isStuck={ false }
+				isHiddenInMobile
+				ref={ bottomHeaderRef }
+				planTypeSelectorProps={ planTypeSelectorProps }
+			/>
 
-			<div className="plan-comparison-grid__footer">
+			<tfoot className="plan-comparison-grid__footer">
 				{ planFeatureFootnotes?.footnoteList && (
 					<FeatureFootnotes>
 						<ol>
@@ -1128,8 +1167,8 @@ const ComparisonGrid = ( {
 						</ol>
 					</FeatureFootnotes>
 				) }
-			</div>
-		</div>
+			</tfoot>
+		</table>
 	);
 };
 

--- a/packages/plans-grid-next/src/components/comparison-grid/style.scss
+++ b/packages/plans-grid-next/src/components/comparison-grid/style.scss
@@ -1,12 +1,20 @@
 @import "../../shared";
 
 .plans-grid-next-comparison-grid {
-	// fixes mobile view cards in features grid not containing content properly
 	min-width: fit-content;
+	border: solid 1px #e0e0e0;
+	background: hsl(0, 0%, 100%);
+	border-radius: 4px;
+	margin: 0 auto;
+
+	> .is-sticky-header-row {
+		border-bottom: solid 1px #e0e0e0;
+		background: #fff;
+	}
 
 	&.has-highlighted-plan {
 		@include plans-grid-medium-large {
-			padding-top: 43px; // enough to cover `plans-grid__popular-badge` repositioning (top: -43px)
+			margin-top: 43px; // enough to cover `plans-grid__popular-badge` repositioning (top: -43px)
 		}
 	}
 

--- a/packages/plans-grid-next/src/components/features-grid/plan-headers.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/plan-headers.tsx
@@ -24,9 +24,9 @@ const PlanHeaders = ( { options, renderedGridPlans }: PlanHeadersProps ) => {
 				scope={ options?.scope }
 				isHeader={ options?.isHeader }
 			>
-				<header aria-label={ planTitle as string } className={ headerClasses }>
+				<div role="columnheader" className={ headerClasses }>
 					<h4 className="plan-features-2023-grid__header-title">{ planTitle }</h4>
-				</header>
+				</div>
 			</PlanDivOrTdContainer>
 		);
 	} );

--- a/packages/plans-grid-next/src/components/features-grid/plan-headers.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/plan-headers.tsx
@@ -7,6 +7,8 @@ type PlanHeadersProps = {
 	renderedGridPlans: GridPlan[];
 	options?: {
 		isTableCell?: boolean;
+		isHeader?: boolean;
+		scope?: string;
 	};
 };
 
@@ -19,8 +21,10 @@ const PlanHeaders = ( { options, renderedGridPlans }: PlanHeadersProps ) => {
 				key={ planSlug }
 				className="plan-features-2023-grid__table-item"
 				isTableCell={ options?.isTableCell }
+				scope={ options?.scope }
+				isHeader={ options?.isHeader }
 			>
-				<header className={ headerClasses }>
+				<header aria-label={ planTitle as string } className={ headerClasses }>
 					<h4 className="plan-features-2023-grid__header-title">{ planTitle }</h4>
 				</header>
 			</PlanDivOrTdContainer>

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -252,7 +252,7 @@
 	@include plans-grid-medium-large {
 		// The .plan-features-2023-grid__table-item is used to render the plan spotlight which doesn't
 		// use a table layout, but borders are only appropriate in table layout.
-		&:is(td) {
+		&:is(td, th) {
 			border-left: solid 1px #e0e0e0;
 		}
 	}

--- a/packages/plans-grid-next/src/components/features-grid/table.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/table.tsx
@@ -92,7 +92,7 @@ const Table = ( {
 				{ translate( 'Available plans to choose from' ) }
 			</caption>
 			<thead>
-				<tr aria-hidden="true">
+				<tr>
 					<PlanLogos
 						renderedGridPlans={ gridPlansWithoutSpotlight }
 						isInSignup={ isInSignup }

--- a/packages/plans-grid-next/src/components/features-grid/table.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/table.tsx
@@ -91,8 +91,8 @@ const Table = ( {
 			<caption className="plan-features-2023-grid__screen-reader-text screen-reader-text">
 				{ translate( 'Available plans to choose from' ) }
 			</caption>
-			<tbody>
-				<tr>
+			<thead>
+				<tr aria-hidden="true">
 					<PlanLogos
 						renderedGridPlans={ gridPlansWithoutSpotlight }
 						isInSignup={ isInSignup }
@@ -102,9 +102,11 @@ const Table = ( {
 				<tr>
 					<PlanHeaders
 						renderedGridPlans={ gridPlansWithoutSpotlight }
-						options={ { isTableCell: true } }
+						options={ { isHeader: true, scope: 'col' } }
 					/>
 				</tr>
+			</thead>
+			<tbody>
 				<tr>
 					<PlanTagline
 						renderedGridPlans={ gridPlansWithoutSpotlight }

--- a/packages/plans-grid-next/src/components/plan-div-td-container.tsx
+++ b/packages/plans-grid-next/src/components/plan-div-td-container.tsx
@@ -2,9 +2,12 @@ const PlanDivOrTdContainer = (
 	props: (
 		| React.HTMLAttributes< HTMLDivElement >
 		| React.HTMLAttributes< HTMLTableCellElement >
-	) & { isTableCell?: boolean; scope?: string }
+	) & { isTableCell?: boolean; scope?: string; isHeader?: boolean }
 ): JSX.Element => {
-	const { children, isTableCell, ...otherProps } = props;
+	const { children, isTableCell, isHeader, ...otherProps } = props;
+	if ( isHeader ) {
+		return <th { ...otherProps }>{ children }</th>;
+	}
 	return isTableCell ? (
 		<td { ...otherProps }>{ children }</td>
 	) : (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13283

## Proposed Changes

* Changed to the correct table elements
* Adjusted `aria-label` and `aria-hidden` as necessary
* Some adjustments to preserve `StickyContainer` logic and behavior

Note: This PR only focus on the table elements and scope, there might still be more a11y improvements necessary on this workflow.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Users should be able to navigate plans comparison page using VoiceOver

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn start`
* Navigation to the plans page on `http://calypso.localhost:3000/setup/onboarding/plans`
* Navigate using VoiceOver
* Confirm that it is possible to navigate table rows and columns, and VoiceOver reads the expected values

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
