### PR TITLE
Purchases: use DataViews for site-level purchases

### DIFF
--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -20,6 +20,8 @@ import {
 	useMembershipsFieldDefinitions,
 } from './hooks/use-field-definitions';
 
+import './style.scss';
+
 const purchasesWideFields = [ 'site', 'product', 'status', 'payment-method' ];
 const purchasesDesktopFields = [ 'site', 'product', 'status' ];
 const purchasesMobileFields = [ 'product' ];

--- a/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
+++ b/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
@@ -1,5 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
 import { CompactCard } from '@automattic/components';
+import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import EmptyContent from 'calypso/components/empty-content';
 import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
@@ -8,6 +10,7 @@ import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { Purchase } from 'calypso/lib/purchases/types';
 import PurchasesListHeader from 'calypso/me/purchases/purchases-list/purchases-list-header';
+import { PurchasesDataViews } from 'calypso/me/purchases/purchases-list-in-dataviews/purchases-data-view';
 import PurchasesSite from 'calypso/me/purchases/purchases-site';
 import { useStoredPaymentMethods } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
 import { useSelector } from 'calypso/state';
@@ -17,6 +20,7 @@ import {
 	hasLoadedSitePurchasesFromServer,
 	isFetchingSitePurchases,
 } from 'calypso/state/purchases/selectors';
+import getSites from 'calypso/state/selectors/get-sites';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { GetManagePurchaseUrlFor } from 'calypso/lib/purchases/types';
@@ -91,6 +95,11 @@ export default function SubscriptionsContentWrapper() {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const selectedSite = useSelector( getSelectedSite );
 	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSiteId ) );
+	const sites = useSelector( getSites ).filter( isValueTruthy );
+
+	if ( config.isEnabled( 'purchases/purchase-list-dataview' ) ) {
+		return <PurchasesDataViews purchases={ purchases } sites={ sites } />;
+	}
 
 	return (
 		<SubscriptionsContent

--- a/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
+++ b/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
@@ -94,10 +94,33 @@ export default function SubscriptionsContentWrapper() {
 	const hasLoadedPurchases = useSelector( hasLoadedSitePurchasesFromServer );
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const selectedSite = useSelector( getSelectedSite );
-	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSiteId ) );
+	const purchases = useSelector( ( state ) =>
+		isFetchingPurchases || ! hasLoadedPurchases ? [] : getSitePurchases( state, selectedSiteId )
+	);
 	const sites = useSelector( getSites ).filter( isValueTruthy );
 
 	if ( config.isEnabled( 'purchases/purchase-list-dataview' ) ) {
+		if ( ! selectedSiteId ) {
+			return <NoSitesMessage />;
+		}
+		if ( ! hasLoadedPurchases || isFetchingPurchases ) {
+			return (
+				<div className="subscriptions__list">
+					<PurchasesSite isPlaceholder />
+				</div>
+			);
+		}
+		// If there is a selected site but no site data, show the placeholder
+		if ( ! selectedSite?.ID ) {
+			return (
+				<div className="subscriptions__list">
+					<PurchasesSite isPlaceholder />
+				</div>
+			);
+		}
+		if ( purchases.length < 1 ) {
+			return <NoPurchasesMessage />;
+		}
 		return <PurchasesDataViews purchases={ purchases } sites={ sites } />;
 	}
 


### PR DESCRIPTION
## Proposed Changes

This PR updates the site-level purchases list to use the DataViews version to match the user-level purchases list.

Part of https://linear.app/a8c/project/replace-calypsos-active-upgrades-subscriptions-with-dataviews-a7b39dea5417/overview / https://github.com/Automattic/wp-calypso/issues/86616

Tracked by https://linear.app/a8c/issue/CHE-174/migrate-site-level-purchases-view-to-dataviews

## Testing Instructions

- Visit http://calypso.localhost:3000/purchases/subscriptions/your-site-here
- Verify that the list of purchases looks and works like you'd expect.