### PR TITLE
Fixup PHP version capitalisation

### DIFF
--- a/client/data/php-versions/index.jsx
+++ b/client/data/php-versions/index.jsx
@@ -4,7 +4,7 @@ export const getPHPVersions = () => {
 	// PHP 8.3 is now the default recommended version
 	const recommendedValue = '8.3';
 	// translators: PHP Version for a version switcher
-	const recommendedLabel = sprintf( __( '%s (recommended)' ), recommendedValue );
+	const recommendedLabel = sprintf( __( '%s (Recommended)' ), recommendedValue );
 
 	const phpVersions = [
 		{
@@ -14,7 +14,7 @@ export const getPHPVersions = () => {
 		},
 		{
 			// translators: PHP Version for a version switcher
-			label: sprintf( __( '%s (deprecated)' ), '7.4' ),
+			label: sprintf( __( '%s (Deprecated)' ), '7.4' ),
 			value: '7.4',
 			disabled: true, // EOL 1st July, 2024
 		},
@@ -25,7 +25,7 @@ export const getPHPVersions = () => {
 		},
 		{
 			// translators: PHP Version for a version switcher
-			label: sprintf( __( '%s (deprecated)' ), '8.1' ),
+			label: sprintf( __( '%s (Deprecated)' ), '8.1' ),
 			value: '8.1',
 			disabled: false, // EOL 31st December, 2025
 		},


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

Reported in pdtkmj-3H1-p2#comment-7078

Since it's just a capitalisation improvement I don't want the translations to break temporarily. Pretty sure `@wordpress/i18n` doesn't have anything like `useHasEnTranslation()`. So I'll just KISS and use `[Status] String Freeze`

![CleanShot 2025-06-09 at 14 26 55@2x](https://github.com/user-attachments/assets/7133deec-1bdf-40f1-b76e-f98068b1423e)



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Improves capitalisation

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?