### PR TITLE
Dashboard v2: Update Notice's in defensive mode settings

### DIFF
--- a/client/dashboard/sites/settings-defensive-mode/index.tsx
+++ b/client/dashboard/sites/settings-defensive-mode/index.tsx
@@ -9,7 +9,6 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 	Button,
-	Notice,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
@@ -17,6 +16,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { siteQuery, siteDefensiveModeQuery, siteDefensiveModeMutation } from '../../app/queries';
+import Notice from '../../components/notice';
 import PageLayout from '../../components/page-layout';
 import SettingsPageHeader from '../settings-page-header';
 import type { DefensiveModeSettingsUpdate, Site } from '../../data/types';
@@ -120,42 +120,46 @@ export default function DefensiveModeSettings( { siteSlug }: { siteSlug: string 
 		};
 
 		return (
-			<Notice status="success" isDismissible={ false }>
-				<Text as="p">{ __( 'Defensive mode is enabled' ) }</Text>
+			<Notice
+				variant="success"
+				title={ __( 'Defensive mode is enabled' ) }
+				actions={
+					! enabled_by_a11n && (
+						<Button
+							variant="primary"
+							type="submit"
+							isBusy={ isPending }
+							disabled={ isPending }
+							onClick={ handleDisable }
+						>
+							{ __( 'Disable' ) }
+						</Button>
+					)
+				}
+			>
+				<VStack>
+					{ enabled_by_a11n && (
+						<Text as="p">
+							{ createInterpolateElement(
+								__(
+									'We’ve enabled defensive mode to protect your site. <link>Contact a Happiness Engineer</link> if you need assistance.'
+								),
+								{
+									// @ts-expect-error children prop is injected by createInterpolateElement
+									link: <ExternalLink href="/help/contact" />,
+								}
+							) }
+						</Text>
+					) }
 
-				{ enabled_by_a11n && (
 					<Text as="p">
-						{ createInterpolateElement(
-							__(
-								'We’ve enabled defensive mode to protect your site. <link>Contact a Happiness Engineer</link> if you need assistance.'
-							),
-							{
-								// @ts-expect-error children prop is injected by createInterpolateElement
-								link: <ExternalLink href="/help/contact" />,
-							}
+						{ sprintf(
+							// translators: %s: timestamp, e.g. May 27, 2025 11:02 AM
+							__( 'This will be automatically disabled on %s.' ),
+							enabledUntil
 						) }
 					</Text>
-				) }
-
-				<Text as="p">
-					{ sprintf(
-						// translators: %s: timestamp, e.g. May 27, 2025 11:02 AM
-						__( 'This will be automatically disabled on %s.' ),
-						enabledUntil
-					) }
-				</Text>
-
-				{ ! enabled_by_a11n && (
-					<Button
-						variant="primary"
-						type="submit"
-						isBusy={ isPending }
-						disabled={ isPending }
-						onClick={ handleDisable }
-					>
-						{ __( 'Disable' ) }
-					</Button>
-				) }
+				</VStack>
 			</Notice>
 		);
 	};
@@ -171,9 +175,7 @@ export default function DefensiveModeSettings( { siteSlug }: { siteSlug: string 
 
 		return (
 			<VStack spacing={ 8 }>
-				<Notice status="info" isDismissible={ false }>
-					<Text>{ __( 'Defensive mode is disabled' ) }</Text>
-				</Notice>
+				<Notice>{ __( 'Defensive mode is disabled.' ) }</Notice>
 				<Card>
 					<CardBody>
 						<VStack spacing={ 8 } style={ { padding: '8px 0' } }>


### PR DESCRIPTION
## Proposed Changes

This PR updates the `<Notice />` components from https://github.com/Automattic/wp-calypso/pull/103727 to use the newly designed `<Notice />` from `client/dashboard` instead.

|Disabled|Enabled|Enabled by a11n|
|-|-|-|
|<img width="621" alt="image" src="https://github.com/user-attachments/assets/ba3c9223-7c25-442c-9aef-101b8b043d2f" />|<img width="618" alt="image" src="https://github.com/user-attachments/assets/d011aabe-f9aa-47b3-a796-583b45ed40e9" />|<img width="622" alt="image" src="https://github.com/user-attachments/assets/3fbfefcc-8db7-4ba4-b8df-be324c31ee9f" />|

## Testing Instructions

Follow https://github.com/Automattic/wp-calypso/pull/103727.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
