### PR TITLE
Support Link: Better routing when opening Help Center

### DIFF
--- a/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
+++ b/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
@@ -8,6 +8,9 @@ async function fetchZendeskConfig(): Promise< boolean > {
 	return validResponse;
 }
 
+/**
+ * This hook verifies connectivity to Zendesk's messaging service by making a config request and manages automatic retries with error tracking.
+ */
 export function useCanConnectToZendeskMessaging( enabled = true ) {
 	const queryClient = useQueryClient();
 	const [ shouldRefetch, setShouldRefetch ] = useState( false );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTSUP-53/fix-missing-support-chat-messages-in-help-centre-interface#comment-f67f5c7d

## Proposed Changes

This PR:
- removes old and not useful anymore zendesk hooks, used when we had a separate UI for chatting
- improves the tracking
- opens the Help Center to /odie if the user has problems connecting to Zendesk


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try to downgrade a plan in /me/purchases -> a plan actions -> cancel plan
* Ask for help
* You should start a new conversation
* Try to use the extension Mod Response to block the call to Zendesk config
* Try to click the button again and you should see Odie
