### PR TITLE
Revert "chore(deps): update dependency webpack to ^5.99.9"

### DIFF
--- a/apps/blaze-dashboard/package.json
+++ b/apps/blaze-dashboard/package.json
@@ -66,7 +66,7 @@
 		"lodash": "^4.17.21",
 		"path-browserify": "^1.0.1",
 		"postcss": "^8.5.3",
-		"webpack": "^5.99.9",
+		"webpack": "^5.99.8",
 		"webpack-bundle-analyzer": "^4.10.2"
 	}
 }

--- a/apps/command-palette-wp-admin/package.json
+++ b/apps/command-palette-wp-admin/package.json
@@ -48,7 +48,7 @@
 		"lodash": "^4.17.21",
 		"npm-run-all": "^4.1.5",
 		"postcss": "^8.5.3",
-		"webpack": "^5.99.9",
+		"webpack": "^5.99.8",
 		"webpack-bundle-analyzer": "^4.10.2"
 	}
 }

--- a/apps/happy-blocks/package.json
+++ b/apps/happy-blocks/package.json
@@ -58,6 +58,6 @@
 		"copy-webpack-plugin": "^10.2.4",
 		"glob": "^7.2.3",
 		"postcss": "^8.5.3",
-		"webpack": "^5.99.9"
+		"webpack": "^5.99.8"
 	}
 }

--- a/apps/help-center/package.json
+++ b/apps/help-center/package.json
@@ -53,7 +53,7 @@
 		"@wordpress/readable-js-assets-webpack-plugin": "^3.24.0",
 		"copy-webpack-plugin": "^10.2.4",
 		"typescript": "^5.8.3",
-		"webpack": "^5.99.9"
+		"webpack": "^5.99.8"
 	},
 	"peerDependencies": {
 		"@automattic/calypso-router": "workspace:^",

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -57,6 +57,6 @@
 		"html-webpack-plugin": "^5.6.3",
 		"postcss": "^8.5.3",
 		"postcss-custom-properties": "^12.0.0",
-		"webpack": "^5.99.9"
+		"webpack": "^5.99.8"
 	}
 }

--- a/apps/o2-blocks/package.json
+++ b/apps/o2-blocks/package.json
@@ -49,6 +49,6 @@
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"@wordpress/readable-js-assets-webpack-plugin": "^3.24.0",
 		"postcss": "^8.5.3",
-		"webpack": "^5.99.9"
+		"webpack": "^5.99.8"
 	}
 }

--- a/apps/odyssey-stats/package.json
+++ b/apps/odyssey-stats/package.json
@@ -72,7 +72,7 @@
 		"path-browserify": "^1.0.1",
 		"postcss": "^8.5.3",
 		"size-limit": "^8.2.6",
-		"webpack": "^5.99.9",
+		"webpack": "^5.99.8",
 		"webpack-bundle-analyzer": "^4.10.2"
 	}
 }

--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -60,7 +60,7 @@
 		"@wordpress/dependency-extraction-webpack-plugin": "^6.24.0",
 		"npm-run-all": "^4.1.5",
 		"postcss": "^8.5.3",
-		"webpack": "^5.99.9",
+		"webpack": "^5.99.8",
 		"webpack-bundle-analyzer": "^4.10.2"
 	}
 }

--- a/client/package.json
+++ b/client/package.json
@@ -219,7 +219,7 @@
 		"util": "^0.12.5",
 		"utility-types": "^3.10.0",
 		"valid-url": "^1.0.9",
-		"webpack": "^5.99.9",
+		"webpack": "^5.99.8",
 		"webpack-bundle-analyzer": "^4.10.2",
 		"webpack-dev-middleware": "^5.3.4",
 		"webpack-hot-middleware": "^2.26.1",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -48,7 +48,7 @@
 		"postcss": "^8.5.3",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"webpack": "^5.99.9",
+		"webpack": "^5.99.8",
 		"webpack-cli": "^4.10.0"
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -316,7 +316,7 @@
 		"stylelint-scss": "^6.4.0",
 		"tslib": "^2.8.1",
 		"typescript": "5.8.3",
-		"webpack": "^5.99.9",
+		"webpack": "^5.99.8",
 		"webpack-bundle-analyzer": "^4.10.2",
 		"webpack-cli": "^4.10.0",
 		"webpack-dev-middleware": "^5.3.4",

