### PR TITLE
Implement A4A development site launch flow

### DIFF
--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -400,8 +400,12 @@ export function p2HubP2sQuery( siteId: string, options: { limit?: number } = {} 
 	};
 }
 
-export function launchSiteMutation( siteId: string ) {
+export function launchSiteMutation( siteIdOrSlug: string ) {
 	return {
-		mutationFn: () => launchSite( siteId ),
+		mutationFn: () => launchSite( siteIdOrSlug ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'site', siteIdOrSlug ] } );
+			queryClient.invalidateQueries( { queryKey: [ 'site-settings', siteIdOrSlug ] } );
+		},
 	};
 }

--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -39,6 +39,7 @@ import {
 	fetchSiteResetContentSummary,
 	resetSite,
 	fetchSiteResetStatus,
+	launchSite,
 } from '../data';
 import { SITE_FIELDS, SITE_OPTIONS } from '../data/constants';
 import { queryClient } from './query-client';
@@ -396,5 +397,11 @@ export function p2HubP2sQuery( siteId: string, options: { limit?: number } = {} 
 		queryFn: () => {
 			return fetchP2HubP2s( siteId, options );
 		},
+	};
+}
+
+export function launchSiteMutation( siteId: string ) {
+	return {
+		mutationFn: () => launchSite( siteId ),
 	};
 }

