### PR TITLE
Reader - fix recommended posts not appearing.

### DIFF
--- a/client/state/reader/streams/selectors/get-reader-stream.ts
+++ b/client/state/reader/streams/selectors/get-reader-stream.ts
@@ -37,7 +37,7 @@ const emptyStream = {
 	pendingItems: { lastUpdated: null, items: [] },
 	selected: null,
 	lastPage: false,
-	isRequesting: true, // `true` indicates that the stream is yet to fetch.
+	isRequesting: false, // `true` may prevent the stream from requesting at all, as is the case with the recommendations stream.
 };
 
 function getStream( state: AppState, streamKey: string ): ReaderStreamState {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/CML-532/recommended-posts-section-disappeared-from-reader-feeds

## Proposed Changes

* Ensures the emptyStream fallback from the selector has `isRequesting` as `false` (the default state value). This was changed to `true` about a month ago, and this prevents the recommended posts from being requested as reading state indicates that they are already in the process of being requested when they are not.

BEFORE
no recommended posts cards in following stream

AFTER - they appear again
![Screenshot 2025-05-29 at 8 41 21 AM](https://github.com/user-attachments/assets/4f9a1143-5d1c-4f96-9d85-ddcc41f0240c)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Recommended posts were not appearing at all anymore

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the reader following feed
* scroll down and you will eventually find recommended posts in the list.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
