### PR TITLE
Newsletter: Update launchpad CTA when all tasks are completed

### DIFF
--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -10,6 +10,7 @@ import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
+import { fixMe, useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
@@ -33,6 +34,7 @@ export const FullScreenLaunchpad = ( {
 } ): JSX.Element | null => {
 	const dispatch = useDispatch();
 	const { __ } = useI18n();
+	const translate = useTranslate();
 	const [ isLaunching, setIsLaunching ] = useState( false );
 	const siteId = useSelector( getSelectedSiteId ) || 0;
 	const site = useSelector( ( state: AppState ) => getSite( state, siteId ) );
@@ -158,7 +160,13 @@ export const FullScreenLaunchpad = ( {
 						onClick={ onSkipLaunchpad }
 						disabled={ isLaunching }
 					>
-						{ __( 'Skip to dashboard' ) }
+						{ isAllTasksCompleted
+							? fixMe( {
+									text: 'Go to dashboard',
+									newCopy: translate( 'Go to dashboard' ),
+									oldCopy: translate( 'Skip to dashboard' ),
+							  } )
+							: __( 'Skip to dashboard' ) }
 					</Button>
 				</div>
 			</div>


### PR DESCRIPTION
Related: [CML-505](https://linear.app/a8c/issue/CML-505/update-cta-copy-after-completing-checklist)

## Proposed Changes

After completing launchpad checklist, the top copy changes to "You're all set!" which is good but there's no link forward except "Skip to dashboard" - changing this to "Go to dashboard"

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a site, verify launchpad CTA for both uncompleted and completed tasks.

OR

1. Checkout PR.
2. Change [this condition](https://github.com/Automattic/wp-calypso/blob/362f0ca4950aa218dd2dea86fa2b028e5666a297/client/my-sites/customer-home/components/home-content/index.jsx#L154) to `true` to always show Full Screen Launchpad.
3. Update [this condition](https://github.com/Automattic/wp-calypso/blob/c6034f2593d48168e4dd0db5c02e602a1bf107dc/client/my-sites/customer-home/components/full-screen-launchpad.tsx#L163) to `true` / `false` to verify both texts.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
