### PR TITLE
Connect Refresh: Revert Gravatar & Grav-powered Login unification changes

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -29,6 +29,7 @@ import {
 	canDoMagicLogin,
 	getLoginLinkPageUrl,
 } from 'calypso/lib/login';
+import { isGravatarFlowOAuth2Client, isGravatarOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -1034,6 +1035,14 @@ export class LoginForm extends Component {
 			oauth2Client
 		);
 
+		const isFromGravatar3rdPartyApp =
+			isGravatarOAuth2Client( oauth2Client ) && currentQuery?.gravatar_from === '3rd-party';
+		const isFromGravatarQuickEditor =
+			isGravatarOAuth2Client( oauth2Client ) && currentQuery?.gravatar_from === 'quick-editor';
+		const isGravatarFlowWithEmail = !! (
+			isGravatarFlowOAuth2Client( oauth2Client ) && currentQuery?.email_address
+		);
+
 		const showLastUsedAuthenticationMethod =
 			lastUsedAuthenticationMethod &&
 			lastUsedAuthenticationMethod !== 'password' &&
@@ -1043,7 +1052,10 @@ export class LoginForm extends Component {
 		const shouldShowSocialLoginForm =
 			config.isEnabled( 'signup/social' ) &&
 			! isFromAutomatticForAgenciesReferralClient &&
-			! isCoreProfilerLostPasswordFlow;
+			! isCoreProfilerLostPasswordFlow &&
+			! isFromGravatar3rdPartyApp &&
+			! isFromGravatarQuickEditor &&
+			! isGravatarFlowWithEmail;
 
 		if ( isJetpack ) {
 			return (

--- a/client/blocks/login/login-header.tsx
+++ b/client/blocks/login/login-header.tsx
@@ -13,7 +13,7 @@ import {
 	isBlazeProOAuth2Client,
 	isGravatarFlowOAuth2Client,
 	isPartnerPortalOAuth2Client,
-	isWPJobManagerOAuth2Client,
+	isGravatarOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import './login-header.scss';
 
@@ -76,8 +76,6 @@ export function getHeaderText(
 		let clientName = oauth2Client?.name;
 		if ( isFromAkismet ) {
 			clientName = 'Akismet';
-		} else if ( isWPJobManagerOAuth2Client( oauth2Client ) ) {
-			clientName = 'WP Job Manager';
 		} else if ( isBlazeProOAuth2Client( oauth2Client ) ) {
 			clientName = 'Blaze Pro';
 		}
@@ -169,6 +167,12 @@ export function getHeaderText(
 				);
 			}
 		}
+
+		if ( isGravPoweredClient ) {
+			headerText = translate( 'Login to %(clientTitle)s', {
+				args: { clientTitle: oauth2Client.title },
+			} );
+		}
 	} else if ( isWooJPC ) {
 		const isLostPasswordFlow = currentQuery.lostpassword_flow === 'true';
 		if ( isLostPasswordFlow ) {
@@ -198,6 +202,7 @@ export function LoginHeader( {
 	isFromAkismet,
 	isFromAutomatticForAgenciesPlugin,
 	isGravPoweredClient,
+	isGravPoweredLoginPage,
 	isJetpack,
 	isManualRenewalImmediateLoginAttempt,
 	isSocialFirst,
@@ -368,6 +373,28 @@ export function LoginHeader( {
 					) }
 				</p>
 			);
+		}
+
+		if ( isGravPoweredClient ) {
+			if ( isGravPoweredLoginPage ) {
+				const isFromGravatar3rdPartyApp =
+					isGravatarOAuth2Client( oauth2Client ) && currentQuery?.gravatar_from === '3rd-party';
+				const isFromGravatarQuickEditor =
+					isGravatarOAuth2Client( oauth2Client ) && currentQuery?.gravatar_from === 'quick-editor';
+				const isGravatarFlowWithEmail = !! (
+					isGravatarFlowOAuth2Client( oauth2Client ) && currentQuery?.email_address
+				);
+
+				postHeader = (
+					<p className="login__header-subtitle">
+						{ isFromGravatar3rdPartyApp || isFromGravatarQuickEditor || isGravatarFlowWithEmail
+							? translate( 'Please log in with your email and password.' )
+							: translate(
+									'If you prefer logging in with a password, or a social media account, choose below:'
+							  ) }
+					</p>
+				);
+			}
 		}
 
 		if ( isBlazeProOAuth2Client( oauth2Client ) ) {

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -391,3 +391,9 @@ $breakpoint-mobile: 782px; //Mobile size.
 		}
 	}
 }
+
+.is-gravatar {
+	.login__form-terms {
+		display: block;
+	}
+}

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -349,7 +349,6 @@ export default withCurrentRoute(
 						! isWooJPC ) ||
 						isStudioClient ||
 						isCrowdsignalClient ||
-						isGravPoweredClient ||
 						isBlazePro ) ) ||
 				isPartnerPortal;
 

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -77,7 +77,6 @@ const enhanceContextWithLogin = ( context ) => {
 		isPartnerPortalClient ||
 		isStudioLogin ||
 		isCrowdsignalLogin ||
-		isGravPoweredClient ||
 		isBlazePro;
 
 	context.primary = (

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -25,6 +25,8 @@ import {
 	isPartnerPortalOAuth2Client,
 	isStudioAppOAuth2Client,
 	isCrowdsignalOAuth2Client,
+	isGravatarFlowOAuth2Client,
+	isGravatarOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login, lostPassword } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -188,6 +190,79 @@ export class Login extends Component {
 		);
 	}
 
+	renderGravPoweredLoginBlockFooter() {
+		const { oauth2Client, translate, locale, currentQuery, currentRoute } = this.props;
+
+		const isGravatar = isGravatarOAuth2Client( oauth2Client );
+		const isFromGravatar3rdPartyApp = isGravatar && currentQuery?.gravatar_from === '3rd-party';
+		const isFromGravatarQuickEditor = isGravatar && currentQuery?.gravatar_from === 'quick-editor';
+		const isGravatarFlow = isGravatarFlowOAuth2Client( oauth2Client );
+		const isGravatarFlowWithEmail = !! ( isGravatarFlow && currentQuery?.email_address );
+		const shouldShowSignupLink =
+			! isFromGravatar3rdPartyApp && ! isFromGravatarQuickEditor && ! isGravatarFlowWithEmail;
+		const magicLoginUrl = login( {
+			locale,
+			twoFactorAuthType: 'link',
+			oauth2ClientId: currentQuery?.client_id,
+			redirectTo: currentQuery?.redirect_to,
+			gravatarFrom: currentQuery?.gravatar_from,
+			gravatarFlow: isGravatarFlow,
+			emailAddress: currentQuery?.email_address,
+		} );
+		const currentUrl = new URL( window.location.href );
+		currentUrl.searchParams.append( 'lostpassword_flow', true );
+		const lostPasswordUrl = addQueryArgs(
+			{
+				redirect_to: currentUrl.toString(),
+				client_id: currentQuery?.client_id,
+			},
+			lostPassword( { locale } )
+		);
+		const signupUrl = getSignupUrl( currentQuery, currentRoute, oauth2Client, locale );
+
+		return (
+			<>
+				<hr className="grav-powered-login__divider" />
+				<div className="grav-powered-login__footer">
+					<a
+						href={ magicLoginUrl }
+						onClick={ () =>
+							this.props.recordTracksEvent( 'calypso_login_magic_login_request_click' )
+						}
+					>
+						{ isGravatar
+							? translate( 'Email me a login code.' )
+							: translate( 'Email me a login link.' ) }
+					</a>
+					<a
+						href={ lostPasswordUrl }
+						onClick={ () =>
+							this.props.recordTracksEvent( 'calypso_login_reset_password_link_click' )
+						}
+					>
+						{ translate( 'Lost your password?' ) }
+					</a>
+					{ shouldShowSignupLink && (
+						<div>
+							{ translate( 'You have no account yet? {{signupLink}}Create one{{/signupLink}}.', {
+								components: {
+									signupLink: <a href={ signupUrl } />,
+								},
+							} ) }
+						</div>
+					) }
+					<div>
+						{ translate( 'Any question? {{a}}Check our help docs{{/a}}.', {
+							components: {
+								a: <a href="https://gravatar.com/support" target="_blank" rel="noreferrer" />,
+							},
+						} ) }
+					</div>
+				</div>
+			</>
+		);
+	}
+
 	recordResetPasswordLinkClick = () => {
 		this.props.recordTracksEvent( 'calypso_login_reset_password_link_click' );
 	};
@@ -267,6 +342,10 @@ export class Login extends Component {
 			usernameOrEmail,
 		} = this.props;
 
+		if ( isGravPoweredOAuth2Client( oauth2Client ) ) {
+			return null;
+		}
+
 		if (
 			( isJetpackCloudOAuth2Client( oauth2Client ) || isA4AOAuth2Client( oauth2Client ) ) &&
 			'/log-in/authenticator' !== currentRoute
@@ -300,7 +379,7 @@ export class Login extends Component {
 		return this.renderSignUpLink( this.props.translate( 'Create an account' ) );
 	}
 
-	renderLoginBlockFooter( { isSocialFirst } ) {
+	renderLoginBlockFooter( { isGravPoweredLoginPage, isSocialFirst } ) {
 		const {
 			isJetpack,
 			isWhiteLogin,
@@ -317,6 +396,10 @@ export class Login extends Component {
 			isWooJPC,
 			currentRoute,
 		} = this.props;
+
+		if ( isGravPoweredLoginPage ) {
+			return this.renderGravPoweredLoginBlockFooter();
+		}
 
 		if (
 			( currentQuery.lostpassword_flow === 'true' && isWooJPC ) ||
@@ -399,7 +482,7 @@ export class Login extends Component {
 				socialServiceResponse={ socialServiceResponse }
 				domain={ domain }
 				fromSite={ fromSite }
-				footer={ this.renderLoginBlockFooter( { isSocialFirst } ) }
+				footer={ this.renderLoginBlockFooter( { isGravPoweredLoginPage, isSocialFirst } ) }
 				locale={ locale }
 				handleUsernameChange={ this.handleUsernameChange.bind( this ) }
 				signupUrl={ signupUrl }
@@ -434,7 +517,7 @@ export class Login extends Component {
 		} = this.props;
 
 		const canonicalUrl = localizeUrl( 'https://wordpress.com/log-in', locale );
-		const isSocialFirst = isWhiteLogin && ! isWoo;
+		const isSocialFirst = isWhiteLogin && ! isGravPoweredClient && ! isWoo;
 
 		const jetpackLogo = (
 			<div className="magic-login__gutenboarding-wordpress-logo">
@@ -521,7 +604,6 @@ export class Login extends Component {
 			isStudioAppOAuth2Client( oauth2Client ) ||
 			isFromAkismet ||
 			isCrowdsignalOAuth2Client( oauth2Client ) ||
-			isGravPoweredClient ||
 			isBlazePro;
 
 		return (
@@ -596,8 +678,7 @@ export default connect(
 				! isJetpackCloudOAuth2Client( oauth2Client ) &&
 				! isWooOAuth2Client( oauth2Client ) &&
 				! isCrowdsignalOAuth2Client( oauth2Client ) &&
-				! isStudioAppOAuth2Client( oauth2Client ) &&
-				! isGravPoweredOAuth2Client( oauth2Client ),
+				! isStudioAppOAuth2Client( oauth2Client ),
 			currentRoute,
 			currentQuery,
 			redirectTo: getRedirectToOriginal( state ),

--- a/client/login/wp-login/login-footer.tsx
+++ b/client/login/wp-login/login-footer.tsx
@@ -13,6 +13,7 @@ const LoginFooter = ( { lostPasswordLink, shouldRenderTos }: LoginFooterProps ) 
 	const translate = useTranslate();
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
 	const isGravPoweredClient = isGravPoweredOAuth2Client( oauth2Client );
+	const showGravHelperDocs = isGravPoweredClient && false;
 
 	if ( ! lostPasswordLink && ! shouldRenderTos ) {
 		return null;
@@ -22,7 +23,7 @@ const LoginFooter = ( { lostPasswordLink, shouldRenderTos }: LoginFooterProps ) 
 		<div className="wp-login__main-footer">
 			{ shouldRenderTos && <SocialTos /> }
 			{ lostPasswordLink }
-			{ isGravPoweredClient && (
+			{ showGravHelperDocs && (
 				<div className="wp-login__main-footer-help-docs">
 					{ translate( 'Any question? {{a}}Check our help docs{{/a}}.', {
 						components: {

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -597,6 +597,344 @@ $image-height: 47px;
 	}
 }
 
+/* stylelint-disable scales/font-weights, scales/radii */
+.layout.is-section-login.is-grav-powered-client {
+	background-color: #fff;
+
+	&.is-wp-job-manager {
+		background-color: #efefef;
+
+		.login a,
+		.login__form-change-username {
+			color: var(--color-wp-job-manager);
+		}
+
+		.login {
+			border-radius: 2px;
+		}
+
+		.form-button.is-primary {
+			&,
+			&:disabled {
+				background-color: var(--color-wp-job-manager);
+			}
+
+			&:hover:not(&:disabled),
+			&:focus {
+				background-color: darken(#2404eb, 10%);
+			}
+		}
+	}
+
+	.wp-login__main .locale-suggestions .locale-suggestions__notice.is-light {
+		&,
+		.calypso-notice__icon-wrapper {
+			background-color: var(--studio-gray-0);
+		}
+	}
+
+	.layout__content {
+		padding: 0;
+	}
+
+	.wp-login__main {
+		max-width: 480px;
+	}
+
+	.login,
+	.form-text-input {
+		font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	}
+
+	.login {
+		background-color: #fff;
+		border-radius: 8px;
+		padding: 20px;
+		color: #101517;
+		font-size: 14px;
+		line-height: 1.5;
+
+		a:not(.calypso-notice.is-error a) {
+			color: var(--color-gravatar);
+		}
+
+		button {
+			font-family: inherit;
+		}
+	}
+
+	.login__form-header-wrapper {
+		text-align: left;
+	}
+
+	.login__form-header {
+		font-family: "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+		font-size: 32px;
+		font-weight: 900;
+		line-height: 1.2;
+		text-align: left;
+		margin: 24px 0;
+	}
+
+	.login__header-subtitle,
+	.verification-code-form__help-text,
+	.two-factor-authentication__info {
+		margin-bottom: 24px;
+	}
+
+	.verification-code-form__help-text {
+		color: inherit;
+	}
+
+	.card {
+		background: transparent;
+	}
+
+	form {
+		max-width: 100%;
+
+		> .card {
+			padding: 0;
+			border: 0;
+			box-shadow: none;
+		}
+	}
+
+	.form-fieldset {
+		margin-bottom: 0;
+	}
+
+	label.form-label {
+		color: inherit;
+		margin-bottom: 10px;
+	}
+
+	.two-factor-authentication__verification-code-form .form-label {
+		display: none;
+	}
+
+	.login__form-change-username {
+		color: var(--color-gravatar);
+	}
+
+	.login__form-password {
+		margin-top: 15px;
+	}
+
+	.form-text-input,
+	.login__form-userdata input:last-of-type.form-text-input {
+		padding: 14px 16px;
+		border-color: #9ea4a8;
+		font-size: 16px;
+		margin: 0;
+		border-radius: 2px;
+		height: auto;
+	}
+
+	.form-password-input__toggle {
+		top: 14px;
+	}
+
+	.form-input-validation {
+		margin-bottom: 0;
+		padding-top: 15px;
+		padding-bottom: 0;
+	}
+
+	.login__form-terms {
+		color: rgba(#00101c, 0.6);
+		margin: 24px 0 0;
+		font-size: 0.875rem;
+		text-align: left;
+	}
+
+	button.form-button.is-primary,
+	.two-factor-authentication__actions .button {
+		min-height: 56px;
+		margin: 0;
+		padding: 10px 16px;
+		font-size: 16px;
+		font-weight: 600;
+
+		&:disabled {
+			opacity: 0.3;
+		}
+	}
+
+	button.form-button.is-primary {
+		margin-top: 16px;
+		margin-bottom: 0;
+		border: 0;
+
+		&,
+		&:disabled {
+			background-color: var(--color-gravatar);
+		}
+
+		&:hover:not(&:disabled),
+		&:focus {
+			background-color: darken(#1d4fc4, 10%);
+		}
+	}
+
+	.components-button.is-primary {
+		min-height: 56px;
+		margin-top: 16px;
+		font-size: 16px;
+		font-weight: 600;
+	}
+
+	.two-factor-authentication__actions {
+		display: flex;
+		flex-direction: column;
+		margin-top: 24px;
+		padding: 0;
+		gap: 16px;
+		background: transparent;
+
+		&::after {
+			display: none;
+		}
+
+		.button {
+			color: var(--color-gravatar);
+			border: 1px solid #1d4fc44d;
+			box-shadow: none;
+
+			&:hover:not(&:disabled),
+			&:focus {
+				color: darken(#1d4fc4, 13%);
+				border-color: darken(#1d4fc44d, 13%);
+			}
+		}
+	}
+
+	div.two-factor-authentication__small-print {
+		font-size: inherit;
+		margin-top: 24px;
+		padding: 0;
+	}
+
+	.auth-form__separator {
+		margin-top: 24px;
+	}
+
+	.auth-form__separator-text {
+		font-size: 15px;
+		text-transform: lowercase;
+		color: inherit;
+	}
+
+	.auth-form__social {
+		background: transparent;
+		margin: 24px 0 0;
+		padding: 0;
+		width: fit-content;
+		clip-path: unset;
+	}
+
+	.social-buttons__button {
+		box-shadow: none;
+		padding: unset;
+		height: auto;
+
+		> svg {
+			box-shadow: inset 0 0 0 $border-width $gray-300;
+			border-radius: 50%;
+			margin: 0;
+			width: 20px;
+			height: 20px;
+			margin-right: 12px;
+			padding: 12px;
+		}
+
+		> span {
+			margin-left: unset;
+		}
+
+		&:hover {
+			background: unset;
+			box-shadow: none;
+
+			> svg {
+				/* Matches hover state of .components-button */
+				background: color-mix(in srgb, var(--wp-components-color-accent) 4%, transparent);
+			}
+		}
+
+		&:focus {
+			box-shadow: none;
+
+			> svg {
+				/* Matches focus state of .components-button */
+				box-shadow: 0 0 0 currentColor inset, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-components-color-accent);
+			}
+		}
+	}
+
+	.grav-powered-login__divider {
+		background-color: #e7e9ea;
+		width: 80px;
+		margin: 24px 0;
+	}
+
+	.grav-powered-login__footer,
+	.wp-login__links.has-2fa-links {
+		display: flex;
+		flex-direction: column;
+		font-size: 16px;
+		line-height: 1;
+		gap: 24px;
+
+		a,
+		button {
+			font-size: inherit;
+			width: fit-content;
+		}
+
+		button:focus {
+			outline: dotted;
+		}
+	}
+
+	.wp-login__links.has-2fa-links {
+		align-items: center;
+		margin-top: 24px;
+
+		a,
+		button {
+			color: var(--color-gravatar);
+			font-weight: normal;
+			text-decoration: underline;
+			padding: 0;
+			border: 0;
+		}
+	}
+
+	@include break-small {
+		background-color: #efefef;
+
+		.wp-login__main:not(:has(.locale-suggestions)) .login,
+		.grav-powered-magic-login:not(:has(.locale-suggestions)) .grav-powered-magic-login__content {
+			margin-top: 40px;
+		}
+
+		.login {
+			padding: 40px 56px;
+		}
+
+		.login__form-header {
+			font-size: 40px;
+		}
+
+		.grav-powered-login__footer,
+		.wp-login__links.has-2fa-links {
+			gap: 16px;
+		}
+	}
+}
+/* stylelint-enable scales/font-weights, scales/radii */
+
 .wp-login__p2-logo {
 	position: absolute;
 	top: 24px;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Gravatar
Part of https://linear.app/a8c/issue/DOTCOM-13401/gravatar
Part of https://linear.app/a8c/issue/DOTCOM-13389/gravatar

WPJM
Part of https://linear.app/a8c/issue/DOTCOM-13402/wp-job-manager
Part of https://linear.app/a8c/issue/DOTCOM-13390/wp-job-manager

## Proposed Changes

Reverts the Login unification for Gravatar and Grav-powered login screens. Effectively reverts https://github.com/Automattic/wp-calypso/pull/103883 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To be redone next week.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to [Gravatar](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D4a5153e30a28e2ef24ca7e599abd80f3969340cd1f88327c1f5d2fbc88593fa1%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1&client_id=1854) and confirm screens look like before unification
- Go to [WP Job Manager](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fclient_id%3D90057%26response_type%3Dcode%26state%3DeyJyZWRpcmVjdF90byI6Imh0dHBzOlwvXC93cGpvYm1hbmFnZXIuY29tXC9teS1hY2NvdW50In0%26redirect_uri%3Dhttps%253A%252F%252Fwpjobmanager.com%252Fwp-json%252Fwpjmcom-auth%252Fv1%252Fcallback%26blog_id%3D0%26from-calypso%3D1&client_id=90057) and confirm screens look like before unification
- Go to any of the other client Logins from https://linear.app/a8c/issue/DOTCOM-13220/calypso-make-the-two-column-layout-and-unified-design-the-default and confirm no changes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
