### PR TITLE
Dashboard v2 - Add components for consistent padding and spacing

### DIFF
--- a/client/dashboard/components/card-layout/index.tsx
+++ b/client/dashboard/components/card-layout/index.tsx
@@ -1,0 +1,71 @@
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Card,
+	CardBody,
+} from '@wordpress/components';
+import React, { forwardRef } from 'react';
+
+function Header( { children }: { children: React.ReactNode } ) {
+	return <VStack style={ { paddingBottom: '12px' } }>{ children }</VStack>;
+}
+
+function Fields( { children }: { children: React.ReactNode } ) {
+	return (
+		<VStack spacing={ 4 } style={ { padding: '8px 0' } }>
+			{ children }
+		</VStack>
+	);
+}
+
+function ButtonGroup( { children }: { children: React.ReactNode } ) {
+	return (
+		<HStack justify="flex-start" spacing={ 3 } style={ { padding: '8px 0' } }>
+			{ children }
+		</HStack>
+	);
+}
+
+function UnforwardedCardLayout(
+	{ children }: { children: React.ReactNode },
+	ref: React.ForwardedRef< HTMLDivElement >
+) {
+	return (
+		<Card ref={ ref }>
+			<CardBody>{ children }</CardBody>
+		</Card>
+	);
+}
+
+export const CardLayout = Object.assign( forwardRef( UnforwardedCardLayout ), {
+	Header: Object.assign( Header, { displayName: 'CardLayout.Header' } ),
+	Fields: Object.assign( Fields, { displayName: 'CardLayout.Fields' } ),
+	ButtonGroup: Object.assign( ButtonGroup, { displayName: 'CardLayout.ButtonGroup' } ),
+} );
+
+/**
+ * The CardLayout component is designed to provide a consistent layout structure across different pages.
+ * It standardizes padding, spacing, and alignment to ensure visual consistency and reduce repetitive
+ * styling in individual page components. By using CardLayout, we can maintain a unified look and feel
+ * while also simplifying layout management across the dashboard.
+ *
+ * ```jsx
+ *
+ * function MyComponent() {
+ * 	return (
+ * 		<CardLayout>
+ * 			<CardLayout.Header>
+ * 				<SectionHeader />
+ * 			</CardLayout.Header>
+ * 			<CardLayout.Fields>
+ * 				<DataForm />
+ * 			</CardLayout.Fields>
+ * 			<CardLayout.ButtonGroup>
+ * 				<Button>Action</Button>
+ * 			</CardLayout.ButtonGroup>
+ * 		</CardLayout>
+ * 	);
+ * }
+ * ```
+ */
+export default CardLayout;

--- a/client/dashboard/sites/settings-sftp-ssh/enable-sftp-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/enable-sftp-card.tsx
@@ -1,11 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
 	__experimentalText as Text,
 	Button,
-	Card,
-	CardBody,
 	ExternalLink,
 	Panel,
 	PanelBody,
@@ -15,6 +11,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { siteSftpUsersCreateMutation } from '../../app/queries';
+import CardLayout from '../../components/card-layout';
 import { SectionHeader } from '../../components/section-header';
 
 const FILEZILLA_URL = 'https://filezilla-project.org/';
