### PR TITLE
Backup: fix copy site credentials form

### DIFF
--- a/client/my-sites/backup/clone-flow/index.tsx
+++ b/client/my-sites/backup/clone-flow/index.tsx
@@ -19,6 +19,7 @@ import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
 import { applySiteOffset } from 'calypso/lib/site/timezone';
 import { useDispatch, useSelector } from 'calypso/state';
+import { JETPACK_CREDENTIALS_UPDATE_RESET } from 'calypso/state/action-types';
 import { rewindClone, rewindStagingClone } from 'calypso/state/activity-log/actions';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { setValidFrom } from 'calypso/state/jetpack-review-prompt/actions';
@@ -189,6 +190,7 @@ const BackupCloneFlow: FunctionComponent< Props > = ( { siteId } ) => {
 		setShowCredentialForm( true );
 		setIsCloneToStaging( false );
 		dispatch( recordTracksEvent( 'calypso_jetpack_clone_flow_set_new_destination' ) );
+		dispatch( { type: JETPACK_CREDENTIALS_UPDATE_RESET, siteId } );
 	}
 
 	function onSearchChange( newValue: string, isNavigating: boolean ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/BACKUP-107/

## Proposed Changes

Ensure the credentials form is shown when using the `Copy site` option.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

If the `Copy site` option was used after editing the site credentials in the settings, the state from the previous edit was preventing the credentials form from being rendered. This ensures that whenever the Backup Clone Flow is triggered, it will trigger a state reset to launch the credentials form in a clean state.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the `Jetpack Cloud live` link provided by GitHub Actions below.
* Log in with your Jetpack Cloud credentials and select a site.
* Go to `Settings` and edit the `Remote server credentials`.
* Now go to `VaultPress Backup -> Copy site`.
* Click on the `Enter credentials for a new destination site` button.
* The credentials form for the new site should be properly rendered.

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/498c197d-a102-4e73-9f2e-f73bc66d7391) | ![image](https://github.com/user-attachments/assets/e5793f32-b23c-4c97-9f4a-739e6d5c6eaf) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
