### PR TITLE
A4A: Disable magic link flow for Signup v2.

### DIFF
--- a/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-create-agency-mutation.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-create-agency-mutation.ts
@@ -15,6 +15,7 @@ function createAgency( details: AgencyDetailsPayload ): Promise< Agency > {
 			agency_size: details.agencySize,
 			number_sites: details.managedSites,
 			user_type: details.userType,
+			initial_source: details.initialSource,
 			services_offered: details.servicesOffered,
 			products_offered: details.productsOffered,
 			products_to_offer: details.productsToOffer,

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/types.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/types.ts
@@ -23,4 +23,5 @@ export interface AgencyDetailsPayload {
 	state: string;
 	referer?: string | null;
 	tos?: 'consented';
+	initialSource?: string;
 }

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/hooks/use-submit-signup.ts
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/hooks/use-submit-signup.ts
@@ -44,7 +44,11 @@ export default function useSubmitSignup() {
 	return useCallback(
 		async ( payload: AgencyDetailsSignupPayload ) => {
 			dispatch( removeNotice( notificationId ) );
-			const data = { ...payload, referer };
+			const data = {
+				...payload,
+				referer,
+				phone: { phoneNumberFull: payload.phoneNumber, phoneNumber: payload.phoneNumber },
+			};
 
 			if ( shouldRedirectToWPCOM ) {
 				saveSignupDataToLocalStorage( data );
@@ -63,9 +67,11 @@ export default function useSubmitSignup() {
 					agency_size: payload.agencySize,
 					managed_sites: payload.managedSites,
 					user_type: payload.userType,
+					initial_source: payload.initialSource,
 					services_offered: ( payload.servicesOffered || [] ).join( ',' ),
 					products_offered: ( payload.productsOffered || [] ).join( ',' ),
 					products_to_offer: ( payload.productsToOffer || [] ).join( ',' ),
+					expansion_planned: payload.plansToOfferProducts,
 					city: payload.city,
 					line1: payload.line1,
 					line2: payload.line2,

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
@@ -174,10 +174,14 @@ const MultiStepForm = ( {
 
 	const onCreateAgency = useCallback(
 		( data: Partial< AgencyDetailsSignupPayload > ) => {
-			const newFormData = { ...formData, ...data };
+			const newFormData = {
+				...formData,
+				...data,
+				initialSource: sourceName,
+			};
 			submitSignup( newFormData as AgencyDetailsSignupPayload );
 		},
-		[ formData, submitSignup ]
+		[ formData, sourceName, submitSignup ]
 	);
 
 	const currentForm = useMemo( () => {

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -44,7 +44,7 @@
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
-		"a4a-signup-v2-via-email": true,
+		"a4a-signup-v2-via-email": false,
 		"a4a-client-checkout-v2": true,
 		"jetpack/crm-downloads": true
 	},

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -37,7 +37,7 @@
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
-		"a4a-signup-v2-via-email": true,
+		"a4a-signup-v2-via-email": false,
 		"a4a-client-checkout-v2": true,
 		"jetpack/crm-downloads": true
 	},

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -37,7 +37,7 @@
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
-		"a4a-signup-v2-via-email": true,
+		"a4a-signup-v2-via-email": false,
 		"a4a-client-checkout-v2": false,
 		"jetpack/crm-downloads": true
 	},

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -39,7 +39,7 @@
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
-		"a4a-signup-v2-via-email": true,
+		"a4a-signup-v2-via-email": false,
 		"a4a-client-checkout-v2": true,
 		"jetpack/crm-downloads": true
 	},

--- a/test/e2e/specs/a8c-for-agencies/signup__smoke.ts
+++ b/test/e2e/specs/a8c-for-agencies/signup__smoke.ts
@@ -38,10 +38,6 @@ describe( 'A4A > Signup: Smoke Test', function () {
 		const lastName = 'Doe';
 		await page.getByPlaceholder( 'Your last name' ).fill( lastName );
 
-		// Enter email
-		const myEmail = 'johndoe@gmail.com';
-		await page.getByPlaceholder( 'Your email' ).fill( myEmail );
-
 		// Enter the agency name
 		const agencyName = 'Agency name';
 		await page.getByPlaceholder( 'Agency name' ).fill( agencyName );
@@ -53,7 +49,6 @@ describe( 'A4A > Signup: Smoke Test', function () {
 		// Verify the form values
 		expect( await page.getByPlaceholder( 'Your first name' ).inputValue() ).toBe( firstName );
 		expect( await page.getByPlaceholder( 'Your last name' ).inputValue() ).toBe( lastName );
-		expect( await page.getByPlaceholder( 'Your email' ).inputValue() ).toBe( myEmail );
 		expect( await page.getByPlaceholder( 'Business URL' ).inputValue() ).toBe( businessURL );
 	} );
 } );


### PR DESCRIPTION
We have collected enough data and concluded that the magic link flow has lower conversion rate compared to the old flow. This PR disables the magic link flow.

Context: p1749039810348359/1748895723.431849-slack-C07T87RHK44

## Proposed Changes

* Disable magic link flow for the Signup V2.
* Add missing `initial_source` and `phoneNumber` when on manual flow.

## Why are these changes being made?


* The conversion rate isn't meeting our expectation with the magic link flow hence we need to revert to the old flow.

## Testing Instructions

* Spin up this branch locally.
* Navigate to http://agencies.localhost:3000/signup
* Fill up the form and complete the signup (Reach overview page)
* Wait for 1 minute and confirm that all data are correct in the P2 management post. fJMWL-p2

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?