### PR TITLE
Purchases DataView: Fix missing Site Column

### DIFF
--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -77,6 +77,17 @@ export function getPurchasesFieldDefinitions( {
 
 	const fields: Fields< Purchases.Purchase > = [
 		{
+			id: 'purchase-id',
+			label: 'Purchase ID',
+			type: 'text',
+			enableGlobalSearch: false,
+			enableSorting: false,
+			enableHiding: false,
+			getValue: ( { item }: { item: Purchases.Purchase } ) => {
+				return item.id;
+			},
+		},
+		{
 			id: 'site',
 			label: 'Site',
 			type: 'text',

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -13,8 +13,9 @@ export const purchasesDataView: View = {
 	type: 'table',
 	page: 1,
 	perPage: 5,
-	titleField: 'site',
-	fields: [ 'product', 'status', 'payment-method' ],
+	titleField: 'purchase-id',
+	showTitle: false,
+	fields: [ 'site', 'product', 'status', 'payment-method' ],
 	sort: {
 		field: 'site',
 		direction: 'desc',


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://github.com/Automattic/wp-calypso/issues/86616

## Proposed Changes

* This PR creates a new data field `purchase-id` to act as a unique identifier of each item within the Purchases DataView table. This replaces the `site` column as the `titleField` and ensures the `site` column will always render.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* After [PR 103788](https://github.com/Automattic/wp-calypso/pull/103788) merged, I noticed a regression where the `Site` column containing the site icon was no longer rendering. After some investigation, it seems that the update to [usePurchasesFieldDefinitions](https://github.com/Automattic/wp-calypso/blob/9f6cc62b5b44b4a075712d05f2d861d12e253b28/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx#L31) was filtering out the `site` field slug, since it was used as the `titleField` and not included in the `purchasesDataView.fields` array.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> Note
>
> This version of the purchases list is still behind a feature flag. To test this you will need to manually enable the `purchases/purchase-list-dataview` flag in your local development.json config before starting calypso.

**Recreate the regression**
- Spin up a local Calypso environment
- Make sure the `purchases/purchase-list-dataview` feature flag is enabled
- Navigate to `me/purchases`
- See that the 'Site' Column is missing

![Screenshot 2025-05-30 at 8 37 01 AM](https://github.com/user-attachments/assets/290689e3-ebaf-4b8e-8c92-ecb258306f3e)

- Click on the settings icon in the upper right-hand corner of the table; notice the `Site` field is not included as an option in the `Sort By` drop down or the `Properties` section

![Screenshot 2025-05-30 at 8 37 10 AM](https://github.com/user-attachments/assets/e356d315-7718-4ba7-b019-6f147f5bc3b0)

**Apply this PR**
- Refresh `me/purchases`
- See that the `Site` column is rendering again

![Screenshot 2025-05-30 at 8 36 13 AM](https://github.com/user-attachments/assets/8763b737-09cd-474d-8823-86f32c0dcfe1)

- Click on the settings icon in the upper right-hand corner of the table; check that the `Site` field **IS** included as an option in the `Sort By` drop down or the `Properties` section

![Screenshot 2025-05-30 at 8 36 36 AM](https://github.com/user-attachments/assets/0679a264-fcdf-427d-9479-8796aa3b5d44)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
