### PR TITLE
Reader: Fixes react warnings on console

### DIFF
--- a/client/blocks/author-compact-profile/index.tsx
+++ b/client/blocks/author-compact-profile/index.tsx
@@ -66,9 +66,14 @@ export default function AuthorCompactProfile( props: AuthorCompactProfileProps )
 
 	return (
 		<div className={ classes }>
-			<a href={ streamUrl } className="author-compact-profile__avatar-link">
-				<ReaderAvatar siteIcon={ siteIcon } feedIcon={ feedIcon } author={ author || {} } />
-			</a>
+			<div className="author-compact-profile__avatar-link">
+				<ReaderAvatar
+					siteIcon={ siteIcon }
+					feedIcon={ feedIcon }
+					siteUrl={ streamUrl }
+					author={ author || {} }
+				/>
+			</div>
 			<div className="author-compact-profile__names">
 				{ hasAuthorName && ! hasMatchingAuthorAndSiteNames && (
 					<ReaderAuthorLink author={ author } siteUrl={ streamUrl } post={ post }>

--- a/client/blocks/reader-avatar/index.tsx
+++ b/client/blocks/reader-avatar/index.tsx
@@ -113,22 +113,25 @@ export default function ReaderAvatar( {
 		'has-site-icon': hasSiteIcon,
 		'has-gravatar': hasAvatar || showPlaceholder,
 	} );
-	const defaultIconElement = ! hasSiteIcon && ! hasAvatar && ! showPlaceholder && (
-		<Gridicon key="globe-icon" icon="globe" size={ siteIconSize } />
-	);
-	const siteIconElement = hasSiteIcon && (
-		<SiteIcon key="site-icon" size={ siteIconSize } site={ fakeSite } />
-	);
+
+	let siteIconElement = null;
+	if ( ! hasSiteIcon && ! hasAvatar && ! showPlaceholder ) {
+		siteIconElement = <Gridicon icon="globe" size={ siteIconSize } />;
+	} else if ( hasSiteIcon ) {
+		const siteAvatar = <SiteIcon size={ siteIconSize } site={ fakeSite } />;
+		siteIconElement = siteUrl ? <a href={ siteUrl }>{ siteAvatar }</a> : siteAvatar;
+	}
+
 	const avatarUrl = author?.wpcom_login ? getUserProfileUrl( author.wpcom_login ) : null;
 	const authorAvatar = ( hasAvatar || showPlaceholder ) && (
-		<Gravatar key="author-avatar" user={ author } size={ gravatarSize } />
+		<Gravatar user={ author } size={ gravatarSize } />
 	);
 	const avatarElement = avatarUrl ? <a href={ avatarUrl }> { authorAvatar }</a> : authorAvatar;
-	const iconElements = [ defaultIconElement, siteIconElement, avatarElement ];
 
 	return (
 		<div className={ classes } onClick={ onClick } aria-hidden="true">
-			{ siteUrl ? <a href={ siteUrl }>{ iconElements }</a> : iconElements }
+			{ siteIconElement }
+			{ avatarElement }
 		</div>
 	);
 }

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -100,7 +100,7 @@ SidebarItem.propTypes = {
 	className: PropTypes.string,
 	link: PropTypes.string.isRequired,
 	onNavigate: PropTypes.func,
-	icon: PropTypes.oneOfType( [ PropTypes.string, PropTypes.func ] ),
+	icon: PropTypes.oneOfType( [ PropTypes.string, PropTypes.func, PropTypes.object ] ),
 	customIcon: PropTypes.object,
 	selected: PropTypes.bool,
 	expandSection: PropTypes.func,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related: https://github.com/Automattic/wp-calypso/pull/98334/files#r1939126070

## Proposed Changes

- Allow `object` type on `SidebarItem` component `icon` prop  to fix invalid prop icon warning.
- Restructure `ReaderAvatar` component to avoid both unique key and anchor descendant warning.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fix following console warnings:

```
Warning: Failed prop type: Invalid prop `icon` supplied to `SidebarItem`, expected one of type [string, function].
```

```
Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
```

```
Warning: Each child in a list should have a unique "key" prop.
```

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/reader/feeds/75203491/posts/5683365436`.
* Verify the above mentioned warnings are not appearing in console.
* Verify there is no regression in UI by smoke some of the reader pages.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
