### PR TITLE
Close the help center when clicking the Big Sky add site card

### DIFF
--- a/client/dashboard/sites/add-new-site/index.tsx
+++ b/client/dashboard/sites/add-new-site/index.tsx
@@ -8,6 +8,7 @@ import {
 	Button,
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
+import { useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { download, reusableBlock, Icon } from '@wordpress/icons';
 import devSiteBanner from 'calypso/assets/images/a8c-for-agencies/dev-site-banner.svg';
@@ -44,11 +45,6 @@ const offerClick = () => {
 		action: 'offer',
 	} );
 };
-const bigSkyClick = () => {
-	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
-		action: 'big-sky',
-	} );
-};
 
 function AddNewSite( { context }: AddNewSiteProps ) {
 	const isDesktop = useViewportMatch( 'medium' );
@@ -60,6 +56,7 @@ function AddNewSite( { context }: AddNewSiteProps ) {
 			numberFormatOptions: { style: 'percent' },
 		} )
 	);
+	const { setShowHelpCenter } = useDispatch( 'automattic/help-center' );
 
 	return (
 		<Wrapper alignment="flex-start" style={ { padding: '16px' } } spacing={ 6 }>
@@ -77,8 +74,13 @@ function AddNewSite( { context }: AddNewSiteProps ) {
 					description={ __(
 						'Prompt, edit, and launch WordPress websites with Artificial Intelligence.'
 					) }
-					onClick={ bigSkyClick }
-					href={ `/setup/ai-site-builder?source=${ context }&ref=new-site-popover` }
+					onClick={ () => {
+						setShowHelpCenter( false ); // Close the help center
+						recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
+							action: 'big-sky',
+						} );
+					} }
+					href="#"
 				/>
 				<MenuItem
 					icon={ <JetpackLogo /> }

--- a/client/dashboard/sites/add-new-site/index.tsx
+++ b/client/dashboard/sites/add-new-site/index.tsx
@@ -80,7 +80,7 @@ function AddNewSite( { context }: AddNewSiteProps ) {
 							action: 'big-sky',
 						} );
 					} }
-					href="#"
+					href={ `/setup/ai-site-builder?source=${ context }&ref=new-site-popover` }
 				/>
 				<MenuItem
 					icon={ <JetpackLogo /> }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-13474

## Proposed Changes

When clicking the Big Sky add new site card, make sure to close the help center if it's open. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To make sure the help center doesn't stay open through the site creation and onboarding. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- http://calypso.localhost:3000/sites
- Open the help center
- Click Add New Site -> AI website builder
- Help center should close. And remain closed throughout
- Test on a slow network too. 



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
