### PR TITLE
Dashboard: Add php subtitle to settings page.

### DIFF
--- a/client/dashboard/sites/settings-php/index.tsx
+++ b/client/dashboard/sites/settings-php/index.tsx
@@ -8,7 +8,7 @@ import {
 	Button,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { getPHPVersions } from 'calypso/data/php-versions';
@@ -43,7 +43,11 @@ export default function PHPVersionSettings( { siteSlug }: { siteSlug: string } )
 				header={
 					<SettingsPageHeader
 						title="PHP"
-						description={ __( 'Sites on the Personal plan run on our recommended PHP version.' ) }
+						description={ sprintf(
+							/* translators: %s: plan name. Eg. 'Personal' */
+							__( 'Sites on the %s plan run on our recommended PHP version.' ),
+							site?.plan?.product_name_short
+						) }
 					/>
 				}
 			>

--- a/client/dashboard/sites/settings-php/index.tsx
+++ b/client/dashboard/sites/settings-php/index.tsx
@@ -38,7 +38,15 @@ export default function PHPVersionSettings( { siteSlug }: { siteSlug: string } )
 
 	if ( ! canView ) {
 		return (
-			<PageLayout size="small" header={ <SettingsPageHeader title="PHP" /> }>
+			<PageLayout
+				size="small"
+				header={
+					<SettingsPageHeader
+						title="PHP"
+						description={ __( 'Sites on the Personal plan run on our recommended PHP version.' ) }
+					/>
+				}
+			>
 				<SettingsCallout siteSlug={ siteSlug } tracksId="php" />
 			</PageLayout>
 		);


### PR DESCRIPTION
## Proposed Changes

Adds a subtitle under "PHP" section if user must upgrade.

| Before | After |
|--------|--------|
| <img width="679" alt="Screenshot 2025-06-05 at 12 37 11 PM" src="https://github.com/user-attachments/assets/750f9635-49dc-4dbc-8788-f49f26feffc1" /> | <img width="685" alt="Screenshot 2025-06-05 at 12 36 54 PM" src="https://github.com/user-attachments/assets/318cfdf1-29c8-41ec-a259-1b2003048905" /> | 


## Why are these changes being made?

In designs: QOBjujZah0UlGDDdLKZhzi-fi-3823_314275

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?