### PR TITLE
Help Center: more accurate support session detection

### DIFF
--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -67,3 +67,4 @@ export type { StepperInternalSelect } from './stepper-internal';
 export type { SiteActions } from './site';
 export type { UserActions } from './user';
 export type { Member, UseQuery, UsersQuery } from './users/types';
+export { isInSupportSession } from './help-center';

--- a/packages/zendesk-client/src/util.tsx
+++ b/packages/zendesk-client/src/util.tsx
@@ -1,6 +1,8 @@
 import config from '@automattic/calypso-config';
+import { isInSupportSession } from '@automattic/data-stores';
 
 export const isTestModeEnvironment = () => {
 	const currentEnvironment = config( 'env_id' ) as string;
-	return ! [ 'production', 'desktop' ].includes( currentEnvironment );
+	// During SU sessions, we want to always target prod. See HAL-154.
+	return ! isInSupportSession() && ! [ 'production', 'desktop' ].includes( currentEnvironment );
 };


### PR DESCRIPTION
Part of HAL-154
Requires https://github.com/Automattic/jetpack/pull/43752

## Proposed Changes

This fix is twofold:

1. Previously, we tried a couple of ways to prevent the Help Center from re-opening automatically in Support Sessions (https://github.com/Automattic/wp-calypso/pull/99428, https://github.com/Automattic/wp-calypso/pull/99164), these failed so we put together a fallback, to disabling auto-opening in proxied sessions. This broke the UX for Automatticians. This PR disables the auto-open feature in Support Session only. It should work this time.
2. It always targets the production instance of Zendesk when the user in SU. This is congruent with wpcom#83114.

## Why are these changes being made?
To prevent HEs from landing in Stanging when SUing.

## Testing Instructions
### HC

1. Open the live link while proxied.
2. Open the Help Center.
3. Refresh the page.
4. The HC should pop open automatically.

### SU
1. SU into some user while proxied.
2. Open the HC.
3. It should access ZD prod.