### PR TITLE
SummaryButtonList: Fix cliped focus ring while hovering over adjacent elements

### DIFF
--- a/client/dashboard/components/summary-button-list/style.scss
+++ b/client/dashboard/components/summary-button-list/style.scss
@@ -43,7 +43,7 @@
 		}
 
 		// Ensure focused elements appear above adjacent hovered elements.
-		.dashboard-summary-button-list__children-list-item > *:focus {
+		.dashboard-summary-button-list__children-list-item:has( *:focus, *:focus-visible ) {
 			position: relative;
 			z-index: 1;
 		}

--- a/client/dashboard/components/summary-button-list/style.scss
+++ b/client/dashboard/components/summary-button-list/style.scss
@@ -41,5 +41,11 @@
 			border-bottom-left-radius: inherit;
 			border-bottom-right-radius: inherit;
 		}
+
+		// Ensure focused elements appear above adjacent hovered elements.
+		.dashboard-summary-button-list__children-list-item > *:focus {
+			position: relative;
+			z-index: 1;
+		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Follow up of: https://github.com/Automattic/wp-calypso/pull/103555


>When the item is active and hover the next item, the styles look weird

Found by @arthur791004  ([comment](https://github.com/Automattic/wp-calypso/pull/103555#issuecomment-2919163995)).


## Testing Instructions
1. In the new dashboard go to a site's settings
2. Focus an item of the SummaryButtonList
3. hover over an adjacent element
4. The focus ring should not be clipped.


|Before|After|
|-|-|
|<img width="620" alt="Screenshot 2025-05-29 at 6 25 59 PM" src="https://github.com/user-attachments/assets/0f1741bd-d9fc-4446-a70d-a483c2d9697e" />|<img width="620" alt="Screenshot 2025-05-29 at 6 26 27 PM" src="https://github.com/user-attachments/assets/b884f0bc-8a1f-43f8-b273-de0becbbbef5" />|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
