### PR TITLE
Purchases DateView: Translate all field labels

### DIFF
--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -78,7 +78,7 @@ export function getPurchasesFieldDefinitions( {
 	const fields: Fields< Purchases.Purchase > = [
 		{
 			id: 'site',
-			label: 'Site',
+			label: translate( 'Site' ),
 			type: 'text',
 			enableGlobalSearch: true,
 			enableSorting: true,
@@ -97,7 +97,7 @@ export function getPurchasesFieldDefinitions( {
 		},
 		{
 			id: 'product',
-			label: 'Product',
+			label: translate( 'Product' ),
 			type: 'text',
 			enableGlobalSearch: true,
 			enableSorting: true,
@@ -137,7 +137,7 @@ export function getPurchasesFieldDefinitions( {
 		},
 		{
 			id: 'status',
-			label: 'status',
+			label: translate( 'Status' ),
 			type: 'text',
 			enableGlobalSearch: true,
 			enableSorting: true,
@@ -156,7 +156,7 @@ export function getPurchasesFieldDefinitions( {
 		},
 		{
 			id: 'payment-method',
-			label: 'Payment method',
+			label: translate( 'Payment method' ),
 			type: 'text',
 			enableGlobalSearch: true,
 			enableSorting: true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://github.com/Automattic/wp-calypso/issues/86616

A quick fix to make sure all DataView Field labels are being translated. These are not new strings, so they shouldn't need new translations, we just want to make sure they are being rendered.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a local Calypso environment
* Make sure the `purchases/purchase-list-dataview` feature flag is enabled
* Navigate to `me/purchases`
* Make sure you are seeing the DataView table

![Screenshot 2025-05-30 at 8 52 27 AM](https://github.com/user-attachments/assets/1c900d68-2a11-4fe2-9d55-d1b9a9732669)

* Change the language of your account in `Account Settings > Interface settings > Interface language`
* Go back to `me/purchases` and see if the Column labels are correctly translated

**Without this PR**

![Screenshot 2025-05-30 at 8 54 47 AM](https://github.com/user-attachments/assets/2bebf1cb-cd4f-4433-b079-17bfdbc7faca)

**With this PR**

![Screenshot 2025-05-30 at 8 58 04 AM](https://github.com/user-attachments/assets/f5b3e1bb-351d-4da3-9d62-3b28b49caab9)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
