### PR TITLE
STATS: Introduce stats/archive-breakdown feature flag.

### DIFF
--- a/client/my-sites/stats/stats-strings.js
+++ b/client/my-sites/stats/stats-strings.js
@@ -1,12 +1,17 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
 import { SUPPORT_URL, INSIGHTS_SUPPORT_URL, JETPACK_SUPPORT_URL_TRAFFIC } from './const';
 
 export default function () {
+	const isArchiveBreakdownFlag = isEnabled( 'stats/archive-breakdown' );
+
 	const statsStrings = {};
 
 	statsStrings.posts = {
-		title: translate( 'Posts & pages', { context: 'Stats: title of module', textOnly: true } ),
+		title: isArchiveBreakdownFlag
+			? translate( 'Most viewed', { context: 'Stats: title of module', textOnly: true } )
+			: translate( 'Posts & pages', { context: 'Stats: title of module', textOnly: true } ),
 		item: translate( 'Title', { context: 'Stats: module row header for post title.' } ),
 		value: translate( 'Views', { context: 'Stats: module row header for number of post views.' } ),
 		empty: translate(

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -217,7 +217,7 @@ class StatsSummary extends Component {
 				break;
 
 			case 'posts':
-				title = translate( 'Posts & pages' );
+				title = StatsStrings.posts.title;
 				path = 'posts';
 				statType = 'statsTopPosts';
 				summaryView = (

--- a/config/client.json
+++ b/config/client.json
@@ -20,6 +20,7 @@
 	"oauth_url",
 	"readerFollowingSource",
 	"siftscience_key",
+	"stats/archive-breakdown",
 	"stats/chart-library",
 	"stats/empty-module-traffic",
 	"stats/real-time-tab",

--- a/config/development.json
+++ b/config/development.json
@@ -170,6 +170,7 @@
 		"site-profiler/metrics": true,
 		"sites/drive-migrations": true,
 		"ssr/prefetch-timebox": false,
+		"stats/archive-breakdown": true,
 		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
 		"stats/locations": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -110,6 +110,7 @@
 		"site-profiler/metrics": true,
 		"sites/drive-migrations": true,
 		"ssr/prefetch-timebox": true,
+		"stats/archive-breakdown": false,
 		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
 		"stats/paid-wpcom-v2": true,

--- a/config/production.json
+++ b/config/production.json
@@ -142,6 +142,7 @@
 		"ssr/log-prefetch-errors": true,
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,
+		"stats/archive-breakdown": false,
 		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
 		"stats/locations": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -138,6 +138,7 @@
 		"site-profiler/metrics": false,
 		"sites/drive-migrations": true,
 		"ssr/prefetch-timebox": true,
+		"stats/archive-breakdown": false,
 		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
 		"stats/locations": true,

--- a/config/test.json
+++ b/config/test.json
@@ -104,6 +104,7 @@
 		"site-indicator": true,
 		"sites/drive-migrations": true,
 		"ssr/prefetch-timebox": true,
+		"stats/archive-breakdown": true,
 		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
 		"subscribers-helper-library": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -142,6 +142,7 @@
 		"site-profiler/metrics": true,
 		"sites/drive-migrations": true,
 		"ssr/prefetch-timebox": true,
+		"stats/archive-breakdown": true,
 		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
 		"stats/locations": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #STATS-94

## Proposed Changes

* STATS: Introduce stats/archive-breakdown feature flag.

I followed the flow mentioned in the [README](https://github.com/Automattic/wp-calypso/blob/trunk/config/README.md) and added the feature flag only to those files (plus, test.json). I kept staging and prod to be false.

```
For development of WordPress.com, that looks something like:

> development -> wpcalypso -> horizon -> stage -> production
```

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To add archive breakdown features without breaking production.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
