### PR TITLE
Purchases: Update DataViews version to implement design feedback

### DIFF
--- a/client/me/purchases/purchase-item/index.tsx
+++ b/client/me/purchases/purchase-item/index.tsx
@@ -647,7 +647,7 @@ export function PurchaseItemPaymentMethod( {
 			<div className="purchase-item__no-payment-method">
 				{ ! isDisconnectedSite && (
 					<Button
-						variant="primary"
+						variant="link"
 						size="compact"
 						onClick={ ( e: React.MouseEvent< HTMLButtonElement > ) =>
 							goToAddPaymentMethod( e, purchase.id )

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -225,7 +225,7 @@ export function getPurchasesFieldDefinitions( {
 				if (
 					item.isRenewable &&
 					expiryDate &&
-					expireDate > now &&
+					expiryDate > now &&
 					expiryDate - now < expireSoonMs
 				) {
 					return 'expiring-soon';

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -230,7 +230,7 @@ export function getPurchasesFieldDefinitions( {
 				) {
 					return 'expiring-soon';
 				}
-				return 'other';
+				return 'not-expiring-soon';
 			},
 		},
 		{

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -130,7 +130,16 @@ export function getPurchasesFieldDefinitions( {
 			// Render the site icon
 			render: ( { item }: { item: Purchases.Purchase } ) => {
 				const site = { ID: item.siteId };
-				return <PurchaseItemSiteIcon site={ site } purchase={ item } />;
+				return (
+					<Button
+						variant="link"
+						title={ translate( 'Manage purchase', { textOnly: true } ) }
+						label={ translate( 'Manage purchase', { textOnly: true } ) }
+						onClick={ () => goToPurchase( item ) }
+					>
+						<PurchaseItemSiteIcon site={ site } purchase={ item } />
+					</Button>
+				);
 			},
 		},
 		{

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -1,4 +1,6 @@
+import page from '@automattic/calypso-router';
 import { Purchases, SiteDetails } from '@automattic/data-stores';
+import { Button } from '@wordpress/components';
 import { Fields } from '@wordpress/dataviews';
 import { LocalizeProps } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
@@ -75,6 +77,22 @@ export function getPurchasesFieldDefinitions( {
 		( paymentMethod ) => paymentMethod.is_backup === true
 	);
 
+	const goToPurchase = ( item: Purchases.Purchase ) => {
+		const siteUrl = item.domain;
+		const subscriptionId = item.id;
+		if ( ! siteUrl ) {
+			// eslint-disable-next-line no-console
+			console.error( 'Cannot display manage purchase page for subscription without site' );
+			return;
+		}
+		if ( ! subscriptionId ) {
+			// eslint-disable-next-line no-console
+			console.error( 'Cannot display manage purchase page for subscription without ID' );
+			return;
+		}
+		page( `/me/purchases/${ siteUrl }/${ subscriptionId }` );
+	};
+
 	const fields: Fields< Purchases.Purchase > = [
 		{
 			id: 'purchase-id',
@@ -141,7 +159,13 @@ export function getPurchasesFieldDefinitions( {
 				return (
 					<div className="purchase-item__information purchases-layout__information">
 						<div className="purchase-item__title">
-							{ getDisplayName( item ) }
+							<Button
+								variant="link"
+								label={ translate( 'Manage purchase', { textOnly: true } ) }
+								onClick={ () => goToPurchase( item ) }
+							>
+								{ getDisplayName( item ) }
+							</Button>
 							&nbsp;
 							<OwnerInfo purchase={ item } />
 						</div>

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -161,6 +161,7 @@ export function getPurchasesFieldDefinitions( {
 						<div className="purchase-item__title">
 							<Button
 								variant="link"
+								title={ translate( 'Manage purchase', { textOnly: true } ) }
 								label={ translate( 'Manage purchase', { textOnly: true } ) }
 								onClick={ () => goToPurchase( item ) }
 							>

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -95,9 +95,15 @@ export function getPurchasesFieldDefinitions( {
 			enableGlobalSearch: true,
 			enableSorting: true,
 			enableHiding: false,
-			elements: sites.map( ( site ) => {
-				return { value: String( site.ID ), label: `${ site.name } (${ site.domain })` };
-			} ),
+			elements: ( () => {
+				if ( sites.length < 2 ) {
+					// No point in having a filter if there's only one site.
+					return undefined;
+				}
+				return sites.map( ( site ) => {
+					return { value: String( site.ID ), label: `${ site.name } (${ site.domain })` };
+				} );
+			} )(),
 			filterBy: { operators: [ 'is' ], isPrimary: true },
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
 				// getValue must return a string because the DataViews search feature calls `trim()` on it.

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -104,7 +104,7 @@ export function getPurchasesFieldDefinitions( {
 					return { value: String( site.ID ), label: `${ site.name } (${ site.domain })` };
 				} );
 			} )(),
-			filterBy: { operators: [ 'is' ], isPrimary: true },
+			filterBy: { operators: [ 'is' ] },
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
 				// getValue must return a string because the DataViews search feature calls `trim()` on it.
 				return String( item.siteId );
@@ -161,7 +161,7 @@ export function getPurchasesFieldDefinitions( {
 				{ value: 'plan', label: translate( 'Plan' ) },
 				{ value: 'other', label: translate( 'Other' ) },
 			],
-			filterBy: { operators: [ 'is' ], isPrimary: true },
+			filterBy: { operators: [ 'is' ] },
 			getValue: ( { item } ) => {
 				if ( item.isDomain || item.isDomainRegistration ) {
 					return 'domain';

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -207,6 +207,33 @@ export function getPurchasesFieldDefinitions( {
 			},
 		},
 		{
+			id: 'expring-soon',
+			label: translate( 'Expiring soon' ),
+			type: 'text',
+			elements: [
+				{ value: 'expiring-soon', label: translate( 'Expiring soon' ) },
+				{ value: 'not-expiring-soon', label: translate( 'Other' ) },
+			],
+			filterBy: { operators: [ 'is' ] },
+			getValue: ( { item } ) => {
+				const expiryDate = Date.parse( item.expiryDate );
+				const now = Date.now();
+				const msPerDay = 86_400_000;
+				// @todo: this should be updated to be product-specific since
+				// some products renew 30 days in advance.
+				const expireSoonMs = msPerDay * 7;
+				if (
+					item.isRenewable &&
+					expiryDate &&
+					expireDate > now &&
+					expiryDate - now < expireSoonMs
+				) {
+					return 'expiring-soon';
+				}
+				return 'other';
+			},
+		},
+		{
 			id: 'status',
 			label: translate( 'Status' ),
 			type: 'text',

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -180,9 +180,7 @@ export function PurchasesDataViews( {
 		() => [
 			{
 				id: 'manage-purchase',
-				label: translate( 'Manage this purchase', { textOnly: true } ),
-				isPrimary: true,
-				icon: <Gridicon icon="chevron-right" />,
+				label: translate( 'Manage purchase', { textOnly: true } ),
 				isEligible: ( item: Purchases.Purchase ) => Boolean( item.domain && item.id ),
 				callback: ( items: Purchases.Purchase[] ) => {
 					const siteUrl = items[ 0 ].domain;

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -226,7 +226,7 @@ const membershipsMobileFields = [ 'product' ];
 export const membershipDataView: View = {
 	type: 'table',
 	page: 1,
-	perPage: 5,
+	perPage: defaultPerPage,
 	titleField: 'purchase-id',
 	showTitle: false,
 	fields: membershipsDesktopFields,

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -24,7 +24,7 @@ const purchasesDesktopFields = [ 'site', 'product', 'status', 'payment-method' ]
 const purchasesMobileFields = [ 'product' ];
 const defaultPerPage = 10;
 const defaultSort = {
-	field: 'product',
+	field: 'site',
 	direction: 'desc' as SortDirection,
 };
 export const purchasesDataView: View = {

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { Gridicon, Card } from '@automattic/components';
 import { Purchases, SiteDetails } from '@automattic/data-stores';
-import { DESKTOP_BREAKPOINT } from '@automattic/viewport';
+import { DESKTOP_BREAKPOINT, WIDE_BREAKPOINT } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
 import {
 	DataViews,
@@ -20,7 +20,8 @@ import {
 	useMembershipsFieldDefinitions,
 } from './hooks/use-field-definitions';
 
-const purchasesDesktopFields = [ 'site', 'product', 'status', 'payment-method' ];
+const purchasesWideFields = [ 'site', 'product', 'status', 'payment-method' ];
+const purchasesDesktopFields = [ 'site', 'product', 'status' ];
 const purchasesMobileFields = [ 'product' ];
 const defaultPerPage = 10;
 const defaultSort = {
@@ -138,21 +139,29 @@ export function PurchasesDataViews( {
 	purchases: Purchases.Purchase[];
 	sites: SiteDetails[];
 } ) {
+	const isWide = useBreakpoint( WIDE_BREAKPOINT );
 	const isDesktop = useBreakpoint( DESKTOP_BREAKPOINT );
 	const translate = useTranslate();
 	const [ currentView, setView ] = useState( purchasesDataView );
 
 	// Hide fields at mobile width
 	useEffect( () => {
-		if ( isDesktop && currentView.fields === purchasesMobileFields ) {
+		if ( isWide && currentView.fields !== purchasesWideFields ) {
+			setView( { ...currentView, fields: purchasesWideFields } );
+		}
+		if ( isWide ) {
+			return;
+		}
+		if ( isDesktop && currentView.fields !== purchasesDesktopFields ) {
 			setView( { ...currentView, fields: purchasesDesktopFields } );
+		}
+		if ( isDesktop ) {
 			return;
 		}
-		if ( ! isDesktop && currentView.fields === purchasesDesktopFields ) {
+		if ( currentView.fields !== purchasesMobileFields ) {
 			setView( { ...currentView, fields: purchasesMobileFields } );
-			return;
 		}
-	}, [ isDesktop, currentView, setView ] );
+	}, [ isWide, isDesktop, currentView, setView ] );
 
 	// Keep track of the current view params in the URL and restore them when the page loads.
 	usePreservePurchasesFiltersInUrl( { currentView, setView } );

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -22,7 +22,7 @@ import {
 
 const purchasesDesktopFields = [ 'site', 'product', 'status', 'payment-method' ];
 const purchasesMobileFields = [ 'product' ];
-const defaultPerPage = 5;
+const defaultPerPage = 10;
 const defaultSort = {
 	field: 'product',
 	direction: 'desc' as SortDirection,

--- a/client/me/purchases/purchases-list-in-dataviews/style.scss
+++ b/client/me/purchases/purchases-list-in-dataviews/style.scss
@@ -1,6 +1,23 @@
 /* Purchase listing
 ================================================== */
 #purchases-list {
+	padding: 8px 0 0;
+
+	.dataviews__view-actions {
+		margin-top: 0;
+		padding-left: 24px;
+		padding-right: 24px;
+	}
+
+	.dataviews-wrapper .dataviews-view-table__row th:last-child,
+	.dataviews-wrapper .dataviews-view-table__row td:last-child {
+		padding-right: 24px;
+	}
+
+	.dataviews-wrapper .dataviews-view-table__row .dataviews-view-table__actions-column {
+		text-align: right;
+	}
+
 	.dataviews-view-table,
 	.dataviews-view-table tr {
 		max-width: 1040px;
@@ -10,7 +27,6 @@
 	.dataviews-view-table tr.dataviews-view-table__row th,
 	.dataviews-view-table tr.dataviews-view-table__row td {
 		white-space: break-spaces;
-		padding: 16px 0;
 	}
 
 	.dataviews-view-table tr td:first-child,

--- a/client/me/purchases/purchases-list-in-dataviews/style.scss
+++ b/client/me/purchases/purchases-list-in-dataviews/style.scss
@@ -51,6 +51,12 @@
 			overflow: hidden;
 		}
 
+		.purchase-item__title button.components-button.is-link {
+			font-size: inherit;
+			color: inherit;
+			text-decoration: none;
+		}
+
 		div {
 			max-width: 462px;
 		}


### PR DESCRIPTION
## Proposed Changes

This PR updates the UI and UX of the DataViews version of the purchases page to implement a bunch of design feedback from its Call for Testing (see pdtkmj-3Go-p2#comment-7052).

The main points:

- Adjust padding to more closely match the billing-history page.
- Replace chevron link with a link from the product title and an action menu.
- Update per-page default to 10 to match DataViews default.
- Make "Add payment method" button a link because its current primary style clashes badly with other primary actions on the page and other rows with the same button (this will affect production too but I think it's fine).
- Remove primary filters so all filters are hidden behind a click.
- Make default sort by site to match current sorting.
- Add an "Expiring soon" filter.

Part of https://linear.app/a8c/project/replace-calypsos-active-upgrades-subscriptions-with-dataviews-a7b39dea5417/overview / https://github.com/Automattic/wp-calypso/issues/86616

Tracked by https://linear.app/a8c/issue/CHE-177/purchases-update-dataviews-version-to-implement-design-feedback

Before             |  After
:-------------------------:|:-------------------------:
<img width="607" alt="Screenshot 2025-06-05 at 4 23 18 PM" src="https://github.com/user-attachments/assets/ce5e61c1-78e8-4a2d-9430-987550f72608" /> | <img width="608" alt="Screenshot 2025-06-05 at 4 22 49 PM" src="https://github.com/user-attachments/assets/bf2fea68-16e9-4cee-9e84-df39dab553f4" />

## Testing Instructions

- Use calypso.localhost because the DataViews layout is only available there.
- View /me/purchases and verify that everything looks and works as expected.