### PR TITLE
Dashboard v2: Update styles of the SectionHeader

### DIFF
--- a/client/dashboard/components/section-header/index.tsx
+++ b/client/dashboard/components/section-header/index.tsx
@@ -26,30 +26,25 @@ export const SectionHeader = ( {
 }: SectionHeaderProps ) => {
 	const HeadingTag = `h${ level }` as keyof JSX.IntrinsicElements;
 	return (
-		<VStack
-			spacing={ 2 }
-			className={ clsx( 'dashboard-section-header', `is-level-${ level }`, className ) }
-		>
+		<VStack className={ clsx( 'dashboard-section-header', `is-level-${ level }`, className ) }>
 			{ prefix && <div className="dashboard-section-header__prefix">{ prefix }</div> }
 			<HStack
-				spacing={ 4 }
 				justify="flex-start"
-				alignment="flex-start"
+				alignment="center"
 				className="dashboard-section-header__heading-row"
 			>
 				{ decoration && (
 					<span className="dashboard-section-header__decoration">{ decoration }</span>
 				) }
-				<HStack spacing={ 3 } justify="space-between" alignment="flex-start">
+				<HStack justify="space-between" alignment="center">
 					<HeadingTag className="dashboard-section-header__heading" id={ headingId }>
 						{ title }
 					</HeadingTag>
 					{ /* The wrapper is always needed for view transitions. */ }
 					<HStack
-						spacing={ 2 }
 						justify="flex-end"
 						expanded={ false }
-						alignment="flex-start"
+						alignment="center"
 						className="dashboard-section-header__actions"
 					>
 						{ actions }

--- a/client/dashboard/components/section-header/style.scss
+++ b/client/dashboard/components/section-header/style.scss
@@ -4,6 +4,10 @@
 .dashboard-section-header {
 	position: relative;
 	z-index: 1;
+
+	.dashboard-section-header__heading-row {
+		min-height: 32px;
+	}
 }
 
 .dashboard-section-header__heading {
@@ -17,12 +21,10 @@
 
 	.dashboard-section-header.is-level-2 & {
 		@include heading-x-large();
-		margin-top: $grid-unit-05;
 	}
 
 	.dashboard-section-header.is-level-3 & {
 		@include heading-large();
-		margin-top: calc($grid-unit-05 * 1.5);
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of dhW7zYBamXJIeJIE3wy5f4-fi-5107_46321

## Proposed Changes

* Add the min-height to the heading row as it should be `32px`
* Align items of the heading row to the center
* Adjust spacing as it should always be `8px`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Align styles with Figma

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run the storybook
  * `yarn run storybook:start`
* Ensure the styles is correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?