### PR TITLE
Experiment streamlining the plans grid + checkout: Fix subtotal price alignment

### DIFF
--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -1074,10 +1074,10 @@ const CheckoutSummarySubtotal = styled( CheckoutSummaryLineItem )`
 		display: flex;
 		flex: 0 0 auto;
 		gap: 4px;
-		margin-left: 12px;
+		margin-left: auto;
 
 		.rtl & {
-			margin-right: 12px;
+			margin-right: auto;
 			margin-left: 0;
 		}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Adjust the CSS for the subtotal price so that it'd align correctly in case it overflows on the next line.

**Before:**
<img width="420" alt="Screenshot 2025-06-03 at 00 49 21" src="https://github.com/user-attachments/assets/7ebcc3cb-3a45-40e3-ba07-93bdea01bcca" />
**After:**
<img width="420" alt="Screenshot 2025-06-03 at 00 46 19" src="https://github.com/user-attachments/assets/7aa36585-b73a-4761-907f-aacdcee746c7" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* When the the translated `Subtotal` label and the dicounted+actual subtotal price are too wide, the prices get wrapped to the next line and placed below the `Subtotal` label instead of being aligned with the rest of the prices.

## Testing Instructions

* Set your language in Calypso to German and your account currency to IDR.
* To test this feature, you'll need to be assigned to any checkout treatment variation of the calypso_streamlined_plans_checkout experiment.
* Go through the onboarding flow to get assigned and add some expensive products to your cart, like a premium domain.
* Confirm that the prices align correctly.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
