### PR TITLE
Only apply h1 styles when in SectionHeader

### DIFF
--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -44,13 +44,6 @@ a {
 	font-size: $font-size-medium;
 }
 
-h1 {
-	.dashboard-section-header.is-level-1 & {
-	    font-family: var( --dashboard-h1__font-family );
-	    font-weight: var( --dashboard-h1__font-weight ) !important;
-	}
-}
-
 // This is a temporary fix to match forms with the design.
 // The desired approach would be to create a layout component to wrap the form fields.
 // See: https://github.com/Automattic/wp-calypso/pull/103978

--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -45,8 +45,10 @@ a {
 }
 
 h1 {
-	font-family: var( --dashboard-h1__font-family );
-	font-weight: var( --dashboard-h1__font-weight ) !important;
+	.dashboard-section-header.is-level-1 & {
+	    font-family: var( --dashboard-h1__font-family );
+	    font-weight: var( --dashboard-h1__font-weight ) !important;
+	}
 }
 
 // This is a temporary fix to match forms with the design.

--- a/client/dashboard/components/section-header/style.scss
+++ b/client/dashboard/components/section-header/style.scss
@@ -15,7 +15,9 @@
 	font-weight: $font-weight-medium;
 
 	.dashboard-section-header.is-level-1 & {
+	    font-family: var( --dashboard-h1__font-family );
 		font-size: $font-size-2x-large;
+	    font-weight: var( --dashboard-h1__font-weight ) !important;
 		line-height: $font-line-height-2x-large;
 	}
 


### PR DESCRIPTION
## Proposed Changes

Currently, the h1 style is applied globally. Unfortunately, the Modal component also uses h1 and it's not customizable. This PR updates the CSS so that only the h1 in SectionHeader has the branding font Recoleta. 

| Before | After |
| --- | --- |
| ![Screenshot 2025-06-05 at 4 56 44 PM](https://github.com/user-attachments/assets/569f26c6-849a-45de-a9bd-5cdfe767f3fe) | ![Screenshot 2025-06-05 at 4 56 11 PM](https://github.com/user-attachments/assets/f37a87ee-77c7-4545-ad84-24f0e90f8f4a) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

UI polish.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that modals no longer users the font Recoleta.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
