### PR TITLE
Dashboard v2: Display an error notice if any error occurs during the site transfer process

### DIFF
--- a/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
@@ -6,8 +6,10 @@ import {
 	__experimentalText as Text,
 	Button,
 } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { sprintf, __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { siteOwnerTransferEligibilityCheckMutation } from '../../app/queries';
 import { SectionHeader } from '../../components/section-header';
@@ -45,6 +47,8 @@ export function ConfirmNewOwnerForm( {
 
 	const mutation = useMutation( siteOwnerTransferEligibilityCheckMutation( siteSlug ) );
 
+	const { createErrorNotice } = useDispatch( noticesStore );
+
 	const isSaveDisabled = ! isItemValid( formData, fields, form );
 
 	const handleSubmit = ( event: React.FormEvent ) => {
@@ -56,8 +60,19 @@ export function ConfirmNewOwnerForm( {
 				onSuccess: () => {
 					onSubmit( formData );
 				},
-				onError: () => {
-					// TODO: Display error message below the field.
+				onError: ( error ) => {
+					// TODO: Show the error via Data Form when the ValidatedTextControl is ready.
+					createErrorNotice(
+						error.message ??
+							sprintf(
+								/* translators: %s is the new owner's email */
+								__( 'Sorry, the site cannot be transferred to %s' ),
+								formData.email
+							),
+						{
+							type: 'snackbar',
+						}
+					);
 				},
 			}
 		);

--- a/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
@@ -6,8 +6,10 @@ import {
 	__experimentalText as Text,
 	Button,
 } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import React, { useState } from 'react';
 import { siteOwnerTransferMutation } from '../../app/queries';
 import Notice from '../../components/notice';
@@ -79,6 +81,8 @@ export function StartSiteTransferForm( {
 
 	const mutation = useMutation( siteOwnerTransferMutation( siteSlug ) );
 
+	const { createErrorNotice } = useDispatch( noticesStore );
+
 	const isSaveDisabled = Object.values( formData ).some( ( value ) => ! value );
 
 	const renderSiteSlug = () => <strong>{ siteSlug }</strong>;
@@ -94,8 +98,10 @@ export function StartSiteTransferForm( {
 				onSuccess: () => {
 					onSubmit();
 				},
-				onError: () => {
-					// TODO: Display error message
+				onError: ( error ) => {
+					createErrorNotice( error.message ?? __( 'Unable to start site transfer.' ), {
+						type: 'snackbar',
+					} );
 				},
 			}
 		);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Display an error notice if any error occurs during the site transfer process

![image](https://github.com/user-attachments/assets/4f7e7c32-d323-4539-b39f-72c1ea4d2103)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Navigate to any site > Settings > Transfer site
* Enter the your email and continue
* Ensure you can see the error notice

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
