### PR TITLE
Accessibility: Fix Help Center chat buttons

### DIFF
--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -111,6 +111,7 @@ const ChatEllipsisMenu = () => {
 			popoverClassName="help-center help-center__container-header-menu"
 			position="bottom"
 			trackEventProps={ { source: 'help_center' } }
+			ariaLabel={ __( 'Chat options', __i18n_text_domain__ ) }
 		>
 			<div className="conversation-menu__wrapper">
 				<button onClick={ clearChat }>

--- a/packages/odie-client/src/assets/send-message-icon.tsx
+++ b/packages/odie-client/src/assets/send-message-icon.tsx
@@ -1,5 +1,12 @@
 export const SendMessageIcon = () => (
-	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<svg
+		width="24"
+		height="24"
+		viewBox="0 0 24 24"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+		aria-hidden="true"
+	>
 		<g id="Icon">
 			<path
 				id="Shape"

--- a/packages/odie-client/src/assets/wapuu-avatar.tsx
+++ b/packages/odie-client/src/assets/wapuu-avatar.tsx
@@ -1,5 +1,12 @@
 export const WapuuAvatar = () => (
-	<svg width="38" height="38" viewBox="0 0 38 38" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<svg
+		width="38"
+		height="38"
+		viewBox="0 0 38 38"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+		aria-hidden="true"
+	>
 		<circle cx="19" cy="19" r="19" fill="#FFD200" />
 		<g clipPath="url(#clip0_286_11962)">
 			<circle cx="30.0846" cy="15.8333" r="1.58333" fill="black" />

--- a/packages/odie-client/src/components/button/index.tsx
+++ b/packages/odie-client/src/components/button/index.tsx
@@ -10,17 +10,27 @@ type ButtonProps = {
 	title?: string;
 	disabled?: boolean;
 	className?: string;
+	ariaLabel?: string;
 } & PropsWithChildren;
 
 const Button = forwardRef< HTMLButtonElement, ButtonProps >(
-	( { compact, borderless, onClick, className: externalClassName, children, disabled }, ref ) => {
+	(
+		{ compact, borderless, onClick, className: externalClassName, children, disabled, ariaLabel },
+		ref
+	) => {
 		const className = clsx( 'odie-button-default', externalClassName, {
 			'odie-button-compact': compact,
 			'odie-button-borderless': borderless,
 		} );
 
 		return (
-			<button ref={ ref } className={ className } onClick={ onClick } disabled={ disabled }>
+			<button
+				ref={ ref }
+				className={ className }
+				onClick={ onClick }
+				disabled={ disabled }
+				aria-label={ ariaLabel }
+			>
 				{ children }
 			</button>
 		);

--- a/packages/odie-client/src/components/button/index.tsx
+++ b/packages/odie-client/src/components/button/index.tsx
@@ -27,4 +27,6 @@ const Button = forwardRef< HTMLButtonElement, ButtonProps >(
 	}
 );
 
+Button.displayName = 'Button';
+
 export default Button;

--- a/packages/odie-client/src/components/ellipsis-menu/index.tsx
+++ b/packages/odie-client/src/components/ellipsis-menu/index.tsx
@@ -12,6 +12,7 @@ type EllipsisMenuProps = {
 	position?: string;
 	popoverClassName?: string;
 	trackEventProps?: { source: string };
+	ariaLabel?: string;
 } & PropsWithChildren;
 
 export const EllipsisMenu: FunctionComponent< EllipsisMenuProps > = ( {
@@ -19,6 +20,7 @@ export const EllipsisMenu: FunctionComponent< EllipsisMenuProps > = ( {
 	children,
 	popoverClassName,
 	trackEventProps,
+	ariaLabel,
 } ) => {
 	const [ isMenuVisible, setMenuVisible ] = useState( false );
 	const popoverContext = useRef< HTMLButtonElement >( null );
@@ -46,8 +48,9 @@ export const EllipsisMenu: FunctionComponent< EllipsisMenuProps > = ( {
 				onClick={ handleClick }
 				borderless
 				className="ellipsis-menu__toggle"
+				ariaLabel={ ariaLabel }
 			>
-				<Gridicon icon="ellipsis" className="ellipsis-menu__toggle-icon" />
+				<Gridicon icon="ellipsis" className="ellipsis-menu__toggle-icon" aria-hidden />
 			</Button>
 			{ isMenuVisible && (
 				<PopoverMenu

--- a/packages/odie-client/src/components/message/thumbs-icons.tsx
+++ b/packages/odie-client/src/components/message/thumbs-icons.tsx
@@ -5,6 +5,7 @@ export const ThumbsUpIcon = ( { className }: { className?: string } ) => (
 		height="24"
 		viewBox="0 0 24 24"
 		className={ className }
+		aria-hidden="true"
 	>
 		<path
 			fillRule="evenodd"
@@ -21,6 +22,7 @@ export const ThumbsDownIcon = ( { className }: { className?: string } ) => (
 		height="24"
 		viewBox="0 0 24 24"
 		className={ className }
+		aria-hidden="true"
 	>
 		<path
 			fillRule="evenodd"

--- a/packages/odie-client/src/components/message/was-this-helpful-buttons.tsx
+++ b/packages/odie-client/src/components/message/was-this-helpful-buttons.tsx
@@ -91,6 +91,7 @@ const WasThisHelpfulButtons = ( {
 					className={ buttonLikedClasses }
 					onClick={ () => handleIsHelpful( true ) }
 					disabled={ notLiked }
+					aria-label={ __( 'Yes, this was helpful', __i18n_text_domain__ ) }
 				>
 					<ThumbsUpIcon className={ thumbsUpClasses } />
 				</button>
@@ -98,6 +99,7 @@ const WasThisHelpfulButtons = ( {
 					className={ buttonDislikedClasses }
 					onClick={ () => handleIsHelpful( false ) }
 					disabled={ liked }
+					aria-label={ __( 'No, this was not helpful', __i18n_text_domain__ ) }
 				>
 					<ThumbsDownIcon className={ thumbsDownClasses } />
 				</button>

--- a/packages/odie-client/src/components/send-message-input/attachment-button.tsx
+++ b/packages/odie-client/src/components/send-message-input/attachment-button.tsx
@@ -1,4 +1,5 @@
 import { FormFileUpload, Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { Icon, image } from '@wordpress/icons';
 import React from 'react';
 
@@ -17,6 +18,7 @@ export const AttachmentButton: React.FC< {
 				}
 			} }
 			disabled={ isAttachingFile }
+			aria-label={ __( 'Attach image', __i18n_text_domain__ ) }
 		>
 			{ isAttachingFile && <Spinner style={ { margin: 0 } } /> }
 			{ ! isAttachingFile && <Icon ref={ attachmentButtonRef } icon={ image } /> }

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -239,7 +239,12 @@ export const OdieSendMessageButton = () => {
 							isAttachingFile={ isAttachingFile }
 						/>
 					) }
-					<button type="submit" className={ buttonClasses } disabled={ submitDisabled }>
+					<button
+						type="submit"
+						className={ buttonClasses }
+						disabled={ submitDisabled }
+						aria-label={ __( 'Send message', __i18n_text_domain__ ) }
+					>
 						<SendMessageIcon />
 					</button>
 				</form>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-13499.
Related to DOTCOM-13503.

## Proposed Changes

* add proper button labels to "Send message", "Attach image" and "Chat options" (meatballs / kebab menu item in the chat window header), "Yes, this was helpful", "No, this was not helpful" (thumbs-up and thumbs-down buttons).
* hide from screen readers: Wappu's avatar, other non-essential items (e.g. SVGs of buttons)
* fix existing issue where Odie's Button component was missing `displayName`.

| "Send message", "Attach image", "Chat options" buttons and Wappu's avatar  | "Was it helpful?" buttons |
|--------|--------|
| ![Markup on 2025-06-06 at 11:52:06](https://github.com/user-attachments/assets/12dcda52-6423-45fd-a134-16388c3f3a00) | ![Markup on 2025-06-06 at 11:53:16](https://github.com/user-attachments/assets/11554573-d554-4e93-b660-394f8f96b611) | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* a55edfa4e3bf-linear-project

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start` (or use Calypso Live).
2. Open Help Center on WordPress.com.
3. Click on the `Still need help?` button.
4. Send a message to add the chat. 
5. Enable VoiceOver.
6. Try tabbing through the UI with <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Arrows</kbd> or <kbd>Tab</kbd> / <kbd>Shift</kbd> + <kbd>Tab</kbd>.
7. VoiceOver should read all the buttons correctly: i.e. "Send message", "Attach image"* and "Chat options" (meatballs / kebab menu item in the chat window header), "Yes, this was helpful", "No, this was not helpful" (thumbs-up and thumbs-down buttons).
8. There should be no "group" word read at the end of any button label announcement.
9. Wappu's avatar in the chat content **should not** be focusable using VoiceOver.

*In order to see the "Attach image" button, one needs to get connected with support agent (HE). What you can do is to ask the AI Assistant something like "connect me to a real person" and that should trigger the action. If you are proxied, you won't be connected with HE in reality, but the "Attach image" button should appear.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?