### PR TITLE
Dashboard v2: refactor: consistently add padding around forms to conform with design

### DIFF
--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -48,3 +48,7 @@ h1 {
 	font-family: var( --dashboard-h1__font-family );
 	font-weight: var( --dashboard-h1__font-weight ) !important;
 }
+
+form {
+	padding: 8px 0;
+}

--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -49,6 +49,9 @@ h1 {
 	font-weight: var( --dashboard-h1__font-weight ) !important;
 }
 
+// This is a temporary fix to match forms with the design.
+// The desired approach would be to create a layout component to wrap the form fields.
+// See: https://github.com/Automattic/wp-calypso/pull/103978
 form {
 	padding: 8px 0;
 }

--- a/client/dashboard/sites/settings-agency/index.tsx
+++ b/client/dashboard/sites/settings-agency/index.tsx
@@ -115,7 +115,7 @@ export default function SettingsAgency( { siteSlug }: { siteSlug: string } ) {
 			<Card>
 				<CardBody>
 					<form onSubmit={ handleSubmit }>
-						<VStack spacing={ 4 } style={ { padding: '8px 0' } }>
+						<VStack spacing={ 4 }>
 							<DataForm< SiteSettings >
 								data={ formData }
 								fields={ fields }

--- a/client/dashboard/sites/settings-caching/index.tsx
+++ b/client/dashboard/sites/settings-caching/index.tsx
@@ -152,7 +152,7 @@ export default function CachingSettings( { siteSlug }: { siteSlug: string } ) {
 			<Card>
 				<CardBody>
 					<form onSubmit={ handleUpdateEdgeCacheStatus }>
-						<VStack spacing={ 4 } style={ { padding: '8px 0' } }>
+						<VStack spacing={ 4 }>
 							<DataForm< CachingFormData >
 								data={ formData }
 								fields={ fields }

--- a/client/dashboard/sites/settings-hundred-year-plan/index.tsx
+++ b/client/dashboard/sites/settings-hundred-year-plan/index.tsx
@@ -94,7 +94,7 @@ export default function HundredYearPlanSettings( { siteSlug }: { siteSlug: strin
 			<Card>
 				<CardBody>
 					<form onSubmit={ handleSubmit } className="dashboard-site-settings-form">
-						<VStack spacing={ 4 } style={ { padding: '8px 0' } }>
+						<VStack spacing={ 4 }>
 							<VStack spacing={ 2 }>
 								<Text size="15px" weight={ 500 }>
 									{ __( 'Legacy contact' ) }

--- a/client/dashboard/sites/settings-subscription-gifting/index.tsx
+++ b/client/dashboard/sites/settings-subscription-gifting/index.tsx
@@ -99,7 +99,7 @@ export default function SubscriptionGiftingSettings( { siteSlug }: { siteSlug: s
 			<Card>
 				<CardBody>
 					<form onSubmit={ handleSubmit }>
-						<VStack spacing={ 4 } style={ { padding: '8px 0' } }>
+						<VStack spacing={ 4 }>
 							<DataForm< SiteSettings >
 								data={ formData }
 								fields={ fields }

--- a/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
@@ -79,7 +79,7 @@ export function ConfirmNewOwnerForm( {
 				</Text>
 			</VStack>
 			<form onSubmit={ handleSubmit }>
-				<VStack spacing={ 4 } style={ { padding: '8px 0' } }>
+				<VStack spacing={ 4 }>
 					{ /* TODO: Update the gap between each field */ }
 					<DataForm< ConfirmNewOwnerFormData >
 						data={ formData }

--- a/client/dashboard/sites/site-delete-modal/index.tsx
+++ b/client/dashboard/sites/site-delete-modal/index.tsx
@@ -197,7 +197,7 @@ function SiteDeleteConfirmContent( { site, onClose }: { site: Site; onClose: () 
 				) }
 			</Text>
 			<form onSubmit={ handleSubmit }>
-				<VStack spacing={ 4 } style={ { padding: '8px 0' } }>
+				<VStack spacing={ 4 }>
 					<DataForm< SiteDeleteFormData >
 						data={ formData }
 						fields={ fields }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/pull/103929#issuecomment-2940743156

## Proposed Changes

This PR add a 8px top and bottom padding around forms, to consistently match with the design. The design somehow has `DataFormFields` and `Fields` components, which don't actually exist in `<DataForm>` library that we're using.

Additionally, `<DataForm>` does not add any outer `<div>` that we can target this CSS to, so I'm proposing to add the CSS to `form` directly.

Note that we've already been doing this by adding inline styles to the `<VStack>`. With this, we can clean all that up.

Example changes:

|Before|After|Actual Figma design|
|-|-|-|
|![wpcalypso wordpress com_v2_sites_testfusharwoa8 wpcomstaging com_settings_site-visibility](https://github.com/user-attachments/assets/4f3abf34-a5a6-498d-a30a-5136d9ba6143)|![calypso localhost_3000_v2_sites_testfusharwoa8 wpcomstaging com_settings_site-visibility](https://github.com/user-attachments/assets/e21f137f-ba71-4070-803a-0a5a6517da50)|<img alt="image" src="https://github.com/user-attachments/assets/986edbde-d9ef-4a94-b605-92e8e9a9e1e6" />|


## Testing Instructions

Check the forms in the changed files in this PR.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
