### PR TITLE
Show staging domain warning in visibility settings screen

### DIFF
--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -27,6 +27,7 @@ import { siteBySlugQuery } from './queries/site';
 import { siteAgencyBlogQuery } from './queries/site-agency';
 import { siteEdgeCacheStatusQuery } from './queries/site-cache';
 import { siteDefensiveModeSettingsQuery } from './queries/site-defensive-mode';
+import { siteDomainsQuery } from './queries/site-domains';
 import { sitePHPVersionQuery } from './queries/site-php-version';
 import { siteCurrentPlanQuery } from './queries/site-plans';
 import { sitePrimaryDataCenterQuery } from './queries/site-primary-data-center';
@@ -155,7 +156,10 @@ const siteSettingsSiteVisibilityRoute = createRoute( {
 	path: 'settings/site-visibility',
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		queryClient.ensureQueryData( siteSettingsQuery( site.ID ) );
+		Promise.all( [
+			queryClient.ensureQueryData( siteSettingsQuery( site.ID ) ),
+			queryClient.ensureQueryData( siteDomainsQuery( site.ID ) ),
+		] );
 	},
 } ).lazy( () =>
 	import( '../sites/settings-site-visibility' ).then( ( d ) =>

--- a/client/dashboard/data/site-domains.ts
+++ b/client/dashboard/data/site-domains.ts
@@ -1,7 +1,17 @@
 import wpcom from 'calypso/lib/wp';
-import type { Domain } from './types';
 
-export async function fetchSiteDomains( siteId: number ): Promise< Domain[] > {
+export interface SiteDomain {
+	domain: string;
+	blog_id: number;
+	blog_name: string;
+	expiry: string;
+	wpcom_domain: boolean;
+	type: string;
+	primary_domain: boolean;
+	is_wpcom_staging_domain: boolean;
+}
+
+export async function fetchSiteDomains( siteId: number ): Promise< SiteDomain[] > {
 	const { domains } = await wpcom.req.get( {
 		path: `/sites/${ siteId }/domains`,
 		apiVersion: '1.2',

--- a/client/dashboard/data/site.ts
+++ b/client/dashboard/data/site.ts
@@ -38,21 +38,6 @@ export const SITE_OPTIONS = [
 
 export const JOINED_SITE_OPTIONS = SITE_OPTIONS.join( ',' );
 
-export interface SiteDomain {
-	id: number;
-	domain: string;
-	blog_id: number;
-	owner: string;
-	expiry: string;
-	domain_status: {
-		status: string;
-	};
-	wpcom_domain: boolean;
-	sslStatus: string;
-	domain_type: string;
-	primary_domain: boolean;
-}
-
 export interface SitePlan {
 	product_id: number;
 	product_slug: string;

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -6,6 +6,7 @@ export type * from './me-profile';
 export type * from './me-sites';
 export type * from './me-ssh';
 export type * from './site';
+export type * from './site-domains';
 export type * from './site-hosting-edge-cache';
 export type * from './site-hosting-sftp';
 export type * from './site-hosting-ssh';

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -69,7 +69,7 @@ const robotFields: Field< SiteSettings & { isPrimaryDomainStaging: boolean } >[]
 			<CheckboxControl
 				__nextHasNoMarginBottom
 				label={ hideLabelFromVision ? '' : field.label }
-				checked={ field.getValue( { item: data } ) }
+				checked={ data.isPrimaryDomainStaging || field.getValue( { item: data } ) }
 				disabled={ data.isPrimaryDomainStaging }
 				onChange={ () => {
 					onChange( { [ field.id ]: ! field.getValue( { item: data } ) } );
@@ -84,7 +84,7 @@ const robotFields: Field< SiteSettings & { isPrimaryDomainStaging: boolean } >[]
 			<CheckboxControl
 				__nextHasNoMarginBottom
 				label={ hideLabelFromVision ? '' : field.label }
-				checked={ field.getValue( { item: data } ) }
+				checked={ data.isPrimaryDomainStaging || field.getValue( { item: data } ) }
 				disabled={ data.isPrimaryDomainStaging || data.wpcom_discourage_search_engines }
 				onChange={ () => {
 					onChange( { [ field.id ]: ! field.getValue( { item: data } ) } );
@@ -127,12 +127,9 @@ export function PrivacyForm( {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const [ formData, setFormData ] = useState( {
 		wpcom_site_visibility: settings.wpcom_site_visibility,
-		wpcom_discourage_search_engines:
-			settings.wpcom_discourage_search_engines || isPrimaryDomainStaging,
+		wpcom_discourage_search_engines: settings.wpcom_discourage_search_engines,
 		wpcom_prevent_third_party_sharing:
-			settings.wpcom_discourage_search_engines ||
-			isPrimaryDomainStaging ||
-			settings.wpcom_prevent_third_party_sharing,
+			settings.wpcom_discourage_search_engines || settings.wpcom_prevent_third_party_sharing,
 	} );
 
 	const isDirty = Object.entries( formData ).some(
@@ -161,12 +158,9 @@ export function PrivacyForm( {
 
 			if ( edits.wpcom_site_visibility !== undefined ) {
 				// Forget any previous edits to the discoverability controls when the visibility changes.
-				newFormData.wpcom_discourage_search_engines =
-					settings.wpcom_discourage_search_engines || isPrimaryDomainStaging;
+				newFormData.wpcom_discourage_search_engines = settings.wpcom_discourage_search_engines;
 				newFormData.wpcom_prevent_third_party_sharing =
-					settings.wpcom_discourage_search_engines ||
-					isPrimaryDomainStaging ||
-					settings.wpcom_prevent_third_party_sharing;
+					settings.wpcom_discourage_search_engines || settings.wpcom_prevent_third_party_sharing;
 			}
 			if ( edits.wpcom_discourage_search_engines === true ) {
 				// Checking the search engine box forces the third party checkbox too.

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -195,13 +195,7 @@ export function PrivacyForm( {
 									density="medium"
 									actions={
 										hasNonWpcomDomain ? (
-											<Button
-												variant="secondary"
-												href={ addQueryArgs( `/domains/add/${ site.slug }`, {
-													// TODO Have domain management return back to v2 settings page
-													source: '/v2/sites/settings/site-visibility',
-												} ) }
-											>
+											<Button variant="secondary" href={ `/domains/manage/${ site.slug }` }>
 												{ __( 'Manage domains' ) }
 											</Button>
 										) : (

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -196,7 +196,7 @@ export function PrivacyForm( {
 											<Button
 												variant="secondary"
 												href={ addQueryArgs( `/domains/add/${ site.slug }`, {
-													redirect_to: `/v2/sites/${ site.slug }/settings/site-visibility`,
+													redirect_to: window.location.pathname,
 												} ) }
 											>
 												{ __( 'Add new domain' ) }

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -1,4 +1,5 @@
 import { DataForm } from '@automattic/dataviews';
+import { useQuery } from '@tanstack/react-query';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -11,73 +12,15 @@ import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { useState } from 'react';
+import { addQueryArgs } from '@wordpress/url';
+import { useState, useMemo } from 'react';
+import { siteDomainsQuery } from '../../app/queries/site-domains';
 import InlineSupportLink from '../../components/inline-support-link';
+import Notice from '../../components/notice';
 import { ShareSiteForm } from './share-site-form';
 import type { Site, SiteSettings } from '../../data/types';
 import type { Field, Form } from '@automattic/dataviews';
 import type { UseMutationResult } from '@tanstack/react-query';
-
-const fields: Field< SiteSettings >[] = [
-	{
-		id: 'wpcom_site_visibility',
-		Edit: 'toggleGroup',
-		elements: [
-			{
-				label: __( 'Coming soon' ),
-				value: 'coming-soon',
-				description: __(
-					'Your site is hidden from visitors behind a “Coming Soon” notice until it is ready for viewing.'
-				),
-			},
-			{
-				label: __( 'Public' ),
-				value: 'public',
-				description: __( 'Your site is visible to everyone.' ),
-			},
-			{
-				label: __( 'Private' ),
-				value: 'private',
-				description: __(
-					'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
-				),
-			},
-		],
-	},
-	{
-		id: 'wpcom_discourage_search_engines',
-		Edit: 'checkbox',
-		label: __( 'Discourage search engines from indexing this site' ),
-		description: __(
-			'This does not block access to your site — it is up to search engines to honor your request.'
-		),
-		isVisible: ( { wpcom_site_visibility }: SiteSettings ) => wpcom_site_visibility === 'public',
-	},
-	{
-		id: 'wpcom_prevent_third_party_sharing',
-		Edit: ( { field, onChange, data, hideLabelFromVision } ) => (
-			<CheckboxControl
-				__nextHasNoMarginBottom
-				label={ hideLabelFromVision ? '' : field.label }
-				checked={ field.getValue( { item: data } ) }
-				disabled={ data.wpcom_discourage_search_engines }
-				onChange={ () => {
-					onChange( { [ field.id ]: ! field.getValue( { item: data } ) } );
-				} }
-				help={ createInterpolateElement(
-					__(
-						'This will prevent this site’s content from being shared with our licensed network of content and research partners, including those that train AI models. <a>Learn more</a>'
-					),
-					{
-						a: <InlineSupportLink supportContext="privacy-prevent-third-party-sharing" />,
-					}
-				) }
-			/>
-		),
-		label: __( 'Prevent third-party sharing for this site' ),
-		isVisible: ( { wpcom_site_visibility }: SiteSettings ) => wpcom_site_visibility === 'public',
-	},
-];
 
 const form = {
 	type: 'regular',
@@ -97,12 +40,107 @@ export function PrivacyForm( {
 	settings: SiteSettings;
 	mutation: UseMutationResult< Partial< SiteSettings >, Error, Partial< SiteSettings >, unknown >;
 } ) {
+	const { data: domains = [] } = useQuery( siteDomainsQuery( site.ID ) );
+
+	const primaryDomain = domains.find( ( domain ) => domain.primary_domain );
+	const isPrimaryDomainStaging = Boolean( primaryDomain?.is_wpcom_staging_domain );
+	const hasNonWpcomDomain = domains.some( ( domain ) => ! domain.wpcom_domain );
+
+	const fields = useMemo(
+		(): Field< SiteSettings >[] => [
+			{
+				id: 'wpcom_site_visibility',
+				Edit: 'toggleGroup',
+				elements: [
+					{
+						label: __( 'Coming soon' ),
+						value: 'coming-soon',
+						description: __(
+							'Your site is hidden from visitors behind a “Coming Soon” notice until it is ready for viewing.'
+						),
+					},
+					{
+						label: __( 'Public' ),
+						value: 'public',
+						description: __( 'Your site is visible to everyone.' ),
+					},
+					{
+						label: __( 'Private' ),
+						value: 'private',
+						description: __(
+							'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
+						),
+					},
+				],
+			},
+			{
+				id: 'wpcom_discourage_search_engines',
+				label: __( 'Discourage search engines from indexing this site' ),
+				description: __(
+					'This does not block access to your site — it is up to search engines to honor your request.'
+				),
+				isVisible: ( { wpcom_site_visibility }: SiteSettings ) =>
+					wpcom_site_visibility === 'public',
+				Edit: ( { field, onChange, data, hideLabelFromVision } ) => (
+					<VStack spacing={ 4 }>
+						{ isPrimaryDomainStaging && (
+							<StagingDomainNotice
+								siteSlug={ site.slug }
+								primaryDomain={ primaryDomain?.domain }
+								hasNonWpcomDomain={ hasNonWpcomDomain }
+							/>
+						) }
+						<CheckboxControl
+							__nextHasNoMarginBottom
+							label={ hideLabelFromVision ? '' : field.label }
+							checked={ field.getValue( { item: data } ) }
+							disabled={ isPrimaryDomainStaging }
+							onChange={ () => {
+								onChange( { [ field.id ]: ! field.getValue( { item: data } ) } );
+							} }
+							help={ field.description }
+						/>
+					</VStack>
+				),
+			},
+			{
+				id: 'wpcom_prevent_third_party_sharing',
+				Edit: ( { field, onChange, data, hideLabelFromVision } ) => (
+					<CheckboxControl
+						__nextHasNoMarginBottom
+						label={ hideLabelFromVision ? '' : field.label }
+						checked={ field.getValue( { item: data } ) }
+						disabled={ data.wpcom_discourage_search_engines }
+						onChange={ () => {
+							onChange( { [ field.id ]: ! field.getValue( { item: data } ) } );
+						} }
+						help={ createInterpolateElement(
+							__(
+								'This will prevent this site’s content from being shared with our licensed network of content and research partners, including those that train AI models. <a>Learn more</a>'
+							),
+							{
+								a: <InlineSupportLink supportContext="privacy-prevent-third-party-sharing" />,
+							}
+						) }
+					/>
+				),
+				label: __( 'Prevent third-party sharing for this site' ),
+				isVisible: ( { wpcom_site_visibility }: SiteSettings ) =>
+					wpcom_site_visibility === 'public',
+			},
+		],
+		[ site.slug, primaryDomain?.domain, isPrimaryDomainStaging, hasNonWpcomDomain ]
+	);
+
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const [ formData, setFormData ] = useState( {
 		wpcom_site_visibility: settings.wpcom_site_visibility,
-		wpcom_discourage_search_engines: settings.wpcom_discourage_search_engines,
+		wpcom_discourage_search_engines:
+			settings.wpcom_discourage_search_engines || isPrimaryDomainStaging,
 		wpcom_prevent_third_party_sharing:
-			settings.wpcom_discourage_search_engines || settings.wpcom_prevent_third_party_sharing,
+			settings.wpcom_discourage_search_engines ||
+			isPrimaryDomainStaging ||
+			settings.wpcom_prevent_third_party_sharing,
 	} );
 
 	const isDirty = Object.entries( formData ).some(
@@ -142,12 +180,12 @@ export function PrivacyForm( {
 										if ( edits.wpcom_site_visibility !== undefined ) {
 											// Forget any previous edits to the discoverability controls when the visibility changes.
 											newFormData.wpcom_discourage_search_engines =
-												settings.wpcom_discourage_search_engines;
+												settings.wpcom_discourage_search_engines || isPrimaryDomainStaging;
 											newFormData.wpcom_prevent_third_party_sharing =
 												settings.wpcom_discourage_search_engines ||
+												isPrimaryDomainStaging ||
 												settings.wpcom_prevent_third_party_sharing;
 										}
-
 										if ( edits.wpcom_discourage_search_engines === true ) {
 											// Checking the search engine box forces the third party checkbox too.
 											newFormData.wpcom_prevent_third_party_sharing = true;
@@ -176,5 +214,54 @@ export function PrivacyForm( {
 			{ settings.wpcom_site_visibility === 'coming-soon' &&
 				formData.wpcom_site_visibility === 'coming-soon' && <ShareSiteForm site={ site } /> }
 		</>
+	);
+}
+
+function StagingDomainNotice( {
+	siteSlug,
+	primaryDomain,
+	hasNonWpcomDomain,
+}: {
+	siteSlug: string;
+	primaryDomain: string;
+	hasNonWpcomDomain: boolean;
+} ) {
+	return (
+		<Notice
+			variant="warning"
+			density="medium"
+			actions={
+				hasNonWpcomDomain ? (
+					<Button
+						variant="secondary"
+						href={ addQueryArgs( `/domains/add/${ siteSlug }`, {
+							// TODO Have domain management return back to v2 settings page
+							source: '/v2/sites/settings/site-visibility',
+						} ) }
+					>
+						{ __( 'Manage domains' ) }
+					</Button>
+				) : (
+					<Button
+						variant="secondary"
+						href={ addQueryArgs( `/domains/add/${ siteSlug }`, {
+							redirect_to: `/v2/sites/${ siteSlug }/settings/site-visibility`,
+						} ) }
+					>
+						{ __( 'Add new domain' ) }
+					</Button>
+				)
+			}
+		>
+			{ createInterpolateElement(
+				__(
+					/* translators: <domain /> is a placeholder for the site's domain name. */
+					'Your site’s current primary domain is <domain />. This domain is intended for temporary use and will not be indexed by search engines. To ensure your site can be indexed, please register or connect a custom primary domain.'
+				),
+				{
+					domain: <strong style={ { overflowWrap: 'anywhere' } }>{ primaryDomain }</strong>,
+				}
+			) }
+		</Notice>
 	);
 }

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -13,7 +13,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { addQueryArgs } from '@wordpress/url';
-import { useState, useMemo } from 'react';
+import { useState } from 'react';
 import { siteDomainsQuery } from '../../app/queries/site-domains';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
@@ -22,13 +22,91 @@ import type { Site, SiteSettings } from '../../data/types';
 import type { Field, Form } from '@automattic/dataviews';
 import type { UseMutationResult } from '@tanstack/react-query';
 
-const form = {
+const visibilityFields: Field< SiteSettings >[] = [
+	{
+		id: 'wpcom_site_visibility',
+		Edit: 'toggleGroup',
+		elements: [
+			{
+				label: __( 'Coming soon' ),
+				value: 'coming-soon',
+				description: __(
+					'Your site is hidden from visitors behind a “Coming Soon” notice until it is ready for viewing.'
+				),
+			},
+			{
+				label: __( 'Public' ),
+				value: 'public',
+				description: __( 'Your site is visible to everyone.' ),
+			},
+			{
+				label: __( 'Private' ),
+				value: 'private',
+				description: __(
+					'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
+				),
+			},
+		],
+	},
+];
+
+const visibilityForm = {
 	type: 'regular',
-	fields: [
-		{ id: 'wpcom_site_visibility', labelPosition: 'none' },
-		'wpcom_discourage_search_engines',
-		'wpcom_prevent_third_party_sharing',
-	],
+	fields: [ { id: 'wpcom_site_visibility', labelPosition: 'none' } ],
+} satisfies Form;
+
+// This form also has access to `isPrimaryDomainStaging` which isn't a persisted setting, but is data
+// needed to determine whether the checkboxes should be disabled.
+const robotFields: Field< SiteSettings & { isPrimaryDomainStaging: boolean } >[] = [
+	{
+		id: 'wpcom_discourage_search_engines',
+		label: __( 'Discourage search engines from indexing this site' ),
+		description: __(
+			'This does not block access to your site — it is up to search engines to honor your request.'
+		),
+		isVisible: ( { wpcom_site_visibility }: SiteSettings ) => wpcom_site_visibility === 'public',
+		Edit: ( { field, onChange, data, hideLabelFromVision } ) => (
+			<CheckboxControl
+				__nextHasNoMarginBottom
+				label={ hideLabelFromVision ? '' : field.label }
+				checked={ field.getValue( { item: data } ) }
+				disabled={ data.isPrimaryDomainStaging }
+				onChange={ () => {
+					onChange( { [ field.id ]: ! field.getValue( { item: data } ) } );
+				} }
+				help={ field.description }
+			/>
+		),
+	},
+	{
+		id: 'wpcom_prevent_third_party_sharing',
+		Edit: ( { field, onChange, data, hideLabelFromVision } ) => (
+			<CheckboxControl
+				__nextHasNoMarginBottom
+				label={ hideLabelFromVision ? '' : field.label }
+				checked={ field.getValue( { item: data } ) }
+				disabled={ data.isPrimaryDomainStaging || data.wpcom_discourage_search_engines }
+				onChange={ () => {
+					onChange( { [ field.id ]: ! field.getValue( { item: data } ) } );
+				} }
+				help={ createInterpolateElement(
+					__(
+						'This will prevent this site’s content from being shared with our licensed network of content and research partners, including those that train AI models. <a>Learn more</a>'
+					),
+					{
+						a: <InlineSupportLink supportContext="privacy-prevent-third-party-sharing" />,
+					}
+				) }
+			/>
+		),
+		label: __( 'Prevent third-party sharing for this site' ),
+		isVisible: ( { wpcom_site_visibility }: SiteSettings ) => wpcom_site_visibility === 'public',
+	},
+];
+
+const robotForm = {
+	type: 'regular',
+	fields: [ 'wpcom_discourage_search_engines', 'wpcom_prevent_third_party_sharing' ],
 } satisfies Form;
 
 export function PrivacyForm( {
@@ -45,92 +123,6 @@ export function PrivacyForm( {
 	const primaryDomain = domains.find( ( domain ) => domain.primary_domain );
 	const isPrimaryDomainStaging = Boolean( primaryDomain?.is_wpcom_staging_domain );
 	const hasNonWpcomDomain = domains.some( ( domain ) => ! domain.wpcom_domain );
-
-	const fields = useMemo(
-		(): Field< SiteSettings >[] => [
-			{
-				id: 'wpcom_site_visibility',
-				Edit: 'toggleGroup',
-				elements: [
-					{
-						label: __( 'Coming soon' ),
-						value: 'coming-soon',
-						description: __(
-							'Your site is hidden from visitors behind a “Coming Soon” notice until it is ready for viewing.'
-						),
-					},
-					{
-						label: __( 'Public' ),
-						value: 'public',
-						description: __( 'Your site is visible to everyone.' ),
-					},
-					{
-						label: __( 'Private' ),
-						value: 'private',
-						description: __(
-							'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
-						),
-					},
-				],
-			},
-			{
-				id: 'wpcom_discourage_search_engines',
-				label: __( 'Discourage search engines from indexing this site' ),
-				description: __(
-					'This does not block access to your site — it is up to search engines to honor your request.'
-				),
-				isVisible: ( { wpcom_site_visibility }: SiteSettings ) =>
-					wpcom_site_visibility === 'public',
-				Edit: ( { field, onChange, data, hideLabelFromVision } ) => (
-					<VStack spacing={ 4 }>
-						{ isPrimaryDomainStaging && (
-							<StagingDomainNotice
-								siteSlug={ site.slug }
-								primaryDomain={ primaryDomain?.domain }
-								hasNonWpcomDomain={ hasNonWpcomDomain }
-							/>
-						) }
-						<CheckboxControl
-							__nextHasNoMarginBottom
-							label={ hideLabelFromVision ? '' : field.label }
-							checked={ field.getValue( { item: data } ) }
-							disabled={ isPrimaryDomainStaging }
-							onChange={ () => {
-								onChange( { [ field.id ]: ! field.getValue( { item: data } ) } );
-							} }
-							help={ field.description }
-						/>
-					</VStack>
-				),
-			},
-			{
-				id: 'wpcom_prevent_third_party_sharing',
-				Edit: ( { field, onChange, data, hideLabelFromVision } ) => (
-					<CheckboxControl
-						__nextHasNoMarginBottom
-						label={ hideLabelFromVision ? '' : field.label }
-						checked={ field.getValue( { item: data } ) }
-						disabled={ data.wpcom_discourage_search_engines }
-						onChange={ () => {
-							onChange( { [ field.id ]: ! field.getValue( { item: data } ) } );
-						} }
-						help={ createInterpolateElement(
-							__(
-								'This will prevent this site’s content from being shared with our licensed network of content and research partners, including those that train AI models. <a>Learn more</a>'
-							),
-							{
-								a: <InlineSupportLink supportContext="privacy-prevent-third-party-sharing" />,
-							}
-						) }
-					/>
-				),
-				label: __( 'Prevent third-party sharing for this site' ),
-				isVisible: ( { wpcom_site_visibility }: SiteSettings ) =>
-					wpcom_site_visibility === 'public',
-			},
-		],
-		[ site.slug, primaryDomain?.domain, isPrimaryDomainStaging, hasNonWpcomDomain ]
-	);
 
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const [ formData, setFormData ] = useState( {
@@ -163,6 +155,28 @@ export function PrivacyForm( {
 		);
 	};
 
+	const handleChange = ( edits: Partial< SiteSettings > ) => {
+		setFormData( ( data ) => {
+			const newFormData = { ...data, ...edits };
+
+			if ( edits.wpcom_site_visibility !== undefined ) {
+				// Forget any previous edits to the discoverability controls when the visibility changes.
+				newFormData.wpcom_discourage_search_engines =
+					settings.wpcom_discourage_search_engines || isPrimaryDomainStaging;
+				newFormData.wpcom_prevent_third_party_sharing =
+					settings.wpcom_discourage_search_engines ||
+					isPrimaryDomainStaging ||
+					settings.wpcom_prevent_third_party_sharing;
+			}
+			if ( edits.wpcom_discourage_search_engines === true ) {
+				// Checking the search engine box forces the third party checkbox too.
+				newFormData.wpcom_prevent_third_party_sharing = true;
+			}
+
+			return newFormData;
+		} );
+	};
+
 	return (
 		<>
 			<Card>
@@ -171,29 +185,57 @@ export function PrivacyForm( {
 						<VStack spacing={ 4 }>
 							<DataForm< SiteSettings >
 								data={ formData }
-								fields={ fields }
-								form={ form }
-								onChange={ ( edits: Partial< SiteSettings > ) => {
-									setFormData( ( data ) => {
-										const newFormData = { ...data, ...edits };
-
-										if ( edits.wpcom_site_visibility !== undefined ) {
-											// Forget any previous edits to the discoverability controls when the visibility changes.
-											newFormData.wpcom_discourage_search_engines =
-												settings.wpcom_discourage_search_engines || isPrimaryDomainStaging;
-											newFormData.wpcom_prevent_third_party_sharing =
-												settings.wpcom_discourage_search_engines ||
-												isPrimaryDomainStaging ||
-												settings.wpcom_prevent_third_party_sharing;
+								fields={ visibilityFields }
+								form={ visibilityForm }
+								onChange={ handleChange }
+							/>
+							{ formData.wpcom_site_visibility === 'public' && isPrimaryDomainStaging && (
+								<Notice
+									variant="warning"
+									density="medium"
+									actions={
+										hasNonWpcomDomain ? (
+											<Button
+												variant="secondary"
+												href={ addQueryArgs( `/domains/add/${ site.slug }`, {
+													// TODO Have domain management return back to v2 settings page
+													source: '/v2/sites/settings/site-visibility',
+												} ) }
+											>
+												{ __( 'Manage domains' ) }
+											</Button>
+										) : (
+											<Button
+												variant="secondary"
+												href={ addQueryArgs( `/domains/add/${ site.slug }`, {
+													redirect_to: `/v2/sites/${ site.slug }/settings/site-visibility`,
+												} ) }
+											>
+												{ __( 'Add new domain' ) }
+											</Button>
+										)
+									}
+								>
+									{ createInterpolateElement(
+										__(
+											/* translators: <domain /> is a placeholder for the site's domain name. */
+											'Your site’s current primary domain is <domain />. This domain is intended for temporary use and will not be indexed by search engines. To ensure your site can be indexed, please register or connect a custom primary domain.'
+										),
+										{
+											domain: (
+												<strong style={ { overflowWrap: 'anywhere' } }>
+													{ primaryDomain?.domain }
+												</strong>
+											),
 										}
-										if ( edits.wpcom_discourage_search_engines === true ) {
-											// Checking the search engine box forces the third party checkbox too.
-											newFormData.wpcom_prevent_third_party_sharing = true;
-										}
-
-										return newFormData;
-									} );
-								} }
+									) }
+								</Notice>
+							) }
+							<DataForm< SiteSettings & { isPrimaryDomainStaging: boolean } >
+								data={ { ...formData, isPrimaryDomainStaging } }
+								fields={ robotFields }
+								form={ robotForm }
+								onChange={ ( { isPrimaryDomainStaging, ...edits } ) => handleChange( edits ) }
 							/>
 							<HStack justify="flex-start">
 								<Button
@@ -214,54 +256,5 @@ export function PrivacyForm( {
 			{ settings.wpcom_site_visibility === 'coming-soon' &&
 				formData.wpcom_site_visibility === 'coming-soon' && <ShareSiteForm site={ site } /> }
 		</>
-	);
-}
-
-function StagingDomainNotice( {
-	siteSlug,
-	primaryDomain,
-	hasNonWpcomDomain,
-}: {
-	siteSlug: string;
-	primaryDomain: string;
-	hasNonWpcomDomain: boolean;
-} ) {
-	return (
-		<Notice
-			variant="warning"
-			density="medium"
-			actions={
-				hasNonWpcomDomain ? (
-					<Button
-						variant="secondary"
-						href={ addQueryArgs( `/domains/add/${ siteSlug }`, {
-							// TODO Have domain management return back to v2 settings page
-							source: '/v2/sites/settings/site-visibility',
-						} ) }
-					>
-						{ __( 'Manage domains' ) }
-					</Button>
-				) : (
-					<Button
-						variant="secondary"
-						href={ addQueryArgs( `/domains/add/${ siteSlug }`, {
-							redirect_to: `/v2/sites/${ siteSlug }/settings/site-visibility`,
-						} ) }
-					>
-						{ __( 'Add new domain' ) }
-					</Button>
-				)
-			}
-		>
-			{ createInterpolateElement(
-				__(
-					/* translators: <domain /> is a placeholder for the site's domain name. */
-					'Your site’s current primary domain is <domain />. This domain is intended for temporary use and will not be indexed by search engines. To ensure your site can be indexed, please register or connect a custom primary domain.'
-				),
-				{
-					domain: <strong style={ { overflowWrap: 'anywhere' } }>{ primaryDomain }</strong>,
-				}
-			) }
-		</Notice>
 	);
 }

--- a/client/my-sites/site-settings/site-tools/utils.ts
+++ b/client/my-sites/site-settings/site-tools/utils.ts
@@ -1,13 +1,11 @@
 export const SOURCE_SETTINGS_GENERAL = '/settings/general';
 export const SOURCE_SETTINGS_SITE_TOOLS = '/settings/site-tools';
 export const SOURCE_SETTINGS_ADMINISTRATION = '/sites/settings/administration';
-export const SOURCE_V2_VISIBILITY_SETTINGS = '/v2/sites/settings/site-visibility';
 
 const allowedSources = [
 	SOURCE_SETTINGS_GENERAL,
 	SOURCE_SETTINGS_SITE_TOOLS,
 	SOURCE_SETTINGS_ADMINISTRATION,
-	SOURCE_V2_VISIBILITY_SETTINGS,
 ];
 export const getSettingsSource = () => {
 	let source = new URLSearchParams( window.location.search ).get( 'source' ) || '';

--- a/client/my-sites/site-settings/site-tools/utils.ts
+++ b/client/my-sites/site-settings/site-tools/utils.ts
@@ -1,11 +1,13 @@
 export const SOURCE_SETTINGS_GENERAL = '/settings/general';
 export const SOURCE_SETTINGS_SITE_TOOLS = '/settings/site-tools';
 export const SOURCE_SETTINGS_ADMINISTRATION = '/sites/settings/administration';
+export const SOURCE_V2_VISIBILITY_SETTINGS = '/v2/sites/settings/site-visibility';
 
 const allowedSources = [
 	SOURCE_SETTINGS_GENERAL,
 	SOURCE_SETTINGS_SITE_TOOLS,
 	SOURCE_SETTINGS_ADMINISTRATION,
+	SOURCE_V2_VISIBILITY_SETTINGS,
 ];
 export const getSettingsSource = () => {
 	let source = new URLSearchParams( window.location.search ).get( 'source' ) || '';


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-13369

## Proposed Changes

* Add `fetchSiteDomains` and `querySiteDomains` to the data layer
  * Site domains are distinct from the existing `fetchDomains` request. The `Domain` type has a `domain_status` field, but the `SiteDomain` does not. Perhaps this is something to rationalise in the future (could it be the same endpoint that returns the same type of object, except called with a `?filter_by_site=` query param?)
* Display warning notice on public sites with `.wpcomstaging.com` primary domains
* Prevent sites with staging domains from being indexed
* Split the visibility data form in two, so so the warning notice can appear in the middle
* Warning links either to
  * Manage domain - when the site already has a custom domain they could switch to, otherwise
  * Add domain
* Fixed some smart quotes

**Important notes**
* There's a but where the "Save" button might still be enabled. Tracked DOTCOM-13370.
* Clicking "Manage domains" doesn't link back to the v2 dashboard
  * From [the old Calypso code](https://github.com/Automattic/wp-calypso/blob/4bbb58829aa7502df0b361fc21bf808a2feeddc3/client/sites/settings/site/privacy/notice.tsx#L132-L134) it looks like there should be a mechanism to link from the management page back to the visibility settings. There is not. This `?source` query param appears to be stale, its not used anywhere.
* The gap between form elements isn't consistent with mockups. That's because `DataForm` isn't consistent with the mockups. pdtkmj-3H1-p2#comment-7077

![CleanShot 2025-06-05 at 20 13 35@2x](https://github.com/user-attachments/assets/680dec9f-b590-4bc1-a352-37b47976fbc2)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Custom primary domain**
* Use atomic site
* With a custom domain
* Set custom domain as primary
* `/v2/sites/{{ slug }}/settings/site-visibility`
* Warning does not appear
* Google indexing checkbox is enabled

**Staging primary domain**
* Use atomic site
* With a custom domain
* Set `.wpcomstaging.com` domain as primary
* `/v2/sites/{{ slug }}/settings/site-visibility`
* Warning appears
* Google indexing checkbox is disabled
* Button links to `/domains/manage`

**Staging primary domain (with no alternative)**
* Use atomic site
* No custom domain
* `/v2/sites/{{ slug }}/settings/site-visibility`
* Warning appears
* Google indexing checkbox is disabled
* Button links to `/domains/add`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?