### PR TITLE
A4A: Show correct 3pd vendor in product details modal for recently added products

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/lib/get-vendor-info.ts
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/lib/get-vendor-info.ts
@@ -16,6 +16,41 @@ const VENDOR_INFO_MAP: Record< string, VendorInfo > = {
 		vendorName: 'StoreApps',
 		vendorUrl: 'https://woocommerce.com/vendor/storeapps/',
 	},
+	afterpay: {
+		vendorSlug: 'afterpay',
+		vendorName: 'Afterpay',
+		vendorUrl: 'https://woocommerce.com/vendor/afterpay/',
+	},
+	affirm: {
+		vendorSlug: 'affirm',
+		vendorName: 'Affirm',
+		vendorUrl: 'https://woocommerce.com/vendor/affirm/',
+	},
+	mollie: {
+		vendorSlug: 'mollie',
+		vendorName: 'Mollie',
+		vendorUrl: 'https://woocommerce.com/vendor/mollie/',
+	},
+	stripe: {
+		vendorSlug: 'stripe',
+		vendorName: 'Stripe',
+		vendorUrl: 'https://woocommerce.com/vendor/stripe/',
+	},
+	klarna: {
+		vendorSlug: 'klarna',
+		vendorName: 'Klarna',
+		vendorUrl: 'https://woocommerce.com/vendor/klarna/',
+	},
+	paypal: {
+		vendorSlug: 'paypal',
+		vendorName: 'PayPal',
+		vendorUrl: 'https://woocommerce.com/vendor/paypal/',
+	},
+	klaviyo: {
+		vendorSlug: 'klaviyo',
+		vendorName: 'Klaviyo',
+		vendorUrl: 'https://woocommerce.com/vendor/klaviyo/',
+	},
 	woocommerce: {
 		vendorSlug: 'woocommerce',
 		vendorName: 'Woo',
@@ -44,6 +79,13 @@ const THIRD_PARTY_PRODUCT_MAP: Record< string, string > = {
 	'woocommerce-rental-products': 'kestrel',
 	'woocommerce-smart-coupons': 'storeapps',
 	'woocommerce-variation-swatches-and-photos': 'element-stark',
+	'woocommerce-afterpay': 'afterpay',
+	'woocommerce-affirm': 'affirm',
+	'woocommerce-mollie': 'mollie',
+	'woocommerce-stripe': 'stripe',
+	'woocommerce-klarna': 'klarna',
+	'woocommerce-paypal': 'paypal',
+	'woocommerce-klaviyo': 'klaviyo',
 };
 
 export const getVendorInfo = ( productSlug: string ) => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

P2: pfunGA-5Lu-p2#comment-10269

## Proposed Changes

* For the [recently added Woo products](https://github.com/Automattic/wp-calypso/pull/103722), show the correct 3rd-party vendor name in the product details modal.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To show the correct vendor name and link to their wccom vendor page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* From `/marketplace/products`, search for each product that's changed in this PR.
* Click "View details".
* You should see the correct vendor name and it should link to the correct vendor profile on woocommerce.com.

Example:
<img width="895" alt="Screenshot 2025-06-04 at 3 02 32 PM" src="https://github.com/user-attachments/assets/094c9332-00c5-4854-b57b-dfef7b8a45a0" />
<img width="1409" alt="Screenshot 2025-06-04 at 3 02 38 PM" src="https://github.com/user-attachments/assets/4f9d60cb-6ccb-46d2-8cfe-e794524efab3" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?