--- a/packages/calypso-apps-builder/package.json
+++ b/packages/calypso-apps-builder/package.json
@@ -19,7 +19,7 @@
 		"html-webpack-plugin": "^5.6.3",
 		"npm-run-all": "^4.1.5",
 		"tree-kill": "^1.2.2",
-		"webpack": "^5.99.9",
+		"webpack": "^5.99.8",
 		"yargs": "^17.0.1"
 	},
 	"devDependencies": {

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -71,6 +71,6 @@
 	},
 	"peerDependencies": {
 		"postcss": "^8.5.3",
-		"webpack": "^5.99.9"
+		"webpack": "^5.99.8"
 	}
 }

--- a/packages/calypso-storybook/package.json
+++ b/packages/calypso-storybook/package.json
@@ -40,6 +40,6 @@
 		"react-dom": "^18.3.1",
 		"sass-loader": "^13.3.3",
 		"style-loader": "^1.3.0",
-		"webpack": "^5.99.9"
+		"webpack": "^5.99.8"
 	}
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -102,7 +102,7 @@
 		"postcss": "^8.5.3",
 		"storybook": "^8.6.14",
 		"typescript": "^5.8.3",
-		"webpack": "^5.99.9"
+		"webpack": "^5.99.8"
 	},
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",

--- a/packages/design-picker/package.json
+++ b/packages/design-picker/package.json
@@ -66,7 +66,7 @@
 		"react-dom": "^18.3.1",
 		"redux": "^5.0.1",
 		"typescript": "^5.8.3",
-		"webpack": "^5.99.9"
+		"webpack": "^5.99.8"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.23.0",

--- a/packages/domains-table/package.json
+++ b/packages/domains-table/package.json
@@ -66,7 +66,7 @@
 		"react-dom": "^18.3.1",
 		"resize-observer-polyfill": "^1.5.1",
 		"typescript": "^5.8.3",
-		"webpack": "^5.99.9"
+		"webpack": "^5.99.8"
 	},
 	"peerDependencies": {
 		"@automattic/calypso-router": "workspace:^",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -40,7 +40,7 @@
 		"postcss": "^8.5.3",
 		"storybook": "^8.6.14",
 		"typescript": "^5.8.3",
-		"webpack": "^5.99.9"
+		"webpack": "^5.99.8"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0",

--- a/packages/jetpack-ai-calypso/package.json
+++ b/packages/jetpack-ai-calypso/package.json
@@ -60,7 +60,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"typescript": "^5.8.3",
-		"webpack": "^5.99.9"
+		"webpack": "^5.99.8"
 	},
 	"peerDependencies": {
 		"@babel/runtime": "^7.27.1",

--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -48,6 +48,6 @@
 		"react-dom": "^18.3.1",
 		"redux": "^5.0.1",
 		"typescript": "^5.8.3",
-		"webpack": "^5.99.9"
+		"webpack": "^5.99.8"
 	}
 }

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -68,7 +68,7 @@
 		"redux": "^5.0.1",
 		"storybook": "^8.6.14",
 		"typescript": "^5.8.3",
-		"webpack": "^5.99.9"
+		"webpack": "^5.99.8"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.23.0",

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -74,7 +74,7 @@
 		"storybook": "^8.6.14",
 		"style-loader": "^1.3.0",
 		"typescript": "^5.8.3",
-		"webpack": "^5.99.9"
+		"webpack": "^5.99.8"
 	},
 	"peerDependencies": {
 		"@wordpress/i18n": "^5.23.0",

--- a/packages/plans-grid-next/package.json
+++ b/packages/plans-grid-next/package.json
@@ -86,7 +86,7 @@
 		"resize-observer-polyfill": "^1.5.1",
 		"storybook": "^8.6.14",
 		"typescript": "^5.8.3",
-		"webpack": "^5.99.9"
+		"webpack": "^5.99.8"
 	},
 	"msw": {
 		"workerDirectory": "static"

--- a/packages/privacy-toolset/package.json
+++ b/packages/privacy-toolset/package.json
@@ -59,6 +59,6 @@
 		"require-from-string": "^2.0.2",
 		"storybook": "^8.6.14",
 		"typescript": "^5.8.3",
-		"webpack": "^5.99.9"
+		"webpack": "^5.99.8"
 	}
 }

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -67,7 +67,7 @@
 		"react-dom": "^18.3.1",
 		"storybook": "^8.6.14",
 		"typescript": "^5.8.3",
-		"webpack": "^5.99.9"
+		"webpack": "^5.99.8"
 	},
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",

