### PR TITLE
Help Center: Remove extra options on feedback

### DIFF
--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -58,14 +58,8 @@ export const UserMessage = ( {
 
 	const hasCannedResponse = message.context?.flags?.canned_response;
 	const isRequestingHumanSupport = message.context?.flags?.forward_to_human_support ?? false;
-	const hasFeedback = !! message?.rating_value;
 	const isBot = message.role === 'bot';
 	const isConnectedToZendesk = chat?.provider === 'zendesk';
-	const isPositiveFeedback =
-		hasFeedback && message && message.rating_value && +message.rating_value === 1;
-
-	const showExtraContactOptions =
-		( hasFeedback && ! isPositiveFeedback ) || isRequestingHumanSupport;
 
 	const showDirectEscalationLink = useMemo( () => {
 		return (
@@ -91,14 +85,13 @@ export const UserMessage = ( {
 	const displayingThirdPartyMessage =
 		isUserEligibleForPaidSupport && ! canConnectToZendesk && isRequestingHumanSupport;
 
-	const handleContactSupportClick = ( destination: string ) => {
-		trackEvent( 'chat_get_support', {
-			location: 'user-message',
-			destination,
-		} );
-	};
-
 	const renderExtraContactOptions = () => {
+		const handleContactSupportClick = ( destination: string ) => {
+			trackEvent( 'chat_get_support', {
+				location: 'user-message',
+				destination,
+			} );
+		};
 		return (
 			chat.provider === 'odie' && (
 				<GetSupport onClickAdditionalEvent={ handleContactSupportClick } />
@@ -158,12 +151,12 @@ export const UserMessage = ( {
 			{ ! isMessageWithoutEscalationOption && isBot && (
 				<div
 					className={ clsx( 'chat-feedback-wrapper', {
-						'chat-feedback-wrapper-no-extra-contact': ! showExtraContactOptions,
+						'chat-feedback-wrapper-no-extra-contact': ! isRequestingHumanSupport,
 						'chat-feedback-wrapper-third-party-cookies': displayingThirdPartyMessage,
 					} ) }
 				>
 					<Sources message={ message } />
-					{ showExtraContactOptions && renderExtraContactOptions() }
+					{ isRequestingHumanSupport && renderExtraContactOptions() }
 					{ isMessageShowingDisclaimer && renderDisclaimers() }
 				</div>
 			) }

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -128,7 +128,9 @@ export const UserMessage = ( {
 			{ ! isConnectedToZendesk && (
 				<>
 					{ showDirectEscalationLink && <DirectEscalationLink messageId={ message.message_id } /> }
-					<WasThisHelpfulButtons message={ message } isDisliked={ isDisliked } />
+					{ ! message.rating_value && (
+						<WasThisHelpfulButtons message={ message } isDisliked={ isDisliked } />
+					) }
 				</>
 			) }
 		</>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-13428/help-center-no-extra-contact-options-on-feedback

## Proposed Changes

If a user provides negative feedback to an AI answer, we do not present the extra contact options now:

![image](https://github.com/user-attachments/assets/95ffa82a-2b43-466c-8163-436d3f4391af)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To limit users giving feedback just to be able to reach human support

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Help Center
* Talk with AI
* Give feedback to an answer
* You should not be able to see the options like in the screenshot

