### PR TITLE
Help Center: Use the right logging for reset to Odie

### DIFF
--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -37,7 +37,7 @@ export const useGetCombinedChat = ( canConnectToZendesk: boolean ) => {
 	const getZendeskConversation = useGetZendeskConversation();
 	const { data: odieChat, isFetching: isOdieChatLoading } = useOdieChat( Number( odieId ) );
 	const { startNewInteraction } = useManageSupportInteraction();
-	const canFetchConversation = false; //conversationId && canConnectToZendesk;
+	const canFetchConversation = conversationId && canConnectToZendesk;
 
 	useEffect( () => {
 		if ( ! currentSupportInteraction || isOdieChatLoading || chatStatus !== 'loading' ) {

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -1,9 +1,10 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { HelpCenterSelect } from '@automattic/data-stores';
 import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { useSelect } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
 import { ODIE_TRANSFER_MESSAGE } from '../constants';
-import { emptyChat, useOdieAssistantContext } from '../context';
+import { emptyChat } from '../context';
 import { useGetZendeskConversation, useManageSupportInteraction, useOdieChat } from '../data';
 import { getConversationIdFromInteraction, getOdieIdFromInteraction } from '../utils';
 import type { Chat, Message } from '../types';
@@ -36,8 +37,7 @@ export const useGetCombinedChat = ( canConnectToZendesk: boolean ) => {
 	const getZendeskConversation = useGetZendeskConversation();
 	const { data: odieChat, isFetching: isOdieChatLoading } = useOdieChat( Number( odieId ) );
 	const { startNewInteraction } = useManageSupportInteraction();
-	const { trackEvent } = useOdieAssistantContext();
-	const canFetchConversation = conversationId && canConnectToZendesk;
+	const canFetchConversation = false; //conversationId && canConnectToZendesk;
 
 	useEffect( () => {
 		if ( ! currentSupportInteraction || isOdieChatLoading || chatStatus !== 'loading' ) {
@@ -53,7 +53,7 @@ export const useGetCombinedChat = ( canConnectToZendesk: boolean ) => {
 				status: 'loaded',
 			} );
 
-			trackEvent( 'zendesk_chat_reset_to_odie', {
+			recordTracksEvent( 'calypso_odie_zendesk_chat_reset_to_odie', {
 				interaction: currentSupportInteraction.uuid,
 				conversation_id: conversationId,
 				chat_id: odieChat?.odieId,
@@ -62,7 +62,7 @@ export const useGetCombinedChat = ( canConnectToZendesk: boolean ) => {
 			try {
 				getZendeskConversation( {
 					chatId: odieChat?.odieId,
-					conversationId: conversationId.toString(),
+					conversationId: conversationId?.toString(),
 				} )?.then( ( conversation ) => {
 					if ( conversation ) {
 						const filteredOdieMessages =
@@ -85,7 +85,7 @@ export const useGetCombinedChat = ( canConnectToZendesk: boolean ) => {
 				} );
 			} catch ( error ) {
 				// Conversation id was passed but the conversion was not found. Something went wrong.
-				trackEvent( 'zendesk_conversation_not_found', {
+				recordTracksEvent( 'calypso_odie_zendesk_conversation_not_found', {
 					conversationId,
 					odieId,
 				} );
@@ -107,7 +107,6 @@ export const useGetCombinedChat = ( canConnectToZendesk: boolean ) => {
 		canConnectToZendesk,
 		getZendeskConversation,
 		startNewInteraction,
-		trackEvent,
 	] );
 
 	// This effect sets the initial loading state when interaction is set, so that the chat is loaded


### PR DESCRIPTION
## Description

This PR replaces `useOdieAssistantContext` tracking with `recordTracksEvent` from Calypso analytics, as when `useGetCombinedChat` is used the logging has not yet been defined.

## Testing Instructions

1. Set [this](https://github.com/Automattic/wp-calypso/pull/103881/files#diff-58c095d6a46ebcf7f3eea7bdc2abd8633be8345cbc02e93bbdc9acc2d283b1b4L40) to false
2. Open the Help center and go into a chat
3. You should see the event `calypso_odie_zendesk_chat_reset_to_odie` triggered. (use Tracks Vigilante)