--- a/packages/site-admin/package.json
+++ b/packages/site-admin/package.json
@@ -60,7 +60,7 @@
 		"postcss": "^8.5.3",
 		"storybook": "^8.6.14",
 		"typescript": "^5.8.3",
-		"webpack": "^5.99.9"
+		"webpack": "^5.99.8"
 	},
 	"dependencies": {
 		"@wordpress/base-styles": "^5.23.0",

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -67,7 +67,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"typescript": "^5.8.3",
-		"webpack": "^5.99.9"
+		"webpack": "^5.99.8"
 	},
 	"peerDependencies": {
 		"@babel/runtime": "^7.27.1",

--- a/packages/webpack-config-flag-plugin/package.json
+++ b/packages/webpack-config-flag-plugin/package.json
@@ -6,7 +6,7 @@
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"main": "index.js",
 	"peerDependencies": {
-		"webpack": "^5.99.9"
+		"webpack": "^5.99.8"
 	},
 	"author": "Automattic Inc.",
 	"private": true,

--- a/packages/webpack-extensive-lodash-replacement-plugin/package.json
+++ b/packages/webpack-extensive-lodash-replacement-plugin/package.json
@@ -20,7 +20,7 @@
 	},
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"peerDependencies": {
-		"webpack": "^5.99.9"
+		"webpack": "^5.99.8"
 	},
 	"dependencies": {
 		"semver": "^7.7.2"

--- a/packages/webpack-inline-constant-exports-plugin/package.json
+++ b/packages/webpack-inline-constant-exports-plugin/package.json
@@ -18,13 +18,13 @@
 	},
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"peerDependencies": {
-		"webpack": "^5.99.9"
+		"webpack": "^5.99.8"
 	},
 	"devDependencies": {
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"rimraf": "^3.0.2",
-		"webpack": "^5.99.9"
+		"webpack": "^5.99.8"
 	},
 	"files": [
 		"index.js"

--- a/packages/webpack-rtl-plugin/package.json
+++ b/packages/webpack-rtl-plugin/package.json
@@ -27,10 +27,10 @@
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"css-loader": "^6.11.0",
 		"mini-css-extract-plugin": "^1.6.2",
-		"webpack": "^5.99.9"
+		"webpack": "^5.99.8"
 	},
 	"peerDependencies": {
-		"webpack": "^5.99.9"
+		"webpack": "^5.99.8"
 	},
 	"dependencies": {
 		"rtlcss": "^3.1.2"

--- a/packages/wpcom-proxy-request/package.json
+++ b/packages/wpcom-proxy-request/package.json
@@ -55,6 +55,6 @@
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"postcss": "^8.5.3",
-		"webpack": "^5.99.9"
+		"webpack": "^5.99.8"
 	}
 }

--- a/packages/wpcom.js/package.json
+++ b/packages/wpcom.js/package.json
@@ -60,7 +60,7 @@
 		"@babel/core": "^7.27.1",
 		"babel-loader": "^8.2.3",
 		"npm-run-all": "^4.1.5",
-		"webpack": "^5.99.9",
+		"webpack": "^5.99.8",
 		"webpack-cli": "^4.10.0",
 		"wpcom-oauth-cors": "^1.0.2-beta",
 		"wpcom-proxy-request": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -362,7 +362,7 @@ __metadata:
     react-redux: "npm:^9.2.0"
     redux: "npm:^5.0.1"
     redux-thunk: "npm:^3.1.0"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
     webpack-bundle-analyzer: "npm:^4.10.2"
     wpcom: "workspace:^"
     wpcom-proxy-request: "workspace:^"
@@ -429,7 +429,7 @@ __metadata:
     html-webpack-plugin: "npm:^5.6.3"
     npm-run-all: "npm:^4.1.5"
     tree-kill: "npm:^1.2.2"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
     yargs: "npm:^17.0.1"
   bin:
     calypso-apps-builder: ./index.js
@@ -499,7 +499,7 @@ __metadata:
     yargs: "npm:^17.7.2"
   peerDependencies:
     postcss: ^8.5.3
-    webpack: ^5.99.9
+    webpack: ^5.99.8
   bin:
     build-app-languages: ./bin/build-app-languages.js
     calypso-build: ./bin/calypso-build.js
@@ -720,7 +720,7 @@ __metadata:
     sass-loader: "npm:^13.3.3"
     storybook: "npm:^8.6.14"
     style-loader: "npm:^1.3.0"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
   languageName: unknown
   linkType: soft
 
