### PR TITLE
Dashboard v2: Ensure consistent page structure across each setting screen

### DIFF
--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -43,10 +43,3 @@ a {
 #wpcom {
 	font-size: $font-size-medium;
 }
-
-// This is a temporary fix to match forms with the design.
-// The desired approach would be to create a layout component to wrap the form fields.
-// See: https://github.com/Automattic/wp-calypso/pull/103978
-form {
-	padding: 8px 0;
-}

--- a/client/dashboard/sites/settings-defensive-mode/index.tsx
+++ b/client/dashboard/sites/settings-defensive-mode/index.tsx
@@ -19,6 +19,7 @@ import { siteQuery, siteDefensiveModeQuery, siteDefensiveModeMutation } from '..
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
 import PageLayout from '../../components/page-layout';
+import { SectionHeader } from '../../components/section-header';
 import { canUpdateDefensiveMode } from '../../utils/site-features';
 import SettingsPageHeader from '../settings-page-header';
 import type { DefensiveModeSettingsUpdate } from '../../data/types';
@@ -176,34 +177,29 @@ export default function DefensiveModeSettings( { siteSlug }: { siteSlug: string 
 				<Notice>{ __( 'Defensive mode is disabled.' ) }</Notice>
 				<Card>
 					<CardBody>
-						<VStack spacing={ 8 } style={ { padding: '8px 0' } }>
-							<Text size="15px" weight={ 500 } lineHeight="20px">
-								{ __( 'Enable defensive mode' ) }
-							</Text>
-
-							<form onSubmit={ handleEnable }>
-								<VStack spacing={ 4 }>
-									<DataForm< { ttl: string } >
-										data={ formData }
-										fields={ fields }
-										form={ form }
-										onChange={ ( edits: { ttl?: string } ) => {
-											setFormData( ( data ) => ( { ...data, ...edits } ) );
-										} }
-									/>
-									<HStack justify="flex-start">
-										<Button
-											variant="primary"
-											type="submit"
-											isBusy={ isPending }
-											disabled={ isPending }
-										>
-											{ __( 'Enable' ) }
-										</Button>
-									</HStack>
-								</VStack>
-							</form>
-						</VStack>
+						<form onSubmit={ handleEnable }>
+							<VStack spacing={ 4 }>
+								<SectionHeader title={ __( 'Enable defensive mode' ) } level={ 3 } />
+								<DataForm< { ttl: string } >
+									data={ formData }
+									fields={ fields }
+									form={ form }
+									onChange={ ( edits: { ttl?: string } ) => {
+										setFormData( ( data ) => ( { ...data, ...edits } ) );
+									} }
+								/>
+								<HStack justify="flex-start">
+									<Button
+										variant="primary"
+										type="submit"
+										isBusy={ isPending }
+										disabled={ isPending }
+									>
+										{ __( 'Enable' ) }
+									</Button>
+								</HStack>
+							</VStack>
+						</form>
 					</CardBody>
 				</Card>
 			</VStack>

--- a/client/dashboard/sites/settings-hundred-year-plan/index.tsx
+++ b/client/dashboard/sites/settings-hundred-year-plan/index.tsx
@@ -3,7 +3,6 @@ import { useQuery, useMutation } from '@tanstack/react-query';
 import { notFound } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
-	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	Button,
 	Card,
@@ -17,6 +16,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { siteQuery, siteSettingsMutation, siteSettingsQuery } from '../../app/queries';
 import PageLayout from '../../components/page-layout';
+import { SectionHeader } from '../../components/section-header';
 import { canUpdateHundredYearPlanFeatures } from '../../utils/site-features';
 import SettingsPageHeader from '../settings-page-header';
 import type { SiteSettings } from '../../data/types';
@@ -95,41 +95,36 @@ export default function HundredYearPlanSettings( { siteSlug }: { siteSlug: strin
 				<CardBody>
 					<form onSubmit={ handleSubmit } className="dashboard-site-settings-form">
 						<VStack spacing={ 4 }>
-							<VStack spacing={ 2 }>
-								<Text size="15px" weight={ 500 }>
-									{ __( 'Legacy contact' ) }
-								</Text>
-								<Text variant="muted" as="p">
-									{ createInterpolateElement(
-										__(
-											'Choose someone to look after your site when you pass away. To take ownership of the site, we ask that the person you designate contacts us at <link>wordpress.com/help</link> with a copy of the death certificate.'
-										),
-										{
-											link: <ExternalLink href="/help" children={ null } />,
-										}
-									) }
-								</Text>
-							</VStack>
-							<VStack spacing={ 4 }>
-								<DataForm< SiteSettings >
-									data={ formData }
-									fields={ fields }
-									form={ form }
-									onChange={ ( edits: Partial< SiteSettings > ) => {
-										setFormData( ( data ) => ( { ...data, ...edits } ) );
-									} }
-								/>
-								<HStack justify="flex-start">
-									<Button
-										variant="primary"
-										type="submit"
-										isBusy={ isPending }
-										disabled={ isPending || ! isDirty }
-									>
-										{ __( 'Save' ) }
-									</Button>
-								</HStack>
-							</VStack>
+							<SectionHeader
+								title={ __( 'Legacy contact' ) }
+								description={ createInterpolateElement(
+									__(
+										'Choose someone to look after your site when you pass away. To take ownership of the site, we ask that the person you designate contacts us at <link>wordpress.com/help</link> with a copy of the death certificate.'
+									),
+									{
+										link: <ExternalLink href="/help" children={ null } />,
+									}
+								) }
+								level={ 3 }
+							/>
+							<DataForm< SiteSettings >
+								data={ formData }
+								fields={ fields }
+								form={ form }
+								onChange={ ( edits: Partial< SiteSettings > ) => {
+									setFormData( ( data ) => ( { ...data, ...edits } ) );
+								} }
+							/>
+							<HStack justify="flex-start">
+								<Button
+									variant="primary"
+									type="submit"
+									isBusy={ isPending }
+									disabled={ isPending || ! isDirty }
+								>
+									{ __( 'Save' ) }
+								</Button>
+							</HStack>
 						</VStack>
 					</form>
 				</CardBody>

--- a/client/dashboard/sites/settings-primary-data-center/index.tsx
+++ b/client/dashboard/sites/settings-primary-data-center/index.tsx
@@ -1,11 +1,12 @@
 import SummaryButton from '@automattic/components/src/summary-button';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
-import { __experimentalVStack as VStack, Card, Icon, Notice } from '@wordpress/components';
+import { __experimentalVStack as VStack, Card, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { cloud } from '@wordpress/icons';
 import { getDataCenterOptions } from 'calypso/data/data-center';
 import { siteQuery, sitePrimaryDataCenterQuery } from '../../app/queries';
+import Notice from '../../components/notice';
 import PageLayout from '../../components/page-layout';
 import { canGetPrimaryDataCenter } from '../../utils/site-features';
 import SettingsPageHeader from '../settings-page-header';
@@ -39,7 +40,7 @@ export default function PrimaryDataCenterSettings( { siteSlug }: { siteSlug: str
 			}
 		>
 			<VStack spacing={ 8 }>
-				<Notice isDismissible={ false }>
+				<Notice>
 					{ __(
 						'Your site has already been placed in the optimal data center. It’s not currently possible to change your primary data center.'
 					) }

--- a/client/dashboard/sites/settings-sftp-ssh/enable-sftp-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/enable-sftp-card.tsx
@@ -53,7 +53,7 @@ export default function EnableSftpCard( {
 	return (
 		<Card>
 			<CardBody>
-				<VStack style={ { paddingBottom: '12px' } }>
+				<VStack spacing={ 4 }>
 					<SectionHeader
 						title={ __( 'Get started with SFTP/SSH' ) }
 						description={
@@ -67,8 +67,6 @@ export default function EnableSftpCard( {
 						}
 						level={ 3 }
 					/>
-				</VStack>
-				<VStack spacing={ 5 } style={ { padding: '8px 0' } }>
 					{ /* TODO: Replace the Panel with the Accordion component when it's ready */ }
 					<Panel>
 						<PanelBody title={ __( 'What is SFTP?' ) } initialOpen={ false }>
@@ -106,16 +104,16 @@ export default function EnableSftpCard( {
 							}
 						) }
 					</Text>
+					<HStack justify="flex-start">
+						<Button
+							variant="primary"
+							isBusy={ mutation.isPending }
+							onClick={ handleCreateCredentials }
+						>
+							{ __( 'Create credentials' ) }
+						</Button>
+					</HStack>
 				</VStack>
-				<HStack justify="flex-start" style={ { padding: '8px 0' } }>
-					<Button
-						variant="primary"
-						isBusy={ mutation.isPending }
-						onClick={ handleCreateCredentials }
-					>
-						{ __( 'Create credentials' ) }
-					</Button>
-				</HStack>
 			</CardBody>
 		</Card>
 	);

--- a/client/dashboard/sites/settings-sftp-ssh/sftp-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/sftp-card.tsx
@@ -152,7 +152,7 @@ export default function SftpCard( {
 	return (
 		<Card>
 			<CardBody>
-				<VStack style={ { paddingBottom: '12px' } }>
+				<VStack spacing={ 4 }>
 					<SectionHeader
 						title={ __( 'SFTP' ) }
 						description={ createInterpolateElement(
@@ -165,26 +165,24 @@ export default function SftpCard( {
 						) }
 						level={ 3 }
 					/>
-				</VStack>
-				<VStack spacing={ 4 } style={ { padding: '8px 0' } }>
 					<DataForm< SftpCardFormData >
 						data={ formData }
 						fields={ fields }
 						form={ form }
 						onChange={ noop }
 					/>
+					{ ! password && (
+						<HStack justify="flex-start">
+							<Button
+								variant="secondary"
+								isBusy={ mutation.isPending }
+								onClick={ () => setShowResetPasswordConfirmDialog( true ) }
+							>
+								{ __( 'Reset password' ) }
+							</Button>
+						</HStack>
+					) }
 				</VStack>
-				{ ! password && (
-					<HStack style={ { padding: '8px 0' } }>
-						<Button
-							variant="secondary"
-							isBusy={ mutation.isPending }
-							onClick={ () => setShowResetPasswordConfirmDialog( true ) }
-						>
-							{ __( 'Reset password' ) }
-						</Button>
-					</HStack>
-				) }
 			</CardBody>
 			<ConfirmDialog
 				isOpen={ showResetPasswordConfirmDialog }

--- a/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
@@ -293,7 +293,7 @@ export default function SshCard( {
 	return (
 		<Card>
 			<CardBody>
-				<VStack style={ { paddingBottom: '12px' } }>
+				<VStack spacing={ 4 }>
 					<SectionHeader
 						title={ __( 'SSH' ) }
 						description={ createInterpolateElement(
@@ -307,8 +307,6 @@ export default function SshCard( {
 						) }
 						level={ 3 }
 					/>
-				</VStack>
-				<VStack spacing={ 4 } style={ { padding: '8px 0' } }>
 					<ToggleControl
 						label={ __( 'Enable SSH access for this site' ) }
 						checked={ sshEnabled }
@@ -326,27 +324,27 @@ export default function SshCard( {
 							} }
 						/>
 					) }
+					{ sshEnabled && ! userKeyIsAttached && (
+						<HStack justify="flex-start">
+							<Button
+								variant="primary"
+								isBusy={ attachSshKeyMutation.isPending }
+								disabled={ ! hasProfileSshKeys }
+								onClick={ handleAttachSshKey }
+							>
+								{ __( 'Attach SSH key to site' ) }
+							</Button>
+							<Button
+								variant="secondary"
+								target="_blank"
+								href="/me/security/ssh-key"
+								rel="noreferrer"
+							>
+								{ __( 'Add new SSH key ↗' ) }
+							</Button>
+						</HStack>
+					) }
 				</VStack>
-				{ sshEnabled && ! userKeyIsAttached && (
-					<HStack justify="flex-start" style={ { padding: '8px 0' } }>
-						<Button
-							variant="primary"
-							isBusy={ attachSshKeyMutation.isPending }
-							disabled={ ! hasProfileSshKeys }
-							onClick={ handleAttachSshKey }
-						>
-							{ __( 'Attach SSH key to site' ) }
-						</Button>
-						<Button
-							variant="secondary"
-							target="_blank"
-							href="/me/security/ssh-key"
-							rel="noreferrer"
-						>
-							{ __( 'Add new SSH key ↗' ) }
-						</Button>
-					</HStack>
-				) }
 			</CardBody>
 		</Card>
 	);

--- a/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
@@ -79,43 +79,41 @@ export function ConfirmNewOwnerForm( {
 	};
 
 	return (
-		<>
-			<VStack style={ { padding: '8px 0 12px' } }>
-				<SectionHeader title={ __( 'Confirm new owner' ) } level={ 3 } />
-				<Text lineHeight="20px">
-					{ createInterpolateElement(
-						__(
-							"Ready to transfer <siteSlug /> and its associated purchases? Simply enter the new owner's email below, or choose an existing user to start the transfer process."
-						),
-						{
-							siteSlug: <strong>{ siteSlug }</strong>,
-						}
-					) }
-				</Text>
-			</VStack>
-			<form onSubmit={ handleSubmit }>
-				<VStack spacing={ 4 }>
-					{ /* TODO: Update the gap between each field */ }
-					<DataForm< ConfirmNewOwnerFormData >
-						data={ formData }
-						fields={ fields }
-						form={ form }
-						onChange={ ( edits: Partial< ConfirmNewOwnerFormData > ) => {
-							setFormData( ( data ) => ( { ...data, ...edits } ) );
-						} }
-					/>
-					<HStack justify="flex-start">
-						<Button
-							variant="primary"
-							type="submit"
-							isBusy={ mutation.isPending }
-							disabled={ isSaveDisabled }
-						>
-							{ __( 'Continue' ) }
-						</Button>
-					</HStack>
+		<form onSubmit={ handleSubmit }>
+			<VStack spacing={ 4 }>
+				<VStack>
+					<SectionHeader title={ __( 'Confirm new owner' ) } level={ 3 } />
+					{ /* The description in SectionHeader appears in gray-700, so we need to use the Text component to apply that color explicitly. */ }
+					<Text lineHeight="20px">
+						{ createInterpolateElement(
+							__(
+								"Ready to transfer <siteSlug /> and its associated purchases? Simply enter the new owner's email below, or choose an existing user to start the transfer process."
+							),
+							{
+								siteSlug: <strong>{ siteSlug }</strong>,
+							}
+						) }
+					</Text>
 				</VStack>
-			</form>
-		</>
+				<DataForm< ConfirmNewOwnerFormData >
+					data={ formData }
+					fields={ fields }
+					form={ form }
+					onChange={ ( edits: Partial< ConfirmNewOwnerFormData > ) => {
+						setFormData( ( data ) => ( { ...data, ...edits } ) );
+					} }
+				/>
+				<HStack justify="flex-start">
+					<Button
+						variant="primary"
+						type="submit"
+						isBusy={ mutation.isPending }
+						disabled={ isSaveDisabled }
+					>
+						{ __( 'Continue' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		</form>
 	);
 }

--- a/client/dashboard/sites/settings-transfer-site/email-confirmation.tsx
+++ b/client/dashboard/sites/settings-transfer-site/email-confirmation.tsx
@@ -1,8 +1,4 @@
-import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { __experimentalVStack as VStack, __experimentalText as Text } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, inbox } from '@wordpress/icons';
@@ -10,14 +6,12 @@ import { SectionHeader } from '../../components/section-header';
 
 export function EmailConfirmation( { userEmail }: { userEmail: string } ) {
 	return (
-		<VStack style={ { padding: '8px 0 12px' } }>
-			<HStack justify="flex-start">
-				<SectionHeader
-					title={ __( 'Check your inbox' ) }
-					decoration={ <Icon icon={ inbox } /> }
-					level={ 3 }
-				/>
-			</HStack>
+		<VStack spacing={ 4 }>
+			<SectionHeader
+				title={ __( 'Check your inbox' ) }
+				decoration={ <Icon icon={ inbox } /> }
+				level={ 3 }
+			/>
 			<Text>
 				{ createInterpolateElement(
 					__(

--- a/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
@@ -108,15 +108,13 @@ export function StartSiteTransferForm( {
 	};
 
 	return (
-		<>
-			<VStack style={ { padding: '8px 0 12px' } }>
+		<form onSubmit={ handleSubmit }>
+			<VStack spacing={ 4 }>
 				<SectionHeader title={ __( 'Start site transfer' ) } level={ 3 } />
-			</VStack>
-			<VStack spacing={ 5 } style={ { padding: '8px 0' } }>
 				<Notice variant="warning" density="medium">
 					{ __( 'Please read the following carefully. Transferring a site cannot be undone.' ) }
 				</Notice>
-				<VStack spacing={ 6 } style={ { padding: '8px 0' } }>
+				<VStack spacing={ 6 }>
 					<List title={ __( 'Content and ownership' ) }>
 						<li>
 							{ createInterpolateElement(
@@ -187,35 +185,31 @@ export function StartSiteTransferForm( {
 						</li>
 					</List>
 				</VStack>
-				<Text weight={ 500 } as="h3">
+				<Text weight={ 500 } lineHeight="32px" as="h3">
 					{ __( 'To transfer your site, review and accept the following statements:' ) }
 				</Text>
-				<form onSubmit={ handleSubmit }>
-					<VStack spacing={ 5 }>
-						<DataForm< StartSiteTransferFormData >
-							data={ formData }
-							fields={ fields }
-							form={ form }
-							onChange={ ( edits: Partial< StartSiteTransferFormData > ) => {
-								setFormData( ( data ) => ( { ...data, ...edits } ) );
-							} }
-						/>
-						<HStack justify="flex-start">
-							<Button
-								variant="primary"
-								type="submit"
-								isBusy={ mutation.isPending }
-								disabled={ isSaveDisabled }
-							>
-								{ __( 'Start transfer' ) }
-							</Button>
-							<Button variant="tertiary" onClick={ onBack } disabled={ mutation.isPending }>
-								{ __( 'Back' ) }
-							</Button>
-						</HStack>
-					</VStack>
-				</form>
+				<DataForm< StartSiteTransferFormData >
+					data={ formData }
+					fields={ fields }
+					form={ form }
+					onChange={ ( edits: Partial< StartSiteTransferFormData > ) => {
+						setFormData( ( data ) => ( { ...data, ...edits } ) );
+					} }
+				/>
+				<HStack justify="flex-start">
+					<Button
+						variant="primary"
+						type="submit"
+						isBusy={ mutation.isPending }
+						disabled={ isSaveDisabled }
+					>
+						{ __( 'Start transfer' ) }
+					</Button>
+					<Button variant="tertiary" onClick={ onBack } disabled={ mutation.isPending }>
+						{ __( 'Back' ) }
+					</Button>
+				</HStack>
 			</VStack>
-		</>
+		</form>
 	);
 }

--- a/client/dashboard/sites/site-preview-links/index.tsx
+++ b/client/dashboard/sites/site-preview-links/index.tsx
@@ -97,7 +97,7 @@ export default function SitePreviewLinks( { site, title, description }: SitePrev
 		const data = { enabled: links.length > 0 };
 
 		return (
-			<form>
+			<>
 				<VStack spacing={ 4 }>
 					<DataForm< { enabled: boolean } >
 						data={ data }
@@ -117,7 +117,7 @@ export default function SitePreviewLinks( { site, title, description }: SitePrev
 						/>
 					) ) }
 				</VStack>
-			</form>
+			</>
 		);
 	};
 
@@ -125,7 +125,7 @@ export default function SitePreviewLinks( { site, title, description }: SitePrev
 		return (
 			<Card>
 				<CardBody>
-					<VStack spacing={ 3 }>
+					<VStack spacing={ 4 }>
 						<SectionHeader level={ 3 } title={ title } description={ description } />
 						{ renderContent() }
 					</VStack>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://github.com/Automattic/wp-calypso/pull/103988

## Proposed Changes

* This is the follow-up to https://github.com/Automattic/wp-calypso/pull/103988 to ensure consistent page structure across each screen, as below
  ```tsx
  <Card>
    <CardBody>
      {/* Add the <form> element outside the VStack if needed */}
      <VStack spacing={ 4 }>
        <SectionHeader />
        ...
        <DataForm />
        <HStack justify="flex-start">
          <Button />
          ...
        </HStack>
      </VStack>
      {/* </form> */}
    </CardBody>
  </Card>
  ```

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Ensure consistent page structure across each screen

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Navigate to any site > Settings > any setting
* Ensure the layout on each screen looks as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
