### PR TITLE
Hosting Dashboard v2: Update layout for static file 404 screen

### DIFF
--- a/client/dashboard/sites/settings-static-file-404/index.tsx
+++ b/client/dashboard/sites/settings-static-file-404/index.tsx
@@ -22,14 +22,25 @@ const fields: Field< { setting: string } >[] = [
 	{
 		id: 'setting',
 		label: __( 'Server response' ),
-		Edit: 'select',
-		description: __(
-			'Assets are images, fonts, JavaScript, and CSS files that web browsers request as part of loading a web page. This setting controls how the web server handles requests for missing asset files.'
-		),
+		Edit: 'radio',
 		elements: [
-			{ value: 'default', label: __( 'Default' ) },
-			{ value: 'lightweight', label: __( 'Send a lightweight File-Not-Found page' ) },
-			{ value: 'wordpress', label: __( 'Delegate request to WordPress' ) },
+			{
+				value: 'default',
+				label: __( 'Default' ),
+				description: __( 'Use the setting that WordPress.com has decided is the best option.' ),
+			},
+			{
+				value: 'lightweight',
+				label: __( 'Send a lightweight File-Not-Found page' ),
+				description: __(
+					'Let the server handle static file 404 requests. This option is more performant than the others because it doesn’t load the WordPress core code when handling nonexistent assets.'
+				),
+			},
+			{
+				value: 'wordpress',
+				label: __( 'Delegate request to WordPress' ),
+				description: __( 'Let WordPress handle static file 404 requests.' ),
+			},
 		],
 	},
 ];
@@ -37,6 +48,7 @@ const fields: Field< { setting: string } >[] = [
 const form = {
 	type: 'regular' as const,
 	fields: [ 'setting' ],
+	labelPosition: 'none' as const,
 };
 
 export default function SiteStaticFile404Settings( { siteSlug }: { siteSlug: string } ) {


### PR DESCRIPTION
Ref DOTCOM-13430

## Proposed Changes

| Before | After |
| --- | --- | 
| ![Screenshot 2025-06-05 at 12 11 01 PM](https://github.com/user-attachments/assets/2fcffca7-45de-47bf-99b4-d612d24ca961) | ![Screenshot 2025-06-05 at 12 10 22 PM](https://github.com/user-attachments/assets/475062f5-895c-4ec3-ad5e-f32d2d7bf5d2) |

> [!NOTE]
> Form padding will be addressed by merging https://github.com/Automattic/wp-calypso/pull/103978.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

UI improvement.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2/sites/:siteSlug/settings/static-file-404.
* Ensure the UI is updated as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
