### PR TITLE
Refactor Jest mock calls to jest.mocked

### DIFF
--- a/client/data/segmentaton-survey/mutations/test/use-link-answers-mutation.test.tsx
+++ b/client/data/segmentaton-survey/mutations/test/use-link-answers-mutation.test.tsx
@@ -32,7 +32,7 @@ describe( 'useLinkAnswersMutation', () => {
 	let wrapper: React.FC< React.PropsWithChildren< any > >;
 
 	beforeEach( () => {
-		( wpcom.req.post as jest.MockedFunction< typeof wpcom.req.post > ).mockReset();
+		jest.mocked( wpcom.req.post ).mockReset();
 
 		queryClient = new QueryClient( {
 			defaultOptions: {

--- a/client/data/segmentaton-survey/mutations/test/use-save-answers-mutation.test.tsx
+++ b/client/data/segmentaton-survey/mutations/test/use-save-answers-mutation.test.tsx
@@ -31,10 +31,10 @@ jest.mock( 'calypso/lib/wp', () => ( {
 
 describe( 'useSaveAnswersMutation', () => {
 	let queryClient: QueryClient;
-	let wrapper: React.FC< React.PropsWithChildren< any > >;
+	let wrapper: React.FC< React.PropsWithChildren >;
 
 	beforeEach( () => {
-		( wpcom.req.post as jest.MockedFunction< typeof wpcom.req.post > ).mockReset();
+		jest.mocked( wpcom.req.post ).mockReset();
 
 		queryClient = new QueryClient( {
 			defaultOptions: {
@@ -44,7 +44,7 @@ describe( 'useSaveAnswersMutation', () => {
 			},
 		} );
 
-		wrapper = ( { children }: React.PropsWithChildren< any > ) => (
+		wrapper = ( { children } ) => (
 			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
 		);
 	} );

--- a/client/data/segmentaton-survey/queries/test/use-survey-answers-query.test.tsx
+++ b/client/data/segmentaton-survey/queries/test/use-survey-answers-query.test.tsx
@@ -29,7 +29,7 @@ describe( 'useSurveyAnswersQuery', () => {
 	let wrapper: React.FC< React.PropsWithChildren< any > >;
 
 	beforeEach( () => {
-		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockReset();
+		jest.mocked( wpcom.req.get ).mockReset();
 
 		queryClient = new QueryClient( {
 			defaultOptions: {
@@ -49,9 +49,7 @@ describe( 'useSurveyAnswersQuery', () => {
 	} );
 
 	it( 'should call wpcom.req.get with the right parameters', async () => {
-		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockResolvedValue(
-			mockResponse
-		);
+		jest.mocked( wpcom.req.get ).mockResolvedValue( mockResponse );
 
 		const { result } = renderHook( () => useSurveyAnswersQuery( { surveyKey: 'test_key' } ), {
 			wrapper,
@@ -66,9 +64,7 @@ describe( 'useSurveyAnswersQuery', () => {
 	} );
 
 	it( 'should return expected data when successful', async () => {
-		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockResolvedValue(
-			mockResponse
-		);
+		jest.mocked( wpcom.req.get ).mockResolvedValue( mockResponse );
 
 		const { result } = renderHook( () => useSurveyAnswersQuery( { surveyKey: 'test_key' } ), {
 			wrapper,

--- a/client/data/segmentaton-survey/queries/test/use-survey-structure-query.test.tsx
+++ b/client/data/segmentaton-survey/queries/test/use-survey-structure-query.test.tsx
@@ -53,7 +53,7 @@ describe( 'useSurveyStructureQuery', () => {
 	let wrapper: React.FC< React.PropsWithChildren< any > >;
 
 	beforeEach( () => {
-		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockReset();
+		jest.mocked( wpcom.req.get ).mockReset();
 
 		queryClient = new QueryClient( {
 			defaultOptions: {
@@ -73,9 +73,7 @@ describe( 'useSurveyStructureQuery', () => {
 	} );
 
 	it( 'should call wpcom.req.get with the right parameters', async () => {
-		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockResolvedValue(
-			mockResponse
-		);
+		jest.mocked( wpcom.req.get ).mockResolvedValue( mockResponse );
 
 		const { result } = renderHook( () => useSurveyStructureQuery( { surveyKey: 'test-key' } ), {
 			wrapper,
@@ -90,9 +88,7 @@ describe( 'useSurveyStructureQuery', () => {
 	} );
 
 	it( 'should return expected data when successful', async () => {
-		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockResolvedValue(
-			mockResponse
-		);
+		jest.mocked( wpcom.req.get ).mockResolvedValue( mockResponse );
 
 		const { result } = renderHook( () => useSurveyStructureQuery( { surveyKey: 'test-key' } ), {
 			wrapper,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
@@ -15,10 +15,6 @@ import SitesOverview from '../index';
 
 jest.mock( '@automattic/viewport' );
 
-const mockedIsWithinBreakpoint = isWithinBreakpoint as jest.MockedFunction<
-	typeof isWithinBreakpoint
->;
-
 window.IntersectionObserver = jest.fn( () => ( {
 	observe: jest.fn(),
 	disconnect: jest.fn(),
@@ -193,7 +189,7 @@ describe( '<SitesOverview>', () => {
 		setData();
 
 		//set screen to widescreen for this test
-		mockedIsWithinBreakpoint.mockReturnValue( true );
+		jest.mocked( isWithinBreakpoint ).mockReturnValue( true );
 
 		const { queryByText } = render( <Wrapper context={ context } /> );
 
@@ -203,6 +199,6 @@ describe( '<SitesOverview>', () => {
 		expect( issueLicenseButton ).toBeInTheDocument();
 
 		// set screen back to mobile for rest of tests
-		mockedIsWithinBreakpoint.mockReturnValue( false );
+		jest.mocked( isWithinBreakpoint ).mockReturnValue( false );
 	} );
 } );

--- a/client/lib/explat/internals/test/log-error.ts
+++ b/client/lib/explat/internals/test/log-error.ts
@@ -11,7 +11,6 @@ jest.mock( 'calypso/server/lib/logger', () => {
 		getLogger: () => ( { error: logger } ),
 	};
 } );
-const mockedLogger = Logger.getLogger().error as jest.MockedFunction< () => unknown >;
 
 function setSsrContext() {
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -41,7 +40,7 @@ describe( 'logError', () => {
 	it( 'should log to the server in SSR', () => {
 		setSsrContext();
 		logError( { message: 'asdf', foo: 'bar' } );
-		expect( mockedLogger.mock.calls ).toMatchInlineSnapshot( `
+		expect( jest.mocked( Logger.getLogger().error ).mock.calls ).toMatchInlineSnapshot( `
 		Array [
 		  Array [
 		    Object {
@@ -59,7 +58,7 @@ describe( 'logError', () => {
 	} );
 	it( 'should log to the server in the browser', () => {
 		logError( { message: 'asdf', foo: 'bar' } );
-		expect( wpcom.req.post.mock.calls ).toMatchInlineSnapshot( `
+		expect( jest.mocked( wpcom.req.post ).mock.calls ).toMatchInlineSnapshot( `
 		Array [
 		  Array [
 		    Object {

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -66,12 +66,8 @@ function mockWindowLocation(): void {
 
 describe( 'getThankYouPageUrl', () => {
 	beforeEach( () => {
-		( isJetpackCloud as jest.MockedFunction< typeof isJetpackCloud > ).mockImplementation(
-			() => false
-		);
-		(
-			redirectCheckoutToWpAdmin as jest.MockedFunction< typeof redirectCheckoutToWpAdmin >
-		 ).mockImplementation( () => false );
+		jest.mocked( isJetpackCloud ).mockReturnValue( false );
+		jest.mocked( redirectCheckoutToWpAdmin ).mockReturnValue( false );
 	} );
 
 	it( 'redirects to the root page when no site is set', () => {
@@ -204,9 +200,7 @@ describe( 'getThankYouPageUrl', () => {
 	} );
 
 	it( 'redirects to the Jetpack Redirect API if checkout is on Jetpack Cloud and there is a non-atomic jetpack product', () => {
-		( isJetpackCloud as jest.MockedFunction< typeof isJetpackCloud > ).mockImplementation(
-			() => true
-		);
+		jest.mocked( isJetpackCloud ).mockReturnValue( true );
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
@@ -220,9 +214,7 @@ describe( 'getThankYouPageUrl', () => {
 	} );
 
 	it( 'redirects to the Jetpack Redirect API if checkout is on Jetpack Cloud and there is a non-atomic jetpack product in the cart', () => {
-		( isJetpackCloud as jest.MockedFunction< typeof isJetpackCloud > ).mockImplementation(
-			() => true
-		);
+		jest.mocked( isJetpackCloud ).mockReturnValue( true );
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
@@ -244,9 +236,7 @@ describe( 'getThankYouPageUrl', () => {
 	} );
 
 	it( 'redirects to the Jetpack Redirect API if checkout is on Jetpack Cloud and there is a non-atomic Jetpack Security plan', () => {
-		( isJetpackCloud as jest.MockedFunction< typeof isJetpackCloud > ).mockImplementation(
-			() => true
-		);
+		jest.mocked( isJetpackCloud ).mockReturnValue( true );
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
@@ -260,9 +250,7 @@ describe( 'getThankYouPageUrl', () => {
 	} );
 
 	it( 'redirects to the Jetpack Redirect API if checkout is on Jetpack Cloud and there is a non-atomic Jetpack Security plan is in the cart', () => {
-		( isJetpackCloud as jest.MockedFunction< typeof isJetpackCloud > ).mockImplementation(
-			() => true
-		);
+		jest.mocked( isJetpackCloud ).mockReturnValue( true );
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
@@ -284,9 +272,7 @@ describe( 'getThankYouPageUrl', () => {
 	} );
 
 	it( 'redirects to the Jetpack Redirect API if checkout is on Jetpack Cloud and there is a non-atomic Jetpack Complete plan is in the cart', () => {
-		( isJetpackCloud as jest.MockedFunction< typeof isJetpackCloud > ).mockImplementation(
-			() => true
-		);
+		jest.mocked( isJetpackCloud ).mockReturnValue( true );
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
@@ -308,12 +294,8 @@ describe( 'getThankYouPageUrl', () => {
 	} );
 
 	it( 'redirects to the sites wp-admin if checkout is on Jetpack Cloud and if redirectCheckoutToWpAdmin() flag is true and there is a non-atomic jetpack product and adminPageRedirect is omitted', () => {
-		( isJetpackCloud as jest.MockedFunction< typeof isJetpackCloud > ).mockImplementation(
-			() => true
-		);
-		(
-			redirectCheckoutToWpAdmin as jest.MockedFunction< typeof redirectCheckoutToWpAdmin >
-		 ).mockImplementation( () => true );
+		jest.mocked( isJetpackCloud ).mockReturnValue( true );
+		jest.mocked( redirectCheckoutToWpAdmin ).mockReturnValue( true );
 		const adminUrl = 'https://my.site/wp-admin/';
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
@@ -334,12 +316,8 @@ describe( 'getThankYouPageUrl', () => {
 	} );
 
 	it( 'redirects to the sites wp-admin with adminPageRedirect if checkout is on Jetpack Cloud and if redirectCheckoutToWpAdmin() flag is true and there is a non-atomic jetpack product and adminPageRedirect is supplied', () => {
-		( isJetpackCloud as jest.MockedFunction< typeof isJetpackCloud > ).mockImplementation(
-			() => true
-		);
-		(
-			redirectCheckoutToWpAdmin as jest.MockedFunction< typeof redirectCheckoutToWpAdmin >
-		 ).mockImplementation( () => true );
+		jest.mocked( isJetpackCloud ).mockReturnValue( true );
+		jest.mocked( redirectCheckoutToWpAdmin ).mockReturnValue( true );
 		const adminUrl = 'https://my.site/wp-admin/';
 		const adminPageRedirect = 'admin.php?page=jetpack-backup';
 		const url = getThankYouPageUrl( {
@@ -362,12 +340,8 @@ describe( 'getThankYouPageUrl', () => {
 	} );
 
 	it( 'redirects to the sites wp-admin if checkout is on Jetpack Cloud and if redirectCheckoutToWpAdmin() flag is true and there is a non-atomic jetpack product and redirectTo is defined', () => {
-		( isJetpackCloud as jest.MockedFunction< typeof isJetpackCloud > ).mockImplementation(
-			() => true
-		);
-		(
-			redirectCheckoutToWpAdmin as jest.MockedFunction< typeof redirectCheckoutToWpAdmin >
-		 ).mockImplementation( () => true );
+		jest.mocked( isJetpackCloud ).mockReturnValue( true );
+		jest.mocked( redirectCheckoutToWpAdmin ).mockReturnValue( true );
 		const adminUrl = 'https://my.site/wp-admin/';
 		const url = getThankYouPageUrl( {
 			...defaultArgs,

--- a/client/my-sites/checkout/src/test/pending-page.ts
+++ b/client/my-sites/checkout/src/test/pending-page.ts
@@ -135,7 +135,7 @@ describe( 'addUrlToPendingPageRedirect', () => {
 describe( 'redirectThroughPending', () => {
 	it( 'navigates to a relative URL when source is relative', () => {
 		const redirectSpy = jest.fn();
-		( page as jest.MockedFunction< typeof page > ).mockImplementation( redirectSpy );
+		jest.mocked( page ).mockImplementation( redirectSpy );
 		const finalUrl = '/foo/bar/baz';
 		const siteSlug = 'example2.com';
 		const orderId = '12345';

--- a/client/my-sites/patterns/hooks/test/use-pattern-categories.tsx
+++ b/client/my-sites/patterns/hooks/test/use-pattern-categories.tsx
@@ -15,7 +15,7 @@ describe( 'usePatternCategories', () => {
 	let wrapper: React.FC< React.PropsWithChildren< any > >;
 
 	beforeEach( () => {
-		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockReset();
+		jest.mocked( wpcom.req.get ).mockReset();
 
 		const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
 
@@ -29,7 +29,7 @@ describe( 'usePatternCategories', () => {
 	} );
 
 	test( 'calls the API endpoint with the right parameters', async () => {
-		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockResolvedValue( [] );
+		jest.mocked( wpcom.req.get ).mockResolvedValue( [] );
 
 		const { result } = renderHook( () => usePatternCategories( 'fr' ), { wrapper } );
 
@@ -48,9 +48,7 @@ describe( 'usePatternCategories', () => {
 			},
 		];
 
-		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockResolvedValue(
-			categories
-		);
+		jest.mocked( wpcom.req.get ).mockResolvedValue( categories );
 
 		const { result } = renderHook( () => usePatternCategories( 'fr' ), { wrapper } );
 

--- a/client/my-sites/patterns/hooks/test/use-patterns.tsx
+++ b/client/my-sites/patterns/hooks/test/use-patterns.tsx
@@ -10,14 +10,14 @@ import { usePatterns } from '../use-patterns';
 jest.mock( 'calypso/lib/wp', () => ( { req: { get: jest.fn() } } ) );
 
 describe( 'usePatterns', () => {
-	let wrapper: React.FC< React.PropsWithChildren< any > >;
+	let wrapper: React.FC< React.PropsWithChildren >;
 
 	beforeEach( () => {
-		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockReset();
+		jest.mocked( wpcom.req.get ).mockReset();
 
 		const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
 
-		wrapper = ( { children }: React.PropsWithChildren< any > ) => (
+		wrapper = ( { children } ) => (
 			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
 		);
 	} );
@@ -27,7 +27,7 @@ describe( 'usePatterns', () => {
 	} );
 
 	test( 'calls the API endpoint with the right parameters', async () => {
-		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockResolvedValue( [] );
+		jest.mocked( wpcom.req.get ).mockResolvedValue( [] );
 
 		const { result } = renderHook( () => usePatterns( 'fr', 'intro' ), { wrapper } );
 
@@ -50,7 +50,7 @@ describe( 'usePatterns', () => {
 			},
 		];
 
-		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockResolvedValue( patterns );
+		jest.mocked( wpcom.req.get ).mockResolvedValue( patterns );
 
 		const { result } = renderHook( () => usePatterns( 'en', 'about' ), { wrapper } );
 

--- a/client/my-sites/plans-features-main/components/test/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/test/plan-notice.tsx
@@ -1,5 +1,4 @@
 /** @jest-environment jsdom */
-// @ts-nocheck - TODO: Fix TypeScript issues
 
 import {
 	PLAN_BUSINESS,
@@ -70,29 +69,6 @@ jest.mock( 'calypso/state/currency-code/selectors', () => ( {
 } ) );
 jest.mock( '@automattic/calypso-config' );
 
-const mGetDiscountByName = getDiscountByName as jest.MockedFunction< typeof getDiscountByName >;
-const mUseMarketingMessage = useMarketingMessage as jest.MockedFunction<
-	typeof useMarketingMessage
->;
-const mIsCurrentPlanPaid = isCurrentPlanPaid as jest.MockedFunction< typeof isCurrentPlanPaid >;
-const mIsCurrentUserCurrentPlanOwner = isCurrentUserCurrentPlanOwner as jest.MockedFunction<
-	typeof isCurrentUserCurrentPlanOwner
->;
-const mIsRequestingSitePlans = isRequestingSitePlans as jest.MockedFunction<
-	typeof isRequestingSitePlans
->;
-const mUsePlanUpgradeCreditsApplicable = usePlanUpgradeCreditsApplicable as jest.MockedFunction<
-	typeof usePlanUpgradeCreditsApplicable
->;
-const mUseDomainToPlanCreditsApplicable = useDomainToPlanCreditsApplicable as jest.MockedFunction<
-	typeof useDomainToPlanCreditsApplicable
->;
-const mGetCurrentUserCurrencyCode = getCurrentUserCurrencyCode as jest.MockedFunction<
-	typeof getCurrentUserCurrencyCode
->;
-const mGetByPurchaseId = getByPurchaseId as jest.MockedFunction< typeof getByPurchaseId >;
-const mIsProPlan = isProPlan as jest.MockedFunction< typeof isProPlan >;
-
 const plansList: PlanSlug[] = [
 	PLAN_FREE,
 	PLAN_PERSONAL,
@@ -111,32 +87,29 @@ describe( '<PlanNotice /> Tests', () => {
 	beforeEach( () => {
 		jest.resetAllMocks();
 
-		mGetDiscountByName.mockImplementation( () => false );
-		mUseMarketingMessage.mockImplementation( () => [ false, [], () => ( {} ) ] );
-		mIsCurrentPlanPaid.mockImplementation( () => true );
-		mIsCurrentUserCurrentPlanOwner.mockImplementation( () => true );
-		mIsRequestingSitePlans.mockImplementation( () => true );
-		mGetCurrentUserCurrencyCode.mockImplementation( () => 'USD' );
-		mUsePlanUpgradeCreditsApplicable.mockImplementation( () => 100 );
-		mUseDomainToPlanCreditsApplicable.mockImplementation( () => 100 );
-		mGetByPurchaseId.mockImplementation(
-			() =>
-				( {
-					isInAppPurchase: false,
-				} ) as Purchase
-		);
-		mIsProPlan.mockImplementation( () => false );
+		jest.mocked( getDiscountByName ).mockReturnValue( false );
+		jest.mocked( useMarketingMessage ).mockReturnValue( [ false, [], () => ( {} ) ] );
+		jest.mocked( isCurrentPlanPaid ).mockReturnValue( true );
+		jest.mocked( isCurrentUserCurrentPlanOwner ).mockReturnValue( true );
+		jest.mocked( isRequestingSitePlans ).mockReturnValue( true );
+		jest.mocked( getCurrentUserCurrencyCode ).mockReturnValue( 'USD' );
+		jest.mocked( usePlanUpgradeCreditsApplicable ).mockReturnValue( 100 );
+		jest.mocked( useDomainToPlanCreditsApplicable ).mockReturnValue( 100 );
+		jest.mocked( getByPurchaseId ).mockReturnValue( {
+			isInAppPurchase: false,
+		} as Purchase );
+		jest.mocked( isProPlan ).mockReturnValue( false );
 	} );
 
 	test( 'A contact site owner <PlanNotice /> should be shown no matter what other conditions are met, when the current site owner is not logged in, and the site plan is paid', () => {
-		mGetDiscountByName.mockImplementation( () => discount );
-		mUsePlanUpgradeCreditsApplicable.mockImplementation( () => 100 );
-		mIsCurrentPlanPaid.mockImplementation( () => true );
-		mIsCurrentUserCurrentPlanOwner.mockImplementation( () => false );
+		jest.mocked( getDiscountByName ).mockReturnValue( discount );
+		jest.mocked( usePlanUpgradeCreditsApplicable ).mockReturnValue( 100 );
+		jest.mocked( isCurrentPlanPaid ).mockReturnValue( true );
+		jest.mocked( isCurrentUserCurrentPlanOwner ).mockReturnValue( false );
 
 		renderWithProvider(
 			<PlanNotice
-				discountInformation={ { withDiscount: 'test', discountEndDate: new Date() } }
+				discountInformation={ { coupon: 'test', discountEndDate: new Date() } }
 				visiblePlans={ plansList }
 				isInSignup={ false }
 				siteId={ 10000000 }
@@ -148,14 +121,14 @@ describe( '<PlanNotice /> Tests', () => {
 	} );
 
 	test( 'A discount <PlanNotice /> should be shown if the user is the site owner and no matter what other conditions are met', () => {
-		mIsCurrentUserCurrentPlanOwner.mockImplementation( () => true );
-		mIsCurrentPlanPaid.mockImplementation( () => true );
-		mGetDiscountByName.mockImplementation( () => discount );
-		mUsePlanUpgradeCreditsApplicable.mockImplementation( () => 100 );
+		jest.mocked( isCurrentUserCurrentPlanOwner ).mockReturnValue( true );
+		jest.mocked( isCurrentPlanPaid ).mockReturnValue( true );
+		jest.mocked( getDiscountByName ).mockReturnValue( discount );
+		jest.mocked( usePlanUpgradeCreditsApplicable ).mockReturnValue( 100 );
 
 		renderWithProvider(
 			<PlanNotice
-				discountInformation={ { withDiscount: 'test', discountEndDate: new Date() } }
+				discountInformation={ { coupon: 'test', discountEndDate: new Date() } }
 				visiblePlans={ plansList }
 				isInSignup={ false }
 				siteId={ 32234 }
@@ -165,14 +138,14 @@ describe( '<PlanNotice /> Tests', () => {
 	} );
 
 	test( 'A plan upgrade credit <PlanNotice /> should be shown in a site where a plan is purchased, without other active discounts, has upgradeable plan and, the site owner is logged in', () => {
-		mIsCurrentUserCurrentPlanOwner.mockImplementation( () => true );
-		mIsCurrentPlanPaid.mockImplementation( () => true );
-		mGetDiscountByName.mockImplementation( () => false );
-		mUsePlanUpgradeCreditsApplicable.mockImplementation( () => 10000 );
+		jest.mocked( isCurrentUserCurrentPlanOwner ).mockReturnValue( true );
+		jest.mocked( isCurrentPlanPaid ).mockReturnValue( true );
+		jest.mocked( getDiscountByName ).mockReturnValue( false );
+		jest.mocked( usePlanUpgradeCreditsApplicable ).mockReturnValue( 10000 );
 
 		renderWithProvider(
 			<PlanNotice
-				discountInformation={ { withDiscount: 'test', discountEndDate: new Date() } }
+				discountInformation={ { coupon: 'test', discountEndDate: new Date() } }
 				visiblePlans={ plansList }
 				isInSignup={ false }
 				siteId={ 32234 }
@@ -184,8 +157,8 @@ describe( '<PlanNotice /> Tests', () => {
 	} );
 
 	test( 'A domain-to-plan credit <PlanNotice /> should be shown in a site where a domain has been purchased without a paid plan', () => {
-		mUsePlanUpgradeCreditsApplicable.mockImplementation( () => null );
-		mUseDomainToPlanCreditsApplicable.mockImplementation( () => 1000 );
+		jest.mocked( usePlanUpgradeCreditsApplicable ).mockReturnValue( null );
+		jest.mocked( useDomainToPlanCreditsApplicable ).mockReturnValue( 1000 );
 
 		renderWithProvider(
 			<PlanNotice
@@ -201,20 +174,22 @@ describe( '<PlanNotice /> Tests', () => {
 	} );
 
 	test( 'A marketing message <PlanNotice /> when no other notices are available and marketing messages are available and the user is not in signup', () => {
-		mIsCurrentUserCurrentPlanOwner.mockImplementation( () => true );
-		mIsCurrentPlanPaid.mockImplementation( () => true );
-		mGetDiscountByName.mockImplementation( () => false );
-		mUsePlanUpgradeCreditsApplicable.mockImplementation( () => null );
-		mUseDomainToPlanCreditsApplicable.mockImplementation( () => null );
-		mUseMarketingMessage.mockImplementation( () => [
-			false,
-			[ { id: '12121', text: 'An important marketing message' } ],
-			() => ( {} ),
-		] );
+		jest.mocked( isCurrentUserCurrentPlanOwner ).mockReturnValue( true );
+		jest.mocked( isCurrentPlanPaid ).mockReturnValue( true );
+		jest.mocked( getDiscountByName ).mockReturnValue( false );
+		jest.mocked( usePlanUpgradeCreditsApplicable ).mockReturnValue( null );
+		jest.mocked( useDomainToPlanCreditsApplicable ).mockReturnValue( null );
+		jest
+			.mocked( useMarketingMessage )
+			.mockReturnValue( [
+				false,
+				[ { id: '12121', text: 'An important marketing message' } ],
+				() => ( {} ),
+			] );
 		//
 		renderWithProvider(
 			<PlanNotice
-				discountInformation={ { withDiscount: 'test', discountEndDate: new Date() } }
+				discountInformation={ { coupon: 'test', discountEndDate: new Date() } }
 				visiblePlans={ plansList }
 				isInSignup={ false }
 				siteId={ 32234 }
@@ -224,19 +199,21 @@ describe( '<PlanNotice /> Tests', () => {
 	} );
 
 	test( 'No <PlanNotice /> should be shown when in signup', () => {
-		mIsCurrentUserCurrentPlanOwner.mockImplementation( () => true );
-		mIsCurrentPlanPaid.mockImplementation( () => true );
-		mGetDiscountByName.mockImplementation( () => false );
-		mUsePlanUpgradeCreditsApplicable.mockImplementation( () => null );
-		mUseMarketingMessage.mockImplementation( () => [
-			false,
-			[ { id: '12121', text: 'An important marketing message' } ],
-			() => ( {} ),
-		] );
+		jest.mocked( isCurrentUserCurrentPlanOwner ).mockReturnValue( true );
+		jest.mocked( isCurrentPlanPaid ).mockReturnValue( true );
+		jest.mocked( getDiscountByName ).mockReturnValue( false );
+		jest.mocked( usePlanUpgradeCreditsApplicable ).mockReturnValue( null );
+		jest
+			.mocked( useMarketingMessage )
+			.mockReturnValue( [
+				false,
+				[ { id: '12121', text: 'An important marketing message' } ],
+				() => ( {} ),
+			] );
 		//
 		renderWithProvider(
 			<PlanNotice
-				discountInformation={ { withDiscount: 'test', discountEndDate: new Date() } }
+				discountInformation={ { coupon: 'test', discountEndDate: new Date() } }
 				visiblePlans={ plansList }
 				isInSignup
 				siteId={ 32234 }
@@ -246,10 +223,10 @@ describe( '<PlanNotice /> Tests', () => {
 	} );
 
 	test( 'Show retired plan <PlanNotice /> when the current site has the pro plan', () => {
-		mIsProPlan.mockImplementation( () => true );
+		jest.mocked( isProPlan ).mockReturnValue( true );
 		renderWithProvider(
 			<PlanNotice
-				discountInformation={ { withDiscount: 'test', discountEndDate: new Date() } }
+				discountInformation={ { coupon: 'test', discountEndDate: new Date() } }
 				visiblePlans={ plansList }
 				isInSignup={ false }
 				siteId={ 32234 }
@@ -261,15 +238,12 @@ describe( '<PlanNotice /> Tests', () => {
 	} );
 
 	test( 'Show in app purchase <PlanNotice /> when the current site was purchased in an app', () => {
-		mGetByPurchaseId.mockImplementation(
-			() =>
-				( {
-					isInAppPurchase: true,
-				} ) as Purchase
-		);
+		jest.mocked( getByPurchaseId ).mockReturnValue( {
+			isInAppPurchase: true,
+		} as Purchase );
 		renderWithProvider(
 			<PlanNotice
-				discountInformation={ { withDiscount: 'test', discountEndDate: new Date() } }
+				discountInformation={ { coupon: 'test', discountEndDate: new Date() } }
 				visiblePlans={ plansList }
 				isInSignup={ false }
 				siteId={ 32234 }

--- a/client/my-sites/plans-features-main/hooks/test/use-domain-to-plan-credits-applicable.tsx
+++ b/client/my-sites/plans-features-main/hooks/test/use-domain-to-plan-credits-applicable.tsx
@@ -15,51 +15,41 @@ jest.mock( 'calypso/my-sites/plans-features-main/hooks/use-max-plan-upgrade-cred
 
 jest.mock( '@automattic/data-stores/src/plans/queries/use-site-plans', () => jest.fn() );
 
-const mockUseMaxPlanUpgradeCredits = useMaxPlanUpgradeCredits as jest.MockedFunction<
-	typeof useMaxPlanUpgradeCredits
->;
-const mockUseSitePlans = useSitePlans as jest.MockedFunction< typeof useSitePlans >;
 const siteId = 1;
 const overrideCode = COST_OVERRIDE_REASONS.RECENT_DOMAIN_PRORATION;
 
 describe( 'useDomainToPlanCreditsApplicable', () => {
 	beforeEach( () => {
-		mockUseSitePlans.mockImplementation(
-			() =>
-				( {
-					data: {
-						free_plan: {
-							pricing: { costOverrides: [ { overrideCode } ] },
-						},
-					},
-				} ) as UseQueryResult< { free_plan: SitePlan } >
-		);
-		mockUseMaxPlanUpgradeCredits.mockImplementation( () => 0 );
+		jest.mocked( useSitePlans ).mockReturnValue( {
+			data: {
+				free_plan: {
+					pricing: { costOverrides: [ { overrideCode } ] },
+				},
+			},
+		} as UseQueryResult< { free_plan: SitePlan } > );
+		jest.mocked( useMaxPlanUpgradeCredits ).mockReturnValue( 0 );
 	} );
 
 	test( 'Returns the credit value for a site that has domain-to-plan credit', () => {
-		mockUseMaxPlanUpgradeCredits.mockImplementation( () => 1000 );
+		jest.mocked( useMaxPlanUpgradeCredits ).mockReturnValue( 1000 );
 		const { result } = renderHookWithProvider( () => useDomainToPlanCreditsApplicable( siteId ) );
 		expect( result.current ).toEqual( 1000 );
 	} );
 
 	test( 'Returns null for a site that has credit but not domain-to-plan credit', () => {
-		mockUseSitePlans.mockImplementation(
-			() =>
-				( {
-					data: {
-						free_plan: {
-							pricing: { costOverrides: [ { overrideCode: 'some-other-override' } ] },
-						},
-					},
-				} ) as UseQueryResult< { free_plan: SitePlan } >
-		);
+		jest.mocked( useSitePlans ).mockReturnValue( {
+			data: {
+				free_plan: {
+					pricing: { costOverrides: [ { overrideCode: 'some-other-override' } ] },
+				},
+			},
+		} as UseQueryResult< { free_plan: SitePlan } > );
 		const { result } = renderHookWithProvider( () => useDomainToPlanCreditsApplicable( siteId ) );
 		expect( result.current ).toEqual( null );
 	} );
 
 	test( 'Returns 0 (not null) for a site that has domain-to-plan credit value of 0', () => {
-		mockUseMaxPlanUpgradeCredits.mockImplementation( () => 0 );
+		jest.mocked( useMaxPlanUpgradeCredits ).mockReturnValue( 0 );
 		const { result } = renderHookWithProvider( () => useDomainToPlanCreditsApplicable( siteId ) );
 		expect( result.current ).toEqual( 0 );
 	} );

--- a/client/my-sites/plans-features-main/hooks/test/use-plan-upgrade-credits-applicable.tsx
+++ b/client/my-sites/plans-features-main/hooks/test/use-plan-upgrade-credits-applicable.tsx
@@ -33,17 +33,6 @@ jest.mock( 'calypso/state/selectors/is-site-automated-transfer', () => ( {
 	default: jest.fn(),
 } ) );
 
-// Mocked types
-const mUsePlanUpgradeCredits = useMaxPlanUpgradeCredits as jest.MockedFunction<
-	typeof useMaxPlanUpgradeCredits
->;
-const mIsAutomatedTransfer = isAutomatedTransfer as jest.MockedFunction<
-	typeof isAutomatedTransfer
->;
-const mGetSitePlanSlug = getSitePlanSlug as jest.MockedFunction< typeof getSitePlanSlug >;
-const mIsCurrentPlanPaid = isCurrentPlanPaid as jest.MockedFunction< typeof isCurrentPlanPaid >;
-const mIsJetpackSite = isJetpackSite as jest.MockedFunction< typeof isJetpackSite >;
-
 const siteId = 1;
 const plansList: PlanSlug[] = [
 	PLAN_FREE,
@@ -57,11 +46,11 @@ describe( 'usePlanUpgradeCreditsApplicable hook', () => {
 	beforeEach( () => {
 		jest.resetAllMocks();
 
-		mGetSitePlanSlug.mockImplementation( () => 'TYPE_BUSINESS' );
-		mIsCurrentPlanPaid.mockImplementation( () => true );
-		mUsePlanUpgradeCredits.mockImplementation( () => 100 );
-		mIsJetpackSite.mockImplementation( () => true );
-		mIsAutomatedTransfer.mockImplementation( () => true );
+		jest.mocked( getSitePlanSlug ).mockReturnValue( 'TYPE_BUSINESS' );
+		jest.mocked( isCurrentPlanPaid ).mockReturnValue( true );
+		jest.mocked( useMaxPlanUpgradeCredits ).mockReturnValue( 100 );
+		jest.mocked( isJetpackSite ).mockReturnValue( true );
+		jest.mocked( isAutomatedTransfer ).mockReturnValue( true );
 	} );
 
 	test( 'Show a plans upgrade credit when the necessary conditions are met above', () => {
@@ -72,7 +61,7 @@ describe( 'usePlanUpgradeCreditsApplicable hook', () => {
 	} );
 
 	test( 'Plan upgrade credits should not be shown when a site is on the highest purchasable plan', () => {
-		mGetSitePlanSlug.mockImplementation( () => PLAN_ECOMMERCE );
+		jest.mocked( getSitePlanSlug ).mockReturnValue( PLAN_ECOMMERCE );
 		const { result } = renderHookWithProvider( () =>
 			usePlanUpgradeCreditsApplicable( siteId, plansList )
 		);
@@ -80,8 +69,8 @@ describe( 'usePlanUpgradeCreditsApplicable hook', () => {
 	} );
 
 	test( 'A non atomic jetpack site is not shown the plan upgrade credit', () => {
-		mIsAutomatedTransfer.mockImplementation( () => false );
-		mIsJetpackSite.mockImplementation( () => true );
+		jest.mocked( isAutomatedTransfer ).mockReturnValue( false );
+		jest.mocked( isJetpackSite ).mockReturnValue( true );
 
 		const { result } = renderHookWithProvider( () =>
 			usePlanUpgradeCreditsApplicable( siteId, plansList )
@@ -90,7 +79,7 @@ describe( 'usePlanUpgradeCreditsApplicable hook', () => {
 	} );
 
 	test( 'Plan upgrade credit should NOT be shown if there are no discounts provided by the pricing API', () => {
-		mUsePlanUpgradeCredits.mockImplementation( () => null );
+		jest.mocked( useMaxPlanUpgradeCredits ).mockReturnValue( null );
 
 		const { result } = renderHookWithProvider( () =>
 			usePlanUpgradeCreditsApplicable( siteId, plansList )
@@ -99,7 +88,7 @@ describe( 'usePlanUpgradeCreditsApplicable hook', () => {
 	} );
 
 	test( 'Site on a free plan should not show the plan upgrade credit', () => {
-		mIsCurrentPlanPaid.mockImplementation( () => false );
+		jest.mocked( isCurrentPlanPaid ).mockReturnValue( false );
 
 		const { result } = renderHookWithProvider( () =>
 			usePlanUpgradeCreditsApplicable( siteId, plansList )

--- a/client/my-sites/subscribers/queries/test/use-subscriber-count-query-test.tsx
+++ b/client/my-sites/subscribers/queries/test/use-subscriber-count-query-test.tsx
@@ -27,7 +27,7 @@ describe( 'useSubscriberCountQuery', () => {
 	let wrapper: React.FC< React.PropsWithChildren< any > >;
 
 	beforeEach( () => {
-		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockReset();
+		jest.mocked( wpcom.req.get ).mockReset();
 
 		queryClient = new QueryClient( {
 			defaultOptions: {
@@ -47,9 +47,7 @@ describe( 'useSubscriberCountQuery', () => {
 	} );
 
 	it( 'should call wpcom.req.get with the right parameters', async () => {
-		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockResolvedValue(
-			mockResponse
-		);
+		jest.mocked( wpcom.req.get ).mockResolvedValue( mockResponse );
 
 		const { result } = renderHook( () => useSubscriberCountQuery( 123 ), { wrapper } );
 
@@ -62,9 +60,7 @@ describe( 'useSubscriberCountQuery', () => {
 	} );
 
 	it( 'should return expected data when successful', async () => {
-		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockResolvedValue(
-			mockResponse
-		);
+		jest.mocked( wpcom.req.get ).mockResolvedValue( mockResponse );
 
 		const { result } = renderHook( () => useSubscriberCountQuery( 123 ), { wrapper } );
 
@@ -74,7 +70,7 @@ describe( 'useSubscriberCountQuery', () => {
 	} );
 
 	it( 'should handle empty response', async () => {
-		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockResolvedValue( {} );
+		jest.mocked( wpcom.req.get ).mockResolvedValue( {} );
 
 		const { result } = renderHook( () => useSubscriberCountQuery( 123 ), { wrapper } );
 

--- a/packages/data-stores/src/newsletter-categories/test/index.tsx
+++ b/packages/data-stores/src/newsletter-categories/test/index.tsx
@@ -14,7 +14,7 @@ describe( 'useNewsletterCategories', () => {
 	let wrapper: React.FC< { children: React.ReactNode } >;
 
 	beforeEach( () => {
-		( request as jest.MockedFunction< typeof request > ).mockReset();
+		jest.mocked( request ).mockReset();
 
 		queryClient = new QueryClient( {
 			defaultOptions: {
@@ -34,7 +34,7 @@ describe( 'useNewsletterCategories', () => {
 	} );
 
 	it( 'should return expected data when successful', async () => {
-		( request as jest.MockedFunction< typeof request > ).mockResolvedValue( {
+		jest.mocked( request ).mockResolvedValue( {
 			enabled: true,
 			newsletter_categories: [
 				{ id: 1, name: 'Category 1', slug: 'Slug 1', description: 'Description 1', parent: 1 },
@@ -56,7 +56,7 @@ describe( 'useNewsletterCategories', () => {
 	} );
 
 	it( 'should handle empty response', async () => {
-		( request as jest.MockedFunction< typeof request > ).mockResolvedValue( {
+		jest.mocked( request ).mockResolvedValue( {
 			enabled: false,
 			newsletter_categories: [],
 		} );
@@ -69,7 +69,7 @@ describe( 'useNewsletterCategories', () => {
 	} );
 
 	it( 'should call request with correct arguments', async () => {
-		( request as jest.MockedFunction< typeof request > ).mockResolvedValue( {
+		jest.mocked( request ).mockResolvedValue( {
 			enabled: true,
 			newsletter_categories: [],
 		} );
@@ -88,9 +88,7 @@ describe( 'useNewsletterCategories', () => {
 
 	it( 'should handle error response', async () => {
 		const errorMessage = 'API Error';
-		( request as jest.MockedFunction< typeof request > ).mockRejectedValue(
-			new Error( errorMessage )
-		);
+		jest.mocked( request ).mockRejectedValue( new Error( errorMessage ) );
 
 		const { result } = renderHook( () => useNewsletterCategories( { siteId: 123 } ), { wrapper } );
 

--- a/packages/data-stores/src/reader/queries/test/use-read-feed-search-query.tsx
+++ b/packages/data-stores/src/reader/queries/test/use-read-feed-search-query.tsx
@@ -11,7 +11,7 @@ jest.mock( 'wpcom-proxy-request', () => jest.fn() );
 
 describe( 'useReadFeedSearchQuery', () => {
 	beforeEach( () => {
-		( wpcomRequest as jest.MockedFunction< typeof wpcomRequest > ).mockResolvedValue( {
+		jest.mocked( wpcomRequest ).mockResolvedValue( {
 			algorithm: 'example_algorithm',
 			feeds: [],
 			next_page: 'example_next_page',

--- a/packages/explat-client-react-helpers/src/test/index.tsx
+++ b/packages/explat-client-react-helpers/src/test/index.tsx
@@ -3,6 +3,7 @@
  */
 
 import { act, render, renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
 import createExPlatClientReactHelpers from '../index';
 import type { ExPlatClient, ExperimentAssignment } from '@automattic/explat-client';
 
@@ -47,22 +48,18 @@ describe( 'useExperiment', () => {
 		const { useExperiment } = createExPlatClientReactHelpers( exPlatClient );
 
 		const controllablePromise1 = createControllablePromise< ExperimentAssignment >();
-		(
-			exPlatClient.loadExperimentAssignment as jest.MockedFunction<
-				typeof exPlatClient.loadExperimentAssignment
-			>
-		 ).mockImplementationOnce( () => controllablePromise1.promise );
+		jest
+			.mocked( exPlatClient.loadExperimentAssignment )
+			.mockReturnValueOnce( controllablePromise1.promise );
 
 		const { result, rerender } = renderHook( () => useExperiment( 'experiment_a' ) );
 
 		expect( result.current ).toEqual( [ true, null ] );
 		expect( exPlatClient.loadExperimentAssignment ).toHaveBeenCalledTimes( 1 );
 		act( () => controllablePromise1.resolve( validExperimentAssignment ) );
-		(
-			exPlatClient.dangerouslyGetMaybeLoadedExperimentAssignment as jest.MockedFunction<
-				typeof exPlatClient.dangerouslyGetMaybeLoadedExperimentAssignment
-			>
-		 ).mockImplementation( () => validExperimentAssignment );
+		jest
+			.mocked( exPlatClient.dangerouslyGetMaybeLoadedExperimentAssignment )
+			.mockReturnValue( validExperimentAssignment );
 		await waitFor( () => expect( result.current ).toEqual( [ true, null ] ) );
 		rerender();
 		expect( result.current ).toEqual( [ false, validExperimentAssignment ] );
@@ -75,11 +72,9 @@ describe( 'useExperiment', () => {
 		const { useExperiment } = createExPlatClientReactHelpers( exPlatClient );
 
 		const controllablePromise1 = createControllablePromise< ExperimentAssignment >();
-		(
-			exPlatClient.loadExperimentAssignment as jest.MockedFunction<
-				typeof exPlatClient.loadExperimentAssignment
-			>
-		 ).mockImplementationOnce( () => controllablePromise1.promise );
+		jest
+			.mocked( exPlatClient.loadExperimentAssignment )
+			.mockReturnValueOnce( controllablePromise1.promise );
 
 		let isEligible = false;
 		const { result, rerender } = renderHook( () =>
@@ -93,11 +88,9 @@ describe( 'useExperiment', () => {
 		rerender();
 		expect( result.current ).toEqual( [ true, null ] );
 		expect( exPlatClient.loadExperimentAssignment ).toHaveBeenCalledTimes( 1 );
-		(
-			exPlatClient.dangerouslyGetMaybeLoadedExperimentAssignment as jest.MockedFunction<
-				typeof exPlatClient.dangerouslyGetMaybeLoadedExperimentAssignment
-			>
-		 ).mockImplementation( () => validExperimentAssignment );
+		jest
+			.mocked( exPlatClient.dangerouslyGetMaybeLoadedExperimentAssignment )
+			.mockReturnValue( validExperimentAssignment );
 		act( () => controllablePromise1.resolve( validExperimentAssignment ) );
 		await waitFor( () => expect( result.current ).toEqual( [ true, null ] ) );
 		rerender();
@@ -118,11 +111,9 @@ describe( 'Experiment', () => {
 		const { Experiment } = createExPlatClientReactHelpers( exPlatClient );
 
 		const controllablePromise1 = createControllablePromise< ExperimentAssignment >();
-		(
-			exPlatClient.loadExperimentAssignment as jest.MockedFunction<
-				typeof exPlatClient.loadExperimentAssignment
-			>
-		 ).mockImplementationOnce( () => controllablePromise1.promise );
+		jest
+			.mocked( exPlatClient.loadExperimentAssignment )
+			.mockReturnValueOnce( controllablePromise1.promise );
 
 		const { container, rerender } = render(
 			<Experiment
@@ -142,11 +133,9 @@ describe( 'Experiment', () => {
 			/>
 		);
 		expect( container.textContent ).toBe( 'loading-2' );
-		(
-			exPlatClient.dangerouslyGetMaybeLoadedExperimentAssignment as jest.MockedFunction<
-				typeof exPlatClient.dangerouslyGetMaybeLoadedExperimentAssignment
-			>
-		 ).mockImplementation( () => validExperimentAssignment );
+		jest
+			.mocked( exPlatClient.dangerouslyGetMaybeLoadedExperimentAssignment )
+			.mockReturnValue( validExperimentAssignment );
 		await act( async () => controllablePromise1.resolve( validExperimentAssignment ) );
 		await waitFor( () => expect( container.textContent ).toBe( 'treatment-1' ) );
 		rerender(
@@ -165,11 +154,9 @@ describe( 'Experiment', () => {
 		const { Experiment } = createExPlatClientReactHelpers( exPlatClient );
 
 		const controllablePromise1 = createControllablePromise< ExperimentAssignment >();
-		(
-			exPlatClient.loadExperimentAssignment as jest.MockedFunction<
-				typeof exPlatClient.loadExperimentAssignment
-			>
-		 ).mockImplementationOnce( () => controllablePromise1.promise );
+		jest
+			.mocked( exPlatClient.loadExperimentAssignment )
+			.mockReturnValueOnce( controllablePromise1.promise );
 
 		const { container, rerender } = render(
 			<Experiment
@@ -181,11 +168,9 @@ describe( 'Experiment', () => {
 		);
 		expect( container.textContent ).toBe( 'loading' );
 		const resolvedExperimentAssignment = { ...validExperimentAssignment, variationName: null };
-		(
-			exPlatClient.dangerouslyGetMaybeLoadedExperimentAssignment as jest.MockedFunction<
-				typeof exPlatClient.dangerouslyGetMaybeLoadedExperimentAssignment
-			>
-		 ).mockImplementation( () => resolvedExperimentAssignment );
+		jest
+			.mocked( exPlatClient.dangerouslyGetMaybeLoadedExperimentAssignment )
+			.mockReturnValue( resolvedExperimentAssignment );
 		await act( async () => controllablePromise1.resolve( resolvedExperimentAssignment ) );
 		await waitFor( () => expect( container.textContent ).toBe( 'default-1' ) );
 		rerender(
@@ -206,11 +191,9 @@ describe( 'ProvideExperimentData', () => {
 		const { ProvideExperimentData } = createExPlatClientReactHelpers( exPlatClient );
 
 		const controllablePromise1 = createControllablePromise< ExperimentAssignment >();
-		(
-			exPlatClient.loadExperimentAssignment as jest.MockedFunction<
-				typeof exPlatClient.loadExperimentAssignment
-			>
-		 ).mockImplementationOnce( () => controllablePromise1.promise );
+		jest
+			.mocked( exPlatClient.loadExperimentAssignment )
+			.mockReturnValueOnce( controllablePromise1.promise );
 
 		const capture = jest.fn();
 		render(
@@ -224,11 +207,9 @@ describe( 'ProvideExperimentData', () => {
 		expect( capture.mock.calls[ 0 ] ).toEqual( [ true, null ] );
 		capture.mockReset();
 		const experimentAssignment = { ...validExperimentAssignment, variationName: null };
-		(
-			exPlatClient.dangerouslyGetMaybeLoadedExperimentAssignment as jest.MockedFunction<
-				typeof exPlatClient.dangerouslyGetMaybeLoadedExperimentAssignment
-			>
-		 ).mockImplementation( () => experimentAssignment );
+		jest
+			.mocked( exPlatClient.dangerouslyGetMaybeLoadedExperimentAssignment )
+			.mockReturnValue( experimentAssignment );
 		await act( async () => controllablePromise1.resolve( experimentAssignment ) );
 		await waitFor( () => {
 			expect( capture ).toHaveBeenCalledTimes( 1 );


### PR DESCRIPTION
In our Jest tests that use TypeScript we often use a complicated `foo as jest.MockedFunction<typeof foo>` type cast to get an object that has methods like `mockImplementation`. But Jest has a better way of doing this, namely the `jest.mocked` helper. It's an identity function that returns the same function, just differently typed.

See for yourself in the diff how the updated version is much less wordy.

I'm also refactoring many usages of `.mockImplementation` to `.mockReturnValue`: it's more concise to avoid an arrow function.