@@ -50,72 +47,66 @@ export default function EnableSftpCard( {
 	};
 
 	return (
-		<Card>
-			<CardBody>
-				<VStack style={ { paddingBottom: '12px' } }>
-					<SectionHeader
-						title={ __( 'Get started with SFTP/SSH' ) }
-						description={
-							canUseSsh
-								? __(
-										"Access and edit your website's files directly by creating SFTP credentials and using an SFTP client. Optionally, enable SSH to perform advanced site operations using the command line."
-								  )
-								: __(
-										"Access and edit your website's files directly by creating SFTP credentials and using an SFTP client."
-								  )
-						}
-						level={ 3 }
-					/>
-				</VStack>
-				<VStack spacing={ 5 } style={ { padding: '8px 0' } }>
-					{ /* TODO: Replace the Panel with the Accordion component when it's ready */ }
-					<Panel>
-						<PanelBody title={ __( 'What is SFTP?' ) } initialOpen={ false }>
+		<CardLayout>
+			<CardLayout.Header>
+				<SectionHeader
+					title={ __( 'Get started with SFTP/SSH' ) }
+					description={
+						canUseSsh
+							? __(
+									"Access and edit your website's files directly by creating SFTP credentials and using an SFTP client. Optionally, enable SSH to perform advanced site operations using the command line."
+							  )
+							: __(
+									"Access and edit your website's files directly by creating SFTP credentials and using an SFTP client."
+							  )
+					}
+					level={ 3 }
+				/>
+			</CardLayout.Header>
+			<CardLayout.Fields>
+				{ /* TODO: Replace the Panel with the Accordion component when it's ready */ }
+				<Panel>
+					<PanelBody title={ __( 'What is SFTP?' ) } initialOpen={ false }>
+						{ createInterpolateElement(
+							__(
+								'SFTP stands for Secure File Transfer Protocol (or SSH File Transfer Protocol). It’s a secure way for you to access your website files on your local computer via a client program such as <filezillaLink>Filezilla</filezillaLink>. ' +
+									'For more information see <supportLink>SFTP on WordPress.com</supportLink>.'
+							),
+							{
+								filezillaLink: <ExternalLink href={ FILEZILLA_URL } children={ null } />,
+								supportLink: <ExternalLink href="#hosting-sftp" children={ null } />,
+							}
+						) }
+					</PanelBody>
+					{ canUseSsh && (
+						<PanelBody title={ __( 'What is SSH?' ) } initialOpen={ false }>
 							{ createInterpolateElement(
 								__(
-									'SFTP stands for Secure File Transfer Protocol (or SSH File Transfer Protocol). It’s a secure way for you to access your website files on your local computer via a client program such as <filezillaLink>Filezilla</filezillaLink>. ' +
-										'For more information see <supportLink>SFTP on WordPress.com</supportLink>.'
+									'SSH stands for Secure Shell. It’s a way to perform advanced operations on your site using the command line. For more information see <supportLink>Connect to SSH on WordPress.com</supportLink>.'
 								),
 								{
-									filezillaLink: <ExternalLink href={ FILEZILLA_URL } children={ null } />,
-									supportLink: <ExternalLink href="#hosting-sftp" children={ null } />,
+									supportLink: <ExternalLink href="#hosting-connect-to-ssh" children={ null } />,
 								}
 							) }
 						</PanelBody>
-						{ canUseSsh && (
-							<PanelBody title={ __( 'What is SSH?' ) } initialOpen={ false }>
-								{ createInterpolateElement(
-									__(
-										'SSH stands for Secure Shell. It’s a way to perform advanced operations on your site using the command line. For more information see <supportLink>Connect to SSH on WordPress.com</supportLink>.'
-									),
-									{
-										supportLink: <ExternalLink href="#hosting-connect-to-ssh" children={ null } />,
-									}
-								) }
-							</PanelBody>
-						) }
-					</Panel>
-					<Text variant="muted" size="12px" lineHeight="16px" as="p">
-						{ createInterpolateElement(
-							__(
-								'<strong>Ready to access your website files?</strong> Keep in mind, if mistakes happen you can restore your last backup, but will lose changes made after the backup date.'
-							),
-							{
-								strong: <strong />,
-							}
-						) }
-					</Text>
-				</VStack>
-				<HStack justify="flex-start" style={ { padding: '8px 0' } }>
-					<Button
-						variant="primary"
-						isBusy={ mutation.isPending }
-						onClick={ handleCreateCredentials }
-					>
-						{ __( 'Create credentials' ) }
-					</Button>
-				</HStack>
-			</CardBody>
-		</Card>
+					) }
+				</Panel>
+				<Text variant="muted" size="12px" lineHeight="16px" as="p">
+					{ createInterpolateElement(
+						__(
+							'<strong>Ready to access your website files?</strong> Keep in mind, if mistakes happen you can restore your last backup, but will lose changes made after the backup date.'
+						),
+						{
+							strong: <strong />,
+						}
+					) }
+				</Text>
+			</CardLayout.Fields>
+			<CardLayout.ButtonGroup>
+				<Button variant="primary" isBusy={ mutation.isPending } onClick={ handleCreateCredentials }>
+					{ __( 'Create credentials' ) }
+				</Button>
+			</CardLayout.ButtonGroup>
+		</CardLayout>
 	);
 }

