### PR TITLE
Purchases: Update DataViews version to implement design feedback, second pass

### DIFF
--- a/client/me/purchases/purchases-list-in-dataviews/index.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/index.tsx
@@ -40,7 +40,6 @@ import { AppState } from 'calypso/types';
 import { PurchasesByOtherAdminsNotice } from '../purchases-list/purchases-by-other-admins-notice';
 import PurchasesSite from '../purchases-site';
 import { PurchasesDataViews, MembershipsDataViews } from './purchases-data-view';
-import './style.scss';
 
 export interface PurchasesListProps {
 	noticeType?: string | undefined;

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -299,6 +299,16 @@ export function getMembershipsFieldDefinitions( {
 }: {
 	translate: LocalizeProps[ 'translate' ];
 } ): Fields< MembershipSubscription > {
+	const goToPurchase = ( item: MembershipSubscription ) => {
+		const subscriptionId = item.ID;
+		if ( ! subscriptionId ) {
+			// eslint-disable-next-line no-console
+			console.error( 'Cannot display manage purchase page for subscription without ID' );
+			return;
+		}
+		page( `/me/purchases/other/${ subscriptionId }` );
+	};
+
 	return [
 		{
 			id: 'site',
@@ -314,7 +324,14 @@ export function getMembershipsFieldDefinitions( {
 			render: ( { item }: { item: MembershipSubscription } ) => {
 				return (
 					<div className="membership-item__site purchases-layout__site">
-						<Icon subscription={ item } />
+						<Button
+							variant="link"
+							title={ translate( 'Manage purchase', { textOnly: true } ) }
+							label={ translate( 'Manage purchase', { textOnly: true } ) }
+							onClick={ () => goToPurchase( item ) }
+						>
+							<Icon subscription={ item } />
+						</Button>
 					</div>
 				);
 			},
@@ -332,7 +349,16 @@ export function getMembershipsFieldDefinitions( {
 			render: ( { item }: { item: MembershipSubscription } ) => {
 				return (
 					<div className="membership-item__information purchase-item__information purchases-layout__information">
-						<div className="membership-item__title purchase-item__title">{ item.title }</div>
+						<div className="membership-item__title purchase-item__title">
+							<Button
+								variant="link"
+								title={ translate( 'Manage purchase', { textOnly: true } ) }
+								label={ translate( 'Manage purchase', { textOnly: true } ) }
+								onClick={ () => goToPurchase( item ) }
+							>
+								{ item.title }
+							</Button>
+						</div>
 						<div className="membership-item__purchase-type purchase-item__purchase-type">
 							<MembershipType subscription={ item } />
 						</div>

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -207,7 +207,7 @@ export function getPurchasesFieldDefinitions( {
 			},
 		},
 		{
-			id: 'expring-soon',
+			id: 'expiring-soon',
 			label: translate( 'Expiring soon' ),
 			type: 'text',
 			elements: [

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -41,7 +41,33 @@ export const purchasesDataView: View = {
 	layout: {},
 };
 
-function usePreservePurchasesFiltersInUrl( {
+function alterUrlForViewProp(
+	url: URL,
+	urlKey: string,
+	currentViewPropValue: string | number | undefined,
+	defaultValue?: string | number | undefined
+): void {
+	if ( currentViewPropValue && defaultValue && currentViewPropValue !== defaultValue ) {
+		url.searchParams.set( urlKey, String( currentViewPropValue ) );
+	} else if ( currentViewPropValue && ! defaultValue ) {
+		url.searchParams.set( urlKey, String( currentViewPropValue ) );
+	} else {
+		url.searchParams.delete( urlKey );
+	}
+}
+
+function updateUrlForView( url: URL ): void {
+	if ( url.search === window.location.search ) {
+		return;
+	}
+	window.history.pushState( undefined, '', url );
+	// getPreviousRoute will not find this updated route unless we set it
+	// explicitly. It only records the route when the page first loads.
+	// This seems like a bug but it appears to be how it works.
+	reduxDispatch( setRoute( window.location.pathname, Object.fromEntries( url.searchParams ) ) );
+}
+
+function usePreservePurchasesViewInUrl( {
 	currentView,
 	setView,
 }: {
@@ -87,50 +113,22 @@ function usePreservePurchasesFiltersInUrl( {
 	useEffect( () => {
 		const url = new URL( window.location.href );
 		const siteFilter = currentView.filters?.find( ( filter ) => filter.field === 'site' );
-		if ( siteFilter ) {
-			url.searchParams.set( urlSiteFilterKey, siteFilter.value );
-		} else {
-			url.searchParams.delete( urlSiteFilterKey );
-		}
+		alterUrlForViewProp( url, urlSiteFilterKey, siteFilter?.value );
 
 		const typeFilter = currentView.filters?.find( ( filter ) => filter.field === 'type' );
-		if ( typeFilter ) {
-			url.searchParams.set( urlTypeFilterKey, typeFilter.value );
-		} else {
-			url.searchParams.delete( urlTypeFilterKey );
-		}
+		alterUrlForViewProp( url, urlTypeFilterKey, typeFilter?.value );
 
 		const pageNumber = currentView.page;
-		if ( pageNumber && pageNumber > 1 ) {
-			url.searchParams.set( urlPaginationPage, String( pageNumber ) );
-		} else {
-			url.searchParams.delete( urlPaginationPage );
-		}
+		alterUrlForViewProp( url, urlPaginationPage, pageNumber, 1 );
 
 		const perPage = currentView.perPage;
-		if ( perPage && perPage !== defaultPerPage ) {
-			url.searchParams.set( urlPaginationPerPage, String( perPage ) );
-		} else {
-			url.searchParams.delete( urlPaginationPerPage );
-		}
+		alterUrlForViewProp( url, urlPaginationPerPage, perPage, defaultPerPage );
 
 		const sort = currentView.sort;
-		if ( sort && sort !== defaultSort ) {
-			url.searchParams.set( urlSortField, sort.field );
-			url.searchParams.set( urlSortDirection, sort.direction );
-		} else {
-			url.searchParams.delete( urlSortField );
-			url.searchParams.delete( urlSortDirection );
-		}
+		alterUrlForViewProp( url, urlSortField, sort?.field, defaultSort.field );
+		alterUrlForViewProp( url, urlSortDirection, sort?.direction, defaultSort.direction );
 
-		if ( url.search === window.location.search ) {
-			return;
-		}
-		window.history.pushState( undefined, '', url );
-		// getPreviousRoute will not find this updated route unless we set it
-		// explicitly. It only records the route when the page first loads.
-		// This seems like a bug but it appears to be how it works.
-		reduxDispatch( setRoute( window.location.pathname, Object.fromEntries( url.searchParams ) ) );
+		updateUrlForView( url );
 	}, [ currentView ] );
 }
 
@@ -206,7 +204,7 @@ export function PurchasesDataViews( {
 	useHidePurchasesFieldsAtCertainWidths( { setView } );
 
 	// Keep track of the current view params in the URL and restore them when the page loads.
-	usePreservePurchasesFiltersInUrl( { currentView, setView } );
+	usePreservePurchasesViewInUrl( { currentView, setView } );
 
 	const sitesWithPurchases = useMemo( () => {
 		return Array.from(

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -80,6 +80,7 @@ function usePreservePurchasesViewInUrl( {
 	const urlPaginationPerPage = 'perPage';
 	const urlSiteFilterKey = 'siteFilter';
 	const urlTypeFilterKey = 'typeFilter';
+	const urlExpiringSoonFilter = 'expiringSoonFilter';
 	const currentUrl = window.location.href;
 
 	// Apply view from URL
@@ -88,6 +89,7 @@ function usePreservePurchasesViewInUrl( {
 		const filters: Filter[] = [];
 		const siteFilterValue = url.searchParams.get( urlSiteFilterKey );
 		const typeFilterValue = url.searchParams.get( urlTypeFilterKey );
+		const expiringSoonValue = url.searchParams.get( urlExpiringSoonFilter );
 		const pageNumber = url.searchParams.get( urlPaginationPage );
 		const perPage = url.searchParams.get( urlPaginationPerPage );
 		const sortField = url.searchParams.get( urlSortField );
@@ -96,6 +98,9 @@ function usePreservePurchasesViewInUrl( {
 		) as SortDirection;
 		if ( siteFilterValue ) {
 			filters.push( { value: siteFilterValue, operator: 'is', field: 'site' } );
+		}
+		if ( expiringSoonValue ) {
+			filters.push( { value: expiringSoonValue, operator: 'is', field: 'expiring-soon' } );
 		}
 		if ( typeFilterValue ) {
 			filters.push( { value: typeFilterValue, operator: 'is', field: 'type' } );
@@ -117,6 +122,11 @@ function usePreservePurchasesViewInUrl( {
 
 		const typeFilter = currentView.filters?.find( ( filter ) => filter.field === 'type' );
 		alterUrlForViewProp( url, urlTypeFilterKey, typeFilter?.value );
+
+		const expringSoonFilter = currentView.filters?.find(
+			( filter ) => filter.field === 'expiring-soon'
+		);
+		alterUrlForViewProp( url, urlExpiringSoonFilter, expringSoonFilter?.value );
 
 		const pageNumber = currentView.page;
 		alterUrlForViewProp( url, urlPaginationPage, pageNumber, 1 );

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { Gridicon, Card } from '@automattic/components';
+import { Card } from '@automattic/components';
 import { Purchases, SiteDetails } from '@automattic/data-stores';
 import { DESKTOP_BREAKPOINT, WIDE_BREAKPOINT } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
@@ -318,9 +318,7 @@ export function MembershipsDataViews( { memberships }: { memberships: Membership
 		() => [
 			{
 				id: 'manage-purchase',
-				label: translate( 'Manage this purchase', { textOnly: true } ),
-				isPrimary: true,
-				icon: <Gridicon icon="chevron-right" />,
+				label: translate( 'Manage purchase', { textOnly: true } ),
 				isEligible: ( item: MembershipSubscription ) => Boolean( item.ID ),
 				callback: ( items: MembershipSubscription[] ) => {
 					const subscriptionId = items[ 0 ].ID;

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -46,7 +46,7 @@ function usePreservePurchasesFiltersInUrl( {
 	setView,
 }: {
 	currentView: View;
-	setView: ( setter: ( currentView: View ) => View ) => void;
+	setView: ( setter: View | ( ( currentView: View ) => View ) ) => void;
 } ) {
 	const urlSortField = 'sortField';
 	const urlSortDirection = 'sortDir';
@@ -134,19 +134,15 @@ function usePreservePurchasesFiltersInUrl( {
 	}, [ currentView ] );
 }
 
-export function PurchasesDataViews( {
-	purchases,
-	sites,
+function useHidePurchasesFieldsAtCertainWidths( {
+	currentView,
+	setView,
 }: {
-	purchases: Purchases.Purchase[];
-	sites: SiteDetails[];
-} ) {
+	currentView: View;
+	setView: ( setter: View | ( ( currentView: View ) => View ) ) => void;
+} ): void {
 	const isWide = useBreakpoint( WIDE_BREAKPOINT );
 	const isDesktop = useBreakpoint( DESKTOP_BREAKPOINT );
-	const translate = useTranslate();
-	const [ currentView, setView ] = useState( purchasesDataView );
-
-	// Hide fields at mobile width
 	useEffect( () => {
 		if ( isWide && currentView.fields !== purchasesWideFields ) {
 			setView( { ...currentView, fields: purchasesWideFields } );
@@ -164,6 +160,20 @@ export function PurchasesDataViews( {
 			setView( { ...currentView, fields: purchasesMobileFields } );
 		}
 	}, [ isWide, isDesktop, currentView, setView ] );
+}
+
+export function PurchasesDataViews( {
+	purchases,
+	sites,
+}: {
+	purchases: Purchases.Purchase[];
+	sites: SiteDetails[];
+} ) {
+	const translate = useTranslate();
+	const [ currentView, setView ] = useState( purchasesDataView );
+
+	// Hide fields at mobile width
+	useHidePurchasesFieldsAtCertainWidths( { currentView, setView } );
 
 	// Keep track of the current view params in the URL and restore them when the page loads.
 	usePreservePurchasesFiltersInUrl( { currentView, setView } );

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -135,31 +135,61 @@ function usePreservePurchasesFiltersInUrl( {
 }
 
 function useHidePurchasesFieldsAtCertainWidths( {
-	currentView,
 	setView,
 }: {
-	currentView: View;
-	setView: ( setter: View | ( ( currentView: View ) => View ) ) => void;
+	setView: ( setter: View | ( ( view: View ) => View ) ) => void;
 } ): void {
 	const isWide = useBreakpoint( WIDE_BREAKPOINT );
 	const isDesktop = useBreakpoint( DESKTOP_BREAKPOINT );
-	useEffect( () => {
-		if ( isWide && currentView.fields !== purchasesWideFields ) {
-			setView( { ...currentView, fields: purchasesWideFields } );
-		}
+	const currentWidth = ( () => {
 		if ( isWide ) {
-			return;
-		}
-		if ( isDesktop && currentView.fields !== purchasesDesktopFields ) {
-			setView( { ...currentView, fields: purchasesDesktopFields } );
+			return 'wide';
 		}
 		if ( isDesktop ) {
-			return;
+			return 'desktop';
 		}
-		if ( currentView.fields !== purchasesMobileFields ) {
-			setView( { ...currentView, fields: purchasesMobileFields } );
+		return 'mobile';
+	} )();
+	useEffect( () => {
+		switch ( currentWidth ) {
+			case 'wide': {
+				setView( ( view ) => {
+					if ( view.fields?.length !== purchasesWideFields.length ) {
+						return {
+							...view,
+							fields: purchasesWideFields,
+						};
+					}
+					return view;
+				} );
+				return;
+			}
+			case 'desktop': {
+				setView( ( view ) => {
+					if ( view.fields?.length !== purchasesDesktopFields.length ) {
+						return {
+							...view,
+							fields: purchasesDesktopFields,
+						};
+					}
+					return view;
+				} );
+				return;
+			}
+			case 'mobile': {
+				setView( ( view ) => {
+					if ( view.fields?.length !== purchasesMobileFields.length ) {
+						return {
+							...view,
+							fields: purchasesMobileFields,
+						};
+					}
+					return view;
+				} );
+				return;
+			}
 		}
-	}, [ isWide, isDesktop, currentView, setView ] );
+	}, [ currentWidth, setView ] );
 }
 
 export function PurchasesDataViews( {
@@ -173,7 +203,7 @@ export function PurchasesDataViews( {
 	const [ currentView, setView ] = useState( purchasesDataView );
 
 	// Hide fields at mobile width
-	useHidePurchasesFieldsAtCertainWidths( { currentView, setView } );
+	useHidePurchasesFieldsAtCertainWidths( { setView } );
 
 	// Keep track of the current view params in the URL and restore them when the page loads.
 	usePreservePurchasesFiltersInUrl( { currentView, setView } );

--- a/client/me/purchases/purchases-list-in-dataviews/style.scss
+++ b/client/me/purchases/purchases-list-in-dataviews/style.scss
@@ -18,6 +18,15 @@
 		text-align: right;
 	}
 
+	.dataviews-view-table__row {
+		background: var( --studio-white );
+		opacity: 1;
+
+		&:hover {
+			background-color: var( --color-neutral-0 );
+		}
+	}
+
 	.dataviews-view-table,
 	.dataviews-view-table tr {
 		max-width: 1040px;


### PR DESCRIPTION
## Proposed Changes

This PR updates the UI and UX of the DataViews version of the purchases page to implement some additional design feedback from its Call for Testing (see pdtkmj-3Go-p2#comment-7052). The first updates were in https://github.com/Automattic/wp-calypso/pull/104013.

The main points from this PR:

- Add hover effect to each row.
- Update memberships actions to work like purchases actions do now (click on title or site icon, no chevron).
- Preserve "Expiring soon" filter in URL like other filters.
- Only reset fields list when width actually changes (allows changing order of fields).

Part of https://linear.app/a8c/project/replace-calypsos-active-upgrades-subscriptions-with-dataviews-a7b39dea5417/overview / https://github.com/Automattic/wp-calypso/issues/86616

Tracked by https://linear.app/a8c/issue/CHE-177/purchases-update-dataviews-version-to-implement-design-feedback

## Testing Instructions

- Use calypso.localhost because the DataViews layout is only available there.
- View /me/purchases and verify that everything looks and works as expected.