### PR TITLE
Hosting Dashboard: Update Notice component in the Database screen

### DIFF
--- a/client/dashboard/sites/settings-database/index.tsx
+++ b/client/dashboard/sites/settings-database/index.tsx
@@ -7,7 +7,6 @@ import {
 	Button,
 	Card,
 	CardBody,
-	Notice,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
@@ -16,6 +15,7 @@ import { blockTable } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { siteQuery } from '../../app/queries';
+import Notice from '../../components/notice';
 import PageLayout from '../../components/page-layout';
 import { fetchPhpMyAdminToken } from '../../data';
 import { canAccessPhpMyAdmin } from '../../utils/site-features';
@@ -125,7 +125,7 @@ export default function SiteDatabaseSettings( { siteSlug }: { siteSlug: string }
 							</Text>
 						</VStack>
 						<VStack>
-							<Notice isDismissible={ false }>
+							<Notice density="medium">
 								{ __(
 									'Managing a database can be tricky and it’s not necessary for your site to function.'
 								) }


### PR DESCRIPTION
## Proposed Changes

| Before | After |
| --- | --- |
| ![Screenshot 2025-06-02 at 4 19 52 PM](https://github.com/user-attachments/assets/71bfdce5-5ad3-4f2f-961b-431949df221f) | ![Screenshot 2025-06-02 at 4 18 11 PM](https://github.com/user-attachments/assets/d24fe744-af30-4f70-896f-bc0240754087) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /sites/:siteSlug/settings/database using a WoA site.
* Ensure that the Notice component is updated as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
