### PR TITLE
Backup: disable clone from latest failed backup

### DIFF
--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -124,6 +124,7 @@ const BackupSuccessful = ( {
 					hasWarnings={ hasWarnings }
 					availableActions={ availableActions }
 					onClickClone={ onClickClone }
+					disabled={ backup.activityStatus !== 'success' }
 				/>
 			) }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [BACKUP-52][1].

## Proposed Changes

Disable the `Clone from latest point` button when the latest backup wasn't successful.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

In the current implementation, the user is allowed to click on the clone button even if the latest backup cannot be restored. An error will be shown later, confirming the cloning cannot proceed, but it's better to not allow that in the first place.

The backup status in the Activity Log was fixed earlier on 184861-ghe-Automattic/wpcom.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Access the `Jetpack Cloud live` link provided by GitHub Actions below.
- Log in with your Jetpack Cloud credentials.
- Select a site that has a broken last backup.
- Go to `VaultPress Backup` and then `Copy site`.
- Select a destination site or add credentials, if needed.
- In the `Select point to copy` page, the `Clone from latest point` button should be disabled.

| Before | After |
| - | - |
| <img alt="image" src="https://github.com/user-attachments/assets/442c65c9-a7d3-4b8b-88aa-9d0e2e40dd3c" /> | <img alt="image" src="https://github.com/user-attachments/assets/f5727dc1-41c1-4640-8f47-48a7ec0e2155" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

[1]: https://linear.app/a8c/issue/BACKUP-52/