### PR TITLE
Revert "Launches the migration Cancel button "

### DIFF
--- a/client/sites/overview/components/migration-overview/components/cancel-difm-migration/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/cancel-difm-migration/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Modal, Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
@@ -106,6 +107,10 @@ const CancelDifmMigrationForm = ( { siteId }: { siteId: number } ) => {
 	>( null );
 
 	const { site, isMigrationCompleted, isMigrationInProgress } = useSiteMigrationStatus( siteId );
+
+	if ( ! isEnabled( 'migration-flow/cancel-difm' ) ) {
+		return null;
+	}
 
 	if ( ! site ) {
 		return null;

--- a/client/sites/overview/components/migration-overview/components/cancel-difm-migration/test/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/cancel-difm-migration/test/index.tsx
@@ -45,6 +45,12 @@ describe( 'CancelDifmMigrationForm', () => {
 		} );
 	} );
 
+	it( 'renders nothing if feature flag is disabled', () => {
+		isEnabled.mockReturnValue( false );
+		renderWithProvider( <CancelDifmMigrationForm siteId={ siteId } /> );
+		expect( screen.queryByRole( 'button', { name: /cancel migration/i } ) ).toBeNull();
+	} );
+
 	describe( 'when migration is not in progress', () => {
 		beforeEach( () => {
 			useSiteMigrationStatus.mockReturnValue( {

--- a/config/development.json
+++ b/config/development.json
@@ -121,6 +121,7 @@
 		"me/account/color-scheme-picker": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
+		"migration-flow/cancel-difm": true,
 		"oauth": false,
 		"onboarding/create-course": false,
 		"onboarding/import": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -78,6 +78,7 @@
 		"me/account/color-scheme-picker": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
+		"migration-flow/cancel-difm": true,
 		"onboarding/create-course": false,
 		"onboarding/step-container-v2-import-flow": true,
 		"onboarding/step-container-v2-migration-flow": true,

--- a/config/production.json
+++ b/config/production.json
@@ -95,6 +95,7 @@
 		"me/account/color-scheme-picker": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
+		"migration-flow/cancel-difm": false,
 		"onboarding/create-course": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -93,6 +93,7 @@
 		"me/account/color-scheme-picker": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
+		"migration-flow/cancel-difm": false,
 		"onboarding/create-course": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,

--- a/config/test.json
+++ b/config/test.json
@@ -75,6 +75,7 @@
 		"me/account-close": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
+		"migration-flow/cancel-difm": false,
 		"onboarding/create-course": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -98,6 +98,7 @@
 		"me/account/color-scheme-picker": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
+		"migration-flow/cancel-difm": false,
 		"onboarding/create-course": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#103715

I had to revert the cancellation button again. I noticed that some users were attempting to cancel the migration without having an open ticket. I have 9782739-zd-a8c example, in which the migration wasn't actually performed. So, the user has the migration-started-difm, but no ticket is open.
I considered adding the check for the ticket while 183697-ghe-Automattic/wpcom the status we added recently, but since the check for the ticket is a time-costly operation, and the endpoint in which this check would be added runs for all sites, we must not do that there.