### PR TITLE
Notifications: Fix mismatch overlap on notification panels

### DIFF
--- a/client/notifications/style.scss
+++ b/client/notifications/style.scss
@@ -99,7 +99,7 @@ $notification-panel-width: 450px;
 
 	&.wpnt-closed {
 		visibility: hidden;
-		right: -400px;
+		right: -$notification-panel-width;
 		opacity: 0;
 		pointer-events: none;
 		transition: all 0.15s cubic-bezier(0.075, 0.82, 0.165, 1);
@@ -111,7 +111,7 @@ $notification-panel-width: 450px;
 
 	&.wpnc__main .wpnc__single-view {
 		left: inherit;
-		width: 400px;
+		width: $notification-panel-width;
 
 		@include breakpoint-deprecated( "<800px" ) {
 			left: 0;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Issue: [CML-492](https://linear.app/a8c/issue/CML-492/text-in-notification-tabs-overflow-in-non-en-locales)

## Proposed Changes

Increase notification panel width to avoid overlap mismatching of notification panels.

| Before | After |
| -------|------| 
| ![image](https://github.com/user-attachments/assets/dce63746-e354-4e4a-999a-5f4c35c3015e) | ![image](https://github.com/user-attachments/assets/a55780d3-5ab4-4880-95be-3cf6b66c6acc) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to /reader.
1. Open notification panel on with < 1110px and click on any notification.
1. Verify first panel is not peeking behind the second panel

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
