### PR TITLE
SummaryButtonList: ignore empty child elements

### DIFF
--- a/client/dashboard/components/summary-button-list/style.scss
+++ b/client/dashboard/components/summary-button-list/style.scss
@@ -14,7 +14,8 @@
 	}
 
 	&.has-density-low {
-		.dashboard-summary-button-list__children-list-item:not(:last-child) {
+		// Do not add a bottom margin to the last (non-empty) child.
+		.dashboard-summary-button-list__children-list-item:not(:nth-last-child(1 of :not(:empty))) {
 			margin-bottom: $grid-unit-30;
 		}
 	}
@@ -29,17 +30,20 @@
 		// TODO: once the component uses React context, we should use that
 		// to let the summary button component know the appropriate border
 		// radius inheritance behavior.
-		.dashboard-summary-button-list__children-list,
-		.dashboard-summary-button-list__children-list-item {
+		.dashboard-summary-button-list__children-list {
 			border-radius: inherit;
 		}
 
-		.dashboard-summary-button-list__children-list-item:first-child > * {
+		// First (non-empty) <li> and its direct children.
+		.dashboard-summary-button-list__children-list-item:nth-child(1 of :not(:empty)),
+		.dashboard-summary-button-list__children-list-item:nth-child(1 of :not(:empty)) > * {
 			border-top-left-radius: inherit;
 			border-top-right-radius: inherit;
 		}
 
-		.dashboard-summary-button-list__children-list-item:last-child > * {
+		// Last (non-empty) <li> and its direct children.
+		.dashboard-summary-button-list__children-list-item:nth-last-child(1 of :not(:empty)),
+		.dashboard-summary-button-list__children-list-item:nth-last-child(1 of :not(:empty)) > * {
 			// TODO: once the component uses React context, we should use that
 			// to let the correct summary button component know that it's
 			// the last child, and should not have a bottom border.

--- a/client/dashboard/components/summary-button-list/style.scss
+++ b/client/dashboard/components/summary-button-list/style.scss
@@ -7,6 +7,12 @@
 		margin: 0;
 	}
 
+	.dashboard-summary-button-list__children-list-item {
+		&:empty {
+			display: none;
+		}
+	}
+
 	&.has-density-low {
 		.dashboard-summary-button-list__children-list-item:not(:last-child) {
 			margin-bottom: $grid-unit-30;

--- a/client/dashboard/components/summary-button-list/types.ts
+++ b/client/dashboard/components/summary-button-list/types.ts
@@ -22,6 +22,14 @@ export interface SummaryButtonListProps {
 	 * The child components should be either SummaryButton instances or components that
 	 * wrap SummaryButton internally and pass the `density` prop to them. This is because
 	 * the component will override the 'density' prop of these children to match the parent's density.
+	 *
+	 * Note: avoid having children components that don't render any markup to the DOM.
+	 * Instead, prefer rendering each child element conditionally.
+	 *
+	 * Example:
+	 * <SummaryButtonList>
+	 *   { showSummaryItem ? <SummaryItem { ...summaryItemProps } /> : null }
+	 * </SummaryButtonList>
 	 */
 	children: ChildType | ChildType[];
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-13409
Follow-up tp #103555

## Proposed Changes

Tweak some internal CSS selectors of the `SummaryButtonList` component, switching:

- from `:first-child` to `:nth-child( 1 of :not( :empty ) )`
- from `:last-child` to `:nth-last-child( 1 of :not( :empty ) )`

and thus ignoring any empty `<li>` HTML elements from the styling rules.

Additionally, add `display: none` to the empty `<li>`s.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To make `SummaryButtonList` more resilient to consumers rendering children that internally do not render any HTML.

Even if `SummaryButtonList` doesn't have a way to know whether its children will render any HTML to the DOM, the recently added [`of selector` syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child#the_of_selector_syntax) allows for a neat CSS-only solution to this problem.

I also wanted to add tests, but it looks like we're not rendering styles in our tests (meaning that `testing-library` does not know that empty `<li>`s have `display: none`).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Navigate to `/v2/sites/[FREE_SITE_ID].wordpress.com/settings` and observe the "General" and "Server" sections — the last item should have a double bottom border on `trunk`, but that should be fixed in this PR.

| Before (trunk) | After (this PR) |
|---|---|
| ![Screenshot 2025-06-02 at 10 58 14](https://github.com/user-attachments/assets/c93f3896-1889-4dc9-bb15-9066aaef4c89) | ![Screenshot 2025-06-02 at 10 59 17](https://github.com/user-attachments/assets/61f0f669-1009-443b-bd87-46f9b1a14f6c) |

You can also test it in Storybook by applying this diff, and making sure that the component renders without any visual glitches (including hover and focus styles):

<details>

<summary>Click to show diff</summary>

```diff
diff --git i/client/dashboard/components/summary-button-list/index.stories.tsx w/client/dashboard/components/summary-button-list/index.stories.tsx
index efeaeabb809..dab75f04159 100644
--- i/client/dashboard/components/summary-button-list/index.stories.tsx
+++ w/client/dashboard/components/summary-button-list/index.stories.tsx
@@ -23,10 +23,13 @@ const meta: Meta< typeof SummaryButtonList > = {
 export default meta;
 type Story = StoryObj< typeof SummaryButtonList >;
 
+const Empty = () => null;
+
 export const Default: Story = {
 	args: {
 		title: 'General Settings',
 		children: [
+			<Empty key="empty-1" />,
 			<SummaryButton
 				key="visibility"
 				title="Site visibility"
@@ -39,12 +42,15 @@ export const Default: Story = {
 				decoration={ <Icon icon={ brush } /> }
 				badges={ [ { text: 'Twenty Twenty-Four' } ] }
 			/>,
+			<Empty key="empty-2" />,
+			<Empty key="empty-3" />,
 			<SummaryButton
 				key="home"
 				title="Homepage settings"
 				decoration={ <Icon icon={ home } /> }
 				badges={ [ { text: 'Latest posts' } ] }
 			/>,
+			<Empty key="empty-4" />,
 		],
 	},
 };

```

</details>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
