### PR TITLE
Help Center: delete the local copy of nav history

### DIFF
--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -22,7 +22,9 @@ export function setCurrentSupportInteraction( supportInteraction: SupportInterac
 	} as const;
 }
 
-export function setHelpCenterRouterHistory( history: { entries: Location[]; index: number } ) {
+export function setHelpCenterRouterHistory(
+	history: { entries: Location[]; index: number } | undefined
+) {
 	return {
 		type: 'HELP_CENTER_SET_HELP_CENTER_ROUTER_HISTORY',
 		history,
@@ -138,7 +140,7 @@ export const setShowHelpCenter = function* (
 				body: {
 					calypso_preferences: {
 						help_center_open: show,
-						// Delete navigation history when closing the help center
+						// Delete the remote version of the navigation history when closing the help center
 						...( ! show ? { help_center_router_history: null } : {} ),
 					},
 				},
@@ -150,7 +152,7 @@ export const setShowHelpCenter = function* (
 				path: '/help-center/open-state',
 				method: 'PUT',
 				data: {
-					help_center_open: show, // Delete navigation history when closing the help center
+					help_center_open: show, // Delete the remote version of the navigation history when closing the help center
 					...( ! show ? { help_center_router_history: null } : {} ),
 				},
 			} as APIFetchOptions ).catch( () => {} );
@@ -159,6 +161,8 @@ export const setShowHelpCenter = function* (
 
 	if ( ! show ) {
 		yield setNavigateToRoute( undefined );
+		// Reset the local navigation history when closing the help center
+		yield setHelpCenterRouterHistory( undefined );
 	} else {
 		yield setShowMessagingWidget( false );
 	}


### PR DESCRIPTION
## Proposed Changes
Follow up to https://github.com/Automattic/wp-calypso/pull/104038.

This fixes a bug introduced in #104038 where the nav history is not deleted if the Help Center is closed and reopened in the same session.

## Why are these changes being made?
...

## Testing Instructions

1. Open the HC.
2. Navigate to an article.
3. Close the HC.
4. Open it.
5. It should land at home, not at the article.
