### PR TITLE
A4A: Add the 'Unified onboarding flow' feature flag.

### DIFF
--- a/client/a8c-for-agencies/sections/overview/body/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import OverviewBodyHosting from './hosting';
 import OverviewBodyIntroCards from './intro-cards';
 import OverviewBodyNextSteps from './next-steps';
@@ -6,7 +7,7 @@ import OverviewBodyProducts from './products';
 const OverviewBody = () => {
 	return (
 		<div className="overview-body">
-			<OverviewBodyIntroCards />
+			{ ! isEnabled( 'a4a-unified-onboarding-tour' ) && <OverviewBodyIntroCards /> }
 			<OverviewBodyNextSteps />
 			<OverviewBodyHosting />
 			<OverviewBodyProducts />

--- a/client/a8c-for-agencies/sections/overview/sidebar/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/index.tsx
@@ -4,10 +4,12 @@ import OverviewSidebarContactSupport from './contact-support';
 import OverviewSidebarFeaturedWooPayments from './featured-woopayments';
 import OverviewSidebarGrowthAccelerator from './growth-accelerator';
 import OverviewSidebarQuickLinks from './quick-links';
+import OverviewSidebarRelaunchWelcomeTour from './relaunch-welcome-tour';
 
 const OverviewSidebar = () => {
 	return (
 		<div className="overview-sidebar">
+			{ isEnabled( 'a4a-unified-onboarding-tour' ) && <OverviewSidebarRelaunchWelcomeTour /> }
 			{ isEnabled( 'a8c-for-agencies-agency-tier' ) && <OverviewSidebarAgencyTier /> }
 			<OverviewSidebarQuickLinks />
 			<OverviewSidebarFeaturedWooPayments />

--- a/client/a8c-for-agencies/sections/overview/sidebar/relaunch-welcome-tour/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/relaunch-welcome-tour/index.tsx
@@ -1,0 +1,28 @@
+import { Button } from '@wordpress/components';
+import { layout } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+import './style.scss';
+
+export default function OverviewSidebarRelaunchWelcomeTour() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const handleRelaunchWelcomeTour = () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_overview_relaunch_welcome_tour_click' ) );
+		// TODO: Implement the relaunch welcome tour
+	};
+
+	return (
+		<Button
+			className="overview__relaunch-welcome-tour"
+			variant="secondary"
+			icon={ layout }
+			onClick={ handleRelaunchWelcomeTour }
+		>
+			{ translate( 'Relaunch welcome tour' ) }
+		</Button>
+	);
+}

--- a/client/a8c-for-agencies/sections/overview/sidebar/relaunch-welcome-tour/style.scss
+++ b/client/a8c-for-agencies/sections/overview/sidebar/relaunch-welcome-tour/style.scss
@@ -1,0 +1,10 @@
+.overview__relaunch-welcome-tour.components-button.is-secondary {
+	width: 100%;
+	font-weight: 500;
+	color: var(--color-accent);
+	margin-block-end: 16px;
+	box-shadow: 0 0 0 1px var(--color-border-subtle);
+    border: none;
+	padding: 16px;
+	height: auto;
+}

--- a/client/a8c-for-agencies/sections/overview/sidebar/relaunch-welcome-tour/style.scss
+++ b/client/a8c-for-agencies/sections/overview/sidebar/relaunch-welcome-tour/style.scss
@@ -4,7 +4,7 @@
 	color: var(--color-accent);
 	margin-block-end: 16px;
 	box-shadow: 0 0 0 1px var(--color-border-subtle);
-    border: none;
+	border: none;
 	padding: 16px;
 	height: auto;
 }

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -45,6 +45,7 @@
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": false,
+		"a4a-unified-onboarding-tour": true,
 		"a4a-client-checkout-v2": true,
 		"jetpack/crm-downloads": true
 	},

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -38,6 +38,7 @@
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": false,
+		"a4a-unified-onboarding-tour": false,
 		"a4a-client-checkout-v2": true,
 		"jetpack/crm-downloads": true
 	},

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -38,6 +38,7 @@
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": false,
+		"a4a-unified-onboarding-tour": false,
 		"a4a-client-checkout-v2": false,
 		"jetpack/crm-downloads": true
 	},

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -40,6 +40,7 @@
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": false,
+		"a4a-unified-onboarding-tour": false,
 		"a4a-client-checkout-v2": true,
 		"jetpack/crm-downloads": true
 	},


### PR DESCRIPTION
This PR introduces the feature flag for the unified onboarding flow in A4A.


Closes https://linear.app/a8c/issue/A4A-1051/janitorial-feature-flag

## Proposed Changes

* Add the `a4a-unified-onboarding-tour` feature flag and enable it in the development environment.

## Why are these changes being made?

* This is part of the Agency onboarding improvement part 2 project.

## Testing Instructions

* Use the A4A live link and navigate to `/overview?flags=a4a-unified-onboarding-tour`.
* Confirm you see the 'Relaunch welcome tour' button.
   <img width="552" alt="Screenshot 2025-06-03 at 1 57 39 AM" src="https://github.com/user-attachments/assets/acc493d9-6683-403c-841f-2485aed0401e" />
* Confirm that the Intro card is no longer visible.
   <img width="1028" alt="Screenshot 2025-06-03 at 12 14 50 AM" src="https://github.com/user-attachments/assets/b30e7eed-7065-4280-9d5b-c999f160ac67" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
