### PR TITLE
WIP: Use /site-visibility endpoint to map the site settings to UI elements

### DIFF
--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -12,9 +12,11 @@ import {
 	fetchProfile,
 	updateProfile,
 	fetchSiteSettings,
+	fetchSiteVisibility,
 	fetchBasicMetrics,
 	fetchPerformanceInsights,
 	updateSiteSettings,
+	updateSiteVisibility,
 	restoreSitePlanSoftware,
 	siteOwnerTransfer,
 	siteOwnerTransferEligibilityCheck,
@@ -38,6 +40,7 @@ import type {
 	Profile,
 	Purchase,
 	SiteSettings,
+	SiteVisibility,
 	UrlPerformanceInsights,
 	DefensiveModeSettings,
 	DefensiveModeSettingsUpdate,
@@ -171,6 +174,26 @@ export function siteSettingsMutation( siteId: string ) {
 				...newData,
 			} ) );
 			queryClient.invalidateQueries( { queryKey: [ 'site', siteId ] } );
+		},
+	};
+}
+
+export function siteVisibilityQuery( siteId: string ) {
+	return {
+		queryKey: [ 'site-visibility', siteId ],
+		queryFn: () => {
+			return fetchSiteVisibility( siteId );
+		},
+	};
+}
+
+export function siteVisibilityMutation( siteId: string ) {
+	return {
+		mutationFn: ( newData: SiteVisibility ) => updateSiteVisibility( siteId, newData ),
+		onSuccess: ( newData: SiteVisibility ) => {
+			queryClient.setQueryData( [ 'site-visibility', siteId ], newData );
+			queryClient.invalidateQueries( { queryKey: [ 'site', siteId ] } );
+			queryClient.invalidateQueries( { queryKey: [ 'site-settings', siteId ] } );
 		},
 	};
 }

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -27,6 +27,7 @@ import {
 	sitePHPVersionQuery,
 	sitePrimaryDataCenterQuery,
 	siteDefensiveModeQuery,
+	siteVisibilityQuery,
 } from './queries';
 import { queryClient } from './query-client';
 import Root from './root';
@@ -140,7 +141,7 @@ const siteSettingsSiteVisibilityRoute = createRoute( {
 	getParentRoute: () => siteRoute,
 	path: 'settings/site-visibility',
 	loader: ( { params: { siteSlug } } ) =>
-		queryClient.ensureQueryData( siteSettingsQuery( siteSlug ) ),
+		queryClient.ensureQueryData( siteVisibilityQuery( siteSlug ) ),
 } ).lazy( () =>
 	import( '../sites/settings-site-visibility' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-site-visibility' )( {

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -15,6 +15,7 @@ import type {
 	EngagementStatsDataPoint,
 	BasicMetricsData,
 	SiteSettings,
+	SiteVisibility,
 	UrlPerformanceInsights,
 	PhpMyAdminToken,
 	DefensiveModeSettings,
@@ -308,7 +309,7 @@ export const fetchSiteSettings = async ( siteIdOrSlug: string ): Promise< SiteSe
 		path: `/sites/${ siteIdOrSlug }/settings`,
 		apiVersion: '1.4',
 	} );
-	return fromRawSiteSettings( settings );
+	return settings;
 };
 
 export const updateSiteSettings = async ( siteIdOrSlug: string, data: Partial< SiteSettings > ) => {
@@ -317,75 +318,30 @@ export const updateSiteSettings = async ( siteIdOrSlug: string, data: Partial< S
 			path: `/sites/${ siteIdOrSlug }/settings`,
 			apiVersion: '1.4',
 		},
-		toRawSiteSettings( data )
+		data
 	);
