### PR TITLE
Sharing: Remove the Facebook Service Tip

### DIFF
--- a/client/sites/marketing/connections/service-tip.jsx
+++ b/client/sites/marketing/connections/service-tip.jsx
@@ -7,7 +7,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 /**
  * Module constants
@@ -24,51 +24,14 @@ const SERVICES_WITH_TIPS = [ 'instagram', 'google_plus' ];
  * List of services we provide tips for, only if the site is connected to Jetpack.
  * @type {string[]}
  */
-const JETPACK_SERVICES_WITH_TIPS = SERVICES_WITH_TIPS.concat( [ 'facebook', 'twitter' ] );
+const JETPACK_SERVICES_WITH_TIPS = SERVICES_WITH_TIPS.concat( [ 'twitter' ] );
 
 class SharingServiceTip extends Component {
 	static propTypes = {
 		service: PropTypes.object.isRequired,
 		translate: PropTypes.func,
 		hasJetpack: PropTypes.bool,
-		site: PropTypes.object,
 	};
-
-	getSharingButtonsLink() {
-		if ( this.props.site ) {
-			return isJetpackCloud()
-				? 'https://jetpack.com/redirect/?source=calypso-marketing-sharing-buttons&site=' +
-						this.props.site.slug
-				: '/sharing/buttons/' + this.props.site.slug;
-		}
-		return localizeUrl( 'https://wordpress.com/support/sharing/' );
-	}
-
-	facebook() {
-		return this.props.translate(
-			'You can also add a {{pagePluginWidgetLink}}Page Plugin Widget{{/pagePluginWidgetLink}}, a {{shareButtonLink}}share button{{/shareButtonLink}}, or {{embedLink}}embed{{/embedLink}} your page or profile on your site.',
-			{
-				components: {
-					pagePluginWidgetLink: (
-						<a
-							href={ localizeUrl(
-								'https://wordpress.com/support/facebook-embeds/#facebook-page-plugin-widget'
-							) }
-						/>
-					),
-					shareButtonLink: <a href={ this.getSharingButtonsLink() } />,
-					embedLink: (
-						<a
-							href={ localizeUrl(
-								'https://wordpress.com/support/facebook-integration/facebook-embeds/'
-							) }
-						/>
-					),
-				},
-				context: 'Sharing: Tip in settings',
-			}
-		);
-	}
 
 	twitter() {
 		return this.props.translate(
@@ -130,6 +93,5 @@ class SharingServiceTip extends Component {
 }
 
 export default connect( ( state ) => ( {
-	site: getSelectedSite( state ),
 	hasJetpack: ! isJetpackCloud() || isJetpackSite( state, getSelectedSiteId( state ) ),
 } ) )( localize( SharingServiceTip ) );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-13446

## Proposed Changes

* Remove the Facebook sharing service tip as partly obsolete and partly inaccurate.

| Before | After |
|--------|--------|
| ![Screenshot 2025-06-06 at 14 48 08](https://github.com/user-attachments/assets/efc1d22e-f86d-43c7-b804-b8976aba70e3) | ![Screenshot 2025-06-06 at 14 54 52](https://github.com/user-attachments/assets/be7502e3-2bc2-45b7-8a2f-49aeb49f4f1e) | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Tools -> Marketing -> Connections (if Classic admin interface) or Hosting -> Marketing -> Connections (if Default admin interface).
* Expand the Facebook service.
* Ensure there is no "You can also add..." tip under the CTA.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
