### PR TITLE
Reader: only display public lists when looking at other profiles

### DIFF
--- a/client/reader/user-profile/index.tsx
+++ b/client/reader/user-profile/index.tsx
@@ -9,6 +9,7 @@ import UserProfileHeader from 'calypso/reader/user-profile/components/user-profi
 import { getUserProfileUrl } from 'calypso/reader/user-profile/user-profile.utils';
 import UserLists from 'calypso/reader/user-profile/views/lists';
 import UserPosts from 'calypso/reader/user-profile/views/posts';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { requestUser } from 'calypso/state/reader/users/actions';
 import getReaderUser from 'calypso/state/selectors/get-reader-user';
 import './style.scss';
@@ -19,6 +20,7 @@ export interface UserProfileProps {
 	user: UserData | undefined;
 	path: string;
 	isLoading: boolean;
+	currentUser: UserData | null;
 	requestUser: ( userLogin: string, findById?: boolean ) => Promise< void >;
 }
 
@@ -32,7 +34,7 @@ type UserProfileState = {
 };
 
 export function UserProfile( props: UserProfileProps ): JSX.Element | null {
-	const { userLogin, userId, path, requestUser, user, isLoading } = props;
+	const { userLogin, userId, path, requestUser, user, isLoading, currentUser } = props;
 	const translate = useTranslate();
 
 	useEffect( () => {
@@ -81,7 +83,7 @@ export function UserProfile( props: UserProfileProps ): JSX.Element | null {
 			case userProfileUrl:
 				return <UserPosts user={ user } />;
 			case `${ userProfileUrl }/lists`:
-				return <UserLists user={ user } />;
+				return <UserLists user={ user } currentUser={ currentUser } />;
 			default:
 				return null;
 		}
@@ -102,6 +104,7 @@ export function UserProfile( props: UserProfileProps ): JSX.Element | null {
 
 export default connect(
 	( state: UserProfileState, ownProps: UserProfileProps ) => ( {
+		currentUser: getCurrentUser( state ),
 		// The following logic works because userLogin and userId are mutually exclusive via the
 		// routes.
 		user: getReaderUser(

--- a/client/reader/user-profile/views/lists.tsx
+++ b/client/reader/user-profile/views/lists.tsx
@@ -21,6 +21,7 @@ interface UserListsProps {
 	requestUserLists?: ( userLogin: string ) => void;
 	lists?: List[];
 	isLoading?: boolean;
+	currentUser: UserData | null;
 }
 
 export const UserLists = ( {
@@ -28,9 +29,12 @@ export const UserLists = ( {
 	requestUserLists,
 	lists,
 	isLoading,
+	currentUser,
 }: UserListsProps ): JSX.Element => {
 	const translate = useTranslate();
 	const [ hasRequested, setHasRequested ] = useState( false );
+
+	// Info about the owner of the lists we are viewing.
 	const userLogin = user.user_login;
 
 	useEffect( () => {
@@ -44,7 +48,19 @@ export const UserLists = ( {
 		return <></>;
 	}
 
-	if ( ! lists || lists.length === 0 ) {
+	const filteredLists =
+		lists?.filter( ( list: List ) => {
+			if ( list.is_public ) {
+				return true;
+			}
+
+			// If the current user is looking at their own profile, show all lists.
+			// Otherwise, only show public lists.
+			const isViewingOwnProfile = user.user_login === currentUser?.username;
+			return isViewingOwnProfile;
+		} ) || [];
+
+	if ( filteredLists.length === 0 ) {
 		return (
 			<div className="user-profile__lists">
 				<EmptyContent
@@ -60,7 +76,7 @@ export const UserLists = ( {
 	return (
 		<div className="user-profile__lists">
 			<div className="user-profile__lists-body">
-				{ lists.map( ( list: List ) => (
+				{ filteredLists.map( ( list: List ) => (
 					<a
 						className="user-profile__lists-body-link"
 						href={ `/reader/list/${ list.owner }/${ list.slug }` }


### PR DESCRIPTION
Fixes CML-542

## Proposed Changes, why are these changes being made?

When you're looking at lists created by other users, you should not be able to see their lists marked as private. You should only see those when you are looking at your own Reader profile.

## Testing Instructions

* Go to https://wordpress.com/reader/list/new
* Create a new list and mark it as private.
* Go to `https://wordpress.com/reader/users/<yourUsername>/lists`
    * Ensure your lists are all displayed, including the private one you just created.
* Go to https://wordpress.com/reader/users/jeremyvideopress/lists
    * Ensure you only see public lists. You should not see a "My very private list" list.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
