### PR TITLE
Help Center: distinguish between dev and prod when fetching support interactions

### DIFF
--- a/packages/odie-client/src/data/handle-support-interactions-fetch.ts
+++ b/packages/odie-client/src/data/handle-support-interactions-fetch.ts
@@ -1,16 +1,19 @@
 import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import type { SupportInteraction, SupportInteractionEvent } from '../types';
 
 export const handleSupportInteractionsFetch = async (
 	method: 'GET' | 'POST' | 'PUT',
 	path: string | null,
+	isTestMode: boolean,
 	data?: SupportInteractionEvent | { status: string }
 ): Promise< SupportInteraction[] > => {
+	const fullPath = addQueryArgs( path ?? '', { is_test_mode: isTestMode } );
 	return canAccessWpcomApis()
 		? await wpcomRequest( {
 				method,
-				path: `/support-interactions${ path ?? '' }`,
+				path: `/support-interactions${ fullPath ?? '' }`,
 				apiNamespace: 'wpcom/v2',
 				body: data,
 		  } )

--- a/packages/odie-client/src/data/use-get-support-interaction-by-id.ts
+++ b/packages/odie-client/src/data/use-get-support-interaction-by-id.ts
@@ -1,3 +1,4 @@
+import { isTestModeEnvironment } from '@automattic/zendesk-client';
 import { useQuery } from '@tanstack/react-query';
 import { handleSupportInteractionsFetch } from './handle-support-interactions-fetch';
 
@@ -7,9 +8,10 @@ import { handleSupportInteractionsFetch } from './handle-support-interactions-fe
  * @returns The support interaction.
  */
 export const useGetSupportInteractionById = ( interactionId: string | null ) => {
+	const isTestMode = isTestModeEnvironment();
 	return useQuery( {
-		queryKey: [ 'support-interactions', 'get-interaction-by-id', interactionId ],
-		queryFn: () => handleSupportInteractionsFetch( 'GET', `/${ interactionId }` ),
+		queryKey: [ 'support-interactions', 'get-interaction-by-id', interactionId, isTestMode ],
+		queryFn: () => handleSupportInteractionsFetch( 'GET', `/${ interactionId }`, isTestMode ),
 		refetchOnWindowFocus: false,
 		refetchOnReconnect: false,
 		enabled: !! interactionId,

--- a/packages/odie-client/src/data/use-get-support-interactions.ts
+++ b/packages/odie-client/src/data/use-get-support-interactions.ts
@@ -1,3 +1,4 @@
+import { isTestModeEnvironment } from '@automattic/zendesk-client';
 import { useQuery } from '@tanstack/react-query';
 import { handleSupportInteractionsFetch } from './handle-support-interactions-fetch';
 import type { SupportProvider } from '../types';
@@ -15,11 +16,12 @@ export const useGetSupportInteractions = (
 	freshness = 0
 ) => {
 	const path = `?per_page=${ per_page }&page=${ page }&status=${ status }`;
+	const isTestMode = isTestModeEnvironment();
+
 	return useQuery( {
-		// eslint-disable-next-line
-		queryKey: [ 'support-interactions', 'get-interactions', provider, status, freshness ],
+		queryKey: [ 'support-interactions', 'get-interactions', provider, freshness, path, isTestMode ],
 		queryFn: async () => {
-			const response = await handleSupportInteractionsFetch( 'GET', path );
+			const response = await handleSupportInteractionsFetch( 'GET', path, isTestMode );
 
 			if ( response.length === 0 ) {
 				return null;

--- a/packages/odie-client/src/data/use-manage-support-interaction.ts
+++ b/packages/odie-client/src/data/use-manage-support-interaction.ts
@@ -1,4 +1,5 @@
 import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
+import { isTestModeEnvironment } from '@automattic/zendesk-client';
 import { useMutation } from '@tanstack/react-query';
 import { useDispatch } from '@wordpress/data';
 import { handleSupportInteractionsFetch } from './handle-support-interactions-fetch';
@@ -9,16 +10,17 @@ import type { SupportInteraction, SupportInteractionEvent } from '../types';
  */
 export const useManageSupportInteraction = () => {
 	const { setCurrentSupportInteraction } = useDispatch( HELP_CENTER_STORE );
-
+	const isTestMode = isTestModeEnvironment();
 	/**
 	 * Start a new support interaction.
 	 */
 	const startNewInteraction = useMutation( {
-		mutationKey: [ 'support-interaction', 'new-conversation' ],
+		mutationKey: [ 'support-interaction', 'new-conversation', isTestMode ],
 		mutationFn: ( eventData: SupportInteractionEvent ) =>
 			handleSupportInteractionsFetch(
 				'POST',
 				null,
+				isTestMode,
 				eventData
 			) as unknown as Promise< SupportInteraction >,
 		onSuccess: (
@@ -43,7 +45,7 @@ export const useManageSupportInteraction = () => {
 		Error,
 		{ interactionId: string; eventData: SupportInteractionEvent }
 	>( {
-		mutationKey: [ 'support-interaction', 'add-event' ],
+		mutationKey: [ 'support-interaction', 'add-event', isTestMode ],
 		mutationFn: ( {
 			interactionId,
 			eventData,
@@ -54,6 +56,7 @@ export const useManageSupportInteraction = () => {
 			handleSupportInteractionsFetch(
 				'POST',
 				`/${ interactionId }/events`,
+				isTestMode,
 				eventData
 			) as unknown as Promise< SupportInteraction >,
 		onSuccess: (
@@ -74,9 +77,11 @@ export const useManageSupportInteraction = () => {
 	 * Resolve a support interaction.
 	 */
 	const resolveInteraction = useMutation( {
-		mutationKey: [ 'support-interaction', 'resolve' ],
+		mutationKey: [ 'support-interaction', 'resolve', isTestMode ],
 		mutationFn: ( { interactionId }: { interactionId: string } ) =>
-			handleSupportInteractionsFetch( 'PUT', `/${ interactionId }/status`, { status: 'resolved' } ),
+			handleSupportInteractionsFetch( 'PUT', `/${ interactionId }/status`, isTestMode, {
+				status: 'resolved',
+			} ),
 	} ).mutate;
 
 	return {


### PR DESCRIPTION
Fixes: DOTSUP-69

## Proposed Changes

This fixes the spread confusion between staging and production envs when fetching, posting, and especially caching the user's interactions.

- Previously, we didn't factor in the env flag when keying the query's cache, and `staging` convos were cached as `production` convos, and vice versa.
- This adds the `is_testing_mode` flag to all the requests so we only fetch, update, and create interactions in the right instance of Zendesk. 

## Testing Instructions
### Notes:
- First, apply this to your sandbox wpcom#185125 and sandbox public api.
- This has to be tested in localhost.

### Steps:
1. While incognito, go to `http://calypso.localhost:3000/`.
3. Create a new user. Take note of the username.
4. Give the user some credits. 
5. Create a paid site for the user.
6. Access Odie and send it a message mentioning "staging".
7. Click the three dots on top of the convo and start a new one. 
8. Send another message, also mention "staging". 
9. Go to [this function](https://github.com/Automattic/wp-calypso/blob/56d949625f06fa647a518b6f731cd009718ef3ef/packages/zendesk-client/src/util.tsx#L4) and `return false`. 
10. Refresh the page and re-open the Help Center. 
11. You should have **no conversation history**.
12. Create two conversations but this time mention "Production". in both 
13. Refresh the page. The HC should only have these two prod convos.
14. Go back to the function and remove your `return true`.
15. Refresh the page, you should get the `staging` convos.

## Demo

Working on it