### PR TITLE
Fix color contrast and link style issues in A4A login

### DIFF
--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -44,15 +44,6 @@
 	--wp-components-color-accent: var(--color-accent);
 }
 
-/* A8C for Agencies */
-.a8c-for-agencies {
-	.components-button:not(.is-destructive) {
-		--wp-components-color-accent: var(--color-primary-40);
-		--wp-components-color-accent-darker-10: var(--color-primary-60);
-		--wp-components-color-accent-darker-20: var(--color-primary-60);
-	}
-}
-
 /* Jetpack */
 .layout.is-jetpack-login:not(.is-wccom-oauth-flow):not(.is-woocommerce-core-profiler-flow) {
 	.components-button:not(.is-destructive) {

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -1019,7 +1019,7 @@ export class LoginForm extends Component {
 						) }
 
 						{ ! hideSignupLink && isOauthLogin && (
-							<div className={ clsx( 'login__form-signup-link' ) }>
+							<p className={ clsx( 'login__form-signup-link' ) }>
 								{ this.props.translate(
 									'Not on WordPress.com? {{signupLink}}Create an Account{{/signupLink}}.',
 									{
@@ -1028,7 +1028,7 @@ export class LoginForm extends Component {
 										},
 									}
 								) }
-							</div>
+							</p>
 						) }
 					</>
 				) }

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -289,6 +289,7 @@ $breakpoint-mobile: 782px; //Mobile size.
 	clear: both;
 	font-size: $font-body-small;
 	padding-top: 20px;
+	margin-bottom: unset;
 
 	&.disabled {
 		a,

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -672,17 +672,6 @@
 	}
 }
 
-.a8c-for-agencies {
-	.wp-login__links button {
-		color: var(--color-primary-40);
-
-		&:hover,
-		&:focus {
-			color: var(--color-primary-60);
-		}
-	}
-}
-
 // Adding some CSS to cover the --color-primary
 // background color in the signup flow for Akismet/IntenseDebate.
 .layout.dops.akismet,

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -673,68 +673,6 @@
 }
 
 .a8c-for-agencies {
-	--color-link: var(--color-primary-40);
-	--color-link-dark: var(--color-primary-60);
-
-	input:focus:hover[type],
-	input:focus[type] {
-		box-shadow: 0 0 0 2px var(--color-primary-10);
-	}
-
-	.button {
-		color: var(--color-primary-60);
-		background: var(--studio-white);
-		border: 1px solid var(--color-primary-40);
-		border-radius: 2px;
-
-		&:hover,
-		&:focus {
-			background: var(--color-primary-0);
-		}
-
-		&:active {
-			background: var(--color-primary-5);
-			border-color: var(--color-primary-40);
-			border-width: 1px;
-		}
-
-		&[disabled]:active {
-			border-width: 1px;
-		}
-
-		&[disabled],
-		&:disabled {
-			color: var(--studio-gray-10);
-			border-color: var(--color-gray-10);
-			background: var(--studio-white);
-		}
-	}
-
-	.button.is-primary {
-		color: var(--studio-white);
-		background: var(--color-primary-40);
-		border-color: var(--color-primary-40);
-
-		&:hover,
-		&:focus {
-			background: var(--color-primary-30);
-			border-color: var(--color-primary-30);
-		}
-
-		&:active {
-			background: var(--color-primary-50);
-			border-color: var(--color-primary-50);
-		}
-
-		&[disabled],
-		&:disabled {
-			color: var(--studio-white);
-			background: var(--studio-gray-10);
-			border-color: var(--studio-gray-10);
-		}
-	}
-
-	.login__form-change-username,
 	.wp-login__links button {
 		color: var(--color-primary-40);
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes [DOTCOM-13187: A4A login/signup screens do not meet WCAG 2 AA minimum contrast ratio thresholds](https://linear.app/a8c/issue/DOTCOM-13187/a4a-loginsignup-screens-do-not-meet-wcag-2-aa-minimum-contrast-ratio)

## Proposed Changes

* Removes color overrides from buttons and links allowing the default WordPress blueberry color to be used, which meets WCAG color contrast requirements
* Adds an underline to the 'Create Account' link so that it is not only relying on color to be recognised as a link

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Login and signup screens are required to be accessible for compliance with the EU Accessibility Act

## Testing

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Screenshots

#### Screen scan before

![Screenshot 2025-06-04 at 2 16 43 PM](https://github.com/user-attachments/assets/b548c4a8-24b0-4353-9841-f92ba406071f)

#### Screen scan after

![Screenshot 2025-06-04 at 2 17 18 PM](https://github.com/user-attachments/assets/d7c7871c-cfbe-4951-bf7d-cb5357d0ff94)

| Before | After |
|-|-|
| ![wordpress com_log-in_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D95931%26redirect_uri%3Dhttps%253A%252F%252Fagencies automattic com%252Fconnect%252Foauth%252Ftoken%253Fne (2)](https://github.com/user-attachments/assets/2fedb729-152e-4490-b381-5595bb8ea3f5) | ![calypso localhost_3000_log-in_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D95931%26redirect_uri%3Dhttps%253A%252F%252Fagencies automattic com%252Fconnect%252Foauth%252Fto (10)](https://github.com/user-attachments/assets/0f800cbe-3db9-469d-a3b5-29098c79de96) |
| ![wordpress com_log-in_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D95931%26redirect_uri%3Dhttps%253A%252F%252Fagencies automattic com%252Fconnect%252Foauth%252Ftoken%253Fne (1)](https://github.com/user-attachments/assets/f236d67c-c6c9-4a8a-bfc7-7d7bb6e7b76c) | ![calypso localhost_3000_log-in_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D95931%26redirect_uri%3Dhttps%253A%252F%252Fagencies automattic com%252Fconnect%252Foauth%252Ftok (9)](https://github.com/user-attachments/assets/c592035a-d88d-4d87-b110-c40e11fd01ce) |

### Instructions

1. Go to automatt_c.com/for-agencies/ and click 'Log in'. Edit the URL and change the host to calypso.localhost:3000 
2. Use an accessibility tool like [Axe Dev Tools](https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd) to check color contrast issues on the page
3. Tab through the links and buttons with your keyboard to ensure they have visible focus styles

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
