### PR TITLE
DataViews filters: fix visibility

### DIFF
--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -4,7 +4,7 @@
 
 - `text`, `email` Edit control: add `help` support from the field `description` prop.
 - Add `align` to the `layout.styles` properties, for use in the DataViews table layout. Options are: `start`, `center`, and `end`.
-- Allow fields to opt-opt of filtering via `field.filterBy: false`.
+- Allow fields to opt-out of filtering via `field.filterBy: false`.
 
 ## 0.2.0
 

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -4,6 +4,7 @@
 
 - `text`, `email` Edit control: add `help` support from the field `description` prop.
 - Add `align` to the `layout.styles` properties, for use in the DataViews table layout. Options are: `start`, `center`, and `end`.
+- Allow fields to opt-opt of filtering via `field.filterBy: false`.
 
 ## 0.2.0
 

--- a/packages/dataviews/src/components/dataviews-filters/index.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/index.tsx
@@ -28,7 +28,10 @@ export function useFilters( fields: NormalizedField< any >[], view: View ) {
 	return useMemo( () => {
 		const filters: NormalizedFilter[] = [];
 		fields.forEach( ( field ) => {
-			if ( ! field.elements?.length && ! field.Edit ) {
+			if (
+				field.filterBy === false ||
+				( ! field.elements?.length && ! field.Edit )
+			) {
 				return;
 			}
 

--- a/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
@@ -702,6 +702,7 @@ export const fields: Field< SpaceObject >[] = [
 		type: 'text',
 		enableSorting: false,
 		enableGlobalSearch: true,
+		filterBy: false,
 	},
 	{
 		label: 'Categories',

--- a/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
@@ -82,15 +82,18 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 	const header = field.header;
 
 	operators = sanitizeOperators( field );
-	// Filter can be added:
-	// 1. If the field is not already part of a view's filters.
-	// 2. If the field has elements or Edit property.
-	// 3. If the field meets the type and operator requirements.
-	// 4. If it's not primary. If it is, it should be already visible.
+	// Filter can be added if:
+	//
+	// 1. The field is not already part of a view's filters.
+	// 2. The field has elements or Edit property.
+	// 3. The field has declared filter operators.
+	// 4. The field does not opt-out of filtering.
+	// 5. The filter is not primary (if it is, it is already visible).
 	canAddFilter =
 		! view.filters?.some( ( _filter ) => fieldId === _filter.field ) &&
 		!! ( field.elements?.length || field.Edit ) &&
 		!! operators.length &&
+		field.filterBy !== false &&
 		! field.filterBy?.isPrimary;
 
 	return (

--- a/packages/dataviews/src/field-types/boolean.tsx
+++ b/packages/dataviews/src/field-types/boolean.tsx
@@ -11,6 +11,7 @@ import type {
 	SortDirection,
 	Operator,
 	ValidationContext,
+	FieldTypeDefinition,
 } from '../types';
 import { renderFromElements } from '../utils';
 import { OPERATOR_IS, OPERATOR_IS_NOT } from '../constants';
@@ -65,4 +66,4 @@ export default {
 	filterBy: {
 		operators,
 	},
-};
+} satisfies FieldTypeDefinition< any >;

--- a/packages/dataviews/src/field-types/datetime.tsx
+++ b/packages/dataviews/src/field-types/datetime.tsx
@@ -6,6 +6,7 @@ import type {
 	SortDirection,
 	ValidationContext,
 	Operator,
+	FieldTypeDefinition,
 } from '../types';
 import { renderFromElements } from '../utils';
 import { OPERATOR_IS, OPERATOR_IS_NOT } from '../constants';
@@ -43,4 +44,4 @@ export default {
 	filterBy: {
 		operators,
 	},
-};
+} satisfies FieldTypeDefinition< any >;

--- a/packages/dataviews/src/field-types/email.tsx
+++ b/packages/dataviews/src/field-types/email.tsx
@@ -11,6 +11,7 @@ import type {
 	SortDirection,
 	ValidationContext,
 	Operator,
+	FieldTypeDefinition,
 } from '../types';
 import { renderFromElements } from '../utils';
 import { OPERATOR_IS_ANY, OPERATOR_IS_NONE } from '../constants';
@@ -56,4 +57,4 @@ export default {
 	filterBy: {
 		operators,
 	},
-};
+} satisfies FieldTypeDefinition< any >;

--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -78,8 +78,6 @@ export default function getFieldTypeDefinition< Item >(
 				: field.getValue( { item } );
 		},
 		enableSorting: true,
-		filterBy: {
-			operators: [],
-		},
+		filterBy: false,
 	};
 }

--- a/packages/dataviews/src/field-types/integer.tsx
+++ b/packages/dataviews/src/field-types/integer.tsx
@@ -6,6 +6,7 @@ import type {
 	Operator,
 	SortDirection,
 	ValidationContext,
+	FieldTypeDefinition,
 } from '../types';
 import { renderFromElements } from '../utils';
 import {
@@ -63,4 +64,4 @@ export default {
 	filterBy: {
 		operators,
 	},
-};
+} satisfies FieldTypeDefinition< any >;

--- a/packages/dataviews/src/field-types/media.tsx
+++ b/packages/dataviews/src/field-types/media.tsx
@@ -24,7 +24,5 @@ export default {
 	Edit: null,
 	render: () => null,
 	enableSorting: false,
-	filterBy: {
-		operators: [],
-	},
+	filterBy: false,
 };

--- a/packages/dataviews/src/field-types/media.tsx
+++ b/packages/dataviews/src/field-types/media.tsx
@@ -1,7 +1,11 @@
 /**
  * Internal dependencies
  */
-import type { SortDirection, ValidationContext } from '../types';
+import type {
+	SortDirection,
+	ValidationContext,
+	FieldTypeDefinition,
+} from '../types';
 
 function sort( a: any, b: any, direction: SortDirection ) {
 	return 0;
@@ -24,5 +28,5 @@ export default {
 	Edit: null,
 	render: () => null,
 	enableSorting: false,
-	filterBy: false as const,
-};
+	filterBy: false,
+} satisfies FieldTypeDefinition< any >;

--- a/packages/dataviews/src/field-types/media.tsx
+++ b/packages/dataviews/src/field-types/media.tsx
@@ -24,5 +24,5 @@ export default {
 	Edit: null,
 	render: () => null,
 	enableSorting: false,
-	filterBy: false,
+	filterBy: false as const,
 };

--- a/packages/dataviews/src/field-types/text.tsx
+++ b/packages/dataviews/src/field-types/text.tsx
@@ -6,6 +6,7 @@ import type {
 	SortDirection,
 	ValidationContext,
 	Operator,
+	FieldTypeDefinition,
 } from '../types';
 import { renderFromElements } from '../utils';
 import { OPERATOR_IS_ANY, OPERATOR_IS_NONE } from '../constants';
@@ -42,4 +43,4 @@ export default {
 	filterBy: {
 		operators,
 	},
-};
+} satisfies FieldTypeDefinition< any >;

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -93,7 +93,7 @@ export type FieldTypeDefinition< Item > = {
 	/**
 	 * The filter config for the field.
 	 */
-	filterBy: FilterByConfig;
+	filterBy: FilterByConfig | false;
 
 	/**
 	 * Whether the field is sortable.
@@ -184,7 +184,7 @@ export type Field< Item > = {
 	/**
 	 * Filter config for the field.
 	 */
-	filterBy?: FilterByConfig | undefined;
+	filterBy?: FilterByConfig | undefined | false;
 
 	/**
 	 * Callback used to retrieve the value of the field from the item.

--- a/packages/dataviews/src/utils.ts
+++ b/packages/dataviews/src/utils.ts
@@ -10,7 +10,8 @@ import {
 import type { DataViewRenderFieldProps, NormalizedField } from './types';
 
 export function sanitizeOperators< Item >( field: NormalizedField< Item > ) {
-	let operators = field.filterBy?.operators;
+	let operators =
+		typeof field.filterBy === 'object' && field.filterBy?.operators;
 
 	// Assign default values.
 	if ( ! operators || ! Array.isArray( operators ) ) {


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/103276

## What

This PR fixes DataViews filters visibility.

## Why

Filters in DataViews had been opt-in based on the presence of `field.elements` until https://github.com/Automattic/wp-calypso/pull/103276 when they became opt-in based on the `field.Edit`. If a field provides an Edit function, it'll display a filter.

This is problematic. We want to make the `field.type` required at some point. The type auto-generates part of the field API (how it's rendered, how it's edited, how it's sorted, etc.). For example, it automatically creates a `Edit` function for the field. This means that any field that provides a `type` will render a filter and can't opt out.

This is an example of a field declaration that renders a filter and can't opt-out:

```js
{
  id: 'date',
  label: 'Date',
  type: 'datetime',
},
```

## How

- Fields can opt-out from filtering via `field.filterBy: false`.

## Testing Instructions

- Visit the storybook: `yarn workspace @automattic/dataviews storybook:start`.
- Verify all fields display a filter but `description`, which has opted-out.
