### PR TITLE
Dashboard v2: Update Notice in WP settings

### DIFF
--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -7,7 +7,6 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 	Button,
-	Notice,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
@@ -19,6 +18,7 @@ import {
 	siteWordPressVersionQuery,
 	siteWordPressVersionMutation,
 } from '../../app/queries';
+import Notice from '../../components/notice';
 import PageLayout from '../../components/page-layout';
 import { getFormattedWordPressVersion } from '../../utils/wp-version';
 import SettingsPageHeader from '../settings-page-header';
@@ -111,29 +111,29 @@ export default function WordPressVersionSettings( { siteSlug }: { siteSlug: stri
 
 	const renderNotice = () => {
 		return (
-			<Notice isDismissible={ false }>
-				<Text>
-					{ site.is_wpcom_atomic
-						? createInterpolateElement(
-								sprintf(
-									// translators: %s: WordPress version, e.g. 6.8
-									__(
-										'Every WordPress.com site runs the latest WordPress version (%s). For testing purposes, you can switch to the beta version of the next WordPress release on <a>your staging site</a>.'
-									),
-									getFormattedWordPressVersion( site )
+			<Notice>
+				<VStack>
+					<Text as="p">
+						{ sprintf(
+							// translators: %s: WordPress version, e.g. 6.8
+							__( 'Every WordPress.com site runs the latest WordPress version (%s).' ),
+							getFormattedWordPressVersion( site )
+						) }
+					</Text>
+					{ site.is_wpcom_atomic && (
+						<Text as="p">
+							{ createInterpolateElement(
+								__(
+									'Switch to a <a>staging site</a> to test a beta version of the next WordPress release.'
 								),
 								{
-									// TODO: use correct staging site URL when it's available.
-									// eslint-disable-next-line jsx-a11y/anchor-is-valid
-									a: <a href="#" />,
+									// TODO: use correct v2 staging site URL when it's available.
+									a: <a href={ `/staging-site/${ site.slug }` } />,
 								}
-						  )
-						: sprintf(
-								// translators: %s: WordPress version, e.g. 6.8
-								__( 'Every WordPress.com site runs the latest WordPress version (%s).' ),
-								getFormattedWordPressVersion( site )
-						  ) }
-				</Text>
+							) }
+						</Text>
+					) }
+				</VStack>
 			</Notice>
 		);
 	};


### PR DESCRIPTION
## Proposed Changes

This PR updates the notice in WordPress settings as follows:

- Use the new `<Notice />` component
- Update the copy as per Figma
- Update the staging site URL to point to existing (v1) URL for the time being.

|Simple|Atomic non-staging|
|-|-|
|<img width="627" alt="image" src="https://github.com/user-attachments/assets/7adccffb-14c5-4e29-bad0-986b502a27f9" />|<img width="623" alt="image" src="https://github.com/user-attachments/assets/2d975d3d-6e2d-4243-b2af-04a4c6513ee0" />|

## Testing Instructions

Check the WP settings on a Simple and Atomic (non-staging) site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
