### PR TITLE
Subscribers: remove subscribers-helper-library flag

### DIFF
--- a/client/my-sites/subscribers/helpers/index.ts
+++ b/client/my-sites/subscribers/helpers/index.ts
@@ -28,7 +28,7 @@ const getSubscriberDetailsCacheKey = (
 
 const getSubscriberDetailsType = ( userId: number | undefined ) => ( userId ? 'wpcom' : 'email' );
 
-const getSubscriptionIdFromSubscriber = ( subscriber: Subscriber ): number | string => {
+const getSubscriptionIdFromSubscriber = ( subscriber: Subscriber ): number => {
 	return (
 		subscriber.email_subscription_id ||
 		subscriber.subscription_id ||

--- a/client/my-sites/subscribers/helpers/index.ts
+++ b/client/my-sites/subscribers/helpers/index.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { SubscribersFilterBy } from '../constants';
 import type { Subscriber } from '../types';
 
@@ -10,7 +9,6 @@ const getSubscribersCacheKey = ( {
 	sortTerm,
 	filters,
 	sortOrder,
-	use_new_helper,
 }: {
 	siteId: number | undefined | null;
 	page?: number;
@@ -19,18 +17,7 @@ const getSubscribersCacheKey = ( {
 	sortTerm?: string;
 	filters?: SubscribersFilterBy[];
 	sortOrder?: 'asc' | 'desc';
-	use_new_helper?: boolean;
-} ) => [
-	'subscribers',
-	siteId,
-	page,
-	perPage,
-	search,
-	sortTerm,
-	filters,
-	sortOrder,
-	use_new_helper,
-];
+} ) => [ 'subscribers', siteId, page, perPage, search, sortTerm, filters, sortOrder ];
 
 const getSubscriberDetailsCacheKey = (
 	siteId: number | undefined | null,
@@ -42,16 +29,12 @@ const getSubscriberDetailsCacheKey = (
 const getSubscriberDetailsType = ( userId: number | undefined ) => ( userId ? 'wpcom' : 'email' );
 
 const getSubscriptionIdFromSubscriber = ( subscriber: Subscriber ): number | string => {
-	const useNewHelper = config.isEnabled( 'subscribers-helper-library' );
-	if ( useNewHelper ) {
-		return (
-			subscriber.email_subscription_id ||
-			subscriber.subscription_id ||
-			subscriber.wpcom_subscription_id ||
-			0
-		);
-	}
-	return subscriber.subscription_id || 0;
+	return (
+		subscriber.email_subscription_id ||
+		subscriber.subscription_id ||
+		subscriber.wpcom_subscription_id ||
+		0
+	);
 };
 
 export {

--- a/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
@@ -14,16 +14,35 @@ type ApiResponseError = {
 	message: string;
 };
 
+/**
+ * Gets the email subscription ID from a subscriber object.
+ * @param {Subscriber} subscriber - The subscriber object
+ * @returns {number} The email subscription ID, or 0 if not found
+ * @deprecated The `subscription_id` property is deprecated and from the old API endpoint response. Use `email_subscription_id` instead.
+ */
 const getEmailSubscriptionId = ( subscriber: Subscriber ): number => {
 	// `subscription_id` is from the old API endpoint response.
 	return subscriber.email_subscription_id || subscriber.subscription_id || 0;
 };
 
+/**
+ * Gets the WordPress.com subscription ID from a subscriber object.
+ * @param {Subscriber} subscriber - The subscriber object
+ * @returns {number} The WordPress.com subscription ID, or 0 if not found
+ * @deprecated The `subscription_id` property is deprecated and from the old API endpoint response. Use `wpcom_subscription_id` instead.
+ */
 const getWpcomSubscriptionId = ( subscriber: Subscriber ): number => {
 	// `subscription_id` is from the old API endpoint response.
 	return subscriber.wpcom_subscription_id || subscriber.subscription_id || 0;
 };
 
+/**
+ * Hook to remove subscribers from a site.
+ * Handles removal of email subscribers, WordPress.com followers, and paid subscription members.
+ * @param {number | null} siteId - The ID of the site
+ * @param {SubscriberQueryParams} SubscriberQueryParams - Query parameters for subscriber list
+ * @param {boolean} invalidateDetailsCache - Whether to invalidate the subscriber details cache (default: false)
+ */
 const useSubscriberRemoveMutation = (
 	siteId: number | null,
 	SubscriberQueryParams: SubscriberQueryParams,

--- a/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { DEFAULT_PER_PAGE } from '../constants';
@@ -15,21 +14,14 @@ type ApiResponseError = {
 	message: string;
 };
 
-const useNewHelper = config.isEnabled( 'subscribers-helper-library' );
-
 const getEmailSubscriptionId = ( subscriber: Subscriber ): number => {
-	if ( useNewHelper ) {
-		// For new helper library, use email_subscription_id if it exists, otherwise use subscription_id
-		return subscriber.email_subscription_id || subscriber.subscription_id || 0;
-	}
-	return subscriber.subscription_id || 0;
+	// `subscription_id` is from the old API endpoint response.
+	return subscriber.email_subscription_id || subscriber.subscription_id || 0;
 };
 
 const getWpcomSubscriptionId = ( subscriber: Subscriber ): number => {
-	if ( useNewHelper ) {
-		return subscriber.wpcom_subscription_id || 0;
-	}
-	return 0;
+	// `subscription_id` is from the old API endpoint response.
+	return subscriber.wpcom_subscription_id || subscriber.subscription_id || 0;
 };
 
 const useSubscriberRemoveMutation = (

--- a/client/my-sites/subscribers/queries/use-subscribers-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscribers-query.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { DEFAULT_PER_PAGE, SubscribersFilterBy, SubscribersSortBy } from '../constants';
@@ -16,7 +15,6 @@ type SubscriberQueryParams = {
 	filters?: SubscribersFilterBy[];
 	timestamp?: number;
 	limitData?: boolean;
-	use_new_helper?: boolean;
 };
 
 const useSubscribersQuery = ( {
@@ -28,8 +26,6 @@ const useSubscribersQuery = ( {
 	sortOrder,
 	filters = [],
 }: SubscriberQueryParams ) => {
-	const use_new_helper = config.isEnabled( 'subscribers-helper-library' );
-
 	const query = useQuery< SubscriberEndpointResponse >( {
 		queryKey: getSubscribersCacheKey( {
 			siteId,
@@ -39,13 +35,11 @@ const useSubscribersQuery = ( {
 			sortTerm,
 			filters,
 			sortOrder,
-			use_new_helper,
 		} ),
 		queryFn: () => {
 			const params = new URLSearchParams( {
 				per_page: perPage.toString(),
 				page: page.toString(),
-				use_new_helper: use_new_helper.toString(),
 				...( search && { search } ),
 				...( sortTerm && { sort: sortTerm } ),
 				...( sortOrder && { sort_order: sortOrder } ),

--- a/config/development.json
+++ b/config/development.json
@@ -177,7 +177,6 @@
 		"stats/paid-wpcom-v3": true,
 		"stats/real-time-tab": true,
 		"subscriber-importer": true,
-		"subscribers-helper-library": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -115,7 +115,6 @@
 		"stats/paid-wpcom-v2": true,
 		"stats/real-time-tab": false,
 		"subscriber-importer": true,
-		"subscribers-helper-library": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -75,7 +75,6 @@
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
 		"site-indicator": false,
-		"subscribers-helper-library": true,
 		"upgrades/redirect-payments": true,
 		"jetpack/pricing-page-cart": true,
 		"yolo/command-palette": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -67,7 +67,6 @@
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
 		"site-indicator": false,
-		"subscribers-helper-library": true,
 		"upgrades/redirect-payments": true,
 		"jetpack/pricing-page-cart": true,
 		"yolo/command-palette": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -72,7 +72,6 @@
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
 		"site-indicator": false,
-		"subscribers-helper-library": true,
 		"upgrades/redirect-payments": false,
 		"jetpack/pricing-page-cart": true,
 		"yolo/command-palette": false

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -72,7 +72,6 @@
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
 		"site-indicator": false,
-		"subscribers-helper-library": true,
 		"upgrades/redirect-payments": true,
 		"jetpack/pricing-page-cart": true,
 		"yolo/command-palette": false,

--- a/config/production.json
+++ b/config/production.json
@@ -150,7 +150,6 @@
 		"stats/paid-wpcom-v3": true,
 		"stats/real-time-tab": false,
 		"subscriber-importer": true,
-		"subscribers-helper-library": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -145,7 +145,6 @@
 		"stats/paid-wpcom-v3": true,
 		"stats/real-time-tab": false,
 		"subscriber-importer": true,
-		"subscribers-helper-library": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,

--- a/config/test.json
+++ b/config/test.json
@@ -106,7 +106,6 @@
 		"stats/archive-breakdown": true,
 		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
-		"subscribers-helper-library": true,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -149,7 +149,6 @@
 		"stats/paid-wpcom-v3": true,
 		"stats/real-time-tab": false,
 		"subscriber-importer": true,
-		"subscribers-helper-library": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,


### PR DESCRIPTION
## Proposed Changes

Remove `subscribers-helper-library` config setting.

## Why are these changes being made?

This feature has been fully released and the config flag is no longer needed.

## Testing Instructions

Smoke check `/subscribers/YOUR-DOMAIN`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
