### PR TITLE
Fix localization of theme descriptions

### DIFF
--- a/client/components/data/query-theme-filters/index.jsx
+++ b/client/components/data/query-theme-filters/index.jsx
@@ -6,7 +6,7 @@ import { requestThemeFilters } from 'calypso/state/themes/actions';
 export class QueryThemeFilters extends Component {
 	static propTypes = {
 		requestThemeFilters: PropTypes.func.isRequired,
-		locale: PropTypes.func.isRequired,
+		locale: PropTypes.string.isRequired,
 	};
 
 	componentDidMount() {

--- a/client/components/data/query-theme/index.jsx
+++ b/client/components/data/query-theme/index.jsx
@@ -1,14 +1,17 @@
+import { useLocale } from '@automattic/i18n-utils';
 import PropTypes from 'prop-types';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { requestTheme } from 'calypso/state/themes/actions';
 import { isRequestingTheme } from 'calypso/state/themes/selectors';
 
-const request = ( siteId, themeId ) => ( dispatch, getState ) => {
-	if ( ! isRequestingTheme( getState(), siteId, themeId ) ) {
-		dispatch( requestTheme( themeId, siteId ) );
-	}
-};
+const request =
+	( siteId, themeId, forceRequest = false ) =>
+	( dispatch, getState ) => {
+		if ( ! isRequestingTheme( getState(), siteId, themeId ) || forceRequest ) {
+			dispatch( requestTheme( themeId, siteId ) );
+		}
+	};
 
 function QueryTheme( { siteId, themeId } ) {
 	useQueryTheme( siteId, themeId );
@@ -17,12 +20,19 @@ function QueryTheme( { siteId, themeId } ) {
 
 export function useQueryTheme( siteId, themeId ) {
 	const dispatch = useDispatch();
+	const locale = useLocale();
+	const oldLocale = useRef( locale );
 
 	useEffect( () => {
 		if ( siteId && themeId ) {
-			dispatch( request( siteId, themeId ) );
+			if ( oldLocale.current !== locale ) {
+				oldLocale.current = locale;
+				dispatch( request( siteId, themeId, true ) );
+			} else {
+				dispatch( request( siteId, themeId ) );
+			}
 		}
-	}, [ dispatch, siteId, themeId ] );
+	}, [ dispatch, siteId, themeId, locale ] );
 }
 
 export function useQueryThemes( siteId, themeIds ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13494

## Proposed Changes

* Modify the logic for loading theme details to fetch it again on locale change.

**Before:**
<img width="702" alt="Screenshot 2025-06-09 at 01 23 50" src="https://github.com/user-attachments/assets/e90f72c8-8873-46c3-af4f-48d0704709d6" />

**After:**
<img width="702" alt="Screenshot 2025-06-09 at 01 23 34" src="https://github.com/user-attachments/assets/a4e2d224-76b5-4d1e-adfa-4838acbf0eb8" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* In some cases we're getting theme details before the user locale has been loaded, which means that for non-English users it'd appear untranslated.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To reproduce the issue change your locale in WordPress.com to a popular locale like Brazilian Portuguese, then open https://wordpress.com/theme/folio/{your site}. Refresh a few times to confirm that the theme description appears in English.
* Test the same scenario on calypso.live or local Calypso instance. Refresh a few times and pay attention to the network requests to `themes/` and JS console messages.
* For regression testing check some of the other places where theme details are being loaded:
* Open /themes/{your site} page, open any theme details page, on a theme details page click on `Preview Demo Site`, on a non-Atomic site with a Business plan navigate to /themes page and click on `Install new theme`. In all cases no issues should occur.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
