### PR TITLE
Storybook: Fix Overview doc

### DIFF
--- a/packages/components/.storybook/main.js
+++ b/packages/components/.storybook/main.js
@@ -4,7 +4,8 @@ module.exports = {
 	...storybookDefaultConfig( {
 		stories: [
 			'../{src,styles}/**/*.stories.{js,jsx,ts,tsx}',
-			'../{src,styles,.storybook}/**/*.mdx',
+			'../{src,styles}/**/*.mdx',
+			'./**/*.mdx',
 		],
 	} ),
 	docs: { autodocs: true },

--- a/packages/components/.storybook/overview.mdx
+++ b/packages/components/.storybook/overview.mdx
@@ -17,6 +17,7 @@ yarn components:storybook:start
 ## Special sections
 
 - **WP Overrides**: Automattic-specific overrides for WordPress Core components.
+- **Still Internal**: Components that are still internal to the package and not exported.
 - **Deprecated**: Components that are deprecated and should not be used anymore.
 - **Unaudited**: Components that are not yet audited, and thus not necessarily recommended for further use. After an audit, a component may either be moved to Calypso Components, deprecated, or classified as safe to use. If there is a similar component in [WordPress Core](https://wordpress.github.io/gutenberg), you should probably use that instead. If you have any questions, feel free to ask in the `#design-systems` channel on A8C Slack or ping Team Calypso.
 

--- a/packages/components/.storybook/overview.mdx
+++ b/packages/components/.storybook/overview.mdx
@@ -17,7 +17,7 @@ yarn components:storybook:start
 ## Special sections
 
 - **WP Overrides**: Automattic-specific overrides for WordPress Core components.
-- **Still Internal**: Components that are still internal to the package and not exported.
+- **Unpublished**: Components that are still internal to the package and not exported.
 - **Deprecated**: Components that are deprecated and should not be used anymore.
 - **Unaudited**: Components that are not yet audited, and thus not necessarily recommended for further use. After an audit, a component may either be moved to Calypso Components, deprecated, or classified as safe to use. If there is a similar component in [WordPress Core](https://wordpress.github.io/gutenberg), you should probably use that instead. If you have any questions, feel free to ask in the `#design-systems` channel on A8C Slack or ping Team Calypso.
 

--- a/packages/components/.storybook/preview.js
+++ b/packages/components/.storybook/preview.js
@@ -12,7 +12,13 @@ const parameters = {
 	},
 	options: {
 		storySort: ( a, b ) => {
-			const sectionOrder = [ 'Validated Form Controls', 'WP Overrides', 'Deprecated', 'Unaudited' ];
+			const sectionOrder = [
+				'Validated Form Controls',
+				'WP Overrides',
+				'Still Internal',
+				'Deprecated',
+				'Unaudited',
+			];
 			const aIndex = sectionOrder.findIndex( ( prefix ) => a.title.startsWith( prefix ) );
 			const bIndex = sectionOrder.findIndex( ( prefix ) => b.title.startsWith( prefix ) );
 

--- a/packages/components/.storybook/preview.js
+++ b/packages/components/.storybook/preview.js
@@ -15,7 +15,7 @@ const parameters = {
 			const sectionOrder = [
 				'Validated Form Controls',
 				'WP Overrides',
-				'Still Internal',
+				'Unpublished',
 				'Deprecated',
 				'Unaudited',
 			];

--- a/packages/components/src/calendar/date-calendar/index.stories.tsx
+++ b/packages/components/src/calendar/date-calendar/index.stories.tsx
@@ -33,7 +33,7 @@ import { DateCalendar, TZDate } from '../';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta< typeof DateCalendar > = {
-	title: 'Components/DateCalendar',
+	title: 'DateCalendar',
 	component: DateCalendar,
 	parameters: {
 		controls: { expanded: true },

--- a/packages/components/src/calendar/date-range-calendar/index.stories.tsx
+++ b/packages/components/src/calendar/date-range-calendar/index.stories.tsx
@@ -33,7 +33,7 @@ import { DateRangeCalendar, TZDate } from '../';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta< typeof DateRangeCalendar > = {
-	title: 'Components/DateRangeCalendar',
+	title: 'DateRangeCalendar',
 	component: DateRangeCalendar,
 	parameters: {
 		controls: { expanded: true },

--- a/packages/components/src/icon/index.stories.tsx
+++ b/packages/components/src/icon/index.stories.tsx
@@ -4,7 +4,7 @@ import { Icon } from '.';
 import type { Meta, StoryFn } from '@storybook/react';
 
 const meta: Meta< typeof Icon > = {
-	title: 'Still Internal/Icon',
+	title: 'Unpublished/Icon',
 	component: Icon,
 	parameters: {
 		docs: { canvas: { sourceState: 'shown' } },

--- a/packages/components/src/tabs/stories/index.stories.tsx
+++ b/packages/components/src/tabs/stories/index.stories.tsx
@@ -7,7 +7,7 @@ import { Icon } from '../../icon';
 import type { Meta, StoryFn } from '@storybook/react';
 
 const meta: Meta< typeof Tabs > = {
-	title: 'Components/Containers/Tabs',
+	title: 'Tabs',
 	id: 'components-tabs',
 	component: Tabs,
 	subcomponents: {


### PR DESCRIPTION
Regression discovered while testing #103000

## Proposed Changes

Fixes the "Cannot find module './.storybook/overview.mdx'" error when trying to load the main "Overview" MDX file in Storybook.

Also flattens some of the approved components to the top level.

## Why are these changes being made?

This likely regressed in a recent dependency update.

## Testing Instructions

`yarn components:storybook:start` and confirm that the main "Overview" file loads without error.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
