### PR TITLE
Help Center: Remove not useful tracking method

### DIFF
--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -31,7 +31,6 @@ import { Mail } from '../icons';
 import { HelpCenterClosureNotice } from './help-center-closure-notice';
 import HelpCenterContactSupportOption from './help-center-contact-support-option';
 import { HelpCenterActiveTicketNotice } from './help-center-notice';
-import { generateContactOnClickEvent } from './utils';
 import './help-center-contact-page.scss';
 
 /**
@@ -132,7 +131,14 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 			<div className="help-center-contact-support">
 				<Link
 					to={ emailUrl }
-					onClick={ () => generateContactOnClickEvent( 'email', trackEventName, isUserEligible ) }
+					onClick={ () =>
+						recordTracksEvent( 'calypso_helpcenter_contact_options_click', {
+							location: 'help-center',
+							section: sectionName,
+							contact_option: 'email',
+							is_user_eligible: isUserEligible,
+						} )
+					}
 				>
 					<div
 						className={ clsx( 'help-center-contact-support__box', 'email' ) }

--- a/packages/help-center/src/components/help-center-contact-support-option.tsx
+++ b/packages/help-center/src/components/help-center-contact-support-option.tsx
@@ -6,7 +6,6 @@ import { useNavigate } from 'react-router-dom';
 import useChatStatus from '../hooks/use-chat-status';
 import { useResetSupportInteraction } from '../hooks/use-reset-support-interaction';
 import ThirdPartyCookiesNotice from './help-center-third-party-cookies-notice';
-import { generateContactOnClickEvent } from './utils';
 
 import './help-center-contact-support-option.scss';
 
@@ -32,7 +31,6 @@ const HelpCenterContactSupportOption = ( { sectionName }: HelpCenterContactSuppo
 			destination,
 			is_user_eligible: isEligibleForChat,
 		} );
-		generateContactOnClickEvent( 'chat', 'calypso_helpcenter_feedback_contact_support' );
 		if ( isEligibleForChat ) {
 			await resetSupportInteraction();
 			navigate( '/odie' );

--- a/packages/help-center/src/components/help-center-feedback-form.tsx
+++ b/packages/help-center/src/components/help-center-feedback-form.tsx
@@ -7,7 +7,6 @@ import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useSupportStatus } from '../data/use-support-status';
 import { useResetSupportInteraction } from '../hooks/use-reset-support-interaction';
 import { ThumbsDownIcon, ThumbsUpIcon } from '../icons/thumbs';
-import { generateContactOnClickEvent } from './utils';
 
 import './help-center-feedback-form.scss';
 
@@ -60,7 +59,6 @@ const HelpCenterFeedbackForm = ( { postId }: { postId: number } ) => {
 			destination,
 			is_user_eligible: isUserEligibleForPaidSupport,
 		} );
-		generateContactOnClickEvent( 'chat', 'calypso_helpcenter_feedback_contact_support' );
 		if ( isUserEligibleForPaidSupport ) {
 			await resetSupportInteraction();
 			navigate( '/odie' );

--- a/packages/help-center/src/components/utils.tsx
+++ b/packages/help-center/src/components/utils.tsx
@@ -1,7 +1,5 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { getConversationIdFromInteraction } from '@automattic/odie-client/src/utils';
 import Smooch from 'smooch';
-import type { ContactOption } from '../types';
 import type {
 	OdieConversation,
 	OdieMessage,
@@ -26,20 +24,6 @@ const filterConversationsBySupportInteractions = (
 			isMatchingInteraction( interaction, conversation.metadata.supportInteractionId )
 		)
 	);
-};
-
-export const generateContactOnClickEvent = (
-	contactOption: ContactOption,
-	contactOptionEventName?: string,
-	isUserEligible?: boolean
-) => {
-	if ( contactOptionEventName ) {
-		recordTracksEvent( contactOptionEventName, {
-			location: 'help-center',
-			contact_option: contactOption,
-			is_user_eligible: isUserEligible,
-		} );
-	}
 };
 
 /**


### PR DESCRIPTION
This PR removes the event `calypso_helpcenter_feedback_contact_support`, as it is not used in any funnels and it is fired together with `calypso_odie_chat_get_support`