### PR TITLE
A4A: Allow the user to continue the onboarding tour after exploring a section.

### DIFF
--- a/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-current-onboarding-section.ts
+++ b/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-current-onboarding-section.ts
@@ -1,0 +1,30 @@
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'calypso/state';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
+
+const UNIFIED_ONBOARDING_TOUR_CURRENT_SECTION_PREFERENCE = 'a4a-onboarding-tours-current-section';
+
+export default function useCurrentOnboardingSection() {
+	const dispatch = useDispatch();
+	const currentSection = useSelector( ( state ) =>
+		getPreference( state, UNIFIED_ONBOARDING_TOUR_CURRENT_SECTION_PREFERENCE )
+	);
+
+	const saveCurrentSection = useCallback(
+		( sectionId: string ) => {
+			dispatch( savePreference( UNIFIED_ONBOARDING_TOUR_CURRENT_SECTION_PREFERENCE, sectionId ) );
+		},
+		[ dispatch ]
+	);
+
+	const removeCurrentSection = useCallback( () => {
+		dispatch( savePreference( UNIFIED_ONBOARDING_TOUR_CURRENT_SECTION_PREFERENCE, null ) );
+	}, [ dispatch ] );
+
+	return {
+		currentSection,
+		saveCurrentSection,
+		removeCurrentSection,
+	};
+}

--- a/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour-sections.tsx
+++ b/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour-sections.tsx
@@ -40,7 +40,6 @@ export default function useOnboardingTourSections() {
 					section,
 				} )
 			);
-			saveCurrentSection( section );
 			onNext();
 		};
 
@@ -50,6 +49,7 @@ export default function useOnboardingTourSections() {
 					section,
 				} )
 			);
+			saveCurrentSection( section );
 			onClose();
 		};
 

