### PR TITLE
Dashboard v2: Implement Settings -> Caching

### DIFF
--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -26,6 +26,10 @@ import {
 	fetchPrimaryDataCenter,
 	fetchStaticFile404,
 	updateStaticFile404,
+	clearObjectCache,
+	clearEdgeCache,
+	fetchEdgeCacheStatus,
+	updateEdgeCacheStatus,
 	fetchEdgeCacheDefensiveMode,
 	updateEdgeCacheDefensiveMode,
 	fetchPurchases,
@@ -295,6 +299,36 @@ export function agencyBlogQuery( siteId: string ) {
 		queryKey: [ 'site', siteId, 'agency-blog' ],
 		queryFn: () => {
 			return fetchAgencyBlogBySiteId( siteId );
+		},
+	};
+}
+
+export function siteObjectCacheClearMutation( siteSlug: string ) {
+	return {
+		mutationFn: ( reason: string ) => clearObjectCache( siteSlug, reason ),
+	};
+}
+
+export function siteEdgeCacheClearMutation( siteSlug: string ) {
+	return {
+		mutationFn: () => clearEdgeCache( siteSlug ),
+	};
+}
+
+export function siteEdgeCacheStatusQuery( siteSlug: string ) {
+	return {
+		queryKey: [ 'site', siteSlug, 'edge-cache-status' ],
+		queryFn: () => {
+			return fetchEdgeCacheStatus( siteSlug );
+		},
+	};
+}
+
+export function siteEdgeCacheStatusMutation( siteSlug: string ) {
+	return {
+		mutationFn: ( active: boolean ) => updateEdgeCacheStatus( siteSlug, active ),
+		onSuccess: ( active: boolean ) => {
+			queryClient.setQueryData( [ 'site', siteSlug, 'edge-cache-status' ], active );
 		},
 	};
 }

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -522,6 +522,43 @@ export const updateStaticFile404 = async (
 	);
 };
 
