### PR TITLE
STATS: Improve all time insights responsiveness

### DIFF
--- a/client/my-sites/stats/sections/all-time-views-section/style.scss
+++ b/client/my-sites/stats/sections/all-time-views-section/style.scss
@@ -1,6 +1,13 @@
 @import "calypso/my-sites/stats/modernized-stats-table-styles";
 
+.stats__all-time-views-section {
+	.highlight-cards-list {
+		display: block;
+	}
+}
+
 // TODO: Consolidate the overlay styles back into the highlight card component.
+
 .highlight-card {
 	&.highlight-card--has-overlay {
 		.highlight-card-content {

--- a/client/my-sites/stats/sections/all-time-views-section/style.scss
+++ b/client/my-sites/stats/sections/all-time-views-section/style.scss
@@ -4,6 +4,20 @@
 	.highlight-cards-list {
 		display: block;
 	}
+
+	.highlight-card-heading {
+		flex-wrap: wrap;
+		gap: 16px
+	}
+
+	.highlight-card-heading > * {
+		flex: 1;
+		min-width: fit-content;
+	}
+
+	.highlight-card-heading__title {
+		flex-grow: 999999; // An arbitrary large number to ensure it takes up available space.
+	}
 }
 
 // TODO: Consolidate the overlay styles back into the highlight card component.

--- a/client/my-sites/stats/sections/all-time-views-section/style.scss
+++ b/client/my-sites/stats/sections/all-time-views-section/style.scss
@@ -7,16 +7,11 @@
 
 	.highlight-card-heading {
 		flex-wrap: wrap;
-		gap: 16px
+		gap: 8px 16px;
 	}
 
-	.highlight-card-heading > * {
-		flex: 1;
-		min-width: fit-content;
-	}
-
-	.highlight-card-heading__title {
-		flex-grow: 999999; // An arbitrary large number to ensure it takes up available space.
+	.segmented-control {
+		margin-left: auto;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Keep all-time insights controls visible on smaller screens.
* Segment controls buttons should wrap based on available space.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve responsiveness.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before:

https://github.com/user-attachments/assets/21cc8d61-09a4-44fd-81fc-434d4d75e88f

After:

https://github.com/user-attachments/assets/f2d62357-bc8a-49e5-b4e9-749434bfce35

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
