### PR TITLE
Dashboard v2: disable edge cache if site is not public

### DIFF
--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -6,7 +6,6 @@ import {
 	createLazyRoute,
 } from '@tanstack/react-router';
 import { fetchTwoStep } from '../data';
-import { canUpdateCaching } from '../sites/settings-caching';
 import {
 	canUpdatePHPVersion,
 	canUpdateDefensiveMode,
@@ -14,6 +13,7 @@ import {
 	canUpdateWordPressVersion,
 	canGetPrimaryDataCenter,
 	canSetStaticFile404Handling,
+	canUpdateCaching,
 } from '../utils/site-features';
 import NotFound from './404';
 import UnknownError from './500';

--- a/client/dashboard/sites/settings-caching/index.tsx
+++ b/client/dashboard/sites/settings-caching/index.tsx
@@ -6,8 +6,8 @@ import {
 	CardBody,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
+	__experimentalText as Text,
 	Button,
-	CheckboxControl,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
@@ -34,6 +34,19 @@ import type { Field } from '@automattic/dataviews';
 
 type CachingFormData = {
 	active: boolean;
+};
+
+const fields: Field< CachingFormData >[] = [
+	{
+		id: 'active',
+		label: __( 'Enable global edge caching for faster content delivery' ),
+		Edit: 'checkbox',
+	},
+];
+
+const form = {
+	type: 'regular' as const,
+	fields: [ 'active' ],
 };
 
 export default function CachingSettings( { siteSlug }: { siteSlug: string } ) {
@@ -116,129 +129,113 @@ export default function CachingSettings( { siteSlug }: { siteSlug: string } ) {
 	};
 
 	const renderForm = () => {
-		const fields: Field< CachingFormData >[] = [
-			{
-				id: 'active',
-				label: __( 'Enable global edge caching for faster content delivery' ),
-				Edit: ( { field, onChange, data, hideLabelFromVision } ) => (
-					<CheckboxControl
-						__nextHasNoMarginBottom
-						label={ hideLabelFromVision ? '' : field.label }
-						checked={ field.getValue( { item: data } ) }
-						disabled={ ! isEdgeCacheAvailable }
-						onChange={ () => {
-							onChange( { [ field.id ]: ! field.getValue( { item: data } ) } );
-						} }
-					/>
-				),
-			},
-		];
-		const form = {
-			type: 'regular' as const,
-			fields: [ 'active' ],
-		};
+		if ( ! isEdgeCacheAvailable ) {
+			return (
+				<Notice>
+					<VStack>
+						<Text as="p">
+							{ __(
+								'Faster content delivery with global edge caching is available for public sites.'
+							) }
+						</Text>
+						<Text as="p">
+							{ createInterpolateElement( __( '<a>Review site visibility settings</a>.' ), {
+								a: <Link to={ `/sites/${ siteSlug }/settings/site-visibility` } />,
+							} ) }
+						</Text>
+					</VStack>
+				</Notice>
+			);
+		}
 
 		return (
-			<>
-				<Card>
-					<CardBody>
-						<form onSubmit={ handleUpdateEdgeCacheStatus }>
-							<VStack spacing={ 4 } style={ { padding: '8px 0' } }>
-								<DataForm< CachingFormData >
-									data={ formData }
-									fields={ fields }
-									form={ form }
-									onChange={ ( edits: Partial< CachingFormData > ) => {
-										setFormData( ( data ) => ( { ...data, ...edits } ) );
-									} }
-								/>
+			<Card>
+				<CardBody>
+					<form onSubmit={ handleUpdateEdgeCacheStatus }>
+						<VStack spacing={ 4 } style={ { padding: '8px 0' } }>
+							<DataForm< CachingFormData >
+								data={ formData }
+								fields={ fields }
+								form={ form }
+								onChange={ ( edits: Partial< CachingFormData > ) => {
+									setFormData( ( data ) => ( { ...data, ...edits } ) );
+								} }
+							/>
 
-								{ isEdgeCacheAvailable ? (
-									<HStack justify="flex-start">
-										<Button
-											variant="primary"
-											type="submit"
-											isBusy={ isPending }
-											disabled={ isPending || ! isDirty }
-										>
-											{ __( 'Save' ) }
-										</Button>
-									</HStack>
-								) : (
-									<Notice density="medium">
-										{ createInterpolateElement(
-											__(
-												'Global edge cache can only be enabled for public sites. <a>Review site visibility settings</a>.'
-											),
-											{
-												a: <Link to={ `/sites/${ siteSlug }/settings/site-visibility` } />,
-											}
-										) }
-									</Notice>
-								) }
-							</VStack>
-						</form>
-					</CardBody>
-				</Card>
+							<HStack justify="flex-start">
+								<Button
+									variant="primary"
+									type="submit"
+									isBusy={ isPending }
+									disabled={ isPending || ! isDirty }
+								>
+									{ __( 'Save' ) }
+								</Button>
+							</HStack>
+						</VStack>
+					</form>
+				</CardBody>
+			</Card>
+		);
+	};
 
-				<VStack spacing={ 4 }>
-					<ActionList
-						title={ __( 'Clear caches' ) }
-						description={ __(
-							'Clearing the cache may temporarily make your site less responsive.'
-						) }
-					>
-						<ActionList.ActionItem
-							title={ __( 'Global edge cache' ) }
-							description={ __( 'Edge caching enables faster content delivery.' ) }
-							actions={
-								<Button
-									variant="secondary"
-									size="compact"
-									onClick={ handleClearEdgeCache }
-									isBusy={ edgeCacheClearMutation.isPending && ! isClearingAllCaches }
-									disabled={
-										! isEdgeCacheEnabled || edgeCacheClearMutation.isPending || isClearingAllCaches
-									}
-								>
-									{ __( 'Clear' ) }
-								</Button>
-							}
-						/>
-						<ActionList.ActionItem
-							title={ __( 'Object cache' ) }
-							description={ __( 'Data is cached using Memcached to reduce database lookups.' ) }
-							actions={
-								<Button
-									variant="secondary"
-									size="compact"
-									onClick={ handleClearObjectCache }
-									isBusy={ objectCacheClearMutation.isPending && ! isClearingAllCaches }
-									disabled={ objectCacheClearMutation.isPending || isClearingAllCaches }
-								>
-									{ __( 'Clear' ) }
-								</Button>
-							}
-						/>
-					</ActionList>
-					<ActionList>
-						<ActionList.ActionItem
-							title={ __( 'Clear all caches' ) }
-							actions={
-								<Button
-									variant="secondary"
-									size="compact"
-									onClick={ handleClearAllCaches }
-									isBusy={ isClearingAllCaches }
-									disabled={ isClearingAllCaches }
-								>
-									{ __( 'Clear all' ) }
-								</Button>
-							}
-						/>
-					</ActionList>
-				</VStack>
-			</>
+	const renderActions = () => {
+		return (
+			<VStack spacing={ 4 }>
+				<ActionList
+					title={ __( 'Clear caches' ) }
+					description={ __( 'Clearing the cache may temporarily make your site less responsive.' ) }
+				>
+					<ActionList.ActionItem
+						title={ __( 'Global edge cache' ) }
+						description={ __( 'Edge caching enables faster content delivery.' ) }
+						actions={
+							<Button
+								variant="secondary"
+								size="compact"
+								onClick={ handleClearEdgeCache }
+								isBusy={ edgeCacheClearMutation.isPending && ! isClearingAllCaches }
+								disabled={
+									! isEdgeCacheEnabled || edgeCacheClearMutation.isPending || isClearingAllCaches
+								}
+							>
+								{ __( 'Clear' ) }
+							</Button>
+						}
+					/>
+					<ActionList.ActionItem
+						title={ __( 'Object cache' ) }
+						description={ __( 'Data is cached using Memcached to reduce database lookups.' ) }
+						actions={
+							<Button
+								variant="secondary"
+								size="compact"
+								onClick={ handleClearObjectCache }
+								isBusy={ objectCacheClearMutation.isPending && ! isClearingAllCaches }
+								disabled={ objectCacheClearMutation.isPending || isClearingAllCaches }
+							>
+								{ __( 'Clear' ) }
+							</Button>
+						}
+					/>
+				</ActionList>
+				<ActionList>
+					<ActionList.ActionItem
+						title={ __( 'Clear all caches' ) }
+						actions={
+							<Button
+								variant="secondary"
+								size="compact"
+								onClick={ handleClearAllCaches }
+								isBusy={ isClearingAllCaches }
+								disabled={ isClearingAllCaches }
+							>
+								{ __( 'Clear all' ) }
+							</Button>
+						}
+					/>
+				</ActionList>
+			</VStack>
 		);
 	};
 
@@ -256,7 +253,14 @@ export default function CachingSettings( { siteSlug }: { siteSlug: string } ) {
 			size="small"
 			header={ <SettingsPageHeader title={ __( 'Caching' ) } description={ description } /> }
 		>
-			{ ! canUpdate ? renderCallout() : renderForm() }
+			{ canUpdate ? (
+				<>
+					{ renderForm() }
+					{ renderActions() }
+				</>
+			) : (
+				renderCallout()
+			) }
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/settings-caching/index.tsx
+++ b/client/dashboard/sites/settings-caching/index.tsx
@@ -1,11 +1,13 @@
 import { DataForm } from '@automattic/dataviews';
 import { useQuery, useMutation } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
 import {
 	Card,
 	CardBody,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	Button,
+	CheckboxControl,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
@@ -20,32 +22,19 @@ import {
 	siteObjectCacheClearMutation,
 } from '../../app/queries';
 import { ActionList } from '../../components/action-list';
+import Notice from '../../components/notice';
 import PageLayout from '../../components/page-layout';
+import {
+	canUpdateCaching,
+	isEdgeCacheAvailable as getIsEdgeCacheAvailable,
+} from '../../utils/site-features';
 import SettingsCallout from '../settings-callout';
 import SettingsPageHeader from '../settings-page-header';
-import type { Site } from '../../data/types';
 import type { Field } from '@automattic/dataviews';
 
 type CachingFormData = {
 	active: boolean;
 };
-
-const fields: Field< CachingFormData >[] = [
-	{
-		id: 'active',
-		label: __( 'Enable global edge caching for faster content delivery' ),
-		Edit: 'checkbox',
-	},
-];
-
-const form = {
-	type: 'regular' as const,
-	fields: [ 'active' ],
-};
-
-export function canUpdateCaching( site: Site ) {
-	return site.is_wpcom_atomic;
-}
 
 export default function CachingSettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useQuery( siteQuery( siteSlug ) );
@@ -61,11 +50,14 @@ export default function CachingSettings( { siteSlug }: { siteSlug: string } ) {
 
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
+	const isEdgeCacheAvailable = site && getIsEdgeCacheAvailable( site );
+	const isEdgeCacheEnabled = isEdgeCacheAvailable && isEdgeCacheActive;
+
 	const [ formData, setFormData ] = useState< CachingFormData >( {
-		active: isEdgeCacheActive ?? false,
+		active: isEdgeCacheEnabled ?? false,
 	} );
 
-	const isDirty = isEdgeCacheActive !== formData.active;
+	const isDirty = isEdgeCacheEnabled !== formData.active;
 	const { isPending } = edgeCacheStatusMutation;
 
 	const handleUpdateEdgeCacheStatus = ( e: React.FormEvent ) => {
@@ -111,7 +103,7 @@ export default function CachingSettings( { siteSlug }: { siteSlug: string } ) {
 	}, [ edgeCacheClearMutation.isPending, objectCacheClearMutation.isPending ] );
 
 	const handleClearAllCaches = () => {
-		if ( isEdgeCacheActive ) {
+		if ( isEdgeCacheEnabled ) {
 			handleClearEdgeCache();
 		}
 		handleClearObjectCache();
@@ -124,6 +116,28 @@ export default function CachingSettings( { siteSlug }: { siteSlug: string } ) {
 	};
 
 	const renderForm = () => {
+		const fields: Field< CachingFormData >[] = [
+			{
+				id: 'active',
+				label: __( 'Enable global edge caching for faster content delivery' ),
+				Edit: ( { field, onChange, data, hideLabelFromVision } ) => (
+					<CheckboxControl
+						__nextHasNoMarginBottom
+						label={ hideLabelFromVision ? '' : field.label }
+						checked={ field.getValue( { item: data } ) }
+						disabled={ ! isEdgeCacheAvailable }
+						onChange={ () => {
+							onChange( { [ field.id ]: ! field.getValue( { item: data } ) } );
+						} }
+					/>
+				),
+			},
+		];
+		const form = {
+			type: 'regular' as const,
+			fields: [ 'active' ],
+		};
+
 		return (
 			<>
 				<Card>
@@ -138,16 +152,30 @@ export default function CachingSettings( { siteSlug }: { siteSlug: string } ) {
 										setFormData( ( data ) => ( { ...data, ...edits } ) );
 									} }
 								/>
-								<HStack justify="flex-start">
-									<Button
-										variant="primary"
-										type="submit"
-										isBusy={ isPending }
-										disabled={ isPending || ! isDirty }
-									>
-										{ __( 'Save' ) }
-									</Button>
-								</HStack>
+
+								{ isEdgeCacheAvailable ? (
+									<HStack justify="flex-start">
+										<Button
+											variant="primary"
+											type="submit"
+											isBusy={ isPending }
+											disabled={ isPending || ! isDirty }
+										>
+											{ __( 'Save' ) }
+										</Button>
+									</HStack>
+								) : (
+									<Notice density="medium">
+										{ createInterpolateElement(
+											__(
+												'Global edge cache can only be enabled for public sites. <a>Review site visibility settings</a>.'
+											),
+											{
+												a: <Link to={ `/sites/${ siteSlug }/settings/site-visibility` } />,
+											}
+										) }
+									</Notice>
+								) }
 							</VStack>
 						</form>
 					</CardBody>
@@ -170,7 +198,7 @@ export default function CachingSettings( { siteSlug }: { siteSlug: string } ) {
 									onClick={ handleClearEdgeCache }
 									isBusy={ edgeCacheClearMutation.isPending && ! isClearingAllCaches }
 									disabled={
-										! isEdgeCacheActive || edgeCacheClearMutation.isPending || isClearingAllCaches
+										! isEdgeCacheEnabled || edgeCacheClearMutation.isPending || isClearingAllCaches
 									}
 								>
 									{ __( 'Clear' ) }

--- a/client/dashboard/sites/settings-caching/summary.tsx
+++ b/client/dashboard/sites/settings-caching/summary.tsx
@@ -4,7 +4,7 @@ import { __ } from '@wordpress/i18n';
 import { next } from '@wordpress/icons';
 import { siteEdgeCacheStatusQuery } from '../../app/queries';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
-import { canUpdateCaching } from '.';
+import { canUpdateCaching, isEdgeCacheAvailable } from '../../utils/site-features';
 import type { Site } from '../../data/types';
 import type { Density } from '@automattic/components/src/summary-button/types';
 
@@ -24,7 +24,7 @@ export default function CachingSettingsSummary( {
 
 	let badge;
 	if ( canUpdate ) {
-		if ( isEdgeCacheActive ) {
+		if ( isEdgeCacheAvailable( site ) && isEdgeCacheActive ) {
 			badge = {
 				text: __( 'Edge cache enabled' ),
 				intent: 'success' as const,

--- a/client/dashboard/utils/site-features.ts
+++ b/client/dashboard/utils/site-features.ts
@@ -23,3 +23,7 @@ export const canUpdateHundredYearPlanFeatures = ( site: Site ): boolean => {
 		plan.features.active.includes( feature )
 	);
 };
+
+export const canUpdateCaching = ( site: Site ) => site.is_wpcom_atomic;
+
+export const isEdgeCacheAvailable = ( site: Site ) => ! site.is_private && ! site.is_coming_soon;


### PR DESCRIPTION
Fixes DOTCOM-13423

## Proposed Changes

This PR disallows enabling global edge cache if the site is not public.

|Public|Non-public|
|-|-|
|<img width="617" alt="image" src="https://github.com/user-attachments/assets/ea4cc74d-6f4a-4eb7-8381-84896f869f1f" />|<img width="626" alt="image" src="https://github.com/user-attachments/assets/cdeee2c8-5884-46ca-88f4-7d485204a683" />|


## Testing Instructions

1. Test Atomic site on Dashboard v2
2. Try updating visibility (Settings -> Site visibility) and see that Settings -> Caching is updated as above screenshot.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
