### PR TITLE
Site settings menu hidden for users without manage_options capability

### DIFF
--- a/client/dashboard/sites/site-menu/index.tsx
+++ b/client/dashboard/sites/site-menu/index.tsx
@@ -1,14 +1,9 @@
 import { __ } from '@wordpress/i18n';
 import ResponsiveMenu from '../../components/responsive-menu';
+import type { Site } from '../../data/types';
 
-export interface SiteMenuConfig {
-	hide?: {
-		settings?: boolean;
-	};
-}
-
-const SiteMenu = ( { siteSlug, config }: { siteSlug: string; config?: SiteMenuConfig } ) => {
-	const { hide = {} } = config ?? {};
+const SiteMenu = ( { site }: { site: Site } ) => {
+	const siteSlug = site.slug;
 
 	return (
 		<ResponsiveMenu label={ __( 'Site Menu' ) }>
@@ -21,7 +16,7 @@ const SiteMenu = ( { siteSlug, config }: { siteSlug: string; config?: SiteMenuCo
 			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/performance` }>
 				{ __( 'Performance' ) }
 			</ResponsiveMenu.Item>
-			{ ! hide.settings && (
+			{ site.capabilities.manage_options && (
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/settings` }>
 					{ __( 'Settings' ) }
 				</ResponsiveMenu.Item>

--- a/client/dashboard/sites/site-menu/index.tsx
+++ b/client/dashboard/sites/site-menu/index.tsx
@@ -1,7 +1,14 @@
 import { __ } from '@wordpress/i18n';
 import ResponsiveMenu from '../../components/responsive-menu';
+import type { SiteCapabilities } from '../../data/types';
 
-const SiteMenu = ( { siteSlug }: { siteSlug: string } ) => {
+const SiteMenu = ( {
+	siteSlug,
+	capabilities,
+}: {
+	siteSlug: string;
+	capabilities: SiteCapabilities;
+} ) => {
 	return (
 		<ResponsiveMenu label={ __( 'Site Menu' ) }>
 			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }` } activeOptions={ { exact: true } }>
@@ -13,9 +20,11 @@ const SiteMenu = ( { siteSlug }: { siteSlug: string } ) => {
 			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/performance` }>
 				{ __( 'Performance' ) }
 			</ResponsiveMenu.Item>
-			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/settings` }>
-				{ __( 'Settings' ) }
-			</ResponsiveMenu.Item>
+			{ capabilities.manage_options && (
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/settings` }>
+					{ __( 'Settings' ) }
+				</ResponsiveMenu.Item>
+			) }
 		</ResponsiveMenu>
 	);
 };

--- a/client/dashboard/sites/site-menu/index.tsx
+++ b/client/dashboard/sites/site-menu/index.tsx
@@ -1,14 +1,15 @@
 import { __ } from '@wordpress/i18n';
 import ResponsiveMenu from '../../components/responsive-menu';
-import type { SiteCapabilities } from '../../data/types';
 
-const SiteMenu = ( {
-	siteSlug,
-	capabilities,
-}: {
-	siteSlug: string;
-	capabilities: SiteCapabilities;
-} ) => {
+export interface SiteMenuConfig {
+	hide?: {
+		settings?: boolean;
+	};
+}
+
+const SiteMenu = ( { siteSlug, config }: { siteSlug: string; config?: SiteMenuConfig } ) => {
+	const { hide = {} } = config ?? {};
+
 	return (
 		<ResponsiveMenu label={ __( 'Site Menu' ) }>
 			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }` } activeOptions={ { exact: true } }>
@@ -20,7 +21,7 @@ const SiteMenu = ( {
 			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/performance` }>
 				{ __( 'Performance' ) }
 			</ResponsiveMenu.Item>
-			{ capabilities.manage_options && (
+			{ ! hide.settings && (
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/settings` }>
 					{ __( 'Settings' ) }
 				</ResponsiveMenu.Item>

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -36,7 +36,7 @@ function Site() {
 						/>
 					</HeaderBar.Title>
 					{ isDesktop && <MenuDivider /> }
-					<SiteMenu siteSlug={ siteSlug } />
+					<SiteMenu siteSlug={ siteSlug } capabilities={ site.capabilities } />
 				</HStack>
 			</HeaderBar>
 			<Outlet />

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -36,14 +36,7 @@ function Site() {
 						/>
 					</HeaderBar.Title>
 					{ isDesktop && <MenuDivider /> }
-					<SiteMenu
-						siteSlug={ siteSlug }
-						config={ {
-							hide: {
-								settings: ! site.capabilities.manage_options,
-							},
-						} }
-					/>
+					<SiteMenu site={ site } />
 				</HStack>
 			</HeaderBar>
 			<Outlet />

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -36,7 +36,14 @@ function Site() {
 						/>
 					</HeaderBar.Title>
 					{ isDesktop && <MenuDivider /> }
-					<SiteMenu siteSlug={ siteSlug } capabilities={ site.capabilities } />
+					<SiteMenu
+						siteSlug={ siteSlug }
+						config={ {
+							hide: {
+								settings: ! site.capabilities.manage_options,
+							},
+						} }
+					/>
 				</HStack>
 			</HeaderBar>
 			<Outlet />


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->



## Proposed Changes

* Hide the "Settings" menu item from users who don't have permission to modify site settings.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Currently users who aren't admins see an error like this when trying to navigate to `/v2/sites/{{slug}}/settings`.

![CleanShot 2025-06-03 at 20 06 10@2x](https://github.com/user-attachments/assets/5ee1dc2c-e63a-4509-bfb5-a46cc1ef7308)

Sometimes there are different messages, but the same underlying issue is that users without the `manage_options` capability can't read site settings. Now this "Settings" menu item simply isn't shown.

Raised here p1748936055431509-slack-CRWCHQGUB

This is not an exhaustive fix for all places where non-admin's can't use some part of the dashboard. It's just a fix for the most egregious issue.

There's also issues like this where the storage limit and perf data can't be loaded. But that's something for later.

![CleanShot 2025-06-03 at 20 05 39@2x](https://github.com/user-attachments/assets/f5cc3e0a-bbcc-4e6d-af7b-f9f46eeaaf67)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Invite your user to a site as a "contributor" or some other non-admin role.
* Have them load the site in the v2 dashboard
* Navigate through menus and confirm nothing _too_ bad happens. Some dashboard items might not load. But nothing too drastic.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?