### PR TITLE
Dashboard: Use help property for extra field information.

### DIFF
--- a/client/dashboard/sites/settings-static-file-404/index.tsx
+++ b/client/dashboard/sites/settings-static-file-404/index.tsx
@@ -27,7 +27,7 @@ const fields: Field< { setting: string } >[] = [
 		id: 'setting',
 		label: __( 'Server response' ),
 		Edit: 'select',
-		description: __(
+		help: __(
 			'Assets are images, fonts, JavaScript, and CSS files that web browsers request as part of loading a web page. This setting controls how the web server handles requests for missing asset files.'
 		),
 		elements: [

--- a/client/dashboard/sites/site-delete-modal/index.tsx
+++ b/client/dashboard/sites/site-delete-modal/index.tsx
@@ -135,7 +135,7 @@ function SiteDeleteConfirmContent( { site, onClose }: { site: Site; onClose: () 
 			id: 'domain',
 			label: __( 'Type the site domain to confirm' ),
 			type: 'text' as const,
-			description: sprintf(
+			help: sprintf(
 				/* translators: %s: site domain */
 				__( 'The site domain is: %s' ),
 				site.slug

--- a/client/dashboard/sites/site-reset-modal/index.tsx
+++ b/client/dashboard/sites/site-reset-modal/index.tsx
@@ -76,7 +76,7 @@ function SiteResetContent( {
 			id: 'domain',
 			label: __( 'Type the site domain to confirm' ),
 			type: 'text' as const,
-			description: sprintf(
+			help: sprintf(
 				/* translators: %s: site domain */
 				__( 'The site domain is: %s' ),
 				siteDomain


### PR DESCRIPTION
Relies on #103868 

## Proposed Changes

Update Dashboard components to use `help` property instead of `description`.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
