### PR TITLE
Revert "Purchases: Enable purchases-list-in-dataviews in development/horizon"

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -145,7 +145,7 @@
 		"press-this": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
-		"purchases/purchase-list-dataview": true,
+		"purchases/purchase-list-dataview": false,
 		"push-notifications": true,
 		"reader": true,
 		"reader/comment-polling": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -91,7 +91,7 @@
 		"press-this": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
-		"purchases/purchase-list-dataview": true,
+		"purchases/purchase-list-dataview": false,
 		"reader": true,
 		"reader/quick-post": true,
 		"reader/recommended-blogs-list": false,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#103900