### PR TITLE
Forms: E2E test updates for sentence casing Forms UI

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
@@ -26,7 +26,7 @@ export class AllFormFieldsFlow implements BlockFlow {
 	}
 
 	// You add an individual input field...
-	blockSidebarName = 'Text Input Field';
+	blockSidebarName = 'Text input field';
 	// ... but a full Form block is added and marked as selected in the editor!
 	blockEditorSelector = makeSelectorFromBlockName( 'Form' );
 
@@ -38,31 +38,31 @@ export class AllFormFieldsFlow implements BlockFlow {
 	async configure( context: EditorContext ): Promise< void > {
 		// Determine if we are working with the refactored form fields (released June 2025)
 		const editorCanvas = await context.editorPage.getEditorCanvas();
-		const initailBlock = editorCanvas.locator( makeSelectorFromBlockName( 'Text Input Field' ) );
+		const initailBlock = editorCanvas.locator( makeSelectorFromBlockName( 'Text input field' ) );
 		const inputChild = initailBlock.locator( '[aria-label="Block: Input"]' );
 		const isRefactor = ( await inputChild.count() ) > 0;
 
 		// Text Input Field is already added by the first step, so let's start by labeling it.
 		await labelFormFieldBlock( context.addedBlockLocator, {
-			blockName: 'Text Input Field',
+			blockName: 'Text input field',
 			accessibleLabelName: 'Add label…',
-			labelText: this.addLabelPrefix( 'Text Input Field' ),
+			labelText: this.addLabelPrefix( 'Text input field' ),
 		} );
-		let lastBlockName = 'Text Input Field';
+		let lastBlockName = 'Text input field';
 
 		// Add remaining field blocks, labeling as we go.
 		const remainingBlocksToAdd = [
-			[ 'Name Field', 'Add label…' ],
-			[ 'Email Field', 'Add label…' ],
-			[ 'Website Field', 'Add label…' ],
-			[ 'Date Picker', 'Add label…' ],
-			[ 'Phone Number Field', 'Add label…' ],
-			[ 'Multi-line Text Field', 'Add label…' ],
+			[ 'Name field', 'Add label…' ],
+			[ 'Email field', 'Add label…' ],
+			[ 'Website field', 'Add label…' ],
+			[ 'Date picker', 'Add label…' ],
+			[ 'Phone number field', 'Add label…' ],
+			[ 'Multi-line text field', 'Add label…' ],
 			[ 'Checkbox', 'Add label…' ],
-			[ 'Multiple Choice (Checkbox)', 'Add label' ],
-			[ 'Single Choice (Radio)', 'Add label' ],
-			[ 'Dropdown Field', 'Add label' ],
-			[ 'Terms Consent', 'Add implicit consent message…' ],
+			[ 'Multiple choice (checkbox)', 'Add label' ],
+			[ 'Single choice (radio)', 'Add label' ],
+			[ 'Dropdown field', 'Add label' ],
+			[ 'Terms consent', 'Add implicit consent message…' ],
 		];
 		for ( const [ blockName, accessibleLabelName ] of remainingBlocksToAdd ) {
 			await this.addFieldBlockToForm( context, blockName, lastBlockName, isRefactor );
@@ -79,8 +79,8 @@ export class AllFormFieldsFlow implements BlockFlow {
 		const otherBlocksToLabel = isRefactor
 			? [
 					[ 'Button', 'Add text…' ],
-					[ 'Option', 'Add option…', 'Single Choice (Radio)' ],
-					[ 'Option', 'Add option…', 'Multiple Choice (Checkbox)' ],
+					[ 'Option', 'Add option…', 'Single choice (radio)' ],
+					[ 'Option', 'Add option…', 'Multiple choice (checkbox)' ],
 			  ]
 			: [
 					[ 'Button', 'Add text…' ],
@@ -106,28 +106,28 @@ export class AllFormFieldsFlow implements BlockFlow {
 	 */
 	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
 		const isRefactor = ( await context.page.locator( '.wp-block-jetpack-input' ).count() ) > 0;
-		const radioName = isRefactor ? 'Option' : 'Single Choice Option';
-		const checkboxName = isRefactor ? 'Option' : 'Multiple Choice Option';
+		const radioName = isRefactor ? 'Option' : 'Single choice option';
+		const checkboxName = isRefactor ? 'Option' : 'Multiple choice option';
 
 		await validatePublishedFormFields( context.page, [
-			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Text Input Field' ) },
-			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Name Field' ) },
-			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Email Field' ) },
-			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Website Field' ) },
-			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Phone Number Field' ) },
-			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Multi-line Text Field' ) },
+			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Text input field' ) },
+			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Name field' ) },
+			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Email field' ) },
+			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Website field' ) },
+			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Phone number field' ) },
+			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Multi-line text field' ) },
 			{ type: 'checkbox', accessibleName: this.addLabelPrefix( 'Checkbox' ) },
 			{ type: 'radio', accessibleName: this.addLabelPrefix( radioName ) },
 			{ type: 'checkbox', accessibleName: this.addLabelPrefix( checkboxName ) },
 			{ type: 'button', accessibleName: this.addLabelPrefix( 'Button' ) },
 			// Currently broken, sadly! See: https://github.com/Automattic/jetpack/issues/30762
-			// { type: 'combobox', accessibleName: this.addLabelPrefix( 'Dropdown Field' ) },
+			// { type: 'combobox', accessibleName: this.addLabelPrefix( 'Dropdown field' ) },
 		] );
 
 		// The terms consent is kind of weird because it's applied to a hidden checkbox, so we validate that here.
 		await context.page
 			.getByRole( 'checkbox', {
-				name: this.addLabelPrefix( 'Terms Consent' ),
+				name: this.addLabelPrefix( 'Terms consent' ),
 				includeHidden: true,
 			} )
 			.first()

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/contact-form.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/contact-form.ts
@@ -36,14 +36,14 @@ export class ContactFormFlow implements BlockFlow {
 		// Name and Email are common fields shared amongst all Form patterns.
 		// So let's make them unique here!
 		await labelFormFieldBlock( context.addedBlockLocator, {
-			blockName: 'Name Field',
+			blockName: 'Name field',
 			accessibleLabelName: 'Add label…',
-			labelText: this.addLabelPrefix( 'Name Field' ),
+			labelText: this.addLabelPrefix( 'Name field' ),
 		} );
 		await labelFormFieldBlock( context.addedBlockLocator, {
-			blockName: 'Email Field',
+			blockName: 'Email field',
 			accessibleLabelName: 'Add label…',
-			labelText: this.addLabelPrefix( 'Email Field' ),
+			labelText: this.addLabelPrefix( 'Email field' ),
 		} );
 	}
 
@@ -64,8 +64,8 @@ export class ContactFormFlow implements BlockFlow {
 	 */
 	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
 		await validatePublishedFormFields( context.page, [
-			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Name Field' ) },
-			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Email Field' ) },
+			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Name field' ) },
+			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Email field' ) },
 			// This is the default label pulled in by the Contact Form pattern.
 			// It's unique-ish and a good validation of that pattern, so we've left it alone.
 			{ type: 'textbox', accessibleName: 'Message' },

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
@@ -58,14 +58,14 @@ export class FormPatternsFlow implements BlockFlow {
 		// Name and Email are common fields shared amongst all Form patterns.
 		// So let's make them unique here!
 		await labelFormFieldBlock( newParentBlockLocator, {
-			blockName: 'Name Field',
+			blockName: 'Name field',
 			accessibleLabelName: 'Add label…',
-			labelText: this.addLabelPrefix( 'Name Field' ),
+			labelText: this.addLabelPrefix( 'Name field' ),
 		} );
 		await labelFormFieldBlock( newParentBlockLocator, {
-			blockName: 'Email Field',
+			blockName: 'Email field',
 			accessibleLabelName: 'Add label…',
-			labelText: this.addLabelPrefix( 'Email Field' ),
+			labelText: this.addLabelPrefix( 'Email field' ),
 		} );
 	}
 
@@ -111,8 +111,8 @@ export class FormPatternsFlow implements BlockFlow {
 	 */
 	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
 		await validatePublishedFormFields( context.page, [
-			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Name Field' ) },
-			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Email Field' ) },
+			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Name field' ) },
+			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Email field' ) },
 			...this.validationData.otherExpectedFields,
 		] );
 	}


### PR DESCRIPTION
PR's with upstream changes:
- Sentence case field names https://github.com/Automattic/jetpack/pull/43818
- Sentence case all UI components https://github.com/Automattic/jetpack/pull/43847

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

Addresses changes made in Jetpack Forms:
- https://github.com/Automattic/jetpack/pull/43847
- https://github.com/Automattic/jetpack/pull/43818


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
