### PR TITLE
Explicitly set the locale in requestTheme

### DIFF
--- a/client/components/data/query-theme/index.jsx
+++ b/client/components/data/query-theme/index.jsx
@@ -6,10 +6,10 @@ import { requestTheme } from 'calypso/state/themes/actions';
 import { isRequestingTheme } from 'calypso/state/themes/selectors';
 
 const request =
-	( siteId, themeId, forceRequest = false ) =>
+	( siteId, themeId, locale = null, forceRequest = false ) =>
 	( dispatch, getState ) => {
 		if ( ! isRequestingTheme( getState(), siteId, themeId ) || forceRequest ) {
-			dispatch( requestTheme( themeId, siteId ) );
+			dispatch( requestTheme( themeId, siteId, locale ) );
 		}
 	};
 
@@ -27,9 +27,9 @@ export function useQueryTheme( siteId, themeId ) {
 		if ( siteId && themeId ) {
 			if ( oldLocale.current !== locale ) {
 				oldLocale.current = locale;
-				dispatch( request( siteId, themeId, true ) );
+				dispatch( request( siteId, themeId, locale, true ) );
 			} else {
-				dispatch( request( siteId, themeId ) );
+				dispatch( request( siteId, themeId, locale ) );
 			}
 		}
 	}, [ dispatch, siteId, themeId, locale ] );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13494

## Proposed Changes

* Modify the logic for loading theme details to explicitly set the locale parameter.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* On production the locale parameter is not being set in the request on page refresh so the theme details are being loaded in English.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Change your locale in WordPress.com to a popular locale like Brazilian Portuguese, then open `/theme/folio/{your site}`. Refresh a few times to confirm that the theme description is translated.
* For regression testing check some of the other places where theme details are being loaded:
* Open /themes/{your site} page, open any theme details page, on a theme details page click on `Preview Demo Site`, on a non-Atomic site with a Business plan navigate to /themes page and click on `Install new theme`. In all cases no issues should occur.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
