### PR TITLE
Purchases: Enable purchases-list-in-dataviews in development/horizon

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -145,7 +145,7 @@
 		"press-this": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
-		"purchases/purchase-list-dataview": false,
+		"purchases/purchase-list-dataview": true,
 		"push-notifications": true,
 		"reader": true,
 		"reader/comment-polling": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -91,7 +91,7 @@
 		"press-this": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
-		"purchases/purchase-list-dataview": false,
+		"purchases/purchase-list-dataview": true,
 		"reader": true,
 		"reader/quick-post": true,
 		"reader/recommended-blogs-list": false,


### PR DESCRIPTION
## Proposed Changes

This PR enables the `purchases/purchase-list-dataview` config flag in development and horizon so that that new DataViews version of the purchases list can be tested more easily as we near its completion.

Part of https://linear.app/a8c/project/replace-calypsos-active-upgrades-subscriptions-with-dataviews-a7b39dea5417/overview / https://github.com/Automattic/wp-calypso/issues/86616

## Testing Instructions

None should be required.