### PR TITLE
Experiment streamlining the plans grid + checkout: Update first year discount copy

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -397,7 +397,12 @@ const WPCheckoutCheckIcon = styled( CheckIcon )`
 
 function SingleProductAndCostOverridesList( { product }: { product: ResponseCartProduct } ) {
 	const translate = useTranslate();
-	const costOverridesList = filterCostOverridesForLineItem( product, translate );
+	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
+	const costOverridesList = filterCostOverridesForLineItem(
+		product,
+		translate,
+		isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment )
+	);
 	const label = getLabel( product );
 	const actualAmountDisplay = formatCurrency(
 		product.item_original_subtotal_integer,
@@ -407,7 +412,7 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 			stripZeros: true,
 		}
 	);
-	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
+
 	const monthlyPrices = useEquivalentMonthlyTotals( [ product ] );
 	if ( isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment ) ) {
 		let streamlinedActualAmountDisplay;

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1145,9 +1145,19 @@ function UpgradeCreditInformation( { product }: { product: ResponseCartProduct }
 	return null;
 }
 
-function IntroductoryOfferCallout( { product }: { product: ResponseCartProduct } ) {
+function IntroductoryOfferCallout( {
+	product,
+	isStreamlinedPrice,
+}: {
+	product: ResponseCartProduct;
+	isStreamlinedPrice?: boolean;
+} ) {
 	const translate = useTranslate();
-	const introductoryOffer = getItemIntroductoryOfferDisplay( translate, product );
+	const introductoryOffer = getItemIntroductoryOfferDisplay(
+		translate,
+		product,
+		isStreamlinedPrice
+	);
 
 	if ( ! introductoryOffer ) {
 		return null;
@@ -1422,7 +1432,10 @@ function CheckoutLineItem( {
 								compareToPrice={ compareToPrice }
 							/>
 							<DomainDiscountCallout product={ product } />
-							<IntroductoryOfferCallout product={ product } />
+							<IntroductoryOfferCallout
+								product={ product }
+								isStreamlinedPrice={ shouldShowComparison }
+							/>
 							<JetpackAkismetSaleCouponCallout product={ product } />
 						</LineItemMeta>
 					</>

--- a/packages/wpcom-checkout/src/introductory-offer.ts
+++ b/packages/wpcom-checkout/src/introductory-offer.ts
@@ -85,7 +85,7 @@ export function getIntroductoryOfferIntervalDisplay( {
 					i18n.getLocaleSlug()?.startsWith( 'en' ) ||
 					i18n.hasTranslation( 'Additional discount for first year' );
 				text =
-					isStreamlinedPrice && isAdditionalDiscountTranslated
+					! isPriceIncrease && isStreamlinedPrice && isAdditionalDiscountTranslated
 						? translate( 'Additional discount for first year' )
 						: text;
 			} else {

--- a/packages/wpcom-checkout/src/introductory-offer.ts
+++ b/packages/wpcom-checkout/src/introductory-offer.ts
@@ -81,7 +81,13 @@ export function getIntroductoryOfferIntervalDisplay( {
 				text = isPriceIncrease
 					? translate( 'Price for first year', { textOnly: true } )
 					: String( translate( 'Discount for first year' ) );
-				text = isStreamlinedPrice ? translate( 'Additional discount for first year' ) : text;
+				const isAdditionalDiscountTranslated =
+					i18n.getLocaleSlug()?.startsWith( 'en' ) ||
+					i18n.hasTranslation( 'Additional discount for first year' );
+				text =
+					isStreamlinedPrice && isAdditionalDiscountTranslated
+						? translate( 'Additional discount for first year' )
+						: text;
 			} else {
 				text = isPriceIncrease
 					? translate( 'Price for first %(numberOfYears)d years', {

--- a/packages/wpcom-checkout/src/introductory-offer.ts
+++ b/packages/wpcom-checkout/src/introductory-offer.ts
@@ -12,6 +12,7 @@ export function getIntroductoryOfferIntervalDisplay( {
 	isPriceIncrease,
 	context,
 	remainingRenewalsUsingOffer = 0,
+	isStreamlinedPrice,
 }: {
 	translate: typeof i18n.translate;
 	intervalUnit: string;
@@ -20,6 +21,7 @@ export function getIntroductoryOfferIntervalDisplay( {
 	isPriceIncrease: boolean;
 	context: string;
 	remainingRenewalsUsingOffer: number;
+	isStreamlinedPrice?: boolean;
 } ): string {
 	let text = isPriceIncrease
 		? translate( 'First billing period', { textOnly: true } )
@@ -79,6 +81,7 @@ export function getIntroductoryOfferIntervalDisplay( {
 				text = isPriceIncrease
 					? translate( 'Price for first year', { textOnly: true } )
 					: String( translate( 'Discount for first year' ) );
+				text = isStreamlinedPrice ? translate( 'Additional discount for first year' ) : text;
 			} else {
 				text = isPriceIncrease
 					? translate( 'Price for first %(numberOfYears)d years', {
@@ -202,7 +205,8 @@ export function getPremiumDomainIntroductoryOfferDisplay(
 
 export function getItemIntroductoryOfferDisplay(
 	translate: typeof i18n.translate,
-	product: ResponseCartProduct
+	product: ResponseCartProduct,
+	isStreamlinedPrice?: boolean
 ) {
 	// Introductory offer manual renewals often have prorated prices that are
 	// difficult to display as a simple discount so we keep their display
@@ -235,6 +239,7 @@ export function getItemIntroductoryOfferDisplay(
 		isPriceIncrease: doesIntroductoryOfferHavePriceIncrease( product ),
 		context: 'checkout',
 		remainingRenewalsUsingOffer: product.introductory_offer_terms.transition_after_renewal_count,
+		isStreamlinedPrice,
 	} );
 
 	return { enabled: true, text };

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -139,7 +139,8 @@ function getDiscountReasonForIntroductoryOffer(
 	terms: IntroductoryOfferTerms,
 	translate: ReturnType< typeof useTranslate >,
 	allowFreeText: boolean,
-	isPriceIncrease: boolean
+	isPriceIncrease: boolean,
+	isStreamlinedPrice?: boolean
 ): string {
 	return getIntroductoryOfferIntervalDisplay( {
 		translate,
@@ -149,6 +150,7 @@ function getDiscountReasonForIntroductoryOffer(
 		isPriceIncrease,
 		context: 'checkout',
 		remainingRenewalsUsingOffer: terms.transition_after_renewal_count,
+		isStreamlinedPrice,
 	} );
 }
 
@@ -216,7 +218,8 @@ function makeIntroductoryOfferCostOverrideUnique(
 	costOverride: ResponseCartCostOverride,
 	product: ResponseCartProduct,
 	translate: ReturnType< typeof useTranslate >,
-	allowFreeText: boolean
+	allowFreeText: boolean,
+	isStreamlinedPrice?: boolean
 ): ResponseCartCostOverride {
 	if ( 'introductory-offer' !== costOverride.override_code || ! product.introductory_offer_terms ) {
 		return costOverride;
@@ -242,7 +245,8 @@ function makeIntroductoryOfferCostOverrideUnique(
 			product.introductory_offer_terms,
 			translate,
 			allowFreeText,
-			isPriceIncrease
+			isPriceIncrease,
+			isStreamlinedPrice
 		),
 	};
 }
@@ -336,7 +340,8 @@ export function doesIntroductoryOfferHavePriceIncrease( product: ResponseCartPro
 
 export function filterCostOverridesForLineItem(
 	product: ResponseCartProduct,
-	translate: ReturnType< typeof useTranslate >
+	translate: ReturnType< typeof useTranslate >,
+	isStreamlinedPrice?: boolean
 ): LineItemCostOverrideForDisplay[] {
 	const costOverrides = product?.cost_overrides ?? [];
 
@@ -347,7 +352,13 @@ export function filterCostOverridesForLineItem(
 			.filter( ( costOverride ) => costOverride.override_code !== 'coupon-discount' )
 			.map( ( costOverride ) => makeSaleCostOverrideUnique( costOverride, product, translate ) )
 			.map( ( costOverride ) =>
-				makeIntroductoryOfferCostOverrideUnique( costOverride, product, translate, true )
+				makeIntroductoryOfferCostOverrideUnique(
+					costOverride,
+					product,
+					translate,
+					true,
+					isStreamlinedPrice
+				)
 			)
 			.map( ( costOverride ) => {
 				// Introductory offers which are renewals may have a prorated


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of pdtkmj-3DM-p2#comment-7029

## Proposed Changes

* This updates the `Discount for first year` copy to `Additional discount for first year` for the treatment variations of the streamlined pricing experiment.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This strings makes it clearer that there's an additional introductory offer discount on top of the term discount.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Use an account with a intro offer discount currency (such as MXN)
* To test this feature, you'll need to be assigned to any checkout treatment variation of the `calypso_streamlined_plans_checkout` experiment
* Go through the `onboarding` flow to get assigned
* Select the 1 year plan to get the intro offer discount
* The (green) intro offer discount text should be `Additional discount for first year`

|Before|After|
|------|-----|
|<img width="1267" alt="Screenshot 2025-06-03 at 08 52 00" src="https://github.com/user-attachments/assets/c0dee4c7-241b-4053-8ecc-e24bb5f7b751" />|<img width="1272" alt="Screenshot 2025-06-03 at 08 51 56" src="https://github.com/user-attachments/assets/e66b7a5f-b5d8-4abc-83ca-30e029dd7ea7" />|



* Switch to a `control` variation
* The checkout should be unchanged


<img width="1247" alt="Screenshot 2025-06-03 at 09 03 27" src="https://github.com/user-attachments/assets/a74d4e67-0f0b-45de-9baf-eee7986a0434" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?