### PR TITLE
Fix: set Playground step public

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -53,10 +53,9 @@ function initialize() {
 		STEPS.SITE_CREATION_STEP,
 		STEPS.PROCESSING,
 		STEPS.POST_CHECKOUT_ONBOARDING,
-		STEPS.PLAYGROUND,
 	];
 
-	return stepsWithRequiredLogin( steps );
+	return [ ...stepsWithRequiredLogin( steps ), STEPS.PLAYGROUND ];
 }
 
 const onboarding: FlowV2< typeof initialize > = {


### PR DESCRIPTION
On https://github.com/Automattic/wp-calypso/commit/165adc4c13205f42402e1c7b4156b27ce1db5ee9#diff-765503aedd7677bb1dd2ae81a893ef85568cfca6329ea222102db609326772fcR51-R65 the public `/setup/onboarding/playground` Playground step has [been moved](https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts#L56) to the `stepsWithRequiredLogin` array. So now a user needs to log in to visit it.

## Proposed Changes

* Fix the Playground step logged out page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To fix the flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit http://calypso.localhost:3000/setup/onboarding/playground as a logged-in user and as a guest, and be sure you don't see the create user page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
