### PR TITLE
Stats: Use correct admin colors for dropdown

### DIFF
--- a/apps/odyssey-stats/src/styles/variables.scss
+++ b/apps/odyssey-stats/src/styles/variables.scss
@@ -50,5 +50,4 @@ $display-type-line-height: 40px;
 	--geo-chart-color-light: var(--color-accent-5);
 	--geo-chart-color-dark: var(--color-accent);
 	--wp-admin-theme-color: var(--theme-highlight-color);
-	--color-link: var(--theme-highlight-color);
 }

--- a/client/components/stats-interval-dropdown/index.jsx
+++ b/client/components/stats-interval-dropdown/index.jsx
@@ -7,7 +7,9 @@ import { capitalize } from 'lodash';
 import qs from 'qs';
 import { useRef } from 'react';
 import useOutsideClickCallback from 'calypso/lib/use-outside-click-callback';
+import useWPAdminTheme from 'calypso/my-sites/stats/hooks/use-wp-admin-theme';
 import { useSelector } from 'calypso/state';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import getSiteId from 'calypso/state/sites/selectors/get-site-id';
 import './style.scss';
 
@@ -114,6 +116,10 @@ const IntervalDropdown = ( { slug, period, queryParams, intervals, onGatedHandle
 
 	// Check if the selected period is in the intervals list.
 	const selectedPeriod = intervals[ period ];
+	const isSiteJetpack = useSelector( ( state ) =>
+		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: true } )
+	);
+	const customTheme = useWPAdminTheme( isSiteJetpack );
 
 	return selectedPeriod ? (
 		<Dropdown
@@ -125,7 +131,7 @@ const IntervalDropdown = ( { slug, period, queryParams, intervals, onGatedHandle
 				</Button>
 			) }
 			renderContent={ ( { onClose } ) => (
-				<div className="stats-interval-dropdown__container">
+				<div className={ clsx( 'stats-interval-dropdown__container color-scheme', customTheme ) }>
 					<StatsIntervalDropdownListing
 						selected={ period }
 						onSelection={ onSelectionHandler }

--- a/client/my-sites/stats/components/empty-module-card/styles.scss
+++ b/client/my-sites/stats/components/empty-module-card/styles.scss
@@ -4,7 +4,8 @@
 	align-items: center;
 	padding: 18px 0 32px;
 
-	a {
+	a,
+	a:visited {
 		text-decoration: none;
 	}
 }

--- a/client/my-sites/stats/components/empty-module-card/styles.scss
+++ b/client/my-sites/stats/components/empty-module-card/styles.scss
@@ -4,8 +4,7 @@
 	align-items: center;
 	padding: 18px 0 32px;
 
-	a,
-	a:visited {
+	a {
 		text-decoration: none;
 	}
 }

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -108,6 +108,12 @@ $font-sf-pro-display: "SF Pro Display", $sans;
 	a:visited  {
 		color: var(--theme-highlight-color);
 	}
+
+	a:hover,
+	a:focus,
+	a:active {
+		color: var(--color-accent-dark);
+	}
 }
 
 @import "calypso/my-sites/stats/grid-layout";

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -104,7 +104,8 @@ $font-sf-pro-display: "SF Pro Display", $sans;
 }
 
 .stats {
-	a {
+	a,
+	a:visited  {
 		color: var(--theme-highlight-color);
 	}
 }

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -103,4 +103,10 @@ $font-sf-pro-display: "SF Pro Display", $sans;
 	}
 }
 
+.stats {
+	a {
+		color: var(--theme-highlight-color);
+	}
+}
+
 @import "calypso/my-sites/stats/grid-layout";


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Use the CSS for anchors instead of overriding the color for the link
* The dropdown content is rendered outside of the stats container and hence misses the wrapper CSS classes that define the current theme. This PR adds the classes required for the dropdown to pick up the correct color instead.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use method 2 or 3 under the FG - PCYsg-Pp7-p2
- Test the PR in WPCom simple and the colors should match for links and the dropdown color in the duration picker

Before

![image](https://github.com/user-attachments/assets/c970179b-3548-4d49-adc1-139ce5f2f81c)

After

![Arc -2025-06-05 at 10 41 52@2x](https://github.com/user-attachments/assets/fae8bd3d-8d54-4edd-a4c0-ef618f29a4dd)

Before 

![image](https://github.com/user-attachments/assets/8c2b6d1b-2792-47c2-ae52-ac548b6db936)


After

![Arc -2025-06-05 at 10 42 16@2x](https://github.com/user-attachments/assets/63d7cd91-fd76-4434-b19e-9ba92fb280dd)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?