### PR TITLE
Help Center: Simplify getting the most recent open conversation

### DIFF
--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -21,12 +21,6 @@ export function setCurrentSupportInteraction( supportInteraction: SupportInterac
 	} as const;
 }
 
-export const setLastMessageReceivedAt = ( lastMessageReceivedAt: number ) =>
-	( {
-		type: 'HELP_CENTER_SET_LAST_MESSAGE_RECEIVED_AT',
-		lastMessageReceivedAt,
-	} ) as const;
-
 export const setNavigateToRoute = ( route?: string ) =>
 	( {
 		type: 'HELP_CENTER_SET_NAVIGATE_TO_ROUTE',
@@ -249,6 +243,5 @@ export type HelpCenterAction =
 			| typeof setCurrentSupportInteraction
 			| typeof setAllowPremiumSupport
 			| typeof setHelpCenterOptions
-			| typeof setLastMessageReceivedAt
 	  >
 	| GeneratorReturnType< typeof setShowHelpCenter >;

--- a/packages/data-stores/src/help-center/reducer.ts
+++ b/packages/data-stores/src/help-center/reducer.ts
@@ -50,15 +50,6 @@ const isMinimized: Reducer< boolean, HelpCenterAction > = ( state = false, actio
 	return state;
 };
 
-const lastMessageReceivedAt: Reducer< number | undefined, HelpCenterAction > = (
-	state,
-	action
-) => {
-	return action.type === 'HELP_CENTER_SET_LAST_MESSAGE_RECEIVED_AT'
-		? action.lastMessageReceivedAt
-		: state;
-};
-
 const isChatLoaded: Reducer< boolean, HelpCenterAction > = ( state = false, action ) => {
 	switch ( action.type ) {
 		case 'HELP_CENTER_SET_IS_CHAT_LOADED':
@@ -198,7 +189,6 @@ const reducer = combineReducers( {
 	zendeskClientId,
 	unreadCount,
 	navigateToRoute,
-	lastMessageReceivedAt,
 	odieInitialPromptText,
 	odieBotNameSlug,
 	allowPremiumSupport,

--- a/packages/data-stores/src/help-center/selectors.ts
+++ b/packages/data-stores/src/help-center/selectors.ts
@@ -19,5 +19,4 @@ export const getOdieBotNameSlug = ( state: State ) => state.odieBotNameSlug;
 export const getCurrentSupportInteraction = ( state: State ) => state.currentSupportInteraction;
 export const getAllowPremiumSupport = ( state: State ) => state.allowPremiumSupport;
 export const getHelpCenterOptions = ( state: State ) => state.helpCenterOptions;
-export const getLastMessageReceivedAt = ( state: State ) => state.lastMessageReceivedAt;
 export const getContextTerm = ( state: State ) => state.contextTerm;

--- a/packages/help-center/src/components/help-center-smooch.tsx
+++ b/packages/help-center/src/components/help-center-smooch.tsx
@@ -81,8 +81,7 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 	const { data: authData } = useAuthenticateZendeskMessaging( allowChat, 'messenger' );
 
 	const { isMessagingScriptLoaded } = useLoadZendeskMessaging( allowChat, allowChat );
-	const { setIsChatLoaded, setZendeskClientId, setLastMessageReceivedAt } =
-		useDataStoreDispatch( HELP_CENTER_STORE );
+	const { setIsChatLoaded, setZendeskClientId } = useDataStoreDispatch( HELP_CENTER_STORE );
 	const getUnreadNotifications = useGetUnreadConversations();
 
 	const getUnreadListener = useCallback(
@@ -91,17 +90,13 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 				playNotificationSound();
 			}
 
-			if ( setLastMessageReceivedAt ) {
-				setLastMessageReceivedAt( Date.now() );
-			}
-
 			if ( isHelpCenterShown ) {
 				return;
 			}
 
 			Smooch.getConversationById( data?.conversation?.id ).then( () => getUnreadNotifications() );
 		},
-		[ isHelpCenterShown, areSoundNotificationsEnabled, setLastMessageReceivedAt ]
+		[ isHelpCenterShown, areSoundNotificationsEnabled ]
 	);
 
 	const clientIdListener = useCallback(

--- a/packages/help-center/src/components/help-center-support-chat-message.tsx
+++ b/packages/help-center/src/components/help-center-support-chat-message.tsx
@@ -48,7 +48,7 @@ export const HelpCenterSupportChatMessage = ( {
 	const { setCurrentSupportInteraction } = useDataStoreDispatch( HELP_CENTER_STORE );
 
 	const supportInteraction = supportInteractions.find(
-		( interaction ) => interaction.uuid === conversation.metadata.supportInteractionId
+		( interaction ) => interaction.uuid === conversation.metadata?.supportInteractionId
 	);
 
 	const messageDisplayName =

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -247,7 +247,7 @@ export type OdieConversation = {
 	id: string;
 	createdAt: number;
 	messages: OdieMessage[];
-	metadata: Metadata;
+	metadata?: Metadata;
 };
 
 export type ZendeskConversation = {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Simplify the `useGetMostRecentOpenConversation` function.
* `lastMessageReceivedAt` is not useful anymore.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Support interactions of source 'Zendesk' cannot be in an 'open' status, so we can remove that logic. This simplifies the rest

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Help Center
* Start a conversation with Odie
* If you have already opened Zendesk interactions (talking with Happiness Engineers) you should see the notice
* If not, escalate to Zendesk by asking to talk with a human, then click the three dots and start a new chat with AI