### PR TITLE
Accessibility: Update aria-labels generation for buttons on the "Select Domain" step

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -159,6 +159,15 @@ class DomainRegistrationSuggestion extends Component {
 					comment:
 						'Accessible label for free domain. %(baseLabel)s is the base label (e.g. "Select domain testing.com").',
 				} );
+			case 'FREE_FOR_FIRST_YEAR':
+				return translate( '%(baseLabel)s. Free for the first year, then %(price)s per year', {
+					args: {
+						baseLabel,
+						price: productCost,
+					},
+					comment:
+						'Accessible label for domain free for the first year. %(baseLabel)s is the base label (e.g. "Select domain testing.com"). %(price)s is the price.',
+				} );
 			case 'FREE_WITH_PLAN':
 				return translate(
 					'%(baseLabel)s. Free for the first year with annual paid plans, then %(price)s per year',
@@ -187,6 +196,15 @@ class DomainRegistrationSuggestion extends Component {
 					comment:
 						'Accessible label for domain included in higher plans. %(baseLabel)s is the base label (e.g. "Select domain testing.com").',
 				} );
+			case 'DOMAIN_MOVE_PRICE':
+				return translate( '%(baseLabel)s. %(price)s one-time', {
+					args: {
+						baseLabel,
+						price: productCost,
+					},
+					comment:
+						'Accessible label for domain move price. %(baseLabel)s is the base label (e.g. "Select domain testing.com"). %(price)s is the price.',
+				} );
 			case 'PRICE':
 				if ( productSaleCost && productCost ) {
 					return translate(
@@ -211,7 +229,7 @@ class DomainRegistrationSuggestion extends Component {
 							'Accessible label for regularly priced domain. %(baseLabel)s is the base label (e.g. "Select domain testing.com"). %(price)s is the price.',
 					} );
 				}
-				break;
+				return baseLabel;
 			default:
 				return baseLabel;
 		}

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -132,6 +132,54 @@ class DomainRegistrationSuggestion extends Component {
 		return includes( this.props.unavailableDomains, domain );
 	};
 
