### PR TITLE
Dashboard v2: Show deleted sites only when a search keyword is entered or a status filter is applied

### DIFF
--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -67,10 +67,10 @@ import type {
 } from '../data/types';
 import type { Query } from '@tanstack/react-query';
 
-export function sitesQuery() {
+export function sitesQuery( siteVisibility: Parameters< typeof fetchSites >[ 0 ] = 'all' ) {
 	return {
-		queryKey: [ 'sites', SITE_FIELDS, SITE_OPTIONS ],
-		queryFn: fetchSites,
+		queryKey: [ 'sites', SITE_FIELDS, SITE_OPTIONS, siteVisibility ],
+		queryFn: () => fetchSites( siteVisibility ),
 	};
 }
 

--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -64,13 +64,16 @@ import type {
 	SshAccessStatus,
 	SftpUser,
 	SiteSshKey,
+	FetchSitesOptions,
 } from '../data/types';
 import type { Query } from '@tanstack/react-query';
 
-export function sitesQuery( siteVisibility: Parameters< typeof fetchSites >[ 0 ] = 'all' ) {
+export function sitesQuery(
+	fetchSitesOptions: FetchSitesOptions = { site_visibility: 'visible' }
+) {
 	return {
-		queryKey: [ 'sites', SITE_FIELDS, SITE_OPTIONS, siteVisibility ],
-		queryFn: () => fetchSites( siteVisibility ),
+		queryKey: [ 'sites', SITE_FIELDS, SITE_OPTIONS, fetchSitesOptions.site_visibility ],
+		queryFn: () => fetchSites( fetchSitesOptions ),
 	};
 }
 

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -55,9 +55,7 @@ export const fetchProfileSshKeys = async (): Promise< ProfileSshKey[] > => {
 const JOINED_SITE_FIELDS = SITE_FIELDS.join( ',' );
 const JOINED_SITE_OPTIONS = SITE_OPTIONS.join( ',' );
 
-export const fetchSites = async (
-	site_visibility: FetchSitesOptions[ 'site_visibility' ]
-): Promise< Site[] > => {
+export const fetchSites = async ( { site_visibility }: FetchSitesOptions ): Promise< Site[] > => {
 	const { sites } = await wpcom.req.get(
 		{
 			path: '/me/sites',

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -6,6 +6,7 @@ import type {
 	MediaStorage,
 	MonitorUptime,
 	Plan,
+	FetchSitesOptions,
 	Site,
 	AgencyBlog,
 	Purchase,
@@ -54,14 +55,16 @@ export const fetchProfileSshKeys = async (): Promise< ProfileSshKey[] > => {
 const JOINED_SITE_FIELDS = SITE_FIELDS.join( ',' );
 const JOINED_SITE_OPTIONS = SITE_OPTIONS.join( ',' );
 
-export const fetchSites = async (): Promise< Site[] > => {
+export const fetchSites = async (
+	site_visibility: FetchSitesOptions[ 'site_visibility' ]
+): Promise< Site[] > => {
 	const { sites } = await wpcom.req.get(
 		{
 			path: '/me/sites',
 			apiVersion: '1.2',
 		},
 		{
-			site_visibility: 'visible',
+			site_visibility,
 			include_domain_only: 'true',
 			site_activity: 'active',
 			fields: JOINED_SITE_FIELDS,

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -61,7 +61,7 @@ export const fetchSites = async (): Promise< Site[] > => {
 			apiVersion: '1.2',
 		},
 		{
-			site_visibility: 'all',
+			site_visibility: 'visible',
 			include_domain_only: 'true',
 			site_activity: 'active',
 			fields: JOINED_SITE_FIELDS,

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -83,6 +83,10 @@ export interface SiteOptions {
 	software_version: string;
 }
 
+export interface FetchSitesOptions {
+	site_visibility: 'all' | 'visible' | 'hidden' | 'deleted';
+}
+
 export interface Site {
 	ID: string;
 	slug: string;

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -182,7 +182,9 @@ const getFetchSitesOptions = (
 export default function Sites() {
 	const navigate = useNavigate( { from: sitesRoute.fullPath } );
 	const viewOptions: Partial< ViewTable | ViewGrid > | undefined = sitesRoute.useSearch().view;
-	const sites = useQuery( sitesQuery( getFetchSitesOptions( viewOptions ) ) ).data;
+	const { data: sites, isLoading: isLoadingSites } = useQuery(
+		sitesQuery( getFetchSitesOptions( viewOptions ) )
+	);
 	const hasA8CSites = sites?.some( ( site ) => site.is_a8c );
 	const defaultView = useMemo(
 		() =>
@@ -219,10 +221,6 @@ export default function Sites() {
 	);
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
-	if ( ! sites ) {
-		return;
-	}
-
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( sites, view, fields );
 
 	return (
@@ -255,6 +253,7 @@ export default function Sites() {
 						fields={ fields }
 						actions={ actions }
 						view={ view }
+						isLoading={ isLoadingSites }
 						onChangeView={ ( view ) => {
 							if ( view.type === 'list' ) {
 								return;

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -221,7 +221,7 @@ export default function Sites() {
 	);
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
-	const { data: filteredData, paginationInfo } = filterSortAndPaginate( sites, view, fields );
+	const { data: filteredData, paginationInfo } = filterSortAndPaginate( sites ?? [], view, fields );
 
 	return (
 		<>

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -15,8 +15,15 @@ import { STATUS_LABELS, getSiteStatus, getSiteStatusLabel } from '../utils/site-
 import AddNewSite from './add-new-site';
 import SiteIcon from './site-icon';
 import SitePreview from './site-preview';
-import type { Site } from '../data/types';
-import type { Field, Operator, SortDirection, ViewTable, ViewGrid } from '@automattic/dataviews';
+import type { FetchSitesOptions, Site } from '../data/types';
+import type {
+	Field,
+	Operator,
+	SortDirection,
+	ViewTable,
+	ViewGrid,
+	Filter,
+} from '@automattic/dataviews';
 
 const actions = [
 	{
@@ -81,6 +88,9 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		label: __( 'Status' ),
 		getValue: ( { item }: { item: Site } ) => getSiteStatus( item ),
 		elements: Object.entries( STATUS_LABELS ).map( ( [ value, label ] ) => ( { value, label } ) ),
+		filterBy: {
+			operators: [ 'is' ],
+		},
 		render: ( { item }: { item: Site } ) => getSiteStatusLabel( item ),
 	},
 	{
@@ -155,9 +165,24 @@ const DEFAULT_VIEW = {
 	search: '',
 };
 
+const getSiteVisibilityByViewOptions = (
+	viewOptions: Partial< ViewTable | ViewGrid > | undefined = {}
+): FetchSitesOptions[ 'site_visibility' ] => {
+	if (
+		viewOptions.filters?.find(
+			( filter: Filter ) => filter.field === 'status' && filter.value === 'deleted'
+		)
+	) {
+		return 'deleted';
+	}
+
+	return viewOptions.search ? 'all' : 'visible';
+};
+
 export default function Sites() {
 	const navigate = useNavigate( { from: sitesRoute.fullPath } );
-	const sites = useQuery( sitesQuery() ).data;
+	const viewOptions: Partial< ViewTable | ViewGrid > | undefined = sitesRoute.useSearch().view;
+	const sites = useQuery( sitesQuery( getSiteVisibilityByViewOptions( viewOptions ) ) ).data;
 	const hasA8CSites = sites?.some( ( site ) => site.is_a8c );
 	const defaultView = useMemo(
 		() =>
@@ -175,16 +200,17 @@ export default function Sites() {
 				: DEFAULT_VIEW,
 		[ hasA8CSites ]
 	);
-	const search: Partial< ViewTable | ViewGrid > | undefined = sitesRoute.useSearch().view;
 	const view = useMemo(
 		() => ( {
 			...defaultView,
-			...DEFAULT_LAYOUTS[ search?.type ?? DEFAULT_VIEW.type ],
-			...( search
-				? Object.fromEntries( Object.entries( search ).filter( ( [ , v ] ) => v !== undefined ) )
+			...DEFAULT_LAYOUTS[ viewOptions?.type ?? DEFAULT_VIEW.type ],
+			...( viewOptions
+				? Object.fromEntries(
+						Object.entries( viewOptions ).filter( ( [ , v ] ) => v !== undefined )
+				  )
 				: {} ),
 		} ),
-		[ defaultView, search ]
+		[ defaultView, viewOptions ]
 	);
 	const fields = useMemo(
 		() =>

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -165,24 +165,24 @@ const DEFAULT_VIEW = {
 	search: '',
 };
 
-const getSiteVisibilityByViewOptions = (
+const getFetchSitesOptions = (
 	viewOptions: Partial< ViewTable | ViewGrid > | undefined = {}
-): FetchSitesOptions[ 'site_visibility' ] => {
+): FetchSitesOptions => {
 	if (
 		viewOptions.filters?.find(
 			( filter: Filter ) => filter.field === 'status' && filter.value === 'deleted'
 		)
 	) {
-		return 'deleted';
+		return { site_visibility: 'deleted' };
 	}
 
-	return viewOptions.search ? 'all' : 'visible';
+	return { site_visibility: viewOptions.search ? 'all' : 'visible' };
 };
 
 export default function Sites() {
 	const navigate = useNavigate( { from: sitesRoute.fullPath } );
 	const viewOptions: Partial< ViewTable | ViewGrid > | undefined = sitesRoute.useSearch().view;
-	const sites = useQuery( sitesQuery( getSiteVisibilityByViewOptions( viewOptions ) ) ).data;
+	const sites = useQuery( sitesQuery( getFetchSitesOptions( viewOptions ) ) ).data;
 	const hasA8CSites = sites?.some( ( site ) => site.is_a8c );
 	const defaultView = useMemo(
 		() =>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://github.com/Automattic/wp-calypso/pull/104062

## Proposed Changes

* We should return only the sites that are visible to users. Including a large number of deleted sites could significantly slow down the `/me/sites` endpoint, especially for users with many deletions. I think it's reasonable for the site list to show only visible sites, and we can surface hidden or deleted sites elsewhere if there's a strong enough use case for it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve performance and don't load unnecessary sites on dashboard v2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Ensure you won't see any deleted site on your list

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
