### PR TITLE
Dashboard:Delay rendering Leave Site modal until `hasPurchasesCancelable` has loaded.

### DIFF
--- a/client/dashboard/sites/site-leave-modal/index.tsx
+++ b/client/dashboard/sites/site-leave-modal/index.tsx
@@ -196,9 +196,13 @@ function ContentLeaveSite( { site, onClose }: ContentProps ) {
 
 export default function SiteLeaveModal( { site, onClose }: SiteLeaveModalProps ) {
 	const { user } = useAuth();
-	const { data: hasPurchasesCancelable } = useQuery(
+	const { data: hasPurchasesCancelable, isLoading: isLoadingHasPurchasesCancelable } = useQuery(
 		siteHasPurchasesCancelableQuery( site.slug, user.ID )
 	);
+
+	if ( isLoadingHasPurchasesCancelable ) {
+		return null;
+	}
 
 	const renderContent = () => {
 		if ( hasPurchasesCancelable ) {


### PR DESCRIPTION
## Proposed Changes

Wait for `siteHasPurchasesCancelableQuery` to return before displaying content to avoid content switching on load.

### Issue:


https://github.com/user-attachments/assets/b50a7bff-0263-498a-b789-c378d8e34539




## Why are these changes being made?

Noticeable when the cache is empty, we don't wait to determine whether a purchase can be canceled and display the "You are the owner" screen, which is quickly switched out.

## Testing Instructions

_Clear the local application cache_

On a site with an active subscription....

1. Click "Leave"
2. Expect the content to not switch.




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