@@ -814,7 +814,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     redux: "npm:^5.0.1"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
     webpack-bundle-analyzer: "npm:^4.10.2"
   languageName: unknown
   linkType: soft
@@ -908,7 +908,7 @@ __metadata:
     storybook: "npm:^8.6.14"
     typescript: "npm:^5.8.3"
     utility-types: "npm:^3.10.0"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
   peerDependencies:
     "@wordpress/data": ^10.23.0
     react: ^18.3.1
@@ -1065,7 +1065,7 @@ __metadata:
     tslib: "npm:^2.8.1"
     typescript: "npm:^5.8.3"
     utility-types: "npm:^3.10.0"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
   peerDependencies:
     "@wordpress/data": ^10.23.0
     "@wordpress/element": ^6.23.0
@@ -1200,7 +1200,7 @@ __metadata:
     react-intersection-observer: "npm:^9.4.3"
     resize-observer-polyfill: "npm:^1.5.1"
     typescript: "npm:^5.8.3"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
   peerDependencies:
     "@automattic/calypso-router": "workspace:^"
     "@wordpress/data": ^10.23.0
@@ -1339,7 +1339,7 @@ __metadata:
     postcss: "npm:^8.5.3"
     storybook: "npm:^8.6.14"
     typescript: "npm:^5.8.3"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
@@ -1370,7 +1370,7 @@ __metadata:
     copy-webpack-plugin: "npm:^10.2.4"
     postcss-prefix-selector: "npm:^1.16.1"
     typescript: "npm:^5.8.3"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
   peerDependencies:
     "@automattic/calypso-router": "workspace:^"
     "@wordpress/data": ^10.23.0
@@ -1487,7 +1487,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     typescript: "npm:^5.8.3"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
   peerDependencies:
     "@babel/runtime": ^7.27.1
     "@wordpress/data": ^10.23.0
@@ -1543,7 +1543,7 @@ __metadata:
     redux: "npm:^5.0.1"
     tslib: "npm:^2.8.1"
     typescript: "npm:^5.8.3"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
   languageName: unknown
   linkType: soft
 
@@ -1588,7 +1588,7 @@ __metadata:
     tslib: "npm:^2.8.1"
     typescript: "npm:^5.8.3"
     utility-types: "npm:^3.10.0"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
     wpcom-proxy-request: "workspace:^"
   peerDependencies:
     "@wordpress/data": ^10.23.0
@@ -1678,7 +1678,7 @@ __metadata:
     react-redux: "npm:^9.2.0"
     redux: "npm:^5.0.1"
     redux-thunk: "npm:^3.1.0"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
     webpack-bundle-analyzer: "npm:^4.10.2"
     wpcom: "workspace:^"
     wpcom-proxy-request: "workspace:^"
@@ -1725,7 +1725,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     redux: "npm:^5.0.1"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
   languageName: unknown
   linkType: soft
 
@@ -1813,7 +1813,7 @@ __metadata:
     redux: "npm:^5.0.1"
     redux-thunk: "npm:^3.1.0"
     size-limit: "npm:^8.2.6"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
     webpack-bundle-analyzer: "npm:^4.10.2"
     wpcom: "workspace:^"
   languageName: unknown
@@ -1850,7 +1850,7 @@ __metadata:
     style-loader: "npm:^1.3.0"
     tslib: "npm:^2.8.1"
     typescript: "npm:^5.8.3"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
     wpcom-proxy-request: "workspace:^"
   peerDependencies:
     "@wordpress/i18n": ^5.23.0
@@ -1894,7 +1894,7 @@ __metadata:
     resize-observer-polyfill: "npm:^1.5.1"
     storybook: "npm:^8.6.14"
     typescript: "npm:^5.8.3"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
   peerDependencies:
     "@wordpress/i18n": ^5.23.0
     postcss: ^8.5.3
@@ -1928,7 +1928,7 @@ __metadata:
     require-from-string: "npm:^2.0.2"
     storybook: "npm:^8.6.14"
     typescript: "npm:^5.8.3"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
   peerDependencies:
     react: ^18.3.1
     react-dom: ^18.3.1
@@ -1990,7 +1990,7 @@ __metadata:
     storybook: "npm:^8.6.14"
     tslib: "npm:^2.8.1"
     typescript: "npm:^5.8.3"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
   peerDependencies:
     react: ^18.3.1
     react-dom: ^18.3.1
@@ -2037,7 +2037,7 @@ __metadata:
     route-recognizer: "npm:^0.3.4"
     storybook: "npm:^8.6.14"
     typescript: "npm:^5.8.3"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
   peerDependencies:
     "@wordpress/data": ^10.23.0
     react: ^18.3.1
