### PR TITLE
Forms E2E tests: Fix inline block insertion and options menu open state

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
@@ -1,4 +1,3 @@
-import { envVariables } from '../../..';
 import { OpenInlineInserter } from '../../pages';
 import {
 	labelFormFieldBlock,
@@ -167,16 +166,7 @@ export class AllFormFieldsFlow implements BlockFlow {
 				await context.editorPage.selectParentBlock( 'Form' );
 			}
 
-			const addBlockLocater = await editorCanvas.getByRole( 'button', { name: 'Add block' } );
-			if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-				// See: https://github.com/Automattic/jetpack/issues/32695
-				// On mobile, we can't click the inline button directly due to an overlay z-index bug.
-				// So we force the click via dispatchEvent.
-				await addBlockLocater.waitFor();
-				await addBlockLocater.dispatchEvent( 'click' );
-			} else {
-				await addBlockLocater.click();
-			}
+			await editorCanvas.getByRole( 'button', { name: 'Add block' } ).click();
 		};
 		await context.editorPage.addBlockInline(
 			blockName,

--- a/packages/calypso-e2e/src/lib/components/editor-block-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-block-toolbar-component.ts
@@ -46,6 +46,25 @@ export class EditorBlockToolbarComponent {
 		this.editor = editor;
 	}
 
+	/* General helper */
+
+	/**
+	 * Given a Locator, determines whether the target button/toggle is
+	 * in an expanded state.
+	 *
+	 * If the toggle is in the on state or otherwise in an expanded
+	 * state, this method will return true. Otherwise, false.
+	 *
+	 * @param {Locator} target Target button.
+	 * @returns {Promise<boolean>} True if target is in an expanded state. False otherwise.
+	 */
+	private async targetIsOpen( target: Locator ): Promise< boolean > {
+		const checked = await target.getAttribute( 'aria-checked' );
+		const pressed = await target.getAttribute( 'aria-pressed' );
+		const expanded = await target.getAttribute( 'aria-expanded' );
+		return checked === 'true' || pressed === 'true' || expanded === 'true';
+	}
+
 	/**
 	 * Click one of the primary (not buried under a drop down) buttons in the block toolbar.
 	 *
@@ -86,13 +105,10 @@ export class EditorBlockToolbarComponent {
 	 *
 	 * @returns {boolean} True if the menu button is open, false otherwise.
 	 */
-	async isMenuButtonOpen(): Promise< boolean > {
+	async isOptionsMenuOpen(): Promise< boolean > {
 		const editorParent = await this.editor.parent();
-		const locator = editorParent.locator( selectors.button( { ariaLabel: 'Options' } ) );
-		const checked = await locator.getAttribute( 'aria-checked' );
-		const pressed = await locator.getAttribute( 'aria-pressed' );
-		const expanded = await locator.getAttribute( 'aria-expanded' );
-		return checked === 'true' || pressed === 'true' || expanded === 'true';
+		const optionsLocator = editorParent.locator( selectors.button( { ariaLabel: 'Options' } ) );
+		return this.targetIsOpen( optionsLocator );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/editor-block-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-block-toolbar-component.ts
@@ -82,6 +82,20 @@ export class EditorBlockToolbarComponent {
 	}
 
 	/**
+	 * Checks if a menu button is open.
+	 *
+	 * @returns {boolean} True if the menu button is open, false otherwise.
+	 */
+	async isMenuButtonOpen(): Promise< boolean > {
+		const editorParent = await this.editor.parent();
+		const locator = editorParent.locator( selectors.button( { ariaLabel: 'Options' } ) );
+		const checked = await locator.getAttribute( 'aria-checked' );
+		const pressed = await locator.getAttribute( 'aria-pressed' );
+		const expanded = await locator.getAttribute( 'aria-expanded' );
+		return checked === 'true' || pressed === 'true' || expanded === 'true';
+	}
+
+	/**
 	 * Click the up arrow button to move the current block up.
 	 */
 	async moveUp(): Promise< void > {

--- a/packages/calypso-e2e/src/lib/components/editor-popover-menu-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-popover-menu-component.ts
@@ -29,4 +29,32 @@ export class EditorPopoverMenuComponent {
 		await locator.waitFor();
 		await locator.click();
 	}
+
+	/**
+	 * Checks if a menu button is visible.
+	 *
+	 * @param {string} name The name of the menu button.
+	 * @returns {Promise<boolean>} True if the menu button is visible, false otherwise.
+	 */
+	async isMenuButtonVisible( name: string ): Promise< boolean > {
+		const editorParent = await this.editor.parent();
+
+		const locator = editorParent.getByRole( 'menuitem', { name: name } );
+
+		try {
+			await locator.waitFor( { timeout: 100 } );
+		} catch ( e ) {
+			// Probably doesn't exist. That's ok.
+			return false;
+		}
+		if ( ( await locator.count() ) === 0 ) {
+			return false;
+		}
+
+		if ( await locator.isVisible() ) {
+			return true;
+		}
+
+		return false;
+	}
 }

--- a/packages/calypso-e2e/src/lib/components/editor-popover-menu-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-popover-menu-component.ts
@@ -29,32 +29,4 @@ export class EditorPopoverMenuComponent {
 		await locator.waitFor();
 		await locator.click();
 	}
-
-	/**
-	 * Checks if a menu button is visible.
-	 *
-	 * @param {string} name The name of the menu button.
-	 * @returns {Promise<boolean>} True if the menu button is visible, false otherwise.
-	 */
-	async isMenuButtonVisible( name: string ): Promise< boolean > {
-		const editorParent = await this.editor.parent();
-
-		const locator = editorParent.getByRole( 'menuitem', { name: name } );
-
-		try {
-			await locator.waitFor( { timeout: 100 } );
-		} catch ( e ) {
-			// Probably doesn't exist. That's ok.
-			return false;
-		}
-		if ( ( await locator.count() ) === 0 ) {
-			return false;
-		}
-
-		if ( await locator.isVisible() ) {
-			return true;
-		}
-
-		return false;
-	}
 }

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -530,10 +530,17 @@ export class EditorPage {
 		if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
 			await this.editorBlockToolbarComponent.clickParentBlockButton( expectedParentBlockName );
 		} else {
-			await this.editorBlockToolbarComponent.clickOptionsButton();
+			const isMenuButtonVisible = await this.editorPopoverMenuComponent.isMenuButtonVisible(
+				`Select parent block (${ expectedParentBlockName })`
+			);
+			if ( ! isMenuButtonVisible ) {
+				await this.editorBlockToolbarComponent.clickOptionsButton();
+			}
 			await this.editorPopoverMenuComponent.clickMenuButton(
 				`Select parent block (${ expectedParentBlockName })`
 			);
+			// It stays open on modal! We have to close it again.
+			await this.editorBlockToolbarComponent.clickOptionsButton();
 		}
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -530,7 +530,7 @@ export class EditorPage {
 		if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
 			await this.editorBlockToolbarComponent.clickParentBlockButton( expectedParentBlockName );
 		} else {
-			const isMenuButtonOpen = await await this.editorBlockToolbarComponent.isMenuButtonOpen();
+			const isMenuButtonOpen = await this.editorBlockToolbarComponent.isMenuButtonOpen();
 
 			if ( ! isMenuButtonOpen ) {
 				await this.editorBlockToolbarComponent.clickOptionsButton();

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -530,16 +530,18 @@ export class EditorPage {
 		if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
 			await this.editorBlockToolbarComponent.clickParentBlockButton( expectedParentBlockName );
 		} else {
-			const isOptionsMenuOpen = await this.editorBlockToolbarComponent.isOptionsMenuOpen();
-
-			if ( ! isOptionsMenuOpen ) {
+			// If the menu was already open due to another action, don't open it again.
+			if ( ! ( await this.editorBlockToolbarComponent.isOptionsMenuOpen() ) ) {
 				await this.editorBlockToolbarComponent.clickOptionsButton();
 			}
 			await this.editorPopoverMenuComponent.clickMenuButton(
 				`Select parent block (${ expectedParentBlockName })`
 			);
-			// It stays open on modal! We have to close it again.
-			await this.editorBlockToolbarComponent.clickOptionsButton();
+			// The menu usually closes itself on click, but this might be inconsistent.
+			// Check if it did close and if not, close it for sure.
+			if ( await this.editorBlockToolbarComponent.isOptionsMenuOpen() ) {
+				await this.editorBlockToolbarComponent.clickOptionsButton();
+			}
 		}
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -530,9 +530,9 @@ export class EditorPage {
 		if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
 			await this.editorBlockToolbarComponent.clickParentBlockButton( expectedParentBlockName );
 		} else {
-			const isMenuButtonOpen = await this.editorBlockToolbarComponent.isMenuButtonOpen();
+			const isOptionsMenuOpen = await this.editorBlockToolbarComponent.isOptionsMenuOpen();
 
-			if ( ! isMenuButtonOpen ) {
+			if ( ! isOptionsMenuOpen ) {
 				await this.editorBlockToolbarComponent.clickOptionsButton();
 			}
 			await this.editorPopoverMenuComponent.clickMenuButton(

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -530,10 +530,9 @@ export class EditorPage {
 		if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
 			await this.editorBlockToolbarComponent.clickParentBlockButton( expectedParentBlockName );
 		} else {
-			const isMenuButtonVisible = await this.editorPopoverMenuComponent.isMenuButtonVisible(
-				`Select parent block (${ expectedParentBlockName })`
-			);
-			if ( ! isMenuButtonVisible ) {
+			const isMenuButtonOpen = await await this.editorBlockToolbarComponent.isMenuButtonOpen();
+
+			if ( ! isMenuButtonOpen ) {
 				await this.editorBlockToolbarComponent.clickOptionsButton();
 			}
 			await this.editorPopoverMenuComponent.clickMenuButton(

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -534,8 +534,6 @@ export class EditorPage {
 			await this.editorPopoverMenuComponent.clickMenuButton(
 				`Select parent block (${ expectedParentBlockName })`
 			);
-			// It stays open on modal! We have to close it again.
-			await this.editorBlockToolbarComponent.clickOptionsButton();
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

While deploying https://github.com/Automattic/jetpack/pull/43765, a few of us looked into a failing test related to selecting the parent block on mobile.

It looks like the test opens the options menu, selects the parent and then attempts to close the options menu. The options menu actually closes itself, so attempting to close it was actually reopening it, causing the menu to be in the wrong state, and later actions in the test to fail. To fix this, some guards have been added around the opening and closing of the options menu to ensure the menu is left in the right state.

After fixing that the tests still had issues, block insertion wasn't working correctly. It seems that in the past a workaround was added, rather than clicking the block appender using playwright's `click` function, the test was dispatching an event. The workaround doesn't seem to be required anymore, so I've removed it. I believe it was causing some issues that resulted in the wrong block being selected after an insertion.

## Proposed Changes

* Add guards around opening/closing the block options menu. Only open the menu if it isn't already open. Only close the menu if it is open.
* Remove the use of `dispatchEvent( 'click' )` in favor of `click()`.

## Why are these changes being made?
See above explanation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check that all mobile e2e tests pass, and nothing breaks

For the form tests specifically, run `yarn workspace wp-e2e-tests test:mobile test/e2e/specs/blocks/blocks__jetpack-forms.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
