### PR TITLE
Fix wp-admin URL on inbox search test

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -22,11 +22,7 @@ export class FeedbackInboxPage {
 	 * @param {string} siteUrlWithProtocol Site URL with the protocol.
 	 */
 	async visit( siteUrlWithProtocol: string ): Promise< void > {
-		const url = new URL(
-			// The query arg is necessary for sites that were using the "Classic" feedback view.
-			'/wp-admin/admin.php?page=jetpack-forms&dashboard-preferred-view=modern',
-			siteUrlWithProtocol
-		);
+		const url = new URL( '/wp-admin/admin.php?page=jetpack-forms-admin', siteUrlWithProtocol );
 		await this.page.goto( url.href, { timeout: 20 * 1000 } );
 	}
 


### PR DESCRIPTION
As title

Related to FORMS-27

## Proposed Changes
The new Jetpack Forms wp-admin page now lives at `wp-admin/admin.php?page=jetpack-forms-admin`, this PR adjusts the search test to load the new URL.

## Why are these changes being made?
Because after merging https://github.com/Automattic/jetpack/pull/43705 we use a different URL for Jetpack Forms dashboard

## Testing Instructions
Run the test, see that it works fine: 

```bash
yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/published-content/forms__submissions.ts
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
