### PR TITLE
A4A: Show all term variants in a4a checkout

### DIFF
--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -404,8 +404,9 @@ function LineItemWrapper( {
 		}
 		const isAkismet = isAkismetProduct( { product_slug: variant.productSlug } );
 		const isMarketplace = product.extra?.is_marketplace_product;
+		const isA4A = product.extra?.isA4ASitelessCheckout;
 
-		if ( isJetpack || isAkismet || isMarketplace ) {
+		if ( isJetpack || isAkismet || isMarketplace || isA4A ) {
 			return true;
 		}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Linear issue: https://linear.app/a8c/issue/A4A-753/enable-monthly-and-yearly-options-in-checkout

## Proposed Changes

* Show all term variants (monthly, yearly, etc.) in A4A checkout

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create and send a referral for any product (except Jetpack backup addons as they're monthly only).
* As the client, visit the purchase link sent in the email.
* In the URL change `client/checkout` to `client/checkout/v2`.
* On the checkout page you should see options for both monthly and yearly and should be able to choose either one.
<img width="1101" alt="Screenshot 2025-06-11 at 4 49 09 PM" src="https://github.com/user-attachments/assets/55b8d477-ccd2-4087-8a01-91076f99c1bd" />

* Choosing a different option should cause the price to get updated on the page.
* No need to make the purchase. But if you're up for testing that you can see this backend PR: 184433-ghe-Automattic/wpcom

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?