+	getSelectDomainAriaLabel() {
+		const { suggestion, translate, productCost, productSaleCost } = this.props;
+		const priceRule = this.getPriceRule();
+
+		const baseLabel = translate( 'Select domain %(domainName)s', {
+			args: { domainName: suggestion.domain_name },
+			context: 'Accessible label for domain selection button. %(domainName)s is the domain name.',
+		} );
+
+		if ( ( priceRule === 'FREE_DOMAIN' || priceRule === 'FREE_WITH_PLAN' ) && productCost ) {
+			return translate(
+				'%(baseLabel)s. Free for the first year with annual paid plans, then %(price)s per year',
+				{
+					args: {
+						baseLabel,
+						price: productCost,
+					},
+					comment:
+						'Accessible label for free domain with normal price. %(baseLabel)s is the base label (e.g. "Select domain testing.com"). %(price)s is the price.',
+				}
+			);
+		} else if ( productSaleCost && productCost ) {
+			return translate(
+				'%(baseLabel)s. %(salePrice)s for the first year, then %(price)s per year',
+				{
+					args: {
+						baseLabel,
+						salePrice: productSaleCost,
+						price: productCost,
+					},
+					comment:
+						'Accessible label for domain with sale price. %(baseLabel)s is the base label (e.g. "Select domain testing.com"). %(salePrice)s is the sale price. %(price)s is the price.',
+				}
+			);
+		} else if ( productCost ) {
+			return translate( '%(baseLabel)s. %(price)s per year', {
+				args: {
+					baseLabel,
+					price: productCost,
+				},
+				comment:
+					'Accessible label for regularly priced domain. %(baseLabel)s is the base label (e.g. "Select domain testing.com"). %(price)s is the price.',
+			} );
+		}
+
+		return baseLabel;
+	}
+
 	getButtonProps() {
 		const {
 			cart,
@@ -165,12 +213,18 @@ class DomainRegistrationSuggestion extends Component {
 		}
 
 		let buttonContent;
+		let ariaLabel;
 		let buttonStyles = this.props.buttonStyles;
 
 		if ( isAdded ) {
 			buttonContent = translate( '{{checkmark/}} In Cart', {
 				context: 'Domain is already added to shopping cart',
 				components: { checkmark: <Gridicon icon="checkmark" /> },
+			} );
+			ariaLabel = translate( 'Domain %(domainName)s is already in the shopping cart', {
+				args: { domainName: suggestion.domain_name },
+				context:
+					'Accessible label for domain that is already in the shopping cart. %(domainName)s is the domain name.',
 			} );
 
 			buttonStyles = { ...buttonStyles, primary: false };
@@ -182,15 +236,32 @@ class DomainRegistrationSuggestion extends Component {
 					context: 'Domain is already added to shopping cart',
 					components: { checkmark: <Gridicon style={ { height: 21 } } icon="checkmark" /> },
 				} );
+				ariaLabel = translate( 'Selected domain %(domainName)s', {
+					args: { domainName: suggestion.domain_name },
+					context:
+						'Accessible label for domain that is selected. %(domainName)s is the domain name.',
+				} );
 			}
 		} else {
-			buttonContent =
+			const shouldUpgrade =
 				! isSignupStep &&
-				shouldBundleDomainWithPlan( domainsWithPlansOnly, selectedSite, cart, suggestion )
-					? translate( 'Upgrade', {
-							context: 'Domain mapping suggestion button with plan upgrade',
-					  } )
-					: translate( 'Select', { context: 'Domain mapping suggestion button' } );
+				shouldBundleDomainWithPlan( domainsWithPlansOnly, selectedSite, cart, suggestion );
+
+			if ( shouldUpgrade ) {
+				buttonContent = translate( 'Upgrade', {
+					context: 'Domain mapping suggestion button with plan upgrade',
+				} );
+				ariaLabel = translate( 'Upgrade domain %(domainName)s', {
+					args: { domainName: suggestion.domain_name },
+					context:
+						'Accessible label for domain mapping suggestion button with plan upgrade. %(domainName)s is the domain name.',
+				} );
+			} else {
+				buttonContent = translate( 'Select', {
+					context: 'Domain mapping suggestion button',
+				} );
+				ariaLabel = this.getSelectDomainAriaLabel();
+			}
 		}
 
 		if ( premiumDomain?.pending ) {
@@ -200,10 +271,18 @@ class DomainRegistrationSuggestion extends Component {
 			buttonContent = translate( 'Restricted', {
 				context: 'Premium domain is not available for registration',
 			} );
+			ariaLabel = translate( 'Premium domain %(domainName)s is not available for registration', {
+				args: { domainName: suggestion.domain_name },
+				context: 'Accessible label for restricted premium domain',
+			} );
 		} else if ( this.isUnavailableDomain( suggestion.domain_name ) ) {
 			buttonStyles = { ...buttonStyles, disabled: true };
 			buttonContent = translate( 'Unavailable', {
 				context: 'Domain suggestion is not available for registration',
+			} );
+			ariaLabel = translate( 'Domain %(domainName)s is unavailable for registration', {
+				args: { domainName: suggestion.domain_name },
+				context: 'Accessible label for unavailable domain',
 			} );
 		} else if (
 			pendingCheckSuggestion?.domain_name === domain ||
@@ -225,6 +304,7 @@ class DomainRegistrationSuggestion extends Component {
 			buttonContent,
 			buttonStyles,
 			isAdded,
+			ariaLabel,
 		};
 	}
 

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -181,7 +181,7 @@ class DomainRegistrationSuggestion extends Component {
 					}
 				);
 			case 'UPGRADE_TO_HIGHER_PLAN_TO_BUY':
