### PR TITLE
Dashboard v2: create a temporary RequiredSelect control

### DIFF
--- a/client/dashboard/components/required-select/index.tsx
+++ b/client/dashboard/components/required-select/index.tsx
@@ -1,0 +1,35 @@
+import { SelectControl } from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
+import type { DataFormControlProps } from '@automattic/dataviews';
+
+// A verbatim copy of @automattic/dataviews/src/dataform-controls/select.tsx,
+// but without the first placeholder option.
+export default function RequiredSelect< Item >( {
+	data,
+	field,
+	onChange,
+	hideLabelFromVision,
+}: DataFormControlProps< Item > ) {
+	const { id, label } = field;
+	const value = field.getValue( { item: data } ) ?? '';
+	const onChangeControl = useCallback(
+		( newValue: any ) =>
+			onChange( {
+				[ id ]: newValue,
+			} ),
+		[ id, onChange ]
+	);
+
+	return (
+		<SelectControl
+			label={ label }
+			value={ value }
+			help={ field.description }
+			options={ field.elements }
+			onChange={ onChangeControl }
+			__next40pxDefaultSize
+			__nextHasNoMarginBottom
+			hideLabelFromVision={ hideLabelFromVision }
+		/>
+	);
+}

--- a/client/dashboard/sites/settings-php/index.tsx
+++ b/client/dashboard/sites/settings-php/index.tsx
@@ -14,6 +14,7 @@ import { useState } from 'react';
 import { getPHPVersions } from 'calypso/data/php-versions';
 import { siteQuery, sitePHPVersionQuery, sitePHPVersionMutation } from '../../app/queries';
 import PageLayout from '../../components/page-layout';
+import RequiredSelect from '../../components/required-select';
 import { canUpdatePHPVersion } from '../../utils/site-features';
 import SettingsCallout from '../settings-callout';
 import SettingsPageHeader from '../settings-page-header';
@@ -52,7 +53,7 @@ export default function PHPVersionSettings( { siteSlug }: { siteSlug: string } )
 		{
 			id: 'version',
 			label: __( 'PHP version' ),
-			Edit: 'select',
+			Edit: RequiredSelect, // TODO: use DataForm's validation when available. See: DOTCOM-13298
 			elements: phpVersions.filter( ( option ) => {
 				// Show disabled PHP version only if the site is still using it.
 				if ( option.disabled && option.value !== currentVersion ) {

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../app/queries';
 import Notice from '../../components/notice';
 import PageLayout from '../../components/page-layout';
+import RequiredSelect from '../../components/required-select';
 import { canUpdateWordPressVersion } from '../../utils/site-features';
 import { getFormattedWordPressVersion } from '../../utils/wp-version';
 import SettingsPageHeader from '../settings-page-header';
@@ -48,7 +49,7 @@ export default function WordPressVersionSettings( { siteSlug }: { siteSlug: stri
 		{
 			id: 'version',
 			label: __( 'WordPress version' ),
-			Edit: 'select',
+			Edit: RequiredSelect, // TODO: use DataForm's validation when available. See: DOTCOM-13298
 			elements: [
 				{ value: 'latest', label: getFormattedWordPressVersion( site, 'latest' ) },
 				{ value: 'beta', label: getFormattedWordPressVersion( site, 'beta' ) },


### PR DESCRIPTION
Part of DOTCOM-13298

## Proposed Changes

This is a temporary solution for having a `<select>` component in DataForm where we don't want the `Select item` placeholder option. It's meant as a stopgap until DataForm actually supports such validation.

This works by copying the existing [`'select'` control](https://github.com/Automattic/wp-calypso/blob/f435b0faa9e7f904950495049246f340d214b4ec/packages/dataviews/src/dataform-controls/select.tsx) and removing the placeholder option.

|Before|After|
|-|-|
|<img width="635" alt="image" src="https://github.com/user-attachments/assets/b41175d9-ca8f-4979-b343-55b104cb3b93" />|<img width="622" alt="image" src="https://github.com/user-attachments/assets/51d9f548-d55e-4e0d-8f80-f918fe9156bf" />|

## Why are these changes being made?

Otherwise the form is "broken".

## Testing Instructions

1. Use an Atomic staging site.
2. Go to Settings -> WordPress and Settings -> PHP; verify that you can't select any placeholder selection anymore.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
