### PR TITLE
Backup: fix title buttons

### DIFF
--- a/client/components/jetpack/backup-actions-toolbar/style.scss
+++ b/client/components/jetpack/backup-actions-toolbar/style.scss
@@ -7,7 +7,7 @@
 	flex-direction: column-reverse;
 
 	@include break-small {
-		flex-direction: row;
+		flex-direction: column;
 	}
 
 	a {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/BACKUP-76.

This PR is a follow-up for #103790, which used a different approach.

## Proposed Changes

Fixes the `Copy site`/`Back up now` buttons for languages other than English.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Translations should also have their buttons presented in a clear, well-aligned way.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Access the `Jetpack Cloud live` link provided by GitHub Actions below.
- Log in with your Jetpack Cloud credentials and select a site.
- Go to `VaultPress Backup` in the left menu. The buttons are shown in this page.
- Try different languages at https://wordpress.com/me/account and check how they look like.

### Before

These screenshots illustrate the current form, before the fixes are applied:

#### English

![image](https://github.com/user-attachments/assets/7e5056f4-1053-42a2-9488-88419138a1c1)

#### Spanish

![image](https://github.com/user-attachments/assets/b17c0bae-eb8e-455d-a766-78d264a6a358)

---

### After

These screenshots show how it will look like, with different terms, after the fixes are applied:

#### English

![image](https://github.com/user-attachments/assets/e05b53b2-5fde-497f-8a3f-c2409d4aeb3f)

#### Spanish

![image](https://github.com/user-attachments/assets/8c972dbf-f92e-4832-a400-65d84bc36eb2)

#### Spanish, short term

![image](https://github.com/user-attachments/assets/cf7fbe55-0581-4e85-8dd4-198ab1b3d5aa)

#### Spanish, even shorter term

![image](https://github.com/user-attachments/assets/eabfce0b-fadb-4493-88e7-de561a82031b)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
