### PR TITLE
Connect Refresh: Migrate Blaze Pro to unified Login

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -225,11 +225,7 @@ export class LoginForm extends Component {
 	isFullView() {
 		const { accountType, hasAccountTypeLoaded, socialAccountIsLinking } = this.props;
 
-		return (
-			socialAccountIsLinking ||
-			( hasAccountTypeLoaded && isRegularAccount( accountType ) ) ||
-			this.props.isBlazePro
-		);
+		return socialAccountIsLinking || ( hasAccountTypeLoaded && isRegularAccount( accountType ) );
 	}
 
 	isPasswordView() {
@@ -240,10 +236,7 @@ export class LoginForm extends Component {
 
 	isUsernameOrEmailView() {
 		const { hasAccountTypeLoaded, socialAccountIsLinking, isSendingEmail } = this.props;
-		return (
-			isSendingEmail ||
-			( ! socialAccountIsLinking && ! hasAccountTypeLoaded && ! this.props.isBlazePro )
-		);
+		return isSendingEmail || ( ! socialAccountIsLinking && ! hasAccountTypeLoaded );
 	}
 
 	resetView = ( event ) => {
@@ -276,8 +269,7 @@ export class LoginForm extends Component {
 	onSubmitForm = ( event ) => {
 		event.preventDefault();
 
-		// Skip this step if we're in the Blaze Pro signup flows, and hasAccountTypeLoaded.
-		if ( ! this.props.hasAccountTypeLoaded && ! this.props.isBlazePro ) {
+		if ( ! this.props.hasAccountTypeLoaded ) {
 			// Google Chrome on iOS will autofill without sending events, leading the user
 			// to see a filled box but getting an error. We fetch the value directly from
 			// the DOM as a workaround.
@@ -535,10 +527,6 @@ export class LoginForm extends Component {
 	renderUsernameorEmailLabel() {
 		if ( this.props.isWoo ) {
 			return this.props.translate( 'Your email or username' );
-		}
-
-		if ( this.props.isBlazePro ) {
-			return this.props.translate( 'Your email address' );
 		}
 
 		if ( this.props.isWoo ) {

--- a/client/blocks/login/login-header.tsx
+++ b/client/blocks/login/login-header.tsx
@@ -78,6 +78,8 @@ export function getHeaderText(
 			clientName = 'Akismet';
 		} else if ( isWPJobManagerOAuth2Client( oauth2Client ) ) {
 			clientName = 'WP Job Manager';
+		} else if ( isBlazeProOAuth2Client( oauth2Client ) ) {
+			clientName = 'Blaze Pro';
 		}
 
 		headerText = clientName
@@ -166,10 +168,6 @@ export function getHeaderText(
 					'Howdy! Log into the Automattic Partner Portal with your WordPress.com account.'
 				);
 			}
-		}
-
-		if ( isBlazeProOAuth2Client( oauth2Client ) ) {
-			headerText = translate( 'Log in to your Blaze Pro account' );
 		}
 	} else if ( isWooJPC ) {
 		const isLostPasswordFlow = currentQuery.lostpassword_flow === 'true';

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -161,7 +161,15 @@ const LayoutLoggedOut = ( {
 		window.open( createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ), '_blank' );
 	}
 
-	if ( useOAuth2Layout && ( isGravatar || isGravPoweredClient ) ) {
+	if ( isBlazePro && isWhiteLogin ) {
+		/**
+		 * This effectively removes the masterbar completely from Login pages (only).
+		 * However, in some cases, we want the styles imported from the masterbar to be applied.
+		 * They are more generic and affect the whole page, unfortunately.
+		 * For that, importing OauthClientMasterbar suffices to apply those styles, until refactored (we are in the process ofrefactoring).
+		 */
+		masterbar = null;
+	} else if ( useOAuth2Layout && ( isGravatar || isGravPoweredClient ) ) {
 		masterbar = null;
 	} else if ( useOAuth2Layout && oauth2Client && oauth2Client.name && ! masterbarIsHidden ) {
 		classes.dops = true;
@@ -338,11 +346,11 @@ export default withCurrentRoute(
 					( ( ! isJetpackLogin &&
 						Boolean( currentQuery?.client_id ) === false &&
 						Boolean( currentQuery?.oauth2_client_id ) === false &&
-						! isBlazePro &&
 						! isWooJPC ) ||
 						isStudioClient ||
 						isCrowdsignalClient ||
-						isGravPoweredClient ) ) ||
+						isGravPoweredClient ||
+						isBlazePro ) ) ||
 				isPartnerPortal;
 
 			const noMasterbarForRoute =

--- a/client/layout/masterbar/blaze-pro.scss
+++ b/client/layout/masterbar/blaze-pro.scss
@@ -53,7 +53,6 @@ body.is-section-signup {
 	--color-link: var(--color-blaze-pro);
 	--color-link-dark: var(--color-blaze-pro);
 
-	background: var(--color-white);
 	min-height: 100%;
 
 	$login-form-max-width: 327px;

--- a/client/layout/masterbar/oauth-client.jsx
+++ b/client/layout/masterbar/oauth-client.jsx
@@ -11,6 +11,7 @@ import {
 } from 'calypso/lib/oauth2-clients';
 import BlazeProOauthMasterbar from './blaze-pro';
 import WooOauthMasterbar from './woo';
+import './blaze-pro.scss';
 
 import './oauth-client.scss';
 
@@ -63,6 +64,10 @@ const OauthClientMasterbar = ( { oauth2Client } ) => {
 		return <WooOauthMasterbar />;
 	}
 
+	/**
+	 * This is a special case for Blaze Pro that is used in both Login and Signup pages.
+	 * TODO clk Refactor (remove) this to use the same approach as the other oauth2 clients.
+	 */
 	if ( isBlazeProOAuth2Client( oauth2Client ) ) {
 		return <BlazeProOauthMasterbar />;
 	}

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -73,12 +73,12 @@ const enhanceContextWithLogin = ( context ) => {
 		( ! isJetpackLogin &&
 			Boolean( clientId ) === false &&
 			Boolean( oauth2ClientId ) === false &&
-			! isBlazePro &&
 			! isWooJPC ) ||
 		isPartnerPortalClient ||
 		isStudioLogin ||
 		isCrowdsignalLogin ||
-		isGravPoweredClient;
+		isGravPoweredClient ||
+		isBlazePro;
 
 	context.primary = (
 		<WPLogin

--- a/client/login/wp-login/components/heading-logo.tsx
+++ b/client/login/wp-login/components/heading-logo.tsx
@@ -1,3 +1,4 @@
+import blazeProLogo from 'calypso/assets/images/blaze/blaze-pro-logo.png';
 import akismetLogo from 'calypso/assets/images/icons/akismet-logo.svg';
 import crowdsignalLogo from 'calypso/assets/images/icons/crowdsignal.svg';
 import gravatarLogo from 'calypso/assets/images/icons/gravatar.svg';
@@ -8,6 +9,7 @@ import {
 	isGravPoweredOAuth2Client,
 	isStudioAppOAuth2Client,
 	isWPJobManagerOAuth2Client,
+	isBlazeProOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { useSelector } from 'calypso/state';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
@@ -28,6 +30,8 @@ const HeadingLogo = ( { isFromAkismet }: Props ) => {
 		logo = <img src={ akismetLogo } alt="Akismet Logo" />;
 	} else if ( isWPJobManagerOAuth2Client( oauth2Client ) ) {
 		logo = <img src={ wpJobManagerLogo } alt="WP Job Manager Logo" />;
+	} else if ( isBlazeProOAuth2Client( oauth2Client ) ) {
+		logo = <img src={ blazeProLogo } alt="Blaze Pro Logo" />;
 	} else if ( isGravPoweredOAuth2Client( oauth2Client ) ) {
 		/**
 		 * Leave last to avoid overriding other grav-powered client logos.

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -326,7 +326,7 @@ export class Login extends Component {
 			return null;
 		}
 
-		if ( ( isWoo || isBlazePro ) && isLoginView ) {
+		if ( isWoo && isLoginView ) {
 			return <LoginFooter lostPasswordLink={ this.getLostPasswordLink() } shouldRenderTos />;
 		}
 
@@ -434,7 +434,7 @@ export class Login extends Component {
 		} = this.props;
 
 		const canonicalUrl = localizeUrl( 'https://wordpress.com/log-in', locale );
-		const isSocialFirst = isWhiteLogin && ! isWoo && ! isBlazePro;
+		const isSocialFirst = isWhiteLogin && ! isWoo;
 
 		const jetpackLogo = (
 			<div className="magic-login__gutenboarding-wordpress-logo">
@@ -521,7 +521,8 @@ export class Login extends Component {
 			isStudioAppOAuth2Client( oauth2Client ) ||
 			isFromAkismet ||
 			isCrowdsignalOAuth2Client( oauth2Client ) ||
-			isGravPoweredClient;
+			isGravPoweredClient ||
+			isBlazePro;
 
 		return (
 			<>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-13398/blaze-pro
Fixes https://linear.app/a8c/issue/DOTCOM-13386/blaze-pro

## Proposed Changes

Updates the Blaze Pro Login screen to the unified design.

| Before | After |
|--------|--------|
| <img width="1105" alt="Screenshot 2025-06-04 at 12 02 07 PM" src="https://github.com/user-attachments/assets/4bb6df49-0086-4ef3-84c4-ae6256454cd7" /> | <img width="1004" alt="Screenshot 2025-06-04 at 12 08 35 PM" src="https://github.com/user-attachments/assets/056d6102-63b8-4fc2-aee3-49a5bd092349" /> | 

## Needs confirmation

1. The original included two fields for username and password. I switched this to the single input of "username or password" that is used for the default Login.
2. The original custom masterbar is still kept in the code as it's used in Signup and other pages. (It's also not as straightforward to remove right now due to enclosing more styles than just masterbar's)

@jasmussen On the second point, it probably raises a wider issue: Whether we need to refresh other screens (e.g., Signup) instead of just Login. These are usually linked together. For example, clicking on `Create an account` will take you to a customised Signup (with a masterbar):

<img width="911" alt="Screenshot 2025-06-04 at 12 14 45 PM" src="https://github.com/user-attachments/assets/bafe9928-5598-465b-a8fe-220a8fb46bfc" />

Then, clicking `Log in here` takes you back to the refreshed Login Page (without the masterbar).

If we are ok with this as an intermediate state, then perhaps we can create a separate project and unify Signup ("Signup Refresh")?

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-13398/blaze-pro
Fixes https://linear.app/a8c/issue/DOTCOM-13386/blaze-pro

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [Blaze Pro](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D99370%26state%3D0f0d1f16975b65cf8e9e924461b7c892f78eabeeb190dc03654cef0465786da0%26redirect_uri%3Dhttps%253A%252F%252Fblazepro.tumblr.com%252Fauth%252Fconnected%26blog_id%3D0%26wpcom_connect%3D1%26calypso_env%3Dproduction%26scope%3Dglobal%26from-calypso%3D1&client_id=99370&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D99370%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%253Fresponse_type%253Dcode%2526client_id%253D99370%2526state%253D0f0d1f16975b65cf8e9e924461b7c892f78eabeeb190dc03654cef0465786da0%2526redirect_uri%253Dhttps%25253A%25252F%25252Fblazepro.tumblr.com%25252Fauth%25252Fconnected%2526blog_id%253D0%2526wpcom_connect%253D1%2526calypso_env%253Dproduction%2526scope%253Dglobal%2526from-calypso%253D1) and confirm. Try logging in and confirm it works.
* Go to [WP Login](http://calypso.localhost:3000/log-in) and confirm no changes
* Go to [Studio](http://calypso.localhost:3000/log-in?client_id=95109&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dtoken%26client_id%3D95109%26redirect_uri%3Dwpcom-local-dev%253A%252F%252Fauth%26scope%3Dglobal%26client_source%26jetpack-code%26jetpack-user-id%3D0%26action%3Doauth2-login%26from-calypso%3D1) and confirm no changes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