+export const clearObjectCache = async ( siteIdOrSlug: string, reason: string ): Promise< void > => {
+	return wpcom.req.post(
+		{
+			path: `/sites/${ siteIdOrSlug }/hosting/clear-cache`,
+			apiNamespace: 'wpcom/v2',
+		},
+		{ reason }
+	);
+};
+
+export const fetchEdgeCacheStatus = async ( siteIdOrSlug: string ): Promise< boolean > => {
+	return wpcom.req.get( {
+		path: `/sites/${ siteIdOrSlug }/hosting/edge-cache/active`,
+		apiNamespace: 'wpcom/v2',
+	} );
+};
+
+export const updateEdgeCacheStatus = async (
+	siteIdOrSlug: string,
+	active: boolean
+): Promise< boolean > => {
+	return wpcom.req.post(
+		{
+			path: `/sites/${ siteIdOrSlug }/hosting/edge-cache/active`,
+			apiNamespace: 'wpcom/v2',
+		},
+		{ active }
+	);
+};
+
+export const clearEdgeCache = async ( siteIdOrSlug: string ): Promise< void > => {
+	return wpcom.req.post( {
+		path: `/sites/${ siteIdOrSlug }/hosting/edge-cache/purge`,
+		apiNamespace: 'wpcom/v2',
+	} );
+};
+
 export const fetchEdgeCacheDefensiveMode = async (
 	siteIdOrSlug: string
 ): Promise< DefensiveModeSettings > => {

--- a/client/dashboard/sites/settings-caching/index.tsx
+++ b/client/dashboard/sites/settings-caching/index.tsx
@@ -1,0 +1,238 @@
+import { DataForm } from '@automattic/dataviews';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import {
+	Card,
+	CardBody,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Button,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useEffect, useState } from 'react';
+import {
+	siteQuery,
+	siteEdgeCacheStatusQuery,
+	siteEdgeCacheStatusMutation,
+	siteEdgeCacheClearMutation,
+	siteObjectCacheClearMutation,
+} from '../../app/queries';
+import { ActionList } from '../../components/action-list';
+import PageLayout from '../../components/page-layout';
+import SettingsCallout from '../settings-callout';
+import SettingsPageHeader from '../settings-page-header';
+import type { Site } from '../../data/types';
+import type { Field } from '@automattic/dataviews';
+
+type CachingFormData = {
+	active: boolean;
+};
+
+const fields: Field< CachingFormData >[] = [
+	{
+		id: 'active',
+		label: __( 'Enable global edge caching for faster content delivery' ),
+		Edit: 'checkbox',
+	},
+];
+
+const form = {
+	type: 'regular' as const,
+	fields: [ 'active' ],
+};
+
+export function canUpdateCaching( site: Site ) {
+	return site.is_wpcom_atomic;
+}
+
+export default function CachingSettings( { siteSlug }: { siteSlug: string } ) {
+	const { data: site } = useQuery( siteQuery( siteSlug ) );
+	const canUpdate = site && canUpdateCaching( site );
+
+	const { data: isEdgeCacheActive } = useQuery( {
+		...siteEdgeCacheStatusQuery( siteSlug ),
+		enabled: canUpdate,
+	} );
+	const edgeCacheStatusMutation = useMutation( siteEdgeCacheStatusMutation( siteSlug ) );
+	const edgeCacheClearMutation = useMutation( siteEdgeCacheClearMutation( siteSlug ) );
+	const objectCacheClearMutation = useMutation( siteObjectCacheClearMutation( siteSlug ) );
+
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const [ formData, setFormData ] = useState< CachingFormData >( {
+		active: isEdgeCacheActive ?? false,
+	} );
+
+	const isDirty = isEdgeCacheActive !== formData.active;
+	const { isPending } = edgeCacheStatusMutation;
+
+	const handleUpdateEdgeCacheStatus = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		edgeCacheStatusMutation.mutate( formData.active, {
+			onSuccess: () => {
+				createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
+			},
+			onError: () => {
+				createErrorNotice( __( 'Failed to save settings.' ), { type: 'snackbar' } );
+			},
+		} );
+	};
+
+	const handleClearEdgeCache = () => {
+		edgeCacheClearMutation.mutate( undefined, {
+			onSuccess: () => {
+				createSuccessNotice( __( 'Edge cache cleared.' ), { type: 'snackbar' } );
+			},
+			onError: () => {
+				createErrorNotice( __( 'Failed to clear edge cache.' ), { type: 'snackbar' } );
+			},
+		} );
+	};
+
+	const handleClearObjectCache = () => {
+		objectCacheClearMutation.mutate( 'Manually clearing again.', {
+			onSuccess: () => {
+				createSuccessNotice( __( 'Object cache cleared.' ), { type: 'snackbar' } );
+			},
+			onError: () => {
+				createErrorNotice( __( 'Failed to clear object cache.' ), { type: 'snackbar' } );
+			},
+		} );
+	};
+
+	const [ isClearingAllCaches, setIsClearingAllCaches ] = useState( false );
+
+	useEffect( () => {
+		if ( ! edgeCacheClearMutation.isPending && ! objectCacheClearMutation.isPending ) {
+			setIsClearingAllCaches( false );
+		}
+	}, [ edgeCacheClearMutation.isPending, objectCacheClearMutation.isPending ] );
+
+	const handleClearAllCaches = () => {
+		if ( isEdgeCacheActive ) {
+			handleClearEdgeCache();
+		}
+		handleClearObjectCache();
+
+		setIsClearingAllCaches( true );
+	};
+
+	const renderCallout = () => {
+		return <SettingsCallout siteSlug={ siteSlug } />;
+	};
+
+	const renderForm = () => {
+		return (
+			<>
+				<Card>
+					<CardBody>
+						<form onSubmit={ handleUpdateEdgeCacheStatus }>
+							<VStack spacing={ 4 } style={ { padding: '8px 0' } }>
+								<DataForm< CachingFormData >
+									data={ formData }
+									fields={ fields }
+									form={ form }
+									onChange={ ( edits: Partial< CachingFormData > ) => {
+										setFormData( ( data ) => ( { ...data, ...edits } ) );
+									} }
+								/>
+								<HStack justify="flex-start">
+									<Button
+										variant="primary"
+										type="submit"
+										isBusy={ isPending }
+										disabled={ isPending || ! isDirty }
+									>
+										{ __( 'Save' ) }
+									</Button>
+								</HStack>
+							</VStack>
+						</form>
+					</CardBody>
+				</Card>
+
+				<VStack spacing={ 4 }>
+					<ActionList
+						title={ __( 'Clear caches' ) }
+						description={ __(
+							'Clearing the cache may temporarily make your site less responsive.'
+						) }
+					>
+						<ActionList.ActionItem
+							title={ __( 'Global edge cache' ) }
+							description={ __( 'Edge caching enables faster content delivery.' ) }
+							actions={
+								<Button
+									variant="secondary"
+									size="compact"
+									onClick={ handleClearEdgeCache }
+									isBusy={ edgeCacheClearMutation.isPending && ! isClearingAllCaches }
+									disabled={
+										! isEdgeCacheActive || edgeCacheClearMutation.isPending || isClearingAllCaches
+									}
+								>
+									{ __( 'Clear' ) }
+								</Button>
+							}
+						/>
+						<ActionList.ActionItem
+							title={ __( 'Object cache' ) }
+							description={ __( 'Data is cached using Memcached to reduce database lookups.' ) }
+							actions={
+								<Button
+									variant="secondary"
+									size="compact"
+									onClick={ handleClearObjectCache }
+									isBusy={ objectCacheClearMutation.isPending && ! isClearingAllCaches }
+									disabled={ objectCacheClearMutation.isPending || isClearingAllCaches }
+								>
+									{ __( 'Clear' ) }
+								</Button>
+							}
+						/>
+					</ActionList>
+					<ActionList>
+						<ActionList.ActionItem
+							title={ __( 'Clear all caches' ) }
+							actions={
+								<Button
+									variant="secondary"
+									size="compact"
+									onClick={ handleClearAllCaches }
+									isBusy={ isClearingAllCaches }
+									disabled={
+										edgeCacheClearMutation.isPending ||
+										objectCacheClearMutation.isPending ||
+										isClearingAllCaches
+									}
+								>
+									{ __( 'Clear all' ) }
+								</Button>
+							}
+						/>
+					</ActionList>
+				</VStack>
+			</>
+		);
+	};
+
+	const description = canUpdate
+		? createInterpolateElement(
+				__( 'Manage your site’s server-side caching. <learnMoreLink />.' ),
+				{
+					learnMoreLink: <a href="#learn-more">{ __( 'Learn more' ) }</a>,
+				}
+		  )
+		: '';
+
+	return (
+		<PageLayout
+			size="small"
+			header={ <SettingsPageHeader title={ __( 'Caching' ) } description={ description } /> }
+		>
+			{ ! canUpdate ? renderCallout() : renderForm() }
+		</PageLayout>
+	);
+}

