### PR TITLE
Plan select page -add currently selected label

### DIFF
--- a/packages/plans-grid-next/src/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/packages/plans-grid-next/src/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -32,7 +32,13 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 				) : null }
 			</DropdownOption>
 		 ) as unknown as string,
+		accessibleName: option.name as string,
 	} ) );
+
+	const selectedOption = selectOptionsList.find( ( { key } ) => key === supportedIntervalType );
+	const describedByText = selectedOption?.accessibleName
+		? `Currently selected: ${ selectedOption.accessibleName }`
+		: undefined;
 
 	return (
 		<div className="plan-type-selector__interval-type-dropdown-container">
@@ -49,8 +55,9 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 				} }
 				className="plan-type-selector__interval-type-dropdown"
 				label=""
+				describedBy={ describedByText }
 				options={ selectOptionsList }
-				value={ selectOptionsList.find( ( { key } ) => key === supportedIntervalType ) }
+				value={ selectedOption }
 				onChange={ ( {
 					selectedItem: { key: intervalType },
 				}: {

--- a/packages/plans-grid-next/src/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/packages/plans-grid-next/src/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -1,5 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { CustomSelectControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
 import { useRef } from 'react';
 import DropdownOption from '../../dropdown-option';
 import useIntervalOptions from '../hooks/use-interval-options';
@@ -19,6 +20,7 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 	) as SupportedUrlFriendlyTermType;
 	const optionsList = useIntervalOptions( props );
 	const hasOpenedDropdown = useRef( false );
+	const translate = useTranslate();
 
 	const selectOptionsList = Object.values( optionsList ).map( ( option ) => ( {
 		key: option.key,
@@ -36,8 +38,12 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 	} ) );
 
 	const selectedOption = selectOptionsList.find( ( { key } ) => key === supportedIntervalType );
+	// Translators: This is a description of the currently selected billing period for accessibility.
+	// billingPeriod is the name of the billing period and it's translated.
 	const describedByText = selectedOption?.accessibleName
-		? `Currently selected billing period:: ${ selectedOption.accessibleName }`
+		? translate( 'Currently selected billing period: %(billingPeriod)s', {
+				args: { billingPeriod: selectedOption.accessibleName },
+		  } )
 		: undefined;
 
 	return (

--- a/packages/plans-grid-next/src/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/packages/plans-grid-next/src/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -61,7 +61,7 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 				} }
 				className="plan-type-selector__interval-type-dropdown"
 				label=""
-				describedBy={ describedByText }
+				describedBy={ describedByText as string }
 				options={ selectOptionsList }
 				value={ selectedOption }
 				onChange={ ( {

--- a/packages/plans-grid-next/src/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/packages/plans-grid-next/src/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -37,7 +37,7 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 
 	const selectedOption = selectOptionsList.find( ( { key } ) => key === supportedIntervalType );
 	const describedByText = selectedOption?.accessibleName
-		? `Currently selected: ${ selectedOption.accessibleName }`
+		? `Currently selected billing period:: ${ selectedOption.accessibleName }`
 		: undefined;
 
 	return (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-13363
## Proposed Changes

* Add `describedBy` attribute

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The billing period selector button on the plan selection screen lacks discernible text for screen readers, violating accessibility standards. VoiceOver reads as [Object Object] instead of properly identifying the billing period selector.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn start`
* Navigate to the plan selector page
* Using VoiceOver, navigate over the selected option and confirm it's reading "Currently Selected: x" with the correct interval

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
