### PR TITLE
Onboarding: Skip focused launchpad experiment

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -6,6 +6,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs, removeQueryArgs } from '@wordpress/url';
 import { useState, useEffect } from 'react';
 import { isSimplifiedOnboarding } from 'calypso/landing/stepper/hooks/use-simplified-onboarding';
+import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { pathToUrl } from 'calypso/lib/url';
 import {
@@ -237,13 +238,19 @@ const onboarding: FlowV2< typeof initialize > = {
 					const [ destination, backDestination ] =
 						await getPostCheckoutDestination( providedDependencies );
 					if ( providedDependencies.processingResult === ProcessingResult.SUCCESS ) {
+						const siteId = providedDependencies.siteId as number;
+						const siteSlug = providedDependencies.siteSlug as string;
+
 						persistSignupDestination( destination );
 						setSignupCompleteFlowName( flowName );
 						setSignupCompleteSlug( providedDependencies.siteSlug );
 
-						if ( providedDependencies.goToCheckout ) {
-							const siteSlug = providedDependencies.siteSlug as string;
+						await skipLaunchpad( {
+							siteId,
+							siteSlug,
+						} );
 
+						if ( providedDependencies.goToCheckout ) {
 							/**
 							 * If the user comes from the Playground onboarding flow,
 							 * redirect the user back to Playground to start the import.
@@ -252,7 +259,7 @@ const onboarding: FlowV2< typeof initialize > = {
 							const redirectTo: string = playgroundId
 								? addQueryArgs( withLocale( '/setup/site-setup/importerPlayground', locale ), {
 										siteSlug,
-										siteId: providedDependencies.siteId,
+										siteId,
 										playground: playgroundId,
 								  } )
 								: addQueryArgs(

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -5,6 +5,7 @@ import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs, removeQueryArgs } from '@wordpress/url';
 import { useState, useEffect } from 'react';
+import { useRemoveFocusedLaunchpadExperiment } from 'calypso/landing/stepper/hooks/use-remove-focused-launchpad-experiment';
 import { isSimplifiedOnboarding } from 'calypso/landing/stepper/hooks/use-simplified-onboarding';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
@@ -89,6 +90,7 @@ const onboarding: FlowV2< typeof initialize > = {
 
 		const [ useMyDomainTracksEventProps, setUseMyDomainTracksEventProps ] = useState( {} );
 		const { setShouldShowNotification } = usePurchasePlanNotification();
+		const [ , shouldSkipLaunchpad ] = useRemoveFocusedLaunchpadExperiment();
 
 		/**
 		 * Returns [destination, backDestination] for the post-checkout destination.
@@ -245,10 +247,12 @@ const onboarding: FlowV2< typeof initialize > = {
 						setSignupCompleteFlowName( flowName );
 						setSignupCompleteSlug( providedDependencies.siteSlug );
 
-						await skipLaunchpad( {
-							siteId,
-							siteSlug,
-						} );
+						if ( shouldSkipLaunchpad ) {
+							await skipLaunchpad( {
+								siteId,
+								siteSlug,
+							} );
+						}
 
 						if ( providedDependencies.goToCheckout ) {
 							/**

--- a/client/landing/stepper/hooks/use-remove-focused-launchpad-experiment.ts
+++ b/client/landing/stepper/hooks/use-remove-focused-launchpad-experiment.ts
@@ -1,0 +1,13 @@
+import { useExperiment } from 'calypso/lib/explat';
+
+const REMOVE_FOCUSED_LAUNCHPAD_EXPERIMENT_NAME =
+	'calypso_signup_simplified_onboarding_remove_focused_launchpad';
+
+export function useRemoveFocusedLaunchpadExperiment(): [ boolean, boolean | null ] {
+	const [ isLoadingExperiment, assignment ] = useExperiment(
+		REMOVE_FOCUSED_LAUNCHPAD_EXPERIMENT_NAME
+	);
+	const isTreatment = assignment?.variationName === 'treatment';
+
+	return [ isLoadingExperiment, isTreatment ];
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves https://linear.app/a8c/issue/DOTCOM-13415/implement-a-new-experiment-for-onboarding

## Proposed Changes

* Skip the focused launchpad when the user is in the `treatment` group of the `calypso_signup_simplified_onboarding_remove_focused_launchpad` experiment.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to test if users who don't see the Focused Launchpad, have the same launching rate as the ones who see it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites` and create a new free site.
* You should land on the Focused Launchpad as before.
* Assign yourself to the treatment group of the experiment - 22256-explat-experiment.
* Go to `/sites` and create a new free site.
* You should land on the standard /home page, which contains the normal Launchpad component.

![image](https://github.com/user-attachments/assets/62d1e744-34c2-4036-99bd-27cfa8f84bbb)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?