### PR TITLE
Update Playground client

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground.ts
@@ -49,7 +49,7 @@ export async function initializeWordPressPlayground(
 
 		const client = await startPlaygroundWeb( {
 			iframe,
-			remoteUrl: 'https://wordpress-playground.atomicsites.blog/remote.html',
+			remoteUrl: 'https://playground.wordpress.net/remote.html',
 			blueprint: await getBlueprint( isWordPressInstalled, recommendedPhpVersion ),
 			shouldInstallWordPress: ! isWordPressInstalled,
 			mounts: isWordPressInstalled ? [ mountDescriptor ] : [],

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/resolve-blueprint-from-url.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/resolve-blueprint-from-url.ts
@@ -176,7 +176,7 @@ export async function resolveBlueprintFromURL( url: URL ) {
 
 	if ( query.has( 'core-pr' ) ) {
 		const prNumber = query.get( 'core-pr' );
-		blueprint.preferredVersions!.wp = `https://wordpress-playground.atomicsites.blog/plugin-proxy.php?org=WordPress&repo=wordpress-develop&workflow=Test%20Build%20Processes&artifact=wordpress-build-${ prNumber }&pr=${ prNumber }`;
+		blueprint.preferredVersions!.wp = `https://playground.wordpress.net/plugin-proxy.php?org=WordPress&repo=wordpress-develop&workflow=Test%20Build%20Processes&artifact=wordpress-build-${ prNumber }&pr=${ prNumber }`;
 	}
 
 	if ( query.has( 'gutenberg-pr' ) ) {

--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
 		"@wordpress/rich-text": "^7.23.0",
 		"@wordpress/url": "^4.23.0",
 		"@wordpress/viewport": "^6.23.0",
-		"@wp-playground/client": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.37/@wp-playground-client-1.0.37.tar.gz",
+		"@wp-playground/client": "^1.1.0",
 		"animate.css": "^4.1.1",
 		"browserslist": "^4.24.5",
 		"calypso": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7051,133 +7051,134 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@php-wasm/fs-journal@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-fs-journal-1.0.37.tar.gz":
-  version: 1.0.37
-  resolution: "@php-wasm/fs-journal@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-fs-journal-1.0.37.tar.gz"
+"@php-wasm/fs-journal@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@php-wasm/fs-journal@npm:1.1.0"
   dependencies:
-    "@php-wasm/logger": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-logger-1.0.37.tar.gz"
-    "@php-wasm/node": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-node-1.0.37.tar.gz"
-    "@php-wasm/universal": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-universal-1.0.37.tar.gz"
-    "@php-wasm/util": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-util-1.0.37.tar.gz"
+    "@php-wasm/logger": "npm:1.1.0"
+    "@php-wasm/node": "npm:1.1.0"
+    "@php-wasm/universal": "npm:1.1.0"
+    "@php-wasm/util": "npm:1.1.0"
     comlink: "npm:^4.4.1"
     express: "npm:4.21.2"
     ini: "npm:4.1.2"
     wasm-feature-detect: "npm:1.8.0"
     ws: "npm:8.18.1"
     yargs: "npm:17.7.2"
-  checksum: 732d84071bd1e26623feb2a2f8e9e6fe7d1e0ca75636bdeb1efb379fce7069a5b99047b5b436c1b7e9cae996790e0bb95106a90947c6175787b96d0d131b68a9
+  checksum: f7b8127ea6089b8b69a396e4d2e68ed28c5ba8a0915ce0a451d8e12949cc35bbe9572c69c499b7a31f5eeceb35bf8b92f46c3d7ef4f07549e9292b7c41fe75d2
   languageName: node
   linkType: hard
 
-"@php-wasm/logger@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-logger-1.0.37.tar.gz":
-  version: 1.0.37
-  resolution: "@php-wasm/logger@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-logger-1.0.37.tar.gz"
+"@php-wasm/logger@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@php-wasm/logger@npm:1.1.0"
   dependencies:
-    "@php-wasm/node-polyfills": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-node-polyfills-1.0.37.tar.gz"
-  checksum: fca4aa9a3bc1777a10748f5685e98e01f40ce3f590ee4d165ae53487c7d8e68bf8bd3696c219b3bf1fee5d111f0f5aee27775b2214e77d1c8da25952166a3bc2
+    "@php-wasm/node-polyfills": "npm:1.1.0"
+  checksum: 70d78479c35fc99824d13a26d0d0caa663b408d5157bed19aec8eda6749ac9aeff8c4c73aec74709b1a2b6819c647eebbc626c3202308d25aa77cd694c023ab1
   languageName: node
   linkType: hard
 
-"@php-wasm/node-polyfills@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-node-polyfills-1.0.37.tar.gz":
-  version: 1.0.37
-  resolution: "@php-wasm/node-polyfills@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-node-polyfills-1.0.37.tar.gz"
-  checksum: 8a5414dd0e47a372e2abd3a5aa6e95d582ff690630cfc068fc31237d9d6b11b07830a1869e65df90e95926cc49b0a5a5a53709721fc0be5eb7bf17e7cfffcfd8
+"@php-wasm/node-polyfills@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@php-wasm/node-polyfills@npm:1.1.0"
+  checksum: 1c202f2787e5bdf8e99a59523d66bde943bde8ecaa6856d8b4165e13284e7db26d21472f2154c45385468822379c540e5233957ab0329966c32052d078dfcce7
   languageName: node
   linkType: hard
 
-"@php-wasm/node@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-node-1.0.37.tar.gz":
-  version: 1.0.37
-  resolution: "@php-wasm/node@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-node-1.0.37.tar.gz"
+"@php-wasm/node@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@php-wasm/node@npm:1.1.0"
   dependencies:
-    "@php-wasm/logger": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-logger-1.0.37.tar.gz"
-    "@php-wasm/node-polyfills": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-node-polyfills-1.0.37.tar.gz"
-    "@php-wasm/universal": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-universal-1.0.37.tar.gz"
-    "@php-wasm/util": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-util-1.0.37.tar.gz"
-    "@wp-playground/common": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@wp-playground-common-1.0.37.tar.gz"
+    "@php-wasm/logger": "npm:1.1.0"
+    "@php-wasm/node-polyfills": "npm:1.1.0"
+    "@php-wasm/universal": "npm:1.1.0"
+    "@php-wasm/util": "npm:1.1.0"
+    "@wp-playground/common": "npm:1.1.0"
+    "@wp-playground/wordpress": "npm:1.1.0"
     comlink: "npm:^4.4.1"
     express: "npm:4.21.2"
     ini: "npm:4.1.2"
     wasm-feature-detect: "npm:1.8.0"
     ws: "npm:8.18.1"
     yargs: "npm:17.7.2"
-  checksum: ae39a5cd34dc10bb4f5f38f6d5912fddfdb0492b5fc56779471951efe4c08e64b4def8fcb2adbdbad7df0f6218057e6fa88df3eb33d147282305cddeaeec13fe
+  checksum: b0ed60723301fde330f03473be31b5b481b21d52f330e7254f5f7e2b69e307c9789455dba324381fab1e32cfb2dfe2fcb9e04d72eccb042d846e172bf1102791
   languageName: node
   linkType: hard
 
-"@php-wasm/progress@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-progress-1.0.37.tar.gz":
-  version: 1.0.37
-  resolution: "@php-wasm/progress@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-progress-1.0.37.tar.gz"
+"@php-wasm/progress@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@php-wasm/progress@npm:1.1.0"
   dependencies:
-    "@php-wasm/logger": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-logger-1.0.37.tar.gz"
-    "@php-wasm/node-polyfills": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-node-polyfills-1.0.37.tar.gz"
-  checksum: ca5b7bbc5de1972b3b48202ebdb11ef9532ebac987e6be9e7bd7bf8c4f2e99d8acda8b1f5ba0c3f0a7b1b0efcee955b3faca21bd1cc10cfd22079c343804bf51
+    "@php-wasm/logger": "npm:1.1.0"
+    "@php-wasm/node-polyfills": "npm:1.1.0"
+  checksum: afba266575fc2d8ab59c83761cea53cb711d51fd2ca68db7a8f6547401890c1b6649052d49b9e0fd9d302f07b10618297f6c5ed4e09c31cf99cc9eb2d5d962eb
   languageName: node
   linkType: hard
 
-"@php-wasm/scopes@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-scopes-1.0.37.tar.gz":
-  version: 1.0.37
-  resolution: "@php-wasm/scopes@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-scopes-1.0.37.tar.gz"
-  checksum: 68dfc2600505a5ce8ddc437ae17a5ba60e022cd30fdd9dfa8d16ffde79e2e3dfa035d060c837e4eb9ea034a37299f18178eac812dd9a1e5b09345a306944b298
+"@php-wasm/scopes@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@php-wasm/scopes@npm:1.1.0"
+  checksum: af2d24db010ad6e460e4a7de73a7233b7ad2eb89de4df0a15d78b8945c57bb28344c925acde4cdee1c73fe8fbb0369030473f4ee979261f0a7bb21e1681a3166
   languageName: node
   linkType: hard
 
-"@php-wasm/stream-compression@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-stream-compression-1.0.37.tar.gz":
-  version: 1.0.37
-  resolution: "@php-wasm/stream-compression@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-stream-compression-1.0.37.tar.gz"
+"@php-wasm/stream-compression@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@php-wasm/stream-compression@npm:1.1.0"
   dependencies:
-    "@php-wasm/node-polyfills": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-node-polyfills-1.0.37.tar.gz"
-    "@php-wasm/util": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-util-1.0.37.tar.gz"
-  checksum: 2e751f9527ea9cb56ed763c381f98370d652c9582ab2103bb5446a3bc86a6b56245822e844f6b16680929d81983f9199756967b981490dcb5bde7c4ebc7b1f3c
+    "@php-wasm/node-polyfills": "npm:1.1.0"
+    "@php-wasm/util": "npm:1.1.0"
+  checksum: 1f75f4aeaaaa6968defc599e8fe626ded45223b0d5a449eda49022a7f17f7249e08995c0781e55266133f47254bda14a911f33933e6c59b35fe522706a2f47c0
   languageName: node
   linkType: hard
 
-"@php-wasm/universal@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-universal-1.0.37.tar.gz":
-  version: 1.0.37
-  resolution: "@php-wasm/universal@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-universal-1.0.37.tar.gz"
+"@php-wasm/universal@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@php-wasm/universal@npm:1.1.0"
   dependencies:
-    "@php-wasm/logger": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-logger-1.0.37.tar.gz"
-    "@php-wasm/node-polyfills": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-node-polyfills-1.0.37.tar.gz"
-    "@php-wasm/progress": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-progress-1.0.37.tar.gz"
-    "@php-wasm/stream-compression": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-stream-compression-1.0.37.tar.gz"
-    "@php-wasm/util": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-util-1.0.37.tar.gz"
+    "@php-wasm/logger": "npm:1.1.0"
+    "@php-wasm/node-polyfills": "npm:1.1.0"
+    "@php-wasm/progress": "npm:1.1.0"
+    "@php-wasm/stream-compression": "npm:1.1.0"
+    "@php-wasm/util": "npm:1.1.0"
     comlink: "npm:^4.4.1"
     ini: "npm:4.1.2"
-  checksum: 8ded7abde50de6b4e9d767628acb22810703faa3a9d5cfc6430f3bd3e4385f3bf96bab7f8d9141d3040b6dcb7d2964787214c2238bc25d8b9061d506d66e65fa
+  checksum: 72b0d7fc285a3da64a0bb442b280e8d270aed239b9d4dac280c806d42099e017a8023006bcf993923c4108e3568447ceb82ce78b887dee99108276a3075d97df
   languageName: node
   linkType: hard
 
-"@php-wasm/util@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-util-1.0.37.tar.gz":
-  version: 1.0.37
-  resolution: "@php-wasm/util@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-util-1.0.37.tar.gz"
-  checksum: 71382e9cc3bae9f448d58625943ff61e46a31e26f97d03a806ee8d282c15b846788dad591a9c27d1afa284bc6c191c6c10872658ab06d1cf8c76fa0caaf1db76
+"@php-wasm/util@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@php-wasm/util@npm:1.1.0"
+  checksum: b0419f97d9660dd2c5bb56b0d4a51d6cc8730c0dd165bcaca019ddb7f5ff8e1d774c9d3568bb4537135ec5e6443bea4f233f003b3495e2bac60e39033a1b67b0
   languageName: node
   linkType: hard
 
-"@php-wasm/web-service-worker@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-web-service-worker-1.0.37.tar.gz":
-  version: 1.0.37
-  resolution: "@php-wasm/web-service-worker@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-web-service-worker-1.0.37.tar.gz"
+"@php-wasm/web-service-worker@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@php-wasm/web-service-worker@npm:1.1.0"
   dependencies:
-    "@php-wasm/scopes": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-scopes-1.0.37.tar.gz"
-  checksum: 0de6608b75ef765702cc15ac7dea46ca7e7713be3c09dc402e9a9f64cf3becba4e3af17beef8fabc8f1b93d60fcf3a60401e67e8d028b136c04680dec63878bf
+    "@php-wasm/scopes": "npm:1.1.0"
+  checksum: 5d7dbfcd3443dac493dce7a54337ca70e2dccbc32d62ecff1f37237f4c84cfa2b65b80ac191de5655861d7fdc1fc9ba7a6a22fe1b9e582e141dd5464420c109d
   languageName: node
   linkType: hard
 
-"@php-wasm/web@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-web-1.0.37.tar.gz":
-  version: 1.0.37
-  resolution: "@php-wasm/web@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-web-1.0.37.tar.gz"
+"@php-wasm/web@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@php-wasm/web@npm:1.1.0"
   dependencies:
-    "@php-wasm/fs-journal": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-fs-journal-1.0.37.tar.gz"
-    "@php-wasm/logger": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-logger-1.0.37.tar.gz"
-    "@php-wasm/universal": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-universal-1.0.37.tar.gz"
-    "@php-wasm/util": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-util-1.0.37.tar.gz"
-    "@php-wasm/web-service-worker": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-web-service-worker-1.0.37.tar.gz"
+    "@php-wasm/fs-journal": "npm:1.1.0"
+    "@php-wasm/logger": "npm:1.1.0"
+    "@php-wasm/universal": "npm:1.1.0"
+    "@php-wasm/util": "npm:1.1.0"
+    "@php-wasm/web-service-worker": "npm:1.1.0"
     comlink: "npm:^4.4.1"
     express: "npm:4.21.2"
     ini: "npm:4.1.2"
     wasm-feature-detect: "npm:1.8.0"
     ws: "npm:8.18.1"
     yargs: "npm:17.7.2"
-  checksum: b2512fa2bf8ef2e4b5c549b21157dc43438201465b9c14e366813ad4650efc16643eba5829e19200cf8cc7ac446f435804bbd175fdee1a9e2c5ef13b1190ba28
+  checksum: 6455c4ed9d265e6def59309346531f451ff5d8b876adbf526f97c5778b5544b98e01e39549698a15980f90834fd841685937c44cf34dfc2f2b49a42f4e71c96d
   languageName: node
   linkType: hard
 
@@ -9193,9 +9194,9 @@ __metadata:
   linkType: hard
 
 "@types/aws-lambda@npm:^8.10.83":
-  version: 8.10.148
-  resolution: "@types/aws-lambda@npm:8.10.148"
-  checksum: b2cf5c991263a9276490757ec8f78fa42e41ac5029588d87f6b01f03321ee97eeaed8d66d259165d941717242a84e5b67e5d3a8872e9642a47645c6610f85287
+  version: 8.10.149
+  resolution: "@types/aws-lambda@npm:8.10.149"
+  checksum: 9ef41214a1b69fa30d89cab575429793f1ccc49cfe3a7aa75228aef31a202bb6d2c306a5b33def61ef29e0d0a1a324412bf6a4fa5a615e61117685584a394047
   languageName: node
   linkType: hard
 
@@ -12588,21 +12589,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wp-playground/blueprints@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@wp-playground-blueprints-1.0.37.tar.gz":
-  version: 1.0.37
-  resolution: "@wp-playground/blueprints@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@wp-playground-blueprints-1.0.37.tar.gz"
+"@wp-playground/blueprints@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@wp-playground/blueprints@npm:1.1.0"
   dependencies:
-    "@php-wasm/logger": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-logger-1.0.37.tar.gz"
-    "@php-wasm/node": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-node-1.0.37.tar.gz"
-    "@php-wasm/node-polyfills": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-node-polyfills-1.0.37.tar.gz"
-    "@php-wasm/progress": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-progress-1.0.37.tar.gz"
-    "@php-wasm/stream-compression": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-stream-compression-1.0.37.tar.gz"
-    "@php-wasm/universal": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-universal-1.0.37.tar.gz"
-    "@php-wasm/util": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-util-1.0.37.tar.gz"
-    "@php-wasm/web": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-web-1.0.37.tar.gz"
-    "@wp-playground/common": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@wp-playground-common-1.0.37.tar.gz"
-    "@wp-playground/storage": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@wp-playground-storage-1.0.37.tar.gz"
-    "@wp-playground/wordpress": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@wp-playground-wordpress-1.0.37.tar.gz"
+    "@php-wasm/logger": "npm:1.1.0"
+    "@php-wasm/node": "npm:1.1.0"
+    "@php-wasm/node-polyfills": "npm:1.1.0"
+    "@php-wasm/progress": "npm:1.1.0"
+    "@php-wasm/stream-compression": "npm:1.1.0"
+    "@php-wasm/universal": "npm:1.1.0"
+    "@php-wasm/util": "npm:1.1.0"
+    "@php-wasm/web": "npm:1.1.0"
+    "@wp-playground/common": "npm:1.1.0"
+    "@wp-playground/storage": "npm:1.1.0"
+    "@wp-playground/wordpress": "npm:1.1.0"
     "@zip.js/zip.js": "npm:2.7.57"
     ajv: "npm:8.12.0"
     async-lock: "npm:1.4.1"
@@ -12610,6 +12611,7 @@ __metadata:
     comlink: "npm:^4.4.1"
     crc-32: "npm:1.2.2"
     diff3: "npm:0.0.4"
+    express: "npm:4.21.2"
     ignore: "npm:5.3.2"
     ini: "npm:4.1.2"
     minimisted: "npm:2.0.1"
@@ -12620,21 +12622,23 @@ __metadata:
     sha.js: "npm:2.4.11"
     simple-get: "npm:4.0.1"
     wasm-feature-detect: "npm:1.8.0"
-  checksum: 7e5ec82a458a4e48de6a13ec34fc323a61894bd19424485f99b7c70c1b837725e69ce00f171248fbe139a1281e04614ea7e84f93f02aff80bb98de408889ef2f
+    ws: "npm:8.18.1"
+    yargs: "npm:17.7.2"
+  checksum: b939eafef118691e6126a6564d07c523a01118f52f82f23dd9f8cb0a30dc43458600e5494c5be4a5173c4fd52842ef3483da3182d416f9513144fb576e05398b
   languageName: node
   linkType: hard
 
-"@wp-playground/client@https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.37/@wp-playground-client-1.0.37.tar.gz":
-  version: 1.0.37
-  resolution: "@wp-playground/client@https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.37/@wp-playground-client-1.0.37.tar.gz"
+"@wp-playground/client@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@wp-playground/client@npm:1.1.0"
   dependencies:
-    "@php-wasm/logger": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-logger-1.0.37.tar.gz"
-    "@php-wasm/progress": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-progress-1.0.37.tar.gz"
-    "@php-wasm/universal": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-universal-1.0.37.tar.gz"
-    "@php-wasm/util": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-util-1.0.37.tar.gz"
-    "@php-wasm/web": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-web-1.0.37.tar.gz"
-    "@wp-playground/blueprints": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@wp-playground-blueprints-1.0.37.tar.gz"
-    "@wp-playground/remote": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@wp-playground-remote-1.0.37.tar.gz"
+    "@php-wasm/logger": "npm:1.1.0"
+    "@php-wasm/progress": "npm:1.1.0"
+    "@php-wasm/universal": "npm:1.1.0"
+    "@php-wasm/util": "npm:1.1.0"
+    "@php-wasm/web": "npm:1.1.0"
+    "@wp-playground/blueprints": "npm:1.1.0"
+    "@wp-playground/remote": "npm:1.1.0"
     "@zip.js/zip.js": "npm:2.7.57"
     ajv: "npm:8.12.0"
     async-lock: "npm:1.4.1"
@@ -12642,6 +12646,7 @@ __metadata:
     comlink: "npm:^4.4.1"
     crc-32: "npm:1.2.2"
     diff3: "npm:0.0.4"
+    express: "npm:4.21.2"
     ignore: "npm:5.3.2"
     ini: "npm:4.1.2"
     minimisted: "npm:2.0.1"
@@ -12652,37 +12657,39 @@ __metadata:
     sha.js: "npm:2.4.11"
     simple-get: "npm:4.0.1"
     wasm-feature-detect: "npm:1.8.0"
-  checksum: 45d76a0788a283071ac3dbe8fc6ae6208a5d73189cb6c92dcff5ab0d9985ac661d48d8fc5bce213761ac6ddc7c8780c53b029d8a8f72ee1dc8db17ce16aecb02
+    ws: "npm:8.18.1"
+    yargs: "npm:17.7.2"
+  checksum: dbb5b8e2381172e36aa94d1408a154f39f6610f6c1d7fd945572eb0d8b0b730acf2d067467c34af259b52397fc1fe2f5aab409a00a068149b8a66ecdbd264371
   languageName: node
   linkType: hard
 
-"@wp-playground/common@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@wp-playground-common-1.0.37.tar.gz":
-  version: 1.0.37
-  resolution: "@wp-playground/common@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@wp-playground-common-1.0.37.tar.gz"
+"@wp-playground/common@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@wp-playground/common@npm:1.1.0"
   dependencies:
-    "@php-wasm/universal": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-universal-1.0.37.tar.gz"
-    "@php-wasm/util": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-util-1.0.37.tar.gz"
+    "@php-wasm/universal": "npm:1.1.0"
+    "@php-wasm/util": "npm:1.1.0"
     comlink: "npm:^4.4.1"
     ini: "npm:4.1.2"
-  checksum: 9afcea365fb649ad3993fad55d8f5cf5ae6de7dedf229e647aa74cbec6eec8bb1ded9d2e3bd4977a230cbe9f0f476f040a5bb3dfe190b3b4880885a3965a423e
+  checksum: c827ec1cbd079da3ed2992e149470ba0cd0e9118a8f5a321bba279afa519c22786eaa2f136fa01172c37cceba89c2a50b31a234d9d5acdee40f602df5c476af5
   languageName: node
   linkType: hard
 
-"@wp-playground/remote@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@wp-playground-remote-1.0.37.tar.gz":
-  version: 1.0.37
-  resolution: "@wp-playground/remote@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@wp-playground-remote-1.0.37.tar.gz"
-  checksum: 3a5c0d6148c395eb59c4cc714e875e4523c73d7c21ccd00a67b5f838492ca39d8c4ac3c4556e10031d824de2d585470bbfadafa7e861d8f9a280f785c234329b
+"@wp-playground/remote@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@wp-playground/remote@npm:1.1.0"
+  checksum: bb2c08650c831e2f2ceb1f1c8db00bd2c37f31d84530431a879d6151cdbeda06e048380e7fc342e504714ad0cbe459de20c94fe231a694ee13b73b884dc7bf74
   languageName: node
   linkType: hard
 
-"@wp-playground/storage@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@wp-playground-storage-1.0.37.tar.gz":
-  version: 1.0.37
-  resolution: "@wp-playground/storage@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@wp-playground-storage-1.0.37.tar.gz"
+"@wp-playground/storage@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@wp-playground/storage@npm:1.1.0"
   dependencies:
-    "@php-wasm/stream-compression": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-stream-compression-1.0.37.tar.gz"
-    "@php-wasm/universal": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-universal-1.0.37.tar.gz"
-    "@php-wasm/util": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-util-1.0.37.tar.gz"
-    "@php-wasm/web": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-web-1.0.37.tar.gz"
+    "@php-wasm/stream-compression": "npm:1.1.0"
+    "@php-wasm/universal": "npm:1.1.0"
+    "@php-wasm/util": "npm:1.1.0"
+    "@php-wasm/web": "npm:1.1.0"
     "@zip.js/zip.js": "npm:2.7.57"
     async-lock: "npm:^1.4.1"
     clean-git-ref: "npm:^2.0.1"
@@ -12702,26 +12709,26 @@ __metadata:
     wasm-feature-detect: "npm:1.8.0"
     ws: "npm:8.18.1"
     yargs: "npm:17.7.2"
-  checksum: d02ad986ed801aca3a87948597db7f816a4c52f588a8a6e743c5e3c9f404583e275ffc5d4ea3ca86812c59a7a313c5a4c8742c4a1a8aff08d6a8d86c46c3596f
+  checksum: 96057774e42337e17d9867cf3d6ce133875d9a1c074510c6dea5d8e4e1ab2e2a184430fcc21012b6a7801a95df3b6bd9775c012c8515a7c5a43c88fb302b4628
   languageName: node
   linkType: hard
 
-"@wp-playground/wordpress@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@wp-playground-wordpress-1.0.37.tar.gz":
-  version: 1.0.37
-  resolution: "@wp-playground/wordpress@https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@wp-playground-wordpress-1.0.37.tar.gz"
+"@wp-playground/wordpress@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@wp-playground/wordpress@npm:1.1.0"
   dependencies:
-    "@php-wasm/logger": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-logger-1.0.37.tar.gz"
-    "@php-wasm/node": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-node-1.0.37.tar.gz"
-    "@php-wasm/universal": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-universal-1.0.37.tar.gz"
-    "@php-wasm/util": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@php-wasm-util-1.0.37.tar.gz"
-    "@wp-playground/common": "https://wordpress-playground-packages.atomicsites.blog/packages/v1.0.37/@wp-playground-common-1.0.37.tar.gz"
+    "@php-wasm/logger": "npm:1.1.0"
+    "@php-wasm/node": "npm:1.1.0"
+    "@php-wasm/universal": "npm:1.1.0"
+    "@php-wasm/util": "npm:1.1.0"
+    "@wp-playground/common": "npm:1.1.0"
     comlink: "npm:^4.4.1"
     express: "npm:4.21.2"
     ini: "npm:4.1.2"
     wasm-feature-detect: "npm:1.8.0"
     ws: "npm:8.18.1"
     yargs: "npm:17.7.2"
-  checksum: 26c87622e158828acd7c6b3c4cf42a20056f02c4e7d0019a217e40053de6a270238c1af7255191e0afb9130d3877a480359a577845445ff8ee18bac2fd2fdc76
+  checksum: 9bb0bdd3b6f6ec45af0888f264f5f6d6d637a36a72919303946d257281ade259844559f972048b236c1f90c50e138776764284759beffaf003c961c95581122a
   languageName: node
   linkType: hard
 
@@ -14224,7 +14231,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer-equal-constant-time@npm:1.0.1":
+"buffer-equal-constant-time@npm:^1.0.1":
   version: 1.0.1
   resolution: "buffer-equal-constant-time@npm:1.0.1"
   checksum: fb2294e64d23c573d0dd1f1e7a466c3e978fe94a4e0f8183937912ca374619773bef8e2aceb854129d2efecbbc515bbd0cc78d2734a3e3031edb0888531bbc8e
@@ -24109,13 +24116,13 @@ __metadata:
   linkType: hard
 
 "jwa@npm:^1.4.1":
-  version: 1.4.1
-  resolution: "jwa@npm:1.4.1"
+  version: 1.4.2
+  resolution: "jwa@npm:1.4.2"
   dependencies:
-    buffer-equal-constant-time: "npm:1.0.1"
+    buffer-equal-constant-time: "npm:^1.0.1"
     ecdsa-sig-formatter: "npm:1.0.11"
     safe-buffer: "npm:^5.0.1"
-  checksum: 5c533540bf38702e73cf14765805a94027c66a0aa8b16bc3e89d8d905e61a4ce2791e87e21be97d1293a5ee9d4f3e5e47737e671768265ca4f25706db551d5e9
+  checksum: 210a544a42ca22203e8fc538835205155ba3af6a027753109f9258bdead33086bac3c25295af48ac1981f87f9c5f941bc8f70303670f54ea7dcaafb53993d92c
   languageName: node
   linkType: hard
 
@@ -37251,7 +37258,7 @@ __metadata:
     "@wordpress/stylelint-config": "npm:^23.15.0"
     "@wordpress/url": "npm:^4.23.0"
     "@wordpress/viewport": "npm:^6.23.0"
-    "@wp-playground/client": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.37/@wp-playground-client-1.0.37.tar.gz"
+    "@wp-playground/client": "npm:^1.1.0"
     animate.css: "npm:^4.1.1"
     babel-loader: "npm:^8.2.3"
     browserslist: "npm:^4.24.5"


### PR DESCRIPTION
## Proposed Changes

* Update Playground to the latest version
* Update Playground `iframe` base URL

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* https://github.com/WordPress/wordpress-playground/pull/2226

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit http://calypso.localhost:3000/setup/onboarding/playground and be sure the iframe is loading as well as the launch button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
