### PR TITLE
A4A > Overview: Fix the broken links to Marketplace

### DIFF
--- a/client/a8c-for-agencies/components/offering/offering-item.tsx
+++ b/client/a8c-for-agencies/components/offering/offering-item.tsx
@@ -10,6 +10,7 @@ const OfferingItem: React.FC< OfferingItemProps > = ( {
 	expanded,
 	clickableHeader = true,
 	actionHandler,
+	href,
 } ) => {
 	const header = (
 		<div>
@@ -38,7 +39,7 @@ const OfferingItem: React.FC< OfferingItemProps > = ( {
 					</li>
 				) ) }
 			</ul>
-			<Button className="a4a-offering-item__button" onClick={ actionHandler } primary>
+			<Button className="a4a-offering-item__button" onClick={ actionHandler } href={ href } primary>
 				{ buttonTitle }
 			</Button>
 		</FoldableCard>

--- a/client/a8c-for-agencies/components/offering/types.ts
+++ b/client/a8c-for-agencies/components/offering/types.ts
@@ -14,4 +14,5 @@ export type OfferingItemProps = {
 	clickableHeader?: boolean;
 	buttonTitle: string;
 	actionHandler: () => void;
+	href?: string;
 };

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/index.tsx
@@ -1,6 +1,8 @@
+import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { DropdownMenu, MenuGroup } from '@wordpress/components';
 import { funnel } from '@wordpress/icons';
+import { getQueryArg, removeQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useRef, useState } from 'react';
 import {
@@ -59,6 +61,20 @@ export default function ProductFilter( {
 			[ type ]: newFilters,
 		} );
 	};
+
+	const category = getQueryArg( window.location.href, 'category' ) as string | undefined;
+
+	useEffect( () => {
+		if ( category ) {
+			updateFilter( PRODUCT_FILTER_KEY_CATEGORIES, category );
+			// Remove the category query arg from the URL as we don't support URL params for filters
+			page.redirect(
+				removeQueryArgs( window.location.pathname + window.location.search, 'category' )
+			);
+		}
+		// Do not add updateFilter to the dependency array as it will cause an infinite loop
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ category ] );
 
 	useEffect( () => {
 		// Dropdown doesn't play well with our layout when scrolling. We need to close it when the toggle is not visible to avoid overlapping issues.

--- a/client/a8c-for-agencies/sections/overview/body/products/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/products/index.tsx
@@ -1,9 +1,10 @@
-import page from '@automattic/calypso-router';
 import { useDispatch } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import Offering from 'calypso/a8c-for-agencies/components/offering';
 import { OfferingItemProps } from 'calypso/a8c-for-agencies/components/offering/types';
+import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import {
 	PRODUCT_BRAND_FILTER_JETPACK,
 	PRODUCT_BRAND_FILTER_WOOCOMMERCE,
@@ -13,8 +14,6 @@ import JetpackLogo from 'calypso/components/jetpack-logo';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 
 import './style.scss';
-
-const A4A_PRODUCTS_MARKETPLACE_LINK = '/marketplace/products';
 
 const OverviewBodyProducts = () => {
 	const translate = useTranslate();
@@ -52,8 +51,10 @@ const OverviewBodyProducts = () => {
 		expanded: true,
 		actionHandler: () => {
 			actionHandlerCallback( 'products', 'jetpack' );
-			page( `${ A4A_PRODUCTS_MARKETPLACE_LINK }/${ PRODUCT_BRAND_FILTER_JETPACK }` );
 		},
+		href: addQueryArgs( A4A_MARKETPLACE_PRODUCTS_LINK, {
+			category: PRODUCT_BRAND_FILTER_JETPACK,
+		} ),
 	};
 
 	const woo: OfferingItemProps = {
@@ -95,8 +96,10 @@ const OverviewBodyProducts = () => {
 		expanded: true,
 		actionHandler: () => {
 			actionHandlerCallback( 'products', 'woocommerce' );
-			page( `${ A4A_PRODUCTS_MARKETPLACE_LINK }/${ PRODUCT_BRAND_FILTER_WOOCOMMERCE }` );
 		},
+		href: addQueryArgs( A4A_MARKETPLACE_PRODUCTS_LINK, {
+			category: PRODUCT_BRAND_FILTER_WOOCOMMERCE,
+		} ),
 	};
 
 	return (


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1079/overview-fix-the-broken-marketplace-links

## Proposed Changes

This PR fixes the broken links on the Overview page

## Why are these changes being made?

* To fix the broken links

## Testing Instructions

* Open the A4A live link
* Go to Overview > Hover over the `View all WooCommerce products` button > Verify you can see the link on the browser footer > Click the button > Verify you are redirected to the Marketplace, and you can see the category filter applied  and you can see all/only WooCommerce products.
* Repeat the same for the `View all Jetpack products` button.

<img width="942" alt="Screenshot 2025-06-05 at 1 09 31 PM" src="https://github.com/user-attachments/assets/f5bb5019-5282-4719-a892-a5234941ac23" />

<img width="654" alt="Screenshot 2025-06-05 at 1 13 33 PM" src="https://github.com/user-attachments/assets/81593ae2-1746-4c35-96a1-a13888875766" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
