### PR TITLE
Accessibility: Accessing AI assistant through Help Center using VoiceOver loses focus

### DIFF
--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -62,7 +62,7 @@ const HelpCenterContainer: React.FC< Container > = ( {
 	const focusReturnRef = useFocusReturn();
 	const cardMergeRefs = useMergeRefs( [ nodeRef, focusReturnRef ] );
 
-	// Keep focus within the help center when clicking "Still need help"
+	// Keep focus within the help center when entering `Zendesk messaging`
 	useEffect( () => {
 		const helpCenter = nodeRef.current;
 		if ( ! helpCenter ) {

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -60,6 +60,7 @@ const HelpCenterContainer: React.FC< Container > = ( {
 	}, [ handleClose ] );
 
 	const focusReturnRef = useFocusReturn();
+
 	const cardMergeRefs = useMergeRefs( [ nodeRef, focusReturnRef ] );
 
 	// Keep focus within the help center when entering `Zendesk messaging`
@@ -72,7 +73,6 @@ const HelpCenterContainer: React.FC< Container > = ( {
 		const handleFocusOut = ( event: FocusEvent ) => {
 			const relatedTarget = event.relatedTarget as HTMLElement;
 			if ( ! helpCenter.contains( relatedTarget ) && show && ! isMinimized ) {
-				// Focus back on the help center container
 				helpCenter.focus();
 			}
 		};

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -60,8 +60,30 @@ const HelpCenterContainer: React.FC< Container > = ( {
 	}, [ handleClose ] );
 
 	const focusReturnRef = useFocusReturn();
-
 	const cardMergeRefs = useMergeRefs( [ nodeRef, focusReturnRef ] );
+
+	// Keep focus within the help center when clicking "Still need help"
+	useEffect( () => {
+		const helpCenter = nodeRef.current;
+		if ( ! helpCenter ) {
+			return;
+		}
+
+		const handleFocusOut = ( event: FocusEvent ) => {
+			const relatedTarget = event.relatedTarget as HTMLElement;
+			if ( ! helpCenter.contains( relatedTarget ) && show && ! isMinimized ) {
+				// Focus back on the help center container
+				helpCenter.focus();
+			}
+		};
+
+		helpCenter.setAttribute( 'tabindex', '-1' );
+		document.addEventListener( 'focusout', handleFocusOut );
+
+		return () => {
+			document.removeEventListener( 'focusout', handleFocusOut );
+		};
+	}, [ show, isMinimized ] );
 
 	const shouldCloseOnEscapeRef = useRef( false );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-13431

## Proposed Changes

This PR ensures that when you open the Zendesk messaging window (through `Still need help` or `AI Assistant` buttons) within the `Help Center` using VoiceOver or similar screen readers, the focus remains within the Help Center and does not jump out to the main page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

 Currently, if you click on `Still need help` or `AI Assisstant` within Help Center with the help of a screen reader, you are thrown out to the main page and the focus does not remain on the Help Center. It becomes quite challening if almost impossible to get back to the messaging. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch or use the Calypso Live Link
* Navigate to `/home/{anySite}`
* Click on the `Help` icon in the top right corner to open the Help Center
* Activate VoiceOver
* Move through the Help Center to the `Still need help` button (you can use `Ctrl + Option + Arrow Right / Left`
* Once on `Still need help`, click with 
* Confirm that you remain within Help Center 
* Confirm that you see the loading state
* Confirm that you can move through the messaging screen 
* Compare this flow to trunk and observe that when you click on  `Still need help` button with `Ctrl + Option + Space`, you are thrown to the main web page that is behind the Help Center

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
