### PR TITLE
Help Center: Filter out odie conversations that have zendesk events

### DIFF
--- a/packages/help-center/src/hooks/use-get-history-chats.ts
+++ b/packages/help-center/src/hooks/use-get-history-chats.ts
@@ -42,18 +42,22 @@ const getAndUpdateOdieConversationsWithSupportInteractions = (
 	odieConversations: OdieConversation[] = [],
 	odieSupportInteractions: SupportInteraction[]
 ): OdieConversation[] => {
+	const odieSupportInteractionsWithoutZendesk = odieSupportInteractions.filter(
+		( interaction ) => ! interaction.events?.some( ( event ) => event.event_source === 'zendesk' )
+	);
+
 	const eventExternalIds = new Set(
-		odieSupportInteractions
+		odieSupportInteractionsWithoutZendesk
 			.flatMap( ( interaction ) => interaction.events || [] )
 			.filter( ( event ) => event.event_source === 'odie' )
 			.map( ( event ) => event.event_external_id )
 	);
 
-	const filteredOdieConversations = odieConversations.filter( ( conversation ) =>
+	const odieConversationsWithoutZendesk = odieConversations.filter( ( conversation ) =>
 		eventExternalIds.has( conversation.id )
 	);
 
-	return filteredOdieConversations.map( ( conversation ) => {
+	return odieConversationsWithoutZendesk.map( ( conversation ) => {
 		const supportInteraction = odieSupportInteractions.find( ( interaction ) =>
 			interaction.events.some(
 				( event ) => event.event_source === 'odie' && event.event_external_id === conversation.id


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-13560/help-center-history-duplicate-ai-zendesk-chats

## Proposed Changes

When retrieving chats to display on the History page, we were showing two rows for chats with AI that escalated to Happiness Engineers.
Usually both showed the same conversation, but due to a bug in retrieving AI conversations, these ones were shown even if we already were showing the AI+HappinessEngineers chats.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open a chat with AI
* Manage to escalate to an Happiness Engineer (ask to talk to a human)
* In the History tab there should be only one entry for this chat. 
* Switch to production
* You should see two entries.
