### PR TITLE
Cancel Button: Add the Zendesk ticket lookup query

### DIFF
--- a/client/sites/overview/components/migration-overview/components/cancel-difm-migration/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/cancel-difm-migration/index.tsx
@@ -6,6 +6,7 @@ import { useDispatch } from 'react-redux';
 import { LoadingBar } from 'calypso/components/loading-bar';
 import wp from 'calypso/lib/wp';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import { useFindZendeskMigrationTicket } from './use-find-zendesk-migration-ticket';
 import { useSiteMigrationStatus } from './use-site-migration-status';
 
 type CancelMigrationButtonProps = {
@@ -107,8 +108,13 @@ const CancelDifmMigrationForm = ( { siteId }: { siteId: number } ) => {
 	>( null );
 
 	const { site, isMigrationCompleted, isMigrationInProgress } = useSiteMigrationStatus( siteId );
+	const { data } = useFindZendeskMigrationTicket( siteId, isMigrationCompleted === false );
 
 	if ( ! isEnabled( 'migration-flow/cancel-difm' ) ) {
+		return null;
+	}
+
+	if ( ! data?.ticket_id ) {
 		return null;
 	}
 

--- a/client/sites/overview/components/migration-overview/components/cancel-difm-migration/use-find-zendesk-migration-ticket.ts
+++ b/client/sites/overview/components/migration-overview/components/cancel-difm-migration/use-find-zendesk-migration-ticket.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { SiteId } from 'calypso/types';
+
+interface ZendeskMigrationTicketResponse {
+	ticket_id: string;
+	status: string;
+	created_at: string;
+	updated_at: string;
+}
+
+const findZendeskMigrationTicket = async (
+	siteId: SiteId
+): Promise< ZendeskMigrationTicketResponse > => {
+	return wpcom.req.get( {
+		path: `/sites/${ siteId }/automated-migration/find-ticket`,
+		apiNamespace: 'wpcom/v2',
+	} );
+};
+
+export const useFindZendeskMigrationTicket = ( siteId: SiteId, enabled: boolean ) => {
+	return useQuery( {
+		queryKey: [ 'zendesk-migration-ticket', siteId ],
+		queryFn: () => findZendeskMigrationTicket( siteId ),
+		enabled: !! siteId && enabled,
+	} );
+};


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCON-26

## Proposed Changes

* Add a query to consume the Zendesk ticket lookup: 184422-ghe-Automattic/wpcom
* We now verify if the ticket is open to determine if we should show the cancel button.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* After deploying the Migration Cancel button on Friday, we noticed that some users were still seeing the button even though their migration requests had already been resolved.
* This occurred because when Happiness Engineers don’t perform the migration(e.g. the site is already in WordPress.com) and simply close the ticket, the user is left with the "migration started" sticker even though the request is no longer active.
* As a result, the Cancel Migration button was being shown despite the migration request having already been closed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link below.
* Go through the assisted migration flow until you reach `/overview/YOUR-SITE`
* Ensure to enable the feature flag: `migration-flow/cancel-difm`
* You should see the Cancel button
* You can close your ticket to ensure that the button is hidden.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?