### PR TITLE
Help Center: Show direct escalation only if Zendesk works

### DIFF
--- a/packages/odie-client/src/components/message/direct-escalation-link.tsx
+++ b/packages/odie-client/src/components/message/direct-escalation-link.tsx
@@ -11,7 +11,8 @@ import { getHelpCenterZendeskConversationStarted, interactionHasZendeskEvent } f
 export const DirectEscalationLink = ( { messageId }: { messageId: number | undefined } ) => {
 	const conversationStarted = Boolean( getHelpCenterZendeskConversationStarted() );
 	const newConversation = useCreateZendeskConversation();
-	const { trackEvent, isUserEligibleForPaidSupport, chat } = useOdieAssistantContext();
+	const { trackEvent, isUserEligibleForPaidSupport, chat, canConnectToZendesk } =
+		useOdieAssistantContext();
 	const navigate = useNavigate();
 
 	const { currentSupportInteraction } = useSelect( ( select ) => {
@@ -70,7 +71,7 @@ export const DirectEscalationLink = ( { messageId }: { messageId: number | undef
 		<div className="disclaimer">
 			{ __( 'Feeling stuck?', __i18n_text_domain__ ) }{ ' ' }
 			<button onClick={ handleClick } className="odie-button-link">
-				{ isUserEligibleForPaidSupport
+				{ isUserEligibleForPaidSupport && canConnectToZendesk
 					? __( 'Contact our support team.', __i18n_text_domain__ )
 					: __( 'Ask in our forums.', __i18n_text_domain__ ) }
 			</button>

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -59,15 +59,15 @@ export const UserMessage = ( {
 	const hasCannedResponse = message.context?.flags?.canned_response;
 	const isRequestingHumanSupport = message.context?.flags?.forward_to_human_support ?? false;
 	const isBot = message.role === 'bot';
-	const isConnectedToZendesk = chat?.provider === 'zendesk';
 
 	const showDirectEscalationLink = useMemo( () => {
 		return (
+			canConnectToZendesk &&
 			! chat.conversationId &&
 			userProvidedEnoughInformation( chat?.messages ) &&
 			! interactionHasZendeskEvent( currentSupportInteraction )
 		);
-	}, [ chat.conversationId, currentSupportInteraction, chat?.messages ] );
+	}, [ chat.conversationId, currentSupportInteraction, chat?.messages, canConnectToZendesk ] );
 
 	const forwardMessage = isUserEligibleForPaidSupport
 		? ODIE_FORWARD_TO_ZENDESK_MESSAGE
@@ -125,7 +125,7 @@ export const UserMessage = ( {
 					}
 				) }
 			</div>
-			{ ! isConnectedToZendesk && (
+			{ ! interactionHasZendeskEvent( currentSupportInteraction ) && (
 				<>
 					{ showDirectEscalationLink && <DirectEscalationLink messageId={ message.message_id } /> }
 					{ ! message.rating_value && (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTSUP-54/user-unable-to-talk-with-support

## Proposed Changes

Do not show the direct escalation link after an AI response if the user is not able to connect to Zendesk (network issues)

![image](https://github.com/user-attachments/assets/23fef117-f1f0-4bd3-8d67-d2e3f1b5f038)



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

If the user is not able to connect to zendesk, we'll be in an inconsistent state.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use ModResponse browser extension and block Zendesk config URL
* Talk with Odie and give all the info, you should be able to see the link to contact support
* If not, comment [this](https://github.com/Automattic/wp-calypso/blob/trunk/packages/odie-client/src/components/message/user-message.tsx#L67) line
* On prod, you should be able to click on the link and end up in an inconsistent state
* Here you should be able to go to forums instead