### PR TITLE
DataViews: declare which operators are valid per field type

### DIFF
--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+- Update the field type definitions to declare the default and valid operators they support.
 - Add a story for each FieldTypeDefinition.
 
 ## 0.2.1

--- a/packages/dataviews/src/components/dataviews-filters/index.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/index.tsx
@@ -20,7 +20,6 @@ import Filter from './filter';
 import { default as AddFilter, AddFilterMenu } from './add-filter';
 import ResetFilters from './reset-filters';
 import DataViewsContext from '../dataviews-context';
-import { sanitizeOperators } from '../../utils';
 import { ALL_OPERATORS, SINGLE_SELECTION_OPERATORS } from '../../constants';
 import type { NormalizedFilter, NormalizedField, View } from '../../types';
 
@@ -35,7 +34,7 @@ export function useFilters( fields: NormalizedField< any >[], view: View ) {
 				return;
 			}
 
-			const operators = sanitizeOperators( field );
+			const operators = field.filterBy?.operators || [];
 			if ( operators.length === 0 ) {
 				return;
 			}

--- a/packages/dataviews/src/components/dataviews-filters/index.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/index.tsx
@@ -34,11 +34,7 @@ export function useFilters( fields: NormalizedField< any >[], view: View ) {
 				return;
 			}
 
