### PR TITLE
Domains: Replace domain price rule string literals with constants

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import { DOMAIN_PRICE_RULE } from 'calypso/lib/cart-values/cart-items';
 import { DOMAINS_WITH_PLANS_ONLY } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getSitePlanSlug, hasDomainCredit } from 'calypso/state/sites/plans/selectors';
@@ -91,7 +92,7 @@ export class DomainProductPrice extends Component {
 
 		let message;
 		if (
-			( isMappingProduct && this.props.rule === 'FREE_WITH_PLAN' ) ||
+			( isMappingProduct && this.props.rule === DOMAIN_PRICE_RULE.FREE_WITH_PLAN ) ||
 			isCurrentPlan100YearPlan
 		) {
 			message = translate( 'Free with your plan' );
@@ -103,7 +104,7 @@ export class DomainProductPrice extends Component {
 					{ translate( 'Free domain for one year' ) }
 				</span>
 			);
-		} else if ( this.props.rule === 'UPGRADE_TO_HIGHER_PLAN_TO_BUY' ) {
+		} else if ( this.props.rule === DOMAIN_PRICE_RULE.UPGRADE_TO_HIGHER_PLAN_TO_BUY ) {
 			message = translate( '%(planName)s plan required', {
 				args: { planName: getPlan( PLAN_PERSONAL )?.getTitle() ?? '' },
 			} );
@@ -239,19 +240,19 @@ export class DomainProductPrice extends Component {
 		}
 
 		switch ( this.props.rule ) {
-			case 'ONE_TIME_PRICE':
+			case DOMAIN_PRICE_RULE.ONE_TIME_PRICE:
 				return this.renderOneTimePrice();
-			case 'FREE_DOMAIN':
+			case DOMAIN_PRICE_RULE.FREE_DOMAIN:
 				return this.renderFree();
-			case 'FREE_FOR_FIRST_YEAR':
+			case DOMAIN_PRICE_RULE.FREE_FOR_FIRST_YEAR:
 				return this.renderFreeForFirstYear();
-			case 'FREE_WITH_PLAN':
-			case 'INCLUDED_IN_HIGHER_PLAN':
-			case 'UPGRADE_TO_HIGHER_PLAN_TO_BUY':
+			case DOMAIN_PRICE_RULE.FREE_WITH_PLAN:
+			case DOMAIN_PRICE_RULE.INCLUDED_IN_HIGHER_PLAN:
+			case DOMAIN_PRICE_RULE.UPGRADE_TO_HIGHER_PLAN_TO_BUY:
 				return this.renderFreeWithPlan();
-			case 'DOMAIN_MOVE_PRICE':
+			case DOMAIN_PRICE_RULE.DOMAIN_MOVE_PRICE:
 				return this.renderDomainMovePrice();
-			case 'PRICE':
+			case DOMAIN_PRICE_RULE.PRICE:
 			default:
 				return this.renderPrice();
 		}

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -20,6 +20,7 @@ import {
 	getDomainPriceRule,
 	hasDomainInCart,
 	isPaidDomain,
+	DOMAIN_PRICE_RULE,
 } from 'calypso/lib/cart-values/cart-items';
 import {
 	getDomainPrice,
@@ -142,7 +143,7 @@ class DomainRegistrationSuggestion extends Component {
 		} );
 
 		switch ( priceRule ) {
-			case 'ONE_TIME_PRICE':
+			case DOMAIN_PRICE_RULE.ONE_TIME_PRICE:
 				return translate( '%(baseLabel)s. %(price)s one-time', {
 					args: {
 						baseLabel,
@@ -151,7 +152,7 @@ class DomainRegistrationSuggestion extends Component {
 					comment:
 						'Accessible label for one-time priced domain (e.g. domain with 100-year plan). %(baseLabel)s is the base label (e.g. "Select domain testing.com"). %(price)s is the price.',
 				} );
-			case 'FREE_DOMAIN':
+			case DOMAIN_PRICE_RULE.FREE_DOMAIN:
 				return translate( '%(baseLabel)s. Free', {
 					args: {
 						baseLabel,
@@ -159,7 +160,7 @@ class DomainRegistrationSuggestion extends Component {
 					comment:
 						'Accessible label for free domain. %(baseLabel)s is the base label (e.g. "Select domain testing.com").',
 				} );
-			case 'FREE_FOR_FIRST_YEAR':
+			case DOMAIN_PRICE_RULE.FREE_FOR_FIRST_YEAR:
 				return translate( '%(baseLabel)s. Free for the first year, then %(price)s per year', {
 					args: {
 						baseLabel,
@@ -168,7 +169,7 @@ class DomainRegistrationSuggestion extends Component {
 					comment:
 						'Accessible label for domain free for the first year. %(baseLabel)s is the base label (e.g. "Select domain testing.com"). %(price)s is the price.',
 				} );
-			case 'FREE_WITH_PLAN':
+			case DOMAIN_PRICE_RULE.FREE_WITH_PLAN:
 				return translate(
 					'%(baseLabel)s. Free for the first year with annual paid plans, then %(price)s per year',
 					{
@@ -180,7 +181,7 @@ class DomainRegistrationSuggestion extends Component {
 							'Accessible label for free domain with normal price. %(baseLabel)s is the base label (e.g. "Select domain testing.com"). %(price)s is the price.',
 					}
 				);
-			case 'UPGRADE_TO_HIGHER_PLAN_TO_BUY':
+			case DOMAIN_PRICE_RULE.UPGRADE_TO_HIGHER_PLAN_TO_BUY:
 				return translate( '%(baseLabel)s. Plan upgrade required to register this domain.', {
 					args: {
 						baseLabel,
@@ -188,7 +189,7 @@ class DomainRegistrationSuggestion extends Component {
 					comment:
 						'Accessible label for domain that requires a plan upgrade. %(baseLabel)s is the base label (e.g. "Select domain testing.com").',
 				} );
-			case 'INCLUDED_IN_HIGHER_PLAN':
+			case DOMAIN_PRICE_RULE.INCLUDED_IN_HIGHER_PLAN:
 				return translate( '%(baseLabel)s. Included in paid plans', {
 					args: {
 						baseLabel,
@@ -196,7 +197,7 @@ class DomainRegistrationSuggestion extends Component {
 					comment:
 						'Accessible label for domain included in higher plans. %(baseLabel)s is the base label (e.g. "Select domain testing.com").',
 				} );
-			case 'DOMAIN_MOVE_PRICE':
+			case DOMAIN_PRICE_RULE.DOMAIN_MOVE_PRICE:
 				return translate( '%(baseLabel)s. %(price)s one-time', {
 					args: {
 						baseLabel,
@@ -205,7 +206,7 @@ class DomainRegistrationSuggestion extends Component {
 					comment:
 						'Accessible label for domain move price. %(baseLabel)s is the base label (e.g. "Select domain testing.com"). %(price)s is the price.',
 				} );
-			case 'PRICE':
+			case DOMAIN_PRICE_RULE.PRICE:
 				if ( productSaleCost && productCost ) {
 					return translate(
 						'%(baseLabel)s. %(salePrice)s for the first year, then %(price)s per year',

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -71,7 +71,9 @@ export const DOMAIN_PRICE_RULE = {
 	DOMAIN_MOVE_PRICE: 'DOMAIN_MOVE_PRICE',
 	INCLUDED_IN_HIGHER_PLAN: 'INCLUDED_IN_HIGHER_PLAN',
 	UPGRADE_TO_HIGHER_PLAN_TO_BUY: 'UPGRADE_TO_HIGHER_PLAN_TO_BUY',
-};
+} as const;
+
+type DomainPriceRule = ( typeof DOMAIN_PRICE_RULE )[ keyof typeof DOMAIN_PRICE_RULE ];
 
 export type ObjectWithProducts = Pick< ResponseCart, 'products' >;
 
@@ -873,7 +875,7 @@ export function getDomainPriceRule(
 	isDomainOnly: boolean,
 	flowName: string,
 	domainAndPlanUpsellFlow: boolean
-): string {
+): DomainPriceRule {
 	// We'll show a fixed, one time price in the 100-year domain flow
 	if ( isHundredYearDomainFlow( flowName ) ) {
 		return DOMAIN_PRICE_RULE.ONE_TIME_PRICE;

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -62,6 +62,17 @@ import type {
 	MinimalRequestCartProduct,
 } from '@automattic/shopping-cart';
 
+export const DOMAIN_PRICE_RULE = {
+	ONE_TIME_PRICE: 'ONE_TIME_PRICE',
+	FREE_DOMAIN: 'FREE_DOMAIN',
+	FREE_FOR_FIRST_YEAR: 'FREE_FOR_FIRST_YEAR',
+	FREE_WITH_PLAN: 'FREE_WITH_PLAN',
+	PRICE: 'PRICE',
+	DOMAIN_MOVE_PRICE: 'DOMAIN_MOVE_PRICE',
+	INCLUDED_IN_HIGHER_PLAN: 'INCLUDED_IN_HIGHER_PLAN',
+	UPGRADE_TO_HIGHER_PLAN_TO_BUY: 'UPGRADE_TO_HIGHER_PLAN_TO_BUY',
+};
+
 export type ObjectWithProducts = Pick< ResponseCart, 'products' >;
 
 export function getAllCartItems( cart?: ObjectWithProducts ): ResponseCartProduct[] {
@@ -831,7 +842,7 @@ export function isDomainMappingFree( selectedSite: SiteDetails | null | undefine
 }
 
 export function isPaidDomain( domainPriceRule: string ): boolean {
-	return 'PRICE' === domainPriceRule;
+	return DOMAIN_PRICE_RULE.PRICE === domainPriceRule;
 }
 
 const isMonthlyOrFreeFlow = ( flowName: string | undefined ): boolean => {
@@ -865,62 +876,64 @@ export function getDomainPriceRule(
 ): string {
 	// We'll show a fixed, one time price in the 100-year domain flow
 	if ( isHundredYearDomainFlow( flowName ) ) {
-		return 'ONE_TIME_PRICE';
+		return DOMAIN_PRICE_RULE.ONE_TIME_PRICE;
 	}
 
 	if ( ! suggestion.product_slug || suggestion.cost === 'Free' ) {
-		return 'FREE_DOMAIN';
+		return DOMAIN_PRICE_RULE.FREE_DOMAIN;
 	}
 
 	if ( suggestion?.is_premium ) {
-		return 'PRICE';
+		return DOMAIN_PRICE_RULE.PRICE;
 	}
 
 	if ( hasSomeSlug( suggestion ) && isDomainMoveInternal( suggestion ) ) {
-		return 'DOMAIN_MOVE_PRICE';
+		return DOMAIN_PRICE_RULE.DOMAIN_MOVE_PRICE;
 	}
 
 	if ( isMonthlyOrFreeFlow( flowName ) ) {
-		return 'PRICE';
+		return DOMAIN_PRICE_RULE.PRICE;
 	}
 
 	if ( isDomainForGravatarFlow( flowName ) ) {
-		return suggestion.sale_cost === 0 ? 'FREE_FOR_FIRST_YEAR' : 'PRICE';
+		return suggestion.sale_cost === 0
+			? DOMAIN_PRICE_RULE.FREE_FOR_FIRST_YEAR
+			: DOMAIN_PRICE_RULE.PRICE;
 	}
 
 	if ( domainAndPlanUpsellFlow ) {
-		return 'FREE_WITH_PLAN';
+		return DOMAIN_PRICE_RULE.FREE_WITH_PLAN;
 	}
 
 	if ( isDomainBeingUsedForPlan( cart, suggestion.domain_name ) ) {
-		return 'FREE_WITH_PLAN';
+		return DOMAIN_PRICE_RULE.FREE_WITH_PLAN;
 	}
 
 	if ( hasSomeSlug( suggestion ) && isDomainMapping( suggestion ) ) {
 		if ( isDomainMappingFree( selectedSite ) ) {
-			return 'FREE_WITH_PLAN';
+			return DOMAIN_PRICE_RULE.FREE_WITH_PLAN;
 		}
 
 		if ( withPlansOnly ) {
-			return 'INCLUDED_IN_HIGHER_PLAN';
+			return DOMAIN_PRICE_RULE.INCLUDED_IN_HIGHER_PLAN;
 		}
 
-		return 'PRICE';
+		return DOMAIN_PRICE_RULE.PRICE;
 	}
 
 	if ( isNextDomainFree( cart, suggestion.domain_name ) ) {
-		return 'FREE_WITH_PLAN';
+		return DOMAIN_PRICE_RULE.FREE_WITH_PLAN;
 	}
 
 	if ( shouldBundleDomainWithPlan( withPlansOnly, selectedSite, cart, suggestion ) ) {
-		return 'INCLUDED_IN_HIGHER_PLAN';
+		return DOMAIN_PRICE_RULE.INCLUDED_IN_HIGHER_PLAN;
 	}
 
 	if ( hasToUpgradeToPayForADomain( selectedSite, cart, suggestion.domain_name ) ) {
-		return 'UPGRADE_TO_HIGHER_PLAN_TO_BUY';
+		return DOMAIN_PRICE_RULE.UPGRADE_TO_HIGHER_PLAN_TO_BUY;
 	}
 
-	return 'PRICE';
+	return DOMAIN_PRICE_RULE.PRICE;
 }
 
 export function getPlanCartItem( cartItems?: MinimalRequestCartProduct[] | null ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* replace domain price rule string literals with constants for better maintainability

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* related discussion: https://github.com/Automattic/wp-calypso/pull/103804/files#r2115992772

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Manually testing all the possible flows where domain price rules are used might be challenging. We can test main cases with the domain selection flow.

1. Review and double-check the proposed code changes.
2. Build the app with `yarn start` or use Calypso Live.
3. Head over to http://calypso.localhost:3000/start/domain/domain-only.
4. Open the same flow in current production / staging (if sandboxed).
5. Search for different domain names.
6. The price information of domains in the search results should match the price information in the current Calypso production / staging environment.
7. We can focus on information like "Free for the first year with annual paid plans" or whether the domain is premium.
8. There should be no change in the functionality.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
