### PR TITLE
Newsletter: Use total_subscribers field while displaying all subscribers

### DIFF
--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -103,12 +103,14 @@ const selectSubscribers = ( payload: {
 // email_subscribers includes both email and wpcom subscribers so it can't be used for calculations
 const selectPaidSubscribers = ( payload: {
 	counts: {
+		total_subscribers: number;
 		email_subscribers: number;
 		paid_subscribers: number;
 		social_followers: number;
 	};
 } ) => {
 	return {
+		total_subscribers: payload?.counts?.total_subscribers,
 		email_subscribers: payload?.counts?.email_subscribers,
 		paid_subscribers: payload?.counts?.paid_subscribers,
 		social_followers: payload?.counts?.social_followers,

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -203,7 +203,7 @@ export default function SubscriberDataViews( {
 	}, [ subscriberId, subscriberDetails ] );
 
 	const { data: subscribersTotals } = useSubscriberCountQuery( siteId ?? null );
-	const grandTotal = subscribersTotals?.email_subscribers ?? 0;
+	const grandTotal = subscribersTotals?.total_subscribers ?? 0;
 	const {
 		subscribers,
 		is_owner_subscribed: isOwnerSubscribed,

--- a/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
+++ b/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
@@ -32,7 +32,7 @@ const SubscribersHeaderPopover = ( {
 		'https://dashboard.wordpress.com/wp-admin/index.php'
 	);
 	const { data: subscribersTotals } = useSubscriberCountQuery( siteId );
-	const hasSubscribers = subscribersTotals?.email_subscribers ?? 0 > 0;
+	const hasSubscribers = !! subscribersTotals?.total_subscribers;
 	const recordExport = useRecordExport();
 	const currentUserSiteCount = useSelector( getCurrentUserSiteCount );
 

--- a/client/my-sites/subscribers/hooks/use-add-subscribers-callback.ts
+++ b/client/my-sites/subscribers/hooks/use-add-subscribers-callback.ts
@@ -62,7 +62,7 @@ export const useAddSubscribersCallback = ( siteId: number | null ) => {
 
 					// Invalidate the subscribers queries to ensure that the new subscribers are fetched.
 					queryClient.invalidateQueries( { queryKey: [ 'subscribers', siteId ] } );
-					queryClient.invalidateQueries( { queryKey: [ 'subscribers', 'count', siteId ] } );
+					queryClient.invalidateQueries( { queryKey: [ 'subscribers', 'counts', siteId ] } );
 				}
 			} else {
 				dispatch(

--- a/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
@@ -165,7 +165,7 @@ const useSubscriberRemoveMutation = (
 			// Get the current count data
 			const previousCountData = queryClient.getQueryData< { total_subscribers: number } >( [
 				'subscribers',
-				'count',
+				'counts',
 				siteId,
 			] );
 

--- a/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
@@ -156,14 +156,14 @@ const useSubscriberRemoveMutation = (
 		onMutate: async ( subscribers ) => {
 			// Cancel any outgoing refetches
 			await queryClient.cancelQueries( { queryKey: [ 'subscribers', siteId ] } );
-			await queryClient.cancelQueries( { queryKey: [ 'subscribers', 'count', siteId ] } );
+			await queryClient.cancelQueries( { queryKey: [ 'subscribers', 'counts', siteId ] } );
 
 			// Get the current page data
 			const previousData =
 				queryClient.getQueryData< SubscriberEndpointResponse >( currentPageCacheKey );
 
 			// Get the current count data
-			const previousCountData = queryClient.getQueryData< { email_subscribers: number } >( [
+			const previousCountData = queryClient.getQueryData< { total_subscribers: number } >( [
 				'subscribers',
 				'count',
 				siteId,
@@ -212,9 +212,9 @@ const useSubscriberRemoveMutation = (
 			if ( previousCountData ) {
 				const updatedCountData = {
 					...previousCountData,
-					email_subscribers: previousCountData.email_subscribers - subscribers.length,
+					total_subscribers: previousCountData.total_subscribers - subscribers.length,
 				};
-				queryClient.setQueryData( [ 'subscribers', 'count', siteId ], updatedCountData );
+				queryClient.setQueryData( [ 'subscribers', 'counts', siteId ], updatedCountData );
 			}
 
 			// Handle subscriber details cache if needed
@@ -246,7 +246,7 @@ const useSubscriberRemoveMutation = (
 
 			// Revert the count data if it exists
 			if ( context?.previousCountData ) {
-				queryClient.setQueryData( [ 'subscribers', 'count', siteId ], context.previousCountData );
+				queryClient.setQueryData( [ 'subscribers', 'counts', siteId ], context.previousCountData );
 			}
 
 			if ( context?.previousDetailsData ) {
@@ -261,12 +261,12 @@ const useSubscriberRemoveMutation = (
 
 			// Force invalidate all subscriber queries to ensure UI is in sync
 			queryClient.invalidateQueries( { queryKey: [ 'subscribers', siteId ] } );
-			queryClient.invalidateQueries( { queryKey: [ 'subscribers', 'count', siteId ] } );
+			queryClient.invalidateQueries( { queryKey: [ 'subscribers', 'counts', siteId ] } );
 		},
 		onSuccess: ( data, subscribers ) => {
 			// Force invalidate all subscriber queries to ensure UI is in sync
 			queryClient.invalidateQueries( { queryKey: [ 'subscribers', siteId ] } );
-			queryClient.invalidateQueries( { queryKey: [ 'subscribers', 'count', siteId ] } );
+			queryClient.invalidateQueries( { queryKey: [ 'subscribers', 'counts', siteId ] } );
 
 			for ( const subscriber of subscribers ) {
 				recordSubscriberRemoved( {
@@ -279,7 +279,7 @@ const useSubscriberRemoveMutation = (
 		onSettled: ( data, error, subscribers ) => {
 			// Always invalidate and refetch everything to ensure consistency
 			queryClient.invalidateQueries( { queryKey: [ 'subscribers', siteId ] } );
-			queryClient.invalidateQueries( { queryKey: [ 'subscribers', 'count', siteId ] } );
+			queryClient.invalidateQueries( { queryKey: [ 'subscribers', 'counts', siteId ] } );
 
 			// Always handle subscriber details cache if requested
 			if ( invalidateDetailsCache ) {

--- a/client/my-sites/subscribers/queries/test/use-subscriber-count-query-test.tsx
+++ b/client/my-sites/subscribers/queries/test/use-subscriber-count-query-test.tsx
@@ -6,10 +6,14 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import React from 'react';
 import wpcom from 'calypso/lib/wp';
-import useSubscriberCountQuery, { defaultSubscribersTotals } from '../use-subscriber-count-query';
+import useSubscriberCountQuery, {
+	defaultSubscribersTotals,
+	SubscribersTotals,
+} from '../use-subscriber-count-query';
 
-const mockResponse = {
+const mockResponse: { counts: SubscribersTotals } = {
 	counts: {
+		total_subscribers: 300,
 		email_subscribers: 100,
 		paid_subscribers: 50,
 		social_followers: 200,

--- a/client/my-sites/subscribers/queries/use-subscriber-count-query.ts
+++ b/client/my-sites/subscribers/queries/use-subscriber-count-query.ts
@@ -2,18 +2,20 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
 export interface SubscribersTotals {
+	total_subscribers: number;
 	email_subscribers: number;
 	paid_subscribers: number;
 	social_followers: number;
 }
 
-export const defaultSubscribersTotals = {
+export const defaultSubscribersTotals: SubscribersTotals = {
+	total_subscribers: 0,
 	email_subscribers: 0,
 	paid_subscribers: 0,
 	social_followers: 0,
 };
 
-const getSubscriberCount = ( siteId: number | null ): Promise< any > => {
+const getSubscriberCounts = ( siteId: number | null ): Promise< any > => {
 	return wpcom.req.get( {
 		apiNamespace: 'wpcom/v2',
 		path: `/sites/${ siteId }/subscribers/counts`,
@@ -22,9 +24,9 @@ const getSubscriberCount = ( siteId: number | null ): Promise< any > => {
 
 export default function useSubscriberCountQuery( siteId: number | null ) {
 	return useQuery< SubscribersTotals >( {
-		queryKey: [ 'subscribers', 'count', siteId ],
+		queryKey: [ 'subscribers', 'counts', siteId ],
 		queryFn: () => {
-			return getSubscriberCount( siteId ).then( ( response ) => {
+			return getSubscriberCounts( siteId ).then( ( response ) => {
 				return response.counts || defaultSubscribersTotals;
 			} );
 		},


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related: [CML-212](https://linear.app/a8c/issue/CML-212/newsletter-show-if-the-post-was-actually-sent)

## Proposed Changes

We have both `total_subscribers` and `email_subscribers` fields in the `subscribers/counts` API. Currently we are using `email_subscribers` field even while displaying all subscribers so this PR changes those instances to `total_subscribers`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Before we only had `email_subscribers` field in the API which were retunring all subscribers instead of email only so we have fixed it in the API (182194-ghe-Automattic/wpcom) and now we are making changes in FE to use the new field.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- As of now both `email_subscribers` and `total_subscribers` field maps to same data so technically no changes are expected (will be changed in future PR (182324-ghe-Automattic/wpcom) where email_subscribers will only represent users subscribed via email).
- Do regression testing on `/subscribers/:site_url`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?