-	return fromRawSiteSettings( updated );
+	return updated;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function fromRawSiteSettings( rawSettings: any ): SiteSettings {
-	// Pluck out raw settings which don't map directly to a field in SiteSettings.
-	const {
-		blog_public: blogPublicRaw,
-		wpcom_coming_soon: wpcomComingSoonRaw,
-		wpcom_public_coming_soon: wpcomPublicComingSoonRaw,
-		wpcom_data_sharing_opt_out: wpcomDataSharingOptOutRaw,
-		...settings
-	} = rawSettings;
+export const fetchSiteVisibility = async ( siteIdOrSlug: string ): Promise< SiteVisibility > => {
+	return wpcom.req.get( {
+		path: `/sites/${ siteIdOrSlug }/site-visibility`,
+		apiNamespace: 'wpcom/v3',
+	} );
+};
 
-	const blog_public = Number( blogPublicRaw );
-	const wpcom_coming_soon = Number( wpcomComingSoonRaw );
-	const wpcom_public_coming_soon = Number( wpcomPublicComingSoonRaw );
-	const wpcom_data_sharing_opt_out = Boolean( wpcomDataSharingOptOutRaw );
-
-	if ( wpcom_coming_soon === 1 || wpcom_public_coming_soon === 1 ) {
-		settings.wpcom_site_visibility = 'coming-soon';
-		settings.wpcom_discourage_search_engines = false;
-	} else if ( blog_public === -1 ) {
-		settings.wpcom_site_visibility = 'private';
-		settings.wpcom_discourage_search_engines = false;
-	} else {
-		settings.wpcom_site_visibility = 'public';
-		settings.wpcom_discourage_search_engines = blog_public === 0;
-	}
-
-	settings.wpcom_prevent_third_party_sharing = wpcom_data_sharing_opt_out;
-
-	return settings;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function toRawSiteSettings( settings: Partial< SiteSettings > ): any {
-	// Pluck out settings which don't map directly to a field in the raw settings.
-	const {
-		wpcom_site_visibility,
-		wpcom_discourage_search_engines,
-		wpcom_prevent_third_party_sharing,
-		...rest
-	} = settings;
-	const rawSettings = rest as any; // eslint-disable-line @typescript-eslint/no-explicit-any
-
-	if ( wpcom_site_visibility !== undefined ) {
-		if ( wpcom_site_visibility === 'coming-soon' ) {
-			rawSettings.blog_public = 0;
-			rawSettings.wpcom_public_coming_soon = 1;
-			rawSettings.wpcom_data_sharing_opt_out = false;
-		} else if ( wpcom_site_visibility === 'private' ) {
-			rawSettings.blog_public = -1;
-			rawSettings.wpcom_public_coming_soon = 0;
-			rawSettings.wpcom_data_sharing_opt_out = false;
-		} else {
-			rawSettings.blog_public = wpcom_discourage_search_engines ? 0 : 1;
-			rawSettings.wpcom_public_coming_soon = 0;
-			rawSettings.wpcom_data_sharing_opt_out = wpcom_prevent_third_party_sharing;
-		}
-
-		// Take opportunity, while the user is switching visibility settings, to disable the legacy coming soon setting.
-		rawSettings.wpcom_coming_soon = 0;
-	}
-
-	return rawSettings;
-}
+export const updateSiteVisibility = async (
+	siteIdOrSlug: string,
+	data: SiteVisibility
+): Promise< SiteVisibility > => {
+	return wpcom.req.post(
+		{
+			path: `/sites/${ siteIdOrSlug }/site-visibility`,
+			apiNamespace: 'wpcom/v3',
+		},
+		data
+	);
+};
 
 export const restoreSitePlanSoftware = async ( siteIdOrSlug: string ) => {
 	return wpcom.req.post( {

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -167,11 +167,21 @@ export interface EngagementStats {
 }
 
 export interface SiteSettings {
-	wpcom_site_visibility?: 'coming-soon' | 'public' | 'private';
-	wpcom_discourage_search_engines?: boolean;
-	wpcom_prevent_third_party_sharing?: boolean;
+	blog_public?: 0 | 1 | -1;
+	/**
+	 * @deprecated This setting is for sites still using the old Coming Soon, you probably want `wpcom_public_coming_soon` instead.
+	 */
+	wpcom_coming_soon?: 0 | 1;
+	wpcom_public_coming_soon?: 0 | 1;
+	wpcom_data_sharing_opt_out?: boolean;
 	wpcom_gifting_subscription?: boolean;
 	wpcom_performance_report_url?: string;
+}
+
+export interface SiteVisibility {
+	visibility: 'coming-soon' | 'public' | 'private';
+	discourage_search_engines: boolean;
+	data_sharing_opt_out: boolean;
 }
 
 export interface BasicMetricsData {

--- a/client/dashboard/sites/settings-site-visibility/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/index.tsx
@@ -1,7 +1,7 @@
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { Card, CardBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { siteQuery, siteSettingsMutation, siteSettingsQuery } from '../../app/queries';
+import { siteQuery, siteVisibilityMutation, siteVisibilityQuery } from '../../app/queries';
 import PageLayout from '../../components/page-layout';
 import SettingsPageHeader from '../settings-page-header';
 import { LaunchForm } from './launch-form';
@@ -10,10 +10,10 @@ import './style.scss';
 
 export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useQuery( siteQuery( siteSlug ) );
-	const { data: settings } = useQuery( siteSettingsQuery( siteSlug ) );
-	const mutation = useMutation( siteSettingsMutation( siteSlug ) );
+	const { data: siteVisibility } = useQuery( siteVisibilityQuery( siteSlug ) );
+	const mutation = useMutation( siteVisibilityMutation( siteSlug ) );
 
-	if ( ! settings || ! site ) {
+	if ( ! siteVisibility || ! site ) {
 		return null;
 	}
 
@@ -32,7 +32,7 @@ export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string
 					{ site.launch_status === 'unlaunched' ? (
 						<LaunchForm site={ site } />
 					) : (
-						<PrivacyForm settings={ settings } mutation={ mutation } />
+						<PrivacyForm siteVisibility={ siteVisibility } mutation={ mutation } />
 					) }
 				</CardBody>
 			</Card>

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -11,13 +11,13 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
-import type { SiteSettings } from '../../data/types';
+import type { SiteVisibility } from '../../data/types';
 import type { Field, Form } from '@automattic/dataviews';
 import type { UseMutationResult } from '@tanstack/react-query';
 
-const fields: Field< SiteSettings >[] = [
+const fields: Field< SiteVisibility >[] = [
 	{
-		id: 'wpcom_site_visibility',
+		id: 'visibility',
 		Edit: 'toggleGroup',
 		elements: [
 			{
@@ -42,22 +42,22 @@ const fields: Field< SiteSettings >[] = [
 		],
 	},
 	{
-		id: 'wpcom_discourage_search_engines',
+		id: 'discourage_search_engines',
 		Edit: 'checkbox',
 		label: __( 'Discourage search engines from indexing this site' ),
 		description: __(
 			'This does not block access to your site — it is up to search engines to honor your request.'
 		),
-		isVisible: ( { wpcom_site_visibility }: SiteSettings ) => wpcom_site_visibility === 'public',
+		isVisible: ( data ) => data.visibility === 'public',
 	},
 	{
-		id: 'wpcom_prevent_third_party_sharing',
+		id: 'data_sharing_opt_out',
 		Edit: ( { field, onChange, data, hideLabelFromVision } ) => (
 			<CheckboxControl
 				__nextHasNoMarginBottom
 				label={ hideLabelFromVision ? '' : field.label }
 				checked={ field.getValue( { item: data } ) }
-				disabled={ data.wpcom_discourage_search_engines }
+				disabled={ data.discourage_search_engines }
 				onChange={ () => {
 					onChange( { [ field.id ]: ! field.getValue( { item: data } ) } );
 				} }
@@ -79,36 +79,35 @@ const fields: Field< SiteSettings >[] = [
 			/>
 		),
 		label: __( 'Prevent third-party sharing for this site' ),
-		isVisible: ( { wpcom_site_visibility }: SiteSettings ) => wpcom_site_visibility === 'public',
+		isVisible: ( data ) => data.visibility === 'public',
 	},
 ];
 
 const form = {
 	type: 'regular',
 	fields: [
-		{ id: 'wpcom_site_visibility', labelPosition: 'none' },
-		'wpcom_discourage_search_engines',
-		'wpcom_prevent_third_party_sharing',
+		{ id: 'visibility', labelPosition: 'none' },
+		'discourage_search_engines',
+		'data_sharing_opt_out',
 	],
 } satisfies Form;
 
 export function PrivacyForm( {
-	settings,
+	siteVisibility,
 	mutation,
 }: {
-	settings: SiteSettings;
-	mutation: UseMutationResult< Partial< SiteSettings >, Error, Partial< SiteSettings >, unknown >;
+	siteVisibility: SiteVisibility;
+	mutation: UseMutationResult< SiteVisibility, Error, SiteVisibility, unknown >;
 } ) {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const [ formData, setFormData ] = useState( {
-		wpcom_site_visibility: settings.wpcom_site_visibility,
-		wpcom_discourage_search_engines: settings.wpcom_discourage_search_engines,
-		wpcom_prevent_third_party_sharing:
-			settings.wpcom_discourage_search_engines || settings.wpcom_prevent_third_party_sharing,
+		...siteVisibility,
+		data_sharing_opt_out:
+			siteVisibility.discourage_search_engines || siteVisibility.data_sharing_opt_out,
 	} );
 
 	const isDirty = Object.entries( formData ).some(
-		( [ key, value ] ) => settings[ key as keyof SiteSettings ] !== value
+		( [ key, value ] ) => siteVisibility[ key as keyof SiteVisibility ] !== value
 	);
 	const { isPending } = mutation;
 
@@ -130,26 +129,24 @@ export function PrivacyForm( {
 	return (
 		<form onSubmit={ handleSubmit } className="dashboard-site-settings-privacy-form">
 			<VStack spacing={ 4 }>
-				<DataForm< SiteSettings >
+				<DataForm< SiteVisibility >
 					data={ formData }
 					fields={ fields }
 					form={ form }
-					onChange={ ( edits: Partial< SiteSettings > ) => {
+					onChange={ ( edits: Partial< SiteVisibility > ) => {
 						setFormData( ( data ) => {
 							const newFormData = { ...data, ...edits };
 
-							if ( edits.wpcom_site_visibility !== undefined ) {
+							if ( edits.visibility !== undefined ) {
 								// Forget any previous edits to the discoverability controls when the visibility changes.
-								newFormData.wpcom_discourage_search_engines =
-									settings.wpcom_discourage_search_engines;
-								newFormData.wpcom_prevent_third_party_sharing =
-									settings.wpcom_discourage_search_engines ||
-									settings.wpcom_prevent_third_party_sharing;
+								newFormData.discourage_search_engines = siteVisibility.discourage_search_engines;
+								newFormData.data_sharing_opt_out =
+									siteVisibility.discourage_search_engines || siteVisibility.data_sharing_opt_out;
 							}
 
-							if ( edits.wpcom_discourage_search_engines === true ) {
+							if ( edits.discourage_search_engines === true ) {
 								// Checking the search engine box forces the third party checkbox too.
-								newFormData.wpcom_prevent_third_party_sharing = true;
+								newFormData.data_sharing_opt_out = true;
 							}
 
 							return newFormData;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-13368

Depends on 184234-ghe-Automattic/wpcom

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?