### PR TITLE
Accessibility: Add missing `aria-label` to free domain removal button

### DIFF
--- a/client/signup/steps/domains/domains-mini-cart.jsx
+++ b/client/signup/steps/domains/domains-mini-cart.jsx
@@ -140,6 +140,9 @@ export class DomainsMiniCart extends Component {
 						borderless
 						className="button domains__domain-cart-remove"
 						onClick={ this.props.freeDomainRemoveClickHandler }
+						aria-label={ translate( 'Remove %(domain)s from cart', {
+							args: { domain: this.props.wpcomSubdomainSelected.domain_name },
+						} ) }
 					>
 						{ translate( 'Remove' ) }
 					</Button>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-13539

## Proposed Changes

* add missing `aria-label` to free domain removal button

![Markup on 2025-06-09 at 11:51:40](https://github.com/user-attachments/assets/246e6854-0098-46ac-bc63-45e86a4b6d16)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* a55edfa4e3bf-linear-project

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start` (or use Calypso Live).
2. Start creating a new site to get to the domain selection step. You may also start at http://calypso.localhost:3000/setup/onboarding/domains?source=sites-dashboard directly.
3. Search for a domain name and then pick a free one (`*.wordpress.com` subdomain).
4. Enable VoiceOver and tab through the buttons.
5. The `Remove` of the selected free domain should be properly announced - including the domain name (as can be seen in the screenshot above).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?