### PR TITLE
E2E: Update clickOnPurchase to work for DataViews also

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/me/purchases-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/purchases-page.ts
@@ -34,10 +34,24 @@ export class PurchasesPage {
 	 * @param {string} siteSlug Site slug.
 	 */
 	async clickOnPurchase( name: string, siteSlug: string ) {
+		const purchasesListDataView = this.page.locator( '#purchases-list .dataviews-wrapper' );
+		const purchasesListCardView = this.page.locator( '.card.purchase-item' );
+		await purchasesListDataView.or( purchasesListCardView ).first().waitFor( { state: 'visible' } );
+
+		if ( await purchasesListCardView.isVisible() ) {
+			await this.page
+				.locator( '.card.purchase-item' )
+				.filter( { hasText: name } )
+				.filter( { hasText: siteSlug } )
+				.click();
+			return;
+		}
+
 		await this.page
-			.locator( '.card.purchase-item' )
+			.locator( '#purchases-list .dataviews-view-table__row' )
 			.filter( { hasText: name } )
 			.filter( { hasText: siteSlug } )
+			.locator( '.dataviews-view-table__actions-column button' )
 			.click();
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/me/purchases-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/purchases-page.ts
@@ -36,22 +36,22 @@ export class PurchasesPage {
 	async clickOnPurchase( name: string, siteSlug: string ) {
 		const purchasesListDataView = this.page.locator( '#purchases-list .dataviews-wrapper' );
 		const purchasesListCardView = this.page.locator( '.card.purchase-item' );
-		await purchasesListDataView.or( purchasesListCardView ).first().waitFor( { state: 'visible' } );
+		await purchasesListCardView.or( purchasesListDataView ).first().waitFor( { state: 'visible' } );
 
-		if ( await purchasesListCardView.isVisible() ) {
+		if ( await purchasesListDataView.isVisible() ) {
 			await this.page
-				.locator( '.card.purchase-item' )
+				.locator( '#purchases-list .dataviews-view-table__row' )
 				.filter( { hasText: name } )
 				.filter( { hasText: siteSlug } )
+				.locator( '.dataviews-view-table__actions-column button' )
 				.click();
 			return;
 		}
 
 		await this.page
-			.locator( '#purchases-list .dataviews-view-table__row' )
+			.locator( '.card.purchase-item' )
 			.filter( { hasText: name } )
 			.filter( { hasText: siteSlug } )
-			.locator( '.dataviews-view-table__actions-column button' )
 			.click();
 	}
 


### PR DESCRIPTION
## Proposed Changes

This PR updates the purchases list component of the e2e tests to work with the DataViews version of the purchases list as well as the card version still used in production.

Part of https://linear.app/a8c/project/replace-calypsos-active-upgrades-subscriptions-with-dataviews-a7b39dea5417/overview / https://github.com/Automattic/wp-calypso/issues/86616

## Why are these changes being made?

As we migrate the purchases list to use DataViews, we must make sure that the e2e tests continue to work.

Tracked by https://linear.app/a8c/issue/CHE-155/fix-e2e-tests-to-use-dataviews-subscription-list

## Testing Instructions

First, apply the following diff to disable the parts of the e2e test that rely on the goals page, since the goals page has been recently disabled and the e2e tests have not yet been updated to handle it:

<details>

```diff
diff --git a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
index 77917dfef5d..13d039b4379 100644
--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -132,82 +132,6 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function
 		} );
 	} );
 
-	describe( 'Onboarding', function () {
-		let startSiteFlow: StartSiteFlow;
-
-		beforeAll( async function () {
-			startSiteFlow = new StartSiteFlow( page );
-		} );
-
-		it( 'Land on goal selection step', async function () {
-			page.waitForURL( /setup\/site-setup\/goals\?/, { timeout: 30 * 1000 } );
-		} );
-
-		it( 'Select "Sell services or digital goods" goal', async function () {
-			await startSiteFlow.selectGoal( 'Sell services or digital goods' );
-			await startSiteFlow.clickButton( 'Next' );
-		} );
-	} );
-
-	describe( 'Sell', function () {
-		const themeName = 'Attar';
-		let startSiteFlow: StartSiteFlow;
-
-		beforeAll( async function () {
-			startSiteFlow = new StartSiteFlow( page );
-		} );
-
-		it( 'Select theme', async function () {
-			await startSiteFlow.selectTheme( themeName );
-			await startSiteFlow.clickButton( 'Continue' );
-		} );
-
-		it( 'Focused Launchpad is shown', async function () {
-			const title = await page.getByText( "Let's get started!" );
-			await title.waitFor( { timeout: 30 * 1000 } );
-		} );
-
-		it( 'Site slug exists', async function () {
-			expect( newSiteDetails.blog_details.site_slug ).toBeDefined();
-		} );
-	} );
-
-	describe( 'Check if site is launched', function () {
-		it( 'Verify site is not yet launched', async function () {
-			const tmpPage = await browser.newPage();
-			await tmpPage.goto( newSiteDetails.blog_details.url as string );
-
-			// View site.
-			const comingSoonPage = new ComingSoonPage( tmpPage );
-			await comingSoonPage.validateComingSoonState();
-
-			// Dispose the test page and context.
-			await tmpPage.close();
-		} );
-	} );
-
-	describe( 'Launch site without Focused Launchpad', function () {
-		it( 'Start site launch', async function () {
-			const siteSettingsPage = new SiteSettingsPage( page );
-			await siteSettingsPage.visit( newSiteDetails.blog_details.site_slug );
-			await siteSettingsPage.launchSite();
-		} );
-
-		it( 'Skip domain purchase', async function () {
-			const domainSearchComponent = new DomainSearchComponent( page );
-			await domainSearchComponent.search( newSiteDetails.blog_details.site_slug );
-			await domainSearchComponent.clickButton( 'Skip Purchase' );
-		} );
-
-		it( 'Navigated to Home dashboard', async function () {
-			await page.waitForURL( /home/ );
-			const myHomePage = new MyHomePage( page );
-			await new Promise( ( r ) => setTimeout( r, 2000 ) );
-			await page.reload();
-			return await myHomePage.validateTaskHeadingMessage( 'You launched your site!' );
-		} );
-	} );
-
 	describe( 'Cancel and remove plan', function () {
 		let noticeComponent: NoticeComponent;
 		let purchasesPage: PurchasesPage;
```

</details>

Next, prepare the e2e tests [following these instructions](https://github.com/Automattic/wp-calypso/blob/e7e11899710f88a4ab1f059ca520b7e562bc037f/test/e2e/README.md) but don't actually run any yet. (NOTE: you will need access to the secret store.)

Third, start localhost calypso: `yarn && yarn start`

Fourth, make your environment use calypso.localhost: `export CALYPSO_BASE_URL=http://calypso.localhost:3000`

Finally, run the following test and verify it passes: `yarn workspace wp-e2e-tests test test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts`

