### PR TITLE
Purchases: Add PurchasesByOtherAdminsNotice to DataViews

### DIFF
--- a/client/me/purchases/purchases-list-in-dataviews/index.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/index.tsx
@@ -37,6 +37,7 @@ import getConciergeUserBlocked from 'calypso/state/selectors/get-concierge-user-
 import getSites from 'calypso/state/selectors/get-sites';
 import { getSiteId } from 'calypso/state/sites/selectors';
 import { AppState } from 'calypso/types';
+import { PurchasesByOtherAdminsNotice } from '../purchases-list/purchases-by-other-admins-notice';
 import PurchasesSite from '../purchases-site';
 import { PurchasesDataViews, MembershipsDataViews } from './purchases-data-view';
 import './style.scss';
@@ -145,6 +146,7 @@ function PurchasesListDataView(
 							eventName="calypso_no_purchases_upgrade_nudge_impression"
 							eventProperties={ commonEventProps }
 						/>
+						<PurchasesByOtherAdminsNotice sites={ sites } />
 						<EmptyContent
 							title={ translate( 'Looking to upgrade?' ) }
 							line={ translate(

--- a/client/me/purchases/purchases-list-in-dataviews/index.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/index.tsx
@@ -3,7 +3,6 @@ import { CompactCard } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
 import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { LocalizeProps, localize } from 'i18n-calypso';
-import { Component } from 'react';
 import { connect } from 'react-redux';
 import noSitesIllustration from 'calypso/assets/images/illustrations/illustration-nosites.svg';
 import QueryConciergeInitial from 'calypso/components/data/query-concierge-initial';
@@ -82,103 +81,113 @@ function isDataLoading( {
 	}
 }
 
-class PurchasesListDataView extends Component<
-	PurchasesListProps & PurchasesListConnectedProps & WithStoredPaymentMethodsProps & LocalizeProps
-> {
-	renderConciergeBanner() {
-		const { nextAppointment, availableSessions, isUserBlocked } = this.props;
-		return (
-			<PurchaseListConciergeBanner
-				nextAppointment={ nextAppointment ?? undefined }
-				availableSessions={ availableSessions }
-				isUserBlocked={ isUserBlocked }
-			/>
-		);
+function ConciergeBanner( {
+	nextAppointment,
+	availableSessions,
+	isUserBlocked,
+}: Pick<
+	PurchasesListConnectedProps,
+	'nextAppointment' | 'availableSessions' | 'isUserBlocked'
+> ) {
+	return (
+		<PurchaseListConciergeBanner
+			nextAppointment={ nextAppointment ?? undefined }
+			availableSessions={ availableSessions }
+			isUserBlocked={ isUserBlocked }
+		/>
+	);
+}
+
+function PurchasesListDataView(
+	props: PurchasesListProps &
+		PurchasesListConnectedProps &
+		WithStoredPaymentMethodsProps &
+		LocalizeProps
+) {
+	const { purchases, sites, translate, subscriptions } = props;
+	const commonEventProps = { context: 'me' };
+	let content;
+
+	if (
+		isDataLoading( {
+			isFetchingUserPurchases: props.isFetchingUserPurchases,
+			hasLoadedUserPurchasesFromServer: props.hasLoadedUserPurchasesFromServer,
+		} )
+	) {
+		content = <PurchasesSite isPlaceholder />;
 	}
 
-	render() {
-		const { purchases, sites, translate, subscriptions } = this.props;
-		const commonEventProps = { context: 'me' };
-		let content;
+	if ( purchases && purchases.length ) {
+		content = <PurchasesDataViews purchases={ purchases } sites={ sites } />;
+	}
 
-		if (
-			isDataLoading( {
-				isFetchingUserPurchases: this.props.isFetchingUserPurchases,
-				hasLoadedUserPurchasesFromServer: this.props.hasLoadedUserPurchasesFromServer,
-			} )
-		) {
-			content = <PurchasesSite isPlaceholder />;
-		}
-
-		if ( purchases && purchases.length ) {
-			content = <PurchasesDataViews purchases={ purchases } sites={ sites } />;
-		}
-
-		if ( purchases && ! purchases.length && ! subscriptions.length ) {
-			if ( ! sites.length ) {
-				return (
-					<Main wideLayout className="purchases-list">
-						<PageViewTracker path="/me/purchases" title="Purchases > No Sites" />
-						<NavigationHeader navigationItems={ [] } title={ titles.sectionTitle } />
-						<PurchasesNavigation section="activeUpgrades" />
-						<NoSitesMessage />
-					</Main>
-				);
-			}
-			content = (
-				<>
-					{ this.renderConciergeBanner() }
-					<CompactCard className="purchases-list__no-content">
-						<>
-							<TrackComponentView
-								eventName="calypso_no_purchases_upgrade_nudge_impression"
-								eventProperties={ commonEventProps }
-							/>
-							{ /* this.renderPurchasesByOtherAdminsNotice() to-do: render this as functional component */ }
-							<EmptyContent
-								title={ translate( 'Looking to upgrade?' ) }
-								line={ translate(
-									'Our plans give your site the power to thrive. ' +
-										'Find the plan that works for you.'
-								) }
-								action={ translate( 'Upgrade now' ) }
-								actionURL="/plans"
-								illustration={ noSitesIllustration }
-								actionCallback={ () => {
-									recordTracksEvent( 'calypso_no_purchases_upgrade_nudge_click', commonEventProps );
-								} }
-							/>
-						</>
-					</CompactCard>
-				</>
+	if ( purchases && ! purchases.length && ! subscriptions.length ) {
+		if ( ! sites.length ) {
+			return (
+				<Main wideLayout className="purchases-list">
+					<PageViewTracker path="/me/purchases" title="Purchases > No Sites" />
+					<NavigationHeader navigationItems={ [] } title={ titles.sectionTitle } />
+					<PurchasesNavigation section="activeUpgrades" />
+					<NoSitesMessage />
+				</Main>
 			);
 		}
-
-		return (
-			<Main wideLayout className="purchases-list">
-				<QueryUserPurchases />
-				<QueryMembershipsSubscriptions />
-				<PageViewTracker path="/me/purchases" title="Purchases" />
-
-				<NavigationHeader
-					navigationItems={ [] }
-					title={ titles.sectionTitle }
-					subtitle={ translate(
-						'Manage your sites’ plans and upgrades. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-						{
-							components: {
-								learnMoreLink: <InlineSupportLink supportContext="purchases" showIcon={ false } />,
-							},
-						}
-					) }
+		content = (
+			<>
+				<ConciergeBanner
+					nextAppointment={ props.nextAppointment }
+					availableSessions={ props.availableSessions }
+					isUserBlocked={ props.isUserBlocked }
 				/>
-				<PurchasesNavigation section="activeUpgrades" />
-				{ content }
-				<MembershipSubscriptions memberships={ subscriptions } />
-				<QueryConciergeInitial />
-			</Main>
+				<CompactCard className="purchases-list__no-content">
+					<>
+						<TrackComponentView
+							eventName="calypso_no_purchases_upgrade_nudge_impression"
+							eventProperties={ commonEventProps }
+						/>
+						<EmptyContent
+							title={ translate( 'Looking to upgrade?' ) }
+							line={ translate(
+								'Our plans give your site the power to thrive. ' +
+									'Find the plan that works for you.'
+							) }
+							action={ translate( 'Upgrade now' ) }
+							actionURL="/plans"
+							illustration={ noSitesIllustration }
+							actionCallback={ () => {
+								recordTracksEvent( 'calypso_no_purchases_upgrade_nudge_click', commonEventProps );
+							} }
+						/>
+					</>
+				</CompactCard>
+			</>
 		);
 	}
+
+	return (
+		<Main wideLayout className="purchases-list">
+			<QueryUserPurchases />
+			<QueryMembershipsSubscriptions />
+			<PageViewTracker path="/me/purchases" title="Purchases" />
+
+			<NavigationHeader
+				navigationItems={ [] }
+				title={ titles.sectionTitle }
+				subtitle={ translate(
+					'Manage your sites’ plans and upgrades. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+					{
+						components: {
+							learnMoreLink: <InlineSupportLink supportContext="purchases" showIcon={ false } />,
+						},
+					}
+				) }
+			/>
+			<PurchasesNavigation section="activeUpgrades" />
+			{ content }
+			<MembershipSubscriptions memberships={ subscriptions } />
+			<QueryConciergeInitial />
+		</Main>
+	);
 }
 
 export default connect( ( state: AppState ) => ( {

--- a/client/me/purchases/purchases-list/index.tsx
+++ b/client/me/purchases/purchases-list/index.tsx
@@ -13,7 +13,6 @@ import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
-import Notice from 'calypso/components/notice';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { getPurchasesBySite, getSubscriptionsBySite } from 'calypso/lib/purchases';
@@ -41,6 +40,7 @@ import { getSiteId } from 'calypso/state/sites/selectors';
 import { AppState } from 'calypso/types';
 import MembershipSite from '../membership-site';
 import PurchasesSite from '../purchases-site';
+import { PurchasesByOtherAdminsNotice } from './purchases-by-other-admins-notice';
 import PurchasesListHeader from './purchases-list-header';
 
 export interface PurchasesListProps {
@@ -68,60 +68,6 @@ class PurchasesList extends Component<
 		}
 
 		return ! this.props.sites.length && ! this.props.subscriptions.length;
-	}
-
-	renderPurchasesByOtherAdminsNotice() {
-		const { sites, translate } = this.props;
-
-		/*
-		 * Because this is only rendered when the user has no purchases,
-		 * we don't need to check each site to ensure the purchases aren't
-		 * linked with the user (they can't be, since they don't have any).
-		 */
-		const affectedSites = sites
-			.filter( ( site ) => {
-				if ( ! site?.plan?.is_free ) {
-					return site.capabilities.manage_options;
-				}
-				if ( site?.products && site?.products?.length > 0 ) {
-					return site.capabilities.manage_options;
-				}
-				return false;
-			} )
-			.map( ( site ) => site.slug );
-
-		if ( ! affectedSites.length ) {
-			return;
-		}
-
-		let affectedSitesString = '';
-
-		if ( affectedSites.length === 1 ) {
-			affectedSitesString = affectedSites[ 0 ];
-		} else {
-			const allButLast = affectedSites.slice( 0, -1 ).join( ', ' );
-			const translatedAnd = translate( 'and', {
-				comment: 'last conjunction in a list of blognames: (blog1, blog2,) blog3 _and_ blog4',
-			} );
-			const last = affectedSites[ affectedSites.length - 1 ];
-
-			affectedSitesString = allButLast + ' ' + translatedAnd + ' ' + last;
-		}
-
-		return (
-			<Notice status="is-info" showDismiss={ false }>
-				{ translate(
-					'The upgrades for {{strong}}%(affectedSitesString)s{{/strong}} are owned by another site administrator. ' +
-						'These can only be managed by the purchase owners.',
-					{
-						components: { strong: <strong /> },
-						args: {
-							affectedSitesString,
-						},
-					}
-				) }
-			</Notice>
-		);
 	}
 
 	renderConciergeBanner() {
@@ -197,7 +143,7 @@ class PurchasesList extends Component<
 								eventName="calypso_no_purchases_upgrade_nudge_impression"
 								eventProperties={ commonEventProps }
 							/>
-							{ this.renderPurchasesByOtherAdminsNotice() }
+							<PurchasesByOtherAdminsNotice sites={ sites } />
 							<EmptyContent
 								title={ translate( 'Looking to upgrade?' ) }
 								line={ translate(

--- a/client/me/purchases/purchases-list/purchases-by-other-admins-notice.tsx
+++ b/client/me/purchases/purchases-list/purchases-by-other-admins-notice.tsx
@@ -1,0 +1,56 @@
+import { useTranslate } from 'i18n-calypso';
+import Notice from 'calypso/components/notice';
+import type { SiteDetails } from '@automattic/data-stores';
+
+export function PurchasesByOtherAdminsNotice( { sites }: { sites: SiteDetails[] } ) {
+	const translate = useTranslate();
+	/*
+	 * Because this is only rendered when the user has no purchases,
+	 * we don't need to check each site to ensure the purchases aren't
+	 * linked with the user (they can't be, since they don't have any).
+	 */
+	const affectedSites = sites
+		.filter( ( site ) => {
+			if ( ! site?.plan?.is_free ) {
+				return site.capabilities.manage_options;
+			}
+			if ( site?.products && site?.products?.length > 0 ) {
+				return site.capabilities.manage_options;
+			}
+			return false;
+		} )
+		.map( ( site ) => site.slug );
+
+	if ( ! affectedSites.length ) {
+		return;
+	}
+
+	let affectedSitesString = '';
+
+	if ( affectedSites.length === 1 ) {
+		affectedSitesString = affectedSites[ 0 ];
+	} else {
+		const allButLast = affectedSites.slice( 0, -1 ).join( ', ' );
+		const translatedAnd = translate( 'and', {
+			comment: 'last conjunction in a list of blognames: (blog1, blog2,) blog3 _and_ blog4',
+		} );
+		const last = affectedSites[ affectedSites.length - 1 ];
+
+		affectedSitesString = allButLast + ' ' + translatedAnd + ' ' + last;
+	}
+
+	return (
+		<Notice status="is-info" showDismiss={ false }>
+			{ translate(
+				'The upgrades for {{strong}}%(affectedSitesString)s{{/strong}} are owned by another site administrator. ' +
+					'These can only be managed by the purchase owners.',
+				{
+					components: { strong: <strong /> },
+					args: {
+						affectedSitesString,
+					},
+				}
+			) }
+		</Notice>
+	);
+}


### PR DESCRIPTION
## Proposed Changes

`renderPurchasesByOtherAdminsNotice()` was excluded when the DataViews version of the purchases list was made but we want to retain it. In this PR we add it to the DataViews version. Note that it is only shown when there are no other purchases. This PR does not change any behavior of the notice itself.

Part of https://linear.app/a8c/project/replace-calypsos-active-upgrades-subscriptions-with-dataviews-a7b39dea5417/overview / https://github.com/Automattic/wp-calypso/issues/86616

Tracked by https://linear.app/a8c/issue/CHE-176/add-renderpurchasesbyotheradminsnotice-to-purchases-dataviews

## Testing Instructions

See the original PR that added this feature for details: https://github.com/Automattic/wp-calypso/pull/97198

Basically:

- Use calypso.localhost because the DataViews layout is only available there.
- Use a site with no purchases but which has a subscription paid for by a different user.
- View `/me/purchases` and verify that you see the notice that reads, "The upgrades for ... are owned by another site administrator. These can only be managed by the purchase owners."