### PR TITLE
Theme Preview: Pass the user language to the demo URL

### DIFF
--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -68,7 +68,7 @@ class ThemePreview extends Component {
 
 		let previewUrl = demoUrl + '?demo=true&iframe=true&theme_preview=true';
 		if ( locale && locale.length > 0 && locale !== 'en' ) {
-			previewUrl += '&locale=' + locale;
+			previewUrl += '&language=' + locale;
 		}
 
 		return (

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -59,10 +59,16 @@ class ThemePreview extends Component {
 	};
 
 	render() {
-		const { themeId, siteId, demoUrl, children, isWPForTeamsSite, themeOptions } = this.props;
+		const { themeId, siteId, demoUrl, children, isWPForTeamsSite, themeOptions, locale } =
+			this.props;
 
 		if ( ! themeId || isWPForTeamsSite ) {
 			return null;
+		}
+
+		let previewUrl = demoUrl + '?demo=true&iframe=true&theme_preview=true';
+		if ( locale && locale.length > 0 && locale !== 'en' ) {
+			previewUrl += '&locale=' + locale;
 		}
 
 		return (
@@ -77,10 +83,7 @@ class ThemePreview extends Component {
 						showEditHeaderLink
 						showSEO={ false }
 						onClose={ this.props.hideThemePreview }
-						previewUrl={ this.appendStyleVariationOptionToUrl(
-							demoUrl + '?demo=true&iframe=true&theme_preview=true',
-							'title'
-						) }
+						previewUrl={ this.appendStyleVariationOptionToUrl( previewUrl, 'title' ) }
 						externalUrl={ demoUrl }
 						belowToolbar={ this.props.belowToolbar }
 						themeOptions={ themeOptions }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13068

## Proposed Changes

* Pass the user locale to the Theme Preview demo website so we can localize it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The theme demo site isn't currently aware of the user locale.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `wordpress.com/fr/themes`, preview a theme and confirm the language parameter is sent to the theme demo site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