-			const operators = field.filterBy?.operators || [];
-			if ( operators.length === 0 ) {
-				return;
-			}
-
+			const operators = field.filterBy.operators;
 			const isPrimary = !! field.filterBy?.isPrimary;
 			filters.push( {
 				field: field.id,

--- a/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
@@ -19,7 +19,6 @@ import { forwardRef, Children, Fragment } from '@wordpress/element';
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
-import { sanitizeOperators } from '../../utils';
 import { SORTING_DIRECTIONS, sortArrows, sortLabels } from '../../constants';
 import type {
 	NormalizedField,
@@ -81,7 +80,8 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 	isSortable = field.enableSorting !== false;
 	const header = field.header;
 
-	operators = sanitizeOperators( field );
+	operators = ( !! field.filterBy && field.filterBy?.operators ) || [];
+
 	// Filter can be added if:
 	//
 	// 1. The field is not already part of a view's filters.

--- a/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
@@ -86,13 +86,11 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 	//
 	// 1. The field is not already part of a view's filters.
 	// 2. The field has elements or Edit property.
-	// 3. The field has declared filter operators.
-	// 4. The field does not opt-out of filtering.
-	// 5. The filter is not primary (if it is, it is already visible).
+	// 3. The field does not opt-out of filtering.
+	// 4. The filter is not primary (if it is, it is already visible).
 	canAddFilter =
 		! view.filters?.some( ( _filter ) => fieldId === _filter.field ) &&
 		!! ( field.elements?.length || field.Edit ) &&
-		!! operators.length &&
 		field.filterBy !== false &&
 		! field.filterBy?.isPrimary;
 

--- a/packages/dataviews/src/field-types/boolean.tsx
+++ b/packages/dataviews/src/field-types/boolean.tsx
@@ -41,8 +41,6 @@ function isValid( value: any, context?: ValidationContext ) {
 	return true;
 }
 
-const operators: Operator[] = [ OPERATOR_IS, OPERATOR_IS_NOT ];
-
 export default {
 	sort,
 	isValid,
@@ -64,6 +62,7 @@ export default {
 	},
 	enableSorting: true,
 	filterBy: {
-		operators,
+		defaultOperators: [ OPERATOR_IS, OPERATOR_IS_NOT ],
+		validOperators: [ OPERATOR_IS, OPERATOR_IS_NOT ],
 	},
 } satisfies FieldTypeDefinition< any >;

--- a/packages/dataviews/src/field-types/datetime.tsx
+++ b/packages/dataviews/src/field-types/datetime.tsx
@@ -29,8 +29,6 @@ function isValid( value: any, context?: ValidationContext ) {
 	return true;
 }
 
-const operators: Operator[] = [ OPERATOR_IS, OPERATOR_IS_NOT ];
-
 export default {
 	sort,
 	isValid,
@@ -42,6 +40,7 @@ export default {
 	},
 	enableSorting: true,
 	filterBy: {
-		operators,
+		defaultOperators: [ OPERATOR_IS, OPERATOR_IS_NOT ],
+		validOperators: [ OPERATOR_IS, OPERATOR_IS_NOT ],
 	},
 } satisfies FieldTypeDefinition< any >;

--- a/packages/dataviews/src/field-types/email.tsx
+++ b/packages/dataviews/src/field-types/email.tsx
@@ -14,7 +14,17 @@ import type {
 	FieldTypeDefinition,
 } from '../types';
 import { renderFromElements } from '../utils';
-import { OPERATOR_IS_ANY, OPERATOR_IS_NONE } from '../constants';
+import {
+	OPERATOR_IS,
+	OPERATOR_IS_ALL,
+	OPERATOR_IS_NOT_ALL,
+	OPERATOR_IS_ANY,
+	OPERATOR_IS_NONE,
+	OPERATOR_IS_NOT,
+	OPERATOR_CONTAINS,
+	OPERATOR_NOT_CONTAINS,
+	OPERATOR_STARTS_WITH,
+} from '../constants';
 
 function sort( valueA: any, valueB: any, direction: SortDirection ) {
 	return direction === 'asc'
@@ -42,8 +52,6 @@ function isValid( value: any, context?: ValidationContext ) {
 	return true;
 }
 
-const operators: Operator[] = [ OPERATOR_IS_ANY, OPERATOR_IS_NONE ];
-
 export default {
 	sort,
 	isValid,
@@ -55,6 +63,18 @@ export default {
 	},
 	enableSorting: true,
 	filterBy: {
-		operators,
+		defaultOperators: [ OPERATOR_IS_ANY, OPERATOR_IS_NONE ],
+		validOperators: [
+			OPERATOR_IS,
+			OPERATOR_IS_NOT,
+			OPERATOR_CONTAINS,
+			OPERATOR_NOT_CONTAINS,
+			OPERATOR_STARTS_WITH,
+			// Multiple selection
+			OPERATOR_IS_ANY,
+			OPERATOR_IS_NONE,
+			OPERATOR_IS_ALL,
+			OPERATOR_IS_NOT_ALL,
+		],
 	},
 } satisfies FieldTypeDefinition< any >;

--- a/packages/dataviews/src/field-types/integer.tsx
+++ b/packages/dataviews/src/field-types/integer.tsx
@@ -16,6 +16,10 @@ import {
 	OPERATOR_GREATER_THAN,
 	OPERATOR_LESS_THAN_OR_EQUAL,
 	OPERATOR_GREATER_THAN_OR_EQUAL,
+	OPERATOR_IS_ANY,
+	OPERATOR_IS_NONE,
+	OPERATOR_IS_ALL,
+	OPERATOR_IS_NOT_ALL,
 } from '../constants';
 
 function sort( a: any, b: any, direction: SortDirection ) {
@@ -42,15 +46,6 @@ function isValid( value: any, context?: ValidationContext ) {
 	return true;
 }
 
-const operators: Operator[] = [
-	OPERATOR_IS,
-	OPERATOR_IS_NOT,
-	OPERATOR_LESS_THAN,
-	OPERATOR_GREATER_THAN,
-	OPERATOR_LESS_THAN_OR_EQUAL,
-	OPERATOR_GREATER_THAN_OR_EQUAL,
-];
-
 export default {
 	sort,
 	isValid,
@@ -62,6 +57,27 @@ export default {
 	},
 	enableSorting: true,
 	filterBy: {
-		operators,
+		defaultOperators: [
+			OPERATOR_IS,
+			OPERATOR_IS_NOT,
+			OPERATOR_LESS_THAN,
+			OPERATOR_GREATER_THAN,
+			OPERATOR_LESS_THAN_OR_EQUAL,
+			OPERATOR_GREATER_THAN_OR_EQUAL,
+		],
+		validOperators: [
+			// Single-selection
+			OPERATOR_IS,
+			OPERATOR_IS_NOT,
+			OPERATOR_LESS_THAN,
+			OPERATOR_GREATER_THAN,
+			OPERATOR_LESS_THAN_OR_EQUAL,
+			OPERATOR_GREATER_THAN_OR_EQUAL,
+			// Multiple-selection
+			OPERATOR_IS_ANY,
+			OPERATOR_IS_NONE,
+			OPERATOR_IS_ALL,
+			OPERATOR_IS_NOT_ALL,
+		],
 	},
 } satisfies FieldTypeDefinition< any >;

--- a/packages/dataviews/src/field-types/text.tsx
+++ b/packages/dataviews/src/field-types/text.tsx
@@ -9,7 +9,17 @@ import type {
 	FieldTypeDefinition,
 } from '../types';
 import { renderFromElements } from '../utils';
-import { OPERATOR_IS_ANY, OPERATOR_IS_NONE } from '../constants';
+import {
+	OPERATOR_CONTAINS,
+	OPERATOR_IS,
+	OPERATOR_IS_ALL,
+	OPERATOR_IS_ANY,
+	OPERATOR_IS_NONE,
+	OPERATOR_IS_NOT,
+	OPERATOR_IS_NOT_ALL,
+	OPERATOR_NOT_CONTAINS,
+	OPERATOR_STARTS_WITH,
+} from '../constants';
 
 function sort( valueA: any, valueB: any, direction: SortDirection ) {
 	return direction === 'asc'
@@ -28,8 +38,6 @@ function isValid( value: any, context?: ValidationContext ) {
 	return true;
 }
 
-const operators: Operator[] = [ OPERATOR_IS_ANY, OPERATOR_IS_NONE ];
-
 export default {
 	sort,
 	isValid,
@@ -41,6 +49,19 @@ export default {
 	},
 	enableSorting: true,
 	filterBy: {
-		operators,
+		defaultOperators: [ OPERATOR_IS_ANY, OPERATOR_IS_NONE ],
+		validOperators: [
+			// Single selection
+			OPERATOR_IS,
+			OPERATOR_IS_NOT,
+			OPERATOR_CONTAINS,
+			OPERATOR_NOT_CONTAINS,
+			OPERATOR_STARTS_WITH,
+			// Multiple selection
+			OPERATOR_IS_ANY,
+			OPERATOR_IS_NONE,
+			OPERATOR_IS_ALL,
+			OPERATOR_IS_NOT_ALL,
+		],
 	},
 } satisfies FieldTypeDefinition< any >;

--- a/packages/dataviews/src/normalize-fields.ts
+++ b/packages/dataviews/src/normalize-fields.ts
@@ -11,7 +11,7 @@ import type {
 	DataViewRenderFieldProps,
 	Field,
 	FieldTypeDefinition,
-	FilterByConfig,
+	NormalizedFilterByConfig,
 	NormalizedField,
 } from './types';
 import { getControl } from './dataform-controls';
@@ -41,7 +41,7 @@ const getValueFromId =
 function getFilterBy< Item >(
 	field: Field< Item >,
 	fieldTypeDefinition: FieldTypeDefinition< Item >
-): FilterByConfig | false {
+): NormalizedFilterByConfig | false {
 	if ( field.filterBy === false ) {
 		return false;
 	}
@@ -72,6 +72,12 @@ function getFilterBy< Item >(
 			operators = operators.filter( ( operator ) =>
 				SINGLE_SELECTION_OPERATORS.includes( operator )
 			);
+		}
+
+		// If no operators are left at this point,
+		// the filters should be disabled.
+		if ( operators.length === 0 ) {
+			return false;
 		}
 
 		return {

--- a/packages/dataviews/src/normalize-fields.ts
+++ b/packages/dataviews/src/normalize-fields.ts
@@ -7,8 +7,20 @@ import type { FunctionComponent } from 'react';
  * Internal dependencies
  */
 import getFieldTypeDefinition from './field-types';
-import type { DataViewRenderFieldProps, Field, NormalizedField } from './types';
+import type {
+	DataViewRenderFieldProps,
+	Field,
+	FieldTypeDefinition,
+	FilterByConfig,
+	NormalizedField,
+} from './types';
 import { getControl } from './dataform-controls';
+import {
+	ALL_OPERATORS,
+	OPERATOR_IS_ANY,
+	OPERATOR_IS_NONE,
+	SINGLE_SELECTION_OPERATORS,
+} from './constants';
 
 const getValueFromId =
 	( id: string ) =>
@@ -25,6 +37,57 @@ const getValueFromId =
 
 		return value;
 	};
+
+function getFilterBy< Item >(
+	field: Field< Item >,
+	fieldTypeDefinition: FieldTypeDefinition< Item >
+): FilterByConfig | false {
+	if ( field.filterBy === false ) {
+		return false;
+	}
+
+	if ( typeof field.filterBy === 'object' ) {
+		let operators = field.filterBy.operators;
+
+		// Assign default values if no operator was provided.
+		if ( ! operators || ! Array.isArray( operators ) ) {
+			operators = [ OPERATOR_IS_ANY, OPERATOR_IS_NONE ];
+		}
+
+		// Make sure only valid operators are included.
+		let validOperators = ALL_OPERATORS;
+		if ( typeof fieldTypeDefinition.filterBy === 'object' ) {
+			validOperators = fieldTypeDefinition.filterBy.validOperators;
+		}
+		operators = operators.filter( ( operator ) =>
+			validOperators.includes( operator )
+		);
+
+		// Do not allow mixing single & multiselection operators.
+		// Remove multiselection operators if any of the single selection ones is present.
+		const hasSingleSelectionOperator = operators.some( ( operator ) =>
+			SINGLE_SELECTION_OPERATORS.includes( operator )
+		);
+		if ( hasSingleSelectionOperator ) {
+			operators = operators.filter( ( operator ) =>
+				SINGLE_SELECTION_OPERATORS.includes( operator )
+			);
+		}
+
+		return {
+			isPrimary: !! field.filterBy.isPrimary,
+			operators,
+		};
+	}
+
+	if ( fieldTypeDefinition.filterBy === false ) {
+		return false;
+	}
+
+	return {
+		operators: fieldTypeDefinition.filterBy.defaultOperators,
+	};
+}
 
 /**
  * Apply default values and normalize the fields config.
@@ -75,6 +138,8 @@ export function normalizeFields< Item >(
 				 )( { item, field } );
 			};
 
+		const filterBy = getFilterBy( field, fieldTypeDefinition );
+
 		return {
 			...field,
 			label: field.label || field.id,
@@ -89,7 +154,7 @@ export function normalizeFields< Item >(
 				field.enableSorting ??
 				fieldTypeDefinition.enableSorting ??
 				true,
-			filterBy: field.filterBy ?? fieldTypeDefinition.filterBy,
+			filterBy,
 		};
 	} );
 }

--- a/packages/dataviews/src/test/normalize-fields.ts
+++ b/packages/dataviews/src/test/normalize-fields.ts
@@ -42,4 +42,116 @@ describe( 'normalizeFields: default getValue', () => {
 			expect( result ).toBe( 'value' );
 		} );
 	} );
+	describe( 'filterBy', () => {
+		it( 'returns the default field type definition if undefined for untyped field', () => {
+			const fields: Field< {} >[] = [
+				{
+					id: 'user',
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			const result = normalizedFields[ 0 ].filterBy;
+			expect( result ).toBe( false );
+		} );
+
+		it( 'returns the field type definition for typed fields', () => {
+			const fields: Field< {} >[] = [
+				{
+					id: 'user',
+					type: 'integer',
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			const result = normalizedFields[ 0 ].filterBy;
+			expect( result ).toStrictEqual( {
+				operators: [
+					'is',
+					'isNot',
+					'lessThan',
+					'greaterThan',
+					'lessThanOrEqual',
+					'greaterThanOrEqual',
+				],
+			} );
+		} );
+
+		it( 'returns false if is false', () => {
+			const fields: Field< {} >[] = [
+				{
+					id: 'user',
+					filterBy: false,
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			const result = normalizedFields[ 0 ].filterBy;
+			expect( result ).toBe( false );
+		} );
+
+		it( 'returns the config if it provides one', () => {
+			const fields: Field< {} >[] = [
+				{
+					id: 'user',
+					filterBy: {
+						isPrimary: true,
+						operators: [ 'is', 'isNot' ],
+					},
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			const result = normalizedFields[ 0 ].filterBy;
+			expect( result ).toStrictEqual( {
+				isPrimary: true,
+				operators: [ 'is', 'isNot' ],
+			} );
+		} );
+
+		it( 'returns false if the none of the operators are valid for the type', () => {
+			const fields: Field< {} >[] = [
+				{
+					id: 'user',
+					filterBy: {
+						// @ts-ignore
+						operators: [ 'invalid', 'operator' ],
+					},
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			const result = normalizedFields[ 0 ].filterBy;
+			expect( result ).toBe( false );
+		} );
+
+		it( 'returns false if the list of operators is empty', () => {
+			const fields: Field< {} >[] = [
+				{
+					id: 'user',
+					filterBy: {
+						operators: [],
+					},
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			const result = normalizedFields[ 0 ].filterBy;
+			expect( result ).toBe( false );
+		} );
+
+		it( 'removes invalid operators for the type', () => {
+			const fields: Field< {} >[] = [
+				{
+					id: 'user',
+					type: 'integer',
+					filterBy: {
+						isPrimary: true,
+						// @ts-ignore
+						operators: [ 'invalid', 'lessThan' ],
+					},
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			const result = normalizedFields[ 0 ].filterBy;
+			expect( result ).toStrictEqual( {
+				isPrimary: true,
+				operators: [ 'lessThan' ],
+			} );
+		} );
+	} );
 } );

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -24,7 +24,7 @@ export interface Option< Value extends any = any > {
 	description?: string;
 }
 
-interface FilterByConfig {
+export interface FilterByConfig {
 	/**
 	 * The list of operators supported by the field.
 	 */
@@ -37,6 +37,18 @@ interface FilterByConfig {
 	 * except for the list layout where it behaves like a secondary filter.
 	 */
 	isPrimary?: boolean;
+}
+
+interface FilterConfigForType {
+	/**
+	 * What operators are used by default.
+	 */
+	defaultOperators: Operator[];
+
+	/**
+	 * What operators are supported by the field.
+	 */
+	validOperators: Operator[];
 }
 
 export type Operator =
@@ -93,7 +105,7 @@ export type FieldTypeDefinition< Item > = {
 	/**
 	 * The filter config for the field.
 	 */
-	filterBy: FilterByConfig | false;
+	filterBy: FilterConfigForType | false;
 
 	/**
 	 * Whether the field is sortable.

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -39,6 +39,21 @@ export interface FilterByConfig {
 	isPrimary?: boolean;
 }
 
+export interface NormalizedFilterByConfig {
+	/**
+	 * The list of operators supported by the field.
+	 */
+	operators: Operator[];
+
+	/**
+	 * Whether it is a primary filter.
+	 *
+	 * A primary filter is always visible and is not listed in the "Add filter" component,
+	 * except for the list layout where it behaves like a secondary filter.
+	 */
+	isPrimary?: boolean;
+}
+
 interface FilterConfigForType {
 	/**
 	 * What operators are used by default.
@@ -215,7 +230,7 @@ export type NormalizedField< Item > = Omit< Field< Item >, 'Edit' > & {
 	isValid: ( item: Item, context?: ValidationContext ) => boolean;
 	enableHiding: boolean;
 	enableSorting: boolean;
-	filterBy: FilterByConfig | false;
+	filterBy: NormalizedFilterByConfig | false;
 };
 
 /**

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -215,6 +215,7 @@ export type NormalizedField< Item > = Omit< Field< Item >, 'Edit' > & {
 	isValid: ( item: Item, context?: ValidationContext ) => boolean;
 	enableHiding: boolean;
 	enableSorting: boolean;
+	filterBy: FilterByConfig | false;
 };
 
 /**

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -184,7 +184,7 @@ export type Field< Item > = {
 	/**
 	 * Filter config for the field.
 	 */
-	filterBy?: FilterByConfig | undefined | false;
+	filterBy?: FilterByConfig | false;
 
 	/**
 	 * Callback used to retrieve the value of the field from the item.

--- a/packages/dataviews/src/utils.ts
+++ b/packages/dataviews/src/utils.ts
@@ -1,41 +1,7 @@
 /**
  * Internal dependencies
  */
-import {
-	ALL_OPERATORS,
-	OPERATOR_IS_ANY,
-	OPERATOR_IS_NONE,
-	SINGLE_SELECTION_OPERATORS,
-} from './constants';
-import type { DataViewRenderFieldProps, NormalizedField } from './types';
-
-export function sanitizeOperators< Item >( field: NormalizedField< Item > ) {
-	let operators =
-		typeof field.filterBy === 'object' && field.filterBy?.operators;
-
-	// Assign default values.
-	if ( ! operators || ! Array.isArray( operators ) ) {
-		operators = [ OPERATOR_IS_ANY, OPERATOR_IS_NONE ];
-	}
-
-	// Make sure only valid operators are used.
-	operators = operators.filter( ( operator ) =>
-		ALL_OPERATORS.includes( operator )
-	);
-
-	// Do not allow mixing single & multiselection operators.
-	// Remove multiselection operators if any of the single selection ones is present.
-	const hasSingleSelectionOperator = operators.some( ( operator ) =>
-		SINGLE_SELECTION_OPERATORS.includes( operator )
-	);
-	if ( hasSingleSelectionOperator ) {
-		operators = operators.filter( ( operator ) =>
-			SINGLE_SELECTION_OPERATORS.includes( operator )
-		);
-	}
-
-	return operators;
-}
+import type { DataViewRenderFieldProps } from './types';
 
 export function renderFromElements< Item >( {
 	item,


### PR DESCRIPTION
## What?

This PR makes `FieldTypeDefinitions` declare the default operators that are enabled for a given type, and also the valid operators that can be used in the type.

## Why?

We've introduced a lot of operators lately (contains, starts with, less than, etc.) but don't have any mechanism in place to validate that they make sense per field type. For example, what does it mean for a boolean field type to have an operator "less than"?

## How?

- Update the field type definitions so they declare the default and the valid operators they support:

```js
type FieldTypeDefinition<Item> = {
  filterBy: {
    defaultOperators: Operator[],
    validOperators: Operator[],
  }
}
```

- Remove `sanitizeOperator` function. This normalization is now done earlier in the lifecycle of the field, as part of  `normalizeField`.

## Testing Instructions

- Start the DataViews storybook: `yarn workspace @automattic/dataviews storybook:start`
- Try adding an operator to a boolean field that is not valid.
- The expected result is that you can't.
