### PR TITLE
Components: export `DateCalendar` and `DateRangeCalendar` components

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - `CoreBadge`: Fork from `@wordpress/components` and convert styles to CSS module. Static class names are no longer available ([#103568](https://github.com/Automattic/wp-calypso/pull/103568)).
 
+### New components
+
+- Add new `DateCalendar` and `DateRangeCalendar` components ([#103921](https://github.com/Automattic/wp-calypso/pull/103921)).
+
 ### Enhancements
 
 - Add `BigSkyLogo.Mark` component ([#103612](https://github.com/Automattic/wp-calypso/pull/103612)).

--- a/packages/components/src/calendar/date-calendar/README.md
+++ b/packages/components/src/calendar/date-calendar/README.md
@@ -160,6 +160,20 @@ Event fired when the user navigates between months.
 
 The time zone (IANA or UTC offset) to use in the calendar. See [Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for possible values.
 
+When working with time zones, use the `TZDate` object exported by this package instead of the native `Date` object.
+
+```tsx
+import { DateCalendar, TZDate } from '@automattic/components';
+
+export function WithTimeZone() {
+	const timeZone = 'America/New_York';
+	const [ selected, setSelected ] = useState< Date | undefined >(
+		new TZDate( 2024, 12, 10, timeZone ) // Use `TZDate` instead of `Date`
+	);
+	return <DateCalendar timeZone={ timeZone } selected={ selected } onSelect={ setSelected } />;
+}
+```
+
 ### `role`
 
 - Type: `'application' | 'dialog' | undefined`

--- a/packages/components/src/calendar/date-calendar/index.stories.tsx
+++ b/packages/components/src/calendar/date-calendar/index.stories.tsx
@@ -164,6 +164,9 @@ export const WithSelectedDateAndMonth: Story = {
 	},
 };
 
+/**
+ * When working with time zones, use the `TZDate` object exported by this package instead of the native `Date` object.
+ */
 export const WithTimeZone: Story = {
 	render: function DateCalendarWithTimeZone( args ) {
 		const [ selected, setSelected ] = useState< TZDate | null >( null );
@@ -194,7 +197,7 @@ export const WithTimeZone: Story = {
 
 				<p>
 					Calendar set to { args.timeZone ?? 'current' } timezone, disabling selection for all dates
-					before today, and starting with a default date of 1 week from today`
+					before today, and starting with a default date of 1 week from today.
 				</p>
 			</>
 		);

--- a/packages/components/src/calendar/date-range-calendar/README.md
+++ b/packages/components/src/calendar/date-range-calendar/README.md
@@ -196,6 +196,21 @@ Event fired when the user navigates between months.
 
 The time zone (IANA or UTC offset) to use in the calendar. See [Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for possible values.
 
+When working with time zones, use the `TZDate` object exported by this package instead of the native `Date` object.
+
+```tsx
+import { DateRangeCalendar, TZDate } from '@automattic/components';
+
+export function WithTimeZone() {
+	const timeZone = 'America/New_York';
+	const [ selected, setSelected ] = useState< Date | undefined >( {
+		from: new TZDate( 2024, 12, 10, timeZone ), // Use `TZDate` instead of `Date`
+		to: new TZDate( 2024, 12, 8, timeZone ), // Use `TZDate` instead of `Date`
+	} );
+	return <DateRangeCalendar timeZone={ timeZone } selected={ selected } onSelect={ setSelected } />;
+}
+```
+
 ### `role`
 
 - Type: `'application' | 'dialog' | undefined`

--- a/packages/components/src/calendar/date-range-calendar/index.stories.tsx
+++ b/packages/components/src/calendar/date-range-calendar/index.stories.tsx
@@ -165,6 +165,9 @@ export const WithSelectedRangeAndMonth: Story = {
 	},
 };
 
+/**
+ * When working with time zones, use the `TZDate` object exported by this package instead of the native `Date` object.
+ */
 export const WithTimeZone: Story = {
 	render: function DateCalendarWithTimeZone( args ) {
 		const [ range, setRange ] = useState< typeof args.selected | null >( null );
@@ -203,7 +206,8 @@ export const WithTimeZone: Story = {
 				/>
 				<p>
 					Calendar set to { args.timeZone ?? 'current' } timezone, disabling selection for all dates
-					before today, and starting with a default date of 1 week from today`
+					before today, and starting with a default date range of 1 week from today to 2 weeks from
+					today.
 				</p>
 			</>
 		);

--- a/packages/components/src/calendar/types.ts
+++ b/packages/components/src/calendar/types.ts
@@ -275,6 +275,24 @@ export interface BaseProps
 	 * [Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
 	 * for the possible values.
 	 *
+	 * When working with time zones, use the `TZDate` object exported by this
+	 * package instead of the native `Date` object.
+	 * @example
+	 *   import { DateCalendar, TZDate } from "@automattic/components";
+	 *
+	 *   export function WithTimeZone() {
+	 *     const timeZone = "America/New_York";
+	 *     const [ selected, setSelected ] = useState< Date | undefined >(
+	 *       new TZDate( 2024, 12, 10, timeZone ) // Use `TZDate` instead of `Date`
+	 *     );
+	 *     return (
+	 *       <DateCalendar
+	 *         timeZone={ timeZone }
+	 *         selected={ selected }
+	 *         onSelect={ setSelected }
+	 *     />
+	 *   );
+	 * }
 	 */
 	timeZone?: string;
 	/**

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -60,6 +60,7 @@ export { default as SummaryButton } from './summary-button';
 export { CoreBadge } from './core-badge';
 export { default as Menu } from './menu';
 export { Tabs } from './tabs';
+export { DateCalendar, DateRangeCalendar, TZDate } from './calendar';
 
 // Logos
 export { JetpackLogo } from './logos/jetpack-logo';


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes DS-233

## Proposed Changes

* Export `DateCalendar` and `DateRangeCalendar` from the `@automattic/components` package

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Releasing them to package consumers.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try importing the components from another package in the repo

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
