### PR TITLE
GitHub Deployments: Ensure workflow syntax highlighter height (used for the default workflow file) adjusts based on its content

### DIFF
--- a/client/sites/deployments/components/code-highlighter/style.scss
+++ b/client/sites/deployments/components/code-highlighter/style.scss
@@ -7,11 +7,11 @@
 	position: relative;
 
 	.language-yaml {
-		color: var(--studio-wordpress-blue-60) !important;
+		color: var( --studio-wordpress-blue-60 ) !important;
 		text-wrap: pretty;
 	}
 
 	.token.key.atrule {
-		color: var(--studio-green) !important;
+		color: var( --studio-green ) !important;
 	}
 }

--- a/client/sites/deployments/components/code-highlighter/style.scss
+++ b/client/sites/deployments/components/code-highlighter/style.scss
@@ -1,6 +1,7 @@
 .github-workflow-code-highlighter {
 	font-size: $font-body-small;
-	max-height: 20lh;
+	height: fit-content;
+	max-height: 30lh;
 	border-radius: 4px;
 	background: transparent !important;
 	position: relative;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DOTDEV-151
Related to DOTDEV-146

## Proposed Changes

* ensure workflow syntax highlighter height (used for the default workflow file) adjusts based on its content
* add consistent spacing in CSS variable syntax

![Markup on 2025-06-04 at 13:37:35](https://github.com/user-attachments/assets/32299f04-2496-4a94-bb63-92d6070d05e8)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The syntax highlighter field is currently set to fix height. If we make changes to the default file content, a scrollbar may appear. With the proposed changes the highlighter height will adjust based on its content.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The proposed changes can be tested together with the backend PR 184571-ghe-Automattic/wpcom. You can follow the testing instructions there.

The goal is to ensure user does not need to scroll the syntax highlighter field to see the default workflow file contents in full.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?