--- a/client/dashboard/sites/settings-sftp-ssh/sftp-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/sftp-card.tsx
@@ -2,12 +2,8 @@ import { DataForm } from '@automattic/dataviews';
 import { useMutation } from '@tanstack/react-query';
 import {
 	__experimentalConfirmDialog as ConfirmDialog,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
 	BaseControl,
 	Button,
-	Card,
-	CardBody,
 	ExternalLink,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
@@ -16,6 +12,7 @@ import { sprintf, __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import React, { useState } from 'react';
 import { siteSftpUsersResetPasswordMutation } from '../../app/queries';
+import CardLayout from '../../components/card-layout';
 import ClipboardInputControl from '../../components/clipboard-input-control';
 import { SectionHeader } from '../../components/section-header';
 import type { SftpUser } from '../../data/types';
@@ -150,42 +147,40 @@ export default function SftpCard( {
 	};
 
 	return (
-		<Card>
-			<CardBody>
-				<VStack style={ { paddingBottom: '12px' } }>
-					<SectionHeader
-						title={ __( 'SFTP' ) }
-						description={ createInterpolateElement(
-							__(
-								'Use the credentials below to access and edit your website files using an SFTP client. <link>Learn more</link>.'
-							),
-							{
-								link: <ExternalLink href="#" children={ null } />,
-							}
-						) }
-						level={ 3 }
-					/>
-				</VStack>
-				<VStack spacing={ 4 } style={ { padding: '8px 0' } }>
-					<DataForm< SftpCardFormData >
-						data={ formData }
-						fields={ fields }
-						form={ form }
-						onChange={ noop }
-					/>
-				</VStack>
-				{ ! password && (
-					<HStack style={ { padding: '8px 0' } }>
-						<Button
-							variant="secondary"
-							isBusy={ mutation.isPending }
-							onClick={ () => setShowResetPasswordConfirmDialog( true ) }
-						>
-							{ __( 'Reset password' ) }
-						</Button>
-					</HStack>
-				) }
-			</CardBody>
+		<CardLayout>
+			<CardLayout.Header>
+				<SectionHeader
+					title={ __( 'SFTP' ) }
+					description={ createInterpolateElement(
+						__(
+							'Use the credentials below to access and edit your website files using an SFTP client. <link>Learn more</link>.'
+						),
+						{
+							link: <ExternalLink href="#" children={ null } />,
+						}
+					) }
+					level={ 3 }
+				/>
+			</CardLayout.Header>
+			<CardLayout.Fields>
+				<DataForm< SftpCardFormData >
+					data={ formData }
+					fields={ fields }
+					form={ form }
+					onChange={ noop }
+				/>
+			</CardLayout.Fields>
+			{ ! password && (
+				<CardLayout.ButtonGroup>
+					<Button
+						variant="secondary"
+						isBusy={ mutation.isPending }
+						onClick={ () => setShowResetPasswordConfirmDialog( true ) }
+					>
+						{ __( 'Reset password' ) }
+					</Button>
+				</CardLayout.ButtonGroup>
+			) }
 			<ConfirmDialog
 				isOpen={ showResetPasswordConfirmDialog }
 				confirmButtonText={ __( 'Reset password' ) }
@@ -197,6 +192,6 @@ export default function SftpCard( {
 					'After resetting your password, be sure to update it in any SFTP clients, deployment tools, or scripts that use it to connect to your site.'
 				) }
 			</ConfirmDialog>
-		</Card>
+		</CardLayout>
 	);
 }

--- a/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
@@ -28,6 +28,7 @@ import {
 	siteSshKeysDetachMutation,
 	profileSshKeysQuery,
 } from '../../app/queries';
+import CardLayout from '../../components/card-layout';
 import ClipboardInputControl from '../../components/clipboard-input-control';
 import { SectionHeader } from '../../components/section-header';
 import type { SftpUser, SiteSshKey, ProfileSshKey } from '../../data/types';
@@ -290,63 +291,56 @@ export default function SshCard( {
 	}
 
 	return (
-		<Card>
-			<CardBody>
-				<VStack style={ { paddingBottom: '12px' } }>
-					<SectionHeader
-						title={ __( 'SSH' ) }
-						description={ createInterpolateElement(
-							__(
-								"SSH lets you access your site's backend via a terminal, so you can manage files and use <wpCliLink>WP-CLI</wpCliLink> for quick changes and troubleshooting. <learnMoreLink>Learn more</learnMoreLink>."
-							),
-							{
-								wpCliLink: <ExternalLink href="#" children={ null } />,
-								learnMoreLink: <ExternalLink href="#hosting-connect-to-ssh" children={ null } />,
-							}
-						) }
-						level={ 3 }
-					/>
-				</VStack>
-				<VStack spacing={ 4 } style={ { padding: '8px 0' } }>
-					<ToggleControl
-						label={ __( 'Enable SSH access for this site' ) }
-						checked={ sshEnabled }
-						disabled={ toggleSshAccessMutation.isPending }
-						onChange={ handleToggleSshAccess }
-						__nextHasNoMarginBottom
-					/>
-					{ sshEnabled && (
-						<DataForm< SshCardFormData >
-							data={ formData }
-							fields={ fields }
-							form={ form }
-							onChange={ ( edits: Partial< SshCardFormData > ) => {
-								setFormData( ( data ) => ( { ...data, ...edits } ) );
-							} }
-						/>
+		<CardLayout>
+			<CardLayout.Header>
+				<SectionHeader
+					title={ __( 'SSH' ) }
+					description={ createInterpolateElement(
+						__(
+							"SSH lets you access your site's backend via a terminal, so you can manage files and use <wpCliLink>WP-CLI</wpCliLink> for quick changes and troubleshooting. <learnMoreLink>Learn more</learnMoreLink>."
+						),
+						{
+							wpCliLink: <ExternalLink href="#" children={ null } />,
+							learnMoreLink: <ExternalLink href="#hosting-connect-to-ssh" children={ null } />,
+						}
 					) }
-				</VStack>
-				{ sshEnabled && ! userKeyIsAttached && (
-					<HStack justify="flex-start" style={ { padding: '8px 0' } }>
-						<Button
-							variant="primary"
-							isBusy={ attachSshKeyMutation.isPending }
-							disabled={ ! hasProfileSshKeys }
-							onClick={ handleAttachSshKey }
-						>
-							{ __( 'Attach SSH key to site' ) }
-						</Button>
-						<Button
-							variant="secondary"
-							target="_blank"
-							href="/me/security/ssh-key"
-							rel="noreferrer"
-						>
-							{ __( 'Add new SSH key ↗' ) }
-						</Button>
-					</HStack>
+					level={ 3 }
+				/>
+			</CardLayout.Header>
+			<CardLayout.Fields>
+				<ToggleControl
+					label={ __( 'Enable SSH access for this site' ) }
+					checked={ sshEnabled }
+					disabled={ toggleSshAccessMutation.isPending }
+					onChange={ handleToggleSshAccess }
+					__nextHasNoMarginBottom
+				/>
+				{ sshEnabled && (
+					<DataForm< SshCardFormData >
+						data={ formData }
+						fields={ fields }
+						form={ form }
+						onChange={ ( edits: Partial< SshCardFormData > ) => {
+							setFormData( ( data ) => ( { ...data, ...edits } ) );
+						} }
+					/>
 				) }
-			</CardBody>
-		</Card>
+			</CardLayout.Fields>
+			{ sshEnabled && ! userKeyIsAttached && (
+				<CardLayout.ButtonGroup>
+					<Button
+						variant="primary"
+						isBusy={ attachSshKeyMutation.isPending }
+						disabled={ ! hasProfileSshKeys }
+						onClick={ handleAttachSshKey }
+					>
+						{ __( 'Attach SSH key to site' ) }
+					</Button>
+					<Button variant="secondary" target="_blank" href="/me/security/ssh-key" rel="noreferrer">
+						{ __( 'Add new SSH key ↗' ) }
+					</Button>
+				</CardLayout.ButtonGroup>
+			) }
+		</CardLayout>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13496

## Proposed Changes

* Implement the following layout components for consistent padding and spacing
* Apply them to SFTP/SSH page to demonstrate how it works
  * It would be better to enable the `Hide whitespace` option when reviewing changes

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Make padding and spacing consistent

| Name | Layout | |
| - | - | - |
| Header | padding: '8px 0'; spacing=2 | ![image](https://github.com/user-attachments/assets/a4e7c6c6-3a54-4af8-b041-f21f867e4171) |
| Fields | padding: '8px 0'; spacing=4 | ![image](https://github.com/user-attachments/assets/e9967afa-cc54-4f9e-8ea5-b8d54784cec2) |
| ButtonGroup | padding: '8px 0'; spacing=3 | ![image](https://github.com/user-attachments/assets/20954d60-1d14-4a9a-983e-87d755ff1307) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Pick any site
* Go to Settings > SFTP/SSH
* Ensure the layout looks as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
