### PR TITLE
Open DNS guides in Help Center

### DIFF
--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/dns-record-header.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/dns-record-header.tsx
@@ -1,8 +1,7 @@
-import { ExternalLink } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { SiteExcerptData } from '@automattic/sites';
 import { translate } from 'i18n-calypso';
 import React, { useMemo } from 'react';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { domainManagementAllOverview, domainManagementDns } from 'calypso/my-sites/domains/paths';
 import SiteIcon from 'calypso/sites/components/sites-dataviews/site-icon';
@@ -17,9 +16,7 @@ export const addDnsRecordsSubtitle = translate(
 	'DNS records change how your domain works. {{a}}Learn more{{/a}}.',
 	{
 		components: {
-			a: (
-				<ExternalLink href={ localizeUrl( 'https://wordpress.com/support/domains/custom-dns/' ) } />
-			),
+			a: <InlineSupportLink supportContext="manage-your-dns-records" showIcon={ false } />,
 		},
 	}
 );

--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/dns-records-header.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/dns-records-header.tsx
@@ -1,8 +1,7 @@
-import { ExternalLink } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { SiteExcerptData } from '@automattic/sites';
 import { translate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { domainManagementAllOverview } from 'calypso/my-sites/domains/paths';
 import SiteIcon from 'calypso/sites/components/sites-dataviews/site-icon';
@@ -16,9 +15,7 @@ const dnsRecordsSubtitle = translate(
 	'DNS records change how your domain works. {{a}}Learn more{{/a}}.',
 	{
 		components: {
-			a: (
-				<ExternalLink href={ localizeUrl( 'https://wordpress.com/support/domains/custom-dns/' ) } />
-			),
+			a: <InlineSupportLink supportContext="manage-your-dns-records" showIcon={ false } />,
 		},
 	}
 );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-1725/open-support-link-in-help-center-modal

### Summary

**Update DNS Records Header "Learn More" Link to Use Help Center Modal**

This PR updates the "Learn more" link in the DNS records page header to open the help center modal (using `InlineSupportLink`) instead of a new tab (`ExternalLink`). This ensures a consistent user experience across all DNS management screens (site-level, hosting-level, Atomic, Simple, etc.), matching the behavior already used for A record help.

---

### Details

- Replaced `<ExternalLink>` with `<InlineSupportLink supportContext="manage-your-dns-records" showIcon={false} />` in:
  - `client/my-sites/domains/domain-management/subpage-wrapper/headers/dns-records-header.tsx`
  - `client/my-sites/domains/domain-management/subpage-wrapper/headers/dns-record-header.tsx`
- Cleaned up unused imports and fixed linter issues.
- Ensured the change applies everywhere the DNS records screen appears, regardless of context.

---

### Testing

- Visit the hosting-level Domain dashboard.
- Open a domain and edit DNS settings.
- Confirm the "Learn more" link in the DNS records header opens the help center modal, not a new tab.
- Confirm the same behavior at the site-level and for all domain types (Simple, Atomic, etc.).


