### PR TITLE
Experiment streamlining the plans grid + checkout: Restore feature upsell for monthly plans

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -403,8 +403,7 @@ export default function CheckoutMainContent( {
 
 	const leaveModalProps = useCheckoutLeaveModal( { siteUrl: siteUrl ?? '' } );
 
-	const [ isStreamlinedPriceExperimentLoading, streamlinedPriceExperimentAssignment ] =
-		useStreamlinedPriceExperiment();
+	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
 
 	const searchParams = new URLSearchParams( window.location.search );
 	const isDIFMInCart = hasDIFMProduct( responseCart );
@@ -641,10 +640,7 @@ export default function CheckoutMainContent( {
 							<WPCheckoutOrderSummary
 								siteId={ siteId }
 								onChangeSelection={ changeSelection }
-								showFeaturesList={
-									! isStreamlinedPriceExperimentLoading &&
-									! isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment )
-								}
+								showFeaturesList
 							/>
 							<CheckoutSidebarNudge
 								addItemToCart={ addItemToCart }

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -404,6 +404,9 @@ export default function CheckoutMainContent( {
 	const leaveModalProps = useCheckoutLeaveModal( { siteUrl: siteUrl ?? '' } );
 
 	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
+	const isStreamlinedPrice = isStreamlinedPriceCheckoutTreatment(
+		streamlinedPriceExperimentAssignment
+	);
 
 	const searchParams = new URLSearchParams( window.location.search );
 	const isDIFMInCart = hasDIFMProduct( responseCart );
@@ -637,11 +640,15 @@ export default function CheckoutMainContent( {
 								</div>
 							) }
 
-							<WPCheckoutOrderSummary
-								siteId={ siteId }
-								onChangeSelection={ changeSelection }
-								showFeaturesList
-							/>
+							{ isStreamlinedPrice ? (
+								<WPCheckoutOrderSummary siteId={ siteId } />
+							) : (
+								<WPCheckoutOrderSummary
+									siteId={ siteId }
+									onChangeSelection={ changeSelection }
+									showFeaturesList
+								/>
+							) }
 							<CheckoutSidebarNudge
 								addItemToCart={ addItemToCart }
 								areThereDomainProductsInCart={ areThereDomainProductsInCart }
@@ -656,9 +663,7 @@ export default function CheckoutMainContent( {
 	const checkoutMainContent = (
 		<WPCheckoutMainContent
 			className="checkout-main-content"
-			isStreamlinedPrice={ isStreamlinedPriceCheckoutTreatment(
-				streamlinedPriceExperimentAssignment
-			) }
+			isStreamlinedPrice={ isStreamlinedPrice }
 		>
 			<CheckoutOrderBanner />
 			{ isStepContainerV2 ? (

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -20,6 +20,7 @@ import {
 	getItemVariantCompareToPrice,
 	getItemVariantDiscount,
 } from '../item-variation-picker/util';
+import { CheckoutSummaryFeaturedList } from '../wp-checkout-order-summary';
 import type { WPCOMProductVariant } from '../item-variation-picker';
 import './style.scss';
 
@@ -111,6 +112,9 @@ export function CheckoutSidebarPlanUpsell() {
 		( product ) => isPlan( product ) && ! isJetpackPlan( product )
 	);
 	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
+	const isStreamlinedPrice = isStreamlinedPriceCheckoutTreatment(
+		streamlinedPriceExperimentAssignment
+	);
 
 	const variants = useGetProductVariants( plan );
 
@@ -201,7 +205,7 @@ export function CheckoutSidebarPlanUpsell() {
 		upsellVariant,
 		percentSavings,
 		__,
-		isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment )
+		isStreamlinedPrice
 	);
 
 	if ( ! upsellText ) {
@@ -212,15 +216,13 @@ export function CheckoutSidebarPlanUpsell() {
 
 	const checkoutSidebarPlanUpsellClassName =
 		'checkout-sidebar-plan-upsell' +
-		( isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment )
-			? ' checkout-sidebar-plan-upsell-streamlined'
-			: '' );
+		( isStreamlinedPrice ? ' checkout-sidebar-plan-upsell-streamlined' : '' );
 
 	return (
 		<>
 			<PromoCard title={ cardTitle } className={ checkoutSidebarPlanUpsellClassName }>
 				<div className="checkout-sidebar-plan-upsell__plan-grid">
-					{ ! isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment ) && (
+					{ ! isStreamlinedPrice && (
 						<>
 							<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
 								<strong>{ __( 'Plan' ) }</strong>
@@ -262,6 +264,14 @@ export function CheckoutSidebarPlanUpsell() {
 						} ) }
 					</div>
 				</div>
+				{ isStreamlinedPrice && (
+					<CheckoutSummaryFeaturedList
+						responseCart={ responseCart }
+						siteId={ undefined }
+						isCartUpdating={ FormStatus.VALIDATING === formStatus }
+						isStreamlinedPrice={ isStreamlinedPrice }
+					/>
+				) }
 				<PromoCardCTA
 					cta={ {
 						disabled: isFormLoading,

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/style.scss
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/style.scss
@@ -23,12 +23,9 @@
 	max-width: 384px;
 	width: 100%;
 }
-.promo-card.checkout-sidebar-plan-features-upsell {
-	margin-bottom: 0;
-
-	.action-panel__body {
-		overflow: visible;
-	}
+.promo-card.checkout-sidebar-plan-upsell-streamlined .action-panel__body {
+	overflow: visible;
+	color: var(--studio-gray-100);
 }
 
 .checkout-sidebar-plan-upsell__plan-grid {

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/style.scss
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/style.scss
@@ -25,6 +25,10 @@
 }
 .promo-card.checkout-sidebar-plan-features-upsell {
 	margin-bottom: 0;
+
+	.action-panel__body {
+		overflow: visible;
+	}
 }
 
 .checkout-sidebar-plan-upsell__plan-grid {

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/style.scss
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/style.scss
@@ -19,6 +19,13 @@
 	font-size: $font-title-small;
 	line-height: 1.3;
 }
+.promo-card.checkout-sidebar-plan-upsell-streamlined {
+	max-width: 384px;
+	width: 100%;
+}
+.promo-card.checkout-sidebar-plan-features-upsell {
+	margin-bottom: 0;
+}
 
 .checkout-sidebar-plan-upsell__plan-grid {
 	display: grid;

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -104,23 +104,21 @@ export function WPCheckoutOrderSummary( {
 		streamlinedPriceExperimentAssignment
 	);
 	return (
-		<>
-			<CheckoutSummaryCard
-				className={ isCartUpdating ? 'is-loading' : '' }
-				data-e2e-cart-is-loading={ isCartUpdating }
-				isStreamlinedPrice={ isStreamlinedPrice }
-			>
-				{ showFeaturesList && (
-					<CheckoutSummaryFeaturedList
-						responseCart={ responseCart }
-						siteId={ siteId }
-						isCartUpdating={ isCartUpdating }
-						onChangeSelection={ onChangeSelection }
-					/>
-				) }
-				<CheckoutSummaryPriceList />
-			</CheckoutSummaryCard>
-		</>
+		<CheckoutSummaryCard
+			className={ isCartUpdating ? 'is-loading' : '' }
+			data-e2e-cart-is-loading={ isCartUpdating }
+			isStreamlinedPrice={ isStreamlinedPrice }
+		>
+			{ showFeaturesList && (
+				<CheckoutSummaryFeaturedList
+					responseCart={ responseCart }
+					siteId={ siteId }
+					isCartUpdating={ isCartUpdating }
+					onChangeSelection={ onChangeSelection }
+				/>
+			) }
+			<CheckoutSummaryPriceList />
+		</CheckoutSummaryCard>
 	);
 }
 export function CheckoutSummaryFeaturedList( {

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -923,11 +923,7 @@ function CheckoutSummaryAnnualUpsell( props: {
 					  ) }
 			</CheckoutSummaryFeaturesListWrapper>
 			{ props.onChangeSelection && (
-				<SwitchToAnnualPlan
-					plan={ props.plan }
-					onChangeSelection={ props.onChangeSelection }
-					linkText={ title }
-				/>
+				<SwitchToAnnualPlan plan={ props.plan } onChangeSelection={ props.onChangeSelection } />
 			) }
 		</CheckoutSummaryFeaturesUpsell>
 	);

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -100,25 +100,30 @@ export function WPCheckoutOrderSummary( {
 	const { responseCart } = useShoppingCart( cartKey );
 	const isCartUpdating = FormStatus.VALIDATING === formStatus;
 	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
-
+	const isStreamlinedPrice = isStreamlinedPriceCheckoutTreatment(
+		streamlinedPriceExperimentAssignment
+	);
+	const featuresList = showFeaturesList && (
+		<CheckoutSummaryFeaturedList
+			responseCart={ responseCart }
+			siteId={ siteId }
+			isCartUpdating={ isCartUpdating }
+			onChangeSelection={ onChangeSelection }
+			isStreamlinedPrice={ isStreamlinedPrice }
+		/>
+	);
 	return (
-		<CheckoutSummaryCard
-			className={ isCartUpdating ? 'is-loading' : '' }
-			data-e2e-cart-is-loading={ isCartUpdating }
-			isStreamlinedPrice={ isStreamlinedPriceCheckoutTreatment(
-				streamlinedPriceExperimentAssignment
-			) }
-		>
-			{ showFeaturesList && (
-				<CheckoutSummaryFeaturedList
-					responseCart={ responseCart }
-					siteId={ siteId }
-					isCartUpdating={ isCartUpdating }
-					onChangeSelection={ onChangeSelection }
-				/>
-			) }
-			<CheckoutSummaryPriceList />
-		</CheckoutSummaryCard>
+		<>
+			<CheckoutSummaryCard
+				className={ isCartUpdating ? 'is-loading' : '' }
+				data-e2e-cart-is-loading={ isCartUpdating }
+				isStreamlinedPrice={ isStreamlinedPrice }
+			>
+				{ ! isStreamlinedPrice && featuresList }
+				<CheckoutSummaryPriceList />
+			</CheckoutSummaryCard>
+			{ isStreamlinedPrice && featuresList }
+		</>
 	);
 }
 export function CheckoutSummaryFeaturedList( {
@@ -126,6 +131,7 @@ export function CheckoutSummaryFeaturedList( {
 	siteId,
 	isCartUpdating,
 	onChangeSelection,
+	isStreamlinedPrice,
 }: {
 	responseCart: ResponseCart;
 	siteId: number | undefined;
@@ -136,9 +142,9 @@ export function CheckoutSummaryFeaturedList( {
 		productId: number,
 		volume?: number
 	) => void;
+	isStreamlinedPrice?: boolean;
 } ) {
 	const translate = useTranslate();
-	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
 
 	// Return early if the cart is only Chargebacks fees
 	if ( responseCart.products.every( isChargeback || isCredits ) ) {
@@ -156,7 +162,7 @@ export function CheckoutSummaryFeaturedList( {
 
 	return (
 		<>
-			{ ! isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment ) && (
+			{ ! isStreamlinedPrice && (
 				<CheckoutSummaryFeatures className="checkout__summary-features">
 					<CheckoutSummaryFeaturesTitle>
 						{ responseCart.is_gift_purchase

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -138,6 +138,7 @@ export function CheckoutSummaryFeaturedList( {
 	) => void;
 } ) {
 	const translate = useTranslate();
+	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
 
 	// Return early if the cart is only Chargebacks fees
 	if ( responseCart.products.every( isChargeback || isCredits ) ) {
@@ -155,17 +156,19 @@ export function CheckoutSummaryFeaturedList( {
 
 	return (
 		<>
-			<CheckoutSummaryFeatures className="checkout__summary-features">
-				<CheckoutSummaryFeaturesTitle>
-					{ responseCart.is_gift_purchase
-						? translate( 'WordPress.com Gift Subscription' )
-						: translate( 'Included with your purchase' ) }
-				</CheckoutSummaryFeaturesTitle>
-				<CheckoutSummaryFeaturesWrapper
-					siteId={ siteId }
-					nextDomainIsFree={ responseCart.next_domain_is_free }
-				/>
-			</CheckoutSummaryFeatures>
+			{ ! isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment ) && (
+				<CheckoutSummaryFeatures className="checkout__summary-features">
+					<CheckoutSummaryFeaturesTitle>
+						{ responseCart.is_gift_purchase
+							? translate( 'WordPress.com Gift Subscription' )
+							: translate( 'Included with your purchase' ) }
+					</CheckoutSummaryFeaturesTitle>
+					<CheckoutSummaryFeaturesWrapper
+						siteId={ siteId }
+						nextDomainIsFree={ responseCart.next_domain_is_free }
+					/>
+				</CheckoutSummaryFeatures>
+			) }
 			{ ! isCartUpdating && ! hasRenewalInCart && ! isWcMobile && plan && hasMonthlyPlanInCart && (
 				<CheckoutSummaryAnnualUpsell plan={ plan } onChangeSelection={ onChangeSelection } />
 			) }

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -43,6 +43,8 @@ import styled from '@emotion/styled';
 import { Icon, reusableBlock } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
+import PromoCard from 'calypso/components/promo-section/promo-card';
+import PromoCardCTA from 'calypso/components/promo-section/promo-card/cta';
 import { hasFreeCouponTransfersOnly } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
@@ -176,7 +178,11 @@ export function CheckoutSummaryFeaturedList( {
 				</CheckoutSummaryFeatures>
 			) }
 			{ ! isCartUpdating && ! hasRenewalInCart && ! isWcMobile && plan && hasMonthlyPlanInCart && (
-				<CheckoutSummaryAnnualUpsell plan={ plan } onChangeSelection={ onChangeSelection } />
+				<CheckoutSummaryAnnualUpsell
+					plan={ plan }
+					onChangeSelection={ onChangeSelection }
+					isStreamlinedPrice={ isStreamlinedPrice }
+				/>
 			) }
 		</>
 	);
@@ -325,6 +331,7 @@ function SwitchToAnnualPlan( {
 	plan,
 	onChangeSelection,
 	linkText,
+	isStreamlinedPrice,
 }: {
 	plan: ResponseCartProduct;
 	onChangeSelection: (
@@ -334,6 +341,7 @@ function SwitchToAnnualPlan( {
 		volume?: number
 	) => void;
 	linkText?: React.ReactNode;
+	isStreamlinedPrice?: boolean;
 } ) {
 	const translate = useTranslate();
 	const handleClick = () => {
@@ -343,7 +351,16 @@ function SwitchToAnnualPlan( {
 		}
 	};
 	const text = linkText ?? translate( 'Switch to an annual plan and save!' );
-
+	if ( isStreamlinedPrice ) {
+		return (
+			<PromoCardCTA
+				cta={ {
+					text: String( text ),
+					action: handleClick,
+				} }
+			/>
+		);
+	}
 	return <SwitchToAnnualPlanButton onClick={ handleClick }>{ text }</SwitchToAnnualPlanButton>;
 }
 
@@ -866,6 +883,7 @@ function CheckoutSummaryAnnualUpsell( props: {
 		productId: number,
 		volume?: number
 	) => void;
+	isStreamlinedPrice?: boolean;
 } ) {
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
@@ -878,16 +896,9 @@ function CheckoutSummaryAnnualUpsell( props: {
 	const shouldShowFreeDomainUpsell = ! (
 		isWooExpressPlan( productSlug ) && Boolean( props.plan.introductory_offer_terms?.enabled )
 	);
-
-	return (
-		<CheckoutSummaryFeaturesUpsell>
-			<CheckoutSummaryFeaturesTitle>
-				<SwitchToAnnualPlan
-					plan={ props.plan }
-					onChangeSelection={ props.onChangeSelection }
-					linkText={ translate( 'Included with an annual plan' ) }
-				/>
-			</CheckoutSummaryFeaturesTitle>
+	const title = translate( 'Included with an annual plan' );
+	const content = (
+		<>
 			<CheckoutSummaryFeaturesListWrapper>
 				{ shouldShowFreeDomainUpsell && (
 					<CheckoutSummaryFeaturesListItem isSupported={ false }>
@@ -911,8 +922,36 @@ function CheckoutSummaryAnnualUpsell( props: {
 							</CheckoutSummaryFeaturesListItem>
 					  ) }
 			</CheckoutSummaryFeaturesListWrapper>
-			<SwitchToAnnualPlan plan={ props.plan } onChangeSelection={ props.onChangeSelection } />
-		</CheckoutSummaryFeaturesUpsell>
+			<SwitchToAnnualPlan
+				plan={ props.plan }
+				onChangeSelection={ props.onChangeSelection }
+				isStreamlinedPrice={ props.isStreamlinedPrice }
+			/>
+		</>
+	);
+
+	return (
+		<>
+			{ props.isStreamlinedPrice ? (
+				<PromoCard
+					title={ title }
+					className="checkout-sidebar-plan-upsell checkout-sidebar-plan-features-upsell checkout-sidebar-plan-upsell-streamlined"
+				>
+					{ content }
+				</PromoCard>
+			) : (
+				<CheckoutSummaryFeaturesUpsell>
+					<CheckoutSummaryFeaturesTitle>
+						<SwitchToAnnualPlan
+							plan={ props.plan }
+							onChangeSelection={ props.onChangeSelection }
+							linkText={ title }
+						/>
+					</CheckoutSummaryFeaturesTitle>
+					{ content }
+				</CheckoutSummaryFeaturesUpsell>
+			) }
+		</>
 	);
 }
 

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -335,7 +335,6 @@ function SwitchToAnnualPlan( {
 		volume?: number
 	) => void;
 	linkText?: React.ReactNode;
-	isStreamlinedPrice?: boolean;
 } ) {
 	const translate = useTranslate();
 	const handleClick = () => {
@@ -345,6 +344,7 @@ function SwitchToAnnualPlan( {
 		}
 	};
 	const text = linkText ?? translate( 'Switch to an annual plan and save!' );
+
 	return <SwitchToAnnualPlanButton onClick={ handleClick }>{ text }</SwitchToAnnualPlanButton>;
 }
 
@@ -880,25 +880,23 @@ function CheckoutSummaryAnnualUpsell( props: {
 	const shouldShowFreeDomainUpsell = ! (
 		isWooExpressPlan( productSlug ) && Boolean( props.plan.introductory_offer_terms?.enabled )
 	);
-	const title = translate( 'Included with an annual plan' );
-	const hasStreamlinedPriceTitle =
-		translate.localeSlug?.startsWith( 'en' ) ||
-		hasEnTranslation( 'Extra features with annual plans' );
-	const streamlinedPriceTitle = hasStreamlinedPriceTitle
-		? translate( 'Extra features with annual plans' )
-		: title;
+	let title = translate( 'Included with an annual plan' );
+
+	if ( props.isStreamlinedPrice && hasEnTranslation( 'Extra features with annual plans' ) ) {
+		title = translate( 'Extra features with annual plans' );
+	}
 
 	return (
 		<CheckoutSummaryFeaturesUpsell>
 			<CheckoutSummaryFeaturesTitle>
-				{ ! props.onChangeSelection ? (
-					<>{ streamlinedPriceTitle }</>
-				) : (
+				{ props.onChangeSelection ? (
 					<SwitchToAnnualPlan
 						plan={ props.plan }
 						onChangeSelection={ props.onChangeSelection }
 						linkText={ title }
 					/>
+				) : (
+					<>{ title }</>
 				) }
 			</CheckoutSummaryFeaturesTitle>
 			<CheckoutSummaryFeaturesListWrapper>

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -43,8 +43,6 @@ import styled from '@emotion/styled';
 import { Icon, reusableBlock } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
-import PromoCard from 'calypso/components/promo-section/promo-card';
-import PromoCardCTA from 'calypso/components/promo-section/promo-card/cta';
 import { hasFreeCouponTransfersOnly } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
@@ -89,7 +87,7 @@ export function WPCheckoutOrderSummary( {
 	showFeaturesList,
 }: {
 	siteId: number | undefined;
-	onChangeSelection: (
+	onChangeSelection?: (
 		uuid: string,
 		productSlug: string,
 		productId: number,
@@ -105,15 +103,6 @@ export function WPCheckoutOrderSummary( {
 	const isStreamlinedPrice = isStreamlinedPriceCheckoutTreatment(
 		streamlinedPriceExperimentAssignment
 	);
-	const featuresList = showFeaturesList && (
-		<CheckoutSummaryFeaturedList
-			responseCart={ responseCart }
-			siteId={ siteId }
-			isCartUpdating={ isCartUpdating }
-			onChangeSelection={ onChangeSelection }
-			isStreamlinedPrice={ isStreamlinedPrice }
-		/>
-	);
 	return (
 		<>
 			<CheckoutSummaryCard
@@ -121,10 +110,16 @@ export function WPCheckoutOrderSummary( {
 				data-e2e-cart-is-loading={ isCartUpdating }
 				isStreamlinedPrice={ isStreamlinedPrice }
 			>
-				{ ! isStreamlinedPrice && featuresList }
+				{ showFeaturesList && (
+					<CheckoutSummaryFeaturedList
+						responseCart={ responseCart }
+						siteId={ siteId }
+						isCartUpdating={ isCartUpdating }
+						onChangeSelection={ onChangeSelection }
+					/>
+				) }
 				<CheckoutSummaryPriceList />
 			</CheckoutSummaryCard>
-			{ isStreamlinedPrice && featuresList }
 		</>
 	);
 }
@@ -138,7 +133,7 @@ export function CheckoutSummaryFeaturedList( {
 	responseCart: ResponseCart;
 	siteId: number | undefined;
 	isCartUpdating: boolean;
-	onChangeSelection: (
+	onChangeSelection?: (
 		uuid: string,
 		productSlug: string,
 		productId: number,
@@ -331,7 +326,6 @@ function SwitchToAnnualPlan( {
 	plan,
 	onChangeSelection,
 	linkText,
-	isStreamlinedPrice,
 }: {
 	plan: ResponseCartProduct;
 	onChangeSelection: (
@@ -351,16 +345,6 @@ function SwitchToAnnualPlan( {
 		}
 	};
 	const text = linkText ?? translate( 'Switch to an annual plan and save!' );
-	if ( isStreamlinedPrice ) {
-		return (
-			<PromoCardCTA
-				cta={ {
-					text: String( text ),
-					action: handleClick,
-				} }
-			/>
-		);
-	}
 	return <SwitchToAnnualPlanButton onClick={ handleClick }>{ text }</SwitchToAnnualPlanButton>;
 }
 
@@ -877,7 +861,7 @@ function CheckoutSummarySupportIfAvailable( props: {
 
 function CheckoutSummaryAnnualUpsell( props: {
 	plan: ResponseCartProduct;
-	onChangeSelection: (
+	onChangeSelection?: (
 		uuid: string,
 		productSlug: string,
 		productId: number,
@@ -897,8 +881,26 @@ function CheckoutSummaryAnnualUpsell( props: {
 		isWooExpressPlan( productSlug ) && Boolean( props.plan.introductory_offer_terms?.enabled )
 	);
 	const title = translate( 'Included with an annual plan' );
-	const content = (
-		<>
+	const hasStreamlinedPriceTitle =
+		translate.localeSlug?.startsWith( 'en' ) ||
+		hasEnTranslation( 'Extra features with annual plans' );
+	const streamlinedPriceTitle = hasStreamlinedPriceTitle
+		? translate( 'Extra features with annual plans' )
+		: title;
+
+	return (
+		<CheckoutSummaryFeaturesUpsell>
+			<CheckoutSummaryFeaturesTitle>
+				{ ! props.onChangeSelection ? (
+					<>{ streamlinedPriceTitle }</>
+				) : (
+					<SwitchToAnnualPlan
+						plan={ props.plan }
+						onChangeSelection={ props.onChangeSelection }
+						linkText={ title }
+					/>
+				) }
+			</CheckoutSummaryFeaturesTitle>
 			<CheckoutSummaryFeaturesListWrapper>
 				{ shouldShowFreeDomainUpsell && (
 					<CheckoutSummaryFeaturesListItem isSupported={ false }>
@@ -922,36 +924,14 @@ function CheckoutSummaryAnnualUpsell( props: {
 							</CheckoutSummaryFeaturesListItem>
 					  ) }
 			</CheckoutSummaryFeaturesListWrapper>
-			<SwitchToAnnualPlan
-				plan={ props.plan }
-				onChangeSelection={ props.onChangeSelection }
-				isStreamlinedPrice={ props.isStreamlinedPrice }
-			/>
-		</>
-	);
-
-	return (
-		<>
-			{ props.isStreamlinedPrice ? (
-				<PromoCard
-					title={ title }
-					className="checkout-sidebar-plan-upsell checkout-sidebar-plan-features-upsell checkout-sidebar-plan-upsell-streamlined"
-				>
-					{ content }
-				</PromoCard>
-			) : (
-				<CheckoutSummaryFeaturesUpsell>
-					<CheckoutSummaryFeaturesTitle>
-						<SwitchToAnnualPlan
-							plan={ props.plan }
-							onChangeSelection={ props.onChangeSelection }
-							linkText={ title }
-						/>
-					</CheckoutSummaryFeaturesTitle>
-					{ content }
-				</CheckoutSummaryFeaturesUpsell>
+			{ props.onChangeSelection && (
+				<SwitchToAnnualPlan
+					plan={ props.plan }
+					onChangeSelection={ props.onChangeSelection }
+					linkText={ title }
+				/>
 			) }
-		</>
+		</CheckoutSummaryFeaturesUpsell>
 	);
 }
 
@@ -1001,6 +981,17 @@ const CheckoutSummaryFeaturesUpsell = styled( CheckoutSummaryFeatures )`
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		padding: 0 0 24px;
 	}
+
+	.checkout-sidebar-plan-upsell-streamlined & {
+		padding-top: 12px;
+		padding-bottom: 0;
+		color: ${ ( props ) => props.theme.colors.textColorDark };
+		line-height: 1.6;
+
+		svg {
+			opacity: 100%;
+		}
+	}
 `;
 
 const CheckoutSummaryFeaturesTitle = styled.h3`
@@ -1013,6 +1004,10 @@ const CheckoutSummaryFeaturesTitle = styled.h3`
 		font-size: 16px;
 		font-weight: ${ ( props ) => props.theme.weights.bold };
 		text-decoration: none;
+	}
+	.checkout-sidebar-plan-upsell-streamlined & {
+		font-weight: 500;
+		margin-bottom: 6px;
 	}
 `;
 
@@ -1063,6 +1058,10 @@ const CheckoutSummaryFeaturesListItem = styled( 'li' )< { isSupported?: boolean 
 	.rtl & {
 		padding-right: 24px;
 		padding-left: 0;
+	}
+
+	.checkout-sidebar-plan-upsell-streamlined & {
+		color: inherit;
 	}
 `;
 CheckoutSummaryFeaturesListItem.defaultProps = {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of pdtkmj-3DM-p2#comment-7032

## Proposed Changes

* Restores the upsell features section for monthly plans

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We should inform users of the monthly feature limitations for the streamline experiment variations.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To test this feature, you'll need to be assigned to any checkout treatment variation of the `calypso_streamlined_plans_checkout` experiment
* Go through the `onboarding` flow to get assigned
* On checkout, select the `Monthly` plan interval
* You should see the upsell features on the right

|Before|After|
|------|-----|
|<img width="1769" alt="Screenshot 2025-06-04 at 09 26 52" src="https://github.com/user-attachments/assets/e4c83a45-0375-4904-b0c4-4596ea84cca9" />|<img width="1763" alt="Screenshot 2025-06-04 at 09 41 56" src="https://github.com/user-attachments/assets/7781ef00-6d63-4f82-864d-c2d1844a46e9" />|


* `Control` should be unchanged

<img width="1556" alt="Screenshot 2025-06-04 at 16 41 58" src="https://github.com/user-attachments/assets/d91c0837-0004-490c-b1a0-8ba1173919ff" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?