### PR TITLE
A4A: Implement the withOnboardingTour HOC.

### DIFF
--- a/client/a8c-for-agencies/components/hoc/with-onboarding-tour.tsx
+++ b/client/a8c-for-agencies/components/hoc/with-onboarding-tour.tsx
@@ -1,0 +1,63 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { ComponentType, useCallback, useEffect, useState } from 'react';
+import OnboardingTourModal from '../onboarding-tour-modal';
+
+export const ONBOARDING_TOUR_HASH = '#onboarding-tour';
+
+function useOnboardingTour() {
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	useEffect( () => {
+		const handleHashChange = () => {
+			const hash = window.location.hash;
+			if ( isEnabled( 'a4a-unified-onboarding-tour' ) && hash === ONBOARDING_TOUR_HASH ) {
+				setIsOpen( true );
+			}
+		};
+
+		// Check hash on mount
+		handleHashChange();
+
+		// Listen for hash changes
+		window.addEventListener( 'hashchange', handleHashChange );
+
+		return () => {
+			window.removeEventListener( 'hashchange', handleHashChange );
+		};
+	}, [] );
+
+	const onClose = useCallback( () => {
+		setIsOpen( false );
+		// Remove the hash from the URL
+		window.history.replaceState( '', '', window.location.pathname );
+	}, [] );
+
+	return {
+		isOpen,
+		onClose,
+	};
+}
+
+export function withOnboardingTour< T extends JSX.IntrinsicAttributes >(
+	WrappedComponent: ComponentType< T >
+) {
+	return function WithOnboardingTourWrapper( props: T ) {
+		const { isOpen, onClose } = useOnboardingTour();
+
+		return (
+			<>
+				<WrappedComponent { ...props } />
+				{ isOpen && (
+					<OnboardingTourModal onClose={ onClose }>
+						<OnboardingTourModal.Section id="1" title="Section 1">
+							<p>Section 1</p>
+						</OnboardingTourModal.Section>
+						<OnboardingTourModal.Section id="1" title="Section 2">
+							<p>Section 2</p>
+						</OnboardingTourModal.Section>
+					</OnboardingTourModal>
+				) }
+			</>
+		);
+	};
+}

--- a/client/a8c-for-agencies/components/onboarding-tour-modal/index.tsx
+++ b/client/a8c-for-agencies/components/onboarding-tour-modal/index.tsx
@@ -1,0 +1,24 @@
+import { Modal } from '@wordpress/components';
+import { Children, isValidElement, ReactNode } from 'react';
+import OnboardingTourModalSection from './section';
+
+interface OnboardingTourModalProps {
+	onClose: () => void;
+	children?: React.ReactNode;
+}
+
+function OnboardingTourModal( { onClose, children }: OnboardingTourModalProps ) {
+	const sections = Children.toArray( children ).filter(
+		( child: ReactNode ) => isValidElement( child ) && child.type === OnboardingTourModalSection
+	);
+
+	return (
+		<Modal className="onboarding-tour-modal" onRequestClose={ onClose } __experimentalHideHeader>
+			<div className="onboarding-tour-modal__main">{ sections }</div>
+		</Modal>
+	);
+}
+
+OnboardingTourModal.Section = OnboardingTourModalSection;
+
+export default OnboardingTourModal;

--- a/client/a8c-for-agencies/components/onboarding-tour-modal/section.tsx
+++ b/client/a8c-for-agencies/components/onboarding-tour-modal/section.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+
+export type OnboardingTourModalSectionProps = {
+	id: string;
+	title: string;
+	children: ReactNode;
+};
+
+export default function OnboardingTourModalSection( {
+	children,
+}: OnboardingTourModalSectionProps ) {
+	return <div className="onboarding-tour-modal__section">{ children }</div>;
+}

--- a/client/a8c-for-agencies/sections/overview/overview.tsx
+++ b/client/a8c-for-agencies/sections/overview/overview.tsx
@@ -1,6 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import A4AAgencyApprovalNotice from 'calypso/a8c-for-agencies/components/a4a-agency-approval-notice';
 import ContentSidebar from 'calypso/a8c-for-agencies/components/content-sidebar';
+import { withOnboardingTour } from 'calypso/a8c-for-agencies/components/hoc/with-onboarding-tour';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
 import PressableUsageLimitNotice from 'calypso/a8c-for-agencies/components/pressable-usage-limit-notice';
@@ -18,7 +19,7 @@ import OverviewSidebar from './sidebar';
 
 import './style.scss';
 
-export default function Overview() {
+function Overview() {
 	const translate = useTranslate();
 	const title = translate( 'Agency overview' );
 
@@ -45,3 +46,5 @@ export default function Overview() {
 		</Layout>
 	);
 }
+
+export default withOnboardingTour( Overview );

--- a/client/a8c-for-agencies/sections/overview/sidebar/relaunch-welcome-tour/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/relaunch-welcome-tour/index.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@wordpress/components';
 import { layout } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { ONBOARDING_TOUR_HASH } from 'calypso/a8c-for-agencies/components/hoc/with-onboarding-tour';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
@@ -12,7 +13,7 @@ export default function OverviewSidebarRelaunchWelcomeTour() {
 
 	const handleRelaunchWelcomeTour = () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_overview_relaunch_welcome_tour_click' ) );
-		// TODO: Implement the relaunch welcome tour
+		window.location.hash = ONBOARDING_TOUR_HASH;
 	};
 
 	return (


### PR DESCRIPTION
This PR introduces the `withOnboardingTour` higher-order component (HOC), facilitating the reuse of the new onboarding tour logic easily.


Depends on https://github.com/Automattic/wp-calypso/pull/103895
Closes https://github.com/Automattic/wp-calypso/pull/103895

## Proposed Changes

* Implement initial Reusable `OnboardingTourModal` component. The full implementation will be addressed in a separate PR.
* Implement the `withOnboardingTour` higher-order component (HOC) to facilitate reusable onboarding tour logic. This logic integrates the onboarding tour modal into the wrapped component and introduces a URL hash fragment parsing mechanism that allows the page to display the modal when the URL includes the `#onboarding-tour` fragment.
* Revise the Overview page component to incorporate the Onboarding tour logic by using the `withOnboardingTour` HOC. This PR serves solely for demonstration. We will subsequently update the rest of the pages that reference the onboarding tour.

## Why are these changes being made?

* This is part of the Agency onboarding improvement part 2 project.

## Testing Instructions

* Use the A4A live link and navigate to `/overview?flags=a4a-unified-onboarding-tour`.
* Click the relaunch Welcome tour button.
  <img width="415" alt="Screenshot 2025-06-03 at 8 00 11 PM" src="https://github.com/user-attachments/assets/843cbfa7-c0fe-4c99-97af-a1fd7004dc25" />
* Confirm that the Onboarding modal shows up.
   <img width="431" alt="Screenshot 2025-06-03 at 8 00 23 PM" src="https://github.com/user-attachments/assets/be6c6a41-d021-43e5-ae40-18f42266268f" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
