### PR TITLE
Environment Badge: show on mobile

### DIFF
--- a/client/components/environment-badge/style.scss
+++ b/client/components/environment-badge/style.scss
@@ -106,8 +106,17 @@
 }
 
 @include breakpoint-deprecated( "<960px" ) {
-	// Don't show environment badge on smaller screens. It just gets in the way.
 	.environment-badge {
-		display: none;
+		right: 20px;
+
+		&.hovered {
+			display: flex;
+			flex-wrap: wrap-reverse;
+			justify-content: flex-end;
+			padding-left: 20px;
+		}
+	}
+	.bug-report {
+		margin-top: -10px;
 	}
 }


### PR DESCRIPTION
## Proposed Changes

This shows the environment badge on mobile.

| Before | After |
| ----------- | ----------- |
| <img width="373" alt="Screenshot 2025-06-02 at 10 30 02 AM" src="https://github.com/user-attachments/assets/1189c17d-c121-441f-9304-35b15ed30b1c" /> | <img width="371" alt="Screenshot 2025-06-02 at 10 27 55 AM" src="https://github.com/user-attachments/assets/6ee87887-0cfe-48a1-a1b2-5992b152c51a" /> |

## Why are these changes being made?

The environment badge has become a home to a decent amount of testing tooling when expanded (Store Sandbox, Language Settings, Bug Reports, etc.). By hiding it entirely on mobile, we're obscuring those options. The original reasoning to hide it of `It just gets in the way.` seems like it can be addressed in a more nuanced way if people complain.

This is an initial quick pass at showing the badge and tooling on mobile to address this request: pfOicC-4C-p2#comment-580

## Testing Instructions

- View Calypso with a screen `<960px`
- Verify that the dev environment badge is still shown
- Click on the environment name (e.g. `dev`)
- Verify that the different environment tooling options are shown