### PR TITLE
Add story for each field type definition (DataViews & DataForm)

### DIFF
--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Add a story for each FieldTypeDefinition.
+
 ## 0.2.1
 
 - `text`, `email` Edit control: add `help` support from the field `description` prop.

--- a/packages/dataviews/src/components/dataviews-dataform-story/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews-dataform-story/index.story.tsx
@@ -19,7 +19,7 @@ import {
 	type SpaceObject,
 } from '../dataviews/stories/fixtures';
 import { filterSortAndPaginate } from '../../filter-and-sort-data-view';
-import type { View, Form } from '../../types';
+import type { View, Form, Field } from '../../types';
 
 const meta = {
 	title: 'DataViews/FieldTypes',
@@ -46,27 +46,30 @@ const defaultLayouts = {
 	list: {},
 };
 
-export const All = ( {
-	type,
-	labelPosition,
-}: {
-	type: 'default' | 'regular' | 'panel';
-	labelPosition: 'default' | 'top' | 'side' | 'none';
-} ) => {
+interface FieldTypeStoryProps {
+	fields: Field< SpaceObject >[];
+	titleField?: string;
+	descriptionField?: string;
+	mediaField?: string;
+	type?: 'default' | 'regular' | 'panel';
+	labelPosition?: 'default' | 'top' | 'side' | 'none';
+}
+
+const FieldTypeStory = ( {
+	fields: storyFields,
+	titleField,
+	descriptionField,
+	mediaField,
+	type = 'default',
+	labelPosition = 'default',
+}: FieldTypeStoryProps ) => {
 	const form = useMemo(
 		() => ( {
 			type,
 			labelPosition,
-			fields: [
-				'title',
-				'description',
-				'type',
-				'isPlanet',
-				'satellites',
-				'date',
-			],
+			fields: storyFields.map( ( field ) => field.id ),
 		} ),
-		[ type, labelPosition ]
+		[ type, labelPosition, storyFields ]
 	) as Form;
 
 	const [ view, setView ] = useState< View >( {
@@ -76,18 +79,25 @@ export const All = ( {
 		perPage: 10,
 		layout: {},
 		filters: [],
-		titleField: 'title',
-		descriptionField: 'description',
-		mediaField: 'image',
-		fields: [ 'type', 'isPlanet', 'satellites', 'categories', 'date' ],
+		titleField,
+		descriptionField,
+		mediaField,
+		fields: storyFields
+			.filter(
+				( field ) =>
+					! [ titleField, descriptionField, mediaField ].includes(
+						field.id
+					)
+			)
+			.map( ( field ) => field.id ),
 	} );
 
 	const [ selectedIds, setSelectedIds ] = useState< number[] >( [] );
 	const [ modifiedData, setModifiedData ] = useState< SpaceObject[] >( data );
 
 	const { data: shownData, paginationInfo } = useMemo( () => {
-		return filterSortAndPaginate( modifiedData, view, fields );
-	}, [ modifiedData, view ] );
+		return filterSortAndPaginate( modifiedData, view, storyFields );
+	}, [ modifiedData, view, storyFields ] );
 
 	let selectedItem =
 		( selectedIds.length === 1 &&
@@ -102,7 +112,7 @@ export const All = ( {
 					data={ shownData }
 					paginationInfo={ paginationInfo }
 					view={ view }
-					fields={ fields }
+					fields={ storyFields }
 					onChangeView={ setView }
 					actions={ actions }
 					defaultLayouts={ defaultLayouts }
@@ -120,7 +130,7 @@ export const All = ( {
 					<DataForm
 						data={ selectedItem }
 						form={ form }
-						fields={ fields }
+						fields={ storyFields }
 						onChange={ ( updatedValues ) => {
 							const updatedItem = {
 								...selectedItem,
@@ -149,6 +159,25 @@ export const All = ( {
 				</VStack>
 			) }
 		</HStack>
+	);
+};
+
+export const All = ( {
+	type,
+	labelPosition,
+}: {
+	type: 'default' | 'regular' | 'panel';
+	labelPosition: 'default' | 'top' | 'side' | 'none';
+} ) => {
+	return (
+		<FieldTypeStory
+			fields={ fields }
+			titleField="title"
+			descriptionField="description"
+			mediaField="image"
+			type={ type }
+			labelPosition={ labelPosition }
+		/>
 	);
 };
 
@@ -159,96 +188,17 @@ export const Text = ( {
 	type: 'default' | 'regular' | 'panel';
 	labelPosition: 'default' | 'top' | 'side' | 'none';
 } ) => {
-	const _fields = useMemo(
+	const textFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'text' ),
-		[ fields ]
+		[]
 	);
 
-	const form = useMemo(
-		() => ( {
-			type,
-			labelPosition,
-			fields: _fields.map( ( field ) => field.id ),
-		} ),
-		[ type, labelPosition ]
-	) as Form;
-
-	const [ view, setView ] = useState< View >( {
-		type: 'table' as const,
-		search: '',
-		page: 1,
-		perPage: 10,
-		layout: {},
-		filters: [],
-		fields: _fields.map( ( field ) => field.id ),
-	} );
-
-	const [ selectedIds, setSelectedIds ] = useState< number[] >( [] );
-	const [ modifiedData, setModifiedData ] = useState< SpaceObject[] >( data );
-
-	const { data: shownData, paginationInfo } = useMemo( () => {
-		return filterSortAndPaginate( modifiedData, view, _fields );
-	}, [ modifiedData, view ] );
-
-	let selectedItem =
-		( selectedIds.length === 1 &&
-			shownData.find( ( item ) => item.id === selectedIds[ 0 ] ) ) ||
-		null;
-
 	return (
-		<HStack alignment="stretch">
-			<div style={ { flex: 2 } }>
-				<DataViews
-					getItemId={ ( item ) => item.id.toString() }
-					data={ shownData }
-					paginationInfo={ paginationInfo }
-					view={ view }
-					fields={ _fields }
-					onChangeView={ setView }
-					actions={ actions }
-					defaultLayouts={ defaultLayouts }
-					selection={ selectedIds.map( ( id ) => id.toString() ) }
-					onChangeSelection={ ( newSelection ) =>
-						setSelectedIds(
-							newSelection.map( ( id ) => parseInt( id, 10 ) )
-						)
-					}
-				/>
-			</div>
-			{ selectedItem ? (
-				<VStack alignment="top">
-					<DataForm
-						data={ selectedItem }
-						form={ form }
-						fields={ _fields }
-						onChange={ ( updatedValues ) => {
-							const updatedItem = {
-								...selectedItem,
-								...updatedValues,
-							};
-
-							setModifiedData(
-								modifiedData.map( ( item ) =>
-									item.id === selectedItem.id
-										? updatedItem
-										: item
-								)
-							);
-						} }
-					/>
-				</VStack>
-			) : (
-				<VStack alignment="center">
-					<span
-						style={ {
-							color: '#888',
-						} }
-					>
-						Please, select a single item.
-					</span>
-				</VStack>
-			) }
-		</HStack>
+		<FieldTypeStory
+			fields={ textFields }
+			type={ type }
+			labelPosition={ labelPosition }
+		/>
 	);
 };
 
@@ -259,96 +209,17 @@ export const Integer = ( {
 	type: 'default' | 'regular' | 'panel';
 	labelPosition: 'default' | 'top' | 'side' | 'none';
 } ) => {
-	const _fields = useMemo(
+	const integerFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'integer' ),
-		[ fields ]
+		[]
 	);
 
-	const form = useMemo(
-		() => ( {
-			type,
-			labelPosition,
-			fields: _fields.map( ( field ) => field.id ),
-		} ),
-		[ type, labelPosition ]
-	) as Form;
-
-	const [ view, setView ] = useState< View >( {
-		type: 'table' as const,
-		search: '',
-		page: 1,
-		perPage: 10,
-		layout: {},
-		filters: [],
-		fields: _fields.map( ( field ) => field.id ),
-	} );
-
-	const [ selectedIds, setSelectedIds ] = useState< number[] >( [] );
-	const [ modifiedData, setModifiedData ] = useState< SpaceObject[] >( data );
-
-	const { data: shownData, paginationInfo } = useMemo( () => {
-		return filterSortAndPaginate( modifiedData, view, _fields );
-	}, [ modifiedData, view ] );
-
-	let selectedItem =
-		( selectedIds.length === 1 &&
-			shownData.find( ( item ) => item.id === selectedIds[ 0 ] ) ) ||
-		null;
-
 	return (
-		<HStack alignment="stretch">
-			<div style={ { flex: 2 } }>
-				<DataViews
-					getItemId={ ( item ) => item.id.toString() }
-					data={ shownData }
-					paginationInfo={ paginationInfo }
-					view={ view }
-					fields={ _fields }
-					onChangeView={ setView }
-					actions={ actions }
-					defaultLayouts={ defaultLayouts }
-					selection={ selectedIds.map( ( id ) => id.toString() ) }
-					onChangeSelection={ ( newSelection ) =>
-						setSelectedIds(
-							newSelection.map( ( id ) => parseInt( id, 10 ) )
-						)
-					}
-				/>
-			</div>
-			{ selectedItem ? (
-				<VStack alignment="top">
-					<DataForm
-						data={ selectedItem }
-						form={ form }
-						fields={ _fields }
-						onChange={ ( updatedValues ) => {
-							const updatedItem = {
-								...selectedItem,
-								...updatedValues,
-							};
-
-							setModifiedData(
-								modifiedData.map( ( item ) =>
-									item.id === selectedItem.id
-										? updatedItem
-										: item
-								)
-							);
-						} }
-					/>
-				</VStack>
-			) : (
-				<VStack alignment="center">
-					<span
-						style={ {
-							color: '#888',
-						} }
-					>
-						Please, select a single item.
-					</span>
-				</VStack>
-			) }
-		</HStack>
+		<FieldTypeStory
+			fields={ integerFields }
+			type={ type }
+			labelPosition={ labelPosition }
+		/>
 	);
 };
 
@@ -359,96 +230,17 @@ export const Boolean = ( {
 	type: 'default' | 'regular' | 'panel';
 	labelPosition: 'default' | 'top' | 'side' | 'none';
 } ) => {
-	const _fields = useMemo(
+	const booleanFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'boolean' ),
-		[ fields ]
+		[]
 	);
 
-	const form = useMemo(
-		() => ( {
-			type,
-			labelPosition,
-			fields: _fields.map( ( field ) => field.id ),
-		} ),
-		[ type, labelPosition ]
-	) as Form;
-
-	const [ view, setView ] = useState< View >( {
-		type: 'table' as const,
-		search: '',
-		page: 1,
-		perPage: 10,
-		layout: {},
-		filters: [],
-		fields: _fields.map( ( field ) => field.id ),
-	} );
-
-	const [ selectedIds, setSelectedIds ] = useState< number[] >( [] );
-	const [ modifiedData, setModifiedData ] = useState< SpaceObject[] >( data );
-
-	const { data: shownData, paginationInfo } = useMemo( () => {
-		return filterSortAndPaginate( modifiedData, view, _fields );
-	}, [ modifiedData, view ] );
-
-	let selectedItem =
-		( selectedIds.length === 1 &&
-			shownData.find( ( item ) => item.id === selectedIds[ 0 ] ) ) ||
-		null;
-
 	return (
-		<HStack alignment="stretch">
-			<div style={ { flex: 2 } }>
-				<DataViews
-					getItemId={ ( item ) => item.id.toString() }
-					data={ shownData }
-					paginationInfo={ paginationInfo }
-					view={ view }
-					fields={ _fields }
-					onChangeView={ setView }
-					actions={ actions }
-					defaultLayouts={ defaultLayouts }
-					selection={ selectedIds.map( ( id ) => id.toString() ) }
-					onChangeSelection={ ( newSelection ) =>
-						setSelectedIds(
-							newSelection.map( ( id ) => parseInt( id, 10 ) )
-						)
-					}
-				/>
-			</div>
-			{ selectedItem ? (
-				<VStack alignment="top">
-					<DataForm
-						data={ selectedItem }
-						form={ form }
-						fields={ _fields }
-						onChange={ ( updatedValues ) => {
-							const updatedItem = {
-								...selectedItem,
-								...updatedValues,
-							};
-
-							setModifiedData(
-								modifiedData.map( ( item ) =>
-									item.id === selectedItem.id
-										? updatedItem
-										: item
-								)
-							);
-						} }
-					/>
-				</VStack>
-			) : (
-				<VStack alignment="center">
-					<span
-						style={ {
-							color: '#888',
-						} }
-					>
-						Please, select a single item.
-					</span>
-				</VStack>
-			) }
-		</HStack>
+		<FieldTypeStory
+			fields={ booleanFields }
+			type={ type }
+			labelPosition={ labelPosition }
+		/>
 	);
 };
 
@@ -459,96 +251,17 @@ export const DateTime = ( {
 	type: 'default' | 'regular' | 'panel';
 	labelPosition: 'default' | 'top' | 'side' | 'none';
 } ) => {
-	const _fields = useMemo(
+	const dateTimeFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'datetime' ),
-		[ fields ]
+		[]
 	);
 
-	const form = useMemo(
-		() => ( {
-			type,
-			labelPosition,
-			fields: _fields.map( ( field ) => field.id ),
-		} ),
-		[ type, labelPosition ]
-	) as Form;
-
-	const [ view, setView ] = useState< View >( {
-		type: 'table' as const,
-		search: '',
-		page: 1,
-		perPage: 10,
-		layout: {},
-		filters: [],
-		fields: _fields.map( ( field ) => field.id ),
-	} );
-
-	const [ selectedIds, setSelectedIds ] = useState< number[] >( [] );
-	const [ modifiedData, setModifiedData ] = useState< SpaceObject[] >( data );
-
-	const { data: shownData, paginationInfo } = useMemo( () => {
-		return filterSortAndPaginate( modifiedData, view, _fields );
-	}, [ modifiedData, view ] );
-
-	let selectedItem =
-		( selectedIds.length === 1 &&
-			shownData.find( ( item ) => item.id === selectedIds[ 0 ] ) ) ||
-		null;
-
 	return (
-		<HStack alignment="stretch">
-			<div style={ { flex: 2 } }>
-				<DataViews
-					getItemId={ ( item ) => item.id.toString() }
-					data={ shownData }
-					paginationInfo={ paginationInfo }
-					view={ view }
-					fields={ _fields }
-					onChangeView={ setView }
-					actions={ actions }
-					defaultLayouts={ defaultLayouts }
-					selection={ selectedIds.map( ( id ) => id.toString() ) }
-					onChangeSelection={ ( newSelection ) =>
-						setSelectedIds(
-							newSelection.map( ( id ) => parseInt( id, 10 ) )
-						)
-					}
-				/>
-			</div>
-			{ selectedItem ? (
-				<VStack alignment="top">
-					<DataForm
-						data={ selectedItem }
-						form={ form }
-						fields={ _fields }
-						onChange={ ( updatedValues ) => {
-							const updatedItem = {
-								...selectedItem,
-								...updatedValues,
-							};
-
-							setModifiedData(
-								modifiedData.map( ( item ) =>
-									item.id === selectedItem.id
-										? updatedItem
-										: item
-								)
-							);
-						} }
-					/>
-				</VStack>
-			) : (
-				<VStack alignment="center">
-					<span
-						style={ {
-							color: '#888',
-						} }
-					>
-						Please, select a single item.
-					</span>
-				</VStack>
-			) }
-		</HStack>
+		<FieldTypeStory
+			fields={ dateTimeFields }
+			type={ type }
+			labelPosition={ labelPosition }
+		/>
 	);
 };
 
@@ -559,96 +272,17 @@ export const Email = ( {
 	type: 'default' | 'regular' | 'panel';
 	labelPosition: 'default' | 'top' | 'side' | 'none';
 } ) => {
-	const _fields = useMemo(
+	const emailFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'email' ),
-		[ fields ]
+		[]
 	);
 
-	const form = useMemo(
-		() => ( {
-			type,
-			labelPosition,
-			fields: _fields.map( ( field ) => field.id ),
-		} ),
-		[ type, labelPosition ]
-	) as Form;
-
-	const [ view, setView ] = useState< View >( {
-		type: 'table' as const,
-		search: '',
-		page: 1,
-		perPage: 10,
-		layout: {},
-		filters: [],
-		fields: _fields.map( ( field ) => field.id ),
-	} );
-
-	const [ selectedIds, setSelectedIds ] = useState< number[] >( [] );
-	const [ modifiedData, setModifiedData ] = useState< SpaceObject[] >( data );
-
-	const { data: shownData, paginationInfo } = useMemo( () => {
-		return filterSortAndPaginate( modifiedData, view, _fields );
-	}, [ modifiedData, view ] );
-
-	let selectedItem =
-		( selectedIds.length === 1 &&
-			shownData.find( ( item ) => item.id === selectedIds[ 0 ] ) ) ||
-		null;
-
 	return (
-		<HStack alignment="stretch">
-			<div style={ { flex: 2 } }>
-				<DataViews
-					getItemId={ ( item ) => item.id.toString() }
-					data={ shownData }
-					paginationInfo={ paginationInfo }
-					view={ view }
-					fields={ _fields }
-					onChangeView={ setView }
-					actions={ actions }
-					defaultLayouts={ defaultLayouts }
-					selection={ selectedIds.map( ( id ) => id.toString() ) }
-					onChangeSelection={ ( newSelection ) =>
-						setSelectedIds(
-							newSelection.map( ( id ) => parseInt( id, 10 ) )
-						)
-					}
-				/>
-			</div>
-			{ selectedItem ? (
-				<VStack alignment="top">
-					<DataForm
-						data={ selectedItem }
-						form={ form }
-						fields={ _fields }
-						onChange={ ( updatedValues ) => {
-							const updatedItem = {
-								...selectedItem,
-								...updatedValues,
-							};
-
-							setModifiedData(
-								modifiedData.map( ( item ) =>
-									item.id === selectedItem.id
-										? updatedItem
-										: item
-								)
-							);
-						} }
-					/>
-				</VStack>
-			) : (
-				<VStack alignment="center">
-					<span
-						style={ {
-							color: '#888',
-						} }
-					>
-						Please, select a single item.
-					</span>
-				</VStack>
-			) }
-		</HStack>
+		<FieldTypeStory
+			fields={ emailFields }
+			type={ type }
+			labelPosition={ labelPosition }
+		/>
 	);
 };
 
@@ -659,96 +293,17 @@ export const Media = ( {
 	type: 'default' | 'regular' | 'panel';
 	labelPosition: 'default' | 'top' | 'side' | 'none';
 } ) => {
-	const _fields = useMemo(
+	const mediaFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'media' ),
-		[ fields ]
+		[]
 	);
 
-	const form = useMemo(
-		() => ( {
-			type,
-			labelPosition,
-			fields: _fields.map( ( field ) => field.id ),
-		} ),
-		[ type, labelPosition ]
-	) as Form;
-
-	const [ view, setView ] = useState< View >( {
-		type: 'table' as const,
-		search: '',
-		page: 1,
-		perPage: 10,
-		layout: {},
-		filters: [],
-		fields: _fields.map( ( field ) => field.id ),
-	} );
-
-	const [ selectedIds, setSelectedIds ] = useState< number[] >( [] );
-	const [ modifiedData, setModifiedData ] = useState< SpaceObject[] >( data );
-
-	const { data: shownData, paginationInfo } = useMemo( () => {
-		return filterSortAndPaginate( modifiedData, view, _fields );
-	}, [ modifiedData, view ] );
-
-	let selectedItem =
-		( selectedIds.length === 1 &&
-			shownData.find( ( item ) => item.id === selectedIds[ 0 ] ) ) ||
-		null;
-
 	return (
-		<HStack alignment="stretch">
-			<div style={ { flex: 2 } }>
-				<DataViews
-					getItemId={ ( item ) => item.id.toString() }
-					data={ shownData }
-					paginationInfo={ paginationInfo }
-					view={ view }
-					fields={ _fields }
-					onChangeView={ setView }
-					actions={ actions }
-					defaultLayouts={ defaultLayouts }
-					selection={ selectedIds.map( ( id ) => id.toString() ) }
-					onChangeSelection={ ( newSelection ) =>
-						setSelectedIds(
-							newSelection.map( ( id ) => parseInt( id, 10 ) )
-						)
-					}
-				/>
-			</div>
-			{ selectedItem ? (
-				<VStack alignment="top">
-					<DataForm
-						data={ selectedItem }
-						form={ form }
-						fields={ _fields }
-						onChange={ ( updatedValues ) => {
-							const updatedItem = {
-								...selectedItem,
-								...updatedValues,
-							};
-
-							setModifiedData(
-								modifiedData.map( ( item ) =>
-									item.id === selectedItem.id
-										? updatedItem
-										: item
-								)
-							);
-						} }
-					/>
-				</VStack>
-			) : (
-				<VStack alignment="center">
-					<span
-						style={ {
-							color: '#888',
-						} }
-					>
-						Please, select a single item.
-					</span>
-				</VStack>
-			) }
-		</HStack>
+		<FieldTypeStory
+			fields={ mediaFields }
+			type={ type }
+			labelPosition={ labelPosition }
+		/>
 	);
 };
 
@@ -759,95 +314,16 @@ export const NoType = ( {
 	type: 'default' | 'regular' | 'panel';
 	labelPosition: 'default' | 'top' | 'side' | 'none';
 } ) => {
-	const _fields = useMemo(
+	const noTypeFields = useMemo(
 		() => fields.filter( ( field ) => field.type === undefined ),
-		[ fields ]
+		[]
 	);
 
-	const form = useMemo(
-		() => ( {
-			type,
-			labelPosition,
-			fields: _fields.map( ( field ) => field.id ),
-		} ),
-		[ type, labelPosition ]
-	) as Form;
-
-	const [ view, setView ] = useState< View >( {
-		type: 'table' as const,
-		search: '',
-		page: 1,
-		perPage: 10,
-		layout: {},
-		filters: [],
-		fields: _fields.map( ( field ) => field.id ),
-	} );
-
-	const [ selectedIds, setSelectedIds ] = useState< number[] >( [] );
-	const [ modifiedData, setModifiedData ] = useState< SpaceObject[] >( data );
-
-	const { data: shownData, paginationInfo } = useMemo( () => {
-		return filterSortAndPaginate( modifiedData, view, _fields );
-	}, [ modifiedData, view ] );
-
-	let selectedItem =
-		( selectedIds.length === 1 &&
-			shownData.find( ( item ) => item.id === selectedIds[ 0 ] ) ) ||
-		null;
-
 	return (
-		<HStack alignment="stretch">
-			<div style={ { flex: 2 } }>
-				<DataViews
-					getItemId={ ( item ) => item.id.toString() }
-					data={ shownData }
-					paginationInfo={ paginationInfo }
-					view={ view }
-					fields={ _fields }
-					onChangeView={ setView }
-					actions={ actions }
-					defaultLayouts={ defaultLayouts }
-					selection={ selectedIds.map( ( id ) => id.toString() ) }
-					onChangeSelection={ ( newSelection ) =>
-						setSelectedIds(
-							newSelection.map( ( id ) => parseInt( id, 10 ) )
-						)
-					}
-				/>
-			</div>
-			{ selectedItem ? (
-				<VStack alignment="top">
-					<DataForm
-						data={ selectedItem }
-						form={ form }
-						fields={ _fields }
-						onChange={ ( updatedValues ) => {
-							const updatedItem = {
-								...selectedItem,
-								...updatedValues,
-							};
-
-							setModifiedData(
-								modifiedData.map( ( item ) =>
-									item.id === selectedItem.id
-										? updatedItem
-										: item
-								)
-							);
-						} }
-					/>
-				</VStack>
-			) : (
-				<VStack alignment="center">
-					<span
-						style={ {
-							color: '#888',
-						} }
-					>
-						Please, select a single item.
-					</span>
-				</VStack>
-			) }
-		</HStack>
+		<FieldTypeStory
+			fields={ noTypeFields }
+			type={ type }
+			labelPosition={ labelPosition }
+		/>
 	);
 };

--- a/packages/dataviews/src/components/dataviews-dataform-story/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews-dataform-story/index.story.tsx
@@ -5,9 +5,6 @@ import { useState, useMemo } from '@wordpress/element';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
-	Card,
-	CardHeader,
-	CardBody,
 } from '@wordpress/components';
 
 /**
@@ -25,7 +22,7 @@ import { filterSortAndPaginate } from '../../filter-and-sort-data-view';
 import type { View, Form } from '../../types';
 
 const meta = {
-	title: 'DataViews/DataViewsAndDataForm',
+	title: 'DataViews/FieldTypes',
 	component: DataForm,
 	argTypes: {
 		type: {
@@ -49,7 +46,7 @@ const defaultLayouts = {
 	list: {},
 };
 
-export const Default = ( {
+export const All = ( {
 	type,
 	labelPosition,
 }: {
@@ -124,6 +121,706 @@ export const Default = ( {
 						data={ selectedItem }
 						form={ form }
 						fields={ fields }
+						onChange={ ( updatedValues ) => {
+							const updatedItem = {
+								...selectedItem,
+								...updatedValues,
+							};
+
+							setModifiedData(
+								modifiedData.map( ( item ) =>
+									item.id === selectedItem.id
+										? updatedItem
+										: item
+								)
+							);
+						} }
+					/>
+				</VStack>
+			) : (
+				<VStack alignment="center">
+					<span
+						style={ {
+							color: '#888',
+						} }
+					>
+						Please, select a single item.
+					</span>
+				</VStack>
+			) }
+		</HStack>
+	);
+};
+
+export const Text = ( {
+	type,
+	labelPosition,
+}: {
+	type: 'default' | 'regular' | 'panel';
+	labelPosition: 'default' | 'top' | 'side' | 'none';
+} ) => {
+	const _fields = useMemo(
+		() => fields.filter( ( field ) => field.type === 'text' ),
+		[ fields ]
+	);
+
+	const form = useMemo(
+		() => ( {
+			type,
+			labelPosition,
+			fields: _fields.map( ( field ) => field.id ),
+		} ),
+		[ type, labelPosition ]
+	) as Form;
+
+	const [ view, setView ] = useState< View >( {
+		type: 'table' as const,
+		search: '',
+		page: 1,
+		perPage: 10,
+		layout: {},
+		filters: [],
+		fields: _fields.map( ( field ) => field.id ),
+	} );
+
+	const [ selectedIds, setSelectedIds ] = useState< number[] >( [] );
+	const [ modifiedData, setModifiedData ] = useState< SpaceObject[] >( data );
+
+	const { data: shownData, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( modifiedData, view, _fields );
+	}, [ modifiedData, view ] );
+
+	let selectedItem =
+		( selectedIds.length === 1 &&
+			shownData.find( ( item ) => item.id === selectedIds[ 0 ] ) ) ||
+		null;
+
+	return (
+		<HStack alignment="stretch">
+			<div style={ { flex: 2 } }>
+				<DataViews
+					getItemId={ ( item ) => item.id.toString() }
+					data={ shownData }
+					paginationInfo={ paginationInfo }
+					view={ view }
+					fields={ _fields }
+					onChangeView={ setView }
+					actions={ actions }
+					defaultLayouts={ defaultLayouts }
+					selection={ selectedIds.map( ( id ) => id.toString() ) }
+					onChangeSelection={ ( newSelection ) =>
+						setSelectedIds(
+							newSelection.map( ( id ) => parseInt( id, 10 ) )
+						)
+					}
+				/>
+			</div>
+			{ selectedItem ? (
+				<VStack alignment="top">
+					<DataForm
+						data={ selectedItem }
+						form={ form }
+						fields={ _fields }
+						onChange={ ( updatedValues ) => {
+							const updatedItem = {
+								...selectedItem,
+								...updatedValues,
+							};
+
+							setModifiedData(
+								modifiedData.map( ( item ) =>
+									item.id === selectedItem.id
+										? updatedItem
+										: item
+								)
+							);
+						} }
+					/>
+				</VStack>
+			) : (
+				<VStack alignment="center">
+					<span
+						style={ {
+							color: '#888',
+						} }
+					>
+						Please, select a single item.
+					</span>
+				</VStack>
+			) }
+		</HStack>
+	);
+};
+
+export const Integer = ( {
+	type,
+	labelPosition,
+}: {
+	type: 'default' | 'regular' | 'panel';
+	labelPosition: 'default' | 'top' | 'side' | 'none';
+} ) => {
+	const _fields = useMemo(
+		() => fields.filter( ( field ) => field.type === 'integer' ),
+		[ fields ]
+	);
+
+	const form = useMemo(
+		() => ( {
+			type,
+			labelPosition,
+			fields: _fields.map( ( field ) => field.id ),
+		} ),
+		[ type, labelPosition ]
+	) as Form;
+
+	const [ view, setView ] = useState< View >( {
+		type: 'table' as const,
+		search: '',
+		page: 1,
+		perPage: 10,
+		layout: {},
+		filters: [],
+		fields: _fields.map( ( field ) => field.id ),
+	} );
+
+	const [ selectedIds, setSelectedIds ] = useState< number[] >( [] );
+	const [ modifiedData, setModifiedData ] = useState< SpaceObject[] >( data );
+
+	const { data: shownData, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( modifiedData, view, _fields );
+	}, [ modifiedData, view ] );
+
+	let selectedItem =
+		( selectedIds.length === 1 &&
+			shownData.find( ( item ) => item.id === selectedIds[ 0 ] ) ) ||
+		null;
+
+	return (
+		<HStack alignment="stretch">
+			<div style={ { flex: 2 } }>
+				<DataViews
+					getItemId={ ( item ) => item.id.toString() }
+					data={ shownData }
+					paginationInfo={ paginationInfo }
+					view={ view }
+					fields={ _fields }
+					onChangeView={ setView }
+					actions={ actions }
+					defaultLayouts={ defaultLayouts }
+					selection={ selectedIds.map( ( id ) => id.toString() ) }
+					onChangeSelection={ ( newSelection ) =>
+						setSelectedIds(
+							newSelection.map( ( id ) => parseInt( id, 10 ) )
+						)
+					}
+				/>
+			</div>
+			{ selectedItem ? (
+				<VStack alignment="top">
+					<DataForm
+						data={ selectedItem }
+						form={ form }
+						fields={ _fields }
+						onChange={ ( updatedValues ) => {
+							const updatedItem = {
+								...selectedItem,
+								...updatedValues,
+							};
+
+							setModifiedData(
+								modifiedData.map( ( item ) =>
+									item.id === selectedItem.id
+										? updatedItem
+										: item
+								)
+							);
+						} }
+					/>
+				</VStack>
+			) : (
+				<VStack alignment="center">
+					<span
+						style={ {
+							color: '#888',
+						} }
+					>
+						Please, select a single item.
+					</span>
+				</VStack>
+			) }
+		</HStack>
+	);
+};
+
+export const Boolean = ( {
+	type,
+	labelPosition,
+}: {
+	type: 'default' | 'regular' | 'panel';
+	labelPosition: 'default' | 'top' | 'side' | 'none';
+} ) => {
+	const _fields = useMemo(
+		() => fields.filter( ( field ) => field.type === 'boolean' ),
+		[ fields ]
+	);
+
+	const form = useMemo(
+		() => ( {
+			type,
+			labelPosition,
+			fields: _fields.map( ( field ) => field.id ),
+		} ),
+		[ type, labelPosition ]
+	) as Form;
+
+	const [ view, setView ] = useState< View >( {
+		type: 'table' as const,
+		search: '',
+		page: 1,
+		perPage: 10,
+		layout: {},
+		filters: [],
+		fields: _fields.map( ( field ) => field.id ),
+	} );
+
+	const [ selectedIds, setSelectedIds ] = useState< number[] >( [] );
+	const [ modifiedData, setModifiedData ] = useState< SpaceObject[] >( data );
+
+	const { data: shownData, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( modifiedData, view, _fields );
+	}, [ modifiedData, view ] );
+
+	let selectedItem =
+		( selectedIds.length === 1 &&
+			shownData.find( ( item ) => item.id === selectedIds[ 0 ] ) ) ||
+		null;
+
+	return (
+		<HStack alignment="stretch">
+			<div style={ { flex: 2 } }>
+				<DataViews
+					getItemId={ ( item ) => item.id.toString() }
+					data={ shownData }
+					paginationInfo={ paginationInfo }
+					view={ view }
+					fields={ _fields }
+					onChangeView={ setView }
+					actions={ actions }
+					defaultLayouts={ defaultLayouts }
+					selection={ selectedIds.map( ( id ) => id.toString() ) }
+					onChangeSelection={ ( newSelection ) =>
+						setSelectedIds(
+							newSelection.map( ( id ) => parseInt( id, 10 ) )
+						)
+					}
+				/>
+			</div>
+			{ selectedItem ? (
+				<VStack alignment="top">
+					<DataForm
+						data={ selectedItem }
+						form={ form }
+						fields={ _fields }
+						onChange={ ( updatedValues ) => {
+							const updatedItem = {
+								...selectedItem,
+								...updatedValues,
+							};
+
+							setModifiedData(
+								modifiedData.map( ( item ) =>
+									item.id === selectedItem.id
+										? updatedItem
+										: item
+								)
+							);
+						} }
+					/>
+				</VStack>
+			) : (
+				<VStack alignment="center">
+					<span
+						style={ {
+							color: '#888',
+						} }
+					>
+						Please, select a single item.
+					</span>
+				</VStack>
+			) }
+		</HStack>
+	);
+};
+
+export const DateTime = ( {
+	type,
+	labelPosition,
+}: {
+	type: 'default' | 'regular' | 'panel';
+	labelPosition: 'default' | 'top' | 'side' | 'none';
+} ) => {
+	const _fields = useMemo(
+		() => fields.filter( ( field ) => field.type === 'datetime' ),
+		[ fields ]
+	);
+
+	const form = useMemo(
+		() => ( {
+			type,
+			labelPosition,
+			fields: _fields.map( ( field ) => field.id ),
+		} ),
+		[ type, labelPosition ]
+	) as Form;
+
+	const [ view, setView ] = useState< View >( {
+		type: 'table' as const,
+		search: '',
+		page: 1,
+		perPage: 10,
+		layout: {},
+		filters: [],
+		fields: _fields.map( ( field ) => field.id ),
+	} );
+
+	const [ selectedIds, setSelectedIds ] = useState< number[] >( [] );
+	const [ modifiedData, setModifiedData ] = useState< SpaceObject[] >( data );
+
+	const { data: shownData, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( modifiedData, view, _fields );
+	}, [ modifiedData, view ] );
+
+	let selectedItem =
+		( selectedIds.length === 1 &&
+			shownData.find( ( item ) => item.id === selectedIds[ 0 ] ) ) ||
+		null;
+
+	return (
+		<HStack alignment="stretch">
+			<div style={ { flex: 2 } }>
+				<DataViews
+					getItemId={ ( item ) => item.id.toString() }
+					data={ shownData }
+					paginationInfo={ paginationInfo }
+					view={ view }
+					fields={ _fields }
+					onChangeView={ setView }
+					actions={ actions }
+					defaultLayouts={ defaultLayouts }
+					selection={ selectedIds.map( ( id ) => id.toString() ) }
+					onChangeSelection={ ( newSelection ) =>
+						setSelectedIds(
+							newSelection.map( ( id ) => parseInt( id, 10 ) )
+						)
+					}
+				/>
+			</div>
+			{ selectedItem ? (
+				<VStack alignment="top">
+					<DataForm
+						data={ selectedItem }
+						form={ form }
+						fields={ _fields }
+						onChange={ ( updatedValues ) => {
+							const updatedItem = {
+								...selectedItem,
+								...updatedValues,
+							};
+
+							setModifiedData(
+								modifiedData.map( ( item ) =>
+									item.id === selectedItem.id
+										? updatedItem
+										: item
+								)
+							);
+						} }
+					/>
+				</VStack>
+			) : (
+				<VStack alignment="center">
+					<span
+						style={ {
+							color: '#888',
+						} }
+					>
+						Please, select a single item.
+					</span>
+				</VStack>
+			) }
+		</HStack>
+	);
+};
+
+export const Email = ( {
+	type,
+	labelPosition,
+}: {
+	type: 'default' | 'regular' | 'panel';
+	labelPosition: 'default' | 'top' | 'side' | 'none';
+} ) => {
+	const _fields = useMemo(
+		() => fields.filter( ( field ) => field.type === 'email' ),
+		[ fields ]
+	);
+
+	const form = useMemo(
+		() => ( {
+			type,
+			labelPosition,
+			fields: _fields.map( ( field ) => field.id ),
+		} ),
+		[ type, labelPosition ]
+	) as Form;
+
+	const [ view, setView ] = useState< View >( {
+		type: 'table' as const,
+		search: '',
+		page: 1,
+		perPage: 10,
+		layout: {},
+		filters: [],
+		fields: _fields.map( ( field ) => field.id ),
+	} );
+
+	const [ selectedIds, setSelectedIds ] = useState< number[] >( [] );
+	const [ modifiedData, setModifiedData ] = useState< SpaceObject[] >( data );
+
+	const { data: shownData, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( modifiedData, view, _fields );
+	}, [ modifiedData, view ] );
+
+	let selectedItem =
+		( selectedIds.length === 1 &&
+			shownData.find( ( item ) => item.id === selectedIds[ 0 ] ) ) ||
+		null;
+
+	return (
+		<HStack alignment="stretch">
+			<div style={ { flex: 2 } }>
+				<DataViews
+					getItemId={ ( item ) => item.id.toString() }
+					data={ shownData }
+					paginationInfo={ paginationInfo }
+					view={ view }
+					fields={ _fields }
+					onChangeView={ setView }
+					actions={ actions }
+					defaultLayouts={ defaultLayouts }
+					selection={ selectedIds.map( ( id ) => id.toString() ) }
+					onChangeSelection={ ( newSelection ) =>
+						setSelectedIds(
+							newSelection.map( ( id ) => parseInt( id, 10 ) )
+						)
+					}
+				/>
+			</div>
+			{ selectedItem ? (
+				<VStack alignment="top">
+					<DataForm
+						data={ selectedItem }
+						form={ form }
+						fields={ _fields }
+						onChange={ ( updatedValues ) => {
+							const updatedItem = {
+								...selectedItem,
+								...updatedValues,
+							};
+
+							setModifiedData(
+								modifiedData.map( ( item ) =>
+									item.id === selectedItem.id
+										? updatedItem
+										: item
+								)
+							);
+						} }
+					/>
+				</VStack>
+			) : (
+				<VStack alignment="center">
+					<span
+						style={ {
+							color: '#888',
+						} }
+					>
+						Please, select a single item.
+					</span>
+				</VStack>
+			) }
+		</HStack>
+	);
+};
+
+export const Media = ( {
+	type,
+	labelPosition,
+}: {
+	type: 'default' | 'regular' | 'panel';
+	labelPosition: 'default' | 'top' | 'side' | 'none';
+} ) => {
+	const _fields = useMemo(
+		() => fields.filter( ( field ) => field.type === 'media' ),
+		[ fields ]
+	);
+
+	const form = useMemo(
+		() => ( {
+			type,
+			labelPosition,
+			fields: _fields.map( ( field ) => field.id ),
+		} ),
+		[ type, labelPosition ]
+	) as Form;
+
+	const [ view, setView ] = useState< View >( {
+		type: 'table' as const,
+		search: '',
+		page: 1,
+		perPage: 10,
+		layout: {},
+		filters: [],
+		fields: _fields.map( ( field ) => field.id ),
+	} );
+
+	const [ selectedIds, setSelectedIds ] = useState< number[] >( [] );
+	const [ modifiedData, setModifiedData ] = useState< SpaceObject[] >( data );
+
+	const { data: shownData, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( modifiedData, view, _fields );
+	}, [ modifiedData, view ] );
+
+	let selectedItem =
+		( selectedIds.length === 1 &&
+			shownData.find( ( item ) => item.id === selectedIds[ 0 ] ) ) ||
+		null;
+
+	return (
+		<HStack alignment="stretch">
+			<div style={ { flex: 2 } }>
+				<DataViews
+					getItemId={ ( item ) => item.id.toString() }
+					data={ shownData }
+					paginationInfo={ paginationInfo }
+					view={ view }
+					fields={ _fields }
+					onChangeView={ setView }
+					actions={ actions }
+					defaultLayouts={ defaultLayouts }
+					selection={ selectedIds.map( ( id ) => id.toString() ) }
+					onChangeSelection={ ( newSelection ) =>
+						setSelectedIds(
+							newSelection.map( ( id ) => parseInt( id, 10 ) )
+						)
+					}
+				/>
+			</div>
+			{ selectedItem ? (
+				<VStack alignment="top">
+					<DataForm
+						data={ selectedItem }
+						form={ form }
+						fields={ _fields }
+						onChange={ ( updatedValues ) => {
+							const updatedItem = {
+								...selectedItem,
+								...updatedValues,
+							};
+
+							setModifiedData(
+								modifiedData.map( ( item ) =>
+									item.id === selectedItem.id
+										? updatedItem
+										: item
+								)
+							);
+						} }
+					/>
+				</VStack>
+			) : (
+				<VStack alignment="center">
+					<span
+						style={ {
+							color: '#888',
+						} }
+					>
+						Please, select a single item.
+					</span>
+				</VStack>
+			) }
+		</HStack>
+	);
+};
+
+export const NoType = ( {
+	type,
+	labelPosition,
+}: {
+	type: 'default' | 'regular' | 'panel';
+	labelPosition: 'default' | 'top' | 'side' | 'none';
+} ) => {
+	const _fields = useMemo(
+		() => fields.filter( ( field ) => field.type === undefined ),
+		[ fields ]
+	);
+
+	const form = useMemo(
+		() => ( {
+			type,
+			labelPosition,
+			fields: _fields.map( ( field ) => field.id ),
+		} ),
+		[ type, labelPosition ]
+	) as Form;
+
+	const [ view, setView ] = useState< View >( {
+		type: 'table' as const,
+		search: '',
+		page: 1,
+		perPage: 10,
+		layout: {},
+		filters: [],
+		fields: _fields.map( ( field ) => field.id ),
+	} );
+
+	const [ selectedIds, setSelectedIds ] = useState< number[] >( [] );
+	const [ modifiedData, setModifiedData ] = useState< SpaceObject[] >( data );
+
+	const { data: shownData, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( modifiedData, view, _fields );
+	}, [ modifiedData, view ] );
+
+	let selectedItem =
+		( selectedIds.length === 1 &&
+			shownData.find( ( item ) => item.id === selectedIds[ 0 ] ) ) ||
+		null;
+
+	return (
+		<HStack alignment="stretch">
+			<div style={ { flex: 2 } }>
+				<DataViews
+					getItemId={ ( item ) => item.id.toString() }
+					data={ shownData }
+					paginationInfo={ paginationInfo }
+					view={ view }
+					fields={ _fields }
+					onChangeView={ setView }
+					actions={ actions }
+					defaultLayouts={ defaultLayouts }
+					selection={ selectedIds.map( ( id ) => id.toString() ) }
+					onChangeSelection={ ( newSelection ) =>
+						setSelectedIds(
+							newSelection.map( ( id ) => parseInt( id, 10 ) )
+						)
+					}
+				/>
+			</div>
+			{ selectedItem ? (
+				<VStack alignment="top">
+					<DataForm
+						data={ selectedItem }
+						form={ form }
+						fields={ _fields }
 						onChange={ ( updatedValues ) => {
 							const updatedItem = {
 								...selectedItem,

--- a/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
@@ -33,6 +33,7 @@ export type SpaceObject = {
 	categories: string[];
 	satellites: number;
 	date: string;
+	email: string;
 };
 
 export const data: SpaceObject[] = [
@@ -46,6 +47,7 @@ export const data: SpaceObject[] = [
 		categories: [ 'Space', 'NASA' ],
 		satellites: 0,
 		date: '2021-01-01T00:00:00Z',
+		email: 'apollo@example.com',
 	},
 	{
 		id: 2,
@@ -57,6 +59,7 @@ export const data: SpaceObject[] = [
 		categories: [ 'Space' ],
 		satellites: 0,
 		date: '2019-01-02T00:00:00Z',
+		email: 'space@example.com',
 	},
 	{
 		id: 3,
@@ -68,6 +71,7 @@ export const data: SpaceObject[] = [
 		categories: [ 'NASA' ],
 		satellites: 0,
 		date: '2025-01-03T00:00:00Z',
+		email: 'nasa@example.com',
 	},
 	{
 		id: 4,
@@ -79,6 +83,7 @@ export const data: SpaceObject[] = [
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 14,
 		date: '2020-01-01T00:00:00Z',
+		email: 'neptune@example.com',
 	},
 	{
 		id: 5,
@@ -90,6 +95,7 @@ export const data: SpaceObject[] = [
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 0,
 		date: '2020-01-02T01:00:00Z',
+		email: 'mercury@example.com',
 	},
 	{
 		id: 6,
@@ -101,6 +107,7 @@ export const data: SpaceObject[] = [
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 0,
 		date: '2020-01-02T00:00:00Z',
+		email: 'venus@example.com',
 	},
 	{
 		id: 7,
@@ -112,6 +119,7 @@ export const data: SpaceObject[] = [
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 1,
 		date: '2023-01-03T00:00:00Z',
+		email: 'earth@example.com',
 	},
 	{
 		id: 8,
@@ -123,6 +131,7 @@ export const data: SpaceObject[] = [
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 2,
 		date: '2020-01-01T00:00:00Z',
+		email: 'mars@example.com',
 	},
 	{
 		id: 9,
@@ -134,6 +143,7 @@ export const data: SpaceObject[] = [
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 95,
 		date: '2017-01-01T00:01:00Z',
+		email: 'jupiter@example.com',
 	},
 	{
 		id: 10,
@@ -145,6 +155,7 @@ export const data: SpaceObject[] = [
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 146,
 		date: '2020-02-01T00:02:00Z',
+		email: 'saturn@example.com',
 	},
 	{
 		id: 11,
@@ -156,6 +167,7 @@ export const data: SpaceObject[] = [
 		categories: [ 'Space', 'Ice giant', 'Solar system' ],
 		satellites: 28,
 		date: '2020-03-01T00:00:00Z',
+		email: 'uranus@example.com',
 	},
 ];
 
@@ -703,6 +715,11 @@ export const fields: Field< SpaceObject >[] = [
 		enableSorting: false,
 		enableGlobalSearch: true,
 		filterBy: false,
+	},
+	{
+		label: 'Email',
+		id: 'email',
+		type: 'email',
 	},
 	{
 		label: 'Categories',


### PR DESCRIPTION
## What

This PR adds a story for each field type definition to the storybook.

<img width="2556" alt="Screenshot 2025-06-06 at 12 28 12" src="https://github.com/user-attachments/assets/e9dd407b-35c1-4d76-9978-955316bb6426" />

## Why are these changes being made?

There's a lot of activity around field type definitions (new ones, new capabilities, etc.) but we don't have a place to test them and see the current gaps.

## Testing Instructions

`yarn workspace @automattic/dataviews storybook:start` and explore the `FieldTypes` story.