### PR TITLE
Dashboard: Add subtitle to defensive mode.

### DIFF
--- a/client/dashboard/sites/settings-defensive-mode/index.tsx
+++ b/client/dashboard/sites/settings-defensive-mode/index.tsx
@@ -210,7 +210,22 @@ export default function DefensiveModeSettings( { siteSlug }: { siteSlug: string 
 	};
 
 	return (
-		<PageLayout size="small" header={ <SettingsPageHeader title={ __( 'Defensive mode' ) } /> }>
+		<PageLayout
+			size="small"
+			header={
+				<SettingsPageHeader
+					title={ __( 'Defensive mode' ) }
+					description={ createInterpolateElement(
+						__(
+							'Extra protection against spam bots and attacks. Visitors will see a quick loading page while we run additional security checks. <learnMoreLink />'
+						),
+						{
+							learnMoreLink: <a href="#learn-more">{ __( 'Learn more' ) }</a>,
+						}
+					) }
+				/>
+			}
+		>
 			{ enabled ? renderEnabled() : renderDisabled() }
 		</PageLayout>
 	);


### PR DESCRIPTION
## Proposed Changes

Adds the subtitle.


| Before | After |
|--------|--------|
| <img width="674" alt="Screenshot 2025-06-05 at 12 27 23 PM" src="https://github.com/user-attachments/assets/26d3c419-03e6-4fee-88c7-5ac054c9c6fc" /> | <img width="692" alt="Screenshot 2025-06-05 at 12 27 29 PM" src="https://github.com/user-attachments/assets/f89b786a-0148-4d97-b058-3330e189cc37" /> | 
| <img width="679" alt="Screenshot 2025-06-05 at 12 27 50 PM" src="https://github.com/user-attachments/assets/7fd0b1f6-1d4d-4cf4-8ddc-40241c9c0ebe" /> | <img width="650" alt="Screenshot 2025-06-05 at 12 27 42 PM" src="https://github.com/user-attachments/assets/5f800c20-e65f-403b-95b8-9f7d0a56de07" /> | 


## Notes

This sets up a "learn more" placeholder that will be connected to the Help Center in #103761.

## Why are these changes being made?

In designs: QOBjujZah0UlGDDdLKZhzi-fi-3725_156603 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?