### PR TITLE
Newsletter: Fix appearance of full screen launchpad if skipped

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/use-my-home-card-launchpad.ts
+++ b/client/my-sites/customer-home/cards/launchpad/use-my-home-card-launchpad.ts
@@ -23,7 +23,13 @@ export function useMyHomeCardLaunchpad( { checklistSlug, launchpadContext }: Use
 	const { mutate: dismiss } = useLaunchpadDismisser( siteSlug, checklistSlug, launchpadContext );
 
 	const {
-		data: { checklist, is_dismissed: isDismissed, is_dismissible: isDismissible, title },
+		data: {
+			checklist,
+			is_dismissed: isDismissed,
+			is_dismissible: isDismissible,
+			launchpad_screen: launchpadScreen,
+			title,
+		},
 		refetch,
 	} = useSortedLaunchpadTasks( siteSlug, checklistSlug, launchpadContext );
 
@@ -48,6 +54,7 @@ export function useMyHomeCardLaunchpad( { checklistSlug, launchpadContext }: Use
 		completedSteps,
 		hasChecklist,
 		launchpadTitle,
+		launchpadScreen,
 		temporaryDismiss,
 		permanentDismiss,
 		refetch,

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -51,6 +51,7 @@ export const FullScreenLaunchpad = ( {
 		numberOfSteps,
 		completedSteps,
 		launchpadTitle,
+		launchpadScreen,
 		hasChecklist,
 		refetch,
 	} = useMyHomeCardLaunchpad( {
@@ -104,7 +105,10 @@ export const FullScreenLaunchpad = ( {
 		data: { checklist },
 	} = useSortedLaunchpadTasks( siteSlug, checklistSlug, launchpadContext );
 
-	if ( isDismissed ) {
+	if (
+		isDismissed ||
+		launchpadScreen !== 'full' // Only display if the launchpad screen is set to 'full'.
+	) {
 		return null;
 	}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Issue [CML-533](https://linear.app/a8c/issue/CML-533/free-newsletter-launchpad-doesnt-go-away)

## Proposed Changes

Added a check to make sure that `FullScreenLaunchpad` component only rendered if the `launchpad_screen` value coming from the API is `full`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

`FullScreenLaunchpad` is appearing again and again even after dismissing.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

For testing we'll use an existing site (245179953) instead of creating new one just to avoid extra overhead. If you want to test with a new site then feel free to do so.

1. Login into sandbox, allow writes and reset the launchpad state.
```
wp option update launchpad_screen 'full' --blog=245179953
wp option patch update launchpad_checklist_tasks_statuses first_post_published 0 --blog=245179953
```
2. Go to https://wordpress.com/home/wploopnewsletter.wordpress.com.
3. Click on "Skip to dashboard".
4. Refresh the page and notice that full screen launchpad is still appearing.
5. Checkout this PR and repeat all of above steps and verify that full screen launchpad is not appearing now once skipped.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
