### PR TITLE
A4A > Reports: Integrate the API endpoint for the reports dashboard

### DIFF
--- a/client/a8c-for-agencies/sections/reports/hooks/use-fetch-reports.ts
+++ b/client/a8c-for-agencies/sections/reports/hooks/use-fetch-reports.ts
@@ -2,27 +2,17 @@ import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
-import type { Report } from '../types';
-
-// // Mock data for demonstration
-const mockReportsData: Report[] = [];
 
 export default function useFetchReports() {
 	const agencyId = useSelector( getActiveAgencyId );
 
-	const isMock = true;
-
 	return useQuery( {
-		// TODO: Remove this once the API is ready
-		// eslint-disable-next-line @tanstack/query/exhaustive-deps
 		queryKey: [ 'a4a-reports', agencyId ],
 		queryFn: () =>
-			isMock
-				? mockReportsData
-				: wpcom.req.get( {
-						apiNamespace: 'wpcom/v2',
-						path: `/agency/${ agencyId }/reports`,
-				  } ),
+			wpcom.req.get( {
+				apiNamespace: 'wpcom/v2',
+				path: `/agency/${ agencyId }/reports`,
+			} ),
 		enabled: !! agencyId,
 		refetchOnWindowFocus: true,
 		staleTime: 0,

--- a/client/a8c-for-agencies/sections/reports/lib/get-site-reports.ts
+++ b/client/a8c-for-agencies/sections/reports/lib/get-site-reports.ts
@@ -18,9 +18,9 @@ export const getSiteReports = ( reports: Report[] ): SiteReports[] => {
 
 	return Object.entries( grouped )
 		.map( ( [ site, siteReports ] ) => {
-			// Sort reports by createdAt (newest first)
+			// Sort reports by created_at (newest first)
 			const sortedReports = siteReports.sort(
-				( a, b ) => new Date( b.createdAt ).getTime() - new Date( a.createdAt ).getTime()
+				( a, b ) => new Date( b.created_at ).getTime() - new Date( a.created_at ).getTime()
 			);
 
 			const latestReport = sortedReports[ 0 ];
@@ -34,8 +34,8 @@ export const getSiteReports = ( reports: Report[] ): SiteReports[] => {
 		} )
 		.sort(
 			( a, b ) =>
-				// Sort groups by latest report's createdAt (newest first)
-				new Date( b.latestReport.createdAt ).getTime() -
-				new Date( a.latestReport.createdAt ).getTime()
+				// Sort groups by latest report's created_at (newest first)
+				new Date( b.latestReport.created_at ).getTime() -
+				new Date( a.latestReport.created_at ).getTime()
 		);
 };

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
@@ -18,11 +18,12 @@ export const ReportCountColumn = ( { count }: { count: number } ) => {
 	);
 };
 
-export const ReportStatusColumn = ( { status }: { status: 'sent' | 'error' } ) => {
+export const ReportStatusColumn = ( { status }: { status: 'sent' | 'pending' | 'error' } ) => {
 	const translate = useTranslate();
 
 	const statusConfig = {
 		sent: { type: 'success', text: translate( 'Sent' ) },
+		pending: { type: 'warning', text: translate( 'Pending' ) },
 		error: { type: 'error', text: translate( 'Error' ) },
 	};
 

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/reports-list.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/reports-list.tsx
@@ -80,7 +80,7 @@ export default function ReportsList( {
 							label: translate( 'Last Generated' ),
 							getValue: () => '-',
 							render: ( { item }: { item: SiteReports } ) => (
-								<ReportDateColumn date={ item.latestReport.createdAt } />
+								<ReportDateColumn date={ item.latestReport.created_at } />
 							),
 							enableHiding: false,
 							enableSorting: false,

--- a/client/a8c-for-agencies/sections/reports/reports-details/mobile-view.tsx
+++ b/client/a8c-for-agencies/sections/reports/reports-details/mobile-view.tsx
@@ -31,7 +31,7 @@ export default function ReportsMobileView( {
 						</ListItemCardContent>
 						<ListItemCardContent title={ translate( 'Created' ) }>
 							<div className="reports-details-mobile-view__column">
-								<ReportDateColumn date={ report.createdAt } />
+								<ReportDateColumn date={ report.created_at } />
 							</div>
 						</ListItemCardContent>
 					</ListItemCard>

--- a/client/a8c-for-agencies/sections/reports/reports-details/reports.tsx
+++ b/client/a8c-for-agencies/sections/reports/reports-details/reports.tsx
@@ -30,7 +30,7 @@ export default function Reports( { reports, actions }: { reports: Report[]; acti
 				id: 'createdAt',
 				label: translate( 'Created' ),
 				getValue: () => '-',
-				render: ( { item }: { item: Report } ) => <ReportDateColumn date={ item.createdAt } />,
+				render: ( { item }: { item: Report } ) => <ReportDateColumn date={ item.created_at } />,
 				enableHiding: false,
 				enableSorting: false,
 			},

--- a/client/a8c-for-agencies/sections/reports/types.ts
+++ b/client/a8c-for-agencies/sections/reports/types.ts
@@ -2,7 +2,7 @@ export interface Report {
 	id: string;
 	site: string;
 	status: 'sent' | 'error';
-	createdAt: string;
+	created_at: string;
 }
 
 export interface SiteReports {


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1086/reports-dashboard-api-endpoint-integration

## Proposed Changes

This PR integrates the API endpoint for the reports dashboard. 

Please note: We are currently receiving mock data from the API endpoint. 

## Why are these changes being made?

* To get the data from the API endpoint. 

## Testing Instructions

* Open the A4A live link
* Go to Reports: Dashboard > Verify the page looks as shown below

<img width="1725" alt="Screenshot 2025-06-06 at 1 01 31 PM" src="https://github.com/user-attachments/assets/15aad50a-6cc6-4478-a72d-1a8f8d4795e4" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
