### PR TITLE
Purchases: Add filters for DataView

### DIFF
--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -23,7 +23,9 @@ import PurchasesNavigation from 'calypso/me/purchases/purchases-navigation';
 import { useTaxName } from 'calypso/my-sites/checkout/src/hooks/use-country-list';
 import { logStashLoadErrorEvent } from 'calypso/my-sites/checkout/src/lib/analytics';
 import CrmDownloads from 'calypso/my-sites/purchases/crm-downloads';
+import { useSelector } from 'calypso/state';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
+import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import CancelPurchase from './cancel-purchase';
 import ConfirmCancelDomain from './confirm-cancel-domain';
 import { Downgrade } from './downgrade';
@@ -197,6 +199,8 @@ export function vatDetails( context, next ) {
 export function managePurchase( context, next ) {
 	const ManagePurchasesWrapper = localize( () => {
 		const classes = 'manage-purchase';
+		const previousRoute = useSelector( getPreviousRoute );
+		const purchaseListUrl = previousRoute.includes( '/purchases' ) ? previousRoute : undefined;
 
 		return (
 			<PurchasesWrapper title={ titles.managePurchase }>
@@ -209,6 +213,7 @@ export function managePurchase( context, next ) {
 					<ManagePurchase
 						purchaseId={ parseInt( context.params.purchaseId, 10 ) }
 						siteSlug={ context.params.site }
+						purchaseListUrl={ purchaseListUrl }
 					/>
 				</Main>
 			</PurchasesWrapper>

--- a/client/me/purchases/purchases-list-in-dataviews/hooks/use-field-definitions.ts
+++ b/client/me/purchases/purchases-list-in-dataviews/hooks/use-field-definitions.ts
@@ -1,18 +1,17 @@
+import { SiteDetails } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useStoredPaymentMethods } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
-import { useSelector } from 'calypso/state';
 import {
 	getPurchasesFieldDefinitions,
 	getMembershipsFieldDefinitions,
 } from '../purchases-data-field';
 
-export function usePurchasesFieldDefinitions() {
+export function usePurchasesFieldDefinitions( { sites }: { sites: SiteDetails[] } ) {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 	const paymentMethods = useStoredPaymentMethods().paymentMethods;
-	const sites = useSelector( ( state ) => state.sites?.items );
 
 	return useMemo( () => {
 		const fieldDefinitions = getPurchasesFieldDefinitions( {

--- a/client/me/purchases/purchases-list-in-dataviews/hooks/use-field-definitions.ts
+++ b/client/me/purchases/purchases-list-in-dataviews/hooks/use-field-definitions.ts
@@ -8,7 +8,7 @@ import {
 	getMembershipsFieldDefinitions,
 } from '../purchases-data-field';
 
-export function usePurchasesFieldDefinitions( fieldIds?: string[] ) {
+export function usePurchasesFieldDefinitions() {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 	const paymentMethods = useStoredPaymentMethods().paymentMethods;
@@ -20,10 +20,9 @@ export function usePurchasesFieldDefinitions( fieldIds?: string[] ) {
 			moment,
 			paymentMethods,
 			sites,
-			fieldIds,
 		} );
 		return fieldDefinitions;
-	}, [ translate, moment, paymentMethods, fieldIds, sites ] );
+	}, [ translate, moment, paymentMethods, sites ] );
 }
 
 export function useMembershipsFieldDefinitions() {

--- a/client/me/purchases/purchases-list-in-dataviews/index.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/index.tsx
@@ -111,7 +111,7 @@ class PurchasesListDataView extends Component<
 		}
 
 		if ( purchases && purchases.length ) {
-			content = <PurchasesDataViews purchases={ purchases } />;
+			content = <PurchasesDataViews purchases={ purchases } sites={ sites } />;
 		}
 
 		if ( purchases && ! purchases.length && ! subscriptions.length ) {

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -75,10 +75,6 @@ export function getPurchasesFieldDefinitions( {
 		( paymentMethod ) => paymentMethod.is_backup === true
 	);
 
-	const getSiteValue = ( site: SiteDetails ): string => {
-		return `${ site.name } (${ site.domain })`;
-	};
-
 	const fields: Fields< Purchases.Purchase > = [
 		{
 			id: 'purchase-id',
@@ -99,17 +95,11 @@ export function getPurchasesFieldDefinitions( {
 			enableSorting: true,
 			enableHiding: false,
 			elements: sites.map( ( site ) => {
-				// This has to match the format of `getValue()` for filtering to work.
-				return { value: getSiteValue( site ), label: getSiteValue( site ) };
+				return { value: site.ID, label: `${ site.name } (${ site.domain })` };
 			} ),
 			filterBy: { operators: [ 'is' ], isPrimary: true },
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
-				const site = sites.find( ( site ) => site.ID === item.siteId );
-				// This format has to match the `elements` for filtering to work.
-				if ( site ) {
-					return getSiteValue( site );
-				}
-				return item.siteName;
+				return item.siteId;
 			},
 			// Render the site icon
 			render: ( { item }: { item: Purchases.Purchase } ) => {

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -94,7 +94,18 @@ export function getPurchasesFieldDefinitions( {
 			enableGlobalSearch: true,
 			enableSorting: true,
 			enableHiding: false,
+			elements: Object.values( sites ?? {} ).map( ( site ) => {
+				// This has to match the format of `getValue()` for filtering to work.
+				const key = `${ site.name } (${ site.URL })`;
+				return { value: key, label: key };
+			} ),
+			filterBy: { operators: [ 'is' ], isPrimary: true },
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
+				const site = sites?.[ item.siteId ];
+				// This format has to match the `elements` for filtering to work.
+				if ( site ) {
+					return `${ site.name } (${ site.URL })`;
+				}
 				return item.siteName;
 			},
 			// Render the site icon

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -68,12 +68,16 @@ export function getPurchasesFieldDefinitions( {
 	translate: LocalizeProps[ 'translate' ];
 	moment: ReturnType< typeof useLocalizedMoment >;
 	paymentMethods: Array< StoredPaymentMethod >;
-	sites?: Record< number | string, SiteDetails >;
+	sites: SiteDetails[];
 	fieldIds?: string[];
 } ): Fields< Purchases.Purchase > {
 	const backupPaymentMethods = paymentMethods.filter(
 		( paymentMethod ) => paymentMethod.is_backup === true
 	);
+
+	const getSiteValue = ( site: SiteDetails ): string => {
+		return `${ site.name } (${ site.domain })`;
+	};
 
 	const fields: Fields< Purchases.Purchase > = [
 		{
@@ -94,17 +98,16 @@ export function getPurchasesFieldDefinitions( {
 			enableGlobalSearch: true,
 			enableSorting: true,
 			enableHiding: false,
-			elements: Object.values( sites ?? {} ).map( ( site ) => {
+			elements: sites.map( ( site ) => {
 				// This has to match the format of `getValue()` for filtering to work.
-				const key = `${ site.name } (${ site.URL })`;
-				return { value: key, label: key };
+				return { value: getSiteValue( site ), label: getSiteValue( site ) };
 			} ),
 			filterBy: { operators: [ 'is' ], isPrimary: true },
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
-				const site = sites?.[ item.siteId ];
+				const site = sites.find( ( site ) => site.ID === item.siteId );
 				// This format has to match the `elements` for filtering to work.
 				if ( site ) {
-					return `${ site.name } (${ site.URL })`;
+					return getSiteValue( site );
 				}
 				return item.siteName;
 			},
@@ -123,7 +126,7 @@ export function getPurchasesFieldDefinitions( {
 			enableHiding: false,
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
 				// Render a bunch of things to make this easily searchable.
-				const site = sites?.[ item.siteId ];
+				const site = sites.find( ( site ) => site.ID === item.siteId );
 				return (
 					getDisplayName( item ) +
 					' ' +

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -152,6 +152,26 @@ export function getPurchasesFieldDefinitions( {
 			},
 		},
 		{
+			id: 'type',
+			label: translate( 'Type' ),
+			type: 'text',
+			elements: [
+				{ value: 'domain', label: translate( 'Domains' ) },
+				{ value: 'plan', label: translate( 'Plan' ) },
+				{ value: 'other', label: translate( 'Other' ) },
+			],
+			filterBy: { operators: [ 'is' ], isPrimary: true },
+			getValue: ( { item } ) => {
+				if ( item.isDomain || item.isDomainRegistration ) {
+					return 'domain';
+				}
+				if ( item.productType === 'bundle' ) {
+					return 'plan';
+				}
+				return 'other';
+			},
+		},
+		{
 			id: 'status',
 			label: translate( 'Status' ),
 			type: 'text',

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -23,7 +23,7 @@ function PurchaseItemRowProduct( props: {
 } ) {
 	const { purchase, translate } = props;
 	const site = useSelector( ( state ) => getSite( state, purchase.siteId ?? 0 ) );
-	const slug = purchase.siteName ?? purchase.siteId;
+	const slug = site?.domain ?? undefined;
 	return (
 		<PurchaseItemProduct
 			purchase={ purchase }

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -43,7 +43,7 @@ export function PurchasesDataViews( { purchases }: { purchases: Purchases.Purcha
 			return;
 		}
 	}, [ isDesktop, currentView, setView ] );
-	const purchasesDataFields = usePurchasesFieldDefinitions( purchasesDataView.fields );
+	const purchasesDataFields = usePurchasesFieldDefinitions();
 
 	const { data: adjustedPurchases, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( purchases, currentView, purchasesDataFields );

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -72,7 +72,7 @@ function usePreservePurchasesFiltersInUrl( {
 		} else {
 			url.searchParams.delete( urlTypeFilterKey );
 		}
-		window.history.replaceState( {}, '', url );
+		window.history.pushState( undefined, '', url );
 		// getPreviousRoute will not find this updated route unless we set it
 		// explicitly. It only records the route when the page first loads.
 		// This seems like a bug but it appears to be how it works.

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -106,7 +106,21 @@ export function PurchasesDataViews( {
 	// Keep track of the current view params in the URL and restore them when the page loads.
 	usePreservePurchasesFiltersInUrl( { currentView, setView } );
 
-	const purchasesDataFields = usePurchasesFieldDefinitions( { sites } );
+	const sitesWithPurchases = useMemo( () => {
+		return Array.from(
+			purchases.reduce( ( collected, purchase ) => {
+				const siteForPurchase = sites.find( ( site ) => site.ID === purchase.siteId );
+				if ( siteForPurchase ) {
+					collected.add( siteForPurchase );
+				}
+				return collected;
+			}, new Set< SiteDetails >() )
+		);
+	}, [ sites, purchases ] );
+
+	const purchasesDataFields = usePurchasesFieldDefinitions( {
+		sites: sitesWithPurchases,
+	} );
 	const { data: adjustedPurchases, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( purchases, currentView, purchasesDataFields );
 	}, [ purchases, currentView, purchasesDataFields ] );

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -37,8 +37,9 @@ function usePreservePurchasesFiltersInUrl( {
 } ) {
 	const urlSiteFilterKey = 'siteFilter';
 	const urlTypeFilterKey = 'typeFilter';
+	const currentUrl = window.location.href;
 	useEffect( () => {
-		const url = new URL( window.location.href );
+		const url = new URL( currentUrl );
 		const filters: Filter[] = [];
 		const siteFilterValue = url.searchParams.get( urlSiteFilterKey );
 		const typeFilterValue = url.searchParams.get( urlTypeFilterKey );
@@ -54,7 +55,7 @@ function usePreservePurchasesFiltersInUrl( {
 				filters,
 			} ) );
 		}
-	}, [ setView ] );
+	}, [ setView, currentUrl ] );
 	useEffect( () => {
 		const url = new URL( window.location.href );
 		const siteFilter = currentView.filters?.find( ( filter ) => filter.field === 'site' );

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -3,7 +3,7 @@ import { Gridicon, Card } from '@automattic/components';
 import { Purchases, SiteDetails } from '@automattic/data-stores';
 import { DESKTOP_BREAKPOINT } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
-import { DataViews, View, filterSortAndPaginate } from '@wordpress/dataviews';
+import { DataViews, View, Filter, filterSortAndPaginate } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
 import { MembershipSubscription } from 'calypso/lib/purchases/types';
@@ -28,6 +28,51 @@ export const purchasesDataView: View = {
 	layout: {},
 };
 
+function usePreservePurchasesFiltersInUrl( {
+	currentView,
+	setView,
+}: {
+	currentView: View;
+	setView: ( setter: ( currentView: View ) => View ) => void;
+} ) {
+	const urlSiteFilterKey = 'siteFilter';
+	const urlTypeFilterKey = 'typeFilter';
+	useEffect( () => {
+		const url = new URL( window.location.href );
+		const filters: Filter[] = [];
+		const siteFilterValue = url.searchParams.get( urlSiteFilterKey );
+		const typeFilterValue = url.searchParams.get( urlTypeFilterKey );
+		if ( siteFilterValue ) {
+			filters.push( { value: parseInt( siteFilterValue ), operator: 'is', field: 'site' } );
+		}
+		if ( typeFilterValue ) {
+			filters.push( { value: typeFilterValue, operator: 'is', field: 'type' } );
+		}
+		if ( filters.length > 0 ) {
+			setView( ( currentView ) => ( {
+				...currentView,
+				filters,
+			} ) );
+		}
+	}, [ setView ] );
+	useEffect( () => {
+		const url = new URL( window.location.href );
+		const siteFilter = currentView.filters?.find( ( filter ) => filter.field === 'site' );
+		if ( siteFilter ) {
+			url.searchParams.set( urlSiteFilterKey, siteFilter.value );
+		} else {
+			url.searchParams.delete( urlSiteFilterKey );
+		}
+		const typeFilter = currentView.filters?.find( ( filter ) => filter.field === 'type' );
+		if ( typeFilter ) {
+			url.searchParams.set( urlTypeFilterKey, typeFilter.value );
+		} else {
+			url.searchParams.delete( urlTypeFilterKey );
+		}
+		window.history.replaceState( {}, '', url );
+	}, [ currentView ] );
+}
+
 export function PurchasesDataViews( {
 	purchases,
 	sites,
@@ -38,6 +83,7 @@ export function PurchasesDataViews( {
 	const isDesktop = useBreakpoint( DESKTOP_BREAKPOINT );
 	const translate = useTranslate();
 	const [ currentView, setView ] = useState( purchasesDataView );
+
 	// Hide fields at mobile width
 	useEffect( () => {
 		if ( isDesktop && currentView.fields === purchasesMobileFields ) {
@@ -49,8 +95,11 @@ export function PurchasesDataViews( {
 			return;
 		}
 	}, [ isDesktop, currentView, setView ] );
-	const purchasesDataFields = usePurchasesFieldDefinitions( { sites } );
 
+	// Keep track of the current view params in the URL and restore them when the page loads.
+	usePreservePurchasesFiltersInUrl( { currentView, setView } );
+
+	const purchasesDataFields = usePurchasesFieldDefinitions( { sites } );
 	const { data: adjustedPurchases, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( purchases, currentView, purchasesDataFields );
 	}, [ purchases, currentView, purchasesDataFields ] );

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -1,6 +1,6 @@
 import page from '@automattic/calypso-router';
 import { Gridicon, Card } from '@automattic/components';
-import { Purchases } from '@automattic/data-stores';
+import { Purchases, SiteDetails } from '@automattic/data-stores';
 import { DESKTOP_BREAKPOINT } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { DataViews, View, filterSortAndPaginate } from '@wordpress/dataviews';
@@ -28,7 +28,13 @@ export const purchasesDataView: View = {
 	layout: {},
 };
 
-export function PurchasesDataViews( { purchases }: { purchases: Purchases.Purchase[] } ) {
+export function PurchasesDataViews( {
+	purchases,
+	sites,
+}: {
+	purchases: Purchases.Purchase[];
+	sites: SiteDetails[];
+} ) {
 	const isDesktop = useBreakpoint( DESKTOP_BREAKPOINT );
 	const translate = useTranslate();
 	const [ currentView, setView ] = useState( purchasesDataView );
@@ -43,7 +49,7 @@ export function PurchasesDataViews( { purchases }: { purchases: Purchases.Purcha
 			return;
 		}
 	}, [ isDesktop, currentView, setView ] );
-	const purchasesDataFields = usePurchasesFieldDefinitions();
+	const purchasesDataFields = usePurchasesFieldDefinitions( { sites } );
 
 	const { data: adjustedPurchases, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( purchases, currentView, purchasesDataFields );

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -7,6 +7,8 @@ import { DataViews, View, Filter, filterSortAndPaginate } from '@wordpress/datav
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
 import { MembershipSubscription } from 'calypso/lib/purchases/types';
+import { reduxDispatch } from 'calypso/lib/redux-bridge';
+import { setRoute } from 'calypso/state/route/actions';
 import {
 	usePurchasesFieldDefinitions,
 	useMembershipsFieldDefinitions,
@@ -71,6 +73,10 @@ function usePreservePurchasesFiltersInUrl( {
 			url.searchParams.delete( urlTypeFilterKey );
 		}
 		window.history.replaceState( {}, '', url );
+		// getPreviousRoute will not find this updated route unless we set it
+		// explicitly. It only records the route when the page first loads.
+		// This seems like a bug but it appears to be how it works.
+		reduxDispatch( setRoute( window.location.pathname, Object.fromEntries( url.searchParams ) ) );
 	}, [ currentView ] );
 }
 


### PR DESCRIPTION
## Proposed Changes

This PR adds filtering to the DataViews version of the purchases list.

Part of https://linear.app/a8c/project/replace-calypsos-active-upgrades-subscriptions-with-dataviews-a7b39dea5417/overview / https://github.com/Automattic/wp-calypso/issues/86616

Tracked by https://linear.app/a8c/issue/CHE-153/implement-filter-on-dataviews-subscription-list

This will allow filtering purchases by site and by type (currently Domain, Plan, or Other but we can add other fields later).

> [!NOTE]
> This saves the current filter in the URL query string and also alters the manage purchase "back" button behavior so that it will return to the page with the same filters applied.

Site list             |  Site filter
:-------------------------:|:-------------------------:
<img width="1055" alt="Screenshot 2025-06-02 at 4 59 09 PM" src="https://github.com/user-attachments/assets/89cf436b-a73e-45d0-9cec-4ae3a25fccfb" /> |  <img width="1059" alt="Screenshot 2025-06-02 at 4 59 20 PM" src="https://github.com/user-attachments/assets/1acde8c1-2886-4981-bfcc-0fcdcac83347" />

Type list |  Type filter
:-------------------------:|:-------------------------:
<img width="1060" alt="Screenshot 2025-06-02 at 4 59 30 PM" src="https://github.com/user-attachments/assets/2c8f23c0-af0b-4716-9a6b-506a12f23298" /> | <img width="1063" alt="Screenshot 2025-06-02 at 4 59 41 PM" src="https://github.com/user-attachments/assets/ed1b3473-82de-4469-ba35-9c1dd50e998e" />


## Testing Instructions

**NOTE** You have to currently test using localhost calypso because calypso.live will not have the feature enabled yet.

- Use an account with a number of purchases.
- Visit `/me/purchases`.
- Click the "Site" filter and try filtering by site. Verify that it works as you'd expect.
- Click the "Type" filter and try filtering by type. Verify that it works as you'd expect.
- With at least one filter enabled, try clicking to view a purchase, then click the ← "back" button and verify that the filters remain applied when you return.
- With at least one filter enabled, try clicking to view a purchase, then click the back button _on the browser_ and verify that the filters remain applied when you return.
- With at least one filter enabled, try reloading the page and verify that the filters remain applied.