### PR TITLE
Hosting Dashboard v2: Implement Big Sky trial site launch flow

### DIFF
--- a/client/dashboard/data/constants.ts
+++ b/client/dashboard/data/constants.ts
@@ -8,6 +8,17 @@ export enum DotcomFeatures {
 	SITE_PREVIEW_LINKS = 'site-preview-links',
 }
 
+export enum DotcomPlans {
+	BUSINESS = 'business-bundle',
+	BUSINESS_MONTHLY = 'business-bundle-monthly',
+	BUSINESS_2_YEARS = 'business-bundle-2y',
+	BUSINESS_3_YEARS = 'business-bundle-3y',
+	PREMIUM = 'value_bundle',
+	PREMIUM_MONTHLY = 'value_bundle_monthly',
+	PREMIUM_2_YEARS = 'value_bundle-2y',
+	PREMIUM_3_YEARS = 'value_bundle-3y',
+}
+
 export const SITE_FIELDS = [
 	'ID',
 	'slug',
@@ -34,8 +45,9 @@ export const SITE_FIELDS = [
 
 export const SITE_OPTIONS = [
 	'admin_url',
-	'software_version',
 	'is_redirect',
 	'is_wpforteams_site',
 	'p2_hub_blog_id',
+	'site_creation_flow',
+	'software_version',
 ];

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -75,11 +75,12 @@ export interface SiteCapabilities {
 }
 
 export interface SiteOptions {
-	software_version: string;
 	admin_url: string;
 	is_redirect?: boolean;
-	p2_hub_blog_id?: number;
 	is_wpforteams_site?: boolean;
+	p2_hub_blog_id?: number;
+	site_creation_flow?: string;
+	software_version: string;
 }
 
 export interface Site {

--- a/client/dashboard/sites/settings-site-visibility/launch-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/launch-form.tsx
@@ -119,13 +119,9 @@ export function LaunchForm( { site }: { site: Site } ) {
 
 	return (
 		<Notice
-			title={ __( "Your site hasn’t been launched yet" ) }
+			title={ __( 'Your site hasn’t been launched yet' ) }
 			actions={
-				<Button
-					size="compact"
-					variant="primary"
-					href={ getLaunchUrl() }
-				>
+				<Button size="compact" variant="primary" href={ getLaunchUrl() }>
 					{ __( 'Launch site' ) }
 				</Button>
 			}

--- a/client/dashboard/sites/settings-site-visibility/launch-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/launch-form.tsx
@@ -11,7 +11,8 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { agencyBlogQuery } from '../../app/queries';
 import Notice from '../../components/notice';
-import type { Site, AgencyBlog } from '../../data/types';
+import { isBigSkyTrial } from '../../utils/site-features';
+import type { AgencyBlog, Site } from '../../data/types';
 
 function getAgencyBillingMessage( agency: AgencyBlog | undefined, isAgencyQueryError: boolean ) {
 	if ( ! agency ) {
@@ -98,24 +99,38 @@ export function LaunchAgencyDevelopmentSiteForm( {
 }
 
 export function LaunchForm( { site }: { site: Site } ) {
+	const getLaunchUrl = () => {
+		if ( isBigSkyTrial( site ) ) {
+			return addQueryArgs( '/setup/ai-site-builder/domains', {
+				siteId: site.ID,
+				source: 'general-settings',
+				redirect: 'site-launch',
+				new: site.name,
+				search: 'yes',
+			} );
+		}
+
+		return addQueryArgs( '/start/launch-site', {
+			siteSlug: site.slug,
+			new: site.name,
+			hide_initial_query: 'yes',
+		} );
+	};
+
 	return (
 		<Notice
-			title={ __( "Your site hasn't been launched yet" ) }
+			title={ __( "Your site hasn’t been launched yet" ) }
 			actions={
 				<Button
 					size="compact"
 					variant="primary"
-					href={ addQueryArgs( '/start/launch-site', {
-						siteSlug: site.slug,
-						new: site.name,
-						hide_initial_query: 'yes',
-					} ) }
+					href={ getLaunchUrl() }
 				>
 					{ __( 'Launch site' ) }
 				</Button>
 			}
 		>
-			{ __( 'It is hidden from visitors behind a "Coming Soon" notice until it is launched.' ) }
+			{ __( 'It is hidden from visitors behind a “Coming Soon” notice until it is launched.' ) }
 		</Notice>
 	);
 }

--- a/client/dashboard/utils/site-features.ts
+++ b/client/dashboard/utils/site-features.ts
@@ -1,4 +1,4 @@
-import { DotcomFeatures } from '../data/constants';
+import { DotcomFeatures, DotcomPlans } from '../data/constants';
 import type { Site } from '../data/types';
 
 export const hasPlanFeature = ( site: Site, feature: DotcomFeatures ) => {
@@ -40,4 +40,33 @@ export const canUseSftp = ( site: Site ) => {
 
 export const canUseSsh = ( site: Site ) => {
 	return canUseSftp( site ) && hasPlanFeature( site, DotcomFeatures.SSH );
+};
+
+export const isBigSkyTrial = ( site: Site ) => {
+	if ( ! site.plan ) {
+		return false;
+	}
+
+	const { launch_status, options, plan } = site;
+	if ( options?.site_creation_flow !== 'ai-site-builder' || launch_status !== 'unlaunched' ) {
+		return false;
+	}
+
+	const { product_slug } = plan;
+	if ( ! product_slug ) {
+		return true;
+	}
+
+	const bigSkyPlans = [
+		DotcomPlans.BUSINESS,
+		DotcomPlans.BUSINESS_MONTHLY,
+		DotcomPlans.BUSINESS_2_YEARS,
+		DotcomPlans.BUSINESS_3_YEARS,
+		DotcomPlans.PREMIUM,
+		DotcomPlans.PREMIUM_MONTHLY,
+		DotcomPlans.PREMIUM_2_YEARS,
+		DotcomPlans.PREMIUM_3_YEARS,
+	];
+
+	return ! bigSkyPlans.includes( product_slug as DotcomPlans );
 };


### PR DESCRIPTION
Ref DOTDASH-6

## Proposed Changes

This PR implements the Big Sky trial site launch flow. The UI is the same, but the button URL takes users to /setup/ai-site-builder/domains instead of /start-launch site.

![Screenshot 2025-06-05 at 6 00 34 PM](https://github.com/user-attachments/assets/89eb459f-9a51-4dd5-bd36-7b490a3bd84f)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Hosting Dashboard v2 implementation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2/sites/:siteSlug/settings/site-visibility using a Big Sky trial site.
* Ensure that the URL is /setup/ai-site-builder/domains.
* Ensure that the URL parameters is the same as the one in v1.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
