### PR TITLE
Odie history: add 'resolved' to interactions

### DIFF
--- a/packages/help-center/src/hooks/use-get-history-chats.ts
+++ b/packages/help-center/src/hooks/use-get-history-chats.ts
@@ -125,7 +125,7 @@ export const useGetHistoryChats = (): UseGetHistoryChatsResult => {
 	const { data: otherSupportInteractions, isLoading: isLoadingOtherSupportInteractions } =
 		useGetSupportInteractions( 'zendesk', 100, [ 'resolved', 'solved', 'closed' ] );
 	const { data: odieSupportInteractions, isLoading: isLoadingOdieSupportInteractions } =
-		useGetSupportInteractions( 'odie', 100, [ 'open' ] );
+		useGetSupportInteractions( 'odie', 100, [ 'open', 'resolved' ] );
 	const { data: odieConversations, isLoading: isLoadingOdieConversations } =
 		useGetOdieConversations();
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

Add 'resolved' to the list of Odie interactions that will be retrieved in the History

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When a user clicks on "New chat" in the 3 dots menu in a chat, the current chat gets 'resolved'. With this, these Odie history chats will be in the History page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new user and start a chat with Odie
* Click on New Chat in the 3-dots menu in the header
* Chat with Odie
* Go back to the homepage, you should see the History button at the bottom
* Open History and you'll see all chats
