### PR TITLE
100-year confirmation page: Fix view guide button styling

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-thank-you/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-thank-you/styles.scss
@@ -31,8 +31,17 @@
 		max-height: 460px;
 	}
 
-	.components-button {
+	.hundred-year-plan-step-wrapper__step-container {
+		text-align: center;
+	}
+
+	.components-button.is-secondary:not( .is-destructive ) {
 		box-shadow: none;
-		margin-bottom: 1rem;
+		margin: 2rem auto ;
+		--wp-components-color-accent: var( --studio-gray-100 );
+		--wp-components-color-accent-darker-20: var( --studio-gray-100 );
+		background: var( --studio-white );
+		font-weight: 500;
+		border: none;
 	}
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://github.com/Automattic/wp-calypso/issues/101961

## Proposed Changes

* Adjusts the `View guide` button's styling on the 100-year confirmations page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The current styling makes the `View guide` button look broken
<img width="480" alt="Screenshot 2025-06-03 at 12 29 13" src="https://github.com/user-attachments/assets/bfd4f43a-2c87-4616-b7b3-b51d0d724629" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/hundred-year-plan/thank-you?ref=100-year-lp`
* The `View guide` button should be styled
<img width="480" alt="Screenshot 2025-06-03 at 12 29 33" src="https://github.com/user-attachments/assets/f94190f7-eb94-4c2f-9651-74ad548acfad" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