--- a/client/dashboard/data/constants.ts
+++ b/client/dashboard/data/constants.ts
@@ -12,6 +12,7 @@ export const SITE_FIELDS = [
 	'subscribers_count',
 	'plan',
 	'capabilities',
+	'is_a4a_dev_site',
 	'is_a8c',
 	'is_deleted',
 	'is_coming_soon',

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -7,6 +7,7 @@ import type {
 	MonitorUptime,
 	Plan,
 	Site,
+	AgencyBlog,
 	Purchase,
 	User,
 	SiteUser,
@@ -486,7 +487,7 @@ export const resetPhpMyAdminPassword = async ( siteIdOrSlug: string ): Promise< 
 };
 
 // This endpoint only accepts site ID, not slug.
-export const fetchAgencyBlogBySiteId = async ( siteId: string ): Promise< void > => {
+export const fetchAgencyBlogBySiteId = async ( siteId: string ): Promise< AgencyBlog > => {
 	return wpcom.req.get( {
 		path: `/agency/blog/${ siteId }`,
 		apiNamespace: 'wpcom/v2',

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -639,3 +639,10 @@ export const fetchSiteResetStatus = async ( siteIdOrSlug: string ): Promise< Sit
 		apiNamespace: 'wpcom/v2',
 	} );
 };
+
+export const launchSite = async ( siteId: string ): Promise< void > => {
+	return wpcom.req.post( {
+		path: `/sites/${ siteId }/launch`,
+		apiNamespace: 'wpcom/v2',
+	} );
+};

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -116,7 +116,7 @@ export interface Site {
 export interface AgencyBlog {
 	name: string;
 	existing_wpcom_license_count: number;
-	referral_status: string;
+	referral_status: 'active' | 'pending' | 'canceled' | 'archived';
 	prices: {
 		actual_price: number;
 		currency: string;

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -116,6 +116,7 @@ export interface Site {
 export interface AgencyBlog {
 	name: string;
 	existing_wpcom_license_count: number;
+	referral_status: string;
 	prices: {
 		actual_price: number;
 		currency: string;

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -113,6 +113,15 @@ export interface Site {
 	jetpack_modules: string[] | null;
 }
 
+export interface AgencyBlog {
+	name: string;
+	existing_wpcom_license_count: number;
+	prices: {
+		actual_price: number;
+		currency: string;
+	};
+}
+
 export interface Purchase {
 	ID: number | string;
 	active: boolean;

--- a/client/dashboard/sites/settings-site-visibility/agency-development-site-launch-modal.tsx
+++ b/client/dashboard/sites/settings-site-visibility/agency-development-site-launch-modal.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import {
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
@@ -22,15 +22,9 @@ export default function AgencyDevelopmentSiteLaunchModal( {
 	site,
 	onClose,
 }: AgencyDevelopmentSiteLaunchModalProps ) {
-	const queryClient = useQueryClient();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const [ isLaunching, setIsLaunching ] = useState( false );
-	const mutation = useMutation( {
-		...launchSiteMutation( site.ID ),
-		onSuccess: () => {
-			queryClient.invalidateQueries( { queryKey: [ 'site', site.slug ] } );
-		},
-	} );
+	const mutation = useMutation( launchSiteMutation( site.slug ) );
 
 	const handleLaunch = () => {
 		setIsLaunching( true );
@@ -42,15 +36,13 @@ export default function AgencyDevelopmentSiteLaunchModal( {
 						type: 'snackbar',
 					}
 				);
-
-				setIsLaunching( false );
-				onClose();
 			},
 			onError: ( error: Error ) => {
 				createErrorNotice( error.message || __( 'Failed to launch site' ), {
 					type: 'snackbar',
 				} );
-
+			},
+			onSettled: () => {
 				setIsLaunching( false );
 				onClose();
 			},

--- a/client/dashboard/sites/settings-site-visibility/agency-development-site-launch-modal.tsx
+++ b/client/dashboard/sites/settings-site-visibility/agency-development-site-launch-modal.tsx
@@ -55,9 +55,10 @@ export default function AgencyDevelopmentSiteLaunchModal( {
 				<Text as="p">
 					{ __( "After launch, we'll bill your agency in the next billing cycle." ) }
 				</Text>
-				<Text as="p">{ __( 'Ready to launch?' ) }</Text>
 				<HStack justify="flex-end" spacing={ 2 }>
-					<Button onClick={ onClose }>{ __( 'Cancel' ) }</Button>
+					<Button disabled={ isLaunching } onClick={ onClose }>
+						{ __( 'Cancel' ) }
+					</Button>
 					<Button variant="primary" isBusy={ isLaunching } onClick={ handleLaunch }>
 						{ __( 'Launch site' ) }
 					</Button>

--- a/client/dashboard/sites/settings-site-visibility/agency-development-site-launch-modal.tsx
+++ b/client/dashboard/sites/settings-site-visibility/agency-development-site-launch-modal.tsx
@@ -1,0 +1,76 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	Button,
+	Modal,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useState } from 'react';
+import { launchSiteMutation } from '../../app/queries';
+import type { Site } from '../../data/types';
+
+interface AgencyDevelopmentSiteLaunchModalProps {
+	site: Site;
+	onClose: () => void;
+}
+
+export default function AgencyDevelopmentSiteLaunchModal( {
+	site,
+	onClose,
+}: AgencyDevelopmentSiteLaunchModalProps ) {
+	const queryClient = useQueryClient();
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const [ isLaunching, setIsLaunching ] = useState( false );
+	const mutation = useMutation( {
+		...launchSiteMutation( site.ID ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'site', site.slug ] } );
+		},
+	} );
+
+	const handleLaunch = () => {
+		setIsLaunching( true );
+		mutation.mutate( undefined, {
+			onSuccess: () => {
+				createSuccessNotice(
+					__( 'Your site has been launched; now you can share it with the world!' ),
+					{
+						type: 'snackbar',
+					}
+				);
+
+				setIsLaunching( false );
+				onClose();
+			},
+			onError: ( error: Error ) => {
+				createErrorNotice( error.message || __( 'Failed to launch site' ), {
+					type: 'snackbar',
+				} );
+
+				setIsLaunching( false );
+				onClose();
+			},
+		} );
+	};
+
+	return (
+		<Modal title={ __( "You're about to launch this website" ) } onRequestClose={ onClose }>
+			<VStack spacing={ 6 }>
+				<Text as="p">
+					{ __( "After launch, we'll bill your agency in the next billing cycle." ) }
+				</Text>
+				<Text as="p">{ __( 'Ready to launch?' ) }</Text>
+				<HStack justify="flex-end" spacing={ 2 }>
+					<Button onClick={ onClose }>{ __( 'Cancel' ) }</Button>
+					<Button variant="primary" isBusy={ isLaunching } onClick={ handleLaunch }>
+						{ __( 'Launch site' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		</Modal>
+	);
+}

--- a/client/dashboard/sites/settings-site-visibility/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/index.tsx
@@ -27,12 +27,10 @@ export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string
 		if ( site.launch_status === 'unlaunched' && site.is_a4a_dev_site ) {
 			return (
 				<>
-					<Notice>
-						<LaunchAgencyDevelopmentSiteForm
-							site={ site }
-							onLaunchClick={ () => setIsAgencyDevelopmentSiteLaunchModalOpen( true ) }
-						/>
-					</Notice>
+					<LaunchAgencyDevelopmentSiteForm
+						site={ site }
+						onLaunchClick={ () => setIsAgencyDevelopmentSiteLaunchModalOpen( true ) }
+					/>
 					{ isAgencyDevelopmentSiteLaunchModalOpen && (
 						<AgencyDevelopmentSiteLaunchModal
 							site={ site }

--- a/client/dashboard/sites/settings-site-visibility/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/index.tsx
@@ -2,9 +2,10 @@ import { useQuery, useMutation } from '@tanstack/react-query';
 import { Card, CardBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { siteQuery, siteSettingsMutation, siteSettingsQuery } from '../../app/queries';
+import { Notice } from '../../components/notice';
 import PageLayout from '../../components/page-layout';
 import SettingsPageHeader from '../settings-page-header';
-import { LaunchForm } from './launch-form';
+import { LaunchAgencyDevelopmentSiteForm, LaunchForm } from './launch-form';
 import { PrivacyForm } from './privacy-form';
 import './style.scss';
 
@@ -27,15 +28,21 @@ export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string
 				/>
 			}
 		>
-			<Card>
-				<CardBody>
-					{ site.launch_status === 'unlaunched' ? (
-						<LaunchForm site={ site } />
+			{ site.launch_status === 'unlaunched' ? (
+				<Notice>
+					{ site.is_a4a_dev_site ? (
+						<LaunchAgencyDevelopmentSiteForm site={ site } />
 					) : (
-						<PrivacyForm settings={ settings } mutation={ mutation } />
+						<LaunchForm site={ site } />
 					) }
-				</CardBody>
-			</Card>
+				</Notice>
+			) : (
+				<Card>
+					<CardBody>
+						<PrivacyForm settings={ settings } mutation={ mutation } />
+					</CardBody>
+				</Card>
+			) }
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/settings-site-visibility/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/index.tsx
@@ -1,10 +1,12 @@
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { Card, CardBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
 import { siteQuery, siteSettingsMutation, siteSettingsQuery } from '../../app/queries';
 import { Notice } from '../../components/notice';
 import PageLayout from '../../components/page-layout';
 import SettingsPageHeader from '../settings-page-header';
+import AgencyDevelopmentSiteLaunchModal from './agency-development-site-launch-modal';
 import { LaunchAgencyDevelopmentSiteForm, LaunchForm } from './launch-form';
 import { PrivacyForm } from './privacy-form';
 import './style.scss';
@@ -14,9 +16,49 @@ export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string
 	const { data: settings } = useQuery( siteSettingsQuery( siteSlug ) );
 	const mutation = useMutation( siteSettingsMutation( siteSlug ) );
 
+	const [ isAgencyDevelopmentSiteLaunchModalOpen, setIsAgencyDevelopmentSiteLaunchModalOpen ] =
+		useState( false );
+
 	if ( ! settings || ! site ) {
 		return null;
 	}
+
+	const renderContent = () => {
+		if ( site.launch_status === 'unlaunched' && site.is_a4a_dev_site ) {
+			return (
+				<>
+					<Notice>
+						<LaunchAgencyDevelopmentSiteForm
+							site={ site }
+							onLaunchClick={ () => setIsAgencyDevelopmentSiteLaunchModalOpen( true ) }
+						/>
+					</Notice>
+					{ isAgencyDevelopmentSiteLaunchModalOpen && (
+						<AgencyDevelopmentSiteLaunchModal
+							site={ site }
+							onClose={ () => setIsAgencyDevelopmentSiteLaunchModalOpen( false ) }
+						/>
+					) }
+				</>
+			);
+		}
+
+		if ( site.launch_status === 'unlaunched' ) {
+			return (
+				<Notice>
+					<LaunchForm site={ site } />
+				</Notice>
+			);
+		}
+
+		return (
+			<Card>
+				<CardBody>
+					<PrivacyForm settings={ settings } mutation={ mutation } />
+				</CardBody>
+			</Card>
+		);
+	};
 
 	return (
 		<PageLayout
@@ -28,21 +70,7 @@ export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string
 				/>
 			}
 		>
-			{ site.launch_status === 'unlaunched' ? (
-				<Notice>
-					{ site.is_a4a_dev_site ? (
-						<LaunchAgencyDevelopmentSiteForm site={ site } />
-					) : (
-						<LaunchForm site={ site } />
-					) }
-				</Notice>
-			) : (
-				<Card>
-					<CardBody>
-						<PrivacyForm settings={ settings } mutation={ mutation } />
-					</CardBody>
-				</Card>
-			) }
+			{ renderContent() }
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/settings-site-visibility/launch-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/launch-form.tsx
@@ -11,22 +11,21 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { agencyBlogQuery } from '../../app/queries';
-import type { Site } from '../../data/types';
+import type { AgencyBlog, Site } from '../../data/types';
 
-function useAgencyBillingMessage( site: Site ) {
-	const { data, isError } = useQuery( agencyBlogQuery( site.ID ) );
-	if ( ! data ) {
+function getAgencyBillingMessage( agency: AgencyBlog | undefined, isError: boolean ) {
+	if ( ! agency ) {
 		return undefined;
 	}
 
 	const priceInfoIsDefined =
-		Number.isFinite( data.prices?.actual_price ) && typeof data.prices?.currency === 'string';
+		Number.isFinite( agency.prices?.actual_price ) && typeof agency.prices?.currency === 'string';
 
 	if ( isError || ! priceInfoIsDefined ) {
 		return __( "After launch, we'll bill your agency in the next billing cycle." );
 	}
 
-	const { existing_wpcom_license_count: existingWPCOMLicenseCount = 0, name, prices } = data;
+	const { existing_wpcom_license_count: existingWPCOMLicenseCount = 0, name, prices } = agency;
 	const price = formatCurrency( prices.actual_price, prices.currency );
 
 	return createInterpolateElement(
@@ -61,7 +60,12 @@ export function LaunchAgencyDevelopmentSiteForm( {
 	site: Site;
 	onLaunchClick: () => void;
 } ) {
-	const billingMessage = useAgencyBillingMessage( site );
+	const { data, isError } = useQuery( agencyBlogQuery( site.ID ) );
+
+	const billingMessage = getAgencyBillingMessage( data, isError );
+	const isReferralStatusActive = data?.referral_status === 'active';
+	const shouldShowBillingMessage = ! isReferralStatusActive && !! billingMessage;
+	const shouldShowReferClientButton = ! isReferralStatusActive;
 
 	return (
 		<VStack spacing={ 4 } alignment="left">
@@ -70,18 +74,19 @@ export function LaunchAgencyDevelopmentSiteForm( {
 					'Your site hasn\'t been launched yet. It is hidden from visitors behind a "Coming Soon" notice until it is launched.'
 				) }
 			</Text>
-			{ billingMessage && <Text>{ billingMessage }</Text> }
+			{ shouldShowBillingMessage && <Text>{ billingMessage }</Text> }
 			<HStack justify="flex-start">
-				<Button __next40pxDefaultSize variant="primary" onClick={ () => onLaunchClick() }>
+				<Button variant="primary" onClick={ () => onLaunchClick() }>
 					{ __( 'Launch site' ) }
 				</Button>
-				<Button
-					__next40pxDefaultSize
-					variant="secondary"
-					href={ `https://agencies.automattic.com/marketplace/checkout?referral_blog_id=${ site.ID }` }
-				>
-					{ __( 'Refer a client ↗' ) }
-				</Button>
+				{ shouldShowReferClientButton && (
+					<Button
+						variant="secondary"
+						href={ `https://agencies.automattic.com/marketplace/checkout?referral_blog_id=${ site.ID }` }
+					>
+						{ __( 'Refer a client' ) }
+					</Button>
+				) }
 			</HStack>
 		</VStack>
 	);

--- a/client/dashboard/sites/settings-site-visibility/launch-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/launch-form.tsx
@@ -1,7 +1,6 @@
 import { formatCurrency } from '@automattic/number-formatters';
 import { useQuery } from '@tanstack/react-query';
 import {
-	__experimentalHStack as HStack,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	Button,
@@ -11,9 +10,10 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { agencyBlogQuery } from '../../app/queries';
+import { Notice } from '../../components/notice';
 import type { AgencyBlog, Site } from '../../data/types';
 
-function getAgencyBillingMessage( agency: AgencyBlog | undefined, isError: boolean ) {
+function getAgencyBillingMessage( agency: AgencyBlog | undefined, isAgencyQueryError: boolean ) {
 	if ( ! agency ) {
 		return undefined;
 	}
@@ -21,7 +21,7 @@ function getAgencyBillingMessage( agency: AgencyBlog | undefined, isError: boole
 	const priceInfoIsDefined =
 		Number.isFinite( agency.prices?.actual_price ) && typeof agency.prices?.currency === 'string';
 
-	if ( isError || ! priceInfoIsDefined ) {
+	if ( isAgencyQueryError || ! priceInfoIsDefined ) {
 		return __( "After launch, we'll bill your agency in the next billing cycle." );
 	}
 
@@ -32,8 +32,8 @@ function getAgencyBillingMessage( agency: AgencyBlog | undefined, isError: boole
 		sprintf(
 			/* translators: agencyName is the name of the agency that will be billed for the site; licenseCount is the number of licenses the agency will be billed for; price is the price per license */
 			_n(
-				"After launch, we'll bill %(agencyName)s in the next billing cycle. With %(licenseCount)d production hosting license, you will be charged %(price)s / license / month. <learnMoreLink>Learn more.</learnMoreLink>",
-				"After launch, we'll bill %(agencyName)s in the next billing cycle. With %(licenseCount)d production hosting licenses, you will be charged %(price)s / license / month. <learnMoreLink>Learn more.</learnMoreLink>",
+				"After launch, we'll bill %(agencyName)s in the next billing cycle. With %(licenseCount)d production hosting license, you will be charged %(price)s / license / month. <learnMoreLink>Learn more</learnMoreLink>",
+				"After launch, we'll bill %(agencyName)s in the next billing cycle. With %(licenseCount)d production hosting licenses, you will be charged %(price)s / license / month. <learnMoreLink>Learn more</learnMoreLink>",
 				existingWPCOMLicenseCount + 1
 			),
 			{
@@ -68,27 +68,32 @@ export function LaunchAgencyDevelopmentSiteForm( {
 	const shouldShowReferClientButton = ! isReferralStatusActive;
 
 	return (
-		<VStack spacing={ 4 } alignment="left">
-			<Text>
-				{ __(
-					'Your site hasn\'t been launched yet. It is hidden from visitors behind a "Coming Soon" notice until it is launched.'
-				) }
-			</Text>
-			{ shouldShowBillingMessage && <Text>{ billingMessage }</Text> }
-			<HStack justify="flex-start">
-				<Button variant="primary" onClick={ () => onLaunchClick() }>
-					{ __( 'Launch site' ) }
-				</Button>
-				{ shouldShowReferClientButton && (
-					<Button
-						variant="secondary"
-						href={ `https://agencies.automattic.com/marketplace/checkout?referral_blog_id=${ site.ID }` }
-					>
-						{ __( 'Refer a client' ) }
+		<Notice
+			title={ __( "Your site hasn't been launched yet" ) }
+			actions={
+				<>
+					<Button size="compact" variant="primary" onClick={ () => onLaunchClick() }>
+						{ __( 'Launch site' ) }
 					</Button>
-				) }
-			</HStack>
-		</VStack>
+					{ shouldShowReferClientButton && (
+						<Button
+							size="compact"
+							variant="secondary"
+							href={ `https://agencies.automattic.com/marketplace/checkout?referral_blog_id=${ site.ID }` }
+						>
+							{ __( 'Refer a client' ) }
+						</Button>
+					) }
+				</>
+			}
+		>
+			<VStack spacing={ 5 } alignment="left">
+				<Text as="p">
+					{ __( 'It is hidden from visitors behind a "Coming Soon" notice until it is launched.' ) }
+				</Text>
+				{ shouldShowBillingMessage && <Text as="p">{ billingMessage }</Text> }
+			</VStack>
+		</Notice>
 	);
 }
 

--- a/client/dashboard/sites/settings-site-visibility/launch-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/launch-form.tsx
@@ -14,7 +14,7 @@ import { agencyBlogQuery } from '../../app/queries';
 import type { Site } from '../../data/types';
 
 function useAgencyBillingMessage( site: Site ) {
-	const { data, isLoading: isLoading, isError: isError } = useQuery( agencyBlogQuery( site.ID ) );
+	const { data, isError } = useQuery( agencyBlogQuery( site.ID ) );
 	if ( ! data ) {
 		return undefined;
 	}
@@ -22,7 +22,7 @@ function useAgencyBillingMessage( site: Site ) {
 	const priceInfoIsDefined =
 		Number.isFinite( data.prices?.actual_price ) && typeof data.prices?.currency === 'string';
 
-	if ( isLoading || isError || ! priceInfoIsDefined ) {
+	if ( isError || ! priceInfoIsDefined ) {
 		return __( "After launch, we'll bill your agency in the next billing cycle." );
 	}
 
@@ -33,8 +33,8 @@ function useAgencyBillingMessage( site: Site ) {
 		sprintf(
 			/* translators: agencyName is the name of the agency that will be billed for the site; licenseCount is the number of licenses the agency will be billed for; price is the price per license */
 			_n(
-				"After launch, we'll bill %(agencyName)s in the next billing cycle. With %(licenseCount)s production hosting license, you will be charged %(price)s / license / month. <learnMoreLink>Learn more.</learnMoreLink>",
-				"After launch, we'll bill %(agencyName)s in the next billing cycle. With %(licenseCount)s production hosting licenses, you will be charged %(price)s / license / month. <learnMoreLink>Learn more.</learnMoreLink>",
+				"After launch, we'll bill %(agencyName)s in the next billing cycle. With %(licenseCount)d production hosting license, you will be charged %(price)s / license / month. <learnMoreLink>Learn more.</learnMoreLink>",
+				"After launch, we'll bill %(agencyName)s in the next billing cycle. With %(licenseCount)d production hosting licenses, you will be charged %(price)s / license / month. <learnMoreLink>Learn more.</learnMoreLink>",
 				existingWPCOMLicenseCount + 1
 			),
 			{
@@ -62,9 +62,6 @@ export function LaunchAgencyDevelopmentSiteForm( {
 	onLaunchClick: () => void;
 } ) {
 	const billingMessage = useAgencyBillingMessage( site );
-	const handleReferClientClick = () => {
-		window.location.href = `https://agencies.automattic.com/marketplace/checkout?referral_blog_id=${ site.ID }`;
-	};
 
 	return (
 		<VStack spacing={ 4 } alignment="left">
@@ -78,8 +75,12 @@ export function LaunchAgencyDevelopmentSiteForm( {
 				<Button __next40pxDefaultSize variant="primary" onClick={ () => onLaunchClick() }>
 					{ __( 'Launch site' ) }
 				</Button>
-				<Button __next40pxDefaultSize variant="secondary" onClick={ handleReferClientClick }>
-					{ __( 'Refer a client' ) }
+				<Button
+					__next40pxDefaultSize
+					variant="secondary"
+					href={ `https://agencies.automattic.com/marketplace/checkout?referral_blog_id=${ site.ID }` }
+				>
+					{ __( 'Refer a client ↗' ) }
 				</Button>
 			</HStack>
 		</VStack>

--- a/client/dashboard/sites/settings-site-visibility/launch-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/launch-form.tsx
@@ -54,11 +54,14 @@ function useAgencyBillingMessage( site: Site ) {
 	);
 }
 
-export function LaunchAgencyDevelopmentSiteForm( { site }: { site: Site } ) {
+export function LaunchAgencyDevelopmentSiteForm( {
+	site,
+	onLaunchClick,
+}: {
+	site: Site;
+	onLaunchClick: () => void;
+} ) {
 	const billingMessage = useAgencyBillingMessage( site );
-
-	const handleLaunchSiteClick = () => {};
-
 	const handleReferClientClick = () => {
 		window.location.href = `https://agencies.automattic.com/marketplace/checkout?referral_blog_id=${ site.ID }`;
 	};
@@ -72,7 +75,7 @@ export function LaunchAgencyDevelopmentSiteForm( { site }: { site: Site } ) {
 			</Text>
 			{ billingMessage && <Text>{ billingMessage }</Text> }
 			<HStack justify="flex-start">
-				<Button __next40pxDefaultSize variant="primary" onClick={ handleLaunchSiteClick }>
+				<Button __next40pxDefaultSize variant="primary" onClick={ () => onLaunchClick() }>
 					{ __( 'Launch site' ) }
 				</Button>
 				<Button __next40pxDefaultSize variant="secondary" onClick={ handleReferClientClick }>

--- a/client/dashboard/sites/settings-site-visibility/launch-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/launch-form.tsx
@@ -1,11 +1,87 @@
+import { formatCurrency } from '@automattic/number-formatters';
+import { useQuery } from '@tanstack/react-query';
 import {
+	__experimentalHStack as HStack,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	Button,
+	ExternalLink,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
+import { agencyBlogQuery } from '../../app/queries';
 import type { Site } from '../../data/types';
+
+function useAgencyBillingMessage( site: Site ) {
+	const { data, isLoading: isLoading, isError: isError } = useQuery( agencyBlogQuery( site.ID ) );
+	if ( ! data ) {
+		return undefined;
+	}
+
+	const priceInfoIsDefined =
+		Number.isFinite( data.prices?.actual_price ) && typeof data.prices?.currency === 'string';
+
+	if ( isLoading || isError || ! priceInfoIsDefined ) {
+		return __( "After launch, we'll bill your agency in the next billing cycle." );
+	}
+
+	const { existing_wpcom_license_count: existingWPCOMLicenseCount = 0, name, prices } = data;
+	const price = formatCurrency( prices.actual_price, prices.currency );
+
+	return createInterpolateElement(
+		sprintf(
+			/* translators: agencyName is the name of the agency that will be billed for the site; licenseCount is the number of licenses the agency will be billed for; price is the price per license */
+			_n(
+				"After launch, we'll bill %(agencyName)s in the next billing cycle. With %(licenseCount)s production hosting license, you will be charged %(price)s / license / month. <learnMoreLink>Learn more.</learnMoreLink>",
+				"After launch, we'll bill %(agencyName)s in the next billing cycle. With %(licenseCount)s production hosting licenses, you will be charged %(price)s / license / month. <learnMoreLink>Learn more.</learnMoreLink>",
+				existingWPCOMLicenseCount + 1
+			),
+			{
+				agencyName: name,
+				licenseCount: existingWPCOMLicenseCount + 1,
+				price,
+			}
+		),
+		{
+			learnMoreLink: (
+				<ExternalLink
+					href="https://agencieshelp.automattic.com/knowledge-base/free-development-licenses-for-wordpress-com-hosting/"
+					children={ null }
+				/>
+			),
+		}
+	);
+}
+
+export function LaunchAgencyDevelopmentSiteForm( { site }: { site: Site } ) {
+	const billingMessage = useAgencyBillingMessage( site );
+
+	const handleLaunchSiteClick = () => {};
+
+	const handleReferClientClick = () => {
+		window.location.href = `https://agencies.automattic.com/marketplace/checkout?referral_blog_id=${ site.ID }`;
+	};
+
+	return (
+		<VStack spacing={ 4 } alignment="left">
+			<Text>
+				{ __(
+					'Your site hasn\'t been launched yet. It is hidden from visitors behind a "Coming Soon" notice until it is launched.'
+				) }
+			</Text>
+			{ billingMessage && <Text>{ billingMessage }</Text> }
+			<HStack justify="flex-start">
+				<Button __next40pxDefaultSize variant="primary" onClick={ handleLaunchSiteClick }>
+					{ __( 'Launch site' ) }
+				</Button>
+				<Button __next40pxDefaultSize variant="secondary" onClick={ handleReferClientClick }>
+					{ __( 'Refer a client' ) }
+				</Button>
+			</HStack>
+		</VStack>
+	);
+}
 
 export function LaunchForm( { site }: { site: Site } ) {
 	return (


### PR DESCRIPTION
Ref DOTCOM-13435

## Proposed Changes

This PR implements the site launch flow for A4A development sites in the Site Visibility setting screen.

User will see the following notice.
![SCR-20250603-orha](https://github.com/user-attachments/assets/04c1399e-3f89-4628-88c0-24bbb26aa245)

Clicking "Launch site" they will see the following confirmation modal.
![Screenshot 2025-06-03 at 4 41 08 PM](https://github.com/user-attachments/assets/a4d20a0d-4aeb-4e86-9b25-f50d8fe1c236)

Clicking "Launch site" will launch the site, and the notice will be replaced with site visibility controls.

## Why are these changes being made?

<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Hosting Dashboard v2 implementation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

It might be helpful to use the shared A4A account for testing.

* Head to /v2/sites/:siteSlug/settings/site-visibility using an A4A development site.
* Ensure that the site launch flow is as described above. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
