### PR TITLE
Hosting Dashboard v2: Enable site settings backport in horizon, and wpcalypso

### DIFF
--- a/client/sites/settings/controller.tsx
+++ b/client/sites/settings/controller.tsx
@@ -212,7 +212,7 @@ export function dashboardBackportSiteSettings( context: PageJSContext, next: () 
 	const state = context.store.getState();
 	const site = getSelectedSite( state );
 
-	if ( ! isEnabled( 'dashboard/v2' ) ) {
+	if ( ! isEnabled( 'dashboard/v2/backport/site-settings' ) ) {
 		return page.redirect( `/sites/settings/site/${ site?.slug }` );
 	}
 

--- a/client/sites/settings/index.tsx
+++ b/client/sites/settings/index.tsx
@@ -123,6 +123,7 @@ export default function () {
 	page(
 		'/sites/settings/performance/:site',
 		siteSelection,
+		redirectToHostingDashboardBackportIfEnabled( SETTINGS_PERFORMANCE ),
 		redirectToSiteSettingsIfHostingFeaturesNotSupported,
 		navigation,
 		performanceSettings,

--- a/client/sites/settings/index.tsx
+++ b/client/sites/settings/index.tsx
@@ -42,7 +42,7 @@ export default function () {
 		siteSelection,
 		navigation,
 		redirectIfCurrentUserCannot( 'manage_options' ),
-		redirectToHostingDashboardBackportIfEnabled( SETTINGS_SITE ),
+		redirectToHostingDashboardBackportIfEnabled,
 		siteSettings,
 		siteDashboard( SETTINGS_SITE ),
 		makeLayout,
@@ -84,7 +84,7 @@ export default function () {
 	page(
 		'/sites/settings/server/:site',
 		siteSelection,
-		redirectToHostingDashboardBackportIfEnabled( SETTINGS_SERVER ),
+		redirectToHostingDashboardBackportIfEnabled,
 		redirectToSiteSettingsIfAdvancedHostingFeaturesNotSupported,
 		navigation,
 		serverSettings,
@@ -97,7 +97,7 @@ export default function () {
 	page(
 		'/sites/settings/sftp-ssh/:site',
 		siteSelection,
-		redirectToHostingDashboardBackportIfEnabled( SETTINGS_SFTP_SSH ),
+		redirectToHostingDashboardBackportIfEnabled,
 		redirectToSiteSettingsIfAdvancedHostingFeaturesNotSupported,
 		navigation,
 		sftpSshSettings,
@@ -110,7 +110,7 @@ export default function () {
 	page(
 		'/sites/settings/database/:site',
 		siteSelection,
-		redirectToHostingDashboardBackportIfEnabled( SETTINGS_DATABASE ),
+		redirectToHostingDashboardBackportIfEnabled,
 		redirectToSiteSettingsIfAdvancedHostingFeaturesNotSupported,
 		navigation,
 		databaseSettings,
@@ -123,7 +123,7 @@ export default function () {
 	page(
 		'/sites/settings/performance/:site',
 		siteSelection,
-		redirectToHostingDashboardBackportIfEnabled( SETTINGS_PERFORMANCE ),
+		redirectToHostingDashboardBackportIfEnabled,
 		redirectToSiteSettingsIfHostingFeaturesNotSupported,
 		navigation,
 		performanceSettings,

--- a/client/sites/settings/index.tsx
+++ b/client/sites/settings/index.tsx
@@ -33,6 +33,7 @@ import {
 	redirectToSiteSettingsIfAdvancedHostingFeaturesNotSupported,
 	redirectToSiteSettingsIfHostingFeaturesNotSupported,
 } from './controller';
+import { redirectToHostingDashboardBackportIfEnabled } from './v2/controller';
 
 export default function () {
 	page( '/sites/settings/site', siteSelection, sites, makeLayout, clientRender );
@@ -41,6 +42,7 @@ export default function () {
 		siteSelection,
 		navigation,
 		redirectIfCurrentUserCannot( 'manage_options' ),
+		redirectToHostingDashboardBackportIfEnabled( SETTINGS_SITE ),
 		siteSettings,
 		siteDashboard( SETTINGS_SITE ),
 		makeLayout,
@@ -82,6 +84,7 @@ export default function () {
 	page(
 		'/sites/settings/server/:site',
 		siteSelection,
+		redirectToHostingDashboardBackportIfEnabled( SETTINGS_SERVER ),
 		redirectToSiteSettingsIfAdvancedHostingFeaturesNotSupported,
 		navigation,
 		serverSettings,
@@ -94,6 +97,7 @@ export default function () {
 	page(
 		'/sites/settings/sftp-ssh/:site',
 		siteSelection,
+		redirectToHostingDashboardBackportIfEnabled( SETTINGS_SFTP_SSH ),
 		redirectToSiteSettingsIfAdvancedHostingFeaturesNotSupported,
 		navigation,
 		sftpSshSettings,
@@ -106,6 +110,7 @@ export default function () {
 	page(
 		'/sites/settings/database/:site',
 		siteSelection,
+		redirectToHostingDashboardBackportIfEnabled( SETTINGS_DATABASE ),
 		redirectToSiteSettingsIfAdvancedHostingFeaturesNotSupported,
 		navigation,
 		databaseSettings,

--- a/client/sites/settings/v2/controller.tsx
+++ b/client/sites/settings/v2/controller.tsx
@@ -1,35 +1,14 @@
 import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
-import {
-	SETTINGS_DATABASE,
-	SETTINGS_PERFORMANCE,
-	SETTINGS_SFTP_SSH,
-} from 'calypso/sites/components/site-preview-pane/constants';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { Context as PageJSContext } from '@automattic/calypso-router';
 
-export function redirectToHostingDashboardBackportIfEnabled( feature: string | undefined ) {
-	return ( context: PageJSContext, next: () => void ) => {
-		const state = context.store.getState();
-		const site = getSelectedSite( state );
+export function redirectToHostingDashboardBackportIfEnabled(
+	context: PageJSContext,
+	next: () => void
+) {
+	if ( isEnabled( 'dashboard/v2/backport/site-settings' ) ) {
+		return page.redirect( `/sites/settings/v2/${ context.params.site }` );
+	}
 
-		if ( isEnabled( 'dashboard/v2/backport/site-settings' ) ) {
-			let route = '';
-			switch ( feature ) {
-				case SETTINGS_DATABASE:
-					route = '/database';
-					break;
-				case SETTINGS_PERFORMANCE:
-					route = '/caching';
-					break;
-				case SETTINGS_SFTP_SSH:
-					route = '/sftp-ssh';
-					break;
-			}
-
-			return page.redirect( `/sites/settings/v2/${ site?.slug }${ route }` );
-		}
-
-		next();
-	};
+	next();
 }

--- a/client/sites/settings/v2/controller.tsx
+++ b/client/sites/settings/v2/controller.tsx
@@ -1,0 +1,35 @@
+import { isEnabled } from '@automattic/calypso-config';
+import page from '@automattic/calypso-router';
+import {
+	SETTINGS_DATABASE,
+	SETTINGS_PERFORMANCE,
+	SETTINGS_SFTP_SSH,
+} from 'calypso/sites/components/site-preview-pane/constants';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import type { Context as PageJSContext } from '@automattic/calypso-router';
+
+export function redirectToHostingDashboardBackportIfEnabled( feature: string | undefined ) {
+	return ( context: PageJSContext, next: () => void ) => {
+		const state = context.store.getState();
+		const site = getSelectedSite( state );
+
+		if ( isEnabled( 'dashboard/v2/backport/site-settings' ) ) {
+			let route = '';
+			switch ( feature ) {
+				case SETTINGS_DATABASE:
+					route = '/database';
+					break;
+				case SETTINGS_PERFORMANCE:
+					route = '/caching';
+					break;
+				case SETTINGS_SFTP_SSH:
+					route = '/sftp-ssh';
+					break;
+			}
+
+			return page.redirect( `/sites/settings/v2/${ site?.slug }${ route }` );
+		}
+
+		next();
+	};
+}

--- a/config/development.json
+++ b/config/development.json
@@ -49,6 +49,8 @@
 		"cookie-banner": false,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
+		"dashboard/v2": true,
+		"dashboard/v2/backport/site-settings": true,
 		"design-picker/use-assembler-styles": true,
 		"dev/account-settings-helper": true,
 		"dev/auth-helper": true,
@@ -188,7 +190,6 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"user-management-revamp": true,
 		"wpcom-user-bootstrap": false,
-		"yolo/command-palette": true,
-		"dashboard/v2": true
+		"yolo/command-palette": true
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -50,7 +50,7 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"dashboard/v2": true,
-		"dashboard/v2/backport/site-settings": true,
+		"dashboard/v2/backport/site-settings": false,
 		"design-picker/use-assembler-styles": true,
 		"dev/account-settings-helper": true,
 		"dev/auth-helper": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -26,6 +26,8 @@
 		"cookie-banner": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
+		"dashboard/v2": false,
+		"dashboard/v2/backport/site-settings": true,
 		"design-picker/use-assembler-styles": true,
 		"devdocs": false,
 		"global-styles/on-personal-plan": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -35,6 +35,8 @@
 		"checkout/razorpay": false,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
+		"dashboard/v2": true,
+		"dashboard/v2/backport/site-settings": true,
 		"design-picker/use-assembler-styles": true,
 		"dev/auth-helper": true,
 		"dev/account-settings-helper": true,
@@ -160,8 +162,7 @@
 		"use-translation-chunks": true,
 		"user-management-revamp": true,
 		"wpcom-user-bootstrap": true,
-		"yolo/command-palette": true,
-		"dashboard/v2": true
+		"yolo/command-palette": true
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",


### PR DESCRIPTION
## Proposed Changes

This PR enables the site settings backport in horizon, and, wpcalypso, and adds redirection to prevent users going to the existing site settings screen.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Sites Settings backport.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /sites/:siteSlug
* Click on the Settings tab
* Ensure you see the Sites Settings backport

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
