### PR TITLE
Fix/mailosaur code comment

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -51,6 +51,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/comments/',
 		post_id: 113,
 	},
+	com_vs_org: {
+		link: 'https://wordpress.com/support/com-vs-org/',
+		post_id: 38,
+	},
 	dashboard: {
 		link: 'https://wordpress.com/support/dashboard/',
 		post_id: 137,

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -14,6 +14,7 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import MainComponent from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
@@ -335,13 +336,7 @@ function PluginDetails( props ) {
 					rel="noreferrer noopener"
 				/>
 			),
-			wpcom_vs_wporg_link: (
-				<a
-					href={ localizeUrl( 'https://wordpress.com/support/com-vs-org/' ) }
-					target="_blank"
-					rel="noreferrer noopener"
-				/>
-			),
+			wpcom_vs_wporg_link: <InlineSupportLink supportContext="com_vs_org" showIcon={ false } />,
 		},
 	};
 

--- a/packages/calypso-e2e/src/data-helper.ts
+++ b/packages/calypso-e2e/src/data-helper.ts
@@ -214,7 +214,7 @@ export function getTosUploadDestination(): string {
 }
 
 /**
- * Returns a new test email address with the domain name `mailosaur.io` within a specific inbox.
+ * Returns a new test email address with the domain name `mailosaur.net` within a specific inbox.
  *
  * Examples:
  * 	e2eflowtestingpaid1600000@inboxID.mailosaur.net


### PR DESCRIPTION
Minor code typo. Mailosaur uses various TLDs: .io, .net, and .in