### PR TITLE
Theme showcase: Enable preview for active theme

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -404,12 +404,7 @@ class ThemeSheet extends Component {
 
 	shouldRenderPreviewButton() {
 		const { isWPForTeamsSite } = this.props;
-		return (
-			this.isThemeAvailable() &&
-			! this.isThemeCurrentOne() &&
-			! isWPForTeamsSite &&
-			! this.shouldRenderForStaging()
-		);
+		return this.isThemeAvailable() && ! isWPForTeamsSite && ! this.shouldRenderForStaging();
 	}
 
 	shouldRenderUnlockStyleButton() {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -430,10 +430,6 @@ class ThemeSheet extends Component {
 		);
 	}
 
-	isThemeCurrentOne() {
-		return this.props.isActive;
-	}
-
 	isThemeAvailable() {
 		const { demoUrl, retired } = this.props;
 		return demoUrl && ! retired;

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1250,15 +1250,16 @@ class ThemeSheet extends Component {
 	}
 }
 
-const withSiteGlobalStylesStatus = createHigherOrderComponent(
-	( Wrapped ) => ( props ) => {
+const withSiteGlobalStylesStatus = createHigherOrderComponent( ( Wrapped ) => {
+	const WithSiteGlobalStylesStatusComponent = ( props ) => {
 		const { siteId } = props;
 		const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( siteId );
 
 		return <Wrapped { ...props } shouldLimitGlobalStyles={ shouldLimitGlobalStyles } />;
-	},
-	'withSiteGlobalStylesStatus'
-);
+	};
+	WithSiteGlobalStylesStatusComponent.displayName = 'WithSiteGlobalStylesStatus';
+	return WithSiteGlobalStylesStatusComponent;
+}, 'withSiteGlobalStylesStatus' );
 
 const ConnectedThemeSheet = connectOptions( ThemeSheet );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTTHEM-19

## Proposed Changes

 * In the theme showcase, show "Preview demo site" button on the active theme.
 * Adhere to new eslint rule

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The theme showcase allows each theme to be demoed by showing the demo site in an iframe. However the active theme doesn't show the button to open this overlaid iframe.

Seeing the theme demo site, and being able to click through and explore it can still be useful for the active theme. This is doubly so for block themes where the active theme on the site might have been substantially modified.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use calypso.live link
2. Go to wordpress.com/themes/site:Slug
3. Click the site's active theme (first in the list)
4. On the theme page, hover over the screenshot
5. Notice you can click 'Preview demo site'
6. Click it
7. The theme demo site should open in an overlay, just the same as it does for inactive themes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
