### PR TITLE
Chat has zendesk even if it has ended

### DIFF
--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -66,9 +66,7 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
 		const currentInteraction = helpCenterSelect.getCurrentSupportInteraction();
 		return {
-			alreadyHasActiveZendeskChat:
-				interactionHasZendeskEvent( currentInteraction ) &&
-				! interactionHasEnded( currentInteraction ),
+			alreadyHasActiveZendeskChat: interactionHasZendeskEvent( currentInteraction ),
 			chatHasEnded: interactionHasEnded( currentInteraction ),
 		};
 	}, [] );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

`alreadyHasActiveZendeskChat` value should be set to true even if the chat has ended

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Talking with AI, escalate to an Happiness Engineer, it should work.