### PR TITLE
Jetpack Forms: change dashboard URL on fallback menu

### DIFF
--- a/client/my-sites/sidebar/static-data/fallback-menu.js
+++ b/client/my-sites/sidebar/static-data/fallback-menu.js
@@ -307,7 +307,7 @@ export default function buildFallbackResponse( {
 					slug: 'edit-phppost_typefeedback',
 					title: translate( 'Feedback' ),
 					type: 'submenu-item',
-					url: `https://${ siteDomain }/wp-admin/edit.php?post_type=feedback`,
+					url: `https://${ siteDomain }/wp-admin/admin.php?page=jetpack-forms`,
 				},
 				{
 					parent: 'feedback',


### PR DESCRIPTION
Part of FORMS-27
Part of FORMS-120

## Proposed Changes
This PR changes one last occurrence of Jetpack Forms dashboard URL on the fallback menu structure used by Calypso

## Why are these changes being made?
Because we're deprecating the legacy view `edit.php?post_type=feedback`. All those links should now point to either our new dashboard URL (`admin.php?page=jetpack-forms-admin`) or to our migration page for the dashboard view at Feedback > Forms responses (`admin.php?page=jetpack-forms`)

## Testing Instructions
TBD

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
