### PR TITLE
E2E: Fix tests for refactored form fields

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
@@ -37,12 +37,19 @@ export class AllFormFieldsFlow implements BlockFlow {
 	 * @param {EditorContext} context The current context for the editor at the point of test execution
 	 */
 	async configure( context: EditorContext ): Promise< void > {
+		// Determine if we are working with the refactored form fields (released June 2025)
+		const editorCanvas = await context.editorPage.getEditorCanvas();
+		const initailBlock = editorCanvas.locator( makeSelectorFromBlockName( 'Text Input Field' ) );
+		const inputChild = initailBlock.locator( '[aria-label="Block: Input"]' );
+		const isRefactor = ( await inputChild.count() ) > 0;
+
 		// Text Input Field is already added by the first step, so let's start by labeling it.
 		await labelFormFieldBlock( context.addedBlockLocator, {
 			blockName: 'Text Input Field',
 			accessibleLabelName: 'Add label…',
 			labelText: this.addLabelPrefix( 'Text Input Field' ),
 		} );
+		let lastBlockName = 'Text Input Field';
 
 		// Add remaining field blocks, labeling as we go.
 		const remainingBlocksToAdd = [
@@ -52,32 +59,43 @@ export class AllFormFieldsFlow implements BlockFlow {
 			[ 'Date Picker', 'Add label…' ],
 			[ 'Phone Number Field', 'Add label…' ],
 			[ 'Multi-line Text Field', 'Add label…' ],
-			[ 'Checkbox', 'Add label…' ],
+			[ 'Checkbox', isRefactor ? 'Add option…' : 'Add label…' ],
 			[ 'Multiple Choice (Checkbox)', 'Add label' ],
 			[ 'Single Choice (Radio)', 'Add label' ],
 			[ 'Dropdown Field', 'Add label' ],
 			[ 'Terms Consent', 'Add implicit consent message…' ],
 		];
 		for ( const [ blockName, accessibleLabelName ] of remainingBlocksToAdd ) {
-			await this.addFieldBlockToForm( context, blockName );
+			await this.addFieldBlockToForm( context, blockName, lastBlockName, isRefactor );
 			await labelFormFieldBlock( context.addedBlockLocator, {
 				blockName,
 				accessibleLabelName,
 				labelText: this.addLabelPrefix( blockName ),
+				isRefactor,
 			} );
+			lastBlockName = blockName;
 		}
 
 		// And we just wrap up labeling the auto-added blocks.
-		const otherBlocksToLabel = [
-			[ 'Button', 'Add text…' ],
-			[ 'Single Choice Option', 'Add option…' ],
-			[ 'Multiple Choice Option', 'Add option…' ],
-		];
-		for ( const [ blockName, accessibleLabelName ] of otherBlocksToLabel ) {
+		const otherBlocksToLabel = isRefactor
+			? [
+					[ 'Button', 'Add text…' ],
+					[ 'Option', 'Add option…', 'Single Choice (Radio)' ],
+					[ 'Option', 'Add option…', 'Multiple Choice (Checkbox)' ],
+			  ]
+			: [
+					[ 'Button', 'Add text…' ],
+					[ 'Single Choice Option', 'Add option…' ],
+					[ 'Multiple Choice Option', 'Add option…' ],
+			  ];
+
+		for ( const [ blockName, accessibleLabelName, parentBlockName ] of otherBlocksToLabel ) {
 			await labelFormFieldBlock( context.addedBlockLocator, {
 				blockName,
 				accessibleLabelName,
 				labelText: this.addLabelPrefix( blockName ),
+				parentBlockName,
+				isRefactor,
 			} );
 		}
 	}
@@ -88,6 +106,10 @@ export class AllFormFieldsFlow implements BlockFlow {
 	 * @param {PublishedPostContext} context The current context for the published post at the point of test execution
 	 */
 	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
+		const isRefactor = ( await context.page.locator( '.wp-block-jetpack-input' ).count() ) > 0;
+		const radioName = isRefactor ? 'Option' : 'Single Choice Option';
+		const checkboxName = isRefactor ? 'Option' : 'Multiple Choice Option';
+
 		await validatePublishedFormFields( context.page, [
 			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Text Input Field' ) },
 			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Name Field' ) },
@@ -96,8 +118,8 @@ export class AllFormFieldsFlow implements BlockFlow {
 			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Phone Number Field' ) },
 			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Multi-line Text Field' ) },
 			{ type: 'checkbox', accessibleName: this.addLabelPrefix( 'Checkbox' ) },
-			{ type: 'radio', accessibleName: this.addLabelPrefix( 'Single Choice Option' ) },
-			{ type: 'checkbox', accessibleName: this.addLabelPrefix( 'Multiple Choice Option' ) },
+			{ type: 'radio', accessibleName: this.addLabelPrefix( radioName ) },
+			{ type: 'checkbox', accessibleName: this.addLabelPrefix( checkboxName ) },
 			{ type: 'button', accessibleName: this.addLabelPrefix( 'Button' ) },
 			// Currently broken, sadly! See: https://github.com/Automattic/jetpack/issues/30762
 			// { type: 'combobox', accessibleName: this.addLabelPrefix( 'Dropdown Field' ) },
@@ -128,10 +150,23 @@ export class AllFormFieldsFlow implements BlockFlow {
 	 *
 	 * @param {EditorContext} context The editor context object.
 	 * @param {string} blockName Name of the block.
+	 * @param {string} lastBlockName The name of the previously inserted block.
+	 * @param {boolean} isRefactor Whether the block is part of the refactored form fields.
 	 */
-	private async addFieldBlockToForm( context: EditorContext, blockName: string ) {
+	private async addFieldBlockToForm(
+		context: EditorContext,
+		blockName: string,
+		lastBlockName: string,
+		isRefactor: boolean
+	) {
 		const openInlineInserter: OpenInlineInserter = async ( editorCanvas ) => {
-			await context.editorPage.selectParentBlock( 'Form' );
+			if ( isRefactor ) {
+				await context.editorPage.selectParentBlock( lastBlockName );
+				await context.editorPage.selectParentBlock( 'Form' );
+			} else {
+				await context.editorPage.selectParentBlock( 'Form' );
+			}
+
 			const addBlockLocater = await editorCanvas.getByRole( 'button', { name: 'Add block' } );
 			if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
 				// See: https://github.com/Automattic/jetpack/issues/32695

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
@@ -59,7 +59,7 @@ export class AllFormFieldsFlow implements BlockFlow {
 			[ 'Date Picker', 'Add label…' ],
 			[ 'Phone Number Field', 'Add label…' ],
 			[ 'Multi-line Text Field', 'Add label…' ],
-			[ 'Checkbox', isRefactor ? 'Add option…' : 'Add label…' ],
+			[ 'Checkbox', 'Add label…' ],
 			[ 'Multiple Choice (Checkbox)', 'Add label' ],
 			[ 'Single Choice (Radio)', 'Add label' ],
 			[ 'Dropdown Field', 'Add label' ],

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/shared/block-helpers.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/shared/block-helpers.ts
@@ -44,10 +44,29 @@ export async function validatePublishedFormFields(
  * @param {Locator} parentFormBlock Locator for the parent form block.
  * @param {FieldLabelDetails} details The details for labeling.
  */
-export async function labelFormFieldBlock( parentFormBlock: Locator, details: FieldLabelDetails ) {
-	const { blockName, accessibleLabelName, labelText } = details;
-	await parentFormBlock
+export async function labelFormFieldBlock(
+	parentFormBlock: Locator,
+	{
+		blockName,
+		accessibleLabelName,
+		labelText,
+		parentBlockName = undefined,
+		isRefactor = false,
+	}: {
+		blockName: string;
+		accessibleLabelName: string;
+		labelText: string;
+		parentBlockName?: string;
+		isRefactor?: boolean;
+	}
+) {
+	let scope = parentFormBlock;
+	if ( isRefactor && parentBlockName ) {
+		scope = scope.locator( makeSelectorFromBlockName( parentBlockName ) );
+	}
+	await scope
 		.locator( makeSelectorFromBlockName( blockName ) )
 		.getByRole( 'textbox', { name: accessibleLabelName } )
+		.first()
 		.fill( labelText );
 }


### PR DESCRIPTION
## Proposed Changes

We will be deploying a major refactor to the structure of Jetpack Forms field blocks as part of [this Jetpack PR](https://github.com/Automattic/jetpack/pull/43765). This PR updates the related form E2E tests. 

To avoid failures both before and after the merge, I've updated the code to pass whether running against the old or new/refactored code. I would be happy to take responsibility for following up after the big merge to remove the conditional logic, and just make the code work for the refactored branch. 

For context, you can see discussion about E2E tests failing when we tried to merge an earlier version of the Jetpack PR on slack here: p1749022761155249/1749020374.475259-slack-C086RGTJT1D

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

See above.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You'll need to run the tests twice: once against the old form fields and once against the refactored branch and fields. 

*1. Testing against the older form fields on Jetpack trunk*
- You'll need to set up your environment to run Calypso E2E testing locally. You can follow the instructions [here](https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e#quick-start). But assuming you have all the usually dependencies on your machine to do Calypso development, you'll then need to do this:
- Obtain the secrets decryption key from the MC Secret Store
- Export the decryption key as an environment variable: `export E2E_SECRETS_KEY=secret-from-secret-store`
- Decrypt the secrets file: `yarn decrypt-secrets` (you may need to do this from the e2e dir)
- Run yarn workspace wp-e2e-tests build && yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__jetpack-forms.ts (from repo root)
- Confirm all tests pass.

*2. Testing against the refactor form fields on this branch*
- You will need to load the Jetpack branch in your sandbox, and run the E2E tests against that
- Ensure you are proxied, and ssh into your sandbox
- From your sandbox, run `bin/jetpack-downloader test jetpack update/migrate-form-fields-to-inner-blocks` to load the Jetpack branch in your sandbox. 
- From your sandbox, run `allow-sandbox-production-writes` (needed for login to work)
- Update your hosts file so that `public-api.wordpress.com` and `e2eflowtestingsimplepersonal.wordpress.com` are both sandboxed. 
- Run the E2E tests the same as step 1. 
- You'll know you are doing it right because you'll see the orange 'sandboxed' notice in the lower right of the browser when the tests are running.
- Confirm all tests pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?