### PR TITLE
Bump @automattic/components package to 3.0.0

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking changes
 
 - `CoreBadge`: Fork from `@wordpress/components` and convert styles to CSS module. Static class names are no longer available ([#103568](https://github.com/Automattic/wp-calypso/pull/103568)).
+- Remove `CountCard`, `CountComparisonCard`, `AnnualHighlightCards`, and `MobileHighlightCardListing` components from the package ([#103799](https://github.com/Automattic/wp-calypso/pull/103799)).
 
 ### New components
 
@@ -15,6 +16,11 @@
 - Add `BigSkyLogo.Mark` component ([#103612](https://github.com/Automattic/wp-calypso/pull/103612)).
 - Add `ValidatedFormControls` components, still in beta ([#100771](https://github.com/Automattic/wp-calypso/pull/100771)).
 - `Tabs.Tablist`: added `density` prop with new `compact` variant ([#103843](https://github.com/Automattic/wp-calypso/pull/103843)).
+- Add `title` to the `WooLogo` component's SVG ([#103800](https://github.com/Automattic/wp-calypso/pull/103800)).
+- Add `role` prop to the `Gravatar` component ([#103888](https://github.com/Automattic/wp-calypso/pull/103888)).
+- `SummaryButton`: tweak horizontal spacing to match `CardBody` ([#103573](https://github.com/Automattic/wp-calypso/pull/103573)).
+- `SummaryButton`: use `border` instead of `box-shadow` ([#103555](https://github.com/Automattic/wp-calypso/pull/103555)).
+- `TimeSince`: support new `lll` value for the `dateFormat` prop ([#103586](https://github.com/Automattic/wp-calypso/pull/103586)).
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-## 2.4.0
+## 3.0.0
 
 ### Breaking changes
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 2.4.0
+
 ### Breaking changes
 
 - `CoreBadge`: Fork from `@wordpress/components` and convert styles to CSS module. Static class names are no longer available ([#103568](https://github.com/Automattic/wp-calypso/pull/103568)).

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/components",
-	"version": "2.4.0",
+	"version": "3.0.0",
 	"description": "Automattic Components.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/components",
-	"version": "2.3.0",
+	"version": "2.4.0",
 	"description": "Automattic Components.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

Bump the @automattic/components package from version 2.3.0 to version 3.0.0

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* In preparation for the NPM release 
* To release the latest changes, including new `DateCalendar` and `DateRangeCalendar` components, a new `density` variant for `Tabs.Tablist`, a new `BigSkyLogo.Mark` component, beta `ValidatedFormControls` component, and various refactors to (S)CSS modules
* Given that the release includes a breaking change, we're bumping the major version.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
