### PR TITLE
Accessibility: Update disabled text color from `Gray 10` to `Gray 50` for better contrast in checkout

### DIFF
--- a/packages/composite-checkout/src/lib/theme.ts
+++ b/packages/composite-checkout/src/lib/theme.ts
@@ -81,7 +81,7 @@ const theme: Theme = {
 		textColor: colorStudio.colors[ 'Gray 60' ],
 		textColorLight: colorStudio.colors[ 'Gray 50' ],
 		textColorDark: colorStudio.colors[ 'Gray 100' ],
-		textColorDisabled: colorStudio.colors[ 'Gray 10' ],
+		textColorDisabled: colorStudio.colors[ 'Gray 50' ],
 		error: swatches.red50,
 		warningBackground: swatches.red0,
 		outline: colorStudio.colors[ 'WordPress Blue 30' ],


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTCOM-13280

## Proposed Changes

* update disabled text color from Gray 10 to Gray 50

| Before | After |
|--------|--------|
| ![Markup on 2025-05-29 at 18:28:25](https://github.com/user-attachments/assets/4765a591-878d-4c19-af9c-7a861e3eda92) | ![Markup on 2025-05-29 at 18:26:50](https://github.com/user-attachments/assets/2989bbbc-ba26-49ba-8b8d-ec70e7f6e7f4) | 

> [!NOTE]
> I have tried a bit lighter shade of gray than 50, but it already triggered the contrast error

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* a55edfa4e3bf-linear-project

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out the PR brach and build it with `yarn start` (or use Calypso Live).
* Add any product to your cart and head over to the checkout page.
* Click on the "Edit" button by your contact details.
* Look at the "Pick a payment method" heading below. It should be in darker gray color.
* If you install the axe DevTools extension (https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd) and scan the checkout page, the following contrast issue shoulln't be there anymore:

![Markup on 2025-05-29 at 18:23:21](https://github.com/user-attachments/assets/2f0b1a08-d754-446a-a69d-3afaf36fbd81)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?