### PR TITLE
Hosting Dashboard Settings page: extract summary list items visibility checks

### DIFF
--- a/client/dashboard/components/summary-button-list/types.ts
+++ b/client/dashboard/components/summary-button-list/types.ts
@@ -1,7 +1,7 @@
 import { ReactElement } from 'react';
 import type { Density } from '@automattic/components/src/summary-button/types';
 
-type ChildType = ReactElement< { density?: string } >;
+type ChildType = ReactElement< { density?: string } > | null;
 export interface SummaryButtonListProps {
 	/**
 	 * The main label that identifies the section.

--- a/client/dashboard/sites/settings-agency/summary.tsx
+++ b/client/dashboard/sites/settings-agency/summary.tsx
@@ -7,26 +7,29 @@ import RouterLinkSummaryButton from '../../components/router-link-summary-button
 import type { Site } from '../../data/types';
 import type { Density } from '@automattic/components/src/summary-button/types';
 
-export default function AgencySettingsSummary( {
-	site,
-	density,
-}: {
-	site: Site;
-	density?: Density;
-} ) {
+export function useCanRenderAgencySettingsSummary( { site }: { site: Site } ) {
 	const { data: siteSettings } = useQuery( siteSettingsQuery( site.slug ) );
 	const { data: agencyBlog } = useQuery( {
 		...agencyBlogQuery( site.ID ),
 		enabled: site.is_wpcom_atomic,
 	} );
 
-	if ( ! agencyBlog ) {
-		return null;
-	}
+	return {
+		show: !! agencyBlog,
+		props: {
+			site,
+			isWpcomFeaturesDisabled: siteSettings?.is_fully_managed_agency_site || site.is_a4a_dev_site,
+		},
+	};
+}
 
-	const isWpcomFeaturesDisabled =
-		siteSettings?.is_fully_managed_agency_site || site.is_a4a_dev_site;
-
+export default function AgencySettingsSummary( {
+	site,
+	isWpcomFeaturesDisabled,
+	density,
+}: ReturnType< typeof useCanRenderAgencySettingsSummary >[ 'props' ] & {
+	density?: Density;
+} ) {
 	return (
 		<RouterLinkSummaryButton
 			to={ `/sites/${ site.slug }/settings/agency` }

--- a/client/dashboard/sites/settings-defensive-mode/summary.tsx
+++ b/client/dashboard/sites/settings-defensive-mode/summary.tsx
@@ -8,27 +8,33 @@ import { canUpdateDefensiveMode } from '../../utils/site-features';
 import type { Site } from '../../data/types';
 import type { Density } from '@automattic/components/src/summary-button/types';
 
-export default function DefensiveModeSettingsSummary( {
-	site,
-	density,
-}: {
-	site: Site;
-	density?: Density;
-} ) {
+export function useCanRenderSettingsDefensiveModeSummary( { site }: { site: Site } ) {
 	const canUpdate = canUpdateDefensiveMode( site );
 
-	const { data } = useQuery( {
+	const { data: siteDefensiveModeData } = useQuery( {
 		...siteDefensiveModeQuery( site.slug ),
 		enabled: canUpdate,
 	} );
 
-	if ( ! canUpdate ) {
-		return null;
-	}
+	return {
+		show: !! canUpdate,
+		props: {
+			site,
+			siteDefensiveModeData,
+		},
+	};
+}
 
+export default function DefensiveModeSettingsSummary( {
+	site,
+	siteDefensiveModeData,
+	density,
+}: ReturnType< typeof useCanRenderSettingsDefensiveModeSummary >[ 'props' ] & {
+	density?: Density;
+} ) {
 	let badge;
-	if ( data ) {
-		if ( data.enabled ) {
+	if ( siteDefensiveModeData ) {
+		if ( siteDefensiveModeData.enabled ) {
 			badge = {
 				text: __( 'Enabled' ),
 				intent: 'info' as const,

--- a/client/dashboard/sites/settings-hundred-year-plan/summary.tsx
+++ b/client/dashboard/sites/settings-hundred-year-plan/summary.tsx
@@ -6,19 +6,26 @@ import { canUpdateHundredYearPlanFeatures } from '../../utils/site-features';
 import type { Site, SiteSettings } from '../../data/types';
 import type { Density } from '@automattic/components/src/summary-button/types';
 
+export function useCanRenderHundredYearPlanSettingsSummary( {
+	site,
+	settings,
+}: {
+	site: Site;
+	settings: SiteSettings;
+} ) {
+	return {
+		show: canUpdateHundredYearPlanFeatures( site ),
+		props: { site, settings },
+	};
+}
+
 export default function HundredYearPlanSummary( {
 	site,
 	settings,
 	density,
-}: {
-	site: Site;
-	settings: SiteSettings;
+}: ReturnType< typeof useCanRenderHundredYearPlanSettingsSummary >[ 'props' ] & {
 	density?: Density;
 } ) {
-	if ( ! canUpdateHundredYearPlanFeatures( site ) ) {
-		return null;
-	}
-
 	return (
 		<RouterLinkSummaryButton
 			to={ `/sites/${ site.slug }/settings/hundred-year-plan` }

--- a/client/dashboard/sites/settings-primary-data-center/summary.tsx
+++ b/client/dashboard/sites/settings-primary-data-center/summary.tsx
@@ -9,13 +9,7 @@ import { canGetPrimaryDataCenter } from '../../utils/site-features';
 import type { Site } from '../../data/types';
 import type { Density } from '@automattic/components/src/summary-button/types';
 
-export default function SettingsPrimaryDataCenterSummary( {
-	site,
-	density,
-}: {
-	site: Site;
-	density?: Density;
-} ) {
+export function useCanRenderSettingsPrimaryDataCenterSummary( { site }: { site: Site } ) {
 	const { data: primaryDataCenter } = useQuery( {
 		...sitePrimaryDataCenterQuery( site.slug ),
 		enabled: canGetPrimaryDataCenter( site ),
@@ -24,10 +18,22 @@ export default function SettingsPrimaryDataCenterSummary( {
 	const dataCenterOptions = getDataCenterOptions();
 	const primaryDataCenterName = primaryDataCenter ? dataCenterOptions[ primaryDataCenter ] : null;
 
-	if ( ! primaryDataCenterName ) {
-		return null;
-	}
+	return {
+		show: !! primaryDataCenterName,
+		props: {
+			site,
+			primaryDataCenterName: primaryDataCenterName as string,
+		},
+	};
+}
 
+export default function SettingsPrimaryDataCenterSummary( {
+	site,
+	primaryDataCenterName,
+	density,
+}: ReturnType< typeof useCanRenderSettingsPrimaryDataCenterSummary >[ 'props' ] & {
+	density?: Density;
+} ) {
 	return (
 		<RouterLinkSummaryButton
 			to={ `/sites/${ site.slug }/settings/primary-data-center` }

--- a/client/dashboard/sites/settings-subscription-gifting/summary.tsx
+++ b/client/dashboard/sites/settings-subscription-gifting/summary.tsx
@@ -6,6 +6,19 @@ import { hasSubscriptionGiftingFeature } from './utils';
 import type { Site, SiteSettings } from '../../data/types';
 import type { Density } from '@automattic/components/src/summary-button/types';
 
+export function useCanRenderSubscriptionGiftingSettingsSummary( {
+	site,
+	settings,
+}: {
+	site: Site;
+	settings: SiteSettings;
+} ) {
+	return {
+		show: hasSubscriptionGiftingFeature( site ),
+		props: { site, settings },
+	};
+}
+
 export default function SubscriptionGiftingSettingsSummary( {
 	site,
 	settings,
@@ -15,9 +28,6 @@ export default function SubscriptionGiftingSettingsSummary( {
 	settings: SiteSettings;
 	density?: Density;
 } ) {
-	if ( ! hasSubscriptionGiftingFeature( site ) ) {
-		return null;
-	}
 	return (
 		<RouterLinkSummaryButton
 			to={ `/sites/${ site.slug }/settings/subscription-gifting` }

--- a/client/dashboard/sites/settings-wordpress/summary.tsx
+++ b/client/dashboard/sites/settings-wordpress/summary.tsx
@@ -8,37 +8,44 @@ import { getFormattedWordPressVersion } from '../../utils/wp-version';
 import type { Site } from '../../data/types';
 import type { Density } from '@automattic/components/src/summary-button/types';
 
-export default function WordPressSettingsSummary( {
-	site,
-	density,
-}: {
-	site: Site;
-	density?: Density;
-} ) {
-	const { data: versionTag } = useQuery( {
-		...siteWordPressVersionQuery( site.slug ),
+export function useCanRenderWordPressSettingsSummary( { site }: { site: Site } ) {
+	const { data: wpVersionTag } = useQuery( {
+		...siteWordPressVersionQuery( site?.slug ),
 		enabled: canUpdateWordPressVersion( site ),
 	} );
 
-	const wpVersion = getFormattedWordPressVersion( site, versionTag );
-	if ( ! wpVersion ) {
-		return null;
-	}
+	const wpVersion = getFormattedWordPressVersion( site, wpVersionTag );
 
-	const badges = [
-		{
-			text: wpVersion,
-			intent: versionTag === 'beta' ? ( 'warning' as const ) : ( 'success' as const ),
+	return {
+		show: !! wpVersion,
+		props: {
+			site,
+			wpVersion,
+			wpVersionTag,
 		},
-	];
+	};
+}
 
+export default function WordPressSettingsSummary( {
+	site,
+	wpVersion,
+	wpVersionTag,
+	density,
+}: ReturnType< typeof useCanRenderWordPressSettingsSummary >[ 'props' ] & {
+	density?: Density;
+} ) {
 	return (
 		<RouterLinkSummaryButton
 			to={ `/sites/${ site.slug }/settings/wordpress` }
 			title="WordPress"
 			density={ density }
 			decoration={ <Icon icon={ wordpress } /> }
-			badges={ badges }
+			badges={ [
+				{
+					text: wpVersion,
+					intent: wpVersionTag === 'beta' ? ( 'warning' as const ) : ( 'success' as const ),
+				},
+			] }
 		/>
 	);
 }

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -5,39 +5,92 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { SectionHeader } from '../../components/section-header';
 import { SummaryButtonList } from '../../components/summary-button-list';
-import AgencySettingsSummary from '../settings-agency/summary';
+import {
+	default as AgencySettingsSummary,
+	useCanRenderAgencySettingsSummary,
+} from '../settings-agency/summary';
 import CachingSettingsSummary from '../settings-caching/summary';
 import DatabaseSettingsSummary from '../settings-database/summary';
-import DefensiveModeSettingsSummary from '../settings-defensive-mode/summary';
-import HundredYearPlanSettingsSummary from '../settings-hundred-year-plan/summary';
+import {
+	default as DefensiveModeSettingsSummary,
+	useCanRenderSettingsDefensiveModeSummary,
+} from '../settings-defensive-mode/summary';
+import {
+	default as HundredYearPlanSettingsSummary,
+	useCanRenderHundredYearPlanSettingsSummary,
+} from '../settings-hundred-year-plan/summary';
 import PHPSettingsSummary from '../settings-php/summary';
-import PrimaryDataCenterSettingsSummary from '../settings-primary-data-center/summary';
+import {
+	default as PrimaryDataCenterSettingsSummary,
+	useCanRenderSettingsPrimaryDataCenterSummary,
+} from '../settings-primary-data-center/summary';
 import SiteVisibilitySettingsSummary from '../settings-site-visibility/summary';
 import StaticFile404SettingsSummary from '../settings-static-file-404/summary';
-import SubscriptionGiftingSettingsSummary from '../settings-subscription-gifting/summary';
-import WordPressSettingsSummary from '../settings-wordpress/summary';
+import {
+	default as SubscriptionGiftingSettingsSummary,
+	useCanRenderSubscriptionGiftingSettingsSummary,
+} from '../settings-subscription-gifting/summary';
+import {
+	default as WordPressSettingsSummary,
+	useCanRenderWordPressSettingsSummary,
+} from '../settings-wordpress/summary';
 import DangerZone from './danger-zone';
 import SiteActions from './site-actions';
+import type { Site, SiteSettings } from '../../data/types';
 
 function InnerSiteSettings( { site, settings }: { site: Site; settings: SiteSettings } ) {
+	const {
+		show: showSubscriptionGiftingSettingsSummary,
+		props: subscriptionGiftingSettingsSummaryProps,
+	} = useCanRenderSubscriptionGiftingSettingsSummary( { site, settings } );
+
+	const { show: showHundredYearPlanSettingsSummary, props: hundredYearPlanSettingsSummaryProps } =
+		useCanRenderHundredYearPlanSettingsSummary( { site, settings } );
+
+	const { show: showWordPressSettingsSummary, props: wordPressSettingsSummaryProps } =
+		useCanRenderWordPressSettingsSummary( { site } );
+
+	const { show: showAgencySettingsSummary, props: agencySettingsSummaryProps } =
+		useCanRenderAgencySettingsSummary( { site } );
+
+	const {
+		show: showPrimaryDataCenterSettingsSummary,
+		props: primaryDataCenterSettingsSummaryProps,
+	} = useCanRenderSettingsPrimaryDataCenterSummary( { site } );
+
+	const { show: showDefensiveModeSettingsSummary, props: defensiveModeSettingsSummaryProps } =
+		useCanRenderSettingsDefensiveModeSummary( { site } );
+
 	return (
 		<PageLayout size="small" header={ <PageHeader title={ __( 'Settings' ) } /> }>
 			<SectionHeader title={ __( 'General' ) } />
 			<SummaryButtonList>
 				<SiteVisibilitySettingsSummary site={ site } />
-				<SubscriptionGiftingSettingsSummary site={ site } settings={ settings } />
-				<HundredYearPlanSettingsSummary site={ site } settings={ settings } />
+				{ showSubscriptionGiftingSettingsSummary ? (
+					<SubscriptionGiftingSettingsSummary { ...subscriptionGiftingSettingsSummaryProps } />
+				) : null }
+				{ showHundredYearPlanSettingsSummary ? (
+					<HundredYearPlanSettingsSummary { ...hundredYearPlanSettingsSummaryProps } />
+				) : null }
 			</SummaryButtonList>
 			<SectionHeader title={ __( 'Server' ) } />
 			<SummaryButtonList>
 				<DatabaseSettingsSummary site={ site } />
-				<WordPressSettingsSummary site={ site } />
+				{ showWordPressSettingsSummary ? (
+					<WordPressSettingsSummary { ...wordPressSettingsSummaryProps } />
+				) : null }
 				<PHPSettingsSummary site={ site } />
-				<AgencySettingsSummary site={ site } />
-				<PrimaryDataCenterSettingsSummary site={ site } />
+				{ showAgencySettingsSummary ? (
+					<AgencySettingsSummary { ...agencySettingsSummaryProps } />
+				) : null }
+				{ showPrimaryDataCenterSettingsSummary ? (
+					<PrimaryDataCenterSettingsSummary { ...primaryDataCenterSettingsSummaryProps } />
+				) : null }
 				<StaticFile404SettingsSummary site={ site } />
 				<CachingSettingsSummary site={ site } />
-				<DefensiveModeSettingsSummary site={ site } />
+				{ showDefensiveModeSettingsSummary ? (
+					<DefensiveModeSettingsSummary { ...defensiveModeSettingsSummaryProps } />
+				) : null }
 			</SummaryButtonList>
 			<SiteActions site={ site } />
 			<DangerZone site={ site } />

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -19,14 +19,7 @@ import WordPressSettingsSummary from '../settings-wordpress/summary';
 import DangerZone from './danger-zone';
 import SiteActions from './site-actions';
 
-export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
-	const { data: site } = useQuery( siteQuery( siteSlug ) );
-	const { data: settings } = useQuery( siteSettingsQuery( siteSlug ) );
-
-	if ( ! site || ! settings ) {
-		return null;
-	}
-
+function InnerSiteSettings( { site, settings }: { site: Site; settings: SiteSettings } ) {
 	return (
 		<PageLayout size="small" header={ <PageHeader title={ __( 'Settings' ) } /> }>
 			<SectionHeader title={ __( 'General' ) } />
@@ -50,4 +43,15 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 			<DangerZone site={ site } />
 		</PageLayout>
 	);
+}
+
+export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
+	const { data: site } = useQuery( siteQuery( siteSlug ) );
+	const { data: settings } = useQuery( siteSettingsQuery( siteSlug ) );
+
+	if ( ! site || ! settings ) {
+		return null;
+	}
+
+	return <InnerSiteSettings site={ site } settings={ settings } />;
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to #103876
Fixes DOTCOM-13409

## Proposed Changes

Refactor code for the Hosting Dashboard's site settings page to avoid rendering empty `<li>` elements when using `SummaryButtonList`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

`SummaryButtonList` expects to receive valid `ReactElement` children, and wraps them in a `<li>` — but if a `ReactElement` internally doesn't render any HTML markup, it will cause `SummaryButtonList` to render an empty `<li>`.

This PR refactors the logic for children of `SummaryButtonList` in order to render `null` instead of a `ReactElement`, and therefore avoid empty `<li>` elements in the DOM.

See #103876 for more context.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Navigate to `/v2/sites/[FREE_SITE_ID].wordpress.com/settings` and observe the "General" and "Server" sections — the last item should have a double bottom border on `trunk`, but that should be fixed in this PR.

| Before (trunk) | After (this PR) |
|---|---|
| ![Screenshot 2025-06-02 at 10 58 14](https://github.com/user-attachments/assets/c93f3896-1889-4dc9-bb15-9066aaef4c89) | ![Screenshot 2025-06-02 at 10 59 17](https://github.com/user-attachments/assets/61f0f669-1009-443b-bd87-46f9b1a14f6c) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
