### PR TITLE
Open 'Learn more' in Help Center modal for 60-day transfer lock

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-out/transfer-prohibited.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/transfer-prohibited.jsx
@@ -1,8 +1,8 @@
 import { Card } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { TRANSFER_DOMAIN_REGISTRATION } from '@automattic/urls';
-import InlineSupportLink from 'client/components/inline-support-link';
 import { localize } from 'i18n-calypso';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 
 const TransferProhibited = ( { translate } ) => (
 	<div>

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/transfer-prohibited.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/transfer-prohibited.jsx
@@ -1,6 +1,7 @@
 import { Card } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { TRANSFER_DOMAIN_REGISTRATION } from '@automattic/urls';
+import InlineSupportLink from 'client/components/inline-support-link';
 import { localize } from 'i18n-calypso';
 
 const TransferProhibited = ( { translate } ) => (
@@ -13,11 +14,7 @@ const TransferProhibited = ( { translate } ) => (
 				{
 					components: {
 						learnMoreLink: (
-							<a
-								href={ localizeUrl( TRANSFER_DOMAIN_REGISTRATION ) }
-								target="_blank"
-								rel="noopener noreferrer"
-							/>
+							<InlineSupportLink supportLink={ localizeUrl( TRANSFER_DOMAIN_REGISTRATION ) } />
 						),
 					},
 				}


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-44/open-support-link-in-help-center

### Summary

- Changed the "Learn more" link in the 60-day transfer lock message (`TransferProhibited`) to use `InlineSupportLink`, so it opens in the Help Center modal instead of a new tab.

### Details

- Updated `client/my-sites/domains/domain-management/transfer/transfer-out/transfer-prohibited.jsx`
- Replaced the raw `<a>` with `<InlineSupportLink>` for the support article.
- Fixed import order for linter compliance.

### Testing

1. Register a new domain.
2. Turn off auto-renew.
3. Delete the domain.
4. Click on the transfer option in the modal.
5. Confirm the "Learn more" link opens the Help Center modal, not a new tab.
