### PR TITLE
Downgrade plan: Check Zendesk before connecting

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
@@ -10,6 +10,7 @@ import {
 import page from '@automattic/calypso-router';
 import { AddOns, Plans } from '@automattic/data-stores';
 import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
+import { useCanConnectToZendeskMessaging } from '@automattic/zendesk-client';
 import { useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { getPlanCartItem } from 'calypso/lib/cart-values/cart-items';
@@ -112,7 +113,8 @@ function useDowngradeHandler( {
 	siteUrl?: string | null;
 	currentPlan: Plans.SitePlan | undefined;
 } ) {
-	const { setNewMessagingChat } = useDispatch( HELP_CENTER_STORE );
+	const { setNewMessagingChat, setNavigateToOdie } = useDispatch( HELP_CENTER_STORE );
+	const { data: canConnectToZendeskMessaging } = useCanConnectToZendeskMessaging();
 
 	return useCallback(
 		( planSlug: PlanSlug ) => {
@@ -122,12 +124,23 @@ function useDowngradeHandler( {
 				return;
 			}
 
-			setNewMessagingChat( {
-				initialMessage: 'User wants to downgrade plan.',
-				siteUrl,
-			} );
+			if ( canConnectToZendeskMessaging ) {
+				setNewMessagingChat( {
+					initialMessage: 'User wants to downgrade plan.',
+					siteUrl,
+				} );
+			} else {
+				setNavigateToOdie();
+			}
 		},
-		[ currentPlan?.purchaseId, setNewMessagingChat, siteUrl, siteSlug ]
+		[
+			currentPlan?.purchaseId,
+			setNewMessagingChat,
+			siteUrl,
+			siteSlug,
+			canConnectToZendeskMessaging,
+			setNavigateToOdie,
+		]
 	);
 }
 

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -243,11 +243,10 @@ export type HelpCenterAction =
 			| typeof setAreSoundNotificationsEnabled
 			| typeof setZendeskClientId
 			| typeof setNavigateToRoute
-			| typeof setNavigateToOdie
 			| typeof setOdieInitialPromptText
 			| typeof setOdieBotNameSlug
 			| typeof setCurrentSupportInteraction
 			| typeof setAllowPremiumSupport
 			| typeof setHelpCenterOptions
 	  >
-	| GeneratorReturnType< typeof setShowHelpCenter >;
+	| GeneratorReturnType< typeof setShowHelpCenter | typeof setNavigateToOdie >;

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -249,4 +249,4 @@ export type HelpCenterAction =
 			| typeof setAllowPremiumSupport
 			| typeof setHelpCenterOptions
 	  >
-	| GeneratorReturnType< typeof setShowHelpCenter | typeof setNavigateToOdie >;
+	| GeneratorReturnType< typeof setShowHelpCenter >;

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -210,6 +210,11 @@ export const setNewMessagingChat = function* ( {
 	yield setShowHelpCenter( true );
 };
 
+export const setNavigateToOdie = function* () {
+	yield setNavigateToRoute( '/odie' );
+	yield setShowHelpCenter( true );
+};
+
 export const setShowSupportDoc = function* ( link: string, postId?: number, blogId?: number ) {
 	const params = new URLSearchParams( {
 		link,
@@ -238,6 +243,7 @@ export type HelpCenterAction =
 			| typeof setAreSoundNotificationsEnabled
 			| typeof setZendeskClientId
 			| typeof setNavigateToRoute
+			| typeof setNavigateToOdie
 			| typeof setOdieInitialPromptText
 			| typeof setOdieBotNameSlug
 			| typeof setCurrentSupportInteraction


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTSUP-53/fix-missing-support-chat-messages-in-help-centre-interface#comment-1df1c5a0

## Proposed Changes

* Check if it is possible to connect to Zendesk before creating a chat.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It is possible that users encounter problems with Zendesk and we did not check if it was possible to create a new chat.