-				return translate( '%(baseLabel)s. Plan upgrade required', {
+				return translate( '%(baseLabel)s. Plan upgrade required to register this domain.', {
 					args: {
 						baseLabel,
 					},
@@ -335,7 +335,7 @@ class DomainRegistrationSuggestion extends Component {
 			buttonContent = translate( 'Unavailable', {
 				context: 'Domain suggestion is not available for registration',
 			} );
-			ariaLabel = translate( 'Domain %(domainName)s is unavailable for registration', {
+			ariaLabel = translate( 'Domain %(domainName)s is not available for registration', {
 				args: { domainName: suggestion.domain_name },
 				context: 'Accessible label for unavailable domain',
 			} );

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -153,6 +153,14 @@ class DomainRegistrationSuggestion extends Component {
 						'Accessible label for free domain with normal price. %(baseLabel)s is the base label (e.g. "Select domain testing.com"). %(price)s is the price.',
 				}
 			);
+		} else if ( priceRule === 'FREE_DOMAIN' && ! productCost ) {
+			return translate( '%(baseLabel)s. Free', {
+				args: {
+					baseLabel,
+				},
+				comment:
+					'Accessible label for free domain. %(baseLabel)s is the base label (e.g. "Select domain testing.com").',
+			} );
 		} else if ( productSaleCost && productCost ) {
 			return translate(
 				'%(baseLabel)s. %(salePrice)s for the first year, then %(price)s per year',

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -276,10 +276,10 @@ class DomainRegistrationSuggestion extends Component {
 				context: 'Domain is already added to shopping cart',
 				components: { checkmark: <Gridicon icon="checkmark" /> },
 			} );
-			ariaLabel = translate( 'Domain %(domainName)s is already in the shopping cart', {
+			ariaLabel = translate( 'Domain %(domainName)s is already added to shopping cart', {
 				args: { domainName: suggestion.domain_name },
 				context:
-					'Accessible label for domain that is already in the shopping cart. %(domainName)s is the domain name.',
+					'Accessible label for domain that is already added to shopping cart. %(domainName)s is the domain name.',
 			} );
 
 			buttonStyles = { ...buttonStyles, primary: false };
@@ -306,7 +306,7 @@ class DomainRegistrationSuggestion extends Component {
 				buttonContent = translate( 'Upgrade', {
 					context: 'Domain mapping suggestion button with plan upgrade',
 				} );
-				ariaLabel = translate( 'Upgrade domain %(domainName)s', {
+				ariaLabel = translate( 'Upgrade plan to add domain %(domainName)s', {
 					args: { domainName: suggestion.domain_name },
 					context:
 						'Accessible label for domain mapping suggestion button with plan upgrade. %(domainName)s is the domain name.',

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -141,7 +141,16 @@ class DomainRegistrationSuggestion extends Component {
 			context: 'Accessible label for domain selection button. %(domainName)s is the domain name.',
 		} );
 
-		if ( ( priceRule === 'FREE_DOMAIN' || priceRule === 'FREE_WITH_PLAN' ) && productCost ) {
+		if ( priceRule === 'ONE_TIME_PRICE' ) {
+			return translate( '%(baseLabel)s. %(price)s one-time', {
+				args: {
+					baseLabel,
+					price: productCost,
+				},
+				comment:
+					'Accessible label for one-time priced domain (e.g. domain with 100-year plan). %(baseLabel)s is the base label (e.g. "Select domain testing.com"). %(price)s is the price.',
+			} );
+		} else if ( priceRule === 'FREE_WITH_PLAN' && productCost ) {
 			return translate(
 				'%(baseLabel)s. Free for the first year with annual paid plans, then %(price)s per year',
 				{
@@ -153,7 +162,7 @@ class DomainRegistrationSuggestion extends Component {
 						'Accessible label for free domain with normal price. %(baseLabel)s is the base label (e.g. "Select domain testing.com"). %(price)s is the price.',
 				}
 			);
-		} else if ( priceRule === 'FREE_DOMAIN' && ! productCost ) {
+		} else if ( priceRule === 'FREE_DOMAIN' ) {
 			return translate( '%(baseLabel)s. Free', {
 				args: {
 					baseLabel,

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -141,60 +141,80 @@ class DomainRegistrationSuggestion extends Component {
 			context: 'Accessible label for domain selection button. %(domainName)s is the domain name.',
 		} );
 
-		if ( priceRule === 'ONE_TIME_PRICE' ) {
-			return translate( '%(baseLabel)s. %(price)s one-time', {
-				args: {
-					baseLabel,
-					price: productCost,
-				},
-				comment:
-					'Accessible label for one-time priced domain (e.g. domain with 100-year plan). %(baseLabel)s is the base label (e.g. "Select domain testing.com"). %(price)s is the price.',
-			} );
-		} else if ( priceRule === 'FREE_WITH_PLAN' && productCost ) {
-			return translate(
-				'%(baseLabel)s. Free for the first year with annual paid plans, then %(price)s per year',
-				{
+		switch ( priceRule ) {
+			case 'ONE_TIME_PRICE':
+				return translate( '%(baseLabel)s. %(price)s one-time', {
 					args: {
 						baseLabel,
 						price: productCost,
 					},
 					comment:
-						'Accessible label for free domain with normal price. %(baseLabel)s is the base label (e.g. "Select domain testing.com"). %(price)s is the price.',
-				}
-			);
-		} else if ( priceRule === 'FREE_DOMAIN' ) {
-			return translate( '%(baseLabel)s. Free', {
-				args: {
-					baseLabel,
-				},
-				comment:
-					'Accessible label for free domain. %(baseLabel)s is the base label (e.g. "Select domain testing.com").',
-			} );
-		} else if ( productSaleCost && productCost ) {
-			return translate(
-				'%(baseLabel)s. %(salePrice)s for the first year, then %(price)s per year',
-				{
+						'Accessible label for one-time priced domain (e.g. domain with 100-year plan). %(baseLabel)s is the base label (e.g. "Select domain testing.com"). %(price)s is the price.',
+				} );
+			case 'FREE_DOMAIN':
+				return translate( '%(baseLabel)s. Free', {
 					args: {
 						baseLabel,
-						salePrice: productSaleCost,
-						price: productCost,
 					},
 					comment:
-						'Accessible label for domain with sale price. %(baseLabel)s is the base label (e.g. "Select domain testing.com"). %(salePrice)s is the sale price. %(price)s is the price.',
+						'Accessible label for free domain. %(baseLabel)s is the base label (e.g. "Select domain testing.com").',
+				} );
+			case 'FREE_WITH_PLAN':
+				return translate(
+					'%(baseLabel)s. Free for the first year with annual paid plans, then %(price)s per year',
+					{
+						args: {
+							baseLabel,
+							price: productCost,
+						},
+						comment:
+							'Accessible label for free domain with normal price. %(baseLabel)s is the base label (e.g. "Select domain testing.com"). %(price)s is the price.',
+					}
+				);
+			case 'UPGRADE_TO_HIGHER_PLAN_TO_BUY':
+				return translate( '%(baseLabel)s. Plan upgrade required', {
+					args: {
+						baseLabel,
+					},
+					comment:
+						'Accessible label for domain that requires a plan upgrade. %(baseLabel)s is the base label (e.g. "Select domain testing.com").',
+				} );
+			case 'INCLUDED_IN_HIGHER_PLAN':
+				return translate( '%(baseLabel)s. Included in paid plans', {
+					args: {
+						baseLabel,
+					},
+					comment:
+						'Accessible label for domain included in higher plans. %(baseLabel)s is the base label (e.g. "Select domain testing.com").',
+				} );
+			case 'PRICE':
+				if ( productSaleCost && productCost ) {
+					return translate(
+						'%(baseLabel)s. %(salePrice)s for the first year, then %(price)s per year',
+						{
+							args: {
+								baseLabel,
+								salePrice: productSaleCost,
+								price: productCost,
+							},
+							comment:
+								'Accessible label for domain with sale price. %(baseLabel)s is the base label (e.g. "Select domain testing.com"). %(salePrice)s is the sale price. %(price)s is the price.',
+						}
+					);
+				} else if ( productCost ) {
+					return translate( '%(baseLabel)s. %(price)s per year', {
+						args: {
+							baseLabel,
+							price: productCost,
+						},
+						comment:
+							'Accessible label for regularly priced domain. %(baseLabel)s is the base label (e.g. "Select domain testing.com"). %(price)s is the price.',
+					} );
 				}
-			);
-		} else if ( productCost ) {
-			return translate( '%(baseLabel)s. %(price)s per year', {
-				args: {
-					baseLabel,
-					price: productCost,
-				},
-				comment:
-					'Accessible label for regularly priced domain. %(baseLabel)s is the base label (e.g. "Select domain testing.com"). %(price)s is the price.',
-			} );
+				break;
+			default:
+				return baseLabel;
 		}
-
-		return baseLabel;
 	}
 
 	getButtonProps() {

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -219,7 +219,8 @@ class DomainRegistrationSuggestion extends Component {
 								'Accessible label for domain with sale price. %(baseLabel)s is the base label (e.g. "Select domain testing.com"). %(salePrice)s is the sale price. %(price)s is the price.',
 						}
 					);
-				} else if ( productCost ) {
+				}
+				if ( productCost ) {
 					return translate( '%(baseLabel)s. %(price)s per year', {
 						args: {
 							baseLabel,

--- a/client/components/domains/domain-skip-suggestion/index.jsx
+++ b/client/components/domains/domain-skip-suggestion/index.jsx
@@ -21,6 +21,7 @@ class DomainSkipSuggestion extends Component {
 				hidePrice
 				onButtonClick={ this.props.onButtonClick }
 				showChevron={ false }
+				ariaLabel={ buttonContent }
 				// tracksButtonClickSource={ this.props.tracksButtonClickSource }
 			>
 				<div className="domain-skip-suggestion__domain-description">

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -21,74 +21,12 @@ class DomainSuggestion extends Component {
 		hidePrice: PropTypes.bool,
 		showChevron: PropTypes.bool,
 		isAdded: PropTypes.bool,
+		ariaLabel: PropTypes.string,
 	};
 
 	static defaultProps = {
 		showChevron: false,
 	};
-
-	getAccessibleButtonLabel() {
-		const { buttonContent, domain, translate, price, salePrice, priceRule } = this.props;
-		let actionText = '';
-
-		if ( typeof buttonContent === 'string' ) {
-			actionText = buttonContent;
-		} else if ( typeof buttonContent?.props?.children === 'string' ) {
-			actionText = buttonContent.props.children;
-		} else if ( Array.isArray( buttonContent?.props?.children ) ) {
-			actionText = buttonContent.props.children.reduce( ( acc, item ) => {
-				return typeof item === 'string' ? acc + item : acc;
-			}, '' );
-		}
-
-		if ( ! domain ) {
-			return actionText;
-		}
-
-		const baseLabel = translate( '%(action)s domain %(domain)s', {
-			args: {
-				action: actionText,
-				domain,
-			},
-			comment:
-				'Accessible label for domain selection button. %(action)s is the button action (Select, Selected, Upgrade, etc), %(domain)s is the domain name',
-		} );
-
-		if ( ( priceRule === 'FREE_DOMAIN' || priceRule === 'FREE_WITH_PLAN' ) && price ) {
-			return translate(
-				'%(baseLabel)s. Free for the first year with annual paid plans, then %(price)s per year',
-				{
-					args: {
-						baseLabel,
-						price,
-					},
-					comment: 'Accessible label for free domain with normal price',
-				}
-			);
-		} else if ( salePrice && price ) {
-			return translate(
-				'%(baseLabel)s. %(salePrice)s for the first year, then %(price)s per year',
-				{
-					args: {
-						baseLabel,
-						salePrice,
-						price,
-					},
-					comment: 'Accessible label for domain with sale price',
-				}
-			);
-		} else if ( price ) {
-			return translate( '%(baseLabel)s. %(price)s per year', {
-				args: {
-					baseLabel,
-					price,
-				},
-				comment: 'Accessible label for regularly priced domain',
-			} );
-		}
-
-		return baseLabel;
-	}
 
 	renderPrice() {
 		const {
@@ -123,8 +61,15 @@ class DomainSuggestion extends Component {
 	}
 
 	render() {
-		const { children, extraClasses, isAdded, isFeatured, showStrikedOutPrice, hideMatchReasons } =
-			this.props;
+		const {
+			children,
+			extraClasses,
+			isAdded,
+			isFeatured,
+			showStrikedOutPrice,
+			hideMatchReasons,
+			ariaLabel,
+		} = this.props;
 		const classes = clsx(
 			'domain-suggestion',
 			'card',
@@ -160,7 +105,7 @@ class DomainSuggestion extends Component {
 								this.props.onButtonClick( isAdded );
 							} }
 							data-tracks-button-click-source={ this.props.tracksButtonClickSource }
-							aria-label={ this.getAccessibleButtonLabel() }
+							aria-label={ ariaLabel }
 							{ ...this.props.buttonStyles }
 						>
 							{ this.props.buttonContent }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DOTCOM-13261
Related to https://github.com/Automattic/wp-calypso/pull/103751

## Proposed Changes

We have received feedback from our translators that some of the aria-label strings introduced in https://github.com/Automattic/wp-calypso/pull/103751 are not easily translatable to certain languages. The aim of this PR is to address those issues and also improve the way we generate aria-labels for the "Select Domain" step in general.

* improve aria-labels logic for "Select Domain" step; we won't be extracting them from `buttonContent` prop anymore
* refactor the code to allow proper translations into certain languages 

![Markup on 2025-05-27 at 15:48:05](https://github.com/user-attachments/assets/e388de18-cf17-422b-ae40-612c17318707)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* DOTCOM-13261

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start` or use Calypso Live.
2. Head over to the Domain Select step at http://calypso.localhost:3000/start/domain/domain-only.
3. Enable VoiceOver.
4. Try to search for a domain and then tab through the page. Focus on the `Select` buttons and listen to the announcements.
5. Try to select the domain by pressing `Control` + `Option` + `Space`. The announcement should be read again, but now with updated action, i.e.: `Select` → `Selected` (without pricing information). 

It can be tricky to test all the possible cases that a suggested domain be in. However, I built the aria-labels also based on the existing logic in `client/components/domains/domain-product-price/index.jsx`: (fbhepr%2Skers%2Spnylcfb%2Spyvrag%2Spbzcbaragf%2Sqbznvaf%2Sqbznva%2Qcebqhpg%2Qcevpr%2Svaqrk.wfk%3Se%3Q78p63339%26zb%3Q6988%26sv%3Q241%23241%2Q257-og).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?