### PR TITLE
A4A > Reports: Implement empty state for the dashboard

### DIFF
--- a/client/a8c-for-agencies/sections/reports/hooks/use-fetch-reports.ts
+++ b/client/a8c-for-agencies/sections/reports/hooks/use-fetch-reports.ts
@@ -5,56 +5,7 @@ import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selecto
 import type { Report } from '../types';
 
 // // Mock data for demonstration
-const mockReportsData: Report[] = [
-	{
-		id: 'rpt_1',
-		site: 'example.com',
-		status: 'sent',
-		createdAt: '2024-01-01T09:00:00Z',
-	},
-	{
-		id: 'rpt_2',
-		site: 'mybusiness.com',
-		status: 'sent',
-		createdAt: '2024-01-02T09:00:00Z',
-	},
-	{
-		id: 'rpt_3',
-		site: 'example.com',
-		status: 'error',
-		createdAt: '2024-01-05T16:45:00Z',
-	},
-	{
-		id: 'rpt_4',
-		site: 'mybusiness.com',
-		status: 'sent',
-		createdAt: '2024-01-03T09:00:00Z',
-	},
-	{
-		id: 'rpt_5',
-		site: 'example.com',
-		status: 'sent',
-		createdAt: '2024-01-04T09:00:00Z',
-	},
-	{
-		id: 'rpt_6',
-		site: 'clientsite.org',
-		status: 'sent',
-		createdAt: '2024-01-06T09:00:00Z',
-	},
-	{
-		id: 'rpt_7',
-		site: 'mybusiness.com',
-		status: 'error',
-		createdAt: '2024-01-07T09:00:00Z',
-	},
-	{
-		id: 'rpt_8',
-		site: 'example.com',
-		status: 'sent',
-		createdAt: '2024-01-08T09:00:00Z',
-	},
-];
+const mockReportsData: Report[] = [];
 
 export default function useFetchReports() {
 	const agencyId = useSelector( getActiveAgencyId );

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/empty-state.tsx
@@ -1,5 +1,56 @@
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import StepSection from 'calypso/a8c-for-agencies/components/step-section';
+import StepSectionItem from 'calypso/a8c-for-agencies/components/step-section-item';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
 const ReportsDashboardEmptyState = () => {
-	return <div>Empty state</div>;
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const handleBuildNewReport = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_reports_empty_state_build_new_report_click' ) );
+		// Build new report action - placeholder for future implementation
+	}, [ dispatch ] );
+
+	const handleViewExampleReport = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_reports_empty_state_view_example_report_click' ) );
+		// View example report action - placeholder for future implementation
+	}, [ dispatch ] );
+
+	return (
+		<div className="reports-dashboard-empty-state__content">
+			<div>
+				<div className="reports-dashboard-empty-state__heading">
+					{ translate( 'Create detailed reports for your clients' ) }
+				</div>
+				<div className="reports-dashboard-empty-state__description">
+					{ translate(
+						'Build professional reports in three simple steps. Include website stats, showcase your value, and keep clients informed.'
+					) }
+				</div>
+			</div>
+			<StepSection heading={ translate( 'How to get started' ) }>
+				<StepSectionItem
+					heading={ translate( 'Create your first report' ) }
+					description={ translate(
+						'Choose a site, select the content to include, add a personal message, then preview and send it to your client.'
+					) }
+				>
+					<div className="reports-dashboard-empty-state__buttons">
+						<Button __next40pxDefaultSize variant="primary" onClick={ handleBuildNewReport }>
+							{ translate( 'Build a new report' ) }
+						</Button>
+						<Button __next40pxDefaultSize variant="secondary" onClick={ handleViewExampleReport }>
+							{ translate( 'View example report' ) }
+						</Button>
+					</div>
+				</StepSectionItem>
+			</StepSection>
+		</div>
+	);
 };
 
 export default ReportsDashboardEmptyState;

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/style.scss
@@ -64,3 +64,59 @@
 		align-items: center;
 	}
 }
+
+.reports-dashboard-empty-state__content {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+
+
+	@include break-large {
+		.step-section-item__description {
+			max-width: 80%;
+		}
+	}
+}
+
+.reports-dashboard-empty-state__heading {
+	@include heading-2x-large;
+	margin-block-end: 8px;
+}
+
+.reports-dashboard-empty-state__description {
+	@include body-large;
+
+	> div {
+		margin-block-end: 16px;
+	}
+
+	a {
+		text-decoration: underline;
+	}
+}
+
+.reports-dashboard-empty-state__buttons {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	margin-block-start: 16px;
+	align-items: center;
+
+	@include break-large {
+		margin-block-start: 0;
+	}
+
+	@include break-xlarge {
+		flex-direction: row;
+		gap: 12px;
+	}
+
+	button {
+		width: 100%;
+
+		@include break-large {
+			width: auto;
+			min-width: 160px;
+		}
+	}
+}


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/A4A-1073/dashboard-implement-empty-screen-view

## Proposed Changes

This PR implements an empty state for the reports dashboard.

## Why are these changes being made?

* To show an empty view on the reports dashboard when there are no reports.

## Testing Instructions

 * Open the A4A live link
 * Go to Reports > Dashboard. Verify the empty state is displayed as shown below.

<img width="1917" alt="Screenshot 2025-06-06 at 11 56 42 AM" src="https://github.com/user-attachments/assets/96eccb11-ea23-4535-8878-2419b442f59b" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
