### PR TITLE
DOTCON-75 Remove onboarding/step-container-v2-import-flow feature flag and conditional code

### DIFF
--- a/client/blocks/import/list/index.tsx
+++ b/client/blocks/import/list/index.tsx
@@ -1,5 +1,4 @@
 import { Button, Gridicon, FormLabel, SelectDropdown } from '@automattic/components';
-import { Title, SubTitle } from '@automattic/onboarding';
 import { chevronRight, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
@@ -22,7 +21,6 @@ interface Props {
 	siteSlug: string | null;
 	title?: string;
 	subTitle?: string;
-	renderHeading?: boolean;
 	submit?: ( dependencies: { platform: ImporterPlatform; url: string } ) => void;
 	getFinalImporterUrl: (
 		siteSlug: string,
@@ -39,9 +37,6 @@ export default function ListStep( props: Props ) {
 	const { siteSlug, submit, getFinalImporterUrl, onNavBack } = props;
 	const backToFlow = urlQueryParams.get( 'backToFlow' );
 	const fromSite = urlQueryParams.get( 'from' );
-	const renderHeading = props.renderHeading ?? true;
-	const title = props.title;
-	const subTitle = props.subTitle;
 
 	// We need to remove the wix importer from the primary importers list.
 	const primaryListOptions: ImporterOption[] = getImportersAsImporterOption( 'primary' ).filter(
@@ -73,12 +68,6 @@ export default function ListStep( props: Props ) {
 				</div>
 			) }
 			<div className="list__wrapper">
-				{ renderHeading && (
-					<div className="import__heading import__heading-center">
-						<Title>{ title }</Title>
-						<SubTitle>{ subTitle }</SubTitle>
-					</div>
-				) }
 				<div className="list__importers list__importers-primary">
 					{ primaryListOptions.map( ( x ) => (
 						<Button

--- a/client/landing/stepper/declarative-flow/helpers/should-use-step-container-v2.ts
+++ b/client/landing/stepper/declarative-flow/helpers/should-use-step-container-v2.ts
@@ -25,10 +25,3 @@ export const shouldUseStepContainerV2MigrationFlow = ( flow: string ) => {
 		FLOWS_USING_STEP_CONTAINER_V2.includes( flow )
 	);
 };
-
-export const shouldUseStepContainerV2ImportFlow = ( flow: string ) => {
-	return (
-		configApi.isEnabled( 'onboarding/step-container-v2-import-flow' ) &&
-		FLOWS_USING_STEP_CONTAINER_V2.includes( flow )
-	);
-};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-list/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-list/index.tsx
@@ -30,7 +30,6 @@ const ImportList: Step< {
 				submit={ navigation.submit }
 				getFinalImporterUrl={ getFinalImporterUrl }
 				{ ...props }
-				renderHeading={ false }
 				title={ text }
 				subTitle={ subText }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-list/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-list/index.tsx
@@ -1,7 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import ListStep from 'calypso/blocks/import/list';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
-import { shouldUseStepContainerV2ImportFlow } from '../../../helpers/should-use-step-container-v2';
 import { ImportWrapper } from '../import';
 import { getFinalImporterUrl } from '../import/helper';
 import type { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
@@ -19,8 +18,7 @@ const ImportList: Step< {
 	};
 } > = function ImportStep( props ) {
 	const siteSlug = useSiteSlug();
-	const { navigation, flow } = props;
-	const useContainerV2 = shouldUseStepContainerV2ImportFlow( flow );
+	const { navigation } = props;
 
 	const text = __( 'Import content from another platform or file' );
 	const subText = __( "Select the platform you're coming from" );
@@ -32,7 +30,7 @@ const ImportList: Step< {
 				submit={ navigation.submit }
 				getFinalImporterUrl={ getFinalImporterUrl }
 				{ ...props }
-				renderHeading={ ! useContainerV2 }
+				renderHeading={ false }
 				title={ text }
 				subTitle={ subText }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
@@ -3,7 +3,6 @@ import { useI18n } from '@wordpress/react-i18n';
 import React, { ReactElement } from 'react';
 import CaptureStep from 'calypso/blocks/import/capture';
 import DocumentHead from 'calypso/components/data/document-head';
-import { shouldUseStepContainerV2ImportFlow } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -23,8 +22,8 @@ export const ImportWrapper: StepType< {
 	};
 } > = function ( props ) {
 	const { __ } = useI18n();
-	const { navigation, children, flow, stepName, text, subText } = props;
-	const useContainerV2 = shouldUseStepContainerV2ImportFlow( flow ) && stepName === 'importList';
+	const { navigation, children, stepName, text, subText } = props;
+	const useContainerV2 = stepName === 'importList';
 	const documentTitle = __( 'Import your site content' );
 	const showHeading = text && subText;
 

--- a/config/development.json
+++ b/config/development.json
@@ -131,7 +131,6 @@
 		"onboarding/import-from-wordpress": true,
 		"onboarding/interval-dropdown": true,
 		"onboarding/step-container-v2-migration-flow": true,
-		"onboarding/step-container-v2-import-flow": true,
 		"onboarding/user-on-stepper-hosting": true,
 		"p2/p2-plus": true,
 		"page/export": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -79,7 +79,6 @@
 		"me/account/color-scheme-picker": true,
 		"migration-flow/introductory-offer": true,
 		"onboarding/create-course": false,
-		"onboarding/step-container-v2-import-flow": true,
 		"onboarding/step-container-v2-migration-flow": true,
 		"p2/p2-plus": true,
 		"plans/hosting-trial": true,

--- a/config/production.json
+++ b/config/production.json
@@ -102,7 +102,6 @@
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
 		"onboarding/interval-dropdown": true,
-		"onboarding/step-container-v2-import-flow": true,
 		"onboarding/step-container-v2-migration-flow": true,
 		"onboarding/user-on-stepper-hosting": false,
 		"p2/p2-plus": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -99,7 +99,6 @@
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
 		"onboarding/interval-dropdown": true,
-		"onboarding/step-container-v2-import-flow": true,
 		"onboarding/step-container-v2-migration-flow": true,
 		"p2/p2-plus": true,
 		"page/export": true,

--- a/config/test.json
+++ b/config/test.json
@@ -79,7 +79,6 @@
 		"onboarding/import-from-squarespace": true,
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
-		"onboarding/step-container-v2-import-flow": true,
 		"onboarding/step-container-v2-migration-flow": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -106,7 +106,6 @@
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
 		"onboarding/interval-dropdown": true,
-		"onboarding/step-container-v2-import-flow": true,
 		"onboarding/step-container-v2-migration-flow": true,
 		"onboarding/user-on-stepper-hosting": true,
 		"p2/p2-plus": true,


### PR DESCRIPTION
## Proposed Changes

* StepContainerV2 is now enabled in all environments so we can drop the flag all conditional code that relies on it being off.

## Testing Instructions

- Start an import flow and make sure all the steps work and there's nothing unexpected happening.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
