### PR TITLE
Stats: Replace NavigationHeader on the Stats purchase page

### DIFF
--- a/client/my-sites/stats/pages/purchase/index.tsx
+++ b/client/my-sites/stats/pages/purchase/index.tsx
@@ -6,16 +6,14 @@ import {
 import page from '@automattic/calypso-router';
 import { ProductsList } from '@automattic/data-stores';
 import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
-import InlineSupportLink from 'calypso/components/inline-support-link';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
-import NavigationHeader from 'calypso/components/navigation-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import PageHeader from 'calypso/my-sites/stats/components/headers/page-header';
 import Main from 'calypso/my-sites/stats/components/stats-main';
 import { STATS_PRODUCT_NAME } from 'calypso/my-sites/stats/constants';
 import { useSelector } from 'calypso/state';
@@ -39,8 +37,6 @@ const StatsPurchasePage = ( {
 }: {
 	query: { redirect_uri: string; from: string; productType: 'commercial' | 'personal' };
 } ) => {
-	const translate = useTranslate();
-
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
@@ -177,19 +173,7 @@ const StatsPurchasePage = ( {
 				{ /** Only show the navigation header on force redirections and site has no plans */ }
 				{ ! isLoading && ! hasAnyPlan && query.from?.startsWith( 'cmp-red' ) && (
 					<>
-						<NavigationHeader
-							className="stats__section-header modernized-header"
-							title={ STATS_PRODUCT_NAME }
-							subtitle={ translate(
-								"Gain insights into the activity and behavior of your site's visitors. {{learnMoreLink}}Learn more{{/learnMoreLink}}",
-								{
-									components: {
-										learnMoreLink: <InlineSupportLink supportContext="stats" showIcon={ false } />,
-									},
-								}
-							) }
-							navigationItems={ [] }
-						></NavigationHeader>
+						<PageHeader />
 						<StatsNavigation
 							selectedItem="traffic"
 							interval="day"


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Replace NavigationHeader with the improved one on the Stats purchase page.

|Before|After|
|-|-|
|<img width="815" alt="截圖 2025-05-29 晚上10 44 36" src="https://github.com/user-attachments/assets/2d3c09cf-c01e-4532-80c7-2a4fdbf654e4" />|<img width="800" alt="截圖 2025-05-29 晚上10 44 26" src="https://github.com/user-attachments/assets/4e854e78-6b19-42ee-a1e4-56bd6362c5e9" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change with the Calypso Live branch.
* Navigate to Stats > Purchase page with the query parameter: `from=cmp-red`.
* Ensure the Navigation Header is replaced with the improved one.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
