### PR TITLE
Update Jetpack Forms dashboard URL

### DIFF
--- a/client/my-sites/sidebar/static-data/jetpack-fallback-menu.js
+++ b/client/my-sites/sidebar/static-data/jetpack-fallback-menu.js
@@ -115,6 +115,13 @@ export default function jetpackMenu( { siteDomain, hasUnifiedImporter } ) {
 					type: 'submenu-item',
 					url: `/jetpack-search/${ siteDomain }`,
 				},
+				{
+					parent: 'jetpack',
+					slug: 'jetpack-forms-admin',
+					title: translate( 'Forms' ),
+					type: 'submenu-item',
+					url: `https://${ siteDomain }/wp-admin/admin.php?page=jetpack-forms-admin`,
+				},
 			],
 		},
 		{

--- a/client/state/admin-menu/test/fixture/menu-fixture.js
+++ b/client/state/admin-menu/test/fixture/menu-fixture.js
@@ -11,7 +11,7 @@ export default [
 				slug: 'edit-phppost_typefeedback',
 				title: 'Feedback',
 				type: 'submenu-item',
-				url: 'https://examplewebsite.wordpress.com/wp-admin/edit.php?post_type=feedback',
+				url: 'https://examplewebsite.wordpress.com/wp-admin/admin.php?page=jetpack-forms',
 			},
 			{
 				parent: 'feedback',

--- a/packages/command-palette/src/commands.tsx
+++ b/packages/command-palette/src/commands.tsx
@@ -1077,7 +1077,7 @@ export function useCommands() {
 				searchLabel: [
 					_x( 'feedback', 'Keyword for the View form responses command', __i18n_text_domain__ ),
 				].join( KEYWORD_SEPARATOR ),
-				callback: commandNavigation( '/wp-admin/edit.php?post_type=feedback' ),
+				callback: commandNavigation( '/wp-admin/admin.php?page=jetpack-forms-admin' ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to view form responses', __i18n_text_domain__ ),
 				capability: SiteCapabilities.EDIT_PAGES,

--- a/packages/data-stores/src/contextual-help/admin-sections.ts
+++ b/packages/data-stores/src/contextual-help/admin-sections.ts
@@ -390,7 +390,7 @@ export function generateAdminSections(
 		},
 		{
 			title: __( 'View contact form messages', __i18n_text_domain__ ),
-			link: `https://${ siteSlug }/wp-admin/edit.php?post_type=feedback&calypsoify=1`,
+			link: `https://${ siteSlug }/wp-admin/admin.php?page=jetpack-forms-admin`,
 			synonyms: [ 'contact', 'form' ],
 			icon: 'cog',
 		},

--- a/packages/help-center/src/route-to-query-mapping.ts
+++ b/packages/help-center/src/route-to-query-mapping.ts
@@ -38,7 +38,6 @@ export const useQueryForRoute = ( currentRoute: string ) => {
 		'/wp-admin/admin.php?page=ratings': __( 'ratings' ),
 		'/wp-admin/admin.php?page=wc': __( 'woocommerce' ),
 		'/wp-admin/admin.php?page=jetpack-forms-admin': __( 'forms' ),
-		'/wp-admin/admin.php?page=jetpack-forms': __( 'forms' ), // Matches /wp-admin/admin.php?page=jetpack-forms#/responses?status=inbox
 		'/wp-admin/edit.php?post_type=jetpack-testimonial': __( 'testimonials' ),
 		'/wp-admin/index.php?page=my-blogs': __( 'my sites' ),
 		'/wp-admin/options-general.php?page=debug-bar-extender': __( 'debug bar extender' ),

--- a/packages/help-center/src/route-to-query-mapping.ts
+++ b/packages/help-center/src/route-to-query-mapping.ts
@@ -37,7 +37,7 @@ export const useQueryForRoute = ( currentRoute: string ) => {
 		'/wp-admin/admin.php?page=polls': __( 'crowdsignal' ),
 		'/wp-admin/admin.php?page=ratings': __( 'ratings' ),
 		'/wp-admin/admin.php?page=wc': __( 'woocommerce' ),
-		'/wp-admin/edit.php?post_type=feedback': __( 'forms' ),
+		'/wp-admin/admin.php?page=jetpack-forms-admin': __( 'forms' ),
 		'/wp-admin/admin.php?page=jetpack-forms': __( 'forms' ), // Matches /wp-admin/admin.php?page=jetpack-forms#/responses?status=inbox
 		'/wp-admin/edit.php?post_type=jetpack-testimonial': __( 'testimonials' ),
 		'/wp-admin/index.php?page=my-blogs': __( 'my sites' ),


### PR DESCRIPTION
Part of FORMS-123

## Proposed Changes
This PR updates several places where Calypso would land the user on the legacy view for forms responses. We now use `admin.php?page=jetpack-forms-admin`

## Why are these changes being made?
Because we're moving the Feedback > Forms responses menu item to Jetpack > Forms and all our references should point to it now (`admin.php?page=jetpack-forms-admin`)

## Testing Instructions
TBD

Visit /home and use the command palette (summon with Cmd+K). Search for "View form responses" and hit enter (or click it). You should land on `/wp-admin/admin.php?page=jetpack-forms-admin`

<img width="467" alt="image" src="https://github.com/user-attachments/assets/e08274f8-24b8-4bc7-a6e3-037a16dfd9ed" />


Open Help center at form management and note how content is searched with "form" keyword (see [PR](https://github.com/Automattic/wp-calypso/pull/102493) for detailed examples)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
