### PR TITLE
Dashboard: Scroll up before animating to ensure consistency.

### DIFF
--- a/client/dashboard/app/layout.tsx
+++ b/client/dashboard/app/layout.tsx
@@ -10,6 +10,15 @@ import { getRouter } from './router';
 function RouterProviderWithAuth( { config }: { config: AppConfig } ) {
 	const auth = useAuth();
 	const router = useMemo( () => getRouter( config ), [ config ] );
+
+	router.subscribe( 'onBeforeLoad', () => {
+		if ( document.startViewTransition ) {
+			document.startViewTransition( () => {
+				window.scrollTo( 0, 0 );
+			} );
+		}
+	} );
+
 	return <RouterProvider router={ router } context={ { auth, config } } />;
 }
 


### PR DESCRIPTION
Context: p1748484079268899-slack-C08JZTRS6NA

## Proposed Changes

This PR stabilizes the transition animations by first scrolling to the top of the page before capturing the second snapshot.

## Why are these changes being made?
The animation works well for items near the top of the page. However, when the user scrolls toward the bottom before a route change, the transition becomes more noticeable or jarring. This is likely because the new snapshot is captured before the scroll position resets.

## Considerations

As @ellatrix notes in [this PR](https://github.com/Automattic/wp-calypso/pull/103278/files#diff-2a476a4c18923d5973023f8be7df960cb3cb2e806238f5c95b43f7c675f8cc33R351), calling `startViewTransition` is potentially "tricky". 

@ellatrix Any thoughts on this change? Is this too risky? Or are there any issues you ran into regarding this?

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?