### PR TITLE
Purchases: Save and load pagination and sorting with url

### DIFF
--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -16,10 +16,11 @@ import {
 
 const purchasesDesktopFields = [ 'site', 'product', 'status', 'payment-method' ];
 const purchasesMobileFields = [ 'product' ];
+const defaultPerPage = 5;
 export const purchasesDataView: View = {
 	type: 'table',
 	page: 1,
-	perPage: 5,
+	perPage: defaultPerPage,
 	titleField: 'purchase-id',
 	showTitle: false,
 	fields: purchasesDesktopFields,
@@ -37,27 +38,35 @@ function usePreservePurchasesFiltersInUrl( {
 	currentView: View;
 	setView: ( setter: ( currentView: View ) => View ) => void;
 } ) {
+	const urlPaginationPage = 'pageNumber';
+	const urlPaginationPerPage = 'perPage';
 	const urlSiteFilterKey = 'siteFilter';
 	const urlTypeFilterKey = 'typeFilter';
 	const currentUrl = window.location.href;
+
+	// Apply view from URL
 	useEffect( () => {
 		const url = new URL( currentUrl );
 		const filters: Filter[] = [];
 		const siteFilterValue = url.searchParams.get( urlSiteFilterKey );
 		const typeFilterValue = url.searchParams.get( urlTypeFilterKey );
+		const pageNumber = url.searchParams.get( urlPaginationPage );
+		const perPage = url.searchParams.get( urlPaginationPerPage );
 		if ( siteFilterValue ) {
 			filters.push( { value: siteFilterValue, operator: 'is', field: 'site' } );
 		}
 		if ( typeFilterValue ) {
 			filters.push( { value: typeFilterValue, operator: 'is', field: 'type' } );
 		}
-		if ( filters.length > 0 ) {
-			setView( ( currentView ) => ( {
-				...currentView,
-				filters,
-			} ) );
-		}
+		setView( ( currentView ) => ( {
+			...currentView,
+			...( filters.length > 0 ? { filters } : { filters: currentView.filters } ),
+			...( pageNumber ? { page: parseInt( pageNumber ) } : {} ),
+			...( perPage ? { perPage: parseInt( perPage ) } : {} ),
+		} ) );
 	}, [ setView, currentUrl ] );
+
+	// Apply URL from view
 	useEffect( () => {
 		const url = new URL( window.location.href );
 		const siteFilter = currentView.filters?.find( ( filter ) => filter.field === 'site' );
@@ -66,11 +75,30 @@ function usePreservePurchasesFiltersInUrl( {
 		} else {
 			url.searchParams.delete( urlSiteFilterKey );
 		}
+
 		const typeFilter = currentView.filters?.find( ( filter ) => filter.field === 'type' );
 		if ( typeFilter ) {
 			url.searchParams.set( urlTypeFilterKey, typeFilter.value );
 		} else {
 			url.searchParams.delete( urlTypeFilterKey );
+		}
+
+		const pageNumber = currentView.page;
+		if ( pageNumber && pageNumber > 1 ) {
+			url.searchParams.set( urlPaginationPage, String( pageNumber ) );
+		} else {
+			url.searchParams.delete( urlPaginationPage );
+		}
+
+		const perPage = currentView.perPage;
+		if ( perPage && perPage !== defaultPerPage ) {
+			url.searchParams.set( urlPaginationPerPage, String( perPage ) );
+		} else {
+			url.searchParams.delete( urlPaginationPerPage );
+		}
+
+		if ( url.search === window.location.search ) {
+			return;
 		}
 		window.history.pushState( undefined, '', url );
 		// getPreviousRoute will not find this updated route unless we set it

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -3,7 +3,13 @@ import { Gridicon, Card } from '@automattic/components';
 import { Purchases, SiteDetails } from '@automattic/data-stores';
 import { DESKTOP_BREAKPOINT } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
-import { DataViews, View, Filter, filterSortAndPaginate } from '@wordpress/dataviews';
+import {
+	DataViews,
+	View,
+	Filter,
+	filterSortAndPaginate,
+	SortDirection,
+} from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
 import { MembershipSubscription } from 'calypso/lib/purchases/types';
@@ -17,6 +23,10 @@ import {
 const purchasesDesktopFields = [ 'site', 'product', 'status', 'payment-method' ];
 const purchasesMobileFields = [ 'product' ];
 const defaultPerPage = 5;
+const defaultSort = {
+	field: 'product',
+	direction: 'desc' as SortDirection,
+};
 export const purchasesDataView: View = {
 	type: 'table',
 	page: 1,
@@ -24,10 +34,7 @@ export const purchasesDataView: View = {
 	titleField: 'purchase-id',
 	showTitle: false,
 	fields: purchasesDesktopFields,
-	sort: {
-		field: 'product',
-		direction: 'desc',
-	},
+	sort: defaultSort,
 	layout: {},
 };
 
@@ -38,6 +45,8 @@ function usePreservePurchasesFiltersInUrl( {
 	currentView: View;
 	setView: ( setter: ( currentView: View ) => View ) => void;
 } ) {
+	const urlSortField = 'sortField';
+	const urlSortDirection = 'sortDir';
 	const urlPaginationPage = 'pageNumber';
 	const urlPaginationPerPage = 'perPage';
 	const urlSiteFilterKey = 'siteFilter';
@@ -52,6 +61,10 @@ function usePreservePurchasesFiltersInUrl( {
 		const typeFilterValue = url.searchParams.get( urlTypeFilterKey );
 		const pageNumber = url.searchParams.get( urlPaginationPage );
 		const perPage = url.searchParams.get( urlPaginationPerPage );
+		const sortField = url.searchParams.get( urlSortField );
+		const sortDir = (
+			url.searchParams.get( urlSortDirection ) === 'asc' ? 'asc' : 'desc'
+		) as SortDirection;
 		if ( siteFilterValue ) {
 			filters.push( { value: siteFilterValue, operator: 'is', field: 'site' } );
 		}
@@ -60,9 +73,10 @@ function usePreservePurchasesFiltersInUrl( {
 		}
 		setView( ( currentView ) => ( {
 			...currentView,
-			...( filters.length > 0 ? { filters } : { filters: currentView.filters } ),
+			...( filters.length > 0 ? { filters } : {} ),
 			...( pageNumber ? { page: parseInt( pageNumber ) } : {} ),
 			...( perPage ? { perPage: parseInt( perPage ) } : {} ),
+			...( sortField ? { sort: { field: sortField, direction: sortDir } } : {} ),
 		} ) );
 	}, [ setView, currentUrl ] );
 
@@ -95,6 +109,15 @@ function usePreservePurchasesFiltersInUrl( {
 			url.searchParams.set( urlPaginationPerPage, String( perPage ) );
 		} else {
 			url.searchParams.delete( urlPaginationPerPage );
+		}
+
+		const sort = currentView.sort;
+		if ( sort && sort !== defaultSort ) {
+			url.searchParams.set( urlSortField, sort.field );
+			url.searchParams.set( urlSortDirection, sort.direction );
+		} else {
+			url.searchParams.delete( urlSortField );
+			url.searchParams.delete( urlSortDirection );
 		}
 
 		if ( url.search === window.location.search ) {


### PR DESCRIPTION
## Proposed Changes

https://github.com/Automattic/wp-calypso/pull/103896 added filtering to the DataViews version of the purchases list. It also allowed saving the filters to the URL query string and loading them again from the query string.

In this PR we also save and load the table pagination and sorting so they will be restored when returning to the page.

Part of https://linear.app/a8c/project/replace-calypsos-active-upgrades-subscriptions-with-dataviews-a7b39dea5417/overview / https://github.com/Automattic/wp-calypso/issues/86616

Tracked by https://linear.app/a8c/issue/CHE-173/save-and-load-pagination-and-sorting-with-url

## Testing Instructions

**NOTE** You have to currently test using localhost calypso because calypso.live will not have the feature enabled yet.

- Use an account with a number of purchases.
- Visit `/me/purchases`.
- Click the "Status" header to sort the table.
- Click the pagination buttons to change the current page.
- Click to view a purchase, then click the back button and verify that the sorting and pagination remains unchanged from when you left.
