### PR TITLE
Dashboard v2: Fix the layout of the transfer site

### DIFF
--- a/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
@@ -10,6 +10,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import { siteOwnerTransferEligibilityCheckMutation } from '../../app/queries';
+import { SectionHeader } from '../../components/section-header';
 import type { Field } from '@automattic/dataviews';
 
 export type ConfirmNewOwnerFormData = {
@@ -63,12 +64,9 @@ export function ConfirmNewOwnerForm( {
 	};
 
 	return (
-		<VStack spacing={ 1 }>
-			<VStack style={ { padding: '8px 0' } }>
-				{ /* TODO: Think about the better way of using <Heading /> as the font size doesn't match now */ }
-				<Text size="15px" weight={ 500 } lineHeight="32px" as="h2">
-					{ __( 'Confirm new owner' ) }
-				</Text>
+		<>
+			<VStack style={ { padding: '8px 0 12px' } }>
+				<SectionHeader title={ __( 'Confirm new owner' ) } level={ 3 } />
 				<Text lineHeight="20px">
 					{ createInterpolateElement(
 						__(
@@ -103,6 +101,6 @@ export function ConfirmNewOwnerForm( {
 					</HStack>
 				</VStack>
 			</form>
-		</VStack>
+		</>
 	);
 }

--- a/client/dashboard/sites/settings-transfer-site/email-confirmation.tsx
+++ b/client/dashboard/sites/settings-transfer-site/email-confirmation.tsx
@@ -6,15 +6,17 @@ import {
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, inbox } from '@wordpress/icons';
+import { SectionHeader } from '../../components/section-header';
 
 export function EmailConfirmation( { userEmail }: { userEmail: string } ) {
 	return (
 		<VStack style={ { padding: '8px 0 12px' } }>
 			<HStack justify="flex-start">
-				<Icon icon={ inbox } />
-				<Text size="15px" weight={ 500 } lineHeight="32px" as="h2">
-					{ __( 'Check your inbox' ) }
-				</Text>
+				<SectionHeader
+					title={ __( 'Check your inbox' ) }
+					decoration={ <Icon icon={ inbox } /> }
+					level={ 3 }
+				/>
 			</HStack>
 			<Text>
 				{ createInterpolateElement(

--- a/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
@@ -11,6 +11,7 @@ import { __ } from '@wordpress/i18n';
 import React, { useState } from 'react';
 import { siteOwnerTransferMutation } from '../../app/queries';
 import Notice from '../../components/notice';
+import { SectionHeader } from '../../components/section-header';
 import type { Site } from '../../data/types';
 import type { Field } from '@automattic/dataviews';
 
@@ -101,11 +102,9 @@ export function StartSiteTransferForm( {
 	};
 
 	return (
-		<VStack spacing={ 0 }>
+		<>
 			<VStack style={ { padding: '8px 0 12px' } }>
-				<Text size="15px" weight={ 500 } lineHeight="32px" as="h2">
-					{ __( 'Start site transfer' ) }
-				</Text>
+				<SectionHeader title={ __( 'Start site transfer' ) } level={ 3 } />
 			</VStack>
 			<VStack spacing={ 5 } style={ { padding: '8px 0' } }>
 				<Notice variant="warning" density="medium">
@@ -182,11 +181,11 @@ export function StartSiteTransferForm( {
 						</li>
 					</List>
 				</VStack>
+				<Text weight={ 500 } as="h3">
+					{ __( 'To transfer your site, review and accept the following statements:' ) }
+				</Text>
 				<form onSubmit={ handleSubmit }>
-					<VStack>
-						<span style={ { textTransform: 'uppercase', fontSize: '11px', fontWeight: 500 } }>
-							{ __( 'To transfer your site, review and accept the following statements:' ) }
-						</span>
+					<VStack spacing={ 5 }>
 						<DataForm< StartSiteTransferFormData >
 							data={ formData }
 							fields={ fields }
@@ -195,7 +194,7 @@ export function StartSiteTransferForm( {
 								setFormData( ( data ) => ( { ...data, ...edits } ) );
 							} }
 						/>
-						<HStack justify="flex-start" style={ { paddingTop: '8px' } }>
+						<HStack justify="flex-start">
 							<Button
 								variant="primary"
 								type="submit"
@@ -211,6 +210,6 @@ export function StartSiteTransferForm( {
 					</VStack>
 				</form>
 			</VStack>
-		</VStack>
+		</>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCON-71

## Proposed Changes

* Use SectionHeader
* Update confirmation section header

![image](https://github.com/user-attachments/assets/1f7f6110-83fb-4c60-a63b-d654da225cfe)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Pick site
* Go to Settings > Transfer site
* Ensure the styles look correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
