### PR TITLE
Akismet checkout: Update checkout title when adjusting number of licenses

### DIFF
--- a/packages/wpcom-checkout/src/checkout-labels.ts
+++ b/packages/wpcom-checkout/src/checkout-labels.ts
@@ -15,6 +15,7 @@ import {
 	isTriennially,
 	isJetpackAISlug,
 	isJetpackStatsPaidTieredProductSlug,
+	isAkismetPro5h,
 } from '@automattic/calypso-products';
 import { formatNumber } from '@automattic/number-formatters';
 import { translate } from 'i18n-calypso';
@@ -118,6 +119,19 @@ export function getLabel( product: ResponseCartProduct ): string {
 			},
 			textOnly: true,
 		} );
+	}
+
+	if ( isAkismetPro5h( product ) ) {
+		if ( quantity > 1 ) {
+			/* translators: %s is the product name "Akismet Pro", %d is a number of requests/month */
+			return translate( '%(productName)s (%(requests)d requests/month)', {
+				args: {
+					productName: product.product_name.replace( /\s*\(.*$/, '' ).trim(),
+					requests: 500 * quantity,
+				},
+				textOnly: true,
+			} );
+		}
 	}
 
 	return product.product_name || '';


### PR DESCRIPTION
Resolves SAFE-173

## Proposed Changes

* This PR nudges copy for Akismet Pro product titles in the checkout, such that it will render out the appropriate number of requests available per month for a selected quantity of licenses for both the line item and product title within the checkout itself.

## Why are these changes being made?

* These changes are being made to clarify the product quantity selected for the checkout in both titles.
  
BEFORE | AFTER
--- | ---
![before](https://github.com/user-attachments/assets/6012bb01-be2a-4251-8728-66320126ae08) | ![after](https://github.com/user-attachments/assets/126f2be7-91d6-4107-bc9d-b20d79870198)

Note that product title's request limits match the details of the selected license.

### Example - Product title changes

## Testing Instructions

* Open the calypso.live link in the comments below
* Navigate to `/checkout/akismet/ak_pro5h_yearly`
* Note that the product title changes are reflected for each quantity selected in the checkout.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
