### PR TITLE
A4A: Referral checkout v2 - don't show confusing purchase messaging

### DIFF
--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -36,7 +36,10 @@ import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getRenewalItemFromProduct } from 'calypso/lib/cart-values/cart-items';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { isMarketplaceTemporarySitePurchase } from 'calypso/me/purchases/utils';
+import {
+	isMarketplaceTemporarySitePurchase,
+	isA4ATemporarySitePurchase,
+} from 'calypso/me/purchases/utils';
 import { errorNotice } from 'calypso/state/notices/actions';
 import type { Purchase } from './types';
 import type { SiteDetails } from '@automattic/data-stores';
@@ -926,6 +929,10 @@ export function purchaseType( purchase: Purchase ): string | null {
 	}
 
 	if ( isMarketplaceTemporarySitePurchase( purchase ) ) {
+		return null;
+	}
+
+	if ( isA4ATemporarySitePurchase( purchase ) ) {
 		return null;
 	}
 

--- a/client/me/purchases/billing-history/field-definitions.tsx
+++ b/client/me/purchases/billing-history/field-definitions.tsx
@@ -22,7 +22,8 @@ function renderServiceNameDescription(
 	const plan = capitalPDangit( transaction.variation );
 	const termLabel = getTransactionTermLabel( transaction, translate );
 	const shouldShowDomain =
-		transaction.domain && ! transaction.domain.startsWith( 'siteless.marketplace.wp.com' );
+		transaction.domain &&
+		! /^siteless.(marketplace.wp|agencies.automattic|a4a).com/.test( transaction.domain );
 	return (
 		<div>
 			<strong>{ plan }</strong>

--- a/client/me/purchases/billing-history/field-definitions.tsx
+++ b/client/me/purchases/billing-history/field-definitions.tsx
@@ -21,9 +21,10 @@ function renderServiceNameDescription(
 ) {
 	const plan = capitalPDangit( transaction.variation );
 	const termLabel = getTransactionTermLabel( transaction, translate );
-	const shouldShowDomain =
-		transaction.domain &&
-		! /^siteless.(marketplace.wp|agencies.automattic|a4a).com/.test( transaction.domain );
+	const isSitelessDomain = /^siteless\.(marketplace\.wp|agencies\.automattic|a4a)\.com/.test(
+		transaction.domain
+	);
+	const shouldShowDomain = transaction.domain && ! isSitelessDomain;
 	return (
 		<div>
 			<strong>{ plan }</strong>

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -167,6 +167,7 @@ import {
 	isAkismetTemporarySitePurchase,
 	isMarketplaceTemporarySitePurchase,
 	getCancelPurchaseSurveyCompletedPreferenceKey,
+	isA4ATemporarySitePurchase,
 } from '../utils';
 import PurchaseNotice from './notices';
 import PurchasePlanDetails from './plan-details';
@@ -1155,7 +1156,10 @@ class ManagePurchase extends Component<
 			return null;
 		}
 
-		if ( isMarketplaceTemporarySitePurchase( purchase ) ) {
+		if (
+			isMarketplaceTemporarySitePurchase( purchase ) ||
+			isA4ATemporarySitePurchase( purchase )
+		) {
 			return null;
 		}
 

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -166,8 +166,8 @@ import {
 	isJetpackTemporarySitePurchase,
 	isAkismetTemporarySitePurchase,
 	isMarketplaceTemporarySitePurchase,
-	getCancelPurchaseSurveyCompletedPreferenceKey,
 	isA4ATemporarySitePurchase,
+	getCancelPurchaseSurveyCompletedPreferenceKey,
 } from '../utils';
 import PurchaseNotice from './notices';
 import PurchasePlanDetails from './plan-details';

--- a/client/me/purchases/purchase-item/index.tsx
+++ b/client/me/purchases/purchase-item/index.tsx
@@ -56,6 +56,7 @@ import {
 	isJetpackTemporarySitePurchase,
 	isAkismetTemporarySitePurchase,
 	isMarketplaceTemporarySitePurchase,
+	isA4ATemporarySitePurchase,
 } from '../utils';
 import OwnerInfo from './owner-info';
 import type { Purchases, SiteDetails } from '@automattic/data-stores';
@@ -351,10 +352,14 @@ export function PurchaseItemStatus( {
 		}
 	}
 
+	console.log( '######################### purchase', purchase );
+	console.log( '######################### isDisconnectedSite', isDisconnectedSite );
+
 	if (
 		isDisconnectedSite &&
 		! isAkismetTemporarySitePurchase( purchase ) &&
-		! isMarketplaceTemporarySitePurchase( purchase )
+		! isMarketplaceTemporarySitePurchase( purchase ) &&
+		! isA4ATemporarySitePurchase( purchase )
 	) {
 		if ( isJetpackTemporarySitePurchase( purchase ) ) {
 			return (

--- a/client/me/purchases/purchase-item/index.tsx
+++ b/client/me/purchases/purchase-item/index.tsx
@@ -352,9 +352,6 @@ export function PurchaseItemStatus( {
 		}
 	}
 
-	console.log( '######################### purchase', purchase );
-	console.log( '######################### isDisconnectedSite', isDisconnectedSite );
-
 	if (
 		isDisconnectedSite &&
 		! isAkismetTemporarySitePurchase( purchase ) &&

--- a/client/me/purchases/utils.ts
+++ b/client/me/purchases/utils.ts
@@ -43,7 +43,9 @@ export function isTemporarySitePurchase( purchase: Purchase ): boolean {
 	// Currently only Jetpack, Akismet, A4A, and some Marketplace products allow siteless/userless(license-based) purchases which require a temporary
 	// site(s) to work. This function may need to be updated in the future as additional products types
 	// incorporate siteless/userless(licensebased) product based purchases..
-	return /^siteless.(jetpack|akismet|marketplace.wp|agencies.automattic|a4a).com$/.test( domain );
+	return /^siteless\.(jetpack|akismet|marketplace\.wp|agencies\.automattic|a4a)\.com$/.test(
+		domain
+	);
 }
 
 export function getTemporarySiteType( purchase: Purchase ): string | null {

--- a/client/me/purchases/utils.ts
+++ b/client/me/purchases/utils.ts
@@ -40,10 +40,10 @@ export function getAddNewPaymentMethodPath(): string {
 
 export function isTemporarySitePurchase( purchase: Purchase ): boolean {
 	const { domain } = purchase;
-	// Currently only Jeypack, Akismet and some Marketplace products allow siteless/userless(license-based) purchases which require a temporary
+	// Currently only Jetpack, Akismet, A4A, and some Marketplace products allow siteless/userless(license-based) purchases which require a temporary
 	// site(s) to work. This function may need to be updated in the future as additional products types
 	// incorporate siteless/userless(licensebased) product based purchases..
-	return /^siteless.(jetpack|akismet|marketplace.wp).com$/.test( domain );
+	return /^siteless.(jetpack|akismet|marketplace.wp|a4a).com$/.test( domain );
 }
 
 export function getTemporarySiteType( purchase: Purchase ): string | null {
@@ -64,6 +64,13 @@ export function isMarketplaceTemporarySitePurchase( purchase: Purchase ): boolea
 export function isJetpackTemporarySitePurchase( purchase: Purchase ): boolean {
 	const { productType } = purchase;
 	return isTemporarySitePurchase( purchase ) && productType === 'jetpack';
+}
+
+export function isA4ATemporarySitePurchase( purchase: Purchase ): boolean {
+	const { productType } = purchase;
+	console.log( 'purchase', purchase );
+	console.log( 'productType', productType );
+	return isTemporarySitePurchase( purchase ) && productType === 'a4a';
 }
 
 export function getCancelPurchaseSurveyCompletedPreferenceKey(

--- a/client/me/purchases/utils.ts
+++ b/client/me/purchases/utils.ts
@@ -43,7 +43,7 @@ export function isTemporarySitePurchase( purchase: Purchase ): boolean {
 	// Currently only Jetpack, Akismet, A4A, and some Marketplace products allow siteless/userless(license-based) purchases which require a temporary
 	// site(s) to work. This function may need to be updated in the future as additional products types
 	// incorporate siteless/userless(licensebased) product based purchases..
-	return /^siteless.(jetpack|akismet|marketplace.wp|agencies.automattic).com$/.test( domain );
+	return /^siteless.(jetpack|akismet|marketplace.wp|agencies.automattic|a4a).com$/.test( domain );
 }
 
 export function getTemporarySiteType( purchase: Purchase ): string | null {
@@ -67,10 +67,8 @@ export function isJetpackTemporarySitePurchase( purchase: Purchase ): boolean {
 }
 
 export function isA4ATemporarySitePurchase( purchase: Purchase ): boolean {
-	const { productType } = purchase;
-	console.log( 'purchase', purchase );
-	console.log( 'productType', productType );
-	return isTemporarySitePurchase( purchase ) && productType === 'a4a';
+	const { meta } = purchase;
+	return isTemporarySitePurchase( purchase ) && meta === 'is-a4a';
 }
 
 export function getCancelPurchaseSurveyCompletedPreferenceKey(

--- a/client/me/purchases/utils.ts
+++ b/client/me/purchases/utils.ts
@@ -43,7 +43,7 @@ export function isTemporarySitePurchase( purchase: Purchase ): boolean {
 	// Currently only Jetpack, Akismet, A4A, and some Marketplace products allow siteless/userless(license-based) purchases which require a temporary
 	// site(s) to work. This function may need to be updated in the future as additional products types
 	// incorporate siteless/userless(licensebased) product based purchases..
-	return /^siteless.(jetpack|akismet|marketplace.wp|a4a).com$/.test( domain );
+	return /^siteless.(jetpack|akismet|marketplace.wp|agencies.automattic).com$/.test( domain );
 }
 
 export function getTemporarySiteType( purchase: Purchase ): string | null {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

This is part of moving referral purchases to the wpcom billing system (BD).

Linear issue: https://linear.app/a8c/issue/A4A-897/dont-show-confusing-purchase-messaging-to-client

## Proposed Changes

* On some WPCOM purchase pages, don't show confusing messaging such as the siteless domain, `is-a4a` meta, etc.
* This follows existing patterns used by akismet and dotcom marketplace.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To avoid showing confusing and irrelevant info to the user

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox `public-api.wordpress.com`
* Use store sandbox by adding this to your `0-sandbox.php` file: `define( 'USE_STORE_SANDBOX', true );`
* Watch your php error log file for any issues: `tail -f /tmp/php-errors`.
* Send a referral to a client for any product other than Pressable.
* As the client, visit the link in the email and on the checkout page change `/client/checkout` to `/client/checkout/v2`. 
* Purchase the product.
* With this branch, either using the live link or booting the wpcom environment, visit `/me/purchases` as the client (eg. http://calypso.localhost:3000/me/purchases).
  * If the purchase doesn't show, try clicking the "Payment Methods" tab, then back to "Active Upgrades"
* Under "Active Upgrades", the purchase should not show the highlighted text in the table below.
* Under "Billing History", the purchase should not show the highlighted text in the table below for unassigned licenses (those still on the siteless site).
* Back on "Active Upgrades", for the purchase click the three dots, then "Manange purchase". The purchase should not show the highlighted text in the table below.

| **Before** | **After** |
|-----------------|-----------------|
| <img width="400" src="https://github.com/user-attachments/assets/6dbbe4eb-13be-4759-8e0e-8ca6bdea74b4" /> | <img width="400" src="https://github.com/user-attachments/assets/3b9acb1b-33a2-425b-baf9-f797868df0d0" /> |
| <img width="400" src="https://github.com/user-attachments/assets/5438599c-8647-441f-909d-371417e2a6ea" /> | <img width="400" src="https://github.com/user-attachments/assets/a7b56e56-a1e1-4c92-b493-ee3390905afc" /> |
| <img width="400" src="https://github.com/user-attachments/assets/37437536-ab87-45b9-9102-17bf56688a61" /> | <img width="400" src="https://github.com/user-attachments/assets/9a44db3e-4a4a-4172-83d5-9158ab051d58" /> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
