### PR TITLE
Newsletter: Update "Set Up" button on Paid Newsletter settings to be dynamic

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/PaidNewsletterSection.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/PaidNewsletterSection.tsx
@@ -1,11 +1,17 @@
-import { Button, Card } from '@automattic/components';
+import { Card } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelectedSiteSelector } from 'calypso/state/sites/hooks';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 
-export const PaidNewsletterSection = () => {
+interface PaidNewsletterSectionProps {
+	newsletterHasActivePlan?: boolean;
+}
+
+export const PaidNewsletterSection = ( props: PaidNewsletterSectionProps ): JSX.Element => {
+	const { newsletterHasActivePlan } = props;
 	const translate = useTranslate();
 	const siteSlug = useSelectedSiteSelector( getSiteSlug );
 
@@ -15,8 +21,12 @@ export const PaidNewsletterSection = () => {
 
 	return (
 		<Card className="site-settings__card">
-			<Button href={ `/earn/payments/${ siteSlug }` } onClick={ onSetUpButtonClick }>
-				{ translate( 'Set up' ) }
+			<Button
+				variant="secondary"
+				href={ `/earn/payments/${ siteSlug }` }
+				onClick={ onSetUpButtonClick }
+			>
+				{ newsletterHasActivePlan ? translate( 'Manage Plans' ) : translate( 'Add Plans' ) }
 			</Button>
 			<FormSettingExplanation>
 				{ translate(

--- a/client/my-sites/site-settings/settings-newsletter/PaidNewsletterSection.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/PaidNewsletterSection.tsx
@@ -1,6 +1,6 @@
 import { Card } from '@automattic/components';
 import { Button } from '@wordpress/components';
-import { useTranslate } from 'i18n-calypso';
+import { fixMe, useTranslate } from 'i18n-calypso';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelectedSiteSelector } from 'calypso/state/sites/hooks';
@@ -26,7 +26,13 @@ export const PaidNewsletterSection = ( props: PaidNewsletterSectionProps ): JSX.
 				href={ `/earn/payments/${ siteSlug }` }
 				onClick={ onSetUpButtonClick }
 			>
-				{ newsletterHasActivePlan ? translate( 'Manage Plans' ) : translate( 'Add Plans' ) }
+				{ newsletterHasActivePlan
+					? translate( 'Manage Plans' )
+					: fixMe( {
+							text: 'Add Plans',
+							newCopy: translate( 'Add Plans' ),
+							oldCopy: translate( 'Set up' ),
+					  } ) }
 			</Button>
 			<FormSettingExplanation>
 				{ translate(

--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -44,6 +44,7 @@ type Fields = {
 	wpcom_newsletter_categories?: number[];
 	wpcom_newsletter_categories_enabled?: boolean;
 	wpcom_subscription_emails_use_excerpt?: boolean;
+	newsletter_has_active_plan?: boolean;
 	jetpack_subscriptions_reply_to?: string;
 	jetpack_subscriptions_from_name?: string;
 	sm_enabled?: boolean;
@@ -70,6 +71,7 @@ const getFormSettings = ( settings?: Fields ) => {
 		wpcom_newsletter_categories,
 		wpcom_newsletter_categories_enabled,
 		wpcom_subscription_emails_use_excerpt,
+		newsletter_has_active_plan,
 		jetpack_subscriptions_reply_to,
 		jetpack_subscriptions_from_name,
 		sm_enabled,
@@ -91,6 +93,7 @@ const getFormSettings = ( settings?: Fields ) => {
 		wpcom_newsletter_categories: wpcom_newsletter_categories || [],
 		wpcom_newsletter_categories_enabled: !! wpcom_newsletter_categories_enabled,
 		wpcom_subscription_emails_use_excerpt: !! wpcom_subscription_emails_use_excerpt,
+		newsletter_has_active_plan,
 		jetpack_subscriptions_reply_to: jetpack_subscriptions_reply_to || '',
 		jetpack_subscriptions_from_name: jetpack_subscriptions_from_name || '',
 		sm_enabled: !! sm_enabled,
@@ -265,7 +268,7 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 				id="paid-newsletter"
 				title={ translate( 'Paid Newsletter' ) }
 			/>
-			<PaidNewsletterSection />
+			<PaidNewsletterSection newsletterHasActivePlan={ fields.newsletter_has_active_plan } />
 			<SettingsSectionHeader
 				disabled={ disabled }
 				id="email-settings"


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [CML-512](https://linear.app/a8c/issue/CML-512/paid-newsletter-setting-says-set-up-when-it-already-exists)

## Proposed Changes

On "Jetpack > Settings > Newsletter > Paid Newsletter" section update the currently present static "Set Up" button to show text "Add Plans" / "Manage Plans" depending on the plans configuration.

| Before | After |
| -------|------| 
| ![image](https://github.com/user-attachments/assets/01e000c1-881d-4f34-adec-9dc0abd35c8d) |  ![image](https://github.com/user-attachments/assets/334a91b1-ec37-4bb1-ba15-b4b11a7d3c0e) |
| ![image](https://github.com/user-attachments/assets/01e000c1-881d-4f34-adec-9dc0abd35c8d) |  ![image](https://github.com/user-attachments/assets/b5fb79d5-e992-422a-89c5-bba908df718d) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Currently we have static text in Settings which is confusing for users if they have plans configured already.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout related Jetpack change on sandbox if not already deployed (https://github.com/Automattic/jetpack/pull/43694)
1. Go to the site that doesn't have any active newsletter plans ( Example: `/settings/newsletter/mehmoodak2.wordpress.com`).
1. Verify the "Set Up" button is now showing "Add Plans".
1. Go to the site that have active newsletter plans. (Example: `/settings/newsletter/loopsimple.wordpress.com`).
1. Verify the "Set Up" button is now showing "Manage Plans".

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
