### PR TITLE
Hosting Dashboard v2: Implement Setting Legacy

### DIFF
--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -10,6 +10,7 @@ import { canUpdateCaching } from '../sites/settings-caching';
 import {
 	canUpdatePHPVersion,
 	canUpdateDefensiveMode,
+	canUpdateHundredYearPlanFeatures,
 	canUpdateWordPressVersion,
 	canGetPrimaryDataCenter,
 	canSetStaticFile404Handling,
@@ -224,6 +225,23 @@ const siteSettingsAgencyRoute = createRoute( {
 } ).lazy( () =>
 	import( '../sites/settings-agency' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-agency' )( {
+			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+const siteSettingsHundredYearPlanRoute = createRoute( {
+	getParentRoute: () => siteRoute,
+	path: 'settings/hundred-year-plan',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteQuery( siteSlug ) );
+		if ( canUpdateHundredYearPlanFeatures( site ) ) {
+			await queryClient.ensureQueryData( siteSettingsQuery( siteSlug ) );
+		}
+	},
+} ).lazy( () =>
+	import( '../sites/settings-hundred-year-plan' ).then( ( d ) =>
+		createLazyRoute( 'site-settings-hundred-year-plan' )( {
 			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
 		} )
 	)
@@ -477,6 +495,7 @@ const createRouteTree = ( config: AppConfig ) => {
 				siteSettingsWordPressRoute,
 				siteSettingsPHPRoute,
 				siteSettingsAgencyRoute,
+				siteSettingsHundredYearPlanRoute,
 				siteSettingsPrimaryDataCenterRoute,
 				siteSettingsStaticFile404Route,
 				siteSettingsCachingRoute,

--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -12,6 +12,14 @@
 	display: none;
 }
 
+// BaseControl currently has an override for the label to accomodate the use case where the label is shown next to the control.
+// In site settings forms, the label is above the control for regular fields so we need to override this override for UI consistency.
+.dashboard-site-settings-form .dataforms-layouts-regular__field .components-base-control__label {
+	font-size: 11px;
+	font-weight: 500;
+	text-transform: uppercase;
+}
+
 // Global Styles
 html,
 body,

--- a/client/dashboard/data/constants.ts
+++ b/client/dashboard/data/constants.ts
@@ -1,6 +1,8 @@
 export enum DotcomFeatures {
 	SUBSCRIPTION_GIFTING = 'subscription-gifting',
 	COPY_SITE = 'copy-site',
+	LEGACY_CONTACT = 'legacy-contact',
+	LOCKED_MODE = 'locked-mode',
 }
 
 export const SITE_FIELDS = [

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -174,6 +174,8 @@ export interface SiteSettings {
 	wpcom_prevent_third_party_sharing?: boolean;
 	wpcom_gifting_subscription?: boolean;
 	wpcom_performance_report_url?: string;
+	wpcom_legacy_contact?: string;
+	wpcom_locked_mode?: boolean;
 }
 
 export interface BasicMetricsData {

--- a/client/dashboard/sites/settings-agency/summary.tsx
+++ b/client/dashboard/sites/settings-agency/summary.tsx
@@ -7,7 +7,7 @@ import RouterLinkSummaryButton from '../../components/router-link-summary-button
 import type { Site } from '../../data/types';
 import type { Density } from '@automattic/components/src/summary-button/types';
 
-export default function SettingsAgencySummary( {
+export default function AgencySettingsSummary( {
 	site,
 	density,
 }: {

--- a/client/dashboard/sites/settings-hundred-year-plan/index.tsx
+++ b/client/dashboard/sites/settings-hundred-year-plan/index.tsx
@@ -1,0 +1,139 @@
+import { DataForm } from '@automattic/dataviews';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { notFound } from '@tanstack/react-router';
+import {
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	Button,
+	Card,
+	CardBody,
+	ExternalLink,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useState } from 'react';
+import { siteQuery, siteSettingsMutation, siteSettingsQuery } from '../../app/queries';
+import PageLayout from '../../components/page-layout';
+import { canUpdateHundredYearPlanFeatures } from '../../utils/site-features';
+import SettingsPageHeader from '../settings-page-header';
+import type { SiteSettings } from '../../data/types';
+import type { Field, SimpleFormField } from '@automattic/dataviews';
+
+const fields: Field< SiteSettings >[] = [
+	{
+		id: 'wpcom_legacy_contact',
+		label: __( 'Contact name' ),
+		Edit: 'text',
+
+		// Workaround to create additional vertical space between the two fields.
+		description: ' ',
+	},
+	{
+		id: 'wpcom_locked_mode',
+		label: __( 'Enable locked mode' ),
+		Edit: 'checkbox',
+		description: __(
+			'Prevents new posts and pages from being created as well as existing posts and pages from being edited, and closes comments site wide.'
+		),
+	},
+];
+
+const form = {
+	type: 'regular' as const,
+	fields: [ { id: 'wpcom_legacy_contact' }, { id: 'wpcom_locked_mode' } ] as SimpleFormField[],
+};
+
+export default function HundredYearPlanSettings( { siteSlug }: { siteSlug: string } ) {
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const { data: site } = useQuery( siteQuery( siteSlug ) );
+	const { data: settings } = useQuery( siteSettingsQuery( siteSlug ) );
+	const mutation = useMutation( siteSettingsMutation( siteSlug ) );
+
+	const [ formData, setFormData ] = useState( {
+		wpcom_legacy_contact: settings?.wpcom_legacy_contact,
+		wpcom_locked_mode: settings?.wpcom_locked_mode,
+	} );
+
+	if ( ! site || ! settings ) {
+		return null;
+	}
+
+	if ( ! canUpdateHundredYearPlanFeatures( site ) ) {
+		throw notFound();
+	}
+
+	const isDirty = Object.entries( formData ).some(
+		( [ key, value ] ) => settings[ key as keyof SiteSettings ] !== value
+	);
+
+	const { isPending } = mutation;
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		mutation.mutate(
+			{ ...formData },
+			{
+				onSuccess: () => {
+					createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
+				},
+				onError: () => {
+					createErrorNotice( __( 'Failed to save settings.' ), { type: 'snackbar' } );
+				},
+			}
+		);
+	};
+
+	return (
+		<PageLayout
+			size="small"
+			header={ <SettingsPageHeader title={ __( 'Control your legacy' ) } /> }
+		>
+			<Card>
+				<CardBody>
+					<form onSubmit={ handleSubmit } className="dashboard-site-settings-form">
+						<VStack spacing={ 4 } style={ { padding: '8px 0' } }>
+							<VStack spacing={ 2 }>
+								<Text size="15px" weight={ 500 }>
+									{ __( 'Legacy contact' ) }
+								</Text>
+								<Text variant="muted" as="p">
+									{ createInterpolateElement(
+										__(
+											'Choose someone to look after your site when you pass away. To take ownership of the site, we ask that the person you designate contacts us at <link>wordpress.com/help</link> with a copy of the death certificate.'
+										),
+										{
+											link: <ExternalLink href="https://wordpress.com/help" children={ null } />,
+										}
+									) }
+								</Text>
+							</VStack>
+							<VStack spacing={ 4 }>
+								<DataForm< SiteSettings >
+									data={ formData }
+									fields={ fields }
+									form={ form }
+									onChange={ ( edits: Partial< SiteSettings > ) => {
+										setFormData( ( data ) => ( { ...data, ...edits } ) );
+									} }
+								/>
+								<HStack justify="flex-start">
+									<Button
+										variant="primary"
+										type="submit"
+										isBusy={ isPending }
+										disabled={ isPending || ! isDirty }
+									>
+										{ __( 'Save' ) }
+									</Button>
+								</HStack>
+							</VStack>
+						</VStack>
+					</form>
+				</CardBody>
+			</Card>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/sites/settings-hundred-year-plan/summary.tsx
+++ b/client/dashboard/sites/settings-hundred-year-plan/summary.tsx
@@ -1,0 +1,33 @@
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { institution } from '@wordpress/icons';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import { canUpdateHundredYearPlanFeatures } from '../../utils/site-features';
+import type { Site, SiteSettings } from '../../data/types';
+import type { Density } from '@automattic/components/src/summary-button/types';
+
+export default function HundredYearPlanSummary( {
+	site,
+	settings,
+	density,
+}: {
+	site: Site;
+	settings: SiteSettings;
+	density?: Density;
+} ) {
+	if ( ! canUpdateHundredYearPlanFeatures( site ) ) {
+		return null;
+	}
+
+	return (
+		<RouterLinkSummaryButton
+			to={ `/sites/${ site.slug }/settings/hundred-year-plan` }
+			title={ __( 'Control your legacy' ) }
+			density={ density }
+			decoration={ <Icon icon={ institution } /> }
+			badges={
+				settings.wpcom_locked_mode ? [ { text: __( 'Site locked' ), intent: 'info' as const } ] : []
+			}
+		/>
+	);
+}

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -5,10 +5,11 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { SectionHeader } from '../../components/section-header';
 import { SummaryButtonList } from '../../components/summary-button-list';
-import AgencySummary from '../settings-agency/summary';
+import AgencySettingsSummary from '../settings-agency/summary';
 import CachingSettingsSummary from '../settings-caching/summary';
 import DatabaseSettingsSummary from '../settings-database/summary';
 import DefensiveModeSettingsSummary from '../settings-defensive-mode/summary';
+import HundredYearPlanSettingsSummary from '../settings-hundred-year-plan/summary';
 import PHPSettingsSummary from '../settings-php/summary';
 import PrimaryDataCenterSettingsSummary from '../settings-primary-data-center/summary';
 import SiteVisibilitySettingsSummary from '../settings-site-visibility/summary';
@@ -38,7 +39,8 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 				<DatabaseSettingsSummary site={ site } />
 				<WordPressSettingsSummary site={ site } />
 				<PHPSettingsSummary site={ site } />
-				<AgencySummary site={ site } />
+				<AgencySettingsSummary site={ site } />
+				<HundredYearPlanSettingsSummary site={ site } settings={ settings } />
 				<PrimaryDataCenterSettingsSummary site={ site } />
 				<StaticFile404SettingsSummary site={ site } />
 				<CachingSettingsSummary site={ site } />

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -33,6 +33,7 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 			<SummaryButtonList>
 				<SiteVisibilitySettingsSummary site={ site } />
 				<SubscriptionGiftingSettingsSummary site={ site } settings={ settings } />
+				<HundredYearPlanSettingsSummary site={ site } settings={ settings } />
 			</SummaryButtonList>
 			<SectionHeader title={ __( 'Server' ) } />
 			<SummaryButtonList>
@@ -40,7 +41,6 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 				<WordPressSettingsSummary site={ site } />
 				<PHPSettingsSummary site={ site } />
 				<AgencySettingsSummary site={ site } />
-				<HundredYearPlanSettingsSummary site={ site } settings={ settings } />
 				<PrimaryDataCenterSettingsSummary site={ site } />
 				<StaticFile404SettingsSummary site={ site } />
 				<CachingSettingsSummary site={ site } />

--- a/client/dashboard/utils/site-features.ts
+++ b/client/dashboard/utils/site-features.ts
@@ -1,3 +1,4 @@
+import { DotcomFeatures } from '../data/constants';
 import type { Site } from '../data/types';
 
 export const canUpdatePHPVersion = ( site: Site ): boolean => site.is_wpcom_atomic;
@@ -11,3 +12,14 @@ export const canUpdateWordPressVersion = ( site: Site ): boolean => site.is_wpco
 export const canSetStaticFile404Handling = ( site: Site ): boolean => site.is_wpcom_atomic;
 
 export const canGetPrimaryDataCenter = ( site: Site ): boolean => site.is_wpcom_atomic;
+
+export const canUpdateHundredYearPlanFeatures = ( site: Site ): boolean => {
+	if ( ! site.plan ) {
+		return false;
+	}
+
+	const { plan } = site;
+	return [ DotcomFeatures.LEGACY_CONTACT, DotcomFeatures.LOCKED_MODE ].some( ( feature ) =>
+		plan.features.active.includes( feature )
+	);
+};


### PR DESCRIPTION
Ref DOTCOM-13309

## Proposed Changes

![Screenshot 2025-06-02 at 10 39 04 PM](https://github.com/user-attachments/assets/e1417551-9466-4167-b62c-0b51f6c1136d)

![Screenshot 2025-06-02 at 10 38 55 PM](https://github.com/user-attachments/assets/8260b933-12fc-48d6-a10f-1eb9894ba55d)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Hosting Dashboard v2 implementation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2/sites/:siteSlug/settings using a site with 100-Year plan.
* Ensure that the setting "Control your legacy" is visible.
* Ensure that clicking the setting takes your to "Control your legacy" screen.
* Ensure that the both the input field and checkbox work as intended.
* Ensure that if the checkbox "Enable locked mode" is checked, the setting summary will have the badge "Site locked".

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