--- a/client/dashboard/sites/settings-caching/index.tsx
+++ b/client/dashboard/sites/settings-caching/index.tsx
@@ -202,11 +202,7 @@ export default function CachingSettings( { siteSlug }: { siteSlug: string } ) {
 									size="compact"
 									onClick={ handleClearAllCaches }
 									isBusy={ isClearingAllCaches }
-									disabled={
-										edgeCacheClearMutation.isPending ||
-										objectCacheClearMutation.isPending ||
-										isClearingAllCaches
-									}
+									disabled={ isClearingAllCaches }
 								>
 									{ __( 'Clear all' ) }
 								</Button>

--- a/client/dashboard/sites/settings-caching/index.tsx
+++ b/client/dashboard/sites/settings-caching/index.tsx
@@ -83,7 +83,7 @@ export default function CachingSettings( { siteSlug }: { siteSlug: string } ) {
 	const handleClearEdgeCache = () => {
 		edgeCacheClearMutation.mutate( undefined, {
 			onSuccess: () => {
-				createSuccessNotice( __( 'Edge cache cleared.' ), { type: 'snackbar' } );
+				createSuccessNotice( __( 'Global edge cache cleared.' ), { type: 'snackbar' } );
 			},
 			onError: () => {
 				createErrorNotice( __( 'Failed to clear edge cache.' ), { type: 'snackbar' } );

--- a/client/dashboard/sites/settings-caching/summary.tsx
+++ b/client/dashboard/sites/settings-caching/summary.tsx
@@ -1,0 +1,53 @@
+import { useQuery } from '@tanstack/react-query';
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { next } from '@wordpress/icons';
+import { siteEdgeCacheStatusQuery } from '../../app/queries';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import { canUpdateCaching } from '.';
+import type { Site } from '../../data/types';
+import type { Density } from '@automattic/components/src/summary-button/types';
+
+export default function CachingSettingsSummary( {
+	site,
+	density,
+}: {
+	site: Site;
+	density?: Density;
+} ) {
+	const canUpdate = site && canUpdateCaching( site );
+
+	const { data: isEdgeCacheActive } = useQuery( {
+		...siteEdgeCacheStatusQuery( site.slug ),
+		enabled: canUpdate,
+	} );
+
+	let badge;
+	if ( canUpdate ) {
+		if ( isEdgeCacheActive ) {
+			badge = {
+				text: __( 'Edge cache enabled' ),
+				intent: 'success' as const,
+			};
+		} else {
+			badge = {
+				text: __( 'Edge cache disabled' ),
+			};
+		}
+	} else {
+		badge = {
+			text: __( 'Managed' ),
+			intent: 'success' as const,
+		};
+	}
+
+	return (
+		<RouterLinkSummaryButton
+			to={ `/sites/${ site.slug }/settings/caching` }
+			title={ __( 'Caching' ) }
+			density={ density }
+			decoration={ <Icon icon={ next } /> }
+			badges={ [ badge ] }
+		/>
+	);
+}

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -6,6 +6,7 @@ import PageLayout from '../../components/page-layout';
 import { SectionHeader } from '../../components/section-header';
 import { SummaryButtonList } from '../../components/summary-button-list';
 import AgencySummary from '../settings-agency/summary';
+import CachingSettingsSummary from '../settings-caching/summary';
 import DatabaseSettingsSummary from '../settings-database/summary';
 import DefensiveModeSettingsSummary from '../settings-defensive-mode/summary';
 import PHPSettingsSummary from '../settings-php/summary';
@@ -40,6 +41,7 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 				<AgencySummary site={ site } />
 				<PrimaryDataCenterSettingsSummary site={ site } />
 				<StaticFile404SettingsSummary site={ site } />
+				<CachingSettingsSummary site={ site } />
 				<DefensiveModeSettingsSummary site={ site } />
 			</SummaryButtonList>
 			<SiteActions site={ site } />


### PR DESCRIPTION
Fixes DOTCOM-13257

## Proposed Changes

This PR implements the Settings -> Caching as follows:

|Simple|Atomic|
|-|-|
|<img width="607" alt="image" src="https://github.com/user-attachments/assets/a6cdafcf-f0a9-4817-b85f-84540f4cc9b2" />|<img width="610" alt="image" src="https://github.com/user-attachments/assets/35886aff-f628-484b-8ac4-3f209c216e62" /><br><img width="607" alt="image" src="https://github.com/user-attachments/assets/abefa89d-d07b-4ea5-9850-a15ecca80026" />|
||<img width="617" alt="image" src="https://github.com/user-attachments/assets/4159e770-0b14-44b9-9b39-d45c4a5e93b2" />|

## Out of scope

I've scoped out these features for future follow-ups:

- DOTCOM-13374 Caching: Implement rate limiting for clearing edge and object caches

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
