### PR TITLE
Update proper value for autocomplete attribute on checkout screen for contact section

### DIFF
--- a/client/my-sites/checkout/src/components/tax-fields.tsx
+++ b/client/my-sites/checkout/src/components/tax-fields.tsx
@@ -142,7 +142,7 @@ export default function TaxFields( {
 						)
 					);
 				} }
-				autoComplete={ section + ' postal-code' }
+				autoComplete={ `section-${ section } postal-code` }
 				isError={ postalCode?.isTouched && ! isValid( postalCode ) }
 				errorMessage={
 					postalCode?.errors?.[ 0 ] ?? String( translate( 'This field is required.' ) )

--- a/client/my-sites/checkout/src/components/tax-fields.tsx
+++ b/client/my-sites/checkout/src/components/tax-fields.tsx
@@ -174,7 +174,7 @@ export default function TaxFields( {
 						)
 					);
 				} }
-				autoComplete={ section + ' city' }
+				autoComplete={ `section-${ section } city` }
 				isError={ city?.isTouched && ! isValid( city ) }
 				errorMessage={ city?.errors?.[ 0 ] ?? String( translate( 'This field is required.' ) ) }
 			/>
@@ -231,7 +231,7 @@ export default function TaxFields( {
 						)
 					);
 				} }
-				autoComplete="organization"
+				autoComplete={ `section-${ section } organization` }
 			/>
 		);
 	}
@@ -259,7 +259,7 @@ export default function TaxFields( {
 						)
 					);
 				} }
-				autoComplete="address"
+				autoComplete={ `section-${ section } street-address` }
 			/>
 		);
 	}

--- a/client/my-sites/checkout/src/components/vat-form/index.tsx
+++ b/client/my-sites/checkout/src/components/vat-form/index.tsx
@@ -261,7 +261,7 @@ export function VatForm( {
 						} )
 					}
 					value={ vatDetailsInForm.address ?? '' }
-					autoComplete="address"
+					autoComplete={ `section-${ section } street-address` }
 					disabled={ isDisabled }
 					onChange={ ( newValue: string ) => {
 						setVatDetailsInForm( {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-13279

## Proposed Changes

* Adjusted `autocomplete` attribute in postal code input

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The autocomplete attribute is incorrectly formatted. We need to change the value to autocomplete="section-contact postal-code" or simply autocomplete="postal-code". According to the standard, section-* is the optional prefix for grouping related fields.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn start`
* Add a new site, choose any domain and paid plan
* On the billing page, check if the postal code attribute has the correct `autocomplete` attribute
* Confirm the error is no longer reported in axe DevTools

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
