### PR TITLE
Jetpack: Enable magic codes on staging

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -108,7 +108,7 @@
 		"livechat_solution": true,
 		"login/last-used-method": true,
 		"login/magic-login": true,
-		"login/use-magic-code": false,
+		"login/use-magic-code": true,
 		"logmein": true,
 		"mailchimp": true,
 		"manage/import/site-importer-endpoints": true,

--- a/config/production.json
+++ b/config/production.json
@@ -85,6 +85,7 @@
 		"livechat_solution": true,
 		"login/last-used-method": true,
 		"login/magic-login": true,
+		"login/use-magic-code": false,
 		"mailchimp": true,
 		"marketplace-fetch-all-dynamic-products": false,
 		"marketplace-personal-premium": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -82,7 +82,7 @@
 		"livechat_solution": true,
 		"login/last-used-method": true,
 		"login/magic-login": true,
-		"login/use-magic-code": false,
+		"login/use-magic-code": true,
 		"mailchimp": true,
 		"marketplace-fetch-all-dynamic-products": true,
 		"marketplace-personal-premium": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -86,7 +86,7 @@
 		"livechat_solution": true,
 		"login/last-used-method": true,
 		"login/magic-login": true,
-		"login/use-magic-code": false,
+		"login/use-magic-code": true,
 		"logmein": true,
 		"mailchimp": true,
 		"marketplace-fetch-all-dynamic-products": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Enable the feature flag for staging for magic codes

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To be able to test the feature with the call for testing

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On staging the feature flag should be on
* It should still be OFF for production!

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
