### PR TITLE
Dashboard v2: Adjust the level of the SectionHeader on settings page

### DIFF
--- a/client/dashboard/components/page-layout/index.tsx
+++ b/client/dashboard/components/page-layout/index.tsx
@@ -25,7 +25,7 @@ function PageLayout( {
 		>
 			{ header }
 			{ notices }
-			<VStack spacing={ 8 } className="dashboard-page-layout__content">
+			<VStack spacing={ 6 } className="dashboard-page-layout__content">
 				{ children }
 			</VStack>
 		</VStack>

--- a/client/dashboard/sites/settings/danger-zone.tsx
+++ b/client/dashboard/sites/settings/danger-zone.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@wordpress/components';
+import { __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import { ActionList } from '../../components/action-list';
@@ -111,9 +111,9 @@ export default function DangerZone( { site }: { site: Site } ) {
 	}
 
 	return (
-		<>
+		<VStack spacing={ 3 }>
 			<SectionHeader title={ __( 'Danger zone' ) } />
 			<ActionList>{ actions }</ActionList>
-		</>
+		</VStack>
 	);
 }

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { siteQuery, siteSettingsQuery } from '../../app/queries';
 import { PageHeader } from '../../components/page-header';
@@ -30,24 +31,28 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 
 	return (
 		<PageLayout size="small" header={ <PageHeader title={ __( 'Settings' ) } /> }>
-			<SectionHeader title={ __( 'General' ) } level={ 3 } />
-			<SummaryButtonList>
-				<SiteVisibilitySettingsSummary site={ site } />
-				<SubscriptionGiftingSettingsSummary site={ site } settings={ settings } />
-				<HundredYearPlanSettingsSummary site={ site } settings={ settings } />
-			</SummaryButtonList>
-			<SectionHeader title={ __( 'Server' ) } level={ 3 } />
-			<SummaryButtonList>
-				<WordPressSettingsSummary site={ site } />
-				<PHPSettingsSummary site={ site } />
-				<SftpSshSettingsSummary site={ site } />
-				<DatabaseSettingsSummary site={ site } />
-				<AgencySettingsSummary site={ site } />
-				<PrimaryDataCenterSettingsSummary site={ site } />
-				<StaticFile404SettingsSummary site={ site } />
-				<CachingSettingsSummary site={ site } />
-				<DefensiveModeSettingsSummary site={ site } />
-			</SummaryButtonList>
+			<VStack spacing={ 3 }>
+				<SectionHeader title={ __( 'General' ) } level={ 3 } />
+				<SummaryButtonList>
+					<SiteVisibilitySettingsSummary site={ site } />
+					<SubscriptionGiftingSettingsSummary site={ site } settings={ settings } />
+					<HundredYearPlanSettingsSummary site={ site } settings={ settings } />
+				</SummaryButtonList>
+			</VStack>
+			<VStack spacing={ 3 }>
+				<SectionHeader title={ __( 'Server' ) } level={ 3 } />
+				<SummaryButtonList>
+					<WordPressSettingsSummary site={ site } />
+					<PHPSettingsSummary site={ site } />
+					<SftpSshSettingsSummary site={ site } />
+					<DatabaseSettingsSummary site={ site } />
+					<AgencySettingsSummary site={ site } />
+					<PrimaryDataCenterSettingsSummary site={ site } />
+					<StaticFile404SettingsSummary site={ site } />
+					<CachingSettingsSummary site={ site } />
+					<DefensiveModeSettingsSummary site={ site } />
+				</SummaryButtonList>
+			</VStack>
 			<SiteActions site={ site } />
 			<DangerZone site={ site } />
 		</PageLayout>

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -30,13 +30,13 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 
 	return (
 		<PageLayout size="small" header={ <PageHeader title={ __( 'Settings' ) } /> }>
-			<SectionHeader title={ __( 'General' ) } />
+			<SectionHeader title={ __( 'General' ) } level={ 3 } />
 			<SummaryButtonList>
 				<SiteVisibilitySettingsSummary site={ site } />
 				<SubscriptionGiftingSettingsSummary site={ site } settings={ settings } />
 				<HundredYearPlanSettingsSummary site={ site } settings={ settings } />
 			</SummaryButtonList>
-			<SectionHeader title={ __( 'Server' ) } />
+			<SectionHeader title={ __( 'Server' ) } level={ 3 } />
 			<SummaryButtonList>
 				<WordPressSettingsSummary site={ site } />
 				<PHPSettingsSummary site={ site } />

--- a/client/dashboard/sites/settings/site-actions.tsx
+++ b/client/dashboard/sites/settings/site-actions.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { Button } from '@wordpress/components';
+import { __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
@@ -88,9 +88,9 @@ export default function SiteActions( { site }: { site: Site } ) {
 	}
 
 	return (
-		<>
+		<VStack spacing={ 3 }>
 			<SectionHeader title={ __( 'Actions' ) } />
 			<ActionList>{ actions }</ActionList>
-		</>
+		</VStack>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of pdtkmj-3H1-p2#comment-7085

## Proposed Changes

* Adjust the level of the `SectionHeader` on settings page

| Before | After |
| - | - |
| <img width="625" alt="image" src="https://github.com/user-attachments/assets/4e191a8e-dc67-4ec7-8049-7c5c50f888f8" /> | <img width="622" alt="image" src="https://github.com/user-attachments/assets/e03251db-d80b-4608-ad2e-dd5942a1570c" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Align with Design spec

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Pick any site, navigate to Settings
* Ensure the font size of the following title is correct
  * General
  * Server
  * Actions
  * Danger zone

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?