### PR TITLE
Revert "Purchases: Enable purchases-list-in-dataviews in development/horizon/wpcalypso"

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -145,7 +145,7 @@
 		"press-this": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
-		"purchases/purchase-list-dataview": true,
+		"purchases/purchase-list-dataview": false,
 		"push-notifications": true,
 		"reader": true,
 		"reader/comment-polling": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -91,7 +91,7 @@
 		"press-this": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
-		"purchases/purchase-list-dataview": true,
+		"purchases/purchase-list-dataview": false,
 		"reader": true,
 		"reader/quick-post": true,
 		"reader/recommended-blogs-list": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -120,7 +120,7 @@
 		"press-this": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
-		"purchases/purchase-list-dataview": true,
+		"purchases/purchase-list-dataview": false,
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/quick-post": true,

--- a/packages/calypso-e2e/src/lib/pages/me/purchases-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/purchases-page.ts
@@ -34,24 +34,10 @@ export class PurchasesPage {
 	 * @param {string} siteSlug Site slug.
 	 */
 	async clickOnPurchase( name: string, siteSlug: string ) {
-		const purchasesListDataView = this.page.locator( '#purchases-list .dataviews-wrapper' );
-		const purchasesListCardView = this.page.locator( '.card.purchase-item' );
-		await purchasesListDataView.or( purchasesListCardView ).first().waitFor( { state: 'visible' } );
-
-		if ( await purchasesListCardView.isVisible() ) {
-			await this.page
-				.locator( '.card.purchase-item' )
-				.filter( { hasText: name } )
-				.filter( { hasText: siteSlug } )
-				.click();
-			return;
-		}
-
 		await this.page
-			.locator( '#purchases-list .dataviews-view-table__row' )
+			.locator( '.card.purchase-item' )
 			.filter( { hasText: name } )
 			.filter( { hasText: siteSlug } )
-			.locator( '.dataviews-view-table__actions-column button' )
 			.click();
 	}
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#103866

There are failing pre-release tests although I can't immediately see how they are related:

<img width="1114" alt="Screenshot 2025-06-02 at 12 47 00 PM" src="https://github.com/user-attachments/assets/a2bde549-26a7-419b-8475-af317349aff3" />

<img width="1049" alt="Screenshot 2025-06-02 at 12 51 47 PM" src="https://github.com/user-attachments/assets/d1674006-88b8-4768-8ab7-a961234ae2f7" />

