### PR TITLE
Purchases: Make sure all DataViews field getValue calls return strings

### DIFF
--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -84,7 +84,8 @@ export function getPurchasesFieldDefinitions( {
 			enableSorting: false,
 			enableHiding: false,
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
-				return item.id;
+				// getValue must return a string because the DataViews search feature calls `trim()` on it.
+				return String( item.id );
 			},
 		},
 		{
@@ -95,11 +96,12 @@ export function getPurchasesFieldDefinitions( {
 			enableSorting: true,
 			enableHiding: false,
 			elements: sites.map( ( site ) => {
-				return { value: site.ID, label: `${ site.name } (${ site.domain })` };
+				return { value: String( site.ID ), label: `${ site.name } (${ site.domain })` };
 			} ),
 			filterBy: { operators: [ 'is' ], isPrimary: true },
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
-				return item.siteId;
+				// getValue must return a string because the DataViews search feature calls `trim()` on it.
+				return String( item.siteId );
 			},
 			// Render the site icon
 			render: ( { item }: { item: Purchases.Purchase } ) => {

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -46,7 +46,7 @@ function usePreservePurchasesFiltersInUrl( {
 		const siteFilterValue = url.searchParams.get( urlSiteFilterKey );
 		const typeFilterValue = url.searchParams.get( urlTypeFilterKey );
 		if ( siteFilterValue ) {
-			filters.push( { value: parseInt( siteFilterValue ), operator: 'is', field: 'site' } );
+			filters.push( { value: siteFilterValue, operator: 'is', field: 'site' } );
 		}
 		if ( typeFilterValue ) {
 			filters.push( { value: typeFilterValue, operator: 'is', field: 'type' } );


### PR DESCRIPTION
## Proposed Changes

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/103896 which introduced a regression: apparently DataViews `getValue()` functions must always return a string; a number causes a fatal error when searching because it tries to call `trim()` on the value.

In this PR we make sure every field in the DataViews version of `/me/purchases` returns a string.

Part of https://linear.app/a8c/project/replace-calypsos-active-upgrades-subscriptions-with-dataviews-a7b39dea5417/overview / https://github.com/Automattic/wp-calypso/issues/86616

## Testing Instructions

**NOTE** You have to currently test using localhost calypso because calypso.live will not have the feature enabled yet.

- Use an account with a number of purchases.
- Visit `/me/purchases`.
- Use the search field to search for purchases and make sure it works as you'd expect.