### PR TITLE
Big Sky: Always capture source param if exists

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
+++ b/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
@@ -106,6 +106,9 @@ const aiSiteBuilder: FlowV2< typeof initialize > = {
 							const prompt = queryParams.get( 'prompt' );
 							let promptParam = '';
 
+							const source = queryParams.get( 'source' );
+							let sourceParam = '';
+
 							addBlogSticker( siteId, 'big-sky-free-trial' );
 
 							const pendingActions = [
@@ -146,13 +149,13 @@ const aiSiteBuilder: FlowV2< typeof initialize > = {
 									window.sessionStorage.getItem( 'stored_ai_prompt' ) || ''
 								) }`;
 								window.sessionStorage.removeItem( 'stored_ai_prompt' );
-							} else if ( queryParams.get( 'source' ) ) {
-								promptParam = `&source=${ encodeURIComponent(
-									queryParams.get( 'source' )?.toString() || ''
-								) }`;
+							}
+
+							if ( source ) {
+								sourceParam = `&source=${ encodeURIComponent( source ) }`;
 							}
 							window.location.replace(
-								`${ siteURL }/wp-admin/site-editor.php?canvas=edit&referrer=${ AI_SITE_BUILDER_FLOW }${ promptParam }`
+								`${ siteURL }/wp-admin/site-editor.php?canvas=edit&referrer=${ AI_SITE_BUILDER_FLOW }${ promptParam }${ sourceParam }`
 							);
 						} else if ( providedDependencies.isLaunched ) {
 							const site = await resolveSelect( SITE_STORE ).getSite(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
@@ -114,7 +114,7 @@ const LaunchBigSky: Step = function ( props ) {
 				}
 
 				window.location.replace(
-					`${ siteURL }/wp-admin/site-editor.php?canvas=edit&referrer=${ flow }${ promptParam }`
+					`${ siteURL }/wp-admin/site-editor.php?canvas=edit&referrer=${ flow }${ promptParam }&source=${ flow }`
 				);
 			} catch ( error ) {
 				// eslint-disable-next-line no-console


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

Fixes https://linear.app/a8c/issue/BSKY-584/pass-source-param-from-landing-page
Fixes https://linear.app/a8c/issue/BSKY-585/pass-source-param-from-regular-onboarding-flow

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To better capture sources of Big Sky onboarding. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test the Free Trial flow: 
- http://calypso.localhost:3000/setup/ai-site-builder/processing?prompt=hello&source=landing-page
- Make sure the param persists all the way to blue screen

Test the regular onboarding flow: 
- Go through the http://calypso.localhost:3000/setup/ onboarding flow. 
- Observe the `source` param persists until the blue screen. 
- _Note: You can also test on an existing site, without going through signing up a new one: http://calypso.localhost:3000/setup/site-setup/design-choices?siteSlug=SOME_BIG_SKY_SITE_

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
