### PR TITLE
Change from using description to using help.

### DIFF
--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- `text`, `email`, `select` Edit control: add `help` property to `Field` and use instead of `description`.
+- `checkbox`, `email`, `integer`, `select`, `text`, `toggle-group` Edit control: add `help` property to `Field` and deprecate `description`.
 - `text`, `email` Edit control: add `help` support from the field `description` prop.
 - Add `align` to the `layout.styles` properties, for use in the DataViews table layout. Options are: `start`, `center`, and `end`.
 

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+- `text`, `email`, `select` Edit control: add `help` property to `Field` and use instead of `description`.
 - `text`, `email` Edit control: add `help` support from the field `description` prop.
 - Add `align` to the `layout.styles` properties, for use in the DataViews table layout. Options are: `start`, `center`, and `end`.
 

--- a/packages/dataviews/src/dataform-controls/checkbox.tsx
+++ b/packages/dataviews/src/dataform-controls/checkbox.tsx
@@ -14,13 +14,13 @@ export default function Checkbox< Item >( {
 	data,
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
-	const { id, getValue, label, description } = field;
+	const { id, getValue, label, description, help } = field;
 
 	return (
 		<CheckboxControl
 			__nextHasNoMarginBottom
 			label={ ! hideLabelFromVision ? label : '' }
-			help={ description }
+			help={ help ?? description }
 			checked={ getValue( { item: data } ) }
 			onChange={ () =>
 				onChange( { [ id ]: ! getValue( { item: data } ) } )

--- a/packages/dataviews/src/dataform-controls/email.tsx
+++ b/packages/dataviews/src/dataform-controls/email.tsx
@@ -15,7 +15,7 @@ export default function Email< Item >( {
 	onChange,
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
-	const { id, label, placeholder, description } = field;
+	const { id, label, placeholder, help } = field;
 	const value = field.getValue( { item: data } );
 
 	const onChangeControl = useCallback(
@@ -32,7 +32,7 @@ export default function Email< Item >( {
 			label={ label }
 			placeholder={ placeholder }
 			value={ value ?? '' }
-			help={ description }
+			help={ help }
 			onChange={ onChangeControl }
 			__next40pxDefaultSize
 			__nextHasNoMarginBottom

--- a/packages/dataviews/src/dataform-controls/email.tsx
+++ b/packages/dataviews/src/dataform-controls/email.tsx
@@ -15,7 +15,7 @@ export default function Email< Item >( {
 	onChange,
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
-	const { id, label, placeholder, help } = field;
+	const { id, label, placeholder, description, help } = field;
 	const value = field.getValue( { item: data } );
 
 	const onChangeControl = useCallback(
@@ -32,7 +32,7 @@ export default function Email< Item >( {
 			label={ label }
 			placeholder={ placeholder }
 			value={ value ?? '' }
-			help={ help }
+			help={ help ?? description }
 			onChange={ onChangeControl }
 			__next40pxDefaultSize
 			__nextHasNoMarginBottom

--- a/packages/dataviews/src/dataform-controls/integer.tsx
+++ b/packages/dataviews/src/dataform-controls/integer.tsx
@@ -15,7 +15,7 @@ export default function Integer< Item >( {
 	onChange,
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
-	const { id, label, description } = field;
+	const { id, label, description, help } = field;
 	const value = field.getValue( { item: data } ) ?? '';
 	const onChangeControl = useCallback(
 		( newValue: string | undefined ) =>
@@ -28,7 +28,7 @@ export default function Integer< Item >( {
 	return (
 		<NumberControl
 			label={ label }
-			help={ description }
+			help={ help ?? description }
 			value={ value }
 			onChange={ onChangeControl }
 			__next40pxDefaultSize

--- a/packages/dataviews/src/dataform-controls/select.tsx
+++ b/packages/dataviews/src/dataform-controls/select.tsx
@@ -16,7 +16,7 @@ export default function Select< Item >( {
 	onChange,
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
-	const { id, label, help } = field;
+	const { id, label, description, help } = field;
 	const value = field.getValue( { item: data } ) ?? '';
 	const onChangeControl = useCallback(
 		( newValue: any ) =>
@@ -42,7 +42,7 @@ export default function Select< Item >( {
 		<SelectControl
 			label={ label }
 			value={ value }
-			help={ help }
+			help={ help ?? description }
 			options={ elements }
 			onChange={ onChangeControl }
 			__next40pxDefaultSize

--- a/packages/dataviews/src/dataform-controls/select.tsx
+++ b/packages/dataviews/src/dataform-controls/select.tsx
@@ -16,7 +16,7 @@ export default function Select< Item >( {
 	onChange,
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
-	const { id, label } = field;
+	const { id, label, help } = field;
 	const value = field.getValue( { item: data } ) ?? '';
 	const onChangeControl = useCallback(
 		( newValue: any ) =>
@@ -42,7 +42,7 @@ export default function Select< Item >( {
 		<SelectControl
 			label={ label }
 			value={ value }
-			help={ field.description }
+			help={ help }
 			options={ elements }
 			onChange={ onChangeControl }
 			__next40pxDefaultSize

--- a/packages/dataviews/src/dataform-controls/text.tsx
+++ b/packages/dataviews/src/dataform-controls/text.tsx
@@ -15,7 +15,7 @@ export default function Text< Item >( {
 	onChange,
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
-	const { id, label, placeholder, description } = field;
+	const { id, label, placeholder, help } = field;
 	const value = field.getValue( { item: data } );
 
 	const onChangeControl = useCallback(
@@ -31,7 +31,7 @@ export default function Text< Item >( {
 			label={ label }
 			placeholder={ placeholder }
 			value={ value ?? '' }
-			help={ description }
+			help={ help }
 			onChange={ onChangeControl }
 			__next40pxDefaultSize
 			__nextHasNoMarginBottom

--- a/packages/dataviews/src/dataform-controls/text.tsx
+++ b/packages/dataviews/src/dataform-controls/text.tsx
@@ -15,7 +15,7 @@ export default function Text< Item >( {
 	onChange,
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
-	const { id, label, placeholder, help } = field;
+	const { id, label, placeholder, description, help } = field;
 	const value = field.getValue( { item: data } );
 
 	const onChangeControl = useCallback(
@@ -31,7 +31,7 @@ export default function Text< Item >( {
 			label={ label }
 			placeholder={ placeholder }
 			value={ value ?? '' }
-			help={ help }
+			help={ help ?? description }
 			onChange={ onChangeControl }
 			__next40pxDefaultSize
 			__nextHasNoMarginBottom

--- a/packages/dataviews/src/dataform-controls/toggle-group.tsx
+++ b/packages/dataviews/src/dataform-controls/toggle-group.tsx
@@ -39,7 +39,12 @@ export default function ToggleGroup< Item >( {
 				__nextHasNoMarginBottom
 				isBlock
 				label={ field.label }
-				help={ selectedOption?.description || field.description }
+				help={
+					selectedOption?.help ||
+					selectedOption?.description ||
+					field.help ||
+					field.description
+				}
 				onChange={ onChangeControl }
 				value={ value }
 				hideLabelFromVision={ hideLabelFromVision }

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -132,6 +132,11 @@ export type Field< Item > = {
 	description?: string;
 
 	/**
+	 * A help text for the field.
+	 */
+	help?: string;
+
+	/**
 	 * Placeholder for the field.
 	 */
 	placeholder?: string;

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -21,6 +21,10 @@ export type SortDirection = 'asc' | 'desc';
 export interface Option< Value extends any = any > {
 	value: Value;
 	label: string;
+	help?: string;
+	/**
+	 * @deprecated Use `help` instead.
+	 */
 	description?: string;
 }
 
@@ -128,6 +132,7 @@ export type Field< Item > = {
 
 	/**
 	 * A description of the field.
+	 * @deprecated Use `help` instead.
 	 */
 	description?: string;
 


### PR DESCRIPTION
## Proposed Changes

Related: #103869

Raised in this thread: https://github.com/Automattic/wp-calypso/pull/103762#discussion_r2113613919.

This PR adds a `help` property to the DataForm `Field` to be passed along the controls' `help` property. We are currently using the `description` field, which isn't a great API (and maybe a total misuse?)

**Why `help`?**

It aligns better with the understand form components who use `help` for displaying strings under the inputs.

## To Do

`description` is deprecated to ease upstreaming, but should we delete `description` altogether?


## Testing Instructions

- `npm run storybook:start` in the package root
- add `help` or `description` props to the fields in `src/components/dataform/stories/index.story.tsx` to try it out

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
