### PR TITLE
Notifications: Improve padding on tabs

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -1,3 +1,4 @@
+$notification-panel-width: 450px;
 $no-sidebar-min-page-width: 800px;
 $with-sidebar-min-page-width: 1114px;
 
@@ -17,11 +18,11 @@ $with-sidebar-min-page-width: 1114px;
 
 	.wpnc__note-list {
 		left: auto;
-		width: 400px;
+		width: $notification-panel-width; // For reader/notifications screen.
 	}
 
 	.wpnc__single-view {
-		right: 400px;
+		right: $notification-panel-width;
 		left: 10px;
 		top: 0;
 		bottom: 0;
@@ -257,8 +258,9 @@ $with-sidebar-min-page-width: 1114px;
 		}
 
 		.components-toggle-group-control-option-base {
-			z-index: initial;
 			padding: 0 6px;
+			white-space: nowrap;
+			z-index: initial;
 		}
 	}
 

--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -258,6 +258,7 @@ $with-sidebar-min-page-width: 1114px;
 
 		.components-toggle-group-control-option-base {
 			z-index: initial;
+			padding: 0 6px;
 		}
 	}
 

--- a/client/notifications/style.scss
+++ b/client/notifications/style.scss
@@ -3,12 +3,14 @@
  */
 @import "@wordpress/base-styles/breakpoints";
 
+$notification-panel-width: 450px;
+
 #wpnc-panel {
 	position: fixed;
 	top: var(--masterbar-height);
 	right: 0;
 	bottom: 0;
-	min-width: 400px;
+	min-width: $notification-panel-width;
 
 	@media only screen and (max-width: 600px) {
 		width: 100%;
@@ -173,7 +175,6 @@ div.reader-notifications__panel {
 	// using the $break-wide which is the closest larger breakpoint).
 	$breakpoint-flyout: 1114px;
 
-	--default-notes-panel-width: 400px;
 	--3pc-notice-external-height: 50px;
 	@media only screen and (min-width: $breakpoint-flyout) {
 		--3pc-notice-external-height: 0px; /* stylelint-disable-line length-zero-no-unit */
@@ -200,11 +201,11 @@ div.reader-notifications__panel {
 				width: calc(100vw - var(--sidebar-width-max) - 16px); // 16px for content frame padding.
 
 				.wpnc__single-view {
-					width: var(--default-notes-panel-width);
+					width: $notification-panel-width;
 					z-index: z-index( ".reader-notifications", ".wpnc__single-view" ); // This ensures the single view flies out above the 3PC notice.
 				}
 				.wpnc__note-list {
-					width: var(--default-notes-panel-width);
+					width: $notification-panel-width;
 					z-index: z-index( ".reader-notifications", ".wpnc__note-list" ); // This ensures the single view does not rise above the note list while animating outwards.
 				}
 			}
@@ -224,7 +225,7 @@ div.reader-notifications__panel {
 			display: none;
 			bottom: 0;
 			padding: 0 30px;
-			right: var(--default-notes-panel-width);
+			right: $notification-panel-width;
 
 			@media only screen and (min-width: $breakpoint-flyout) {
 				display: flex;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Issue: [CML-492](https://linear.app/a8c/issue/CML-492/text-in-notification-tabs-overflow-in-non-en-locales)

## Proposed Changes

* Decrease the padding to accomodate different locales.

| Before | After |
| -------|------| 
| ![image](https://github.com/user-attachments/assets/f863fb1f-4b61-4006-9612-c0adee6d437d) | ![image](https://github.com/user-attachments/assets/723474d1-c0a9-471e-8084-baf0b63db78a) |
| ![image](https://github.com/user-attachments/assets/6775b457-f637-4424-b4fe-98bfcc46631a) | ![image](https://github.com/user-attachments/assets/288429a9-cbb0-4ecd-a4b0-63f0a77955e2) | 
| ![image](https://github.com/user-attachments/assets/787df943-dc6f-48d5-a9fc-2124482cb8ab)| ![image](https://github.com/user-attachments/assets/fb131bf0-251d-4c56-bace-dc26407def31) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Text of tabs were not appearing good in multiple locales.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/reader`.
- Open notifications panel.
- Verify tabs on different locales.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
