### PR TITLE
Experiment streamlining the plans grid + checkout: Remove "extra" wording from monthly-to-annual upsell

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -44,11 +44,8 @@ function getUpsellTextForVariant(
 	isStreamlinedPrice: boolean
 ) {
 	if ( upsellVariant.productBillingTermInMonths === 12 ) {
-		const cardTitle = isStreamlinedPrice
-			? // translators: "percentSavings" is the savings percentage for the upgrade as a number, like '20' for '20%'.
-			  __( '<strong>Save %(percentSavings)d%% extra</strong> by paying annually' )
-			: // translators: "percentSavings" is the savings percentage for the upgrade as a number, like '20' for '20%'.
-			  __( '<strong>Save %(percentSavings)d%%</strong> by paying annually' );
+		// translators: "percentSavings" is the savings percentage for the upgrade as a number, like '20' for '20%'.
+		const cardTitle = __( '<strong>Save %(percentSavings)d%%</strong> by paying annually' );
 		return {
 			cardTitle: createInterpolateElement( sprintf( cardTitle, { percentSavings } ), {
 				strong: createElement( 'strong' ),


### PR DESCRIPTION
Tracked in https://linear.app/a8c/issue/CHE-170/remove-extra-wording-from-monthly-to-annual-upsell-in-checkout

## Proposed Changes

This is a followup to https://github.com/Automattic/wp-calypso/pull/103835 to remove the "extra" wording in the case of a monthly-to-annual upsell, because there is actually nothing "extra" about it.

The "extra" refers to the **additional** savings of the plan being upsold to, compared to the savings (relative to a monthly plan) of the plan you've currently selected.  But if you've currently selected a monthly plan, you aren't saving anything to begin with, so there's no such difference.

### Before:
![annual-upsell-before](https://github.com/user-attachments/assets/93599a47-5ab4-4007-ad87-074f9a234942)

### After:
![annual-upsell-after](https://github.com/user-attachments/assets/a4e4e96c-418e-4411-8ab5-8d099c9bf7bb)

Notice how the savings are 56% in both places, and there's nothing "extra" about it.

In the case of an upsell to a plan that's higher than annual (i.e. where the currently selected plan is not monthly) then the "extra" makes sense, and this pull request makes no changes:

![two-year-upsell-after](https://github.com/user-attachments/assets/e27cfbe6-8a30-4c9d-b18b-fc2348b717df)

In the above, the 19% represents the additional savings of choosing two years vs. annual, in addition to the original savings of choosing annual over monthly.

## Testing Instructions

- To test this feature, you'll need to be assigned to a checkout treatment variation of the `calypso_streamlined_plans_checkout` experiment
- Go through the `onboarding` flow to get assigned
- Select different plan terms in checkout, and observe the upsell in the sidebar

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
