### PR TITLE
Subscriber Stats: Fix and unify the Total subscribers count source

### DIFF
--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -161,7 +161,7 @@ function useSubscribersTotalsQueries( siteId: number | null, filterAdmin?: boole
 			data: {
 				total_email: results[ 0 ]?.data?.total_email,
 				total_wpcom: results[ 0 ]?.data?.total_wpcom,
-				total: results[ 0 ]?.data?.total,
+				total: results[ 1 ]?.data?.total_subscribers,
 				paid_subscribers: results[ 1 ]?.data?.paid_subscribers,
 				free_subscribers:
 					results[ 1 ]?.data?.email_subscribers !== undefined &&
@@ -182,7 +182,7 @@ function useSubscribersTotalsQueries( siteId: number | null, filterAdmin?: boole
 		data: {
 			total_email: results[ 3 ]?.data?.total,
 			total_wpcom: results[ 2 ]?.data?.total,
-			total: results[ 1 ].data?.email_subscribers,
+			total: results[ 1 ]?.data?.total_subscribers,
 			paid_subscribers: results[ 1 ]?.data?.paid_subscribers,
 			free_subscribers:
 				results[ 1 ]?.data?.email_subscribers !== undefined &&


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixed p1749270570611519-slack-C0438NHCLSY.

## Proposed Changes

* Fix and unify the `Total subscribers` count source by using property `total_subscribers` of the `/wpcom/v2/sites/{site-id}/subscribers/counts` endpoint.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The previous `Total subscribers` count was coming from `email_subscribers` of the endpoint `/subscribers/counts`, which seems to be updated with some critical change: 182324-ghe-Automattic/wpcom. Using the `total_subscribers` property instead applies the correct number.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Subscribers page.
* Ensure the `Total subscribers` card shows the correct number in line with the chart.

|Before|After|
|-|-|
|<img width="1302" alt="截圖 2025-06-09 下午4 06 17" src="https://github.com/user-attachments/assets/bb525205-36ad-4b99-bc04-6308fdd9cb13" />|<img width="1273" alt="截圖 2025-06-09 下午4 21 33" src="https://github.com/user-attachments/assets/94cfc883-5273-4083-8f65-2db711f8ab1e" />|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?