### PR TITLE
Hosting Dashboard v2: Halt retry if error code is partner_for_blog_not_found

### DIFF
--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -327,6 +327,13 @@ export function agencyBlogQuery( siteId: string ) {
 		queryFn: () => {
 			return fetchAgencyBlogBySiteId( siteId );
 		},
+		retry: ( failureCount: number, error: { code?: string } ) => {
+			if ( error.hasOwnProperty( 'code' ) && error.code === 'partner_for_blog_not_found' ) {
+				return false;
+			}
+
+			return failureCount < 3;
+		},
 	};
 }
 

--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -328,6 +328,7 @@ export function agencyBlogQuery( siteId: string ) {
 			return fetchAgencyBlogBySiteId( siteId );
 		},
 		retry: ( failureCount: number, error: { code?: string } ) => {
+			// Stop retrying if we already know the blog is not an agency blog.
 			if ( error.hasOwnProperty( 'code' ) && error.code === 'partner_for_blog_not_found' ) {
 				return false;
 			}


### PR DESCRIPTION
Ref DOTCOM-13436.

## Proposed Changes

This PR adds retry logic so that it stops when the endpoint returns error code partner_for_blog_not_found. There is no need to keep retrying the query since we already know from the endpoint response that it's not an A4A site.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2/sites/:siteSlug/settings with a WoA site that's not an A4A site
* Ensure that the endpoint /wpcom/v2/agency/blog/ is only queried once

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
