### PR TITLE
Updated .live to .blog tld on e2e tests

### DIFF
--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection.ts
@@ -49,8 +49,8 @@ describe(
 
 		it( 'Select a domain name', async function () {
 			domainSearchComponent = new DomainSearchComponent( page );
-			await domainSearchComponent.search( blogName + '.live' );
-			selectedDomain = await domainSearchComponent.selectDomain( '.live', false );
+			await domainSearchComponent.search( blogName + '.blog' );
+			selectedDomain = await domainSearchComponent.selectDomain( '.blog', false );
 		} );
 
 		it( `Pick the ${ planName } plan`, async function () {

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection__pre-selected-plan.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection__pre-selected-plan.ts
@@ -55,10 +55,10 @@ describe(
 
 		it( 'Select a domain name', async function () {
 			domainSearchComponent = new DomainSearchComponent( page );
-			await domainSearchComponent.search( blogName + '.live' );
+			await domainSearchComponent.search( blogName + '.blog' );
 
 			const promises = await Promise.all( [
-				domainSearchComponent.selectDomain( '.live', false ),
+				domainSearchComponent.selectDomain( '.blog', false ),
 				page.click( '.domains__domain-cart-continue' ),
 				page.waitForURL( /.*\/checkout\/.*/, { timeout: 30 * 1000 } ),
 			] );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to this Slack thread: p1749119332459689-slack-C02DQP0FP

## Proposed Changes

* Updating `.live` to `.blog` since the first one was unreliable due to reliance on a third-party service, and the second one will allow us to dogfood our services.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Our Teamcity was seeing this error when running these e2e tests:

![image](https://github.com/user-attachments/assets/3f37e02a-b217-4ea4-9872-b1bf99e18032)



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To run the tests in the same environment, run: `export CALYPSO_BASE_URL='https://wpcalypso.wordpress.com'`
* And then trigger the test with `yarn workspace wp-e2e-tests test -- test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection__pre-selected-plan.ts` and the another one with: `yarn workspace wp-e2e-tests test -- test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection.ts`
* Ensure they're passing

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?