### PR TITLE
Experiment streamlining the plans grid + checkout:: Update title copy in Checkout upsell widget

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -40,48 +40,49 @@ function getUpsellVariant( currentVariant: WPCOMProductVariant, variants: WPCOMP
 function getUpsellTextForVariant(
 	upsellVariant: WPCOMProductVariant,
 	percentSavings: number,
-	__: any
+	__: any,
+	isStreamlinedPrice: boolean
 ) {
 	if ( upsellVariant.productBillingTermInMonths === 12 ) {
+		const cardTitle = isStreamlinedPrice
+			? // translators: "percentSavings" is the savings percentage for the upgrade as a number, like '20' for '20%'.
+			  __( '<strong>Save %(percentSavings)d%% extra</strong> by paying annually' )
+			: // translators: "percentSavings" is the savings percentage for the upgrade as a number, like '20' for '20%'.
+			  __( '<strong>Save %(percentSavings)d%%</strong> by paying annually' );
 		return {
-			cardTitle: createInterpolateElement(
-				sprintf(
-					// translators: "percentSavings" is the savings percentage for the upgrade as a number, like '20' for '20%'.
-					__( '<strong>Save %(percentSavings)d%%</strong> by paying annually' ),
-					{ percentSavings }
-				),
-				{ strong: createElement( 'strong' ) }
-			),
+			cardTitle: createInterpolateElement( sprintf( cardTitle, { percentSavings } ), {
+				strong: createElement( 'strong' ),
+			} ),
 			cellLabel: __( 'One-year cost' ),
 			ctaText: __( 'Switch to an annual plan' ),
 		};
 	}
 
 	if ( upsellVariant.productBillingTermInMonths === 24 ) {
+		const cardTitle = isStreamlinedPrice
+			? // translators: "percentSavings" is the savings percentage for the upgrade as a number, like '20' for '20%'.
+			  __( '<strong>Save %(percentSavings)d%% extra</strong> by paying for two years' )
+			: // translators: "percentSavings" is the savings percentage for the upgrade as a number, like '20' for '20%'.
+			  __( '<strong>Save %(percentSavings)d%%</strong> by paying for two years' );
 		return {
-			cardTitle: createInterpolateElement(
-				sprintf(
-					// translators: "percentSavings" is the savings percentage for the upgrade as a number, like '20' for '20%'.
-					__( '<strong>Save %(percentSavings)d%%</strong> by paying for two years' ),
-					{ percentSavings }
-				),
-				{ strong: createElement( 'strong' ) }
-			),
+			cardTitle: createInterpolateElement( sprintf( cardTitle, { percentSavings } ), {
+				strong: createElement( 'strong' ),
+			} ),
 			cellLabel: __( 'Two-year cost' ),
 			ctaText: __( 'Switch to a two-year plan' ),
 		};
 	}
 
 	if ( upsellVariant.productBillingTermInMonths === 36 ) {
+		const cardTitle = isStreamlinedPrice
+			? // translators: "percentSavings" is the savings percentage for the upgrade as a number, like '20' for '20%'.
+			  __( '<strong>Save %(percentSavings)d%% extra</strong> by paying for three years' )
+			: // translators: "percentSavings" is the savings percentage for the upgrade as a number, like '20' for '20%'.
+			  __( '<strong>Save %(percentSavings)d%%</strong> by paying for three years' );
 		return {
-			cardTitle: createInterpolateElement(
-				sprintf(
-					// translators: "percentSavings" is the savings percentage for the upgrade as a number, like '20' for '20%'.
-					__( '<strong>Save %(percentSavings)d%%</strong> by paying for three years' ),
-					{ percentSavings }
-				),
-				{ strong: createElement( 'strong' ) }
-			),
+			cardTitle: createInterpolateElement( sprintf( cardTitle, { percentSavings } ), {
+				strong: createElement( 'strong' ),
+			} ),
 			cellLabel: __( 'Three-year cost' ),
 			ctaText: __( 'Switch to a three-year plan' ),
 		};
@@ -199,7 +200,12 @@ export function CheckoutSidebarPlanUpsell() {
 		currentVariant.introductoryInterval === 1 &&
 		currentVariant.introductoryTerm === 'year';
 
-	const upsellText = getUpsellTextForVariant( upsellVariant, percentSavings, __ );
+	const upsellText = getUpsellTextForVariant(
+		upsellVariant,
+		percentSavings,
+		__,
+		isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment )
+	);
 
 	if ( ! upsellText ) {
 		return;

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -287,15 +287,21 @@ export default function usePlanBillingDescription( {
 	} else if ( showStreamlinedBillingDescription ) {
 		// When streamlined price experiment is active, use simplified billing description
 		if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
-			return translate( 'per month, billed annually' );
+			return translate( 'per month, billed every %(months)s months', {
+				args: { months: 12 },
+			} );
 		}
 
 		if ( PLAN_BIENNIAL_PERIOD === billingPeriod ) {
-			return translate( 'per month, billed every 2 years' );
+			return translate( 'per month, billed every %(months)s months', {
+				args: { months: 24 },
+			} );
 		}
 
 		if ( PLAN_TRIENNIAL_PERIOD === billingPeriod ) {
-			return translate( 'per month, billed every 3 years' );
+			return translate( 'per month, billed every %(months)s months', {
+				args: { months: 36 },
+			} );
 		}
 	} else if ( originalPriceFullTermText ) {
 		if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -287,21 +287,15 @@ export default function usePlanBillingDescription( {
 	} else if ( showStreamlinedBillingDescription ) {
 		// When streamlined price experiment is active, use simplified billing description
 		if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
-			return translate( 'per month, billed every %(months)s months', {
-				args: { months: 12 },
-			} );
+			return translate( 'per month, billed annually' );
 		}
 
 		if ( PLAN_BIENNIAL_PERIOD === billingPeriod ) {
-			return translate( 'per month, billed every %(months)s months', {
-				args: { months: 24 },
-			} );
+			return translate( 'per month, billed every 2 years' );
 		}
 
 		if ( PLAN_TRIENNIAL_PERIOD === billingPeriod ) {
-			return translate( 'per month, billed every %(months)s months', {
-				args: { months: 36 },
-			} );
+			return translate( 'per month, billed every 3 years' );
 		}
 	} else if ( originalPriceFullTermText ) {
 		if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of pdtkmj-3DM-p2#comment-7013

## Proposed Changes

* This updates the Checkout upsell widget title copy by adding an `extra` for the treatment variations of the streamlined pricing

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want the title to be more clear that the longe therm discounts are additional to the current discount

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To test this feature, you'll need to be assigned to a checkout treatment variation of the `calypso_streamlined_plans_checkout` experiment
* Go through the `onboarding` flow to get assigned
* On checkout, you should see the update title on the upsell widget 

|Before|After|
|------|-----|
|<img width="450" alt="Screenshot 2025-05-30 at 14 16 36" src="https://github.com/user-attachments/assets/98b59059-41cf-48d0-9d35-88e67dfbe7ac" />|<img width="431" alt="Screenshot 2025-05-30 at 14 15 55" src="https://github.com/user-attachments/assets/9c9bdf8b-68d6-441f-9539-18f1e76bed51" />|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?