### PR TITLE
Ensure "/ year" price is read "per year" using VoiceOver

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -45,7 +45,8 @@ export class DomainProductPrice extends Component {
 				args: { cost: renewPrice },
 			} );
 			return (
-				<div className="domain-product-price__renewal-price" aria-label={ ariaLabel }>
+				<div className="domain-product-price__renewal-price">
+					<span className="screen-reader-text">{ ariaLabel }</span>
 					<span aria-hidden="true">
 						{ translate( 'Renews for %(cost)s {{small}}/year{{/small}}', {
 							args: { cost: renewPrice },
@@ -79,7 +80,8 @@ export class DomainProductPrice extends Component {
 						{ translate( 'Free for the first year' ) }
 					</span>
 				</div>
-				<div className="domain-product-price__price" aria-label={ ariaLabel }>
+				<div className="domain-product-price__price">
+					<span className="screen-reader-text">{ ariaLabel }</span>
 					<del aria-hidden="true">{ priceText }</del>
 				</div>
 			</div>
@@ -128,7 +130,8 @@ export class DomainProductPrice extends Component {
 		return (
 			<div className={ className }>
 				<div className="domain-product-price__free-text">{ message }</div>
-				<div className="domain-product-price__price" aria-label={ ariaLabel }>
+				<div className="domain-product-price__price">
+					<span className="screen-reader-text">{ ariaLabel }</span>
 					<del aria-hidden="true">
 						{ this.props.isMappingProduct
 							? null
@@ -196,7 +199,8 @@ export class DomainProductPrice extends Component {
 						components: { small: <small /> },
 					} ) }
 				</div>
-				<div className="domain-product-price__regular-price" aria-label={ ariaLabel }>
+				<div className="domain-product-price__regular-price">
+					<span className="screen-reader-text">{ ariaLabel }</span>
 					<span aria-hidden="true">
 						{ translate( '%(cost)s {{small}}/year{{/small}}', {
 							args: { cost: price },
@@ -227,7 +231,8 @@ export class DomainProductPrice extends Component {
 
 		return (
 			<div className={ className }>
-				<span className={ productPriceClassName } aria-label={ ariaLabel }>
+				<span className={ productPriceClassName }>
+					<span className="screen-reader-text">{ ariaLabel }</span>
 					<span aria-hidden="true">
 						{ translate( '%(cost)s {{small}}/year{{/small}}', {
 							args: { cost: price },

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -41,13 +41,18 @@ export class DomainProductPrice extends Component {
 		const isRenewCostDifferent = renewPrice && price !== renewPrice;
 
 		if ( isRenewCostDifferent ) {
+			const ariaLabel = translate( 'Renews for %(cost)s per year', {
+				args: { cost: renewPrice },
+			} );
 			return (
-				<div className="domain-product-price__renewal-price">
-					{ translate( 'Renews for %(cost)s {{small}}/year{{/small}}', {
-						args: { cost: renewPrice },
-						components: { small: <small /> },
-						comment: '%(cost)s is the annual renewal price of the domain',
-					} ) }
+				<div className="domain-product-price__renewal-price" aria-label={ ariaLabel }>
+					<span aria-hidden="true">
+						{ translate( 'Renews for %(cost)s {{small}}/year{{/small}}', {
+							args: { cost: renewPrice },
+							components: { small: <small /> },
+							comment: '%(cost)s is the annual renewal price of the domain',
+						} ) }
+					</span>
 				</div>
 			);
 		}
@@ -63,6 +68,9 @@ export class DomainProductPrice extends Component {
 		const priceText = this.props.translate( '%(cost)s/year', {
 			args: { cost: this.props.price },
 		} );
+		const ariaLabel = this.props.translate( '%(cost)s per year', {
+			args: { cost: this.props.price },
+		} );
 
 		return (
 			<div className={ className }>
@@ -71,8 +79,8 @@ export class DomainProductPrice extends Component {
 						{ translate( 'Free for the first year' ) }
 					</span>
 				</div>
-				<div className="domain-product-price__price">
-					<del>{ priceText }</del>
+				<div className="domain-product-price__price" aria-label={ ariaLabel }>
+					<del aria-hidden="true">{ priceText }</del>
 				</div>
 			</div>
 		);
@@ -113,12 +121,15 @@ export class DomainProductPrice extends Component {
 				components: { span: <span className="domain-product-price__free-price" /> },
 			} );
 		}
+		const ariaLabel = this.props.translate( '%(cost)s per year', {
+			args: { cost: this.props.price },
+		} );
 
 		return (
 			<div className={ className }>
 				<div className="domain-product-price__free-text">{ message }</div>
-				<div className="domain-product-price__price">
-					<del>
+				<div className="domain-product-price__price" aria-label={ ariaLabel }>
+					<del aria-hidden="true">
 						{ this.props.isMappingProduct
 							? null
 							: this.props.translate( '%(cost)s/year', {
@@ -173,6 +184,9 @@ export class DomainProductPrice extends Component {
 		const className = clsx( 'domain-product-price', 'is-free-domain', 'is-sale-domain', {
 			'domain-product-price__domain-step-signup-flow': this.props.showStrikedOutPrice,
 		} );
+		const ariaLabel = this.props.translate( '%(cost)s per year', {
+			args: { cost: this.props.price },
+		} );
 
 		return (
 			<div className={ className }>
@@ -182,12 +196,14 @@ export class DomainProductPrice extends Component {
 						components: { small: <small /> },
 					} ) }
 				</div>
-				<div className="domain-product-price__regular-price">
-					{ translate( '%(cost)s {{small}}/year{{/small}}', {
-						args: { cost: price },
-						components: { small: <small /> },
-						comment: '%(cost)s is the annual renewal price of a domain currently on sale',
-					} ) }
+				<div className="domain-product-price__regular-price" aria-label={ ariaLabel }>
+					<span aria-hidden="true">
+						{ translate( '%(cost)s {{small}}/year{{/small}}', {
+							args: { cost: price },
+							components: { small: <small /> },
+							comment: '%(cost)s is the annual renewal price of a domain currently on sale',
+						} ) }
+					</span>
 				</div>
 				{ this.renderRenewalPrice() }
 			</div>
@@ -205,14 +221,19 @@ export class DomainProductPrice extends Component {
 			'domain-product-price__domain-step-signup-flow': showStrikedOutPrice,
 		} );
 		const productPriceClassName = showStrikedOutPrice ? '' : 'domain-product-price__price';
+		const ariaLabel = this.props.translate( '%(cost)s per year', {
+			args: { cost: this.props.price },
+		} );
 
 		return (
 			<div className={ className }>
-				<span className={ productPriceClassName }>
-					{ translate( '%(cost)s {{small}}/year{{/small}}', {
-						args: { cost: price },
-						components: { small: <small /> },
-					} ) }
+				<span className={ productPriceClassName } aria-label={ ariaLabel }>
+					<span aria-hidden="true">
+						{ translate( '%(cost)s {{small}}/year{{/small}}', {
+							args: { cost: price },
+							components: { small: <small /> },
+						} ) }
+					</span>
 				</span>
 				{ this.renderRenewalPrice() }
 			</div>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-13413

## Proposed Changes

* Added `aria-label` with "per year" translation

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Pricing was being read as "slash year"

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head over to [https://wordpress.com/start/domain/domain-only](http://calypso.localhost:3000/start/domain/domain-only).
* Search for a domain.
* Enable VoiceOver.
* Tab through the suggested domains using Control + Option + Arrow Left / Arrow Right.
* Confirm prices are read as "per year" instead of "slash year"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
