### PR TITLE
Hosting Dashboard v2: Update site settings badge for Simple sites

### DIFF
--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -168,17 +168,6 @@ const siteSettingsSubscriptionGiftingRoute = createRoute( {
 	)
 );
 
-const siteSettingsDatabaseRoute = createRoute( {
-	getParentRoute: () => siteRoute,
-	path: 'settings/database',
-} ).lazy( () =>
-	import( '../sites/settings-database' ).then( ( d ) =>
-		createLazyRoute( 'site-settings-database' )( {
-			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
-		} )
-	)
-);
-
 const siteSettingsWordPressRoute = createRoute( {
 	getParentRoute: () => siteRoute,
 	path: 'settings/wordpress',
@@ -208,6 +197,17 @@ const siteSettingsPHPRoute = createRoute( {
 } ).lazy( () =>
 	import( '../sites/settings-php' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-php' )( {
+			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+const siteSettingsDatabaseRoute = createRoute( {
+	getParentRoute: () => siteRoute,
+	path: 'settings/database',
+} ).lazy( () =>
+	import( '../sites/settings-database' ).then( ( d ) =>
+		createLazyRoute( 'site-settings-database' )( {
 			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
 		} )
 	)

--- a/client/dashboard/sites/settings-caching/summary.tsx
+++ b/client/dashboard/sites/settings-caching/summary.tsx
@@ -22,24 +22,26 @@ export default function CachingSettingsSummary( {
 		enabled: canUpdate,
 	} );
 
-	let badge;
-	if ( canUpdate ) {
-		if ( isEdgeCacheAvailable( site ) && isEdgeCacheActive ) {
-			badge = {
-				text: __( 'Edge cache enabled' ),
-				intent: 'success' as const,
-			};
-		} else {
-			badge = {
-				text: __( 'Edge cache disabled' ),
-			};
+	const getBadge = () => {
+		if ( ! canUpdate ) {
+			return [];
 		}
-	} else {
-		badge = {
-			text: __( 'Managed' ),
-			intent: 'success' as const,
-		};
-	}
+
+		if ( isEdgeCacheAvailable( site ) && isEdgeCacheActive ) {
+			return [
+				{
+					text: __( 'Edge cache enabled' ),
+					intent: 'success' as const,
+				},
+			];
+		}
+
+		return [
+			{
+				text: __( 'Edge cache disabled' ),
+			},
+		];
+	};
 
 	return (
 		<RouterLinkSummaryButton
@@ -47,7 +49,7 @@ export default function CachingSettingsSummary( {
 			title={ __( 'Caching' ) }
 			density={ density }
 			decoration={ <Icon icon={ next } /> }
-			badges={ [ badge ] }
+			badges={ getBadge() }
 		/>
 	);
 }

--- a/client/dashboard/sites/settings-defensive-mode/summary.tsx
+++ b/client/dashboard/sites/settings-defensive-mode/summary.tsx
@@ -26,21 +26,26 @@ export default function DefensiveModeSettingsSummary( {
 		return null;
 	}
 
-	let badge;
-	if ( data ) {
-		if ( data.enabled ) {
-			badge = {
-				text: __( 'Enabled' ),
-				intent: 'info' as const,
-			};
-		} else {
-			badge = {
-				text: __( 'Disabled' ),
-			};
+	const getBadge = () => {
+		if ( ! data ) {
+			return [];
 		}
-	} else {
-		badge = { text: __( 'Managed' ) };
-	}
+
+		if ( data.enabled ) {
+			return [
+				{
+					text: __( 'Enabled' ),
+					intent: 'info' as const,
+				},
+			];
+		}
+
+		return [
+			{
+				text: __( 'Disabled' ),
+			},
+		];
+	};
 
 	return (
 		<RouterLinkSummaryButton
@@ -48,7 +53,7 @@ export default function DefensiveModeSettingsSummary( {
 			title={ __( 'Defensive mode' ) }
 			density={ density }
 			decoration={ <Icon icon={ shield } /> }
-			badges={ [ badge ] }
+			badges={ getBadge() }
 		/>
 	);
 }

--- a/client/dashboard/sites/settings-php/summary.tsx
+++ b/client/dashboard/sites/settings-php/summary.tsx
@@ -1,6 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 import { code } from '@wordpress/icons';
 import { getPHPVersions } from 'calypso/data/php-versions';
 import { sitePHPVersionQuery } from '../../app/queries';
@@ -17,10 +16,17 @@ export default function PHPSettingsSummary( { site, density }: { site: Site; den
 
 	const { recommendedValue } = getPHPVersions();
 
-	const badge = {
-		text: version ?? __( 'Managed' ),
-		intent:
-			version && version !== recommendedValue ? ( 'warning' as const ) : ( 'success' as const ),
+	const getBadge = () => {
+		if ( ! version ) {
+			return [];
+		}
+
+		return [
+			{
+				text: version,
+				intent: version !== recommendedValue ? ( 'warning' as const ) : ( 'success' as const ),
+			},
+		];
 	};
 
 	return (
@@ -29,7 +35,7 @@ export default function PHPSettingsSummary( { site, density }: { site: Site; den
 			title="PHP"
 			density={ density }
 			decoration={ <Icon icon={ code } /> }
-			badges={ [ badge ] }
+			badges={ getBadge() }
 		/>
 	);
 }

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -37,9 +37,9 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 			</SummaryButtonList>
 			<SectionHeader title={ __( 'Server' ) } />
 			<SummaryButtonList>
-				<DatabaseSettingsSummary site={ site } />
 				<WordPressSettingsSummary site={ site } />
 				<PHPSettingsSummary site={ site } />
+				<DatabaseSettingsSummary site={ site } />
 				<AgencySettingsSummary site={ site } />
 				<PrimaryDataCenterSettingsSummary site={ site } />
 				<StaticFile404SettingsSummary site={ site } />


### PR DESCRIPTION
Ref DOTCOM-13379

## Proposed Changes

This PR removes the "Managed" badge for simple site settings.

| Before | After | 
| --- | --- |
| ![Screenshot 2025-06-05 at 9 07 43 AM](https://github.com/user-attachments/assets/7f355e3d-fd60-4562-b388-1358995a6fa5) | ![Screenshot 2025-06-05 at 9 07 24 AM](https://github.com/user-attachments/assets/ea1992ed-509f-43e0-8abb-ff3619a31f29) |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

UI polish.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2/sites/:siteSlug using a Simple site.
* Ensure that the "Managed" badges are no longer shown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
