### PR TITLE
Remove onboarding/step-container-v2-migration-flow feature flag and conditional code

### DIFF
--- a/client/landing/stepper/declarative-flow/helpers/should-use-step-container-v2.ts
+++ b/client/landing/stepper/declarative-flow/helpers/should-use-step-container-v2.ts
@@ -18,10 +18,3 @@ const FLOWS_USING_STEP_CONTAINER_V2 = [
 export const shouldUseStepContainerV2 = ( flow: string ) => {
 	return FLOWS_USING_STEP_CONTAINER_V2.includes( flow );
 };
-
-export const shouldUseStepContainerV2MigrationFlow = ( flow: string ) => {
-	return (
-		configApi.isEnabled( 'onboarding/step-container-v2-migration-flow' ) &&
-		FLOWS_USING_STEP_CONTAINER_V2.includes( flow )
-	);
-};

--- a/client/landing/stepper/declarative-flow/helpers/should-use-step-container-v2.ts
+++ b/client/landing/stepper/declarative-flow/helpers/should-use-step-container-v2.ts
@@ -1,4 +1,3 @@
-import configApi from '@automattic/calypso-config';
 import {
 	SITE_SETUP_FLOW,
 	ONBOARDING_FLOW,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
@@ -1,11 +1,8 @@
-import { Step, StepContainer } from '@automattic/onboarding';
+import { Step } from '@automattic/onboarding';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
-import { shouldUseStepContainerV2MigrationFlow } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { useSiteDomains } from '../../../../hooks/use-site-domains';
 import { useSiteSetupError } from '../../../../hooks/use-site-setup-error';
@@ -21,7 +18,6 @@ const ErrorStep: StepType = function ErrorStep( { flow, variantSlug } ) {
 	const { __ } = useI18n();
 	const siteDomains = useSiteDomains();
 	const { error, message } = useSiteSetupError();
-	const isUsingStepContainerV2 = shouldUseStepContainerV2MigrationFlow( flow );
 
 	let domain = '';
 
@@ -63,35 +59,18 @@ const ErrorStep: StepType = function ErrorStep( { flow, variantSlug } ) {
 		'It looks like something went wrong while setting up your site. Please contact support so that we can help you out.'
 	);
 
-	if ( isUsingStepContainerV2 ) {
-		return (
-			<>
-				<DocumentHead title={ headerText } />
-				<Step.CenteredColumnLayout
-					columnWidth={ 8 }
-					topBar={ <Step.TopBar /> }
-					heading={ <Step.Heading text={ headerText } /> }
-				>
-					{ subHeaderText }
-					{ getContent() }
-				</Step.CenteredColumnLayout>
-			</>
-		);
-	}
-
 	return (
-		<StepContainer
-			stepName="error-step"
-			isHorizontalLayout={ false }
-			formattedHeader={
-				<>
-					<FormattedHeader id="step-error-header" headerText={ headerText } align="left" />
-					<p>{ subHeaderText }</p>
-				</>
-			}
-			stepContent={ getContent() }
-			recordTracksEvent={ recordTracksEvent }
-		/>
+		<>
+			<DocumentHead title={ headerText } />
+			<Step.CenteredColumnLayout
+				columnWidth={ 8 }
+				topBar={ <Step.TopBar /> }
+				heading={ <Step.Heading text={ headerText } /> }
+			>
+				{ subHeaderText }
+				{ getContent() }
+			</Step.CenteredColumnLayout>
+		</>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/index.tsx
@@ -1,10 +1,7 @@
-import { Step, StepContainer } from '@automattic/onboarding';
+import { Step } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { useSearchParams } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
-import { shouldUseStepContainerV2MigrationFlow } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import Form from './components/form';
 import type { Step as StepType } from '../../types';
 import './style.scss';
@@ -18,7 +15,7 @@ const extractDomainFromUrl = ( url: string ) => {
 	}
 };
 
-const SiteMigrationAlreadyWPCOM: StepType = ( { stepName, flow, navigation } ) => {
+const SiteMigrationAlreadyWPCOM: StepType = ( { navigation } ) => {
 	const translate = useTranslate();
 	const [ query ] = useSearchParams();
 	const from = query.get( 'from' )!;
@@ -45,42 +42,16 @@ const SiteMigrationAlreadyWPCOM: StepType = ( { stepName, flow, navigation } ) =
 		navigation?.submit?.();
 	};
 
-	if ( shouldUseStepContainerV2MigrationFlow( flow ) ) {
-		return (
-			<>
-				<DocumentHead title={ translate( 'Your site is already on WordPress.com' ) } />
-				<Step.CenteredColumnLayout
-					columnWidth={ 8 }
-					topBar={
-						<Step.TopBar leftElement={ <Step.BackButton onClick={ navigation.goBack } /> } />
-					}
-					heading={ <Step.Heading text={ title } subText={ subHeaderText } /> }
-				>
-					<Form onComplete={ onSubmit } />
-				</Step.CenteredColumnLayout>
-			</>
-		);
-	}
-
 	return (
 		<>
 			<DocumentHead title={ translate( 'Your site is already on WordPress.com' ) } />
-			<StepContainer
-				stepName={ stepName }
-				flowName={ flow }
-				goBack={ navigation?.goBack }
-				formattedHeader={
-					<FormattedHeader
-						subHeaderAs="div"
-						headerText={ title }
-						subHeaderText={ subHeaderText }
-						align="center"
-					/>
-				}
-				isFullLayout
-				stepContent={ <Form onComplete={ onSubmit } /> }
-				recordTracksEvent={ recordTracksEvent }
-			/>
+			<Step.CenteredColumnLayout
+				columnWidth={ 8 }
+				topBar={ <Step.TopBar leftElement={ <Step.BackButton onClick={ navigation.goBack } /> } /> }
+				heading={ <Step.Heading text={ title } subText={ subHeaderText } /> }
+			>
+				<Form onComplete={ onSubmit } />
+			</Step.CenteredColumnLayout>
 		</>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
@@ -1,16 +1,12 @@
-import { Step, StepContainer } from '@automattic/onboarding';
+import { Step } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
-import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
-import { shouldUseStepContainerV2MigrationFlow } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteIdParam } from 'calypso/landing/stepper/hooks/use-site-id-param';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useDispatch } from 'calypso/state';
 import { resetSite } from 'calypso/state/sites/actions';
 import Authorization from './components/authorization';
@@ -23,7 +19,7 @@ const SiteMigrationApplicationPasswordsAuthorization: StepType< {
 		action: 'migration-started' | 'fallback-credentials' | 'authorization' | 'contact-me';
 		authorizationUrl?: string;
 	};
-} > = function ( { navigation, flow } ) {
+} > = function ( { navigation } ) {
 	const translate = useTranslate();
 	const siteSlug = useSiteSlugParam();
 	const siteId = parseInt( useSiteIdParam() ?? '' );
@@ -44,8 +40,6 @@ const SiteMigrationApplicationPasswordsAuthorization: StepType< {
 	const isLoading =
 		isAuthorizationSuccessful &&
 		( isStoreApplicationPasswordSuccess || isStoreApplicationPasswordPending );
-
-	const isUsingStepContainerV2 = shouldUseStepContainerV2MigrationFlow( flow );
 
 	useEffect( () => {
 		if ( ! isAuthorizationSuccessful || ! siteSlug ) {
@@ -117,15 +111,6 @@ const SiteMigrationApplicationPasswordsAuthorization: StepType< {
 		}
 	);
 
-	const formattedHeader = ! isLoading ? (
-		<FormattedHeader
-			id="site-migration-credentials-header"
-			headerText={ translate( 'Get ready for blazing fast speeds' ) }
-			subHeaderText={ subHeaderText }
-			align="center"
-		/>
-	) : undefined;
-
 	const stepContent = (
 		<Authorization
 			onAuthorizationClick={ startAuthorization }
@@ -133,51 +118,22 @@ const SiteMigrationApplicationPasswordsAuthorization: StepType< {
 		/>
 	);
 
-	if ( isUsingStepContainerV2 ) {
-		if ( isLoading ) {
-			return <Step.Loading title={ title } delay={ 500 } />;
-		}
-		return (
-			<>
-				<DocumentHead title={ title } />
-				<Step.CenteredColumnLayout
-					columnWidth={ 5 }
-					topBar={
-						<Step.TopBar leftElement={ <Step.BackButton onClick={ navigation.goBack } /> } />
-					}
-					heading={ <Step.Heading text={ title } subText={ subHeaderText } /> }
-					className="site-migration-application-password-authorization-v2"
-				>
-					{ notice }
-					{ stepContent }
-				</Step.CenteredColumnLayout>
-			</>
-		);
+	if ( isLoading ) {
+		return <Step.Loading title={ title } delay={ 500 } />;
 	}
 
 	return (
 		<>
 			<DocumentHead title={ title } />
-			<StepContainer
-				stepName="site-migration-application-password-authorization"
-				flowName="site-migration"
-				goBack={ navigation?.goBack }
-				notice={ notice }
-				formattedHeader={ formattedHeader }
-				stepContent={
-					! isLoading ? (
-						<Authorization
-							onAuthorizationClick={ startAuthorization }
-							onShareCredentialsClick={ navigateToFallbackCredentials }
-						/>
-					) : (
-						<div data-testid="loading-ellipsis">
-							<LoadingEllipsis />
-						</div>
-					)
-				}
-				recordTracksEvent={ recordTracksEvent }
-			/>
+			<Step.CenteredColumnLayout
+				columnWidth={ 5 }
+				topBar={ <Step.TopBar leftElement={ <Step.BackButton onClick={ navigation.goBack } /> } /> }
+				heading={ <Step.Heading text={ title } subText={ subHeaderText } /> }
+				className="site-migration-application-password-authorization-v2"
+			>
+				{ notice }
+				{ stepContent }
+			</Step.CenteredColumnLayout>
 		</>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -1,13 +1,11 @@
 import { useLocale } from '@automattic/i18n-utils';
-import { Step, StepContainer } from '@automattic/onboarding';
+import { Step } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { UrlData } from 'calypso/blocks/import/types';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
 import { MigrationStatus } from 'calypso/data/site-migration/landing/types';
 import { useUpdateMigrationStatus } from 'calypso/data/site-migration/landing/use-update-migration-status';
-import { shouldUseStepContainerV2MigrationFlow } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteIdParam } from 'calypso/landing/stepper/hooks/use-site-id-param';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
@@ -60,7 +58,7 @@ const SiteMigrationCredentials: StepType< {
 		authorizationUrl?: string;
 		hasError?: 'ticket-creation';
 	};
-} > = function ( { navigation, flow } ) {
+} > = function ( { navigation } ) {
 	const translate = useTranslate();
 	const siteId = parseInt( useSiteIdParam() ?? '' );
 	const dispatch = useDispatch();
@@ -137,8 +135,6 @@ const SiteMigrationCredentials: StepType< {
 		}
 	}, [ siteId, updateMigrationStatus ] );
 
-	const isUsingStepContainerV2 = shouldUseStepContainerV2MigrationFlow( flow );
-
 	const title = translate( 'Tell us about your WordPress site' );
 	const subHeaderText = translate(
 		'Help us get started by providing some basic details about your current website.'
@@ -146,46 +142,22 @@ const SiteMigrationCredentials: StepType< {
 	const mainForm = <CredentialsForm onSubmit={ handleSubmit } />;
 	const skipButton = <NeedHelpLink onHelpLinkClicked={ handleSkip } />;
 
-	if ( isUsingStepContainerV2 ) {
-		return (
-			<>
-				<DocumentHead title={ title } />
-				<Step.CenteredColumnLayout
-					columnWidth={ 5 }
-					topBar={
-						<Step.TopBar
-							leftElement={ <Step.BackButton onClick={ navigation.goBack } /> }
-							rightElement={ skipButton }
-						/>
-					}
-					heading={ <Step.Heading text={ title } subText={ subHeaderText } /> }
-					className="site-migration-credentials-v2"
-				>
-					{ mainForm }
-				</Step.CenteredColumnLayout>
-			</>
-		);
-	}
 	return (
 		<>
-			<DocumentHead title={ translate( 'Tell us about your WordPress site' ) } />
-			<StepContainer
-				stepName="site-migration-credentials"
-				flowName="site-migration"
-				goBack={ navigation?.goBack }
-				isFullLayout
-				formattedHeader={
-					<FormattedHeader
-						id="site-migration-credentials-header"
-						headerText={ title }
-						subHeaderText={ subHeaderText }
-						align="center"
+			<DocumentHead title={ title } />
+			<Step.CenteredColumnLayout
+				columnWidth={ 5 }
+				topBar={
+					<Step.TopBar
+						leftElement={ <Step.BackButton onClick={ navigation.goBack } /> }
+						rightElement={ skipButton }
 					/>
 				}
-				stepContent={ mainForm }
-				recordTracksEvent={ recordTracksEvent }
-				customizedActionButtons={ skipButton }
-			/>
+				heading={ <Step.Heading text={ title } subText={ subHeaderText } /> }
+				className="site-migration-credentials-v2"
+			>
+				{ mainForm }
+			</Step.CenteredColumnLayout>
 		</>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-fallback-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-fallback-credentials/index.tsx
@@ -1,10 +1,7 @@
-import { Step, StepContainer } from '@automattic/onboarding';
+import { Step } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
-import { shouldUseStepContainerV2MigrationFlow } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { CredentialsForm } from './components/credentials-form';
 import type { Step as StepType } from '../../types';
 import './style.scss';
@@ -16,10 +13,9 @@ const SiteMigrationFallbackCredentials: StepType< {
 				from?: string;
 		  }
 		| undefined;
-} > = function ( { navigation, flow } ) {
+} > = function ( { navigation } ) {
 	const translate = useTranslate();
 	const siteURL = useQuery().get( 'from' ) || '';
-	const isUsingStepContainerV2 = shouldUseStepContainerV2MigrationFlow( flow );
 
 	// Removes "https://" or "http://" from URL
 	const cleanUrl = siteURL.replace( /^(https?:\/\/)?(.*?)(\/)?$/, '$2' );
@@ -43,42 +39,16 @@ const SiteMigrationFallbackCredentials: StepType< {
 	);
 	const content = <CredentialsForm onSubmit={ handleSubmit } onSkip={ handleSkip } />;
 
-	if ( isUsingStepContainerV2 ) {
-		return (
-			<>
-				<DocumentHead title={ title } />
-				<Step.CenteredColumnLayout
-					columnWidth={ 5 }
-					topBar={
-						<Step.TopBar leftElement={ <Step.BackButton onClick={ navigation.goBack } /> } />
-					}
-					heading={ <Step.Heading text={ headerText } subText={ subHeaderText } /> }
-				>
-					{ content }
-				</Step.CenteredColumnLayout>
-			</>
-		);
-	}
-
 	return (
 		<>
 			<DocumentHead title={ title } />
-			<StepContainer
-				stepName="site-migration-fallback-credentials"
-				flowName="site-migration"
-				goBack={ navigation?.goBack }
-				isFullLayout
-				formattedHeader={
-					<FormattedHeader
-						id="site-migration-credentials-header"
-						headerText={ headerText }
-						subHeaderText={ subHeaderText }
-						align="center"
-					/>
-				}
-				stepContent={ content }
-				recordTracksEvent={ recordTracksEvent }
-			/>
+			<Step.CenteredColumnLayout
+				columnWidth={ 5 }
+				topBar={ <Step.TopBar leftElement={ <Step.BackButton onClick={ navigation.goBack } /> } /> }
+				heading={ <Step.Heading text={ headerText } subText={ subHeaderText } /> }
+			>
+				{ content }
+			</Step.CenteredColumnLayout>
 		</>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -1,17 +1,13 @@
 import { PLAN_BUSINESS, getPlan, isWpComBusinessPlan } from '@automattic/calypso-products';
-import { NextButton, Step, StepContainer } from '@automattic/onboarding';
+import { NextButton, Step } from '@automattic/onboarding';
 import { Icon, copy, globe, lockOutline, scheduled } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
 import { useMigrationCancellation } from 'calypso/data/site-migration/landing/use-migration-cancellation';
 import { HOW_TO_MIGRATE_OPTIONS } from 'calypso/landing/stepper/constants';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { usePresalesChat } from 'calypso/lib/presales-chat';
-import { shouldUseStepContainerV2MigrationFlow } from '../../../helpers/should-use-step-container-v2';
-import { DIYOption } from './diy-option';
 import type { Step as StepType } from '../../types';
 import './style.scss';
 
@@ -25,11 +21,10 @@ const SiteMigrationHowToMigrate: StepType< {
 		destination: string;
 	};
 } > = ( props ) => {
-	const { navigation, headerText, stepName, subHeaderText, flow } = props;
+	const { navigation, headerText, subHeaderText } = props;
 	const translate = useTranslate();
 	const site = useSite();
 	const { mutate: cancelMigration } = useMigrationCancellation( site?.ID );
-	const isUsingStepContainerV2 = shouldUseStepContainerV2MigrationFlow( flow );
 
 	usePresalesChat( 'wpcom' );
 
@@ -93,7 +88,7 @@ const SiteMigrationHowToMigrate: StepType< {
 		return isBusinessPlan
 			? // translators: %(planName)s is the name of the Business plan.
 			  translate(
-					'Save yourself the headache of migrating. Our expert team takes care of everything without interrupting your current site. Plus it’s included in your %(planName)s plan.',
+					"Save yourself the headache of migrating. Our expert team takes care of everything without interrupting your current site. Plus it's included in your %(planName)s plan.",
 					{
 						args: {
 							planName,
@@ -138,59 +133,31 @@ const SiteMigrationHowToMigrate: StepType< {
 		);
 	};
 
-	if ( isUsingStepContainerV2 ) {
-		return (
-			<>
-				<DocumentHead title={ translate( 'Let us migrate your site' ) } />
-				<Step.CenteredColumnLayout
-					className="how-to-migrate-v2"
-					columnWidth={ 6 }
-					topBar={
-						<Step.TopBar
-							leftElement={ <Step.BackButton onClick={ goBack } /> }
-							rightElement={
-								<Step.SkipButton
-									onClick={ () => handleClick( HOW_TO_MIGRATE_OPTIONS.DO_IT_MYSELF ) }
-								>
-									{ translate( "I'll do it myself" ) }
-								</Step.SkipButton>
-							}
-						/>
-					}
-					heading={
-						<Step.Heading
-							text={ headerText ?? translate( 'Let us migrate your site' ) }
-							subText={ subHeaderText || renderSubHeaderText() }
-						/>
-					}
-				>
-					{ renderStepContent() }
-				</Step.CenteredColumnLayout>
-			</>
-		);
-	}
-
 	return (
 		<>
 			<DocumentHead title={ translate( 'Let us migrate your site' ) } />
-			<StepContainer
-				stepName={ stepName ?? 'site-migration-how-to-migrate' }
-				className="how-to-migrate"
-				shouldHideNavButtons={ false }
-				hideSkip
-				formattedHeader={
-					<FormattedHeader
-						id="how-to-migrate-header"
-						headerText={ headerText ?? translate( 'Let us migrate your site' ) }
-						subHeaderText={ subHeaderText || renderSubHeaderText() }
-						align="center"
+			<Step.CenteredColumnLayout
+				className="how-to-migrate-v2"
+				columnWidth={ 6 }
+				topBar={
+					<Step.TopBar
+						leftElement={ <Step.BackButton onClick={ goBack } /> }
+						rightElement={
+							<Step.SkipButton onClick={ () => handleClick( HOW_TO_MIGRATE_OPTIONS.DO_IT_MYSELF ) }>
+								{ translate( "I'll do it myself" ) }
+							</Step.SkipButton>
+						}
 					/>
 				}
-				stepContent={ renderStepContent() }
-				recordTracksEvent={ recordTracksEvent }
-				goBack={ goBack }
-				customizedActionButtons={ <DIYOption onClick={ handleClick } /> }
-			/>
+				heading={
+					<Step.Heading
+						text={ headerText ?? translate( 'Let us migrate your site' ) }
+						subText={ subHeaderText || renderSubHeaderText() }
+					/>
+				}
+			>
+				{ renderStepContent() }
+			</Step.CenteredColumnLayout>
 		</>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/test/index.tsx
@@ -59,7 +59,7 @@ describe( 'SiteMigrationHowToMigrate', () => {
 
 		render( { navigation } );
 
-		expect( screen.queryByText( /Plus it’s included in your/ ) ).toBeInTheDocument();
+		expect( screen.queryByText( /Plus it's included in your/ ) ).toBeInTheDocument();
 	} );
 
 	it( 'should render step content', () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -1,5 +1,5 @@
 import { formatNumber } from '@automattic/number-formatters';
-import { StepContainer, Title, SubTitle, Step } from '@automattic/onboarding';
+import { Step } from '@automattic/onboarding';
 import { Icon, next, published, shield } from '@wordpress/icons';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { type FC, ReactElement, useEffect, useState, useCallback } from 'react';
@@ -9,9 +9,6 @@ import DocumentHead from 'calypso/components/data/document-head';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { shouldUseStepContainerV2MigrationFlow } from '../../../helpers/should-use-step-container-v2';
-//TODO: Move it to a more generic folder
 import { useFlowState } from '../../state-manager/store';
 import { useSitePreviewMShotImageHandler } from '../site-migration-instructions/site-preview/hooks/use-site-preview-mshot-image-handler';
 import type { Step as StepType } from '../../types';
@@ -153,7 +150,6 @@ const SiteMigrationIdentify: StepType< {
 	const siteSlug = useSiteSlug();
 	const translate = useTranslate();
 	const { createScreenshots } = useSitePreviewMShotImageHandler();
-	const isUsingStepContainerV2 = shouldUseStepContainerV2MigrationFlow( flow );
 
 	const handleSubmit = useCallback(
 		async ( action: SiteMigrationIdentifyAction, data?: { platform: string; from: string } ) => {
@@ -208,57 +204,25 @@ const SiteMigrationIdentify: StepType< {
 		/>
 	);
 
-	if ( isUsingStepContainerV2 ) {
-		const backButton = getBackButton();
-		return (
-			<>
-				<DocumentHead title={ translate( 'Import your site content' ) } />
-				<Step.CenteredColumnLayout
-					className="step-container-v2--site-migration-identify"
-					columnWidth={ 4 }
-					topBar={ <Step.TopBar leftElement={ backButton } /> }
-					heading={
-						isVisible ? (
-							<Step.Heading
-								text={ translate( 'Let’s find your site' ) }
-								subText={ translate( 'Enter your current site address below to get started.' ) }
-							/>
-						) : undefined
-					}
-				>
-					{ stepContent }
-				</Step.CenteredColumnLayout>
-			</>
-		);
-	}
-
+	const backButton = getBackButton();
 	return (
 		<>
 			<DocumentHead title={ translate( 'Import your site content' ) } />
-			<StepContainer
-				stepName="site-migration-identify"
-				flowName="site-migration"
-				className="import__onboarding-page"
-				hideBack={ ! shouldShowBackButton() }
-				backUrl={ urlQueryParams.get( 'back_to' ) || undefined }
-				hideFormattedHeader
-				goBack={ navigation?.goBack }
-				isFullLayout
-				stepContent={
-					<div className="import__capture-wrapper">
-						{ isVisible && (
-							<div className="import__heading import__heading-center">
-								<Title>{ translate( 'Let’s find your site' ) }</Title>
-								<SubTitle>
-									{ translate( 'Enter your current site address below to get started.' ) }
-								</SubTitle>
-							</div>
-						) }
-						{ stepContent }
-					</div>
+			<Step.CenteredColumnLayout
+				className="step-container-v2--site-migration-identify"
+				columnWidth={ 4 }
+				topBar={ <Step.TopBar leftElement={ backButton } /> }
+				heading={
+					isVisible ? (
+						<Step.Heading
+							text={ translate( "Let's find your site" ) }
+							subText={ translate( 'Enter your current site address below to get started.' ) }
+						/>
+					) : undefined
 				}
-				recordTracksEvent={ recordTracksEvent }
-			/>
+			>
+				{ stepContent }
+			</Step.CenteredColumnLayout>
 		</>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
@@ -1,19 +1,16 @@
 import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { BadgeType } from '@automattic/components';
 import { formatNumber } from '@automattic/number-formatters';
-import { Step, StepContainer } from '@automattic/onboarding';
+import { Step } from '@automattic/onboarding';
 import { canInstallPlugins } from '@automattic/sites';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
 import { useMigrationCancellation } from 'calypso/data/site-migration/landing/use-migration-cancellation';
 import { useMigrationStickerMutation } from 'calypso/data/site-migration/use-migration-sticker';
 import { useHostingProviderUrlDetails } from 'calypso/data/site-profiler/use-hosting-provider-url-details';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { shouldUseStepContainerV2MigrationFlow } from '../../../helpers/should-use-step-container-v2';
 import FlowCard from '../components/flow-card';
 import type { Step as StepType } from '../../types';
 import './style.scss';
@@ -22,7 +19,7 @@ const SiteMigrationImportOrMigrate: StepType< {
 	submits: {
 		destination: 'migrate' | 'import' | 'upgrade';
 	};
-} > = function ( { navigation, flow } ) {
+} > = function ( { navigation } ) {
 	const translate = useTranslate();
 	const site = useSite();
 	const importSiteQueryParam = getQueryArg( window.location.href, 'from' )?.toString() || '';
@@ -30,7 +27,6 @@ const SiteMigrationImportOrMigrate: StepType< {
 	const { mutate: cancelMigration } = useMigrationCancellation( site?.ID );
 	const siteCanInstallPlugins = canInstallPlugins( site );
 	const isUpgradeRequired = ! siteCanInstallPlugins;
-	const isUsingStepContainerV2 = shouldUseStepContainerV2MigrationFlow( flow );
 
 	const options = useMemo( () => {
 		const upgradeRequiredLabel = translate( '%(discountPercentage)s off %(planName)s', {
@@ -107,44 +103,17 @@ const SiteMigrationImportOrMigrate: StepType< {
 		  } )
 		: '';
 
-	if ( isUsingStepContainerV2 ) {
-		return (
-			<>
-				<DocumentHead title={ pageTitle } />
-				<Step.CenteredColumnLayout
-					columnWidth={ 5 }
-					topBar={
-						<Step.TopBar leftElement={ <Step.BackButton onClick={ navigation.goBack } /> } />
-					}
-					heading={ <Step.Heading text={ pageTitle } subText={ pageSubTitle } /> }
-					className="import-or-migrate-v2"
-				>
-					{ stepContent }
-				</Step.CenteredColumnLayout>
-			</>
-		);
-	}
-
 	return (
 		<>
 			<DocumentHead title={ pageTitle } />
-			<StepContainer
-				stepName="site-migration-import-or-migrate"
-				className="import-or-migrate"
-				shouldHideNavButtons={ false }
-				hideSkip
-				formattedHeader={
-					<FormattedHeader
-						id="how-to-migrate-header"
-						headerText={ pageTitle }
-						subHeaderText={ pageSubTitle }
-						align="center"
-					/>
-				}
-				stepContent={ stepContent }
-				recordTracksEvent={ recordTracksEvent }
-				goBack={ navigation.goBack }
-			/>
+			<Step.CenteredColumnLayout
+				columnWidth={ 5 }
+				topBar={ <Step.TopBar leftElement={ <Step.BackButton onClick={ navigation.goBack } /> } /> }
+				heading={ <Step.Heading text={ pageTitle } subText={ pageSubTitle } /> }
+				className="import-or-migrate-v2"
+			>
+				{ stepContent }
+			</Step.CenteredColumnLayout>
 		</>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -1,7 +1,6 @@
 import { captureException } from '@automattic/calypso-sentry';
 import { CircularProgressBar } from '@automattic/components';
-import { LaunchpadContainer } from '@automattic/launchpad';
-import { Step, StepContainer } from '@automattic/onboarding';
+import { Step } from '@automattic/onboarding';
 import { FixedColumnOnTheLeftLayout } from '@automattic/onboarding/src/step-container-v2';
 import { translate } from 'i18n-calypso';
 import { useCallback, useEffect } from 'react';
@@ -17,7 +16,6 @@ import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useDispatch } from 'calypso/state';
 import { resetSite } from 'calypso/state/sites/actions';
-import { shouldUseStepContainerV2MigrationFlow } from '../../../helpers/should-use-step-container-v2';
 import { HostingBadge } from './hosting-badge';
 import { MigrationInstructions } from './migration-instructions';
 import { ProvisionStatus } from './provision-status';
@@ -94,7 +92,6 @@ const SiteMigrationInstructions: StepType< {
 	const queryParams = useQuery();
 	const fromUrl = queryParams.get( 'from' ) ?? '';
 	const dispatch = useDispatch();
-	const useContainerV2 = shouldUseStepContainerV2MigrationFlow( flow );
 
 	const { mutate: updateMigrationStatus } = useUpdateMigrationStatus( siteId );
 
@@ -187,11 +184,7 @@ const SiteMigrationInstructions: StepType< {
 	);
 
 	const migrationInstructions = (
-		<MigrationInstructions
-			withPreview={ withPreview }
-			isContainerV2={ useContainerV2 }
-			progress={ progressCircle }
-		>
+		<MigrationInstructions withPreview={ withPreview } isContainerV2 progress={ progressCircle }>
 			<div className="site-migration-instructions__steps">
 				<Steps steps={ steps } />
 			</div>
@@ -199,48 +192,11 @@ const SiteMigrationInstructions: StepType< {
 		</MigrationInstructions>
 	);
 
-	const stepContent = withPreview ? (
-		<LaunchpadContainer sidebar={ migrationInstructions }>
-			{ showHostingBadge && <HostingBadge hostingName={ hostingDetails.name } /> }
-			<SitePreview />
-		</LaunchpadContainer>
-	) : (
-		<div className="site-migration-instructions__container-without-preview">
-			{ migrationInstructions }
-		</div>
-	);
-
-	if ( useContainerV2 ) {
-		const title = translate( 'Let’s migrate your site' );
+	if ( withPreview ) {
+		const title = translate( "Let's migrate your site" );
 		const topBar = (
 			<Step.TopBar rightElement={ <SupportNudge onAskForHelp={ navigateToDoItForMe } /> } />
 		);
-
-		if ( ! withPreview ) {
-			return (
-				<>
-					<DocumentHead title={ title } />
-					<Step.CenteredColumnLayout
-						columnWidth={ 4 }
-						topBar={ topBar }
-						heading={
-							<>
-								<Step.Heading
-									text={
-										<div className="site-migration-instructions__heading">
-											{ progressCircle }
-											{ title }
-										</div>
-									}
-								/>
-							</>
-						}
-					>
-						{ migrationInstructions }
-					</Step.CenteredColumnLayout>
-				</>
-			);
-		}
 		return (
 			<>
 				<DocumentHead title={ title } />
@@ -264,18 +220,30 @@ const SiteMigrationInstructions: StepType< {
 		);
 	}
 
+	const title = translate( "Let's migrate your site" );
+	const topBar = (
+		<Step.TopBar rightElement={ <SupportNudge onAskForHelp={ navigateToDoItForMe } /> } />
+	);
 	return (
-		<StepContainer
-			stepName="site-migration-instructions"
-			isFullLayout
-			hideFormattedHeader
-			className="is-step-site-migration-instructions site-migration-instructions--launchpad"
-			hideSkip
-			hideBack
-			stepContent={ stepContent }
-			recordTracksEvent={ recordTracksEvent }
-			customizedActionButtons={ <SupportNudge onAskForHelp={ navigateToDoItForMe } /> }
-		/>
+		<>
+			<DocumentHead title={ title } />
+			<Step.CenteredColumnLayout
+				columnWidth={ 4 }
+				topBar={ topBar }
+				heading={
+					<Step.Heading
+						text={
+							<div className="site-migration-instructions__heading">
+								{ progressCircle }
+								{ title }
+							</div>
+						}
+					/>
+				}
+			>
+				{ migrationInstructions }
+			</Step.CenteredColumnLayout>
+		</>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-other-platform-detected-import/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-other-platform-detected-import/index.tsx
@@ -1,14 +1,11 @@
-import { StepContainer, Step } from '@automattic/onboarding';
+import { Step } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { convertPlatformName } from 'calypso/blocks/import/util';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
-import { shouldUseStepContainerV2MigrationFlow } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ImporterPlatform } from 'calypso/lib/importer/types';
 import { Step as StepType } from '../../types';
 import { ImportPlatformForwarder } from './components/importer-forwarding-details';
@@ -29,7 +26,7 @@ const SiteMigrationOtherPlatform: StepType< {
 				platform?: ImporterPlatform | null;
 		  }
 		| undefined;
-} > = function ( { navigation, flow } ) {
+} > = function ( { navigation } ) {
 	const translate = useTranslate();
 	const [ query ] = useSearchParams();
 	const from = query.get( 'from' ) as string;
@@ -70,7 +67,7 @@ const SiteMigrationOtherPlatform: StepType< {
 
 	const descriptionWithPlatform = translate(
 		// translators: platform is the name of the platform importer we are supporting.
-		'Our migration service is for WordPress sites. But don’t worry — our {{strong}}%(platform)s{{/strong}} import tool is ready to bring your content to WordPress.com.',
+		"Our migration service is for WordPress sites. But don't worry — our {{strong}}%(platform)s{{/strong}} import tool is ready to bring your content to WordPress.com.",
 		{
 			args: {
 				platform: platformName || '',
@@ -82,70 +79,31 @@ const SiteMigrationOtherPlatform: StepType< {
 	);
 
 	const descriptionWithoutPlatform = translate(
-		'Our migration service is for WordPress sites. We don’t currently support importing from this platform.'
+		"Our migration service is for WordPress sites. We don't currently support importing from this platform."
 	);
 
 	const title = translate( "Looks like there's been a mix-up" );
 	const description =
 		platformName === 'Unknown' ? descriptionWithoutPlatform : descriptionWithPlatform;
 
-	if ( shouldUseStepContainerV2MigrationFlow( flow ) ) {
-		return (
-			<>
-				<DocumentHead title={ title } />
-				<Step.CenteredColumnLayout
-					columnWidth={ 8 }
-					topBar={
-						<Step.TopBar leftElement={ <Step.BackButton onClick={ navigation.goBack } /> } />
-					}
-					heading={ <Step.Heading text={ title } subText={ description } /> }
-				>
-					{ isAnalyzingUrl ? (
-						<Scanning />
-					) : (
-						<ImportPlatformForwarder
-							platformName={ platformName }
-							onSubmit={ handleSubmit }
-							onHelp={ handleHelp }
-						/>
-					) }
-				</Step.CenteredColumnLayout>
-			</>
-		);
-	}
-
 	return (
 		<>
 			<DocumentHead title={ title } />
-			<StepContainer
-				stepName="site-migration-other-platform"
-				goBack={ navigation?.goBack }
-				isFullLayout
-				formattedHeader={
-					isAnalyzingUrl ? (
-						<span />
-					) : (
-						<FormattedHeader
-							id="site-migration-credentials-header"
-							headerText={ title }
-							subHeaderText={ description }
-							align="center"
-						/>
-					)
-				}
-				stepContent={
-					isAnalyzingUrl ? (
-						<Scanning />
-					) : (
-						<ImportPlatformForwarder
-							platformName={ platformName }
-							onSubmit={ handleSubmit }
-							onHelp={ handleHelp }
-						/>
-					)
-				}
-				recordTracksEvent={ recordTracksEvent }
-			/>
+			<Step.CenteredColumnLayout
+				columnWidth={ 8 }
+				topBar={ <Step.TopBar leftElement={ <Step.BackButton onClick={ navigation.goBack } /> } /> }
+				heading={ <Step.Heading text={ title } subText={ description } /> }
+			>
+				{ isAnalyzingUrl ? (
+					<Scanning />
+				) : (
+					<ImportPlatformForwarder
+						platformName={ platformName }
+						onSubmit={ handleSubmit }
+						onHelp={ handleHelp }
+					/>
+				) }
+			</Step.CenteredColumnLayout>
 		</>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-support-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-support-instructions/index.tsx
@@ -1,12 +1,10 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useLocale } from '@automattic/i18n-utils';
-import { Step, StepContainer } from '@automattic/onboarding';
+import { Step } from '@automattic/onboarding';
 import { translate, useTranslate } from 'i18n-calypso';
 import { useMemo, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
-import { shouldUseStepContainerV2MigrationFlow } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { useSubmitMigrationTicket } from 'calypso/landing/stepper/hooks/use-submit-migration-ticket';
 import { UserData } from 'calypso/lib/user/user';
@@ -41,7 +39,7 @@ const StepContent = () => {
 	);
 };
 
-export const SiteMigrationSupportInstructions: StepType = ( { stepName, flow } ) => {
+export const SiteMigrationSupportInstructions: StepType = () => {
 	const translate = useTranslate();
 	const user = useSelector( getCurrentUser ) as UserData;
 	const [ query ] = useSearchParams();
@@ -98,33 +96,17 @@ export const SiteMigrationSupportInstructions: StepType = ( { stepName, flow } )
 
 	const headerText = translate( 'We’ll take it from here!' );
 
-	const isUsingStepContainerV2 = shouldUseStepContainerV2MigrationFlow( flow );
-
-	if ( isUsingStepContainerV2 ) {
-		return (
-			<>
-				<DocumentHead title={ headerText } />
-				<Step.CenteredColumnLayout
-					columnWidth={ 8 }
-					topBar={ <Step.TopBar leftElement={ null } /> }
-					heading={ <Step.Heading text={ headerText } subText={ subHeaderText } /> }
-				>
-					<StepContent />
-				</Step.CenteredColumnLayout>
-			</>
-		);
-	}
 	return (
-		<StepContainer
-			stepName={ stepName }
-			hideBack
-			formattedHeader={
-				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
-			}
-			isHorizontalLayout={ false }
-			stepContent={ <StepContent /> }
-			recordTracksEvent={ recordTracksEvent }
-		/>
+		<>
+			<DocumentHead title={ headerText } />
+			<Step.CenteredColumnLayout
+				columnWidth={ 8 }
+				topBar={ <Step.TopBar leftElement={ null } /> }
+				heading={ <Step.Heading text={ headerText } subText={ subHeaderText } /> }
+			>
+				<StepContent />
+			</Step.CenteredColumnLayout>
+		</>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
@@ -5,17 +5,14 @@ import {
 	getPlan,
 	getPlanByPathSlug,
 } from '@automattic/calypso-products';
-import { Step, StepContainer } from '@automattic/onboarding';
+import { Step } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { UpgradePlan } from 'calypso/blocks/importer/wordpress/upgrade-plan';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
 import { useSelectedPlanUpgradeQuery } from 'calypso/data/import-flow/use-selected-plan-upgrade';
-import { shouldUseStepContainerV2MigrationFlow } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step as StepType } from '../../types';
 
 import './style.scss';
@@ -26,7 +23,6 @@ const SiteMigrationUpgradePlan: StepType< {
 		onSkip?: () => void;
 		skipPosition?: 'top' | 'bottom';
 		headerText?: string;
-		customizedActionButtons?: React.ReactElement;
 	};
 	submits: {
 		goToCheckout?: boolean;
@@ -34,8 +30,7 @@ const SiteMigrationUpgradePlan: StepType< {
 		sendIntentWhenCreatingTrial?: boolean;
 		verifyEmail?: boolean;
 	};
-} > = ( { navigation, data, customizedActionButtons, flow, ...props } ) => {
-	const { onSkip, skipLabelText, skipPosition } = props;
+} > = ( { navigation, data } ) => {
 	const siteItem = useSite();
 	const siteSlug = useSiteSlug();
 	const translate = useTranslate();
@@ -45,7 +40,6 @@ const SiteMigrationUpgradePlan: StepType< {
 
 	const selectedPlanData = useSelectedPlanUpgradeQuery();
 	const selectedPlanPathSlug = selectedPlanData.data;
-	const isUsingStepContainerV2 = shouldUseStepContainerV2MigrationFlow( flow );
 
 	const plan = selectedPlanPathSlug
 		? getPlanByPathSlug( selectedPlanPathSlug )
@@ -106,49 +100,17 @@ const SiteMigrationUpgradePlan: StepType< {
 		}
 	);
 
-	if ( isUsingStepContainerV2 ) {
-		return (
-			<>
-				<DocumentHead title={ headerText } />
-				<Step.CenteredColumnLayout
-					columnWidth={ 5 }
-					topBar={
-						<Step.TopBar leftElement={ <Step.BackButton onClick={ navigation.goBack } /> } />
-					}
-					heading={ <Step.Heading text={ headerText } subText={ subHeaderText } /> }
-					className="site-migration-upgrade-plan-v2"
-				>
-					{ stepContent }
-				</Step.CenteredColumnLayout>
-			</>
-		);
-	}
-
 	return (
 		<>
-			<DocumentHead title={ translate( 'Upgrade your plan', { textOnly: true } ) } />
-			<StepContainer
-				stepName="site-migration-upgrade-plan"
-				shouldHideNavButtons={ false }
-				className="is-step-site-migration-upgrade-plan"
-				goBack={ navigation.goBack }
-				skipLabelText={ skipLabelText }
-				skipButtonAlign={ skipPosition }
-				goNext={ onSkip }
-				hideSkip={ ! onSkip }
-				isWideLayout
-				customizedActionButtons={ customizedActionButtons }
-				formattedHeader={
-					<FormattedHeader
-						id="site-migration-instructions-header"
-						headerText={ headerText }
-						subHeaderText={ subHeaderText }
-						align="center"
-					/>
-				}
-				stepContent={ stepContent }
-				recordTracksEvent={ recordTracksEvent }
-			/>
+			<DocumentHead title={ headerText } />
+			<Step.CenteredColumnLayout
+				columnWidth={ 5 }
+				topBar={ <Step.TopBar leftElement={ <Step.BackButton onClick={ navigation.goBack } /> } /> }
+				heading={ <Step.Heading text={ headerText } subText={ subHeaderText } /> }
+				className="site-migration-upgrade-plan-v2"
+			>
+				{ stepContent }
+			</Step.CenteredColumnLayout>
 		</>
 	);
 };

--- a/config/development.json
+++ b/config/development.json
@@ -130,7 +130,6 @@
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
 		"onboarding/interval-dropdown": true,
-		"onboarding/step-container-v2-migration-flow": true,
 		"onboarding/user-on-stepper-hosting": true,
 		"p2/p2-plus": true,
 		"page/export": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -79,7 +79,6 @@
 		"me/account/color-scheme-picker": true,
 		"migration-flow/introductory-offer": true,
 		"onboarding/create-course": false,
-		"onboarding/step-container-v2-migration-flow": true,
 		"p2/p2-plus": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/config/production.json
+++ b/config/production.json
@@ -102,7 +102,6 @@
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
 		"onboarding/interval-dropdown": true,
-		"onboarding/step-container-v2-migration-flow": true,
 		"onboarding/user-on-stepper-hosting": false,
 		"p2/p2-plus": true,
 		"plans/hosting-trial": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -99,7 +99,6 @@
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
 		"onboarding/interval-dropdown": true,
-		"onboarding/step-container-v2-migration-flow": true,
 		"p2/p2-plus": true,
 		"page/export": true,
 		"plans/hosting-trial": true,

--- a/config/test.json
+++ b/config/test.json
@@ -79,7 +79,6 @@
 		"onboarding/import-from-squarespace": true,
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
-		"onboarding/step-container-v2-migration-flow": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -106,7 +106,6 @@
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
 		"onboarding/interval-dropdown": true,
-		"onboarding/step-container-v2-migration-flow": true,
 		"onboarding/user-on-stepper-hosting": true,
 		"p2/p2-plus": true,
 		"plans/hosting-trial": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #DOTCON-76

## Proposed Changes

Now that the StepContainerV2 feature flag is enabled in all environments, we can remove the flags as well as the conditional code in each migration component.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You'll want to use the calypso.live url since some of the application password paths can't be accessed locally.

* Go to `/setup/site-migration`.
* Go through all paths of the flow. This means doing a DIFM migration and a DIY migration. You'll also want to make sure that the links to the import flow also work, though you don't have to actually do an import.
* Verify that all steps look correct and function as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
