### PR TITLE
Connect Refresh: Remove client logo from middle of screen Login. Add to masterbar instead.

### DIFF
--- a/client/login/types.ts
+++ b/client/login/types.ts
@@ -1,0 +1,6 @@
+export interface OAuth2Client {
+	id: number;
+	name?: string;
+	title?: string;
+	source?: string;
+}

--- a/client/login/wp-login/components/heading-logo.tsx
+++ b/client/login/wp-login/components/heading-logo.tsx
@@ -13,33 +13,43 @@ import {
 } from 'calypso/lib/oauth2-clients';
 import { useSelector } from 'calypso/state';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import type { OAuth2Client } from 'calypso/login/types';
 
 interface Props {
 	isFromAkismet?: boolean;
+	width?: number;
+	height?: number;
 }
 
-const HeadingLogo = ( { isFromAkismet }: Props ) => {
-	const oauth2Client = useSelector( getCurrentOAuth2Client );
+const HeadingLogo = ( { isFromAkismet, width, height }: Props ) => {
+	const oauth2Client = useSelector( getCurrentOAuth2Client ) as OAuth2Client | null;
 
-	let logo = null;
+	let clientLogo: string | null = null;
 	if ( isStudioAppOAuth2Client( oauth2Client ) ) {
-		logo = <img src={ studioAppLogo } alt="Studio App Logo" />;
+		clientLogo = studioAppLogo;
 	} else if ( isCrowdsignalOAuth2Client( oauth2Client ) ) {
-		logo = <img src={ crowdsignalLogo } alt="Crowdsignal Logo" />;
+		clientLogo = crowdsignalLogo;
 	} else if ( isFromAkismet ) {
-		logo = <img src={ akismetLogo } alt="Akismet Logo" />;
+		clientLogo = akismetLogo;
 	} else if ( isWPJobManagerOAuth2Client( oauth2Client ) ) {
-		logo = <img src={ wpJobManagerLogo } alt="WP Job Manager Logo" />;
+		clientLogo = wpJobManagerLogo;
 	} else if ( isBlazeProOAuth2Client( oauth2Client ) ) {
-		logo = <img src={ blazeProLogo } alt="Blaze Pro Logo" />;
+		clientLogo = blazeProLogo;
 	} else if ( isGravPoweredOAuth2Client( oauth2Client ) ) {
 		/**
 		 * Leave last to avoid overriding other grav-powered client logos.
 		 */
-		logo = <img src={ gravatarLogo } alt="Gravatar Logo" />;
+		clientLogo = gravatarLogo;
 	}
 
-	return logo ? <div className="wp-login__heading-logo">{ logo }</div> : null;
+	return clientLogo ? (
+		<img
+			src={ clientLogo }
+			alt={ `${ oauth2Client?.name ?? 'Login' } Client Logo` }
+			width={ width }
+			height={ height }
+		/>
+	) : null;
 };
 
 export default HeadingLogo;

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -524,6 +524,10 @@ export class Login extends Component {
 			isGravPoweredClient ||
 			isBlazePro;
 
+		if ( shouldUseWideHeading ) {
+			brandLogo = <HeadingLogo isFromAkismet={ isFromAkismet } width={ 21 } height={ 21 } />;
+		}
+
 		return (
 			<>
 				{ isWhiteLogin && (
@@ -537,7 +541,9 @@ export class Login extends Component {
 							<Step.Heading
 								text={
 									<>
-										<HeadingLogo isFromAkismet={ isFromAkismet } />
+										{ /* <div className="wp-login__heading-logo">
+											<HeadingLogo isFromAkismet={ isFromAkismet } />
+										</div> */ }
 										<div className="wp-login__heading-text">{ headerText }</div>
 									</>
 								}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13483/login-remove-the-middle-client-logo-and-add-it-to-the-masterbar

## Proposed Changes

- Based on the discussion with @jasmussen in https://github.com/Automattic/wp-calypso/pull/103948#issuecomment-2939369157, we remove the client logo from the middle of the Login screen, in favor of placing it at the top-left/master bar.
- Experimental, to confirm. We'll proceed and do some cleanup if this checks out.

## Media

A few examples below:

| Before | After |
|--------|--------|
| <img width="1462" alt="Screenshot 2025-06-04 at 2 55 18 PM" src="https://github.com/user-attachments/assets/4c4490d9-a739-46dc-ab33-009b669548a9" /> | <img width="1469" alt="Screenshot 2025-06-04 at 2 52 36 PM" src="https://github.com/user-attachments/assets/53531c72-5ff7-4b02-aad7-3e541372c941" /> |
| <img width="1459" alt="Screenshot 2025-06-04 at 2 55 36 PM" src="https://github.com/user-attachments/assets/9b40fcf8-89b9-461c-8e99-642b992a2f73" /> | <img width="1461" alt="Screenshot 2025-06-04 at 2 52 59 PM" src="https://github.com/user-attachments/assets/c9bfa756-4128-4af2-bf40-0a27c75d2c34" /> |
| <img width="1460" alt="Screenshot 2025-06-04 at 2 55 53 PM" src="https://github.com/user-attachments/assets/faa98ce3-98fb-47ae-b376-24ddcbdb6080" /> | <img width="1465" alt="Screenshot 2025-06-04 at 2 53 14 PM" src="https://github.com/user-attachments/assets/26bde360-2e6f-4e9d-910e-9875b51b385f" /> | 


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13220/calypso-make-the-two-columnwhite-layout-the-default-across-all

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to any client Login and confirm:
* [WordPress.com](http://calypso.localhost:3000/log-in)
* [Studio](http://calypso.localhost:3000/log-in?client_id=95109&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dtoken%26client_id%3D95109%26redirect_uri%3Dwpcom-local-dev%253A%252F%252Fauth%26scope%3Dglobal%26client_source%26jetpack-code%26jetpack-user-id%3D0%26action%3Doauth2-login%26from-calypso%3D1)
* [Akismet](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fr-login.wordpress.com%2Fremote-login.php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet.com%252Faccount%252F&signup_url=%2Fstart%2Faccount%2Fuser-social%3Fredirect_to%3Dhttps%253A%252F%252Fr-login.wordpress.com%252Fremote-login.php%253Faction%253Dlink%2526back%253Dhttps%25253A%25252F%25252Fakismet.com%25252Faccount%25252F) 
* [Crowdsignal](http://calypso.localhost:3000/log-in?client_id=978&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3Df5da55616562ed1b1ef36c8e88328853efcc0167150831e59437c3330ec11509%26redirect_uri%3Dhttps%253A%252F%252Fapp.crowdsignal.com%252Fconnect%253Fsource%253Dlogin%2526action%253Drequest_access_token%26wpcom_connect%3D1%26from-calypso%3D1)
* [Gravatar](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D4a5153e30a28e2ef24ca7e599abd80f3969340cd1f88327c1f5d2fbc88593fa1%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1&client_id=1854)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
