### PR TITLE
Checkout: Typographic fixes for checkout loading message

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -209,7 +209,7 @@ function useRedirectOnTransactionSuccess( {
 		searchParams.get( 'from' ) === 'connect-after-checkout' &&
 		searchParams.get( 'connect_url_redirect' ) === 'true';
 
-	const defaultPendingText = translate( "Almost there – we're currently finalizing your order." );
+	const defaultPendingText = translate( 'Almost there—we’re currently finalizing your order.' );
 	const connectingJetpackText = translate(
 		"Transaction finalized – we're now connecting Jetpack."
 	);

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -546,7 +546,7 @@ export default function CheckoutMainContent( {
 			);
 		}
 
-		const headingText = translate( "Almost there – we're currently finalizing your order." );
+		const headingText = translate( 'Almost there—we’re currently finalizing your order.' );
 
 		return (
 			<WPCheckoutCompletedWrapper>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DES-139

## Proposed Changes

* Use a smart (typographically correct) apostrophe.
* Remove the spaces around the em dash.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/fa428de6-785e-4a9c-9191-af5b329996a4) | <img width="560" alt="Screenshot 2025-06-04 at 16 35 56" src="https://github.com/user-attachments/assets/60384b51-2622-438c-9c1e-ee73737aa77e" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To ensure the copy aligns with the Automattic Style Guide.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch.
* Create a new site.
* Purchase a plan.
* Complete checkout.
* Note the loading message after submitting the checkout page.
