### PR TITLE
Experiment streamlining the plans grid + checkout: Update plan grid term copy

### DIFF
--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -287,15 +287,21 @@ export default function usePlanBillingDescription( {
 	} else if ( showStreamlinedBillingDescription ) {
 		// When streamlined price experiment is active, use simplified billing description
 		if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
-			return translate( 'per month, billed annually' );
+			return translate( 'per month, billed annually', {
+				args: { months: 12 },
+			} );
 		}
 
 		if ( PLAN_BIENNIAL_PERIOD === billingPeriod ) {
-			return translate( 'per month, billed every 2 years' );
+			return translate( 'per month, billed every %(months)s months', {
+				args: { months: 24 },
+			} );
 		}
 
 		if ( PLAN_TRIENNIAL_PERIOD === billingPeriod ) {
-			return translate( 'per month, billed every 3 years' );
+			return translate( 'per month, billed every %(months)s months', {
+				args: { months: 36 },
+			} );
 		}
 	} else if ( originalPriceFullTermText ) {
 		if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -287,7 +287,7 @@ export default function usePlanBillingDescription( {
 	} else if ( showStreamlinedBillingDescription ) {
 		// When streamlined price experiment is active, use simplified billing description
 		if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
-			return translate( 'per month, billed annually', {
+			return translate( 'per month, billed every %(months)s months', {
 				args: { months: 12 },
 			} );
 		}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of pdtkmj-3DM-p2#comment-7012

## Proposed Changes

* This updates the plan term copy below the plan grid prices for the treatment variations of the streamlined pricing experiment

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to show the long-plan term as a number of months, to correlate with the monthly price so that the pricing structure is more clear to users.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To test this feature, you'll need to be assigned to either `plans_3y_checkout_dropdown` or  `plans_3y_checkout_radio ` variation of the `calypso_streamlined_plans_checkout` experiment
* On the plans grid you should see the new copy

|Before|After|
|------|-----|
|<img width="480" alt="Screenshot 2025-05-30 at 13 36 16" src="https://github.com/user-attachments/assets/75f8a073-10c6-4c51-a3f7-27ca2dfe6719" />|<img width="480" alt="Screenshot 2025-05-30 at 13 36 01" src="https://github.com/user-attachments/assets/6caac1d8-84ba-44a8-9542-706680755d4e" />|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?