### PR TITLE
Dashboard: Add subtitle to "Handling requests for nonexistent assets"

### DIFF
--- a/client/dashboard/sites/settings-static-file-404/index.tsx
+++ b/client/dashboard/sites/settings-static-file-404/index.tsx
@@ -87,7 +87,14 @@ export default function SiteStaticFile404Settings( { siteSlug }: { siteSlug: str
 	return (
 		<PageLayout
 			size="small"
-			header={ <SettingsPageHeader title={ __( 'Handling requests for nonexistent assets' ) } /> }
+			header={
+				<SettingsPageHeader
+					title={ __( 'Handling requests for nonexistent assets' ) }
+					description={ __(
+						'Choose how to handle requests for assets (like images, fonts, or JavaScript) that don’t exist on your site.'
+					) }
+				/>
+			}
 		>
 			<Card>
 				<CardBody>


### PR DESCRIPTION
## Proposed Changes

The designs include a subtitle. This PR adds it.

Design: QOBjujZah0UlGDDdLKZhzi-fi-4030_128606 

## Screenshot
### Default

| Before | After |
|--------|--------|
| <img width="674" alt="Screenshot 2025-06-05 at 11 55 11 AM" src="https://github.com/user-attachments/assets/26b57b38-2c3a-49ab-a34c-dadef5756aaa" /> | <img width="668" alt="Screenshot 2025-06-05 at 11 51 41 AM" src="https://github.com/user-attachments/assets/6f07ee15-c505-4670-b66c-6e9de4ac0421" /> | 

### No Access

We could add the subtitle here, but it seems more distracting than anything, seeing that the embedded notice is a higher reading priority.

<img width="666" alt="Screenshot 2025-06-05 at 11 51 27 AM" src="https://github.com/user-attachments/assets/ef9636a9-42dd-465b-b96c-97a0d0230008" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?