### PR TITLE
Connect Refresh: Bring back magic-login link to Grav-powered Login

### DIFF
--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -17,6 +17,8 @@ import { addQueryArgs } from 'calypso/lib/url';
 	from?: string;
 	allowSiteConnection?: boolean;
 	signupUrl?: string;
+	gravatarFlow?: boolean;
+	gravatarFrom?: string;
  }} args The arguments
  * @returns {string}
  */

--- a/client/login/wp-login/login-footer.tsx
+++ b/client/login/wp-login/login-footer.tsx
@@ -1,8 +1,16 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import SocialTos from 'calypso/blocks/authentication/social/social-tos';
-import { isGravPoweredOAuth2Client } from 'calypso/lib/oauth2-clients';
+import {
+	isGravatarFlowOAuth2Client,
+	isGravatarOAuth2Client,
+	isGravPoweredOAuth2Client,
+} from 'calypso/lib/oauth2-clients';
+import { login } from 'calypso/lib/paths';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 
 interface LoginFooterProps {
 	lostPasswordLink: JSX.Element;
@@ -13,6 +21,20 @@ const LoginFooter = ( { lostPasswordLink, shouldRenderTos }: LoginFooterProps ) 
 	const translate = useTranslate();
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
 	const isGravPoweredClient = isGravPoweredOAuth2Client( oauth2Client );
+	const currentQuery = useSelector( getCurrentQueryArguments );
+	const locale = useSelector( getCurrentLocaleSlug );
+	const isGravatar = isGravatarOAuth2Client( oauth2Client );
+	const isGravatarFlow = isGravatarFlowOAuth2Client( oauth2Client );
+
+	const magicLoginUrl = login( {
+		locale,
+		twoFactorAuthType: 'link',
+		oauth2ClientId: currentQuery?.client_id as string,
+		redirectTo: currentQuery?.redirect_to as string,
+		gravatarFrom: currentQuery?.gravatar_from as string,
+		gravatarFlow: isGravatarFlow,
+		emailAddress: currentQuery?.email_address as string,
+	} );
 
 	if ( ! lostPasswordLink && ! shouldRenderTos ) {
 		return null;
@@ -21,6 +43,18 @@ const LoginFooter = ( { lostPasswordLink, shouldRenderTos }: LoginFooterProps ) 
 	return (
 		<div className="wp-login__main-footer">
 			{ shouldRenderTos && <SocialTos /> }
+			{ isGravPoweredClient && (
+				<div className="wp-login__main-footer-magic-login">
+					<a
+						href={ magicLoginUrl }
+						onClick={ () => recordTracksEvent( 'calypso_login_magic_login_request_click' ) }
+					>
+						{ isGravatar
+							? translate( 'Email me a login code' )
+							: translate( 'Email me a login link' ) }
+					</a>
+				</div>
+			) }
 			{ lostPasswordLink }
 			{ isGravPoweredClient && (
 				<div className="wp-login__main-footer-help-docs">

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -511,12 +511,15 @@ $image-height: 47px;
 		}
 
 		.wp-login__main-footer-help-docs,
+		.wp-login__main-footer-magic-login,
 		.login__lost-password-link {
 			font-size: $font-body-small;
 			display: block;
 		}
 
 		.login__lost-password-link,
+		.wp-login__main-footer-magic-login,
+		.wp-login__main-footer-magic-login a,
 		.wp-login__main-footer-help-docs a {
 			color: var(--studio-gray-90, #1d2327);
 			font-weight: 500;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Gravatar
Part of https://linear.app/a8c/issue/DOTCOM-13401/gravatar

WPJM
Part of https://linear.app/a8c/issue/DOTCOM-13402/wp-job-manager

## Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/103883 we migrated the main Login screen to the unified layout/design. In doing so, we removed the magic login link present in the footer of the original (we ripped out the entire footer). 

@wellyshen was fast to spot this in production (https://github.com/Automattic/wp-calypso/pull/103883#issuecomment-2949045294). I should have requested a review from @Automattic/lighthouse before merging the refactors. There is a lot of work to do and a lot of it fell on my plate, so I appreciate the help.

In this PR, we add it back. It's still with the dark color like all screens right now, but we will be migrating the colors to the client palette in a follow-up.

## Media

| Gravatar | WP Job Manager |
|--------|--------|
| <img width="1257" alt="Screenshot 2025-06-06 at 4 21 59 PM" src="https://github.com/user-attachments/assets/ec18d527-ced5-4af9-94c0-cf2f35c0d0c3" /> | <img width="965" alt="Screenshot 2025-06-06 at 4 29 08 PM" src="https://github.com/user-attachments/assets/edb5a582-e2c0-49d1-a3d9-8414ce4275fe" /> | 


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fix an issue with missing magic login link

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the following and confirm the magic login link works like before. It should also send a Tracks request like before.
* [Gravatar](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D4a5153e30a28e2ef24ca7e599abd80f3969340cd1f88327c1f5d2fbc88593fa1%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1&client_id=1854)
* [WP Job Manager](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fclient_id%3D90057%26response_type%3Dcode%26state%3DeyJyZWRpcmVjdF90byI6Imh0dHBzOlwvXC93cGpvYm1hbmFnZXIuY29tXC9teS1hY2NvdW50In0%26redirect_uri%3Dhttps%253A%252F%252Fwpjobmanager.com%252Fwp-json%252Fwpjmcom-auth%252Fv1%252Fcallback%26blog_id%3D0%26from-calypso%3D1&client_id=90057)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
