### PR TITLE
Purchases: Fix sorting in DataViews purchase list

### DIFF
--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -512,7 +512,7 @@ export function isOneTimePurchase( purchase: Purchase ) {
 }
 
 export function isPaidWithPaypal( purchase: Purchase ) {
-	return 'paypal' === purchase.payment.type;
+	return 'paypal' === purchase.payment?.type;
 }
 
 export function isPaidWithCredits( purchase: Purchase ) {
@@ -764,15 +764,15 @@ export function isSubscription( purchase: Purchase ): boolean {
 }
 
 export function isPaidWithCreditCard( purchase: Purchase ) {
-	return 'credit_card' === purchase.payment.type && hasCreditCardData( purchase );
+	return 'credit_card' === purchase.payment?.type && hasCreditCardData( purchase );
 }
 
 export function isPaidWithPayPalDirect( purchase: Purchase ) {
-	return 'paypal_direct' === purchase.payment.type && purchase.payment.expiryDate;
+	return 'paypal_direct' === purchase.payment?.type && purchase.payment.expiryDate;
 }
 
 function hasCreditCardData( purchase: Purchase ) {
-	return Boolean( purchase.payment.creditCard?.expiryDate );
+	return Boolean( purchase.payment?.creditCard?.expiryDate );
 }
 
 export function shouldAddPaymentSourceInsteadOfRenewingNow( purchase: Purchase ) {
@@ -836,7 +836,7 @@ export function shouldRenderExpiringCreditCard( purchase: Purchase ) {
 }
 
 export function monthsUntilCardExpires( purchase: Purchase ) {
-	const creditCard = purchase.payment.creditCard;
+	const creditCard = purchase.payment?.creditCard;
 	const expiry = moment( creditCard?.expiryDate, 'MM/YY' );
 	return expiry.diff( moment(), 'months' );
 }
@@ -857,16 +857,16 @@ export function subscribedWithinPastWeek( purchase: Purchase ) {
  */
 export function paymentLogoType( purchase: Purchase ): string | null | undefined {
 	if ( isPaidWithCreditCard( purchase ) ) {
-		return purchase.payment.creditCard?.displayBrand
+		return purchase.payment?.creditCard?.displayBrand
 			? purchase.payment.creditCard?.displayBrand
-			: purchase.payment.creditCard?.type;
+			: purchase.payment?.creditCard?.type;
 	}
 
 	if ( isPaidWithPayPalDirect( purchase ) ) {
 		return 'placeholder';
 	}
 
-	return purchase.payment.type || null;
+	return purchase.payment?.type || null;
 }
 
 export function isAgencyPartnerType( partnerType: string ) {

--- a/client/me/purchases/purchase-item/index.tsx
+++ b/client/me/purchases/purchase-item/index.tsx
@@ -638,6 +638,7 @@ export function PurchaseItemPaymentMethod( {
 
 	if (
 		purchase.isAutoRenewEnabled &&
+		! isExpired( purchase ) &&
 		( ! hasPaymentMethod( purchase ) || isPaidWithCredits( purchase ) ) &&
 		! isPartnerPurchase( purchase ) &&
 		! isAkismetFreeProduct( purchase )

--- a/client/me/purchases/purchase-item/index.tsx
+++ b/client/me/purchases/purchase-item/index.tsx
@@ -674,7 +674,7 @@ export function PurchaseItemPaymentMethod( {
 	}
 
 	if ( isRenewing( purchase ) ) {
-		if ( purchase.payment.type === 'credit_card' && purchase.payment.creditCard ) {
+		if ( purchase.payment?.type === 'credit_card' && purchase.payment.creditCard ) {
 			const paymentMethodType = purchase.payment.creditCard.displayBrand
 				? purchase.payment.creditCard.displayBrand
 				: purchase.payment.creditCard.type || purchase.payment.paymentPartner || '';
@@ -691,13 +691,13 @@ export function PurchaseItemPaymentMethod( {
 			);
 		}
 
-		if ( purchase.payment.type === 'paypal' ) {
+		if ( purchase.payment?.type === 'paypal' ) {
 			return (
 				<img src={ payPalImage } alt={ purchase.payment.type } className="purchase-item__paypal" />
 			);
 		}
 
-		if ( purchase.payment.type === 'upi' ) {
+		if ( purchase.payment?.type === 'upi' ) {
 			return <img src={ upiImage } alt={ purchase.payment.type } />;
 		}
 

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -1,5 +1,5 @@
 import { Purchases, SiteDetails } from '@automattic/data-stores';
-import { Fields, Operator } from '@wordpress/dataviews';
+import { Fields } from '@wordpress/dataviews';
 import { LocalizeProps } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
@@ -163,15 +163,14 @@ export function getPurchasesFieldDefinitions( {
 			enableGlobalSearch: true,
 			enableSorting: true,
 			enableHiding: false,
-			elements: [
-				{ value: 'exists', label: 'Has payment method' },
-				{ value: 'not-exists', label: 'Has no payment method' },
-			],
-			filterBy: {
-				operators: [ 'is' as Operator ],
-			},
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
-				return ! isExpired( item ) && item.payment?.type ? 'exists' : 'not-exists';
+				// Allows sorting by card number or payment partner (eg: `type === 'paypal'`).
+				return isExpired( item )
+					? // Do not return card number for expired purchases because it
+					  // will not be displayed so it will look wierd if we sort
+					  // expired purchases with active ones that have the same card.
+					  'expired'
+					: item.payment?.creditCard?.number ?? item.payment?.type ?? 'no-payment-method';
 			},
 			render: ( { item }: { item: Purchases.Purchase } ) => {
 				let isBackupMethodAvailable = false;

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -1,5 +1,5 @@
 import { Purchases, SiteDetails } from '@automattic/data-stores';
-import { Fields, Operator } from '@wordpress/dataviews';
+import { Fields, Operator } from '@automattic/dataviews';
 import { LocalizeProps } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -176,7 +176,7 @@ export function getPurchasesFieldDefinitions( {
 				operators: [ 'is' as Operator ],
 			},
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
-				return item.payment.storedDetailsId ?? '';
+				return item.payment?.storedDetailsId ?? '';
 			},
 			render: ( { item }: { item: Purchases.Purchase } ) => {
 				let isBackupMethodAvailable = false;
@@ -184,7 +184,7 @@ export function getPurchasesFieldDefinitions( {
 				if ( backupPaymentMethods ) {
 					const backupPaymentMethodsWithoutCurrentPurchase = backupPaymentMethods.filter(
 						// A payment method is only a back up if it isn't already assigned to the current purchase
-						( paymentMethod ) => item.payment.storedDetailsId !== paymentMethod.stored_details_id
+						( paymentMethod ) => item.payment?.storedDetailsId !== paymentMethod.stored_details_id
 					);
 
 					isBackupMethodAvailable = backupPaymentMethodsWithoutCurrentPurchase.length >= 1;

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -1,9 +1,9 @@
 import { Purchases, SiteDetails } from '@automattic/data-stores';
-import { Fields, Operator } from '@automattic/dataviews';
+import { Fields, Operator } from '@wordpress/dataviews';
 import { LocalizeProps } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
-import { getDisplayName, isRenewing, purchaseType } from 'calypso/lib/purchases';
+import { getDisplayName, isExpired, isRenewing, purchaseType } from 'calypso/lib/purchases';
 import { MembershipSubscription } from 'calypso/lib/purchases/types';
 import { useSelector } from 'calypso/state';
 import { getSite } from 'calypso/state/sites/selectors';
@@ -94,9 +94,6 @@ export function getPurchasesFieldDefinitions( {
 			enableGlobalSearch: true,
 			enableSorting: true,
 			enableHiding: false,
-			filterBy: {
-				operators: [ 'is' as Operator ],
-			},
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
 				return item.siteName;
 			},
@@ -113,9 +110,6 @@ export function getPurchasesFieldDefinitions( {
 			enableGlobalSearch: true,
 			enableSorting: true,
 			enableHiding: false,
-			filterBy: {
-				operators: [ 'is' as Operator ],
-			},
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
 				// Render a bunch of things to make this easily searchable.
 				const site = sites?.[ item.siteId ];
@@ -153,9 +147,6 @@ export function getPurchasesFieldDefinitions( {
 			enableGlobalSearch: true,
 			enableSorting: true,
 			enableHiding: false,
-			filterBy: {
-				operators: [ 'is' as Operator ],
-			},
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
 				return item.expiryStatus;
 			},
@@ -172,11 +163,15 @@ export function getPurchasesFieldDefinitions( {
 			enableGlobalSearch: true,
 			enableSorting: true,
 			enableHiding: false,
+			elements: [
+				{ value: 'exists', label: 'Has payment method' },
+				{ value: 'not-exists', label: 'Has no payment method' },
+			],
 			filterBy: {
 				operators: [ 'is' as Operator ],
 			},
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
-				return item.payment?.storedDetailsId ?? '';
+				return ! isExpired( item ) && item.payment?.type ? 'exists' : 'not-exists';
 			},
 			render: ( { item }: { item: Purchases.Purchase } ) => {
 				let isBackupMethodAvailable = false;
@@ -215,9 +210,6 @@ export function getMembershipsFieldDefinitions( {
 			enableGlobalSearch: true,
 			enableSorting: true,
 			enableHiding: false,
-			filterBy: {
-				operators: [ 'is' as Operator ],
-			},
 			getValue: ( { item }: { item: MembershipSubscription } ) => {
 				return item.site_id + ' ' + item.site_title + ' ' + item.site_url;
 			},
@@ -237,9 +229,6 @@ export function getMembershipsFieldDefinitions( {
 			enableGlobalSearch: true,
 			enableSorting: true,
 			enableHiding: false,
-			filterBy: {
-				operators: [ 'is' as Operator ],
-			},
 			getValue: ( { item }: { item: MembershipSubscription } ) => {
 				return item.title;
 			},
@@ -261,9 +250,6 @@ export function getMembershipsFieldDefinitions( {
 			enableGlobalSearch: true,
 			enableSorting: true,
 			enableHiding: false,
-			filterBy: {
-				operators: [ 'is' as Operator ],
-			},
 			getValue: ( { item }: { item: MembershipSubscription } ) => {
 				return item.end_date ?? '';
 			},

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -148,7 +148,12 @@ export function getPurchasesFieldDefinitions( {
 			enableSorting: true,
 			enableHiding: false,
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
-				return item.expiryStatus;
+				if ( isExpired( item ) ) {
+					// Prefix expired items with a z so they sort to the end of the list.
+					return 'zzz ' + item.expiryStatus + ' ' + item.expiryDate;
+				}
+				// Include date in value to sort similar expiries together.
+				return item.expiryDate + ' ' + item.expiryStatus;
 			},
 			render: ( { item }: { item: Purchases.Purchase } ) => {
 				return (
@@ -207,7 +212,7 @@ export function getMembershipsFieldDefinitions( {
 			label: translate( 'Site' ),
 			type: 'text',
 			enableGlobalSearch: true,
-			enableSorting: true,
+			enableSorting: false,
 			enableHiding: false,
 			getValue: ( { item }: { item: MembershipSubscription } ) => {
 				return item.site_id + ' ' + item.site_title + ' ' + item.site_url;
@@ -229,7 +234,7 @@ export function getMembershipsFieldDefinitions( {
 			enableSorting: true,
 			enableHiding: false,
 			getValue: ( { item }: { item: MembershipSubscription } ) => {
-				return item.title;
+				return item.title + ' ' + item.site_title + ' ' + item.site_url;
 			},
 			render: ( { item }: { item: MembershipSubscription } ) => {
 				return (
@@ -247,7 +252,7 @@ export function getMembershipsFieldDefinitions( {
 			label: translate( 'Status' ),
 			type: 'text',
 			enableGlobalSearch: true,
-			enableSorting: true,
+			enableSorting: false,
 			enableHiding: false,
 			getValue: ( { item }: { item: MembershipSubscription } ) => {
 				return item.end_date ?? '';

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -116,6 +116,7 @@ export function MembershipsDataViews( { memberships }: { memberships: Membership
 	const membershipsDataFields = useMembershipsFieldDefinitions();
 	const [ currentView, setView ] = useState( membershipDataView );
 	const isDesktop = useBreakpoint( DESKTOP_BREAKPOINT );
+	const translate = useTranslate();
 
 	// Hide fields at mobile width
 	useEffect( () => {
@@ -128,6 +129,28 @@ export function MembershipsDataViews( { memberships }: { memberships: Membership
 			return;
 		}
 	}, [ isDesktop, currentView, setView ] );
+
+	const actions = useMemo(
+		() => [
+			{
+				id: 'manage-purchase',
+				label: translate( 'Manage this purchase', { textOnly: true } ),
+				isPrimary: true,
+				icon: <Gridicon icon="chevron-right" />,
+				isEligible: ( item: MembershipSubscription ) => Boolean( item.ID ),
+				callback: ( items: MembershipSubscription[] ) => {
+					const subscriptionId = items[ 0 ].ID;
+					if ( ! subscriptionId ) {
+						// eslint-disable-next-line no-console
+						console.error( 'Cannot display manage purchase page for subscription without ID' );
+						return;
+					}
+					page( `/me/purchases/other/${ subscriptionId }` );
+				},
+			},
+		],
+		[ translate ]
+	);
 
 	const { data: adjustedMemberships, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( memberships, currentView, membershipsDataFields );
@@ -144,7 +167,7 @@ export function MembershipsDataViews( { memberships }: { memberships: Membership
 				view={ currentView }
 				onChangeView={ setView }
 				defaultLayouts={ { table: {} } }
-				actions={ undefined }
+				actions={ actions }
 				getItemId={ getItemId }
 				paginationInfo={ paginationInfo }
 			/>

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -4,7 +4,7 @@ import { Purchases } from '@automattic/data-stores';
 import { DataViews, View, filterSortAndPaginate } from '@automattic/dataviews';
 import { DESKTOP_BREAKPOINT } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
-import { LocalizeProps, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
 import { MembershipSubscription } from 'calypso/lib/purchases/types';
 import {
@@ -12,15 +12,15 @@ import {
 	useMembershipsFieldDefinitions,
 } from './hooks/use-field-definitions';
 
-const desktopFields = [ 'site', 'product', 'status', 'payment-method' ];
-const mobileFields = [ 'product' ];
+const purchasesDesktopFields = [ 'site', 'product', 'status', 'payment-method' ];
+const purchasesMobileFields = [ 'product' ];
 export const purchasesDataView: View = {
 	type: 'table',
 	page: 1,
 	perPage: 5,
 	titleField: 'purchase-id',
 	showTitle: false,
-	fields: desktopFields,
+	fields: purchasesDesktopFields,
 	sort: {
 		field: 'product',
 		direction: 'desc',
@@ -32,13 +32,14 @@ export function PurchasesDataViews( { purchases }: { purchases: Purchases.Purcha
 	const isDesktop = useBreakpoint( DESKTOP_BREAKPOINT );
 	const translate = useTranslate();
 	const [ currentView, setView ] = useState( purchasesDataView );
+	// Hide fields at mobile width
 	useEffect( () => {
-		if ( isDesktop && currentView.fields === mobileFields ) {
-			setView( { ...currentView, fields: desktopFields } );
+		if ( isDesktop && currentView.fields === purchasesMobileFields ) {
+			setView( { ...currentView, fields: purchasesDesktopFields } );
 			return;
 		}
-		if ( ! isDesktop && currentView.fields === desktopFields ) {
-			setView( { ...currentView, fields: mobileFields } );
+		if ( ! isDesktop && currentView.fields === purchasesDesktopFields ) {
+			setView( { ...currentView, fields: purchasesMobileFields } );
 			return;
 		}
 	}, [ isDesktop, currentView, setView ] );
@@ -95,26 +96,38 @@ export function PurchasesDataViews( { purchases }: { purchases: Purchases.Purcha
 	);
 }
 
+const membershipsDesktopFields = [ 'site', 'product', 'status' ];
+const membershipsMobileFields = [ 'product' ];
 export const membershipDataView: View = {
 	type: 'table',
 	page: 1,
 	perPage: 5,
-	titleField: 'site',
-	fields: [ 'product', 'status' ],
+	titleField: 'purchase-id',
+	showTitle: false,
+	fields: membershipsDesktopFields,
 	sort: {
-		field: 'site',
+		field: 'product',
 		direction: 'desc',
 	},
 	layout: {},
 };
 
-export function MembershipsDataViews( props: {
-	memberships: MembershipSubscription[];
-	translate: LocalizeProps[ 'translate' ];
-} ) {
-	const { memberships } = props;
+export function MembershipsDataViews( { memberships }: { memberships: MembershipSubscription[] } ) {
 	const membershipsDataFields = useMembershipsFieldDefinitions();
-	const [ currentView, setView ] = useState( purchasesDataView );
+	const [ currentView, setView ] = useState( membershipDataView );
+	const isDesktop = useBreakpoint( DESKTOP_BREAKPOINT );
+
+	// Hide fields at mobile width
+	useEffect( () => {
+		if ( isDesktop && currentView.fields === membershipsMobileFields ) {
+			setView( { ...currentView, fields: membershipsDesktopFields } );
+			return;
+		}
+		if ( ! isDesktop && currentView.fields === membershipsDesktopFields ) {
+			setView( { ...currentView, fields: membershipsMobileFields } );
+			return;
+		}
+	}, [ isDesktop, currentView, setView ] );
 
 	const { data: adjustedMemberships, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( memberships, currentView, membershipsDataFields );

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -2,21 +2,25 @@ import page from '@automattic/calypso-router';
 import { Gridicon, Card } from '@automattic/components';
 import { Purchases } from '@automattic/data-stores';
 import { DataViews, View, filterSortAndPaginate } from '@automattic/dataviews';
+import { DESKTOP_BREAKPOINT } from '@automattic/viewport';
+import { useBreakpoint } from '@automattic/viewport-react';
 import { LocalizeProps, useTranslate } from 'i18n-calypso';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { MembershipSubscription } from 'calypso/lib/purchases/types';
 import {
 	usePurchasesFieldDefinitions,
 	useMembershipsFieldDefinitions,
 } from './hooks/use-field-definitions';
 
+const desktopFields = [ 'purchase-id', 'product', 'status', 'payment-method' ];
+const mobileFields = [ 'purchase-id', 'product' ];
 export const purchasesDataView: View = {
 	type: 'table',
 	page: 1,
 	perPage: 5,
 	titleField: 'purchase-id',
 	showTitle: false,
-	fields: [ 'site', 'product', 'status', 'payment-method' ],
+	fields: desktopFields,
 	sort: {
 		field: 'site',
 		direction: 'desc',
@@ -24,13 +28,20 @@ export const purchasesDataView: View = {
 	layout: {},
 };
 
-export function PurchasesDataViews( props: {
-	purchases: Purchases.Purchase[];
-	translate: LocalizeProps[ 'translate' ];
-} ) {
-	const { purchases } = props;
+export function PurchasesDataViews( { purchases }: { purchases: Purchases.Purchase[] } ) {
+	const isDesktop = useBreakpoint( DESKTOP_BREAKPOINT );
 	const translate = useTranslate();
 	const [ currentView, setView ] = useState( purchasesDataView );
+	useEffect( () => {
+		if ( isDesktop && currentView.fields === mobileFields ) {
+			setView( { ...currentView, fields: desktopFields } );
+			return;
+		}
+		if ( ! isDesktop && currentView.fields === desktopFields ) {
+			setView( { ...currentView, fields: mobileFields } );
+			return;
+		}
+	}, [ isDesktop, currentView, setView ] );
 	const purchasesDataFields = usePurchasesFieldDefinitions( purchasesDataView.fields );
 
 	const { data: adjustedPurchases, paginationInfo } = useMemo( () => {

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -1,9 +1,9 @@
 import page from '@automattic/calypso-router';
 import { Gridicon, Card } from '@automattic/components';
 import { Purchases } from '@automattic/data-stores';
-import { DataViews, View, filterSortAndPaginate } from '@automattic/dataviews';
 import { DESKTOP_BREAKPOINT } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
+import { DataViews, View, filterSortAndPaginate } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
 import { MembershipSubscription } from 'calypso/lib/purchases/types';

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -55,9 +55,20 @@ export function PurchasesDataViews( { purchases }: { purchases: Purchases.Purcha
 				label: translate( 'Manage this purchase', { textOnly: true } ),
 				isPrimary: true,
 				icon: <Gridicon icon="chevron-right" />,
+				isEligible: ( item: Purchases.Purchase ) => Boolean( item.domain && item.id ),
 				callback: ( items: Purchases.Purchase[] ) => {
 					const siteUrl = items[ 0 ].domain;
 					const subscriptionId = items[ 0 ].id;
+					if ( ! siteUrl ) {
+						// eslint-disable-next-line no-console
+						console.error( 'Cannot display manage purchase page for subscription without site' );
+						return;
+					}
+					if ( ! subscriptionId ) {
+						// eslint-disable-next-line no-console
+						console.error( 'Cannot display manage purchase page for subscription without ID' );
+						return;
+					}
 					page( `/me/purchases/${ siteUrl }/${ subscriptionId }` );
 				},
 			},

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -1,7 +1,8 @@
-import { Card } from '@automattic/components';
+import page from '@automattic/calypso-router';
+import { Gridicon, Card } from '@automattic/components';
 import { Purchases } from '@automattic/data-stores';
 import { DataViews, View, filterSortAndPaginate } from '@wordpress/dataviews';
-import { LocalizeProps } from 'i18n-calypso';
+import { LocalizeProps, useTranslate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
 import { MembershipSubscription } from 'calypso/lib/purchases/types';
 import {
@@ -28,12 +29,30 @@ export function PurchasesDataViews( props: {
 	translate: LocalizeProps[ 'translate' ];
 } ) {
 	const { purchases } = props;
+	const translate = useTranslate();
 	const [ currentView, setView ] = useState( purchasesDataView );
 	const purchasesDataFields = usePurchasesFieldDefinitions( purchasesDataView.fields );
 
 	const { data: adjustedPurchases, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( purchases, currentView, purchasesDataFields );
 	}, [ purchases, currentView, purchasesDataFields ] );
+
+	const actions = useMemo(
+		() => [
+			{
+				id: 'manage-purchase',
+				label: translate( 'Manage this purchase', { textOnly: true } ),
+				isPrimary: true,
+				icon: <Gridicon icon="chevron-right" />,
+				callback: ( items: Purchases.Purchase[] ) => {
+					const siteUrl = items[ 0 ].domain;
+					const subscriptionId = items[ 0 ].id;
+					page( `/me/purchases/${ siteUrl }/${ subscriptionId }` );
+				},
+			},
+		],
+		[ translate ]
+	);
 
 	const getItemId = ( item: Purchases.Purchase ) => {
 		return item.id.toString();
@@ -46,7 +65,7 @@ export function PurchasesDataViews( props: {
 				view={ currentView }
 				onChangeView={ setView }
 				defaultLayouts={ { table: {} } }
-				actions={ undefined }
+				actions={ actions }
 				getItemId={ getItemId }
 				paginationInfo={ paginationInfo }
 			/>

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { Gridicon, Card } from '@automattic/components';
 import { Purchases } from '@automattic/data-stores';
-import { DataViews, View, filterSortAndPaginate } from '@wordpress/dataviews';
+import { DataViews, View, filterSortAndPaginate } from '@automattic/dataviews';
 import { LocalizeProps, useTranslate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
 import { MembershipSubscription } from 'calypso/lib/purchases/types';

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -12,8 +12,8 @@ import {
 	useMembershipsFieldDefinitions,
 } from './hooks/use-field-definitions';
 
-const desktopFields = [ 'purchase-id', 'product', 'status', 'payment-method' ];
-const mobileFields = [ 'purchase-id', 'product' ];
+const desktopFields = [ 'site', 'product', 'status', 'payment-method' ];
+const mobileFields = [ 'product' ];
 export const purchasesDataView: View = {
 	type: 'table',
 	page: 1,
@@ -22,7 +22,7 @@ export const purchasesDataView: View = {
 	showTitle: false,
 	fields: desktopFields,
 	sort: {
-		field: 'site',
+		field: 'product',
 		direction: 'desc',
 	},
 	layout: {},

--- a/client/me/purchases/purchases-list-in-dataviews/style.scss
+++ b/client/me/purchases/purchases-list-in-dataviews/style.scss
@@ -16,6 +16,7 @@
 	.dataviews-view-table tr td:first-child,
 	.dataviews-view-table tr th:first-child {
 		padding-left: 24px;
+		max-width: 250px;
 	}
 
 	.dataviews-view-table__cell-content-wrapper .purchase-item__site {

--- a/client/me/purchases/purchases-list-in-dataviews/style.scss
+++ b/client/me/purchases/purchases-list-in-dataviews/style.scss
@@ -1,8 +1,6 @@
 /* Purchase listing
 ================================================== */
 #purchases-list {
-	padding: 8px 0 0;
-
 	.dataviews-view-table,
 	.dataviews-view-table tr {
 		max-width: 1040px;
@@ -40,7 +38,8 @@
 			max-width: 462px;
 		}
 
-		.purchase-item__purchase-type, .purchase-item__purchase-type a.purchase-item__link {
+		.purchase-item__purchase-type,
+		.purchase-item__purchase-type a.purchase-item__link {
 			overflow: hidden;
 		}
 	}

--- a/client/me/purchases/utils.ts
+++ b/client/me/purchases/utils.ts
@@ -27,7 +27,7 @@ export function canEditPaymentDetails( purchase: Purchase ): boolean {
 }
 
 export function getChangePaymentMethodPath( siteSlug: string, purchase: Purchase ): string {
-	if ( isPaidWithCreditCard( purchase ) && purchase.payment.creditCard ) {
+	if ( isPaidWithCreditCard( purchase ) && purchase.payment?.creditCard ) {
 		return changePaymentMethod( siteSlug, purchase.id, purchase.payment.creditCard.id );
 	}
 

--- a/packages/data-stores/src/purchases/types.ts
+++ b/packages/data-stores/src/purchases/types.ts
@@ -44,7 +44,7 @@ export interface Purchase {
 	partnerName: string | undefined;
 	partnerSlug: string | undefined;
 	partnerType: string | undefined;
-	payment: PurchasePayment | PurchasePaymentWithCreditCard | PurchasePaymentWithPayPal;
+	payment: PurchasePayment | PurchasePaymentWithCreditCard | PurchasePaymentWithPayPal | undefined;
 	pendingTransfer: boolean;
 	priceText: string;
 	priceTierList?: Array< PurchasePriceTier >;


### PR DESCRIPTION
## Proposed Changes

This PR fixes sorting for the DataViews version of the purchases list.

> [!NOTE]
> This version of the purchases list is still behind a feature flag. To test this you will need to manually enable the `purchases/purchase-list-dataview` flag in your local `development.json` config before starting calypso.

Part of https://linear.app/a8c/project/replace-calypsos-active-upgrades-subscriptions-with-dataviews-a7b39dea5417/overview / https://github.com/Automattic/wp-calypso/issues/86616

## Testing Instructions

- Use an account which has a number of purchases, the more the better.
- Visit /me/purchases with the DataView enabled (see above).
- Verify that clicking the various headers of the table sorts the list as you'd expect.
