### PR TITLE
Purchases: Make purchase payment optional

### DIFF
--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -512,7 +512,7 @@ export function isOneTimePurchase( purchase: Purchase ) {
 }
 
 export function isPaidWithPaypal( purchase: Purchase ) {
-	return 'paypal' === purchase.payment.type;
+	return 'paypal' === purchase.payment?.type;
 }
 
 export function isPaidWithCredits( purchase: Purchase ) {
@@ -764,15 +764,15 @@ export function isSubscription( purchase: Purchase ): boolean {
 }
 
 export function isPaidWithCreditCard( purchase: Purchase ) {
-	return 'credit_card' === purchase.payment.type && hasCreditCardData( purchase );
+	return 'credit_card' === purchase.payment?.type && hasCreditCardData( purchase );
 }
 
 export function isPaidWithPayPalDirect( purchase: Purchase ) {
-	return 'paypal_direct' === purchase.payment.type && purchase.payment.expiryDate;
+	return 'paypal_direct' === purchase.payment?.type && purchase.payment.expiryDate;
 }
 
 function hasCreditCardData( purchase: Purchase ) {
-	return Boolean( purchase.payment.creditCard?.expiryDate );
+	return Boolean( purchase.payment?.creditCard?.expiryDate );
 }
 
 export function shouldAddPaymentSourceInsteadOfRenewingNow( purchase: Purchase ) {
@@ -836,7 +836,7 @@ export function shouldRenderExpiringCreditCard( purchase: Purchase ) {
 }
 
 export function monthsUntilCardExpires( purchase: Purchase ) {
-	const creditCard = purchase.payment.creditCard;
+	const creditCard = purchase.payment?.creditCard;
 	const expiry = moment( creditCard?.expiryDate, 'MM/YY' );
 	return expiry.diff( moment(), 'months' );
 }
@@ -857,16 +857,16 @@ export function subscribedWithinPastWeek( purchase: Purchase ) {
  */
 export function paymentLogoType( purchase: Purchase ): string | null | undefined {
 	if ( isPaidWithCreditCard( purchase ) ) {
-		return purchase.payment.creditCard?.displayBrand
+		return purchase.payment?.creditCard?.displayBrand
 			? purchase.payment.creditCard?.displayBrand
-			: purchase.payment.creditCard?.type;
+			: purchase.payment?.creditCard?.type;
 	}
 
 	if ( isPaidWithPayPalDirect( purchase ) ) {
 		return 'placeholder';
 	}
 
-	return purchase.payment.type || null;
+	return purchase.payment?.type || null;
 }
 
 export function isAgencyPartnerType( partnerType: string ) {

--- a/client/me/purchases/purchase-item/index.tsx
+++ b/client/me/purchases/purchase-item/index.tsx
@@ -674,7 +674,7 @@ export function PurchaseItemPaymentMethod( {
 	}
 
 	if ( isRenewing( purchase ) ) {
-		if ( purchase.payment.type === 'credit_card' && purchase.payment.creditCard ) {
+		if ( purchase.payment?.type === 'credit_card' && purchase.payment.creditCard ) {
 			const paymentMethodType = purchase.payment.creditCard.displayBrand
 				? purchase.payment.creditCard.displayBrand
 				: purchase.payment.creditCard.type || purchase.payment.paymentPartner || '';
@@ -691,13 +691,13 @@ export function PurchaseItemPaymentMethod( {
 			);
 		}
 
-		if ( purchase.payment.type === 'paypal' ) {
+		if ( purchase.payment?.type === 'paypal' ) {
 			return (
 				<img src={ payPalImage } alt={ purchase.payment.type } className="purchase-item__paypal" />
 			);
 		}
 
-		if ( purchase.payment.type === 'upi' ) {
+		if ( purchase.payment?.type === 'upi' ) {
 			return <img src={ upiImage } alt={ purchase.payment.type } />;
 		}
 

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -176,7 +176,7 @@ export function getPurchasesFieldDefinitions( {
 				operators: [ 'is' as Operator ],
 			},
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
-				return item.payment.storedDetailsId ?? '';
+				return item.payment?.storedDetailsId ?? '';
 			},
 			render: ( { item }: { item: Purchases.Purchase } ) => {
 				let isBackupMethodAvailable = false;
@@ -184,7 +184,7 @@ export function getPurchasesFieldDefinitions( {
 				if ( backupPaymentMethods ) {
 					const backupPaymentMethodsWithoutCurrentPurchase = backupPaymentMethods.filter(
 						// A payment method is only a back up if it isn't already assigned to the current purchase
-						( paymentMethod ) => item.payment.storedDetailsId !== paymentMethod.stored_details_id
+						( paymentMethod ) => item.payment?.storedDetailsId !== paymentMethod.stored_details_id
 					);
 
 					isBackupMethodAvailable = backupPaymentMethodsWithoutCurrentPurchase.length >= 1;

--- a/client/me/purchases/utils.ts
+++ b/client/me/purchases/utils.ts
@@ -27,7 +27,7 @@ export function canEditPaymentDetails( purchase: Purchase ): boolean {
 }
 
 export function getChangePaymentMethodPath( siteSlug: string, purchase: Purchase ): string {
-	if ( isPaidWithCreditCard( purchase ) && purchase.payment.creditCard ) {
+	if ( isPaidWithCreditCard( purchase ) && purchase.payment?.creditCard ) {
 		return changePaymentMethod( siteSlug, purchase.id, purchase.payment.creditCard.id );
 	}
 

--- a/packages/data-stores/src/purchases/types.ts
+++ b/packages/data-stores/src/purchases/types.ts
@@ -44,7 +44,7 @@ export interface Purchase {
 	partnerName: string | undefined;
 	partnerSlug: string | undefined;
 	partnerType: string | undefined;
-	payment: PurchasePayment | PurchasePaymentWithCreditCard | PurchasePaymentWithPayPal;
+	payment: PurchasePayment | PurchasePaymentWithCreditCard | PurchasePaymentWithPayPal | undefined;
 	pendingTransfer: boolean;
 	priceText: string;
 	priceTierList?: Array< PurchasePriceTier >;


### PR DESCRIPTION
## Proposed Changes

Testing to see if https://github.com/Automattic/wp-calypso/pull/103789 will pass TC if I only make a smaller change.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