@@ -2084,7 +2084,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     tslib: "npm:^2.8.1"
     typescript: "npm:^5.8.3"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
   peerDependencies:
     "@babel/runtime": ^7.27.1
     react: ^18.3.1
@@ -2248,7 +2248,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     rimraf: "npm:^3.0.2"
   peerDependencies:
-    webpack: ^5.99.9
+    webpack: ^5.99.8
   languageName: unknown
   linkType: soft
 
@@ -2259,7 +2259,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     semver: "npm:^7.7.2"
   peerDependencies:
-    webpack: ^5.99.9
+    webpack: ^5.99.8
   languageName: unknown
   linkType: soft
 
@@ -2270,9 +2270,9 @@ __metadata:
     "@automattic/calypso-eslint-overrides": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     rimraf: "npm:^3.0.2"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
   peerDependencies:
-    webpack: ^5.99.9
+    webpack: ^5.99.8
   languageName: unknown
   linkType: soft
 
@@ -2284,9 +2284,9 @@ __metadata:
     css-loader: "npm:^6.11.0"
     mini-css-extract-plugin: "npm:^1.6.2"
     rtlcss: "npm:^3.1.2"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
   peerDependencies:
-    webpack: ^5.99.9
+    webpack: ^5.99.8
   languageName: unknown
   linkType: soft
 
@@ -2356,7 +2356,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     redux: "npm:^5.0.1"
     tinymce: "npm:^5.0.0"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
     webpack-bundle-analyzer: "npm:^4.10.2"
   languageName: unknown
   linkType: soft
@@ -12772,7 +12772,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     semver: "npm:^7.7.2"
     superagent: "npm:^3.8.3"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
     webpack-cli: "npm:^4.10.0"
     winston: "npm:^3.3.3"
     wpcom-xhr-request: "workspace:^"
@@ -14741,7 +14741,7 @@ __metadata:
     util: "npm:^0.12.5"
     utility-types: "npm:^3.10.0"
     valid-url: "npm:^1.0.9"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
     webpack-bundle-analyzer: "npm:^4.10.2"
     webpack-dev-middleware: "npm:^5.3.4"
     webpack-hot-middleware: "npm:^2.26.1"
@@ -21149,7 +21149,7 @@ __metadata:
     postcss: "npm:^8.5.3"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
   languageName: unknown
   linkType: soft
 
@@ -36851,7 +36851,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:5, webpack@npm:^5.63.0, webpack@npm:^5.88.1, webpack@npm:^5.95.0, webpack@npm:^5.99.9":
+"webpack@npm:5, webpack@npm:^5.63.0, webpack@npm:^5.88.1, webpack@npm:^5.95.0, webpack@npm:^5.99.8":
   version: 5.99.9
   resolution: "webpack@npm:5.99.9"
   dependencies:
@@ -37328,7 +37328,7 @@ __metadata:
     swiper: "npm:^10.3.1"
     tslib: "npm:^2.8.1"
     typescript: "npm:5.8.3"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
     webpack-bundle-analyzer: "npm:^4.10.2"
     webpack-cli: "npm:^4.10.0"
     webpack-dev-middleware: "npm:^5.3.4"
@@ -37407,7 +37407,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     debug: "npm:^4.4.1"
     postcss: "npm:^8.5.3"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
     wp-error: "npm:^1.3.0"
   languageName: unknown
   linkType: soft
@@ -37436,7 +37436,7 @@ __metadata:
     npm-run-all: "npm:^4.1.5"
     qs: "npm:^6.5.2"
     tus-js-client: "npm:2.3.2"
-    webpack: "npm:^5.99.9"
+    webpack: "npm:^5.99.8"
     webpack-cli: "npm:^4.10.0"
     wpcom-oauth-cors: "npm:^1.0.2-beta"
     wpcom-proxy-request: "workspace:^"


### PR DESCRIPTION
Reverts Automattic/wp-calypso#103856

There are failing pre-release tests although I can't immediately see how they are related:

<img width="1114" alt="Screenshot 2025-06-02 at 12 47 00 PM" src="https://github.com/user-attachments/assets/a2bde549-26a7-419b-8475-af317349aff3" />

<img width="1049" alt="Screenshot 2025-06-02 at 12 51 47 PM" src="https://github.com/user-attachments/assets/d1674006-88b8-4768-8ab7-a961234ae2f7" />