--- a/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour-sections.tsx
+++ b/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour-sections.tsx
@@ -51,7 +51,7 @@ export default function useOnboardingTourSections() {
 
 		return [
 			{
-				id: 'onboarding-tour-welcome',
+				id: 'welcome',
 				title: translate( 'Welcome' ),
 				bannerImage: OnboardingTourBannerWelcome,
 				isDarkBanner: true,
@@ -88,7 +88,7 @@ export default function useOnboardingTourSections() {
 				},
 			},
 			{
-				id: 'onboarding-tour-sites',
+				id: 'sites',
 				title: translate( 'Sites' ),
 				bannerImage: OnboardingTourBannerSites,
 				content: {
@@ -127,7 +127,7 @@ export default function useOnboardingTourSections() {
 				},
 			},
 			{
-				id: 'onboarding-tour-marketplace',
+				id: 'marketplace',
 				title: translate( 'Marketplace' ),
 				bannerImage: OnboardingTourBannerMarketplace,
 				isDarkBanner: true,
@@ -157,7 +157,7 @@ export default function useOnboardingTourSections() {
 				},
 			},
 			{
-				id: 'onboarding-tour-purchases',
+				id: 'purchases',
 				title: translate( 'Purchases' ),
 				bannerImage: OnboardingTourBannerPurchases,
 				isDarkBanner: true,
@@ -186,7 +186,7 @@ export default function useOnboardingTourSections() {
 				},
 			},
 			{
-				id: 'onboarding-tour-referrals',
+				id: 'referrals',
 				title: translate( 'Referrals' ),
 				bannerImage: OnboardingTourBannerReferrals,
 				content: {
@@ -217,7 +217,7 @@ export default function useOnboardingTourSections() {
 				},
 			},
 			{
-				id: 'onboarding-tour-migrations',
+				id: 'migrations',
 				title: translate( 'Migrations' ),
 				bannerImage: OnboardingTourBannerMigrations,
 				content: {
@@ -256,7 +256,7 @@ export default function useOnboardingTourSections() {
 				},
 			},
 			{
-				id: 'onboarding-tour-woopayments',
+				id: 'woopayments',
 				title: translate( 'WooPayments' ),
 				bannerImage: OnboardingTourBannerWooPayments,
 				isDarkBanner: true,
@@ -288,7 +288,7 @@ export default function useOnboardingTourSections() {
 				},
 			},
 			{
-				id: 'onboarding-tour-agency-tiers',
+				id: 'agency-tiers',
 				title: translate( 'Agency Tiers' ),
 				bannerImage: OnboardingTourBannerAgencyTiers,
 				content: {
@@ -316,7 +316,7 @@ export default function useOnboardingTourSections() {
 				},
 			},
 			{
-				id: 'onboarding-tour-team',
+				id: 'team',
 				title: translate( 'Team' ),
 				bannerImage: OnboardingTourBannerTeam,
 				content: {
@@ -344,7 +344,7 @@ export default function useOnboardingTourSections() {
 				},
 			},
 			{
-				id: 'onboarding-tour-growth-call',
+				id: 'growth-call',
 				title: translate( 'Free growth call' ),
 				bannerImage: OnboardingTourBannerGrowthCall,
 				isDarkBanner: true,

--- a/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour-sections.tsx
+++ b/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour-sections.tsx
@@ -25,10 +25,13 @@ import {
 	A4A_TEAM_LINK,
 	A4A_WOOPAYMENTS_OVERVIEW_LINK,
 } from '../../../sidebar-menu/lib/constants';
+import useCurrentOnboardingSection from './use-current-onboarding-section';
 
 export default function useOnboardingTourSections() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+
+	const { saveCurrentSection } = useCurrentOnboardingSection();
 
 	return useMemo( () => {
 		const onNextBenefit = ( section: string, onNext: () => void ) => {
@@ -37,6 +40,7 @@ export default function useOnboardingTourSections() {
 					section,
 				} )
 			);
+			saveCurrentSection( section );
 			onNext();
 		};
 
@@ -51,7 +55,7 @@ export default function useOnboardingTourSections() {
 
 		return [
 			{
-				id: 'welcome',
+				id: 'overview',
 				title: translate( 'Welcome' ),
 				bannerImage: OnboardingTourBannerWelcome,
 				isDarkBanner: true,
@@ -375,5 +379,5 @@ export default function useOnboardingTourSections() {
 				},
 			},
 		];
-	}, [ dispatch, translate ] );
+	}, [ dispatch, saveCurrentSection, translate ] );
 }

--- a/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour.ts
+++ b/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour.ts
@@ -9,7 +9,7 @@ export default function useOnboardingTour() {
 	useEffect( () => {
 		const handleHashChange = () => {
 			const hash = window.location.hash;
-			if ( isEnabled( 'a4a-unified-onboarding-tour' ) && hash === ONBOARDING_TOUR_HASH ) {
+			if ( isEnabled( 'a4a-unified-onboarding-tour' ) && hash.startsWith( ONBOARDING_TOUR_HASH ) ) {
 				setIsOpen( true );
 			}
 		};

--- a/client/a8c-for-agencies/components/hoc/with-onboarding-tour/index.tsx
+++ b/client/a8c-for-agencies/components/hoc/with-onboarding-tour/index.tsx
@@ -1,17 +1,26 @@
-import { ComponentType } from 'react';
+import { Snackbar } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { ComponentType, useEffect } from 'react';
 import OnboardingTourModal from '../../onboarding-tour-modal';
-import useOnboardingTour from './hooks/use-onboarding-tour';
+import useCurrentOnboardingSection from './hooks/use-current-onboarding-section';
+import useOnboardingTour, { ONBOARDING_TOUR_HASH } from './hooks/use-onboarding-tour';
 import useOnboardingTourSections from './hooks/use-onboarding-tour-sections';
 
 import './style.scss';
 
-export function withOnboardingTour< T extends JSX.IntrinsicAttributes >(
-	WrappedComponent: ComponentType< T >
-) {
+export function withOnboardingTour< T extends object >( WrappedComponent: ComponentType< T > ) {
 	return function WithOnboardingTourWrapper( props: T ) {
+		const translate = useTranslate();
 		const { isOpen, onClose } = useOnboardingTour();
 
 		const sections = useOnboardingTourSections();
+		const { currentSection, removeCurrentSection } = useCurrentOnboardingSection();
+
+		useEffect( () => {
+			if ( currentSection && isOpen ) {
+				removeCurrentSection();
+			}
+		}, [ currentSection, isOpen, removeCurrentSection ] );
 
 		return (
 			<>
@@ -28,6 +37,24 @@ export function withOnboardingTour< T extends JSX.IntrinsicAttributes >(
 							</OnboardingTourModal.Section>
 						) ) }
 					</OnboardingTourModal>
+				) }
+				{ currentSection && (
+					<Snackbar
+						className="a4a-onboarding-tour-snackbar"
+						actions={ [
+							{
+								label: translate( 'Continue the Welcome tour' ),
+								onClick: () => {
+									window.location.hash = `${ ONBOARDING_TOUR_HASH }-${ currentSection }`;
+								},
+							},
+						] }
+						explicitDismiss
+						onDismiss={ removeCurrentSection }
+						onRemove={ removeCurrentSection }
+					>
+						&nbsp;
+					</Snackbar>
 				) }
 			</>
 		);

--- a/client/a8c-for-agencies/components/hoc/with-onboarding-tour/index.tsx
+++ b/client/a8c-for-agencies/components/hoc/with-onboarding-tour/index.tsx
@@ -1,4 +1,5 @@
 import { Snackbar } from '@wordpress/components';
+import { Icon, layout } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { ComponentType, useEffect } from 'react';
 import OnboardingTourModal from '../../onboarding-tour-modal';
@@ -52,6 +53,7 @@ export function withOnboardingTour< T extends object >( WrappedComponent: Compon
 						explicitDismiss
 						onDismiss={ removeCurrentSection }
 						onRemove={ removeCurrentSection }
+						icon={ <Icon icon={ layout } /> }
 					>
 						&nbsp;
 					</Snackbar>

--- a/client/a8c-for-agencies/components/hoc/with-onboarding-tour/index.tsx
+++ b/client/a8c-for-agencies/components/hoc/with-onboarding-tour/index.tsx
@@ -1,7 +1,9 @@
 import { Snackbar } from '@wordpress/components';
 import { Icon, layout } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { ComponentType, useEffect } from 'react';
+import { ComponentType, useCallback, useEffect } from 'react';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import OnboardingTourModal from '../../onboarding-tour-modal';
 import useCurrentOnboardingSection from './hooks/use-current-onboarding-section';
 import useOnboardingTour, { ONBOARDING_TOUR_HASH } from './hooks/use-onboarding-tour';
@@ -12,6 +14,8 @@ import './style.scss';
 export function withOnboardingTour< T extends object >( WrappedComponent: ComponentType< T > ) {
 	return function WithOnboardingTourWrapper( props: T ) {
 		const translate = useTranslate();
+		const dispatch = useDispatch();
+
 		const { isOpen, onClose } = useOnboardingTour();
 
 		const sections = useOnboardingTourSections();
@@ -22,6 +26,11 @@ export function withOnboardingTour< T extends object >( WrappedComponent: Compon
 				removeCurrentSection();
 			}
 		}, [ currentSection, isOpen, removeCurrentSection ] );
+
+		const onDismiss = useCallback( () => {
+			dispatch( recordTracksEvent( 'calypso_a4a_onboarding_tour_snackbar_dismissed' ) );
+			removeCurrentSection();
+		}, [ dispatch, removeCurrentSection ] );
 
 		return (
 			<>
@@ -47,12 +56,17 @@ export function withOnboardingTour< T extends object >( WrappedComponent: Compon
 								label: translate( 'Continue the Welcome tour' ),
 								onClick: () => {
 									window.location.hash = `${ ONBOARDING_TOUR_HASH }-${ currentSection }`;
+									dispatch(
+										recordTracksEvent( 'calypso_a4a_onboarding_tour_snackbar_continue_clicked', {
+											section: currentSection,
+										} )
+									);
 								},
 							},
 						] }
 						explicitDismiss
-						onDismiss={ removeCurrentSection }
-						onRemove={ removeCurrentSection }
+						onDismiss={ onDismiss }
+						onRemove={ onDismiss }
 						icon={ <Icon icon={ layout } /> }
 					>
 						&nbsp;

--- a/client/a8c-for-agencies/components/hoc/with-onboarding-tour/index.tsx
+++ b/client/a8c-for-agencies/components/hoc/with-onboarding-tour/index.tsx
@@ -53,7 +53,7 @@ export function withOnboardingTour< T extends object >( WrappedComponent: Compon
 						className="a4a-onboarding-tour-snackbar"
 						actions={ [
 							{
-								label: translate( 'Continue the Welcome tour' ),
+								label: translate( 'Continue tour' ),
 								onClick: () => {
 									window.location.hash = `${ ONBOARDING_TOUR_HASH }-${ currentSection }`;
 									dispatch(
@@ -69,7 +69,7 @@ export function withOnboardingTour< T extends object >( WrappedComponent: Compon
 						onRemove={ onDismiss }
 						icon={ <Icon icon={ layout } /> }
 					>
-						&nbsp;
+						{ translate( 'Pick up where you left off' ) }
 					</Snackbar>
 				) }
 			</>

--- a/client/a8c-for-agencies/components/hoc/with-onboarding-tour/style.scss
+++ b/client/a8c-for-agencies/components/hoc/with-onboarding-tour/style.scss
@@ -1,3 +1,9 @@
 .components-button.is-primary.overview__growth-accelerator-footer-schedule-call.a4a-onboarding-tour__schedule-a-call-cta {
 	flex: 0;
 }
+
+.a4a-onboarding-tour-snackbar {
+	position: fixed;
+	bottom: 64px;
+	right: 64px;
+}

--- a/client/a8c-for-agencies/components/hoc/with-onboarding-tour/style.scss
+++ b/client/a8c-for-agencies/components/hoc/with-onboarding-tour/style.scss
@@ -6,4 +6,12 @@
 	position: fixed;
 	bottom: 64px;
 	right: 64px;
+
+	.components-snackbar__icon {
+		fill: var(--color-text-inverted);
+	}
+
+	.components-button.components-snackbar__action:hover {
+		background-color: transparent;
+	}
 }

--- a/client/a8c-for-agencies/components/onboarding-tour-modal/index.tsx
+++ b/client/a8c-for-agencies/components/onboarding-tour-modal/index.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { ONBOARDING_TOUR_HASH } from '../hoc/with-onboarding-tour/hooks/use-onboarding-tour';
 import OnboardingTourModalSection, {
 	ActionProps,
 	OnboardingTourModalSectionProps,
@@ -37,8 +38,12 @@ function OnboardingTourModal( { onClose, children }: OnboardingTourModalProps ) 
 		( child: ReactNode ) => isValidElement( child ) && child.type === OnboardingTourModalSection
 	) as ReactElement< OnboardingTourModalSectionProps >[];
 
+	const defaultSection = sections.find(
+		( section ) => `${ ONBOARDING_TOUR_HASH }-${ section?.props?.id }` === window.location.hash
+	);
+
 	const [ currentSectionId, setCurrentSectionId ] = useState(
-		sections.length > 0 ? sections[ 0 ].props?.id : null
+		defaultSection ? defaultSection.props?.id : sections[ 0 ].props?.id
 	);
 
 	const menuItems = useMemo(
@@ -109,6 +114,7 @@ function OnboardingTourModal( { onClose, children }: OnboardingTourModalProps ) 
 							key={ menuItem.id }
 							onClick={ () => {
 								setCurrentSectionId( menuItem.id );
+								window.location.hash = `${ ONBOARDING_TOUR_HASH }-${ menuItem.id }`;
 								dispatch(
 									recordTracksEvent( 'calypso_onboarding_tour_modal_section_menu_item_click', {
 										section: menuItem.id,

--- a/client/a8c-for-agencies/components/sidebar/index.tsx
+++ b/client/a8c-for-agencies/components/sidebar/index.tsx
@@ -18,6 +18,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import A4AContactSupportWidget, { CONTACT_URL_HASH_FRAGMENT } from '../a4a-contact-support-widget';
 import ProvideFeedback from '../a4a-feedback/provide-feedback';
+import { withOnboardingTour } from '../hoc/with-onboarding-tour';
 import SidebarHeader from './header';
 import ProfileDropdown from './header/profile-dropdown';
 
@@ -150,4 +151,4 @@ const A4ASidebar = ( {
 	);
 };
 
-export default A4ASidebar;
+export default withOnboardingTour( A4ASidebar );

--- a/client/a8c-for-agencies/sections/overview/overview.tsx
+++ b/client/a8c-for-agencies/sections/overview/overview.tsx
@@ -1,7 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import A4AAgencyApprovalNotice from 'calypso/a8c-for-agencies/components/a4a-agency-approval-notice';
 import ContentSidebar from 'calypso/a8c-for-agencies/components/content-sidebar';
-import { withOnboardingTour } from 'calypso/a8c-for-agencies/components/hoc/with-onboarding-tour';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
 import PressableUsageLimitNotice from 'calypso/a8c-for-agencies/components/pressable-usage-limit-notice';
@@ -19,7 +18,7 @@ import OverviewSidebar from './sidebar';
 
 import './style.scss';
 
-function Overview() {
+export default function Overview() {
 	const translate = useTranslate();
 	const title = translate( 'Agency overview' );
 
@@ -46,5 +45,3 @@ function Overview() {
 		</Layout>
 	);
 }
-
-export default withOnboardingTour( Overview );

--- a/client/a8c-for-agencies/sections/overview/sidebar/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/index.tsx
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { withOnboardingTour } from 'calypso/a8c-for-agencies/components/hoc/with-onboarding-tour';
 import OverviewSidebarAgencyTier from './agency-tier';
 import OverviewSidebarContactSupport from './contact-support';
 import OverviewSidebarFeaturedWooPayments from './featured-woopayments';
@@ -19,4 +20,4 @@ const OverviewSidebar = () => {
 	);
 };
 
-export default OverviewSidebar;
+export default withOnboardingTour( OverviewSidebar );

--- a/client/a8c-for-agencies/sections/overview/sidebar/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/index.tsx
@@ -1,5 +1,4 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { withOnboardingTour } from 'calypso/a8c-for-agencies/components/hoc/with-onboarding-tour';
 import OverviewSidebarAgencyTier from './agency-tier';
 import OverviewSidebarContactSupport from './contact-support';
 import OverviewSidebarFeaturedWooPayments from './featured-woopayments';
@@ -20,4 +19,4 @@ const OverviewSidebar = () => {
 	);
 };
 
-export default withOnboardingTour( OverviewSidebar );
+export default OverviewSidebar;


### PR DESCRIPTION
This PR enables users to continue the onboarding tour while exploring a section.

https://github.com/user-attachments/assets/710f9a05-8271-4309-89aa-ae1e3d72e762


Depends on https://github.com/Automattic/wp-calypso/pull/103931
Closes https://linear.app/a8c/issue/A4A-1054/welcome-tour-implement-the-continue-snackbar

## Proposed Changes

* We will introduce a new `a4a-onboarding-tours-current-section` preference to track which section where the user last paused in the onboarding tour. The preference allows us to have a global state for tracking the section. Each time the agency explores a section, we save this information in the preference.
* When the `a4a-onboarding-tours-current-section` preference has a value, we show the snackbar. Clicking on the snackbar takes us back to the last section we were in. To achieve this feature, each section must be accessible through a URL fragment.
* The preference will also be reset every time we dismiss the snackbar, or when the onboarding tour modal is displayed.
* Additionally, we are now referencing the `withOnboardingTour` HOC to the sidebar component. This way, we avoid having to add the HOC on every page. This automatically makes the logic globally accessible.

## Why are these changes being made?

This is part of the Agency onboarding improvement part 2 project.

## Testing Instructions

* Use the A4A live link and navigate to the `/overview` page.
* Click the 'Relaunch welcome tour'.
* While progressing with the tour, explore some sections by clicking the CTA.
* Confirm that you are redirected to the page and the snackbar appears at the bottom right of the screen.
* Confirm that by clicking the snackbar link, you get back to the onboarding tour modal with the previous screen.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
