### PR TITLE
Revert "fix(deps): update dependency tracekit to ^0.4.7"

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -210,7 +210,7 @@
 		"supertest": "^7.1.1",
 		"textarea-caret": "^3.1.0",
 		"to-title-case": "^1.0.0",
-		"tracekit": "^0.4.7",
+		"tracekit": "^0.4.5",
 		"twemoji": "^12.1.6",
 		"ua-parser-js": "^0.7.22",
 		"uplot": "^1.6.32",

--- a/renovate.json5
+++ b/renovate.json5
@@ -77,7 +77,14 @@
 			enabled: false,
 		},
 	],
-	ignoreDeps: [ 'electron-builder' ],
+	ignoreDeps: [
+		'electron-builder',
+
+		// The current latest version of TraceKit (0.4.7) creates a lot of noise due to mishandling
+		// of nullish unhandled rejected promise values.
+		// See: https://github.com/csnover/TraceKit/issues/86
+		'tracekit',
+	],
 	regexManagers: [
 		// Update the renovate-version in the action itself.
 		// See also https://github.com/renovatebot/github-action/issues/756

--- a/yarn.lock
+++ b/yarn.lock
@@ -14730,7 +14730,7 @@ __metadata:
     supertest: "npm:^7.1.1"
     textarea-caret: "npm:^3.1.0"
     to-title-case: "npm:^1.0.0"
-    tracekit: "npm:^0.4.7"
+    tracekit: "npm:^0.4.5"
     twemoji: "npm:^12.1.6"
     ua-parser-js: "npm:^0.7.22"
     uplot: "npm:^1.6.32"
@@ -35177,10 +35177,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tracekit@npm:^0.4.7":
-  version: 0.4.7
-  resolution: "tracekit@npm:0.4.7"
-  checksum: ce912e1054ac5c72b519f979ea0be57cf1bbce206165b7f6a34038cf1c172ec8a5217e5fbaa86d96cc06e191734e3ce7a1ca24a896d6dd20378bdca11e7f01f2
+"tracekit@npm:^0.4.5":
+  version: 0.4.5
+  resolution: "tracekit@npm:0.4.5"
+  checksum: 4c9bd11d34a517d1cf10c1fc5e1a2af7c350271e814a1227b86038cdc11a119f0bad10b2b134edb0c3349bc73570eff95a07caf90184028a191d070f9aad3266
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#103687

Adds `renovate.json5` configuration to exclude future dependency updates.

See:

- #103508
- p1747415780359109-slack-C02DQP0FP