### PR TITLE
Add aria label to partner themes navigation buttons

### DIFF
--- a/client/components/theme-collection/index.tsx
+++ b/client/components/theme-collection/index.tsx
@@ -152,12 +152,14 @@ export default function ThemeCollection( {
 					<Button
 						onClick={ () => trackNavigationClick( 'previous' ) }
 						className="theme-collection__carousel-nav-button theme-collection__carousel-nav-button--previous"
+						aria-label={ translate( 'Previous themes' ) }
 					>
 						<Icon icon={ chevronLeft } />
 					</Button>
 					<Button
 						onClick={ () => trackNavigationClick( 'next' ) }
 						className="theme-collection__carousel-nav-button theme-collection__carousel-nav-button--next"
+						aria-label={ translate( 'Next themes' ) }
 					>
 						<Icon icon={ chevronRight } />
 					</Button>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-13360

## Proposed Changes

* Added `aria-label` to partner themes navigation buttons

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Carousel navigation buttons should include aria-label attributes to provide discernible text for screen readers and meet accessibility standards.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn start`
* Visit http://calypso.localhost:3000/themes
* Navigate to the "Partner themes" section
* Inspect the left and right navigation buttons in the carousel
* Use Axe DevTools to scan the page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
