### PR TITLE
Fix 100-year domain header

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/hundred-year-domain/hundred-year-domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/hundred-year-domain/hundred-year-domain.ts
@@ -13,6 +13,7 @@ import { ONBOARD_STORE } from '../../../stores';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
 import { STEPS } from '../../internals/steps';
 import type { ProvidedDependencies, Flow } from '../../internals/types';
+import './style.scss';
 
 const steps = [ STEPS.DOMAINS, ...stepsWithRequiredLogin( [ STEPS.PROCESSING ] ) ];
 

--- a/client/landing/stepper/declarative-flow/flows/hundred-year-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/flows/hundred-year-domain/style.scss
@@ -1,0 +1,12 @@
+.hundred-year-plan,
+.hundred-year-domain-transfer,
+.hundred-year-domain {
+	height: 100%;
+	padding: 0;
+	.signup-header {
+		display: none;
+	}
+}
+.hundred-year-domain.step-route {
+	margin-top: -60px;
+}

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -404,16 +404,3 @@ button {
 		max-width: 100%;
 	}
 }
-
-.hundred-year-plan,
-.hundred-year-domain-transfer,
-.hundred-year-domain {
-	height: 100%;
-	padding: 0;
-	.signup-header {
-		display: none;
-	}
-}
-.hundred-year-domain.step-route {
-	margin-top: -60px;
-}

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -404,3 +404,16 @@ button {
 		max-width: 100%;
 	}
 }
+
+.hundred-year-plan,
+.hundred-year-domain-transfer,
+.hundred-year-domain {
+	height: 100%;
+	padding: 0;
+	.signup-header {
+		display: none;
+	}
+}
+.hundred-year-domain.step-route {
+	margin-top: -60px;
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -425,10 +425,6 @@
 	}
 }
 
-.hundred-year-domain.step-route {
-	margin-top: -60px;
-}
-
 // Hundred year plan flow
 .hundred-year-plan.domains,
 .hundred-year-domain.domains {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/style.scss
@@ -1,15 +1,5 @@
 @import "@automattic/onboarding/styles/mixins";
 
-.hundred-year-plan,
-.hundred-year-domain-transfer,
-.hundred-year-domain {
-	height: 100%;
-	padding: 0;
-	.signup-header {
-		display: none;
-	}
-}
-
 /**
  * A different selector (not `.step-container.${flowName}`) is needed for the 100-year domain transfer
  * since it's just a variation of the `domain-transfer` flow, and variations aren't accounted for


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://github.com/Automattic/wp-calypso/issues/101972

## Proposed Changes

* Moves 100-year header styling adjustments to the global stylesheet

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This addresses an issue where the header for the 100-year is still visible. This is caused by the fact that the CSS needed for this doesn't load if the user doesn't go through the domains step.

<img width="480" alt="Screenshot 2025-06-03 at 15 33 43" src="https://github.com/user-attachments/assets/df120a38-6d11-4e4e-ba64-70959d426aa0" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/hundred-year-domain/domains?new=aaaa&search=yes` while logged out
* Select a domain 
* Create an account or login
* The processing screen should not show the header

<img width="480" alt="Screenshot 2025-06-03 at 15 33 43" src="https://github.com/user-attachments/assets/1e160aec-7779-4a32-abf7-4e32709ba514" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
