### PR TITLE
Stats: Tweak Navigation Header title text

### DIFF
--- a/client/components/navigation-header/navigation-header.scss
+++ b/client/components/navigation-header/navigation-header.scss
@@ -19,7 +19,6 @@
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
-		height: 32px;
 		padding-bottom: 24px;
 	}
 
@@ -31,6 +30,7 @@
 	&__right-section {
 		display: flex;
 		align-items: center;
+		margin-left: 12px;
 
 		.components-button {
 			height: 32px;
@@ -68,8 +68,8 @@
 		display: flex;
 		align-items: center;
 		gap: 12px;
-		line-height: 1;
-		height: 32px;
+		line-height: 1.2;
+		min-height: 32px;
 
 		@media (max-width: $break-small) {
 			font-size: 20px;

--- a/client/components/navigation-header/navigation-header.tsx
+++ b/client/components/navigation-header/navigation-header.tsx
@@ -82,10 +82,8 @@ const NavigationHeader: React.FC< HeaderProps > = ( {
 					{ titleProps.titleLogo }
 				</span>
 			) }
-			{ titleProps?.title && titleProps?.titleLogo ? (
+			{ titleProps?.title && (
 				<span className="calypso-navigation-header__title-text">{ titleProps?.title }</span>
-			) : (
-				titleProps?.title
 			) }
 		</h1>
 	);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Tweak the title layout to display multiple lines of text.

|Before|After|
|-|-|
|<img width="506" alt="截圖 2025-05-29 晚上10 22 32" src="https://github.com/user-attachments/assets/01e00c7d-8ef1-4740-bdd1-4baef1460654" />|<img width="495" alt="截圖 2025-05-29 晚上10 25 01" src="https://github.com/user-attachments/assets/89e44031-ed02-428b-8ab2-291e1e423f77" />|

|Before|After|
|-|-|
|<img width="499" alt="截圖 2025-05-29 晚上10 22 48" src="https://github.com/user-attachments/assets/885c4f5e-afed-4f71-a4e3-ab3b86e826c4" />|<img width="486" alt="截圖 2025-05-29 晚上10 19 13" src="https://github.com/user-attachments/assets/2b59bc57-2a16-4f94-a683-4d6d1ab47d2f" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigat to Stats > Traffic page.
* Go to the Post Details page with a long title post.
* Ensure the Navigation Header title layout works well for multiple lines.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
