### PR TITLE
Accessibility: Adjust onClick handler for list items

### DIFF
--- a/client/my-sites/theme/theme-features-card.js
+++ b/client/my-sites/theme/theme-features-card.js
@@ -29,12 +29,14 @@ const ThemeFeaturesCard = ( { isWpcomTheme, siteSlug, features, translate, onCli
 							! isLoggedIn
 						);
 						return (
-							<li
-								key={ 'theme-features-item-' + slug }
-								role="presentation"
-								onClick={ () => onClick?.( slug ) }
-							>
-								{ ! isWpcomTheme ? <span>{ name }</span> : <a href={ filterPath }>{ name }</a> }
+							<li key={ 'theme-features-item-' + slug }>
+								{ ! isWpcomTheme ? (
+									<span>{ name }</span>
+								) : (
+									<a onClick={ () => onClick?.( slug ) } href={ filterPath }>
+										{ name }
+									</a>
+								) }
 							</li>
 						);
 					} ) }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13361

## Proposed Changes

* Move onClick handle to `a` element from `li`. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The axe dev tools was failing and VoiceOver didn't read the features. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Visit `/theme/grammer`
* Enable VoiceOver
* Check Features section and make sure it read correctly by VoiceOver
* Also, make sure Axe DevTools is not complaining about it. 
![CleanShot 2025-06-03 at 14 50 31@2x](https://github.com/user-attachments/assets/0469d809-4d75-4706-a63f-5e74c624790f)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
