### PR TITLE
Add appropriate alt value to global master profile image

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -700,7 +700,6 @@ class MasterbarLoggedIn extends Component {
 				</span>
 				<Gravatar
 					className="masterbar__item-howdy-gravatar"
-					alt=" "
 					role="presentation"
 					user={ user }
 					size={ 16 }

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -698,7 +698,6 @@ class MasterbarLoggedIn extends Component {
 						args: { display_name: user.display_name },
 					} ) }
 				</span>
-				{ /* translators: This is a description of the user's gravatar for accessibility. */ }
 				<Gravatar
 					className="masterbar__item-howdy-gravatar"
 					alt=" "

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -698,7 +698,14 @@ class MasterbarLoggedIn extends Component {
 						args: { display_name: user.display_name },
 					} ) }
 				</span>
-				<Gravatar className="masterbar__item-howdy-gravatar" alt=" " user={ user } size={ 16 } />
+				{ /* translators: This is a description of the user's gravatar for accessibility. */ }
+				<Gravatar
+					className="masterbar__item-howdy-gravatar"
+					alt=" "
+					role="presentation"
+					user={ user }
+					size={ 16 }
+				/>
 			</Item>
 		);
 	}

--- a/packages/components/src/gravatar/index.tsx
+++ b/packages/components/src/gravatar/index.tsx
@@ -26,6 +26,7 @@ type Props = {
 		| false; // or false if the temp image does not exist
 	alt?: string;
 	title?: string;
+	role?: 'presentation' | 'img' | 'button' | 'link';
 };
 
 export class Gravatar extends Component< Props > {
@@ -67,14 +68,20 @@ export class Gravatar extends Component< Props > {
 	onError = () => this.setState( { failedToLoad: true } );
 
 	render() {
-		const { alt, title, size, tempImage, user } = this.props;
+		const { alt, title, size, tempImage, user, role } = this.props;
 
 		if ( ! user ) {
-			return <span className="gravatar is-placeholder" style={ { width: size, height: size } } />;
+			return (
+				<span
+					className="gravatar is-placeholder"
+					style={ { width: size, height: size } }
+					role={ role }
+				/>
+			);
 		}
 
 		if ( this.state.failedToLoad && ! tempImage ) {
-			return <span className="gravatar is-missing" />;
+			return <span className="gravatar is-missing" role={ role } />;
 		}
 
 		const altText = alt || user.display_name || user.name;
@@ -90,6 +97,7 @@ export class Gravatar extends Component< Props > {
 				width={ size }
 				height={ size }
 				onError={ this.onError }
+				role={ role }
 			/>
 		);
 	}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-13284

## Proposed Changes

* Add `role=presentation` to Gravatar. I decided for this approach since the user name is already read by VoiceOver, so I don't think any other context is necessary. Let me know what you think.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Ensure <img> elements have alternative text or a role of none or presentation

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn start`
* On any pages (`/sites` for example) check if the user Gravatar is displayed correctly.
* Using VoiceOver confirm the proper reading
* Run axe DevTools and confirm no error shows up related to the Gravatar `alt` or `role`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
