### PR TITLE
`Tabs.Tablist`: add `density` prop with `compact` variant

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Add `BigSkyLogo.Mark` component ([#103612](https://github.com/Automattic/wp-calypso/pull/103612)).
 - Add `ValidatedFormControls` components, still in beta ([#100771](https://github.com/Automattic/wp-calypso/pull/100771)).
+- `Tabs.Tablist`: added `density` prop with new `compact` variant ([#103843](https://github.com/Automattic/wp-calypso/pull/103843)).
 
 ### Internal
 

--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -2,6 +2,7 @@
  * Forked from `@wordpress/components`
  * - Removed Tabs.Context from Storybook sub-components.
  * - Converted styles from Emotion to (S)CSS modules.
+ * - Added `density` prop to `Tabs.TabList`, with new `compact` variant.
  */
 
 import * as Ariakit from '@ariakit/react';

--- a/packages/components/src/tabs/stories/index.stories.tsx
+++ b/packages/components/src/tabs/stories/index.stories.tsx
@@ -55,7 +55,37 @@ const Template: StoryFn< typeof Tabs > = ( props ) => {
 	);
 };
 
+const CompactTemplate: StoryFn< typeof Tabs > = ( props ) => {
+	return (
+		<Tabs { ...props }>
+			<Tabs.TabList density="compact">
+				<Tabs.Tab tabId="tab1">Tab 1</Tabs.Tab>
+				<Tabs.Tab tabId="tab2">Tab 2</Tabs.Tab>
+				<Tabs.Tab tabId="tab3">Tab 3</Tabs.Tab>
+			</Tabs.TabList>
+			<Tabs.TabPanel tabId="tab1">
+				<p>Selected tab: Tab 1</p>
+			</Tabs.TabPanel>
+			<Tabs.TabPanel tabId="tab2">
+				<p>Selected tab: Tab 2</p>
+			</Tabs.TabPanel>
+			<Tabs.TabPanel tabId="tab3" focusable={ false }>
+				<p>Selected tab: Tab 3</p>
+				<p>
+					This tabpanel has its <code>focusable</code> prop set to
+					<code> false</code>, so it won&apos;t get a tab stop.
+					<br />
+					Instead, the [Tab] key will move focus to the first focusable element within the panel.
+				</p>
+				<Button variant="primary">I&apos;m a button!</Button>
+			</Tabs.TabPanel>
+		</Tabs>
+	);
+};
+
 export const Default = Template.bind( {} );
+
+export const Compact = CompactTemplate.bind( {} );
 
 export const SizeAndOverflowPlayground: StoryFn< typeof Tabs > = ( props ) => {
 	const [ fullWidth, setFullWidth ] = useState( false );

--- a/packages/components/src/tabs/style.module.scss
+++ b/packages/components/src/tabs/style.module.scss
@@ -60,6 +60,10 @@
 				linear-gradient( to left, var( --fade-gradient-composed ) );
 		}
 
+		&.has-compact-density {
+			gap: 1rem;
+		}
+
 		&::before {
 			bottom: 0;
 			height: 0;
@@ -161,6 +165,16 @@
 		&::after {
 			content: '';
 			inset: variables.$grid-unit-05 * 3;
+		}
+	}
+
+	.has-compact-density[aria-orientation='horizontal'] & {
+		padding-inline: 0;
+
+		&::after {
+			// Add enough inset to prevent the focus ring (which is 1.5px thick)
+			// from being visually clipped by the tablist.
+			inset-inline: 2px;
 		}
 	}
 

--- a/packages/components/src/tabs/tablist.tsx
+++ b/packages/components/src/tabs/tablist.tsx
@@ -58,7 +58,7 @@ function useScrollRectIntoView(
 export const TabList = forwardRef<
 	HTMLDivElement,
 	React.ComponentPropsWithoutRef< 'div' > & TabListProps
->( function TabList( { children, ...otherProps }, ref ) {
+>( function TabList( { children, density = 'default', ...otherProps }, ref ) {
 	const { store } = useTabsContext() ?? {};
 
 	const selectedId = Ariakit.useStoreState( store, 'selectedId' );
@@ -132,6 +132,7 @@ export const TabList = forwardRef<
 				styles.tablist,
 				overflow.first && styles[ 'is-overflowing-first' ],
 				overflow.last && styles[ 'is-overflowing-last' ],
+				styles[ `has-${ density }-density` ],
 				otherProps.className
 			) }
 		>

--- a/packages/components/src/tabs/types.ts
+++ b/packages/components/src/tabs/types.ts
@@ -97,6 +97,11 @@ export type TabListProps = {
 	 * `Tabs.Tab` component.
 	 */
 	children: Ariakit.TabListProps[ 'children' ];
+	/**
+	 * The visual density of the tab list.
+	 * @default "default"
+	 */
+	density?: 'compact' | 'default';
 };
 
 // TODO: consider prop name changes (tabId, selectedTabId)


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes DS-202

## Proposed Changes

Add a `compact` variant to the `Tabs.Tablist` component

https://github.com/user-attachments/assets/0bb5cce7-fe21-4a96-90ba-2f4f8095dfa9


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The current design for Tabs can lead to some awkward alignment issues when text immediately precedes and follows the tablist:

![image](https://github.com/user-attachments/assets/d83a3d12-5c34-4fe1-a7b6-8940787fe768)

We can address this by creating a variant where the options do not include any horizontal padding:

![image](https://github.com/user-attachments/assets/b05bf37f-fb08-4db0-afcd-89fd0783571f)


This also has the benefit of reducing the space occupied by the tablist making it less likely for horizontal scrolling to come into play.

> [!WARNING]
> Given the recent lift of the contribution pause, we may want to wait before merging further changes to components that are forked from `@wordpress/components`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load the new Storybook "compact" example, test sizes and behavior

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
