### PR TITLE
Launches the Cancel Migration button

### DIFF
--- a/client/sites/overview/components/migration-overview/components/cancel-difm-migration/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/cancel-difm-migration/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Modal, Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
@@ -109,10 +108,6 @@ const CancelDifmMigrationForm = ( { siteId }: { siteId: number } ) => {
 
 	const { site, isMigrationCompleted, isMigrationInProgress } = useSiteMigrationStatus( siteId );
 	const { data } = useFindZendeskMigrationTicket( siteId, isMigrationCompleted === false );
-
-	if ( ! isEnabled( 'migration-flow/cancel-difm' ) ) {
-		return null;
-	}
 
 	if ( ! data?.ticket_id ) {
 		return null;

--- a/client/sites/overview/components/migration-overview/components/cancel-difm-migration/test/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/cancel-difm-migration/test/index.tsx
@@ -13,7 +13,6 @@ jest.mock( '@automattic/calypso-config', () => {
 	return {
 		__esModule: true,
 		default: jest.fn(), // mock config()
-		isEnabled: jest.fn(),
 	};
 } );
 
@@ -33,7 +32,6 @@ jest.mock( '../use-find-zendesk-migration-ticket', () => ( {
 
 describe( 'CancelDifmMigrationForm', () => {
 	const siteId = 123;
-	const isEnabled = jest.requireMock( '@automattic/calypso-config' ).isEnabled;
 	const useSiteMigrationStatus = jest.requireMock(
 		'../use-site-migration-status'
 	).useSiteMigrationStatus;
@@ -44,7 +42,6 @@ describe( 'CancelDifmMigrationForm', () => {
 	beforeEach( () => {
 		nock.cleanAll();
 		jest.clearAllMocks();
-		isEnabled.mockReturnValue( true );
 		useSiteMigrationStatus.mockReturnValue( {
 			site: { ID: siteId },
 			isMigrationCompleted: false,
@@ -53,12 +50,6 @@ describe( 'CancelDifmMigrationForm', () => {
 		useFindZendeskMigrationTicket.mockReturnValue( {
 			data: { ticket_id: '123' },
 		} );
-	} );
-
-	it( 'renders nothing if feature flag is disabled', () => {
-		isEnabled.mockReturnValue( false );
-		renderWithProvider( <CancelDifmMigrationForm siteId={ siteId } /> );
-		expect( screen.queryByRole( 'button', { name: /cancel migration/i } ) ).toBeNull();
 	} );
 
 	describe( 'when migration is not in progress', () => {

--- a/client/sites/overview/components/migration-overview/components/cancel-difm-migration/test/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/cancel-difm-migration/test/index.tsx
@@ -13,6 +13,7 @@ jest.mock( '@automattic/calypso-config', () => {
 	return {
 		__esModule: true,
 		default: jest.fn(), // mock config()
+		isEnabled: jest.fn(),
 	};
 } );
 
@@ -32,6 +33,7 @@ jest.mock( '../use-find-zendesk-migration-ticket', () => ( {
 
 describe( 'CancelDifmMigrationForm', () => {
 	const siteId = 123;
+	const isEnabled = jest.requireMock( '@automattic/calypso-config' ).isEnabled;
 	const useSiteMigrationStatus = jest.requireMock(
 		'../use-site-migration-status'
 	).useSiteMigrationStatus;
@@ -42,6 +44,7 @@ describe( 'CancelDifmMigrationForm', () => {
 	beforeEach( () => {
 		nock.cleanAll();
 		jest.clearAllMocks();
+		isEnabled.mockReturnValue( true );
 		useSiteMigrationStatus.mockReturnValue( {
 			site: { ID: siteId },
 			isMigrationCompleted: false,

--- a/config/development.json
+++ b/config/development.json
@@ -119,7 +119,6 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"migration-flow/introductory-offer": true,
-		"migration-flow/cancel-difm": true,
 		"oauth": false,
 		"onboarding/create-course": false,
 		"onboarding/import": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -76,7 +76,6 @@
 		"marketplace-test": false,
 		"me/account/color-scheme-picker": true,
 		"migration-flow/introductory-offer": true,
-		"migration-flow/cancel-difm": true,
 		"onboarding/create-course": false,
 		"onboarding/step-container-v2-import-flow": true,
 		"onboarding/step-container-v2-migration-flow": true,

--- a/config/production.json
+++ b/config/production.json
@@ -94,7 +94,6 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"migration-flow/introductory-offer": true,
-		"migration-flow/cancel-difm": false,
 		"onboarding/create-course": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -91,7 +91,6 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"migration-flow/introductory-offer": true,
-		"migration-flow/cancel-difm": false,
 		"onboarding/create-course": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,

--- a/config/test.json
+++ b/config/test.json
@@ -72,7 +72,6 @@
 		"marketplace-personal-premium": false,
 		"me/account-close": true,
 		"migration-flow/introductory-offer": true,
-		"migration-flow/cancel-difm": false,
 		"onboarding/create-course": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -96,7 +96,6 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"migration-flow/introductory-offer": true,
-		"migration-flow/cancel-difm": false,
 		"onboarding/create-course": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCON-26

## Proposed Changes

* Remove the migration-flow/cancel-difm to make the DIFM cancellation functionality available to all users.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We had to revert because we didn't handle the cases in which the user doesn't have an active Zendesk ticket. We addressed it by adding a new endpoint to find the ticket related to the site:
* 184422-ghe-Automattic/wpcom
* https://github.com/Automattic/wp-calypso/pull/103927

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visual inspection.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?