### PR TITLE
Help Center: add bg color for elements has-background classname

### DIFF
--- a/packages/help-center/src/components/help-center-article.scss
+++ b/packages/help-center/src/components/help-center-article.scss
@@ -141,6 +141,15 @@
 				padding: 0;
 			}
 
+			.has-background {
+				padding: 16px;
+
+				&.has-gray-theme-background-color {
+					background-color: var(--studio-gray-0);
+				}
+			}
+
+
 			.wp-block-button {
 				width: 100%;
 


### PR DESCRIPTION
Fixes DOTSUP-48

### Testing

1. Open the Help Center.
2. Search for Style your site.
3. Verify the change below

### Screenshot

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/2a36719c-5c62-4fdb-b6b4-ceaee68ef9b7) | ![image](https://github.com/user-attachments/assets/4ef5b697-4e39-4fae-a94f-a858f8eda604) |