### PR TITLE
Dashboard V2: Nav bar styling fixes

### DIFF
--- a/client/dashboard/app-a4a/style.scss
+++ b/client/dashboard/app-a4a/style.scss
@@ -22,6 +22,7 @@
 	--dashboard-header__background-color: #021A23;
 	--dashboard-header__color: #FFF;
 	--dashboard-header__border-color: #05374A;
+	--dashboard-header__divider-color: #064057;
 
 	// Menu
 	--dashboard-menu-item__color: #949494;

--- a/client/dashboard/app-dotcom/style.scss
+++ b/client/dashboard/app-dotcom/style.scss
@@ -22,6 +22,7 @@
 	--dashboard-header__background-color: rgba(252, 252, 252, 0.90);
 	--dashboard-header__color: #{$gray-900};
 	--dashboard-header__border-color: #{$gray-100};
+	--dashboard-header__divider-color: #{$gray-200};
 
 	// Menu
 	--dashboard-menu-item__color: #{$gray-700};

--- a/client/dashboard/app/secondary-menu/index.tsx
+++ b/client/dashboard/app/secondary-menu/index.tsx
@@ -11,7 +11,6 @@ import {
 import { __ } from '@wordpress/i18n';
 import { help, bellUnread, bell, commentAuthorAvatar } from '@wordpress/icons';
 import ReaderIcon from 'calypso/assets/icons/reader/reader-icon';
-import MenuDivider from '../../components/menu-divider';
 import RouterLinkMenuItem from '../../components/router-link-menu-item';
 import { useAuth } from '../auth';
 import { useOpenCommandPalette } from '../command-palette/utils';
@@ -98,18 +97,15 @@ function SecondaryMenu() {
 	};
 
 	return (
-		<HStack spacing={ 3 } justify="flex-end">
+		<HStack spacing={ 2 } justify="flex-end">
 			{ supports.reader && (
-				<>
-					<Button
-						className="dashboard-secondary-menu__item"
-						icon={ <ReaderIcon /> }
-						label={ __( 'Reader' ) }
-						text={ __( 'Reader' ) }
-						href="/reader"
-					/>
-					<MenuDivider />
-				</>
+				<Button
+					className="dashboard-secondary-menu__item"
+					icon={ <ReaderIcon /> }
+					label={ __( 'Reader' ) }
+					text={ __( 'Reader' ) }
+					href="/reader"
+				/>
 			) }
 			{ supports.help && (
 				<Button

--- a/client/dashboard/components/menu-divider/style.scss
+++ b/client/dashboard/components/menu-divider/style.scss
@@ -1,6 +1,7 @@
 @import '@wordpress/base-styles/variables';
 
 .dashboard-menu-divider {
-	height: $grid-unit-40;
-	border-left: $border-width solid var( --dashboard-header__border-color );
+	height: $grid-unit-20;
+	border-left: $border-width solid var( --dashboard-header__divider-color );
+	transform: skew( -10deg );
 }

--- a/client/dashboard/sites/site-icon/style.scss
+++ b/client/dashboard/sites/site-icon/style.scss
@@ -1,6 +1,6 @@
 .site-icon,
 .site-letter {
-	border-radius: 4px;
+	border-radius: 2px;
 }
 
 .site-letter {

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Outlet } from '@tanstack/react-router';
 import { __experimentalHStack as HStack, Dropdown, Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
+import { chevronDownSmall } from '@wordpress/icons';
 import { siteQuery } from '../../app/queries';
 import { siteRoute } from '../../app/router';
 import HeaderBar from '../../components/header-bar';
@@ -26,7 +27,12 @@ function Site() {
 					<HeaderBar.Title>
 						<Dropdown
 							renderToggle={ ( { onToggle } ) => (
-								<Button className="dashboard-menu__item active" onClick={ () => onToggle() }>
+								<Button
+									className="dashboard-menu__item active"
+									icon={ chevronDownSmall }
+									iconPosition="right"
+									onClick={ () => onToggle() }
+								>
 									<div style={ { display: 'flex', gap: '8px', alignItems: 'center' } }>
 										<SiteIcon site={ site } size={ 24 } /> { site.name }
 									</div>

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -23,7 +23,7 @@ function Site() {
 	return (
 		<>
 			<HeaderBar>
-				<HStack justify={ isDesktop ? 'flex-start' : 'space-between' } spacing={ 4 }>
+				<HStack justify={ isDesktop ? 'flex-start' : 'space-between' } spacing={ 3 }>
 					<HeaderBar.Title>
 						<Dropdown
 							renderToggle={ ( { onToggle } ) => (

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -34,7 +34,7 @@ function Site() {
 									onClick={ () => onToggle() }
 								>
 									<div style={ { display: 'flex', gap: '8px', alignItems: 'center' } }>
-										<SiteIcon site={ site } size={ 24 } /> { site.name }
+										<SiteIcon site={ site } size={ 16 } /> { site.name }
 									</div>
 								</Button>
 							) }

--- a/client/dashboard/sites/site/switcher.tsx
+++ b/client/dashboard/sites/site/switcher.tsx
@@ -39,6 +39,7 @@ export default function Switcher( { onClose }: { onClose: () => void } ) {
 					label={ __( 'Search' ) }
 					value={ view.search }
 					onChange={ ( value ) => setView( { ...view, search: value } ) }
+					size="compact"
 					__nextHasNoMarginBottom
 				/>
 			</MenuGroup>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

This PR contains various fixes to bring the primary and secondary navigation bars in the v2 dashboard closer to the design.

* Updated styling for the menu divider.
* Removed menu divider from the top bar.
* Added down chevron to the site switcher.
* Reduced spacing around heading dividers.
* Use compact search in the site switcher menu.
* Reduce size of the site icon in the switcher button.

There are some other areas that need cleaning up—particularly in the site switcher menu—but that will be tackled separately.

### Before
<img width="1447" alt="Screenshot 2025-06-06 at 11 11 39" src="https://github.com/user-attachments/assets/41fd2fc8-9cb7-44cd-b7e9-70cb832d8dad" />

### After
<img width="1447" alt="Screenshot 2025-06-06 at 11 11 44" src="https://github.com/user-attachments/assets/f4b32877-ac2d-4761-b750-61042531e5f9" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To align the implementation with the designs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/v2/sites` and `/v2-a4a/sites`.
* Select a site.
* Confirm that the changed styles are appearing correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
