### PR TITLE
Help Center: more precise support session detection

### DIFF
--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -52,7 +52,7 @@ class Document extends Component {
 			initialReduxState,
 			inlineScriptNonce,
 			isSupportSession,
-			disableHelpCenterAutoOpen,
+			isSSP,
 			isWooDna,
 			lang,
 			languageRevisions,
@@ -81,7 +81,7 @@ class Document extends Component {
 			`var BUILD_TARGET = ${ jsonStringifyForHtml( target ) };\n` +
 			( user ? `var currentUser = ${ jsonStringifyForHtml( user ) };\n` : '' ) +
 			( isSupportSession ? 'var isSupportSession = true;\n' : '' ) +
-			( disableHelpCenterAutoOpen ? 'var disableHelpCenterAutoOpen = true;\n' : '' ) +
+			( isSSP ? 'var isSSP = true;\n' : '' ) +
 			( app ? `var app = ${ jsonStringifyForHtml( app ) };\n` : '' ) +
 			( initialReduxState
 				? `var initialReduxState = ${ jsonStringifyForHtml( initialReduxState ) };\n`

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -93,13 +93,13 @@ function getCurrentCommitShortChecksum() {
  */
 function setupLoggedInContext( req, res, next ) {
 	const isSupportSession = !! req.get( 'x-support-session' ) || !! req.cookies.support_session_id;
-	const disableHelpCenterAutoOpen = isSupportSession || !! req.cookies.ssp;
+	const isSSP = !! req.cookies.ssp;
 	const isLoggedIn = !! req.cookies.wordpress_logged_in;
 
 	req.context = {
 		...req.context,
 		isSupportSession,
-		disableHelpCenterAutoOpen,
+		isSSP,
 		isLoggedIn,
 	};
 

--- a/packages/data-stores/src/help-center/index.ts
+++ b/packages/data-stores/src/help-center/index.ts
@@ -11,6 +11,7 @@ export type { State };
 
 declare const helpCenterData: { isProxied: boolean; isSU: boolean; isSSP: boolean } | undefined;
 declare const isSupportSession: boolean;
+declare const isSSP: boolean;
 
 let isRegistered = false;
 
@@ -23,7 +24,6 @@ export const isE2ETest = () =>
 export const isInSupportSession = () => {
 	if ( typeof window !== 'undefined' ) {
 		return (
-			'disableHelpCenterAutoOpen' in window ||
 			// A bit hacky but much easier than passing down data from PHP in Jetpack
 			// Simple
 			!! document.querySelector( '#wp-admin-bar-support-session-details' ) ||
@@ -33,7 +33,8 @@ export const isInSupportSession = () => {
 			document.querySelector( '#wpcom > .is-support-session' ) ||
 			( typeof isSupportSession !== 'undefined' && !! isSupportSession ) ||
 			( typeof helpCenterData !== 'undefined' && helpCenterData?.isSU ) ||
-			( typeof helpCenterData !== 'undefined' && helpCenterData?.isSSP )
+			( typeof helpCenterData !== 'undefined' && helpCenterData?.isSSP ) ||
+			( typeof isSSP !== 'undefined' && !! isSSP )
 		);
 	}
 	return false;

--- a/packages/data-stores/src/help-center/index.ts
+++ b/packages/data-stores/src/help-center/index.ts
@@ -9,7 +9,7 @@ import { isHelpCenterShown } from './resolvers';
 import * as selectors from './selectors';
 export type { State };
 
-declare const helpCenterData: { isProxied: boolean; isSU: boolean } | undefined;
+declare const helpCenterData: { isProxied: boolean; isSU: boolean; isSSP: boolean } | undefined;
 declare const isSupportSession: boolean;
 
 let isRegistered = false;
@@ -32,7 +32,8 @@ export const isInSupportSession = () => {
 			document.body.classList.contains( 'support-session' ) ||
 			document.querySelector( '#wpcom > .is-support-session' ) ||
 			( typeof isSupportSession !== 'undefined' && !! isSupportSession ) ||
-			( typeof helpCenterData !== 'undefined' && helpCenterData?.isSU )
+			( typeof helpCenterData !== 'undefined' && helpCenterData?.isSU ) ||
+			( typeof helpCenterData !== 'undefined' && helpCenterData?.isSSP )
 		);
 	}
 	return false;


### PR DESCRIPTION
## Proposed Changes
Follow up of https://github.com/Automattic/jetpack/pull/43768

## Why are these changes being made?
- Improves the SU check to include SSP sessions.
- Target Zendesk production in SSP too.

## Testing Instructions
- SSP into a paid user **that you own** while proxied. Or use mine yi1bgdadsfdsfsd.
- Open the HC.
- Reach support in Calypso
- You should make it to prod.
- Repeat in wp-admin.

**Note**: the SSP cookie is secure, meaning it won't work in HTTP contexts, you can only use the live link to test.