### PR TITLE
E2E Tests: Use newly created account for site visibility tests

### DIFF
--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -278,6 +278,8 @@ export class RestAPIClient {
 			return null;
 		}
 
+		console.log( `Deleting site ${ targetSite.domain }.` );
+
 		const scheme = 'http://';
 		const targetDomain = targetSite.domain.startsWith( scheme )
 			? targetSite.domain.replace( scheme, '' )
@@ -307,11 +309,13 @@ export class RestAPIClient {
 		);
 
 		if ( response.hasOwnProperty( 'error' ) ) {
+			console.warn( `Failed to delete site ID ${ targetSite.domain }` );
 			throw new Error(
 				`${ ( response as ErrorResponse ).error }: ${ ( response as ErrorResponse ).message }`
 			);
 		}
 
+		console.log( `Successfully deleted site ID ${ targetSite.domain }` );
 		return response;
 	}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of p1749223784624619-slack-C08JZTRS6NA

## Proposed Changes

* Use a newly created account for site visibility tests, since the `/mew/sites/` endpoint returns all sites — including deleted ones — even when the `site_visibility` parameter is set to `visible`. We have to consider whether to filter out the deleted sites from the endpoint.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To avoid /me/sites slow on the test account

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure the `test/e2e/specs/dashboard/settings__site-visibility.ts` still passes!

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?