### PR TITLE
Help Center: Simplify chat function

### DIFF
--- a/packages/help-center/src/components/help-center-chat.tsx
+++ b/packages/help-center/src/components/help-center-chat.tsx
@@ -25,7 +25,8 @@ export function HelpCenterChat( {
 	const navigate = useNavigate();
 	const shouldUseWapuu = useShouldUseWapuu();
 	const preventOdieAccess = ! shouldUseWapuu && ! isUserEligibleForPaidSupport;
-	const { currentUser, site, canConnectToZendesk } = useHelpCenterContext();
+	const { currentUser, site, canConnectToZendesk, isLoadingCanConnectToZendesk } =
+		useHelpCenterContext();
 	const { search } = useLocation();
 	const params = new URLSearchParams( search );
 	const userFieldMessage = params.get( 'userFieldMessage' );
@@ -46,6 +47,7 @@ export function HelpCenterChat( {
 		<OdieAssistantProvider
 			currentUser={ currentUser }
 			canConnectToZendesk={ canConnectToZendesk }
+			isLoadingCanConnectToZendesk={ isLoadingCanConnectToZendesk }
 			selectedSiteId={ Number( siteId ) || ( site?.ID as number ) }
 			selectedSiteURL={ siteUrl || ( site?.URL as string ) }
 			userFieldMessage={ userFieldMessage }

--- a/packages/help-center/src/contexts/HelpCenterContext.tsx
+++ b/packages/help-center/src/contexts/HelpCenterContext.tsx
@@ -13,6 +13,7 @@ export type HelpCenterRequiredInformation = {
 	googleMailServiceFamily: string;
 	onboardingUrl: string;
 	canConnectToZendesk: boolean;
+	isLoadingCanConnectToZendesk: boolean;
 };
 
 const HelpCenterRequiredContext = createContext< HelpCenterRequiredInformation >( {
@@ -35,6 +36,7 @@ const HelpCenterRequiredContext = createContext< HelpCenterRequiredInformation >
 	googleMailServiceFamily: '',
 	onboardingUrl: '',
 	canConnectToZendesk: false,
+	isLoadingCanConnectToZendesk: false,
 } );
 
 export const HelpCenterRequiredContextProvider: React.FC< {
@@ -45,7 +47,11 @@ export const HelpCenterRequiredContextProvider: React.FC< {
 
 	return (
 		<HelpCenterRequiredContext.Provider
-			value={ { ...value, canConnectToZendesk: isLoading ? false : canConnectToZendesk ?? false } }
+			value={ {
+				...value,
+				isLoadingCanConnectToZendesk: isLoading,
+				canConnectToZendesk: canConnectToZendesk ?? false,
+			} }
 		>
 			{ children }
 		</HelpCenterRequiredContext.Provider>

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -66,7 +66,9 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
 		const currentInteraction = helpCenterSelect.getCurrentSupportInteraction();
 		return {
-			alreadyHasActiveZendeskChat: interactionHasZendeskEvent( currentInteraction ),
+			alreadyHasActiveZendeskChat:
+				interactionHasZendeskEvent( currentInteraction ) &&
+				! interactionHasEnded( currentInteraction ),
 			chatHasEnded: interactionHasEnded( currentInteraction ),
 		};
 	}, [] );

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -35,6 +35,7 @@ export const OdieAssistantContext = createContext< OdieAssistantContextInterface
 	botNameSlug: 'wpcom-support-chat' as OdieAllowedBots,
 	chat: emptyChat,
 	canConnectToZendesk: false,
+	isLoadingCanConnectToZendesk: false,
 	clearChat: noop,
 	currentUser: { display_name: 'Me' },
 	experimentVariationName: null,
@@ -65,6 +66,7 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 	botName = 'Wapuu assistant',
 	isUserEligibleForPaidSupport = true,
 	canConnectToZendesk = false,
+	isLoadingCanConnectToZendesk = false,
 	extraContactOptions,
 	selectedSiteId,
 	selectedSiteURL,
@@ -97,7 +99,8 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 	 * This is where we manage the state of the chat.
 	 */
 	const { mainChatState, setMainChatState } = useGetCombinedChat(
-		isUserEligibleForPaidSupport && canConnectToZendesk
+		isUserEligibleForPaidSupport && canConnectToZendesk,
+		isLoadingCanConnectToZendesk
 	);
 
 	/**
@@ -196,6 +199,7 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 				experimentVariationName,
 				isUserEligibleForPaidSupport,
 				canConnectToZendesk,
+				isLoadingCanConnectToZendesk,
 				hasUserEverEscalatedToHumanSupport,
 				odieBroadcastClientId,
 				selectedSiteId,

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -37,38 +37,48 @@ export const useGetCombinedChat = ( canConnectToZendesk: boolean ) => {
 	const getZendeskConversation = useGetZendeskConversation();
 	const { data: odieChat, isFetching: isOdieChatLoading } = useOdieChat( Number( odieId ) );
 	const { startNewInteraction } = useManageSupportInteraction();
-	const canFetchConversation = conversationId && canConnectToZendesk;
 
 	useEffect( () => {
-		if ( ! currentSupportInteraction || isOdieChatLoading || chatStatus !== 'loading' ) {
+		if ( ! currentSupportInteraction?.uuid || isOdieChatLoading || chatStatus !== 'loading' ) {
 			return;
 		}
 
-		if ( ! canFetchConversation ) {
+		// We don't have a conversation id, so our chat is simply the odie chat
+		if ( ! conversationId ) {
 			setMainChatState( {
 				...( odieChat ? odieChat : emptyChat ),
 				conversationId: null,
 				supportInteractionId: currentSupportInteraction.uuid,
-				provider: 'odie',
 				status: 'loaded',
+				provider: 'odie',
 			} );
+			return;
+		}
 
-			recordTracksEvent( 'calypso_odie_zendesk_chat_reset_to_odie', {
-				interaction: currentSupportInteraction.uuid,
-				conversation_id: conversationId,
-				chat_id: odieChat?.odieId,
+		const filteredOdieMessages =
+			odieChat?.messages.filter(
+				( message ) => ! message.context?.flags?.forward_to_human_support
+			) ?? [];
+
+		// We have an ongoing conversation with Zendesk, but we have some problems connecting to it
+		if ( ! canConnectToZendesk ) {
+			setMainChatState( {
+				messages: [ ...( odieChat ? filteredOdieMessages : [] ) ],
+				conversationId,
+				supportInteractionId: currentSupportInteraction.uuid,
+				status: 'loaded',
+				provider: 'zendesk',
 			} );
-		} else if ( isChatLoaded && canFetchConversation ) {
+			return;
+		}
+
+		if ( isChatLoaded ) {
 			try {
 				getZendeskConversation( {
 					chatId: odieChat?.odieId,
 					conversationId: conversationId?.toString(),
 				} )?.then( ( conversation ) => {
 					if ( conversation ) {
-						const filteredOdieMessages =
-							odieChat?.messages.filter(
-								( message ) => ! message.context?.flags?.forward_to_human_support
-							) ?? [];
 						setMainChatState( {
 							...( odieChat ? odieChat : {} ),
 							supportInteractionId: currentSupportInteraction.uuid,
@@ -84,7 +94,6 @@ export const useGetCombinedChat = ( canConnectToZendesk: boolean ) => {
 					}
 				} );
 			} catch ( error ) {
-				// Conversation id was passed but the conversion was not found. Something went wrong.
 				recordTracksEvent( 'calypso_odie_zendesk_conversation_not_found', {
 					conversationId,
 					odieId,
@@ -108,38 +117,6 @@ export const useGetCombinedChat = ( canConnectToZendesk: boolean ) => {
 		getZendeskConversation,
 		startNewInteraction,
 	] );
-
-	// This effect sets the initial loading state when interaction is set, so that the chat is loaded
-	useEffect( () => {
-		if ( ! currentSupportInteraction?.uuid ) {
-			return;
-		}
-
-		setMainChatState( ( prevChat ) => {
-			if ( odieId || conversationId ) {
-				// when we have the same support interaction we don't need to load the messages
-				if ( prevChat?.supportInteractionId === currentSupportInteraction!.uuid ) {
-					return {
-						...prevChat,
-						status: 'loaded',
-					};
-				}
-
-				return {
-					...prevChat,
-					supportInteractionId: currentSupportInteraction!.uuid,
-					status: 'loading',
-				};
-			}
-
-			// empty chat nothing to load
-			return {
-				...emptyChat,
-				supportInteractionId: currentSupportInteraction!.uuid,
-				status: 'loaded',
-			};
-		} );
-	}, [ currentSupportInteraction?.uuid, odieId, conversationId ] );
 
 	return { mainChatState, setMainChatState };
 };

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -2,7 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { HelpCenterSelect } from '@automattic/data-stores';
 import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { useSelect } from '@wordpress/data';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useRef } from '@wordpress/element';
 import { ODIE_TRANSFER_MESSAGE } from '../constants';
 import { emptyChat } from '../context';
 import { useGetZendeskConversation, useManageSupportInteraction, useOdieChat } from '../data';
@@ -13,7 +13,10 @@ import type { Chat, Message } from '../types';
  * This combines the ODIE chat with the ZENDESK conversation.
  * @returns The combined chat.
  */
-export const useGetCombinedChat = ( canConnectToZendesk: boolean ) => {
+export const useGetCombinedChat = (
+	canConnectToZendesk: boolean,
+	isLoadingCanConnectToZendesk: boolean
+) => {
 	const { currentSupportInteraction, conversationId, odieId, isChatLoaded } = useSelect(
 		( select ) => {
 			const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
@@ -31,7 +34,7 @@ export const useGetCombinedChat = ( canConnectToZendesk: boolean ) => {
 		},
 		[]
 	);
-
+	const previousUuidRef = useRef< string | undefined >();
 	const [ mainChatState, setMainChatState ] = useState< Chat >( emptyChat );
 	const chatStatus = mainChatState?.status;
 	const getZendeskConversation = useGetZendeskConversation();
@@ -39,7 +42,14 @@ export const useGetCombinedChat = ( canConnectToZendesk: boolean ) => {
 	const { startNewInteraction } = useManageSupportInteraction();
 
 	useEffect( () => {
-		if ( ! currentSupportInteraction?.uuid || isOdieChatLoading || chatStatus !== 'loading' ) {
+		const interactionHasChanged = previousUuidRef.current !== currentSupportInteraction?.uuid;
+		previousUuidRef.current = currentSupportInteraction?.uuid;
+		if (
+			! currentSupportInteraction?.uuid ||
+			isOdieChatLoading ||
+			isLoadingCanConnectToZendesk ||
+			( chatStatus !== 'loading' && ! interactionHasChanged )
+		) {
 			return;
 		}
 

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -4,6 +4,7 @@ import type { ReactNode, PropsWithChildren, SetStateAction } from 'react';
 export type OdieAssistantContextInterface = {
 	isChatLoaded: boolean;
 	canConnectToZendesk: boolean;
+	isLoadingCanConnectToZendesk: boolean;
 	addMessage: ( message: Message | Message[] ) => void;
 	botName?: string;
 	botNameSlug: OdieAllowedBots;
@@ -34,6 +35,7 @@ export type OdieAssistantContextInterface = {
 
 export type OdieAssistantProviderProps = {
 	canConnectToZendesk?: boolean;
+	isLoadingCanConnectToZendesk?: boolean;
 	botName?: string;
 	botNameSlug?: OdieAllowedBots;
 	isUserEligibleForPaidSupport?: boolean;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTSUP-54/user-unable-to-talk-with-support

## Proposed Changes

The useGetCombinedChat function is extremely complex; it is used to form the chat that users see on the Help Center based on whether we are on Odie or we are on Zendesk or we have connection problems, and so forth.

This PR refactors the function into one single useEffect, instead of two, to be able to scale down its complexity.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Help Center
* Talk with Odie (AI)
* Try to ask to speak with a human and continue until it is possible
* Open another chat (menu on top and then new conversation)
* Talk with Odie
* Go back to the homepage and check History
* Go through the various chats
* Everything should work fine
* To test problems with Zendesk, try ModResponse extension and block Zendesk config