### PR TITLE
Feat/try base UI tabs

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -52,6 +52,7 @@
 		"@automattic/number-formatters": "^1.0.1",
 		"@automattic/typography": "workspace:^",
 		"@automattic/viewport-react": "workspace:^",
+		"@base-ui-components/react": "^1.0.0-beta.0",
 		"@emotion/css": "^11.11.2",
 		"@emotion/react": "^11.11.1",
 		"@emotion/styled": "^11.11.0",

--- a/packages/components/src/tabs-bui/README.md
+++ b/packages/components/src/tabs-bui/README.md
@@ -1,0 +1,212 @@
+# Tabs
+
+Tabs is a collection of React components that combine to render
+an [ARIA-compliant tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/).
+
+Tabs organizes content across different screens, data sets, and interactions.
+It has two sections: a list of tabs, and the view to show when a tab is chosen.
+
+`Tabs` itself is a wrapper component and context provider.
+It is responsible for managing the state of the tabs, and rendering one instance of the `Tabs.TabList` component and one or more instances of the `Tab.TabPanel` component.
+
+## Props
+
+### `activeTabId`
+
+- Type: `string`
+- Required: No
+
+The current active tab `id`. The active tab is the tab element within the
+tablist widget that has DOM focus.
+
+- `null` represents the tablist (ie. the base composite element). Users
+  will be able to navigate out of it using arrow keys.
+- If `activeTabId` is initially set to `null`, the base composite element
+  itself will have focus and users will be able to navigate to it using
+  arrow keys.
+
+### `children`
+
+- Type: `ReactNode`
+- Required: Yes
+
+The children elements, which should include one instance of the
+`Tabs.Tablist` component and as many instances of the `Tabs.TabPanel`
+components as there are `Tabs.Tab` components.
+
+### `defaultTabId`
+
+- Type: `string`
+- Required: No
+
+The id of the tab whose panel is currently visible.
+
+If left `undefined`, it will be automatically set to the first enabled
+tab. If set to `null`, no tab will be selected, and the tablist will be
+tabbable.
+
+Note: this prop will be overridden by the `selectedTabId` prop if it is
+provided (meaning the component will be used in "controlled" mode).
+
+### `defaultActiveTabId`
+
+- Type: `string`
+- Required: No
+
+The tab id that should be active by default when the composite widget is
+rendered. If `null`, the tablist element itself will have focus
+and users will be able to navigate to it using arrow keys. If `undefined`,
+the first enabled item will be focused.
+
+Note: this prop will be overridden by the `activeTabId` prop if it is
+provided.
+
+### `onSelect`
+
+- Type: `(selectedId: string) => void`
+- Required: No
+
+The function called when the `selectedTabId` changes.
+
+### `onActiveTabIdChange`
+
+- Type: `(activeId: string) => void`
+- Required: No
+
+A callback that gets called when the `activeTabId` state changes.
+
+### `orientation`
+
+- Type: `"horizontal" | "vertical" | "both"`
+- Required: No
+- Default: `"horizontal"`
+
+Defines the orientation of the tablist and determines which arrow keys
+can be used to move focus:
+
+- `both`: all arrow keys work.
+- `horizontal`: only left and right arrow keys work.
+- `vertical`: only up and down arrow keys work.
+
+### `selectOnMove`
+
+- Type: `boolean`
+- Required: No
+- Default: `true`
+
+Determines if the tab should be selected when it receives focus. If set to
+`false`, the tab will only be selected upon clicking, not when using arrow
+keys to shift focus (manual tab activation). See the [official W3C docs](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/)
+for more info.
+
+### `selectedTabId`
+
+- Type: `string`
+- Required: No
+
+The id of the tab whose panel is currently visible.
+
+If left `undefined`, it will be automatically set to the first enabled
+tab, and the component assumes it is being used in "uncontrolled" mode.
+
+Consequently, any value different than `undefined` will set the component
+in "controlled" mode. When in "controlled" mode, the `null` value will
+result in no tabs being selected, and the tablist becoming tabbable.
+
+## Subcomponents
+
+### Tabs.TabList
+
+A wrapper component for the `Tab` components.
+
+It is responsible for rendering the list of tabs.
+
+#### Props
+
+##### `children`
+
+- Type: `ReactNode`
+- Required: Yes
+
+The children elements, which should include one or more instances of the
+`Tabs.Tab` component.
+
+### Tabs.Tab
+
+Renders a single tab.
+
+The currently active tab receives default styling that can be
+overridden with CSS targeting `[aria-selected="true"]`.
+
+#### Props
+
+##### `children`
+
+- Type: `ReactNode`
+- Required: No
+
+The contents of the tab.
+
+##### `disabled`
+
+- Type: `boolean`
+- Required: No
+- Default: `false`
+
+Determines if the tab should be disabled. Note that disabled tabs can
+still be accessed via the keyboard when navigating through the tablist.
+
+##### `render`
+
+- Type: `RenderProp<HTMLAttributes<any> & { ref?: Ref<any>; }> | ReactElement<any, string | JSXElementConstructor<any>>`
+- Required: No
+
+Allows the component to be rendered as a different HTML element or React
+component. The value can be a React element or a function that takes in the
+original component props and gives back a React element with the props
+merged.
+
+By default, the tab will be rendered as a `button` element.
+
+##### `tabId`
+
+- Type: `string`
+- Required: Yes
+
+The unique ID of the tab. It will be used to register the tab and match
+it to a corresponding `Tabs.TabPanel` component.
+
+### Tabs.TabPanel
+
+Renders the content to display for a single tab once that tab is selected.
+
+#### Props
+
+##### `children`
+
+- Type: `ReactNode`
+- Required: No
+
+The contents of the tab panel.
+
+##### `focusable`
+
+- Type: `boolean`
+- Required: No
+- Default: `true`
+
+Determines whether or not the tabpanel element should be focusable.
+If `false`, pressing the tab key will skip over the tabpanel, and instead
+focus on the first focusable element in the panel (if there is one).
+
+##### `tabId`
+
+- Type: `string`
+- Required: Yes
+
+The unique `id` of the `Tabs.Tab` component controlling this panel. This
+connection is used to assign the `aria-labelledby` attribute to the tab
+panel and to determine if the tab panel should be visible.
+
+If not provided, this link is automatically established by matching the
+order of `Tabs.Tab` and `Tabs.TabPanel` elements in the DOM.

--- a/packages/components/src/tabs-bui/context.ts
+++ b/packages/components/src/tabs-bui/context.ts
@@ -1,0 +1,6 @@
+import { createContext, useContext } from 'react';
+import type { TabsContextProps } from './types';
+
+export const TabsContext = createContext< TabsContextProps >( undefined );
+
+export const useTabsContext = () => useContext( TabsContext );

--- a/packages/components/src/tabs-bui/context.ts
+++ b/packages/components/src/tabs-bui/context.ts
@@ -1,6 +1,0 @@
-import { createContext, useContext } from 'react';
-import type { TabsContextProps } from './types';
-
-export const TabsContext = createContext< TabsContextProps >( undefined );
-
-export const useTabsContext = () => useContext( TabsContext );

--- a/packages/components/src/tabs-bui/index.tsx
+++ b/packages/components/src/tabs-bui/index.tsx
@@ -1,0 +1,125 @@
+/**
+ * Forked from `@wordpress/components`
+ * - Removed Tabs.Context from Storybook sub-components.
+ * - Converted styles from Emotion to (S)CSS modules.
+ * - Added `density` prop to `Tabs.TabList`, with new `compact` variant.
+ */
+
+import * as Ariakit from '@ariakit/react';
+import { isRTL } from '@wordpress/i18n';
+import { useEffect, useMemo, useId } from 'react';
+import { TabsContext } from './context';
+import { Tab } from './tab';
+import { TabList } from './tablist';
+import { TabPanel } from './tabpanel';
+import type { TabsProps } from './types';
+
+function externalToInternalTabId( externalId: string | undefined | null, instanceId: string ) {
+	return externalId && `${ instanceId }-${ externalId }`;
+}
+
+function internalToExternalTabId( internalId: string | undefined | null, instanceId: string ) {
+	return typeof internalId === 'string' ? internalId.replace( `${ instanceId }-`, '' ) : internalId;
+}
+
+/**
+ * Tabs is a collection of React components that combine to render
+ * an [ARIA-compliant tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/).
+ *
+ * Tabs organizes content across different screens, data sets, and interactions.
+ * It has two sections: a list of tabs, and the view to show when a tab is chosen.
+ *
+ * `Tabs` itself is a wrapper component and context provider.
+ * It is responsible for managing the state of the tabs, and rendering one instance
+ * of the `Tabs.TabList` component and one or more instances of the `Tab.TabPanel`
+ * component.
+ */
+export const Tabs = Object.assign(
+	function Tabs( {
+		selectOnMove = true,
+		defaultTabId,
+		orientation = 'horizontal',
+		onSelect,
+		children,
+		selectedTabId,
+		activeTabId,
+		defaultActiveTabId,
+		onActiveTabIdChange,
+	}: TabsProps ) {
+		const instanceId = useId();
+		const store = Ariakit.useTabStore( {
+			selectOnMove,
+			orientation,
+			defaultSelectedId: externalToInternalTabId( defaultTabId, instanceId ),
+			setSelectedId: ( newSelectedId ) => {
+				onSelect?.( internalToExternalTabId( newSelectedId, instanceId ) );
+			},
+			selectedId: externalToInternalTabId( selectedTabId, instanceId ),
+			defaultActiveId: externalToInternalTabId( defaultActiveTabId, instanceId ),
+			setActiveId: ( newActiveId ) => {
+				onActiveTabIdChange?.( internalToExternalTabId( newActiveId, instanceId ) );
+			},
+			activeId: externalToInternalTabId( activeTabId, instanceId ),
+			rtl: isRTL(),
+		} );
+
+		const { items, activeId } = Ariakit.useStoreState( store );
+		const { setActiveId } = store;
+
+		useEffect( () => {
+			requestAnimationFrame( () => {
+				const focusedElement = items?.[ 0 ]?.element?.ownerDocument.activeElement;
+
+				if ( ! focusedElement || ! items.some( ( item ) => focusedElement === item.element ) ) {
+					return; // Return early if no tabs are focused.
+				}
+
+				// If, after ariakit re-computes the active tab, that tab doesn't match
+				// the currently focused tab, then we force an update to ariakit to avoid
+				// any mismatches, especially when navigating to previous/next tab with
+				// arrow keys.
+				if ( activeId !== focusedElement.id ) {
+					setActiveId( focusedElement.id );
+				}
+			} );
+		}, [ activeId, items, setActiveId ] );
+
+		const contextValue = useMemo(
+			() => ( {
+				store,
+				instanceId,
+			} ),
+			[ store, instanceId ]
+		);
+
+		return <TabsContext.Provider value={ contextValue }>{ children }</TabsContext.Provider>;
+	},
+	{
+		/**
+		 * Renders a single tab.
+		 *
+		 * The currently active tab receives default styling that can be
+		 * overridden with CSS targeting `[aria-selected="true"]`.
+		 */
+		Tab: Object.assign( Tab, {
+			displayName: 'Tabs.Tab',
+		} ),
+		/**
+		 * A wrapper component for the `Tab` components.
+		 *
+		 * It is responsible for rendering the list of tabs.
+		 */
+		TabList: Object.assign( TabList, {
+			displayName: 'Tabs.TabList',
+		} ),
+		/**
+		 * Renders the content to display for a single tab once that tab is selected.
+		 */
+		TabPanel: Object.assign( TabPanel, {
+			displayName: 'Tabs.TabPanel',
+		} ),
+		Context: Object.assign( TabsContext, {
+			displayName: 'Tabs.Context',
+		} ),
+	}
+);

--- a/packages/components/src/tabs-bui/index.tsx
+++ b/packages/components/src/tabs-bui/index.tsx
@@ -5,22 +5,12 @@
  * - Added `density` prop to `Tabs.TabList`, with new `compact` variant.
  */
 
-import * as Ariakit from '@ariakit/react';
-import { isRTL } from '@wordpress/i18n';
-import { useEffect, useMemo, useId } from 'react';
-import { TabsContext } from './context';
+import { Tabs as BaseUITabs } from '@base-ui-components/react/tabs';
+import { forwardRef } from 'react';
 import { Tab } from './tab';
 import { TabList } from './tablist';
 import { TabPanel } from './tabpanel';
 import type { TabsProps } from './types';
-
-function externalToInternalTabId( externalId: string | undefined | null, instanceId: string ) {
-	return externalId && `${ instanceId }-${ externalId }`;
-}
-
-function internalToExternalTabId( internalId: string | undefined | null, instanceId: string ) {
-	return typeof internalId === 'string' ? internalId.replace( `${ instanceId }-`, '' ) : internalId;
-}
 
 /**
  * Tabs is a collection of React components that combine to render
@@ -35,65 +25,58 @@ function internalToExternalTabId( internalId: string | undefined | null, instanc
  * component.
  */
 export const Tabs = Object.assign(
-	function Tabs( {
-		selectOnMove = true,
-		defaultTabId,
-		orientation = 'horizontal',
-		onSelect,
-		children,
-		selectedTabId,
-		activeTabId,
-		defaultActiveTabId,
-		onActiveTabIdChange,
-	}: TabsProps ) {
-		const instanceId = useId();
-		const store = Ariakit.useTabStore( {
-			selectOnMove,
-			orientation,
-			defaultSelectedId: externalToInternalTabId( defaultTabId, instanceId ),
-			setSelectedId: ( newSelectedId ) => {
-				onSelect?.( internalToExternalTabId( newSelectedId, instanceId ) );
-			},
-			selectedId: externalToInternalTabId( selectedTabId, instanceId ),
-			defaultActiveId: externalToInternalTabId( defaultActiveTabId, instanceId ),
-			setActiveId: ( newActiveId ) => {
-				onActiveTabIdChange?.( internalToExternalTabId( newActiveId, instanceId ) );
-			},
-			activeId: externalToInternalTabId( activeTabId, instanceId ),
-			rtl: isRTL(),
-		} );
+	forwardRef< HTMLDivElement, React.ComponentPropsWithoutRef< 'div' > & TabsProps >(
+		function Tabs( props, ref ) {
+			// const instanceId = useId();
+			// const store = Ariakit.useTabStore( {
+			// 	selectOnMove,
+			// 	orientation,
+			// 	defaultSelectedId: externalToInternalTabId( defaultTabId, instanceId ),
+			// 	setSelectedId: ( newSelectedId ) => {
+			// 		onSelect?.( internalToExternalTabId( newSelectedId, instanceId ) );
+			// 	},
+			// 	selectedId: externalToInternalTabId( selectedTabId, instanceId ),
+			// 	defaultActiveId: externalToInternalTabId( defaultActiveTabId, instanceId ),
+			// 	setActiveId: ( newActiveId ) => {
+			// 		onActiveTabIdChange?.( internalToExternalTabId( newActiveId, instanceId ) );
+			// 	},
+			// 	activeId: externalToInternalTabId( activeTabId, instanceId ),
+			// 	rtl: isRTL(),
+			// } );
 
-		const { items, activeId } = Ariakit.useStoreState( store );
-		const { setActiveId } = store;
+			// const { items, activeId } = Ariakit.useStoreState( store );
+			// const { setActiveId } = store;
 
-		useEffect( () => {
-			requestAnimationFrame( () => {
-				const focusedElement = items?.[ 0 ]?.element?.ownerDocument.activeElement;
+			// useEffect( () => {
+			// 	requestAnimationFrame( () => {
+			// 		const focusedElement = items?.[ 0 ]?.element?.ownerDocument.activeElement;
 
-				if ( ! focusedElement || ! items.some( ( item ) => focusedElement === item.element ) ) {
-					return; // Return early if no tabs are focused.
-				}
+			// 		if ( ! focusedElement || ! items.some( ( item ) => focusedElement === item.element ) ) {
+			// 			return; // Return early if no tabs are focused.
+			// 		}
 
-				// If, after ariakit re-computes the active tab, that tab doesn't match
-				// the currently focused tab, then we force an update to ariakit to avoid
-				// any mismatches, especially when navigating to previous/next tab with
-				// arrow keys.
-				if ( activeId !== focusedElement.id ) {
-					setActiveId( focusedElement.id );
-				}
-			} );
-		}, [ activeId, items, setActiveId ] );
+			// 		// If, after ariakit re-computes the active tab, that tab doesn't match
+			// 		// the currently focused tab, then we force an update to ariakit to avoid
+			// 		// any mismatches, especially when navigating to previous/next tab with
+			// 		// arrow keys.
+			// 		if ( activeId !== focusedElement.id ) {
+			// 			setActiveId( focusedElement.id );
+			// 		}
+			// 	} );
+			// }, [ activeId, items, setActiveId ] );
 
-		const contextValue = useMemo(
-			() => ( {
-				store,
-				instanceId,
-			} ),
-			[ store, instanceId ]
-		);
+			// const contextValue = useMemo(
+			// 	() => ( {
+			// 		store,
+			// 		instanceId,
+			// 	} ),
+			// 	[ store, instanceId ]
+			// );
 
-		return <TabsContext.Provider value={ contextValue }>{ children }</TabsContext.Provider>;
-	},
+			// return <TabsContext.Provider value={ contextValue }>{ children }</TabsContext.Provider>;
+			return <BaseUITabs.Root { ...props } ref={ ref } />;
+		}
+	),
 	{
 		/**
 		 * Renders a single tab.
@@ -117,9 +100,6 @@ export const Tabs = Object.assign(
 		 */
 		TabPanel: Object.assign( TabPanel, {
 			displayName: 'Tabs.TabPanel',
-		} ),
-		Context: Object.assign( TabsContext, {
-			displayName: 'Tabs.Context',
 		} ),
 	}
 );

--- a/packages/components/src/tabs-bui/stories/best-practices.mdx
+++ b/packages/components/src/tabs-bui/stories/best-practices.mdx
@@ -1,0 +1,99 @@
+import { Meta } from '@storybook/blocks';
+
+import * as TabsStories from './index.stories';
+
+<Meta of={ TabsStories } name="Best Practices" />
+
+# Tabs
+
+## Usage
+
+### Uncontrolled Mode
+
+Tabs can be used in an uncontrolled mode, where the component manages its own state. In this mode, the `defaultTabId` prop can be used to set the initially selected tab. If this prop is not set, the first tab will be selected by default. In addition, in most cases where the currently active tab becomes disabled or otherwise unavailable, uncontrolled mode will automatically fall back to selecting the first available tab.
+
+```jsx
+import { Tabs } from '@automattic/components';
+
+const onSelect = ( tabName ) => {
+	console.log( 'Selecting tab', tabName );
+};
+
+const MyUncontrolledTabs = () => (
+	<Tabs onSelect={ onSelect } defaultTabId="tab2">
+		<Tabs.TabList>
+			<Tabs.Tab tabId="tab1" title="Tab 1">
+				Tab 1
+			</Tabs.Tab>
+			<Tabs.Tab tabId="tab2" title="Tab 2">
+				Tab 2
+			</Tabs.Tab>
+			<Tabs.Tab tabId="tab3" title="Tab 3">
+				Tab 3
+			</Tabs.Tab>
+		</Tabs.TabList>
+		<Tabs.TabPanel tabId="tab1">
+			<p>Selected tab: Tab 1</p>
+		</Tabs.TabPanel>
+		<Tabs.TabPanel tabId="tab2">
+			<p>Selected tab: Tab 2</p>
+		</Tabs.TabPanel>
+		<Tabs.TabPanel tabId="tab3">
+			<p>Selected tab: Tab 3</p>
+		</Tabs.TabPanel>
+	</Tabs>
+);
+```
+
+### Controlled Mode
+
+Tabs can also be used in a controlled mode, where the parent component specifies the `selectedTabId` and the `onSelect` props to control tab selection. In this mode, the `defaultTabId` prop will be ignored if it is provided. If the `selectedTabId` is `null`, no tab is selected. In this mode, if the currently selected tab becomes disabled or otherwise unavailable, the component will _not_ fall back to another available tab, leaving the controlling component in charge of implementing the desired logic.
+
+```tsx
+import { Tabs } from '@automattic/components';
+
+const [ selectedTabId, setSelectedTabId ] = useState<
+	string | undefined | null
+>();
+
+const onSelect = ( tabName ) => {
+	console.log( 'Selecting tab', tabName );
+};
+
+const MyControlledTabs = () => (
+	<Tabs
+		selectedTabId={ selectedTabId }
+		onSelect={ ( selectedId ) => {
+			setSelectedTabId( selectedId );
+			onSelect( selectedId );
+		} }
+	>
+		<Tabs.TabList>
+			<Tabs.Tab tabId="tab1" title="Tab 1">
+				Tab 1
+			</Tabs.Tab>
+			<Tabs.Tab tabId="tab2" title="Tab 2">
+				Tab 2
+			</Tabs.Tab>
+			<Tabs.Tab tabId="tab3" title="Tab 3">
+				Tab 3
+			</Tabs.Tab>
+		</Tabs.TabList>
+		<Tabs.TabPanel tabId="tab1">
+			<p>Selected tab: Tab 1</p>
+		</Tabs.TabPanel>
+		<Tabs.TabPanel tabId="tab2">
+			<p>Selected tab: Tab 2</p>
+		</Tabs.TabPanel>
+		<Tabs.TabPanel tabId="tab3">
+			<p>Selected tab: Tab 3</p>
+		</Tabs.TabPanel>
+	</Tabs>
+);
+```
+
+### Using `Tabs` with links
+
+The semantics implemented by the `Tabs` component don't align well with the semantics needed by a list of links. Furthermore, end users usually expect every link to be tabbable, while `Tabs.Tablist` is a [composite](https://w3c.github.io/aria/#composite) widget acting as a single tab stop.
+
+For these reasons, even if the `Tabs` component is fully extensible, we don't recommend using `Tabs` with links, and we don't currently provide any related Storybook example.

--- a/packages/components/src/tabs-bui/stories/index.stories.tsx
+++ b/packages/components/src/tabs-bui/stories/index.stories.tsx
@@ -40,10 +40,7 @@ const Template: StoryFn< typeof Tabs > = ( props ) => {
 			<Tabs.TabPanel>
 				<p>Selected tab: Tab 2</p>
 			</Tabs.TabPanel>
-			<Tabs.TabPanel
-
-			// focusable={ false }
-			>
+			<Tabs.TabPanel focusable={ false }>
 				<p>Selected tab: Tab 3</p>
 				<p>
 					This tabpanel has its <code>focusable</code> prop set to
@@ -71,10 +68,7 @@ const ManualActivationTemplate: StoryFn< typeof Tabs > = ( props ) => {
 			<Tabs.TabPanel value="tab2">
 				<p>Selected tab: Tab 2</p>
 			</Tabs.TabPanel>
-			<Tabs.TabPanel
-				value="tab3"
-				// focusable={ false }
-			>
+			<Tabs.TabPanel value="tab3" focusable={ false }>
 				<p>Selected tab: Tab 3</p>
 				<p>
 					This tabpanel has its <code>focusable</code> prop set to
@@ -102,10 +96,7 @@ const CompactTemplate: StoryFn< typeof Tabs > = ( props ) => {
 			<Tabs.TabPanel>
 				<p>Selected tab: Tab 2</p>
 			</Tabs.TabPanel>
-			<Tabs.TabPanel
-
-			//focusable={ false }
-			>
+			<Tabs.TabPanel focusable={ false }>
 				<p>Selected tab: Tab 3</p>
 				<p>
 					This tabpanel has its <code>focusable</code> prop set to

--- a/packages/components/src/tabs-bui/stories/index.stories.tsx
+++ b/packages/components/src/tabs-bui/stories/index.stories.tsx
@@ -7,8 +7,8 @@ import { Icon } from '../../icon';
 import type { Meta, StoryFn } from '@storybook/react';
 
 const meta: Meta< typeof Tabs > = {
-	title: 'Components/Containers/Tabs',
-	id: 'components-tabs',
+	title: 'Components/Containers/Tabs BASE UI',
+	id: 'components-tabs-base-ui',
 	component: Tabs,
 	subcomponents: {
 		'Tabs.TabList': Tabs.TabList,
@@ -21,8 +21,7 @@ const meta: Meta< typeof Tabs > = {
 		docs: { canvas: { sourceState: 'shown' } },
 	},
 	args: {
-		onActiveTabIdChange: fn(),
-		onSelect: fn(),
+		onValueChange: fn(),
 	},
 };
 export default meta;
@@ -31,17 +30,51 @@ const Template: StoryFn< typeof Tabs > = ( props ) => {
 	return (
 		<Tabs { ...props }>
 			<Tabs.TabList>
-				<Tabs.Tab tabId="tab1">Tab 1</Tabs.Tab>
-				<Tabs.Tab tabId="tab2">Tab 2</Tabs.Tab>
-				<Tabs.Tab tabId="tab3">Tab 3</Tabs.Tab>
+				<Tabs.Tab>Tab 1</Tabs.Tab>
+				<Tabs.Tab>Tab 2</Tabs.Tab>
+				<Tabs.Tab>Tab 3</Tabs.Tab>
 			</Tabs.TabList>
-			<Tabs.TabPanel tabId="tab1">
+			<Tabs.TabPanel>
 				<p>Selected tab: Tab 1</p>
 			</Tabs.TabPanel>
-			<Tabs.TabPanel tabId="tab2">
+			<Tabs.TabPanel>
 				<p>Selected tab: Tab 2</p>
 			</Tabs.TabPanel>
-			<Tabs.TabPanel tabId="tab3" focusable={ false }>
+			<Tabs.TabPanel
+
+			// focusable={ false }
+			>
+				<p>Selected tab: Tab 3</p>
+				<p>
+					This tabpanel has its <code>focusable</code> prop set to
+					<code> false</code>, so it won&apos;t get a tab stop.
+					<br />
+					Instead, the [Tab] key will move focus to the first focusable element within the panel.
+				</p>
+				<Button variant="primary">I&apos;m a button!</Button>
+			</Tabs.TabPanel>
+		</Tabs>
+	);
+};
+
+const ManualActivationTemplate: StoryFn< typeof Tabs > = ( props ) => {
+	return (
+		<Tabs { ...props }>
+			<Tabs.TabList activateOnFocus={ false }>
+				<Tabs.Tab value="tab1">Tab 1</Tabs.Tab>
+				<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
+				<Tabs.Tab value="tab3">Tab 3</Tabs.Tab>
+			</Tabs.TabList>
+			<Tabs.TabPanel value="tab1">
+				<p>Selected tab: Tab 1</p>
+			</Tabs.TabPanel>
+			<Tabs.TabPanel value="tab2">
+				<p>Selected tab: Tab 2</p>
+			</Tabs.TabPanel>
+			<Tabs.TabPanel
+				value="tab3"
+				// focusable={ false }
+			>
 				<p>Selected tab: Tab 3</p>
 				<p>
 					This tabpanel has its <code>focusable</code> prop set to
@@ -59,17 +92,20 @@ const CompactTemplate: StoryFn< typeof Tabs > = ( props ) => {
 	return (
 		<Tabs { ...props }>
 			<Tabs.TabList density="compact">
-				<Tabs.Tab tabId="tab1">Tab 1</Tabs.Tab>
-				<Tabs.Tab tabId="tab2">Tab 2</Tabs.Tab>
-				<Tabs.Tab tabId="tab3">Tab 3</Tabs.Tab>
+				<Tabs.Tab>Tab 1</Tabs.Tab>
+				<Tabs.Tab>Tab 2</Tabs.Tab>
+				<Tabs.Tab>Tab 3</Tabs.Tab>
 			</Tabs.TabList>
-			<Tabs.TabPanel tabId="tab1">
+			<Tabs.TabPanel>
 				<p>Selected tab: Tab 1</p>
 			</Tabs.TabPanel>
-			<Tabs.TabPanel tabId="tab2">
+			<Tabs.TabPanel>
 				<p>Selected tab: Tab 2</p>
 			</Tabs.TabPanel>
-			<Tabs.TabPanel tabId="tab3" focusable={ false }>
+			<Tabs.TabPanel
+
+			//focusable={ false }
+			>
 				<p>Selected tab: Tab 3</p>
 				<p>
 					This tabpanel has its <code>focusable</code> prop set to
@@ -149,29 +185,29 @@ export const SizeAndOverflowPlayground: StoryFn< typeof Tabs > = ( props ) => {
 							width: fullWidth ? '100%' : undefined,
 						} }
 					>
-						<Tabs.Tab tabId="tab1">Label with multiple words</Tabs.Tab>
-						<Tabs.Tab tabId="tab2">Short</Tabs.Tab>
-						<Tabs.Tab tabId="tab3">Hippopotomonstrosesquippedaliophobia</Tabs.Tab>
-						<Tabs.Tab tabId="tab4">Tab 4</Tabs.Tab>
-						<Tabs.Tab tabId="tab5">Tab 5</Tabs.Tab>
+						<Tabs.Tab value="tab1">Label with multiple words</Tabs.Tab>
+						<Tabs.Tab value="tab2">Short</Tabs.Tab>
+						<Tabs.Tab value="tab3">Hippopotomonstrosesquippedaliophobia</Tabs.Tab>
+						<Tabs.Tab value="tab4">Tab 4</Tabs.Tab>
+						<Tabs.Tab value="tab5">Tab 5</Tabs.Tab>
 					</Tabs.TabList>
 				</div>
-				<Tabs.TabPanel tabId="tab1">
+				<Tabs.TabPanel value="tab1">
 					<p>Selected tab: Tab 1</p>
 					<p>(Label with multiple words)</p>
 				</Tabs.TabPanel>
-				<Tabs.TabPanel tabId="tab2">
+				<Tabs.TabPanel value="tab2">
 					<p>Selected tab: Tab 2</p>
 					<p>(Short)</p>
 				</Tabs.TabPanel>
-				<Tabs.TabPanel tabId="tab3">
+				<Tabs.TabPanel value="tab3">
 					<p>Selected tab: Tab 3</p>
 					<p>(Hippopotomonstrosesquippedaliophobia)</p>
 				</Tabs.TabPanel>
-				<Tabs.TabPanel tabId="tab4">
+				<Tabs.TabPanel value="tab4">
 					<p>Selected tab: Tab 4</p>
 				</Tabs.TabPanel>
-				<Tabs.TabPanel tabId="tab5">
+				<Tabs.TabPanel value="tab5">
 					<p>Selected tab: Tab 5</p>
 				</Tabs.TabPanel>
 			</Tabs>
@@ -179,16 +215,16 @@ export const SizeAndOverflowPlayground: StoryFn< typeof Tabs > = ( props ) => {
 	);
 };
 SizeAndOverflowPlayground.args = {
-	defaultTabId: 'tab4',
+	defaultValue: 'tab4',
 };
 
 const VerticalTemplate: StoryFn< typeof Tabs > = ( props ) => {
 	return (
 		<Tabs orientation="vertical" { ...props }>
 			<Tabs.TabList style={ { maxWidth: '10rem' } }>
-				<Tabs.Tab tabId="tab1">Tab 1</Tabs.Tab>
-				<Tabs.Tab tabId="tab2">Tab 2</Tabs.Tab>
-				<Tabs.Tab tabId="tab3">Tab 3</Tabs.Tab>
+				<Tabs.Tab value="tab1">Tab 1</Tabs.Tab>
+				<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
+				<Tabs.Tab value="tab3">Tab 3</Tabs.Tab>
 			</Tabs.TabList>
 		</Tabs>
 	);
@@ -200,19 +236,19 @@ const DisabledTabTemplate: StoryFn< typeof Tabs > = ( props ) => {
 	return (
 		<Tabs { ...props }>
 			<Tabs.TabList>
-				<Tabs.Tab tabId="tab1" disabled>
+				<Tabs.Tab value="tab1" disabled>
 					Tab 1
 				</Tabs.Tab>
-				<Tabs.Tab tabId="tab2">Tab 2</Tabs.Tab>
-				<Tabs.Tab tabId="tab3">Tab 3</Tabs.Tab>
+				<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
+				<Tabs.Tab value="tab3">Tab 3</Tabs.Tab>
 			</Tabs.TabList>
-			<Tabs.TabPanel tabId="tab1">
+			<Tabs.TabPanel value="tab1">
 				<p>Selected tab: Tab 1</p>
 			</Tabs.TabPanel>
-			<Tabs.TabPanel tabId="tab2">
+			<Tabs.TabPanel value="tab2">
 				<p>Selected tab: Tab 2</p>
 			</Tabs.TabPanel>
-			<Tabs.TabPanel tabId="tab3">
+			<Tabs.TabPanel value="tab3">
 				<p>Selected tab: Tab 3</p>
 			</Tabs.TabPanel>
 		</Tabs>
@@ -242,19 +278,19 @@ const WithTabIconsAndTooltipsTemplate: StoryFn< typeof Tabs > = ( props ) => {
 					},
 				].map( ( { id, label, icon } ) => (
 					<Tooltip text={ label } key={ id }>
-						<Tabs.Tab tabId={ id } aria-label={ label }>
+						<Tabs.Tab value={ id } aria-label={ label }>
 							<Icon icon={ icon } />
 						</Tabs.Tab>
 					</Tooltip>
 				) ) }
 			</Tabs.TabList>
-			<Tabs.TabPanel tabId="tab1">
+			<Tabs.TabPanel value="tab1">
 				<p>Selected tab: Tab 1</p>
 			</Tabs.TabPanel>
-			<Tabs.TabPanel tabId="tab2">
+			<Tabs.TabPanel value="tab2">
 				<p>Selected tab: Tab 2</p>
 			</Tabs.TabPanel>
-			<Tabs.TabPanel tabId="tab3">
+			<Tabs.TabPanel value="tab3">
 				<p>Selected tab: Tab 3</p>
 			</Tabs.TabPanel>
 		</Tabs>
@@ -262,9 +298,9 @@ const WithTabIconsAndTooltipsTemplate: StoryFn< typeof Tabs > = ( props ) => {
 };
 export const WithTabIconsAndTooltips = WithTabIconsAndTooltipsTemplate.bind( {} );
 
-export const ManualActivation = Template.bind( {} );
+export const ManualActivation = ManualActivationTemplate.bind( {} );
 ManualActivation.args = {
-	selectOnMove: false,
+	...Default.args,
 };
 
 const UsingSlotFillTemplate: StoryFn< typeof Tabs > = ( props ) => {
@@ -272,18 +308,18 @@ const UsingSlotFillTemplate: StoryFn< typeof Tabs > = ( props ) => {
 		<SlotFillProvider>
 			<Tabs { ...props }>
 				<Tabs.TabList>
-					<Tabs.Tab tabId="tab1">Tab 1</Tabs.Tab>
-					<Tabs.Tab tabId="tab2">Tab 2</Tabs.Tab>
-					<Tabs.Tab tabId="tab3">Tab 3</Tabs.Tab>
+					<Tabs.Tab value="tab1">Tab 1</Tabs.Tab>
+					<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
+					<Tabs.Tab value="tab3">Tab 3</Tabs.Tab>
 				</Tabs.TabList>
 				<Fill name="tabs-are-fun">
-					<Tabs.TabPanel tabId="tab1">
+					<Tabs.TabPanel value="tab1">
 						<p>Selected tab: Tab 1</p>
 					</Tabs.TabPanel>
-					<Tabs.TabPanel tabId="tab2">
+					<Tabs.TabPanel value="tab2">
 						<p>Selected tab: Tab 2</p>
 					</Tabs.TabPanel>
-					<Tabs.TabPanel tabId="tab3">
+					<Tabs.TabPanel value="tab3">
 						<p>Selected tab: Tab 3</p>
 					</Tabs.TabPanel>
 				</Fill>
@@ -328,9 +364,9 @@ const CloseButtonTemplate: StoryFn< typeof Tabs > = ( props ) => {
 							} }
 						>
 							<Tabs.TabList>
-								<Tabs.Tab tabId="tab1">Tab 1</Tabs.Tab>
-								<Tabs.Tab tabId="tab2">Tab 2</Tabs.Tab>
-								<Tabs.Tab tabId="tab3">Tab 3</Tabs.Tab>
+								<Tabs.Tab value="tab1">Tab 1</Tabs.Tab>
+								<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
+								<Tabs.Tab value="tab3">Tab 3</Tabs.Tab>
 							</Tabs.TabList>
 							<Button
 								variant="tertiary"
@@ -343,13 +379,13 @@ const CloseButtonTemplate: StoryFn< typeof Tabs > = ( props ) => {
 								Close Tabs
 							</Button>
 						</div>
-						<Tabs.TabPanel tabId="tab1">
+						<Tabs.TabPanel value="tab1">
 							<p>Selected tab: Tab 1</p>
 						</Tabs.TabPanel>
-						<Tabs.TabPanel tabId="tab2">
+						<Tabs.TabPanel value="tab2">
 							<p>Selected tab: Tab 2</p>
 						</Tabs.TabPanel>
-						<Tabs.TabPanel tabId="tab3">
+						<Tabs.TabPanel value="tab3">
 							<p>Selected tab: Tab 3</p>
 						</Tabs.TabPanel>
 					</Tabs>

--- a/packages/components/src/tabs-bui/stories/index.stories.tsx
+++ b/packages/components/src/tabs-bui/stories/index.stories.tsx
@@ -1,0 +1,365 @@
+import { fn } from '@storybook/test';
+import { Button, Tooltip, Slot, Fill, SlotFillProvider } from '@wordpress/components';
+import { wordpress, more, link } from '@wordpress/icons';
+import { useState } from 'react';
+import { Tabs } from '..';
+import { Icon } from '../../icon';
+import type { Meta, StoryFn } from '@storybook/react';
+
+const meta: Meta< typeof Tabs > = {
+	title: 'Components/Containers/Tabs',
+	id: 'components-tabs',
+	component: Tabs,
+	subcomponents: {
+		'Tabs.TabList': Tabs.TabList,
+		'Tabs.Tab': Tabs.Tab,
+		'Tabs.TabPanel': Tabs.TabPanel,
+	},
+	parameters: {
+		actions: { argTypesRegex: '^on.*' },
+		controls: { expanded: true },
+		docs: { canvas: { sourceState: 'shown' } },
+	},
+	args: {
+		onActiveTabIdChange: fn(),
+		onSelect: fn(),
+	},
+};
+export default meta;
+
+const Template: StoryFn< typeof Tabs > = ( props ) => {
+	return (
+		<Tabs { ...props }>
+			<Tabs.TabList>
+				<Tabs.Tab tabId="tab1">Tab 1</Tabs.Tab>
+				<Tabs.Tab tabId="tab2">Tab 2</Tabs.Tab>
+				<Tabs.Tab tabId="tab3">Tab 3</Tabs.Tab>
+			</Tabs.TabList>
+			<Tabs.TabPanel tabId="tab1">
+				<p>Selected tab: Tab 1</p>
+			</Tabs.TabPanel>
+			<Tabs.TabPanel tabId="tab2">
+				<p>Selected tab: Tab 2</p>
+			</Tabs.TabPanel>
+			<Tabs.TabPanel tabId="tab3" focusable={ false }>
+				<p>Selected tab: Tab 3</p>
+				<p>
+					This tabpanel has its <code>focusable</code> prop set to
+					<code> false</code>, so it won&apos;t get a tab stop.
+					<br />
+					Instead, the [Tab] key will move focus to the first focusable element within the panel.
+				</p>
+				<Button variant="primary">I&apos;m a button!</Button>
+			</Tabs.TabPanel>
+		</Tabs>
+	);
+};
+
+const CompactTemplate: StoryFn< typeof Tabs > = ( props ) => {
+	return (
+		<Tabs { ...props }>
+			<Tabs.TabList density="compact">
+				<Tabs.Tab tabId="tab1">Tab 1</Tabs.Tab>
+				<Tabs.Tab tabId="tab2">Tab 2</Tabs.Tab>
+				<Tabs.Tab tabId="tab3">Tab 3</Tabs.Tab>
+			</Tabs.TabList>
+			<Tabs.TabPanel tabId="tab1">
+				<p>Selected tab: Tab 1</p>
+			</Tabs.TabPanel>
+			<Tabs.TabPanel tabId="tab2">
+				<p>Selected tab: Tab 2</p>
+			</Tabs.TabPanel>
+			<Tabs.TabPanel tabId="tab3" focusable={ false }>
+				<p>Selected tab: Tab 3</p>
+				<p>
+					This tabpanel has its <code>focusable</code> prop set to
+					<code> false</code>, so it won&apos;t get a tab stop.
+					<br />
+					Instead, the [Tab] key will move focus to the first focusable element within the panel.
+				</p>
+				<Button variant="primary">I&apos;m a button!</Button>
+			</Tabs.TabPanel>
+		</Tabs>
+	);
+};
+
+export const Default = Template.bind( {} );
+
+export const Compact = CompactTemplate.bind( {} );
+
+export const SizeAndOverflowPlayground: StoryFn< typeof Tabs > = ( props ) => {
+	const [ fullWidth, setFullWidth ] = useState( false );
+	return (
+		<div>
+			<div style={ { maxWidth: '40rem', marginBottom: '1rem' } }>
+				<p>
+					This story helps understand how the TabList component behaves under different conditions.
+					The container below (with the dotted red border) can be horizontally resized, and it has a
+					bit of padding to be out of the way of the TabList.
+				</p>
+				<p>
+					The button will toggle between full width (adding <code>width: 100%</code>) and the
+					default width.
+				</p>
+				<p>Try the following:</p>
+				<ul>
+					<li>
+						<strong>Small container</strong> that causes tabs to overflow with scroll.
+					</li>
+					<li>
+						<strong>Large container</strong> that exceeds the normal width of the tabs.
+						<ul>
+							<li>
+								<strong>
+									With <code>width: 100%</code>
+								</strong>{ ' ' }
+								set on the TabList (tabs fill up the space).
+							</li>
+							<li>
+								<strong>
+									Without <code>width: 100%</code>
+								</strong>{ ' ' }
+								(defaults to <code>auto</code>) set on the TabList (tabs take up space proportional
+								to their content).
+							</li>
+						</ul>
+					</li>
+				</ul>
+			</div>
+			<Button
+				style={ { marginBottom: '1rem' } }
+				variant="primary"
+				onClick={ () => setFullWidth( ! fullWidth ) }
+			>
+				{ fullWidth ? 'Remove width: 100% from TabList' : 'Set width: 100% in TabList' }
+			</Button>
+			<Tabs { ...props }>
+				<div
+					style={ {
+						width: '20rem',
+						border: '2px dotted red',
+						padding: '1rem',
+						resize: 'horizontal',
+						overflow: 'auto',
+					} }
+				>
+					<Tabs.TabList
+						style={ {
+							maxWidth: '100%',
+							width: fullWidth ? '100%' : undefined,
+						} }
+					>
+						<Tabs.Tab tabId="tab1">Label with multiple words</Tabs.Tab>
+						<Tabs.Tab tabId="tab2">Short</Tabs.Tab>
+						<Tabs.Tab tabId="tab3">Hippopotomonstrosesquippedaliophobia</Tabs.Tab>
+						<Tabs.Tab tabId="tab4">Tab 4</Tabs.Tab>
+						<Tabs.Tab tabId="tab5">Tab 5</Tabs.Tab>
+					</Tabs.TabList>
+				</div>
+				<Tabs.TabPanel tabId="tab1">
+					<p>Selected tab: Tab 1</p>
+					<p>(Label with multiple words)</p>
+				</Tabs.TabPanel>
+				<Tabs.TabPanel tabId="tab2">
+					<p>Selected tab: Tab 2</p>
+					<p>(Short)</p>
+				</Tabs.TabPanel>
+				<Tabs.TabPanel tabId="tab3">
+					<p>Selected tab: Tab 3</p>
+					<p>(Hippopotomonstrosesquippedaliophobia)</p>
+				</Tabs.TabPanel>
+				<Tabs.TabPanel tabId="tab4">
+					<p>Selected tab: Tab 4</p>
+				</Tabs.TabPanel>
+				<Tabs.TabPanel tabId="tab5">
+					<p>Selected tab: Tab 5</p>
+				</Tabs.TabPanel>
+			</Tabs>
+		</div>
+	);
+};
+SizeAndOverflowPlayground.args = {
+	defaultTabId: 'tab4',
+};
+
+const VerticalTemplate: StoryFn< typeof Tabs > = ( props ) => {
+	return (
+		<Tabs orientation="vertical" { ...props }>
+			<Tabs.TabList style={ { maxWidth: '10rem' } }>
+				<Tabs.Tab tabId="tab1">Tab 1</Tabs.Tab>
+				<Tabs.Tab tabId="tab2">Tab 2</Tabs.Tab>
+				<Tabs.Tab tabId="tab3">Tab 3</Tabs.Tab>
+			</Tabs.TabList>
+		</Tabs>
+	);
+};
+
+export const Vertical = VerticalTemplate.bind( {} );
+
+const DisabledTabTemplate: StoryFn< typeof Tabs > = ( props ) => {
+	return (
+		<Tabs { ...props }>
+			<Tabs.TabList>
+				<Tabs.Tab tabId="tab1" disabled>
+					Tab 1
+				</Tabs.Tab>
+				<Tabs.Tab tabId="tab2">Tab 2</Tabs.Tab>
+				<Tabs.Tab tabId="tab3">Tab 3</Tabs.Tab>
+			</Tabs.TabList>
+			<Tabs.TabPanel tabId="tab1">
+				<p>Selected tab: Tab 1</p>
+			</Tabs.TabPanel>
+			<Tabs.TabPanel tabId="tab2">
+				<p>Selected tab: Tab 2</p>
+			</Tabs.TabPanel>
+			<Tabs.TabPanel tabId="tab3">
+				<p>Selected tab: Tab 3</p>
+			</Tabs.TabPanel>
+		</Tabs>
+	);
+};
+export const DisabledTab = DisabledTabTemplate.bind( {} );
+
+const WithTabIconsAndTooltipsTemplate: StoryFn< typeof Tabs > = ( props ) => {
+	return (
+		<Tabs { ...props }>
+			<Tabs.TabList>
+				{ [
+					{
+						id: 'tab1',
+						label: 'Tab one',
+						icon: wordpress,
+					},
+					{
+						id: 'tab2',
+						label: 'Tab two',
+						icon: link,
+					},
+					{
+						id: 'tab3',
+						label: 'Tab three',
+						icon: more,
+					},
+				].map( ( { id, label, icon } ) => (
+					<Tooltip text={ label } key={ id }>
+						<Tabs.Tab tabId={ id } aria-label={ label }>
+							<Icon icon={ icon } />
+						</Tabs.Tab>
+					</Tooltip>
+				) ) }
+			</Tabs.TabList>
+			<Tabs.TabPanel tabId="tab1">
+				<p>Selected tab: Tab 1</p>
+			</Tabs.TabPanel>
+			<Tabs.TabPanel tabId="tab2">
+				<p>Selected tab: Tab 2</p>
+			</Tabs.TabPanel>
+			<Tabs.TabPanel tabId="tab3">
+				<p>Selected tab: Tab 3</p>
+			</Tabs.TabPanel>
+		</Tabs>
+	);
+};
+export const WithTabIconsAndTooltips = WithTabIconsAndTooltipsTemplate.bind( {} );
+
+export const ManualActivation = Template.bind( {} );
+ManualActivation.args = {
+	selectOnMove: false,
+};
+
+const UsingSlotFillTemplate: StoryFn< typeof Tabs > = ( props ) => {
+	return (
+		<SlotFillProvider>
+			<Tabs { ...props }>
+				<Tabs.TabList>
+					<Tabs.Tab tabId="tab1">Tab 1</Tabs.Tab>
+					<Tabs.Tab tabId="tab2">Tab 2</Tabs.Tab>
+					<Tabs.Tab tabId="tab3">Tab 3</Tabs.Tab>
+				</Tabs.TabList>
+				<Fill name="tabs-are-fun">
+					<Tabs.TabPanel tabId="tab1">
+						<p>Selected tab: Tab 1</p>
+					</Tabs.TabPanel>
+					<Tabs.TabPanel tabId="tab2">
+						<p>Selected tab: Tab 2</p>
+					</Tabs.TabPanel>
+					<Tabs.TabPanel tabId="tab3">
+						<p>Selected tab: Tab 3</p>
+					</Tabs.TabPanel>
+				</Fill>
+			</Tabs>
+			<div
+				style={ {
+					border: '2px solid #999',
+					width: '300px',
+					margin: '20px auto',
+				} }
+			>
+				<p>other stuff</p>
+				<p>other stuff</p>
+				<p>this is fun!</p>
+				<p>other stuff</p>
+				<Slot bubblesVirtually as="div" name="tabs-are-fun" />
+			</div>
+		</SlotFillProvider>
+	);
+};
+export const UsingSlotFill = UsingSlotFillTemplate.bind( {} );
+UsingSlotFill.storyName = 'Using SlotFill';
+
+const CloseButtonTemplate: StoryFn< typeof Tabs > = ( props ) => {
+	const [ isOpen, setIsOpen ] = useState( true );
+
+	return (
+		<>
+			{ isOpen ? (
+				<div
+					style={ {
+						width: '400px',
+						height: '100vh',
+						borderRight: '1px solid #333',
+					} }
+				>
+					<Tabs { ...props }>
+						<div
+							style={ {
+								display: 'flex',
+								borderBottom: '1px solid #333',
+							} }
+						>
+							<Tabs.TabList>
+								<Tabs.Tab tabId="tab1">Tab 1</Tabs.Tab>
+								<Tabs.Tab tabId="tab2">Tab 2</Tabs.Tab>
+								<Tabs.Tab tabId="tab3">Tab 3</Tabs.Tab>
+							</Tabs.TabList>
+							<Button
+								variant="tertiary"
+								style={ {
+									marginLeft: 'auto',
+									alignSelf: 'center',
+								} }
+								onClick={ () => setIsOpen( false ) }
+							>
+								Close Tabs
+							</Button>
+						</div>
+						<Tabs.TabPanel tabId="tab1">
+							<p>Selected tab: Tab 1</p>
+						</Tabs.TabPanel>
+						<Tabs.TabPanel tabId="tab2">
+							<p>Selected tab: Tab 2</p>
+						</Tabs.TabPanel>
+						<Tabs.TabPanel tabId="tab3">
+							<p>Selected tab: Tab 3</p>
+						</Tabs.TabPanel>
+					</Tabs>
+				</div>
+			) : (
+				<Button variant="tertiary" onClick={ () => setIsOpen( true ) }>
+					Open Tabs
+				</Button>
+			) }
+		</>
+	);
+};
+export const InsertCustomElements = CloseButtonTemplate.bind( {} );

--- a/packages/components/src/tabs-bui/style.module.scss
+++ b/packages/components/src/tabs-bui/style.module.scss
@@ -1,0 +1,245 @@
+@use '@wordpress/base-styles/colors';
+@use '@wordpress/base-styles/mixins';
+@use '@wordpress/base-styles/variables';
+@use '../utils/_theme-variables' as theme;
+
+.tablist {
+	display: flex;
+	align-items: stretch;
+	overflow-x: auto;
+
+	&:where( [aria-orientation='horizontal'] ) {
+		width: fit-content;
+	}
+
+	--direction-factor: 1;
+	--direction-start: left;
+	--direction-end: right;
+	--selected-start: var( --selected-left, 0 );
+	&:dir( rtl ) {
+		--direction-factor: -1;
+		--direction-start: right;
+		--direction-end: left;
+		--selected-start: var( --selected-right, 0 );
+	}
+
+	@media not ( prefers-reduced-motion ) {
+		&[data-indicator-animated]::before {
+			transition-property: transform, border-radius, border-block;
+			transition-duration: 0.2s;
+			transition-timing-function: ease-out;
+		}
+	}
+	position: relative;
+	&::before {
+		content: '';
+		position: absolute;
+		pointer-events: none;
+		transform-origin: var( --direction-start ) top;
+
+		// Windows high contrast mode.
+		outline: 2px solid transparent;
+		outline-offset: -1px;
+	}
+
+	/* Using a large value to avoid antialiasing rounding issues
+			when scaling in the transform, see: https://stackoverflow.com/a/52159123 */
+	--antialiasing-factor: 100;
+	&[aria-orientation='horizontal'] {
+		--fade-width: 4rem;
+		--fade-gradient-base: transparent 0%, #{colors.$black} var( --fade-width );
+		--fade-gradient-composed: var( --fade-gradient-base ), #{colors.$black} 60%, transparent 50%;
+		&.is-overflowing-first {
+			mask-image: linear-gradient( to var( --direction-end ), var( --fade-gradient-base ) );
+		}
+		&.is-overflowing-last {
+			mask-image: linear-gradient( to var( --direction-start ), var( --fade-gradient-base ) );
+		}
+		&.is-overflowing-first.is-overflowing-last {
+			mask-image: linear-gradient( to right, var( --fade-gradient-composed ) ),
+				linear-gradient( to left, var( --fade-gradient-composed ) );
+		}
+
+		&.has-compact-density {
+			gap: 1rem;
+		}
+
+		&::before {
+			bottom: 0;
+			height: 0;
+			width: calc( var( --antialiasing-factor ) * 1px );
+			transform: translateX( calc( var( --selected-start ) * var( --direction-factor ) * 1px ) )
+				scaleX( calc( var( --selected-width, 0 ) / var( --antialiasing-factor ) ) );
+			border-bottom: var( --wp-admin-border-width-focus ) solid theme.$components-color-accent;
+		}
+	}
+
+	&[aria-orientation='vertical'] {
+		flex-direction: column;
+
+		&::before {
+			/* Adjusting the border radius to match the scaling in the y axis. */
+			border-radius: variables.$radius-small /
+				calc(
+					variables.$radius-small / ( var( --selected-height, 0 ) / var( --antialiasing-factor ) )
+				);
+			top: 0;
+			left: 0;
+			width: 100%;
+			height: calc( var( --antialiasing-factor ) * 1px );
+			transform: translateY( calc( var( --selected-top, 0 ) * 1px ) )
+				scaleY( calc( var( --selected-height, 0 ) / var( --antialiasing-factor ) ) );
+			background-color: color-mix( in srgb, theme.$components-color-accent, transparent 96% );
+		}
+		&[data-select-on-move='true']:has( :is( :focus-visible, [data-focus-visible] ) )::before {
+			box-sizing: border-box;
+			border: var( --wp-admin-border-width-focus ) solid theme.$components-color-accent;
+			/* Adjusting the border width to match the scaling in the y axis. */
+			border-block-width: calc(
+				var( --wp-admin-border-width-focus, 1px ) /
+					( var( --selected-height, 0 ) / var( --antialiasing-factor ) )
+			);
+		}
+	}
+}
+
+.tab {
+
+	/* Resets */
+	border-radius: 0;
+	background: transparent;
+	border: none;
+	box-shadow: none;
+
+	flex: 1 0 auto;
+	white-space: nowrap;
+	display: flex;
+	align-items: center;
+	cursor: pointer;
+	line-height: 1.2; // Characters in some languages (e.g. Japanese) may have a native higher line-height.
+	font-weight: 400;
+	color: theme.$components-color-foreground;
+
+	&[aria-disabled='true'] {
+		cursor: default;
+		color: theme.$components-color-gray-600;
+	}
+
+	&:not( [aria-disabled='true'] ):is( :hover, [data-focus-visible] ) {
+		color: theme.$components-color-accent;
+	}
+
+	&:focus:not( :disabled ) {
+		box-shadow: none;
+		outline: none;
+	}
+
+	// Focus indicator.
+	position: relative;
+	&::after {
+		position: absolute;
+		pointer-events: none;
+
+		// Draw the indicator.
+		// Outline works for Windows high contrast mode as well.
+		outline: var( --wp-admin-border-width-focus ) solid theme.$components-color-accent;
+		border-radius: variables.$radius-small;
+
+		// Animation
+		opacity: 0;
+
+		@media not ( prefers-reduced-motion ) {
+			transition: opacity 0.1s linear;
+		}
+	}
+
+	&[data-focus-visible]::after {
+		opacity: 1;
+	}
+
+	[aria-orientation='horizontal'] & {
+		padding-inline: variables.$grid-unit-05 * 4;
+		height: variables.$grid-unit-05 * 12;
+		scroll-margin: 24px;
+
+		&::after {
+			content: '';
+			inset: variables.$grid-unit-05 * 3;
+		}
+	}
+
+	.has-compact-density[aria-orientation='horizontal'] & {
+		padding-inline: 0;
+
+		&::after {
+			// Add enough inset to prevent the focus ring (which is 1.5px thick)
+			// from being visually clipped by the tablist.
+			inset-inline: 2px;
+		}
+	}
+
+	[aria-orientation='vertical'] & {
+		padding: variables.$grid-unit-05 * 2 variables.$grid-unit-05 * 3;
+		min-height: variables.$grid-unit-05 * 10;
+
+		&[aria-selected='true'] {
+			color: theme.$components-color-accent;
+			fill: currentColor;
+		}
+	}
+	[aria-orientation='vertical'][data-select-on-move='false'] &::after {
+		content: '';
+		inset: var( --wp-admin-border-width-focus );
+	}
+}
+
+.tab__children {
+	flex-grow: 1;
+
+	display: flex;
+	align-items: center;
+
+	[aria-orientation='horizontal'] & {
+		justify-content: center;
+	}
+	[aria-orientation='vertical'] & {
+		justify-content: start;
+	}
+}
+
+.tab__chevron {
+	flex-shrink: 0;
+	margin-inline-end: variables.$grid-unit-05 * -1;
+	[aria-orientation='horizontal'] & {
+		display: none;
+	}
+	opacity: 0;
+	[role='tab']:is( [aria-selected='true'], [data-focus-visible], :hover ) & {
+		opacity: 1;
+	}
+	// The chevron is transitioned into existence when selectOnMove is enabled,
+	// because otherwise it looks jarring, as it shows up outside of the focus
+	// indicator that's being animated at the same time.
+	@media not ( prefers-reduced-motion ) {
+		[data-select-on-move='true'] [role='tab']:is( [aria-selected='true']  ) & {
+			transition: opacity 0.15s 0.15s linear;
+		}
+	}
+	&:dir( rtl ) {
+		rotate: 180deg;
+	}
+}
+
+.tabpanel {
+	&:focus {
+		box-shadow: none;
+		outline: none;
+	}
+
+	&[data-focus-visible] {
+		box-shadow: 0 0 0 var( --wp-admin-border-width-focus ) theme.$components-color-accent;
+		// Windows high contrast mode.
+		outline: 2px solid transparent;
+		outline-offset: 0;
+	}
+}

--- a/packages/components/src/tabs-bui/style.module.scss
+++ b/packages/components/src/tabs-bui/style.module.scss
@@ -8,44 +8,24 @@
 	align-items: stretch;
 	overflow-x: auto;
 
-	&:where( [aria-orientation='horizontal'] ) {
+	&:where( [data-orientation='horizontal'] ) {
 		width: fit-content;
 	}
 
 	--direction-factor: 1;
 	--direction-start: left;
 	--direction-end: right;
-	--selected-start: var( --selected-left, 0 );
 	&:dir( rtl ) {
 		--direction-factor: -1;
 		--direction-start: right;
 		--direction-end: left;
-		--selected-start: var( --selected-right, 0 );
 	}
 
-	@media not ( prefers-reduced-motion ) {
-		&[data-indicator-animated]::before {
-			transition-property: transform, border-radius, border-block;
-			transition-duration: 0.2s;
-			transition-timing-function: ease-out;
-		}
-	}
+
 	position: relative;
-	&::before {
-		content: '';
-		position: absolute;
-		pointer-events: none;
-		transform-origin: var( --direction-start ) top;
 
-		// Windows high contrast mode.
-		outline: 2px solid transparent;
-		outline-offset: -1px;
-	}
 
-	/* Using a large value to avoid antialiasing rounding issues
-			when scaling in the transform, see: https://stackoverflow.com/a/52159123 */
-	--antialiasing-factor: 100;
-	&[aria-orientation='horizontal'] {
+	&[data-orientation='horizontal'] {
 		--fade-width: 4rem;
 		--fade-gradient-base: transparent 0%, #{colors.$black} var( --fade-width );
 		--fade-gradient-composed: var( --fade-gradient-base ), #{colors.$black} 60%, transparent 50%;
@@ -63,48 +43,56 @@
 		&.has-compact-density {
 			gap: 1rem;
 		}
-
-		&::before {
-			bottom: 0;
-			height: 0;
-			width: calc( var( --antialiasing-factor ) * 1px );
-			transform: translateX( calc( var( --selected-start ) * var( --direction-factor ) * 1px ) )
-				scaleX( calc( var( --selected-width, 0 ) / var( --antialiasing-factor ) ) );
-			border-bottom: var( --wp-admin-border-width-focus ) solid theme.$components-color-accent;
-		}
 	}
 
-	&[aria-orientation='vertical'] {
+	&[data-orientation='vertical'] {
 		flex-direction: column;
+	}
+}
 
-		&::before {
-			/* Adjusting the border radius to match the scaling in the y axis. */
-			border-radius: variables.$radius-small /
-				calc(
-					variables.$radius-small / ( var( --selected-height, 0 ) / var( --antialiasing-factor ) )
-				);
-			top: 0;
-			left: 0;
-			width: 100%;
-			height: calc( var( --antialiasing-factor ) * 1px );
-			transform: translateY( calc( var( --selected-top, 0 ) * 1px ) )
-				scaleY( calc( var( --selected-height, 0 ) / var( --antialiasing-factor ) ) );
-			background-color: color-mix( in srgb, theme.$components-color-accent, transparent 96% );
-		}
-		&[data-select-on-move='true']:has( :is( :focus-visible, [data-focus-visible] ) )::before {
-			box-sizing: border-box;
-			border: var( --wp-admin-border-width-focus ) solid theme.$components-color-accent;
-			/* Adjusting the border width to match the scaling in the y axis. */
-			border-block-width: calc(
-				var( --wp-admin-border-width-focus, 1px ) /
-					( var( --selected-height, 0 ) / var( --antialiasing-factor ) )
-			);
-		}
+.indicator {
+	@media not ( prefers-reduced-motion ) {
+		transition-property: translate, width, height, border-radius, border-block;
+		transition-duration: 0.2s;
+		transition-timing-function: ease-out;
+	}
+
+	position: absolute;
+	z-index: -1;
+	pointer-events: none;
+
+	// Windows high contrast mode.
+	outline: 2px solid transparent;
+	outline-offset: -1px;
+
+
+	&[data-orientation='horizontal'] {
+		left: 0;
+		bottom: 0;
+		height: 0;
+		width: var(--active-tab-width);
+		translate: var(--active-tab-left) -50%;
+		border-bottom: var( --wp-admin-border-width-focus ) solid theme.$components-color-accent;
+	}
+
+	&[data-orientation='vertical'] {
+		border-radius: variables.$radius-small;
+		top: 0;
+		left: 50%;
+		width: 100%;
+		height: var(--active-tab-height);
+		translate: -50% var(--active-tab-top);
+		background-color: color-mix( in srgb, theme.$components-color-accent, transparent 96% );
+
+	}
+
+	.tablist[data-select-on-move='true']:has( :focus-visible ) &[data-orientation='vertical'] {
+		box-sizing: border-box;
+		border: var( --wp-admin-border-width-focus ) solid theme.$components-color-accent;
 	}
 }
 
 .tab {
-
 	/* Resets */
 	border-radius: 0;
 	background: transparent;
@@ -120,12 +108,12 @@
 	font-weight: 400;
 	color: theme.$components-color-foreground;
 
-	&[aria-disabled='true'] {
+	&[data-disabled] {
 		cursor: default;
 		color: theme.$components-color-gray-600;
 	}
 
-	&:not( [aria-disabled='true'] ):is( :hover, [data-focus-visible] ) {
+	&:not( [data-disabled] ):is( :hover, :focus-visible ) {
 		color: theme.$components-color-accent;
 	}
 
@@ -153,11 +141,11 @@
 		}
 	}
 
-	&[data-focus-visible]::after {
+	&:focus-visible::after {
 		opacity: 1;
 	}
 
-	[aria-orientation='horizontal'] & {
+	[data-orientation='horizontal'] & {
 		padding-inline: variables.$grid-unit-05 * 4;
 		height: variables.$grid-unit-05 * 12;
 		scroll-margin: 24px;
@@ -168,7 +156,7 @@
 		}
 	}
 
-	.has-compact-density[aria-orientation='horizontal'] & {
+	.has-compact-density[data-orientation='horizontal'] & {
 		padding-inline: 0;
 
 		&::after {
@@ -178,7 +166,7 @@
 		}
 	}
 
-	[aria-orientation='vertical'] & {
+	[data-orientation='vertical'] & {
 		padding: variables.$grid-unit-05 * 2 variables.$grid-unit-05 * 3;
 		min-height: variables.$grid-unit-05 * 10;
 
@@ -187,7 +175,7 @@
 			fill: currentColor;
 		}
 	}
-	[aria-orientation='vertical'][data-select-on-move='false'] &::after {
+	[data-orientation='vertical'][data-select-on-move='false'] &::after {
 		content: '';
 		inset: var( --wp-admin-border-width-focus );
 	}
@@ -199,10 +187,10 @@
 	display: flex;
 	align-items: center;
 
-	[aria-orientation='horizontal'] & {
+	[data-orientation='horizontal'] & {
 		justify-content: center;
 	}
-	[aria-orientation='vertical'] & {
+	[data-orientation='vertical'] & {
 		justify-content: start;
 	}
 }
@@ -210,11 +198,11 @@
 .tab__chevron {
 	flex-shrink: 0;
 	margin-inline-end: variables.$grid-unit-05 * -1;
-	[aria-orientation='horizontal'] & {
+	[data-orientation='horizontal'] & {
 		display: none;
 	}
 	opacity: 0;
-	[role='tab']:is( [aria-selected='true'], [data-focus-visible], :hover ) & {
+	[role='tab']:is( [aria-selected='true'], :focus-visible, :hover ) & {
 		opacity: 1;
 	}
 	// The chevron is transitioned into existence when selectOnMove is enabled,
@@ -236,7 +224,7 @@
 		outline: none;
 	}
 
-	&[data-focus-visible] {
+	&:focus-visible {
 		box-shadow: 0 0 0 var( --wp-admin-border-width-focus ) theme.$components-color-accent;
 		// Windows high contrast mode.
 		outline: 2px solid transparent;

--- a/packages/components/src/tabs-bui/tab.tsx
+++ b/packages/components/src/tabs-bui/tab.tsx
@@ -1,0 +1,38 @@
+import * as Ariakit from '@ariakit/react';
+import { chevronRight } from '@wordpress/icons';
+import warning from '@wordpress/warning';
+import clsx from 'clsx';
+import { forwardRef } from 'react';
+import { Icon } from '../icon';
+import { useTabsContext } from './context';
+import styles from './style.module.scss';
+import type { TabProps } from './types';
+
+export const Tab = forwardRef<
+	HTMLButtonElement,
+	Omit< React.ComponentPropsWithoutRef< 'button' >, 'id' > & TabProps
+>( function Tab( { children, tabId, disabled, render, ...otherProps }, ref ) {
+	const { store, instanceId } = useTabsContext() ?? {};
+
+	if ( ! store ) {
+		warning( '`Tabs.Tab` must be wrapped in a `Tabs` component.' );
+		return null;
+	}
+
+	const instancedTabId = `${ instanceId }-${ tabId }`;
+
+	return (
+		<Ariakit.Tab
+			ref={ ref }
+			store={ store }
+			id={ instancedTabId }
+			disabled={ disabled }
+			render={ render }
+			{ ...otherProps }
+			className={ clsx( styles.tab, otherProps.className ) }
+		>
+			<span className={ styles.tab__children }>{ children }</span>
+			<Icon className={ styles.tab__chevron } icon={ chevronRight } />
+		</Ariakit.Tab>
+	);
+} );

--- a/packages/components/src/tabs-bui/tab.tsx
+++ b/packages/components/src/tabs-bui/tab.tsx
@@ -1,38 +1,21 @@
-import * as Ariakit from '@ariakit/react';
+import { Tabs as BaseUITabs } from '@base-ui-components/react/tabs';
 import { chevronRight } from '@wordpress/icons';
-import warning from '@wordpress/warning';
+// import warning from '@wordpress/warning';
 import clsx from 'clsx';
 import { forwardRef } from 'react';
 import { Icon } from '../icon';
-import { useTabsContext } from './context';
+// import { useTabsContext } from './context';
 import styles from './style.module.scss';
 import type { TabProps } from './types';
 
 export const Tab = forwardRef<
 	HTMLButtonElement,
-	Omit< React.ComponentPropsWithoutRef< 'button' >, 'id' > & TabProps
->( function Tab( { children, tabId, disabled, render, ...otherProps }, ref ) {
-	const { store, instanceId } = useTabsContext() ?? {};
-
-	if ( ! store ) {
-		warning( '`Tabs.Tab` must be wrapped in a `Tabs` component.' );
-		return null;
-	}
-
-	const instancedTabId = `${ instanceId }-${ tabId }`;
-
+	React.ComponentPropsWithoutRef< 'button' > & TabProps
+>( function Tab( { className, children, ...otherProps }, ref ) {
 	return (
-		<Ariakit.Tab
-			ref={ ref }
-			store={ store }
-			id={ instancedTabId }
-			disabled={ disabled }
-			render={ render }
-			{ ...otherProps }
-			className={ clsx( styles.tab, otherProps.className ) }
-		>
+		<BaseUITabs.Tab ref={ ref } { ...otherProps } className={ clsx( styles.tab, className ) }>
 			<span className={ styles.tab__children }>{ children }</span>
 			<Icon className={ styles.tab__chevron } icon={ chevronRight } />
-		</Ariakit.Tab>
+		</BaseUITabs.Tab>
 	);
 } );

--- a/packages/components/src/tabs-bui/tablist.tsx
+++ b/packages/components/src/tabs-bui/tablist.tsx
@@ -1,0 +1,142 @@
+import * as Ariakit from '@ariakit/react';
+import { useMergeRefs } from '@wordpress/compose';
+import warning from '@wordpress/warning';
+import clsx from 'clsx';
+import { forwardRef, useLayoutEffect, useState } from 'react';
+import { useTrackElementOffsetRect } from '../utils/element-rect';
+import { useAnimatedOffsetRect } from '../utils/hooks/use-animated-offset-rect';
+import { useTabsContext } from './context';
+import styles from './style.module.scss';
+import { useTrackOverflow } from './use-track-overflow';
+import type { TabListProps } from './types';
+import type { ElementOffsetRect } from '../utils/element-rect';
+
+const DEFAULT_SCROLL_MARGIN = 24;
+
+/**
+ * Scrolls a given parent element so that a given rect is visible.
+ *
+ * The scroll is updated initially and whenever the rect changes.
+ */
+function useScrollRectIntoView(
+	parent: HTMLElement | undefined,
+	rect: ElementOffsetRect,
+	{ margin = DEFAULT_SCROLL_MARGIN } = {}
+) {
+	useLayoutEffect( () => {
+		if ( ! parent || ! rect ) {
+			return;
+		}
+
+		const { scrollLeft: parentScroll } = parent;
+		const parentWidth = parent.getBoundingClientRect().width;
+		const { left: childLeft, width: childWidth } = rect;
+
+		const parentRightEdge = parentScroll + parentWidth;
+		const childRightEdge = childLeft + childWidth;
+		const rightOverflow = childRightEdge + margin - parentRightEdge;
+		const leftOverflow = parentScroll - ( childLeft - margin );
+
+		let scrollLeft = null;
+		if ( leftOverflow > 0 ) {
+			scrollLeft = parentScroll - leftOverflow;
+		} else if ( rightOverflow > 0 ) {
+			scrollLeft = parentScroll + rightOverflow;
+		}
+
+		if ( scrollLeft !== null ) {
+			/**
+			 * The optional chaining is used here to avoid unit test failures.
+			 * It can be removed when JSDOM supports `Element` scroll methods.
+			 * See: https://github.com/WordPress/gutenberg/pull/66498#issuecomment-2441146096
+			 */
+			parent.scroll?.( { left: scrollLeft } );
+		}
+	}, [ margin, parent, rect ] );
+}
+
+export const TabList = forwardRef<
+	HTMLDivElement,
+	React.ComponentPropsWithoutRef< 'div' > & TabListProps
+>( function TabList( { children, density = 'default', ...otherProps }, ref ) {
+	const { store } = useTabsContext() ?? {};
+
+	const selectedId = Ariakit.useStoreState( store, 'selectedId' );
+	const activeId = Ariakit.useStoreState( store, 'activeId' );
+	const selectOnMove = Ariakit.useStoreState( store, 'selectOnMove' );
+	const items = Ariakit.useStoreState( store, 'items' );
+	const [ parent, setParent ] = useState< HTMLElement >();
+	const refs = useMergeRefs( [ ref, setParent ] );
+
+	const selectedItem = store?.item( selectedId );
+	const renderedItems = Ariakit.useStoreState( store, 'renderedItems' );
+
+	const selectedItemIndex =
+		renderedItems && selectedItem ? renderedItems.indexOf( selectedItem ) : -1;
+	// Use selectedItemIndex as a dependency to force recalculation when the
+	// selected item index changes (elements are swapped / added / removed).
+	const selectedRect = useTrackElementOffsetRect( selectedItem?.element, [ selectedItemIndex ] );
+
+	// Track overflow to show scroll hints.
+	const overflow = useTrackOverflow( parent, {
+		first: items?.at( 0 )?.element,
+		last: items?.at( -1 )?.element,
+	} );
+
+	// Size, position, and animate the indicator.
+	useAnimatedOffsetRect( parent, selectedRect, {
+		prefix: 'selected',
+		dataAttribute: 'indicator-animated',
+		transitionEndFilter: ( event ) => event.pseudoElement === '::before',
+		roundRect: true,
+	} );
+
+	// Make sure selected tab is scrolled into view.
+	useScrollRectIntoView( parent, selectedRect );
+
+	const onBlur = () => {
+		if ( ! selectOnMove ) {
+			return;
+		}
+
+		// When automatic tab selection is on, make sure that the active tab is up
+		// to date with the selected tab when leaving the tablist. This makes sure
+		// that the selected tab will receive keyboard focus when tabbing back into
+		// the tablist.
+		if ( selectedId !== activeId ) {
+			store?.setActiveId( selectedId );
+		}
+	};
+
+	if ( ! store ) {
+		warning( '`Tabs.TabList` must be wrapped in a `Tabs` component.' );
+		return null;
+	}
+
+	return (
+		<Ariakit.TabList
+			ref={ refs }
+			store={ store }
+			render={ ( props ) => (
+				<div
+					{ ...props }
+					// Fallback to -1 to prevent browsers from making the tablist
+					// tabbable when it is a scrolling container.
+					tabIndex={ props.tabIndex ?? -1 }
+				/>
+			) }
+			onBlur={ onBlur }
+			data-select-on-move={ selectOnMove ? 'true' : 'false' }
+			{ ...otherProps }
+			className={ clsx(
+				styles.tablist,
+				overflow.first && styles[ 'is-overflowing-first' ],
+				overflow.last && styles[ 'is-overflowing-last' ],
+				styles[ `has-${ density }-density` ],
+				otherProps.className
+			) }
+		>
+			{ children }
+		</Ariakit.TabList>
+	);
+} );

--- a/packages/components/src/tabs-bui/tablist.tsx
+++ b/packages/components/src/tabs-bui/tablist.tsx
@@ -1,122 +1,118 @@
-import * as Ariakit from '@ariakit/react';
-import { useMergeRefs } from '@wordpress/compose';
-import warning from '@wordpress/warning';
+import { Tabs as BaseUITabs } from '@base-ui-components/react/tabs';
+// import { useMergeRefs } from '@wordpress/compose';
 import clsx from 'clsx';
-import { forwardRef, useLayoutEffect, useState } from 'react';
-import { useTrackElementOffsetRect } from '../utils/element-rect';
-import { useAnimatedOffsetRect } from '../utils/hooks/use-animated-offset-rect';
-import { useTabsContext } from './context';
+import { forwardRef /*, useLayoutEffect, useState */ } from 'react';
+// import { useTrackElementOffsetRect } from '../utils/element-rect';
+// import { useAnimatedOffsetRect } from '../utils/hooks/use-animated-offset-rect';
+// import { useTabsContext } from './context';
 import styles from './style.module.scss';
-import { useTrackOverflow } from './use-track-overflow';
+// import { useTrackOverflow } from './use-track-overflow';
 import type { TabListProps } from './types';
-import type { ElementOffsetRect } from '../utils/element-rect';
+// import type { ElementOffsetRect } from '../utils/element-rect';
 
-const DEFAULT_SCROLL_MARGIN = 24;
+// const DEFAULT_SCROLL_MARGIN = 24;
 
 /**
  * Scrolls a given parent element so that a given rect is visible.
  *
  * The scroll is updated initially and whenever the rect changes.
  */
-function useScrollRectIntoView(
-	parent: HTMLElement | undefined,
-	rect: ElementOffsetRect,
-	{ margin = DEFAULT_SCROLL_MARGIN } = {}
-) {
-	useLayoutEffect( () => {
-		if ( ! parent || ! rect ) {
-			return;
-		}
+// function useScrollRectIntoView(
+// 	parent: HTMLElement | undefined,
+// 	rect: ElementOffsetRect,
+// 	{ margin = DEFAULT_SCROLL_MARGIN } = {}
+// ) {
+// 	useLayoutEffect( () => {
+// 		if ( ! parent || ! rect ) {
+// 			return;
+// 		}
 
-		const { scrollLeft: parentScroll } = parent;
-		const parentWidth = parent.getBoundingClientRect().width;
-		const { left: childLeft, width: childWidth } = rect;
+// 		const { scrollLeft: parentScroll } = parent;
+// 		const parentWidth = parent.getBoundingClientRect().width;
+// 		const { left: childLeft, width: childWidth } = rect;
 
-		const parentRightEdge = parentScroll + parentWidth;
-		const childRightEdge = childLeft + childWidth;
-		const rightOverflow = childRightEdge + margin - parentRightEdge;
-		const leftOverflow = parentScroll - ( childLeft - margin );
+// 		const parentRightEdge = parentScroll + parentWidth;
+// 		const childRightEdge = childLeft + childWidth;
+// 		const rightOverflow = childRightEdge + margin - parentRightEdge;
+// 		const leftOverflow = parentScroll - ( childLeft - margin );
 
-		let scrollLeft = null;
-		if ( leftOverflow > 0 ) {
-			scrollLeft = parentScroll - leftOverflow;
-		} else if ( rightOverflow > 0 ) {
-			scrollLeft = parentScroll + rightOverflow;
-		}
+// 		let scrollLeft = null;
+// 		if ( leftOverflow > 0 ) {
+// 			scrollLeft = parentScroll - leftOverflow;
+// 		} else if ( rightOverflow > 0 ) {
+// 			scrollLeft = parentScroll + rightOverflow;
+// 		}
 
-		if ( scrollLeft !== null ) {
-			/**
-			 * The optional chaining is used here to avoid unit test failures.
-			 * It can be removed when JSDOM supports `Element` scroll methods.
-			 * See: https://github.com/WordPress/gutenberg/pull/66498#issuecomment-2441146096
-			 */
-			parent.scroll?.( { left: scrollLeft } );
-		}
-	}, [ margin, parent, rect ] );
-}
+// 		if ( scrollLeft !== null ) {
+// 			/**
+// 			 * The optional chaining is used here to avoid unit test failures.
+// 			 * It can be removed when JSDOM supports `Element` scroll methods.
+// 			 * See: https://github.com/WordPress/gutenberg/pull/66498#issuecomment-2441146096
+// 			 */
+// 			parent.scroll?.( { left: scrollLeft } );
+// 		}
+// 	}, [ margin, parent, rect ] );
+// }
 
 export const TabList = forwardRef<
 	HTMLDivElement,
 	React.ComponentPropsWithoutRef< 'div' > & TabListProps
->( function TabList( { children, density = 'default', ...otherProps }, ref ) {
-	const { store } = useTabsContext() ?? {};
+>( function TabList(
+	{ children, density = 'default', className, activateOnFocus, render, ...otherProps },
+	ref
+) {
+	// const { store } = useTabsContext() ?? {};
 
-	const selectedId = Ariakit.useStoreState( store, 'selectedId' );
-	const activeId = Ariakit.useStoreState( store, 'activeId' );
-	const selectOnMove = Ariakit.useStoreState( store, 'selectOnMove' );
-	const items = Ariakit.useStoreState( store, 'items' );
-	const [ parent, setParent ] = useState< HTMLElement >();
-	const refs = useMergeRefs( [ ref, setParent ] );
+	// const selectedId = Ariakit.useStoreState( store, 'selectedId' );
+	// const activeId = Ariakit.useStoreState( store, 'activeId' );
+	// const selectOnMove = Ariakit.useStoreState( store, 'selectOnMove' );
+	// const items = Ariakit.useStoreState( store, 'items' );
+	// const [ parent, setParent ] = useState< HTMLElement >();
+	// const refs = useMergeRefs( [ ref, setParent ] );
 
-	const selectedItem = store?.item( selectedId );
-	const renderedItems = Ariakit.useStoreState( store, 'renderedItems' );
+	// const selectedItem = store?.item( selectedId );
+	// const renderedItems = Ariakit.useStoreState( store, 'renderedItems' );
 
-	const selectedItemIndex =
-		renderedItems && selectedItem ? renderedItems.indexOf( selectedItem ) : -1;
+	// const selectedItemIndex =
+	// renderedItems && selectedItem ? renderedItems.indexOf( selectedItem ) : -1;
 	// Use selectedItemIndex as a dependency to force recalculation when the
 	// selected item index changes (elements are swapped / added / removed).
-	const selectedRect = useTrackElementOffsetRect( selectedItem?.element, [ selectedItemIndex ] );
+	// const selectedRect = useTrackElementOffsetRect( selectedItem?.element, [ selectedItemIndex ] );
 
 	// Track overflow to show scroll hints.
-	const overflow = useTrackOverflow( parent, {
-		first: items?.at( 0 )?.element,
-		last: items?.at( -1 )?.element,
-	} );
+	// const overflow = useTrackOverflow( parent, {
+	// 	first: items?.at( 0 )?.element,
+	// 	last: items?.at( -1 )?.element,
+	// } );
 
 	// Size, position, and animate the indicator.
-	useAnimatedOffsetRect( parent, selectedRect, {
-		prefix: 'selected',
-		dataAttribute: 'indicator-animated',
-		transitionEndFilter: ( event ) => event.pseudoElement === '::before',
-		roundRect: true,
-	} );
+	// useAnimatedOffsetRect( parent, selectedRect, {
+	// 	prefix: 'selected',
+	// 	dataAttribute: 'indicator-animated',
+	// 	transitionEndFilter: ( event ) => event.pseudoElement === '::before',
+	// 	roundRect: true,
+	// } );
 
 	// Make sure selected tab is scrolled into view.
-	useScrollRectIntoView( parent, selectedRect );
+	// useScrollRectIntoView( parent, selectedRect );
 
-	const onBlur = () => {
-		if ( ! selectOnMove ) {
-			return;
-		}
+	// const onBlur = () => {
+	// 	if ( ! selectOnMove ) {
+	// 		return;
+	// 	}
 
-		// When automatic tab selection is on, make sure that the active tab is up
-		// to date with the selected tab when leaving the tablist. This makes sure
-		// that the selected tab will receive keyboard focus when tabbing back into
-		// the tablist.
-		if ( selectedId !== activeId ) {
-			store?.setActiveId( selectedId );
-		}
-	};
-
-	if ( ! store ) {
-		warning( '`Tabs.TabList` must be wrapped in a `Tabs` component.' );
-		return null;
-	}
+	// 	// When automatic tab selection is on, make sure that the active tab is up
+	// 	// to date with the selected tab when leaving the tablist. This makes sure
+	// 	// that the selected tab will receive keyboard focus when tabbing back into
+	// 	// the tablist.
+	// 	if ( selectedId !== activeId ) {
+	// 		store?.setActiveId( selectedId );
+	// 	}
+	// };
 
 	return (
-		<Ariakit.TabList
-			ref={ refs }
-			store={ store }
+		<BaseUITabs.List
+			ref={ ref }
 			render={ ( props ) => (
 				<div
 					{ ...props }
@@ -125,18 +121,19 @@ export const TabList = forwardRef<
 					tabIndex={ props.tabIndex ?? -1 }
 				/>
 			) }
-			onBlur={ onBlur }
-			data-select-on-move={ selectOnMove ? 'true' : 'false' }
+			activateOnFocus={ activateOnFocus }
+			data-select-on-move={ activateOnFocus ? 'true' : 'false' }
 			{ ...otherProps }
 			className={ clsx(
 				styles.tablist,
-				overflow.first && styles[ 'is-overflowing-first' ],
-				overflow.last && styles[ 'is-overflowing-last' ],
+				// overflow.first && styles[ 'is-overflowing-first' ],
+				// overflow.last && styles[ 'is-overflowing-last' ],
 				styles[ `has-${ density }-density` ],
-				otherProps.className
+				className
 			) }
 		>
 			{ children }
-		</Ariakit.TabList>
+			<BaseUITabs.Indicator className={ styles.indicator } />
+		</BaseUITabs.List>
 	);
 } );

--- a/packages/components/src/tabs-bui/tabpanel.tsx
+++ b/packages/components/src/tabs-bui/tabpanel.tsx
@@ -1,0 +1,38 @@
+import * as Ariakit from '@ariakit/react';
+import warning from '@wordpress/warning';
+import clsx from 'clsx';
+import { forwardRef } from 'react';
+import { useTabsContext } from './context';
+import styles from './style.module.scss';
+import type { TabPanelProps } from './types';
+
+export const TabPanel = forwardRef<
+	HTMLDivElement,
+	Omit< React.ComponentPropsWithoutRef< 'div' >, 'id' > & TabPanelProps
+>( function TabPanel( { children, tabId, focusable = true, ...otherProps }, ref ) {
+	const context = useTabsContext();
+	const selectedId = Ariakit.useStoreState( context?.store, 'selectedId' );
+	if ( ! context ) {
+		warning( '`Tabs.TabPanel` must be wrapped in a `Tabs` component.' );
+		return null;
+	}
+	const { store, instanceId } = context;
+	const instancedTabId = `${ instanceId }-${ tabId }`;
+
+	return (
+		<Ariakit.TabPanel
+			ref={ ref }
+			store={ store }
+			// For TabPanel, the id passed here is the id attribute of the DOM
+			// element.
+			// `tabId` is the id of the tab that controls this panel.
+			id={ `${ instancedTabId }-view` }
+			tabId={ instancedTabId }
+			focusable={ focusable }
+			{ ...otherProps }
+			className={ clsx( styles.tabpanel, otherProps.className ) }
+		>
+			{ selectedId === instancedTabId && children }
+		</Ariakit.TabPanel>
+	);
+} );

--- a/packages/components/src/tabs-bui/tabpanel.tsx
+++ b/packages/components/src/tabs-bui/tabpanel.tsx
@@ -7,11 +7,11 @@ import type { TabPanelProps } from './types';
 export const TabPanel = forwardRef<
 	HTMLDivElement,
 	React.ComponentPropsWithoutRef< 'div' > & TabPanelProps
->( function TabPanel( { className, ...otherProps }, ref ) {
+>( function TabPanel( { className, focusable = true, ...otherProps }, ref ) {
 	return (
 		<BaseUITabs.Panel
 			ref={ ref }
-			// focusable={ focusable }
+			tabIndex={ focusable ? 0 : -1 }
 			{ ...otherProps }
 			className={ clsx( styles.tabpanel, className ) }
 		/>

--- a/packages/components/src/tabs-bui/tabpanel.tsx
+++ b/packages/components/src/tabs-bui/tabpanel.tsx
@@ -1,38 +1,19 @@
-import * as Ariakit from '@ariakit/react';
-import warning from '@wordpress/warning';
+import { Tabs as BaseUITabs } from '@base-ui-components/react/tabs';
 import clsx from 'clsx';
 import { forwardRef } from 'react';
-import { useTabsContext } from './context';
 import styles from './style.module.scss';
 import type { TabPanelProps } from './types';
 
 export const TabPanel = forwardRef<
 	HTMLDivElement,
-	Omit< React.ComponentPropsWithoutRef< 'div' >, 'id' > & TabPanelProps
->( function TabPanel( { children, tabId, focusable = true, ...otherProps }, ref ) {
-	const context = useTabsContext();
-	const selectedId = Ariakit.useStoreState( context?.store, 'selectedId' );
-	if ( ! context ) {
-		warning( '`Tabs.TabPanel` must be wrapped in a `Tabs` component.' );
-		return null;
-	}
-	const { store, instanceId } = context;
-	const instancedTabId = `${ instanceId }-${ tabId }`;
-
+	React.ComponentPropsWithoutRef< 'div' > & TabPanelProps
+>( function TabPanel( { className, ...otherProps }, ref ) {
 	return (
-		<Ariakit.TabPanel
+		<BaseUITabs.Panel
 			ref={ ref }
-			store={ store }
-			// For TabPanel, the id passed here is the id attribute of the DOM
-			// element.
-			// `tabId` is the id of the tab that controls this panel.
-			id={ `${ instancedTabId }-view` }
-			tabId={ instancedTabId }
-			focusable={ focusable }
+			// focusable={ focusable }
 			{ ...otherProps }
-			className={ clsx( styles.tabpanel, otherProps.className ) }
-		>
-			{ selectedId === instancedTabId && children }
-		</Ariakit.TabPanel>
+			className={ clsx( styles.tabpanel, className ) }
+		/>
 	);
 } );

--- a/packages/components/src/tabs-bui/test/index.tsx
+++ b/packages/components/src/tabs-bui/test/index.tsx
@@ -1,0 +1,1729 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { press, click } from '@ariakit/test';
+import { render } from '@ariakit/test/react';
+import { screen, waitFor } from '@testing-library/react';
+import { isRTL } from '@wordpress/i18n';
+import React, { useEffect, useState } from 'react';
+import { Tabs } from '..';
+import type { TabsProps } from '../types';
+
+// Setup mocking the `isRTL` function to test arrow key navigation behavior.
+jest.mock( '@wordpress/i18n', () => {
+	const original = jest.requireActual( '@wordpress/i18n' );
+	return {
+		...original,
+		isRTL: jest.fn( () => false ),
+	};
+} );
+const mockedIsRTL = isRTL as jest.Mock;
+
+type Tab = {
+	tabId: string;
+	title: string;
+	content: React.ReactNode;
+	tab: {
+		className?: string;
+		disabled?: boolean;
+	};
+	tabpanel?: {
+		focusable?: boolean;
+	};
+};
+
+const TABS: Tab[] = [
+	{
+		tabId: 'alpha',
+		title: 'Alpha',
+		content: 'Selected tab: Alpha',
+		tab: { className: 'alpha-class' },
+	},
+	{
+		tabId: 'beta',
+		title: 'Beta',
+		content: 'Selected tab: Beta',
+		tab: { className: 'beta-class' },
+	},
+	{
+		tabId: 'gamma',
+		title: 'Gamma',
+		content: 'Selected tab: Gamma',
+		tab: { className: 'gamma-class' },
+	},
+];
+
+const TABS_WITH_ALPHA_DISABLED = TABS.map( ( tabObj ) =>
+	tabObj.tabId === 'alpha'
+		? {
+				...tabObj,
+				tab: {
+					...tabObj.tab,
+					disabled: true,
+				},
+		  }
+		: tabObj
+);
+
+const TABS_WITH_BETA_DISABLED = TABS.map( ( tabObj ) =>
+	tabObj.tabId === 'beta'
+		? {
+				...tabObj,
+				tab: {
+					...tabObj.tab,
+					disabled: true,
+				},
+		  }
+		: tabObj
+);
+
+const TABS_WITH_DELTA: Tab[] = [
+	...TABS,
+	{
+		tabId: 'delta',
+		title: 'Delta',
+		content: 'Selected tab: Delta',
+		tab: { className: 'delta-class' },
+	},
+];
+
+const UncontrolledTabs = ( {
+	tabs,
+	...props
+}: Omit< TabsProps, 'children' > & {
+	tabs: Tab[];
+} ) => {
+	return (
+		<Tabs { ...props }>
+			<Tabs.TabList>
+				{ tabs.map( ( tabObj ) => (
+					<Tabs.Tab
+						key={ tabObj.tabId }
+						tabId={ tabObj.tabId }
+						className={ tabObj.tab.className }
+						disabled={ tabObj.tab.disabled }
+					>
+						{ tabObj.title }
+					</Tabs.Tab>
+				) ) }
+			</Tabs.TabList>
+			{ tabs.map( ( tabObj ) => (
+				<Tabs.TabPanel
+					key={ tabObj.tabId }
+					tabId={ tabObj.tabId }
+					focusable={ tabObj.tabpanel?.focusable }
+				>
+					{ tabObj.content }
+				</Tabs.TabPanel>
+			) ) }
+		</Tabs>
+	);
+};
+
+const ControlledTabs = ( {
+	tabs,
+	...props
+}: Omit< TabsProps, 'children' > & {
+	tabs: Tab[];
+} ) => {
+	const [ selectedTabId, setSelectedTabId ] = useState< string | undefined | null >(
+		props.selectedTabId
+	);
+
+	useEffect( () => {
+		setSelectedTabId( props.selectedTabId );
+	}, [ props.selectedTabId ] );
+
+	return (
+		<Tabs
+			{ ...props }
+			selectedTabId={ selectedTabId }
+			onSelect={ ( selectedId ) => {
+				setSelectedTabId( selectedId );
+				props.onSelect?.( selectedId );
+			} }
+		>
+			<Tabs.TabList>
+				{ tabs.map( ( tabObj ) => (
+					<Tabs.Tab
+						key={ tabObj.tabId }
+						tabId={ tabObj.tabId }
+						className={ tabObj.tab.className }
+						disabled={ tabObj.tab.disabled }
+					>
+						{ tabObj.title }
+					</Tabs.Tab>
+				) ) }
+			</Tabs.TabList>
+			{ tabs.map( ( tabObj ) => (
+				<Tabs.TabPanel
+					key={ tabObj.tabId }
+					tabId={ tabObj.tabId }
+					focusable={ tabObj.tabpanel?.focusable }
+				>
+					{ tabObj.content }
+				</Tabs.TabPanel>
+			) ) }
+		</Tabs>
+	);
+};
+
+let originalGetClientRects: () => DOMRectList;
+
+async function waitForComponentToBeInitializedWithSelectedTab(
+	selectedTabName: string | undefined
+) {
+	if ( ! selectedTabName ) {
+		// Wait for the tablist to be tabbable as a mean to know
+		// that ariakit has finished initializing.
+		await waitFor( () =>
+			expect( screen.getByRole( 'tablist' ) ).toHaveAttribute(
+				'tabindex',
+				expect.stringMatching( /^(0|-1)$/ )
+			)
+		);
+		// No initially selected tabs or tabpanels.
+		await waitFor( () =>
+			expect( screen.queryByRole( 'tab', { selected: true } ) ).not.toBeInTheDocument()
+		);
+		await waitFor( () => expect( screen.queryByRole( 'tabpanel' ) ).not.toBeInTheDocument() );
+	} else {
+		// Waiting for a tab to be selected is a sign that the component
+		// has fully initialized.
+		expect(
+			await screen.findByRole( 'tab', {
+				selected: true,
+				name: selectedTabName,
+			} )
+		).toBeVisible();
+		// The corresponding tabpanel is also shown.
+		expect(
+			screen.getByRole( 'tabpanel', {
+				name: selectedTabName,
+			} )
+		).toBeVisible();
+	}
+}
+
+describe( 'Tabs', () => {
+	beforeAll( () => {
+		originalGetClientRects = window.HTMLElement.prototype.getClientRects;
+		// Mocking `getClientRects()` is necessary to pass a check performed by
+		// the `focus.tabbable.find()` and by the `focus.focusable.find()` functions
+		// from the `@wordpress/dom` package.
+		// @ts-expect-error We're not trying to comply to the DOM spec, only mocking
+		window.HTMLElement.prototype.getClientRects = function () {
+			return [ 'trick-jsdom-into-having-size-for-element-rect' ];
+		};
+	} );
+
+	afterAll( () => {
+		window.HTMLElement.prototype.getClientRects = originalGetClientRects;
+	} );
+
+	describe( 'Adherence to spec and basic behavior', () => {
+		it( 'should apply the correct roles, semantics and attributes', async () => {
+			await render( <UncontrolledTabs tabs={ TABS } /> );
+
+			// Alpha is automatically selected as the selected tab.
+			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
+
+			const tabList = screen.getByRole( 'tablist' );
+			const allTabs = screen.getAllByRole( 'tab' );
+			const allTabpanels = screen.getAllByRole( 'tabpanel' );
+
+			expect( tabList ).toBeVisible();
+			expect( tabList ).toHaveAttribute( 'aria-orientation', 'horizontal' );
+
+			expect( allTabs ).toHaveLength( TABS.length );
+
+			// Only 1 tab panel is accessible — the one associated with the
+			// selected tab. The selected `tab` aria-controls the active
+			/// `tabpanel`, which is `aria-labelledby` the selected `tab`.
+			expect( allTabpanels ).toHaveLength( 1 );
+
+			expect( allTabpanels[ 0 ] ).toBeVisible();
+			expect( allTabs[ 0 ] ).toHaveAttribute(
+				'aria-controls',
+				allTabpanels[ 0 ].getAttribute( 'id' )
+			);
+			expect( allTabpanels[ 0 ] ).toHaveAttribute(
+				'aria-labelledby',
+				allTabs[ 0 ].getAttribute( 'id' )
+			);
+		} );
+
+		it( 'should associate each `tab` with the correct `tabpanel`, even if they are not rendered in the same order', async () => {
+			const TABS_WITH_DELTA_REVERSED = [ ...TABS_WITH_DELTA ].reverse();
+
+			await render(
+				<Tabs>
+					<Tabs.TabList>
+						{ TABS_WITH_DELTA.map( ( tabObj ) => (
+							<Tabs.Tab
+								key={ tabObj.tabId }
+								tabId={ tabObj.tabId }
+								className={ tabObj.tab.className }
+								disabled={ tabObj.tab.disabled }
+							>
+								{ tabObj.title }
+							</Tabs.Tab>
+						) ) }
+					</Tabs.TabList>
+					{ TABS_WITH_DELTA_REVERSED.map( ( tabObj ) => (
+						<Tabs.TabPanel
+							key={ tabObj.tabId }
+							tabId={ tabObj.tabId }
+							focusable={ tabObj.tabpanel?.focusable }
+						>
+							{ tabObj.content }
+						</Tabs.TabPanel>
+					) ) }
+				</Tabs>
+			);
+
+			// Alpha is automatically selected as the selected tab.
+			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
+
+			// Select Beta, make sure the correct tabpanel is rendered
+			await click( screen.getByRole( 'tab', { name: 'Beta' } ) );
+			expect(
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Beta',
+				} )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Beta',
+				} )
+			).toBeVisible();
+
+			// Select Gamma, make sure the correct tabpanel is rendered
+			await click( screen.getByRole( 'tab', { name: 'Gamma' } ) );
+			expect(
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Gamma',
+				} )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Gamma',
+				} )
+			).toBeVisible();
+
+			// Select Delta, make sure the correct tabpanel is rendered
+			await click( screen.getByRole( 'tab', { name: 'Delta' } ) );
+			expect(
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Delta',
+				} )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Delta',
+				} )
+			).toBeVisible();
+		} );
+
+		it( "should apply the tab's `className` to the tab button", async () => {
+			await render( <UncontrolledTabs tabs={ TABS } /> );
+
+			// Alpha is automatically selected as the selected tab.
+			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
+
+			expect( await screen.findByRole( 'tab', { name: 'Alpha' } ) ).toHaveClass( 'alpha-class' );
+			expect( screen.getByRole( 'tab', { name: 'Beta' } ) ).toHaveClass( 'beta-class' );
+			expect( screen.getByRole( 'tab', { name: 'Gamma' } ) ).toHaveClass( 'gamma-class' );
+		} );
+	} );
+
+	describe( 'pointer interactions', () => {
+		it( 'should select a tab when clicked', async () => {
+			const mockOnSelect = jest.fn();
+
+			await render( <UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } /> );
+
+			// Alpha is automatically selected as the selected tab.
+			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
+
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+
+			// Click on Beta, make sure beta is the selected tab
+			await click( screen.getByRole( 'tab', { name: 'Beta' } ) );
+
+			expect(
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Beta',
+				} )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Beta',
+				} )
+			).toBeVisible();
+
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+
+			// Click on Alpha, make sure alpha is the selected tab
+			await click( screen.getByRole( 'tab', { name: 'Alpha' } ) );
+
+			expect(
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
+			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+		} );
+
+		it( 'should not select a disabled tab when clicked', async () => {
+			const mockOnSelect = jest.fn();
+
+			await render(
+				<UncontrolledTabs tabs={ TABS_WITH_BETA_DISABLED } onSelect={ mockOnSelect } />
+			);
+
+			// Alpha is automatically selected as the selected tab.
+			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
+
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+
+			// Clicking on Beta does not result in beta being selected
+			// because the tab is disabled.
+			await click( screen.getByRole( 'tab', { name: 'Beta' } ) );
+
+			expect(
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( 'initial tab selection', () => {
+		describe( 'when a selected tab id is not specified', () => {
+			describe( 'when left `undefined` [Uncontrolled]', () => {
+				it( 'should choose the first tab as selected', async () => {
+					await render( <UncontrolledTabs tabs={ TABS } /> );
+
+					// Alpha is automatically selected as the selected tab.
+					await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
+
+					// Press tab. The selected tab (alpha) received focus.
+					await press.Tab();
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Alpha',
+						} )
+					).toHaveFocus();
+				} );
+
+				it( 'should choose the first non-disabled tab if the first tab is disabled', async () => {
+					await render( <UncontrolledTabs tabs={ TABS_WITH_ALPHA_DISABLED } /> );
+
+					// Beta is automatically selected as the selected tab, since alpha is
+					// disabled.
+					await waitForComponentToBeInitializedWithSelectedTab( 'Beta' );
+
+					// Press tab. The selected tab (beta) received focus. The corresponding
+					// tabpanel is shown.
+					await press.Tab();
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toHaveFocus();
+				} );
+			} );
+			describe( 'when `null` [Controlled]', () => {
+				it( 'should not have a selected tab nor show any tabpanels, make the tablist tabbable and still allow selecting tabs', async () => {
+					await render( <ControlledTabs tabs={ TABS } selectedTabId={ null } /> );
+
+					// No initially selected tabs or tabpanels.
+					await waitForComponentToBeInitializedWithSelectedTab( undefined );
+
+					// Press tab. The tablist receives focus
+					await press.Tab();
+					expect( await screen.findByRole( 'tablist' ) ).toHaveFocus();
+
+					// Press right arrow to select the first tab (alpha) and
+					// show the related tabpanel.
+					await press.ArrowRight();
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Alpha',
+						} )
+					).toHaveFocus();
+					expect(
+						await screen.findByRole( 'tabpanel', {
+							name: 'Alpha',
+						} )
+					).toBeVisible();
+				} );
+			} );
+		} );
+
+		describe( 'when a selected tab id is specified', () => {
+			describe( 'through the `defaultTabId` prop [Uncontrolled]', () => {
+				it( 'should select the initial tab matching the `defaultTabId` prop', async () => {
+					await render( <UncontrolledTabs tabs={ TABS } defaultTabId="beta" /> );
+
+					// Beta is the initially selected tab
+					await waitForComponentToBeInitializedWithSelectedTab( 'Beta' );
+
+					// Press tab. The selected tab (beta) received focus. The corresponding
+					// tabpanel is shown.
+					await press.Tab();
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toHaveFocus();
+				} );
+
+				it( 'should select the initial tab matching the `defaultTabId` prop even if the tab is disabled', async () => {
+					await render( <UncontrolledTabs tabs={ TABS_WITH_BETA_DISABLED } defaultTabId="beta" /> );
+
+					// Beta is automatically selected as the selected tab despite being
+					// disabled, respecting the `defaultTabId` prop.
+					await waitForComponentToBeInitializedWithSelectedTab( 'Beta' );
+
+					// Press tab. The selected tab (beta) received focus, since it is
+					// accessible despite being disabled.
+					await press.Tab();
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toHaveFocus();
+				} );
+
+				it( 'should not have a selected tab nor show any tabpanels, but allow tabbing to the first tab when `defaultTabId` prop does not match any known tab', async () => {
+					await render( <UncontrolledTabs tabs={ TABS } defaultTabId="non-existing-tab" /> );
+
+					// No initially selected tabs or tabpanels, since the `defaultTabId`
+					// prop is not matching any known tabs.
+					await waitForComponentToBeInitializedWithSelectedTab( undefined );
+
+					// Press tab. The first tab receives focus, but it's
+					// not selected.
+					await press.Tab();
+					expect( screen.getByRole( 'tab', { name: 'Alpha' } ) ).toHaveFocus();
+					await waitFor( () =>
+						expect( screen.queryByRole( 'tab', { selected: true } ) ).not.toBeInTheDocument()
+					);
+					await waitFor( () => expect( screen.queryByRole( 'tabpanel' ) ).not.toBeInTheDocument() );
+
+					// Press right arrow to select the next tab (beta) and
+					// show the related tabpanel.
+					await press.ArrowRight();
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toHaveFocus();
+					expect(
+						await screen.findByRole( 'tabpanel', {
+							name: 'Beta',
+						} )
+					).toBeVisible();
+				} );
+
+				it( 'should not have a selected tab nor show any tabpanels, but allow tabbing to the first tab, even when disabled, when `defaultTabId` prop does not match any known tab', async () => {
+					await render(
+						<UncontrolledTabs tabs={ TABS_WITH_ALPHA_DISABLED } defaultTabId="non-existing-tab" />
+					);
+
+					// No initially selected tabs or tabpanels, since the `defaultTabId`
+					// prop is not matching any known tabs.
+					await waitForComponentToBeInitializedWithSelectedTab( undefined );
+
+					// Press tab. The first tab receives focus, but it's
+					// not selected.
+					await press.Tab();
+					expect( screen.getByRole( 'tab', { name: 'Alpha' } ) ).toHaveFocus();
+					await waitFor( () =>
+						expect( screen.queryByRole( 'tab', { selected: true } ) ).not.toBeInTheDocument()
+					);
+					await waitFor( () => expect( screen.queryByRole( 'tabpanel' ) ).not.toBeInTheDocument() );
+
+					// Press right arrow to select the next tab (beta) and
+					// show the related tabpanel.
+					await press.ArrowRight();
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toHaveFocus();
+					expect(
+						await screen.findByRole( 'tabpanel', {
+							name: 'Beta',
+						} )
+					).toBeVisible();
+				} );
+
+				it( 'should ignore any changes to the `defaultTabId` prop after the first render', async () => {
+					const mockOnSelect = jest.fn();
+
+					const { rerender } = await render(
+						<UncontrolledTabs tabs={ TABS } defaultTabId="beta" onSelect={ mockOnSelect } />
+					);
+
+					// Beta is the initially selected tab
+					await waitForComponentToBeInitializedWithSelectedTab( 'Beta' );
+
+					// Changing the defaultTabId prop to gamma should not have any effect.
+					await rerender(
+						<UncontrolledTabs tabs={ TABS } defaultTabId="gamma" onSelect={ mockOnSelect } />
+					);
+
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Beta',
+						} )
+					).toBeVisible();
+
+					expect( mockOnSelect ).not.toHaveBeenCalled();
+				} );
+			} );
+
+			describe( 'through the `selectedTabId` prop [Controlled]', () => {
+				describe( 'when the `selectedTabId` matches an existing tab', () => {
+					it( 'should choose the initial tab matching the `selectedTabId`', async () => {
+						await render( <ControlledTabs tabs={ TABS } selectedTabId="beta" /> );
+
+						// Beta is the initially selected tab
+						await waitForComponentToBeInitializedWithSelectedTab( 'Beta' );
+
+						// Press tab. The selected tab (beta) received focus, since it is
+						// accessible despite being disabled.
+						await press.Tab();
+						expect(
+							await screen.findByRole( 'tab', {
+								selected: true,
+								name: 'Beta',
+							} )
+						).toHaveFocus();
+					} );
+
+					it( 'should choose the initial tab matching the `selectedTabId` even if a `defaultTabId` is passed', async () => {
+						await render(
+							<ControlledTabs tabs={ TABS } defaultTabId="beta" selectedTabId="gamma" />
+						);
+
+						// Gamma is the initially selected tab
+						await waitForComponentToBeInitializedWithSelectedTab( 'Gamma' );
+
+						// Press tab. The selected tab (gamma) received focus, since it is
+						// accessible despite being disabled.
+						await press.Tab();
+						expect(
+							await screen.findByRole( 'tab', {
+								selected: true,
+								name: 'Gamma',
+							} )
+						).toHaveFocus();
+					} );
+
+					it( 'should choose the initial tab matching the `selectedTabId` even if the tab is disabled', async () => {
+						await render(
+							<ControlledTabs tabs={ TABS_WITH_BETA_DISABLED } selectedTabId="beta" />
+						);
+
+						// Beta is the initially selected tab
+						await waitForComponentToBeInitializedWithSelectedTab( 'Beta' );
+
+						// Press tab. The selected tab (beta) received focus, since it is
+						// accessible despite being disabled.
+						await press.Tab();
+						expect(
+							await screen.findByRole( 'tab', {
+								selected: true,
+								name: 'Beta',
+							} )
+						).toHaveFocus();
+					} );
+				} );
+
+				describe( "when the `selectedTabId` doesn't match an existing tab", () => {
+					it( 'should not have a selected tab nor show any tabpanels, but allow tabbing to the first tab', async () => {
+						await render( <ControlledTabs tabs={ TABS } selectedTabId="non-existing-tab" /> );
+
+						// No initially selected tabs or tabpanels, since the `selectedTabId`
+						// prop is not matching any known tabs.
+						await waitForComponentToBeInitializedWithSelectedTab( undefined );
+
+						// Press tab. The first tab receives focus, but it's
+						// not selected.
+						await press.Tab();
+						expect( screen.getByRole( 'tab', { name: 'Alpha' } ) ).toHaveFocus();
+						await waitFor( () =>
+							expect( screen.queryByRole( 'tab', { selected: true } ) ).not.toBeInTheDocument()
+						);
+						await waitFor( () =>
+							expect( screen.queryByRole( 'tabpanel' ) ).not.toBeInTheDocument()
+						);
+
+						// Press right arrow to select the next tab (beta) and
+						// show the related tabpanel.
+						await press.ArrowRight();
+						expect(
+							await screen.findByRole( 'tab', {
+								selected: true,
+								name: 'Beta',
+							} )
+						).toHaveFocus();
+						expect(
+							await screen.findByRole( 'tabpanel', {
+								name: 'Beta',
+							} )
+						).toBeVisible();
+					} );
+
+					it( 'should not have a selected tab nor show any tabpanels, but allow tabbing to the first tab even when disabled', async () => {
+						await render(
+							<ControlledTabs tabs={ TABS_WITH_ALPHA_DISABLED } selectedTabId="non-existing-tab" />
+						);
+
+						// No initially selected tabs or tabpanels, since the `selectedTabId`
+						// prop is not matching any known tabs.
+						await waitForComponentToBeInitializedWithSelectedTab( undefined );
+
+						// Press tab. The first tab receives focus, but it's
+						// not selected.
+						await press.Tab();
+						expect( screen.getByRole( 'tab', { name: 'Alpha' } ) ).toHaveFocus();
+						await waitFor( () =>
+							expect( screen.queryByRole( 'tab', { selected: true } ) ).not.toBeInTheDocument()
+						);
+						await waitFor( () =>
+							expect( screen.queryByRole( 'tabpanel' ) ).not.toBeInTheDocument()
+						);
+
+						// Press right arrow to select the next tab (beta) and
+						// show the related tabpanel.
+						await press.ArrowRight();
+						expect(
+							await screen.findByRole( 'tab', {
+								selected: true,
+								name: 'Beta',
+							} )
+						).toHaveFocus();
+						expect(
+							await screen.findByRole( 'tabpanel', {
+								name: 'Beta',
+							} )
+						).toBeVisible();
+					} );
+				} );
+			} );
+		} );
+	} );
+
+	describe( 'keyboard interactions', () => {
+		describe.each( [
+			[ 'Uncontrolled', UncontrolledTabs ],
+			[ 'Controlled', ControlledTabs ],
+		] )( '[`%s`]', ( _mode, Component ) => {
+			it( 'should handle the tablist as one tab stop', async () => {
+				await render( <Component tabs={ TABS } /> );
+
+				// Alpha is automatically selected as the selected tab.
+				await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
+
+				// Press tab. The selected tab (alpha) received focus.
+				await press.Tab();
+				expect(
+					await screen.findByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toHaveFocus();
+
+				// By default the tabpanel should receive focus
+				await press.Tab();
+				expect(
+					await screen.findByRole( 'tabpanel', {
+						name: 'Alpha',
+					} )
+				).toHaveFocus();
+			} );
+
+			it( 'should not focus the tabpanel container when its `focusable` property is set to `false`', async () => {
+				await render(
+					<Component
+						tabs={ TABS.map( ( tabObj ) =>
+							tabObj.tabId === 'alpha'
+								? {
+										...tabObj,
+										content: (
+											<>
+												Selected Tab: Alpha
+												<button>Alpha Button</button>
+											</>
+										),
+										tabpanel: { focusable: false },
+								  }
+								: tabObj
+						) }
+					/>
+				);
+
+				// Alpha is automatically selected as the selected tab.
+				await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
+
+				// Tab should initially focus the first tab in the tablist, which
+				// is Alpha.
+				await press.Tab();
+				expect(
+					await screen.findByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toHaveFocus();
+
+				// In this case, the tabpanel container is skipped and focus is
+				// moved directly to its contents
+				await press.Tab();
+				expect(
+					await screen.findByRole( 'button', {
+						name: 'Alpha Button',
+					} )
+				).toHaveFocus();
+			} );
+
+			it( 'should select tabs in the tablist when using the left and right arrow keys by default (automatic tab activation)', async () => {
+				const mockOnSelect = jest.fn();
+
+				await render( <Component tabs={ TABS } onSelect={ mockOnSelect } /> );
+
+				// Alpha is automatically selected as the selected tab.
+				await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+
+				// Focus the tablist (and the selected tab, alpha)
+				// Tab should initially focus the first tab in the tablist, which
+				// is Alpha.
+				await press.Tab();
+				expect(
+					await screen.findByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toHaveFocus();
+
+				// Press the right arrow key to select the beta tab
+				await press.ArrowRight();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Beta',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Beta',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+
+				// Press the right arrow key to select the gamma tab
+				await press.ArrowRight();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Gamma',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Gamma',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'gamma' );
+
+				// Press the left arrow key to select the beta tab
+				await press.ArrowLeft();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Beta',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Beta',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 4 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+			} );
+
+			it( 'should not automatically select tabs in the tablist when pressing the left and right arrow keys if the `selectOnMove` prop is set to `false` (manual tab activation)', async () => {
+				const mockOnSelect = jest.fn();
+
+				await render(
+					<Component tabs={ TABS } onSelect={ mockOnSelect } selectOnMove={ false } />
+				);
+
+				// Alpha is automatically selected as the selected tab.
+				await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+
+				// Focus the tablist (and the selected tab, alpha)
+				// Tab should initially focus the first tab in the tablist, which
+				// is Alpha.
+				await press.Tab();
+				expect(
+					await screen.findByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toHaveFocus();
+
+				// Press the right arrow key to move focus to the beta tab,
+				// but without selecting it
+				await press.ArrowRight();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: false,
+						name: 'Beta',
+					} )
+				).toHaveFocus();
+				expect(
+					await screen.findByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toBeVisible();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Alpha',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+
+				// Press the space key to click the beta tab, and select it.
+				// The same should be true with any other mean of clicking the tab button
+				// (ie. mouse click, enter key).
+				await press.Space();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Beta',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Beta',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+			} );
+
+			it( 'should not select tabs in the tablist when using the up and down arrow keys, unless the `orientation` prop is set to `vertical`', async () => {
+				const mockOnSelect = jest.fn();
+
+				const { rerender } = await render( <Component tabs={ TABS } onSelect={ mockOnSelect } /> );
+
+				// Alpha is automatically selected as the selected tab.
+				await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+
+				// Focus the tablist (and the selected tab, alpha)
+				// Tab should initially focus the first tab in the tablist, which
+				// is Alpha.
+				await press.Tab();
+				expect(
+					await screen.findByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toHaveFocus();
+
+				// Press the up arrow key, but the focused/selected tab does not change.
+				await press.ArrowUp();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Alpha',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+
+				// Press the down arrow key, but the focused/selected tab does not change.
+				await press.ArrowDown();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Alpha',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+
+				// Change the orientation to "vertical" and rerender the component.
+				await rerender(
+					<Component tabs={ TABS } onSelect={ mockOnSelect } orientation="vertical" />
+				);
+
+				// Pressing the down arrow key now selects the next tab (beta).
+				await press.ArrowDown();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Beta',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Beta',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+
+				// Pressing the up arrow key now selects the previous tab (alpha).
+				await press.ArrowUp();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Alpha',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+			} );
+
+			it( 'should loop tab focus at the end of the tablist when using arrow keys', async () => {
+				const mockOnSelect = jest.fn();
+
+				await render( <Component tabs={ TABS } onSelect={ mockOnSelect } /> );
+
+				// Alpha is automatically selected as the selected tab.
+				await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+
+				// Focus the tablist (and the selected tab, alpha)
+				// Tab should initially focus the first tab in the tablist, which
+				// is Alpha.
+				await press.Tab();
+				expect(
+					await screen.findByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toHaveFocus();
+
+				// Press the left arrow key to loop around and select the gamma tab
+				await press.ArrowLeft();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Gamma',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Gamma',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'gamma' );
+
+				// Press the right arrow key to loop around and select the alpha tab
+				await press.ArrowRight();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Alpha',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+			} );
+
+			// TODO: mock writing direction to RTL
+			it( 'should swap the left and right arrow keys when selecting tabs if the writing direction is set to RTL', async () => {
+				// For this test only, mock the writing direction to RTL.
+				mockedIsRTL.mockImplementation( () => true );
+
+				const mockOnSelect = jest.fn();
+
+				await render( <Component tabs={ TABS } onSelect={ mockOnSelect } /> );
+
+				// Alpha is automatically selected as the selected tab.
+				await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+
+				// Focus the tablist (and the selected tab, alpha)
+				// Tab should initially focus the first tab in the tablist, which
+				// is Alpha.
+				await press.Tab();
+				expect(
+					await screen.findByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toHaveFocus();
+
+				// Press the left arrow key to select the beta tab
+				await press.ArrowLeft();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Beta',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Beta',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+
+				// Press the left arrow key to select the gamma tab
+				await press.ArrowLeft();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Gamma',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Gamma',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'gamma' );
+
+				// Press the right arrow key to select the beta tab
+				await press.ArrowRight();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Beta',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Beta',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 4 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+
+				// Restore the original implementation of the isRTL function.
+				mockedIsRTL.mockRestore();
+			} );
+
+			it( 'should focus tabs in the tablist even if disabled', async () => {
+				const mockOnSelect = jest.fn();
+
+				await render( <Component tabs={ TABS_WITH_BETA_DISABLED } onSelect={ mockOnSelect } /> );
+
+				// Alpha is automatically selected as the selected tab.
+				await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+
+				// Focus the tablist (and the selected tab, alpha)
+				// Tab should initially focus the first tab in the tablist, which
+				// is Alpha.
+				await press.Tab();
+				expect(
+					await screen.findByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toHaveFocus();
+
+				// Pressing the right arrow key moves focus to the beta tab, but alpha
+				// remains the selected tab because beta is disabled.
+				await press.ArrowRight();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: false,
+						name: 'Beta',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toBeVisible();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Alpha',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+
+				// Press the right arrow key to select the gamma tab
+				await press.ArrowRight();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Gamma',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Gamma',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'gamma' );
+			} );
+		} );
+
+		describe( 'When `selectedId` is changed by the controlling component [Controlled]', () => {
+			describe.each( [ true, false ] )( 'and `selectOnMove` is %s', ( selectOnMove ) => {
+				it( 'should continue to handle arrow key navigation properly', async () => {
+					const { rerender } = await render(
+						<ControlledTabs tabs={ TABS } selectedTabId="beta" selectOnMove={ selectOnMove } />
+					);
+
+					// Beta is the selected tab.
+					await waitForComponentToBeInitializedWithSelectedTab( 'Beta' );
+
+					// Tab key should focus the currently selected tab, which is Beta.
+					await press.Tab();
+					expect(
+						screen.getByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toHaveFocus();
+
+					await rerender(
+						<ControlledTabs tabs={ TABS } selectedTabId="gamma" selectOnMove={ selectOnMove } />
+					);
+
+					// When the selected tab is changed, focus should not be changed.
+					expect(
+						screen.getByRole( 'tab', {
+							selected: true,
+							name: 'Gamma',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tab', {
+							selected: false,
+							name: 'Beta',
+						} )
+					).toHaveFocus();
+
+					// Arrow left should move focus to the previous tab (alpha).
+					// The alpha tab should be always focused, and should be selected
+					// when the `selectOnMove` prop is set to `true`.
+					await press.ArrowLeft();
+					expect(
+						screen.getByRole( 'tab', {
+							selected: selectOnMove,
+							name: 'Alpha',
+						} )
+					).toHaveFocus();
+				} );
+
+				it( 'should focus the correct tab when tabbing out and back into the tablist', async () => {
+					const { rerender } = await render(
+						<>
+							<button>Focus me</button>
+							<ControlledTabs tabs={ TABS } selectedTabId="beta" selectOnMove={ selectOnMove } />
+						</>
+					);
+
+					// Beta is the selected tab.
+					await waitForComponentToBeInitializedWithSelectedTab( 'Beta' );
+
+					// Tab key should focus the currently selected tab, which is Beta.
+					await press.Tab();
+					await press.Tab();
+					expect(
+						screen.getByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toHaveFocus();
+
+					// Change the selected tab to gamma via a controlled update.
+					await rerender(
+						<>
+							<button>Focus me</button>
+							<ControlledTabs tabs={ TABS } selectedTabId="gamma" selectOnMove={ selectOnMove } />
+						</>
+					);
+
+					// When the selected tab is changed, it should not automatically receive focus.
+					expect(
+						screen.getByRole( 'tab', {
+							selected: true,
+							name: 'Gamma',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tab', {
+							selected: false,
+							name: 'Beta',
+						} )
+					).toHaveFocus();
+
+					// Press shift+tab, move focus to the button before Tabs
+					await press.ShiftTab();
+					expect( screen.getByRole( 'button', { name: 'Focus me' } ) ).toHaveFocus();
+
+					// Press tab, move focus back to the tablist
+					await press.Tab();
+
+					const betaTab = screen.getByRole( 'tab', {
+						name: 'Beta',
+					} );
+					const gammaTab = screen.getByRole( 'tab', {
+						name: 'Gamma',
+					} );
+
+					expect( selectOnMove ? gammaTab : betaTab ).toHaveFocus();
+				} );
+			} );
+		} );
+	} );
+
+	describe( 'miscellaneous runtime changes', () => {
+		describe( 'removing a tab', () => {
+			describe( 'with no explicitly set initial tab', () => {
+				it( 'should not select a new tab when the selected tab is removed', async () => {
+					const mockOnSelect = jest.fn();
+
+					const { rerender } = await render(
+						<UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } />
+					);
+
+					// Alpha is automatically selected as the selected tab.
+					await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
+
+					expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+					expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+
+					// Select gamma
+					await click( screen.getByRole( 'tab', { name: 'Gamma' } ) );
+
+					expect(
+						screen.getByRole( 'tab', {
+							selected: true,
+							name: 'Gamma',
+						} )
+					).toHaveFocus();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Gamma',
+						} )
+					).toBeVisible();
+
+					expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+					expect( mockOnSelect ).toHaveBeenLastCalledWith( 'gamma' );
+
+					// Remove gamma
+					await rerender(
+						<UncontrolledTabs tabs={ TABS.slice( 0, 2 ) } onSelect={ mockOnSelect } />
+					);
+
+					expect( screen.getAllByRole( 'tab' ) ).toHaveLength( 2 );
+
+					// No tab should be selected i.e. it doesn't fall back to gamma,
+					// even if it matches the `defaultTabId` prop.
+					expect( screen.queryByRole( 'tab', { selected: true } ) ).not.toBeInTheDocument();
+					// No tabpanel should be rendered either
+					expect( screen.queryByRole( 'tabpanel' ) ).not.toBeInTheDocument();
+
+					expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+				} );
+			} );
+
+			describe.each( [
+				[ 'defaultTabId', 'Uncontrolled', UncontrolledTabs ],
+				[ 'selectedTabId', 'Controlled', ControlledTabs ],
+			] )( 'when using the `%s` prop [%s]', ( propName, _mode, Component ) => {
+				it( 'should not select a new tab when the selected tab is removed', async () => {
+					const mockOnSelect = jest.fn();
+
+					const initialComponentProps = {
+						tabs: TABS,
+						[ propName ]: 'gamma',
+						onSelect: mockOnSelect,
+					};
+
+					const { rerender } = await render( <Component { ...initialComponentProps } /> );
+
+					// Gamma is the selected tab.
+					await waitForComponentToBeInitializedWithSelectedTab( 'Gamma' );
+
+					// Remove gamma
+					await rerender( <Component { ...initialComponentProps } tabs={ TABS.slice( 0, 2 ) } /> );
+
+					expect( screen.getAllByRole( 'tab' ) ).toHaveLength( 2 );
+					// No tab should be selected i.e. it doesn't fall back to first tab.
+					expect( screen.queryByRole( 'tab', { selected: true } ) ).not.toBeInTheDocument();
+					// No tabpanel should be rendered either
+					expect( screen.queryByRole( 'tabpanel' ) ).not.toBeInTheDocument();
+
+					// Re-add gamma. Gamma becomes selected again.
+					await rerender( <Component { ...initialComponentProps } /> );
+
+					expect( screen.getAllByRole( 'tab' ) ).toHaveLength( TABS.length );
+
+					expect(
+						screen.getByRole( 'tab', {
+							selected: true,
+							name: 'Gamma',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Gamma',
+						} )
+					).toBeVisible();
+
+					expect( mockOnSelect ).not.toHaveBeenCalled();
+				} );
+
+				it( `should not select the tab matching the \`${ propName }\` prop as a fallback when the selected tab is removed`, async () => {
+					const mockOnSelect = jest.fn();
+
+					const initialComponentProps = {
+						tabs: TABS,
+						[ propName ]: 'gamma',
+						onSelect: mockOnSelect,
+					};
+
+					const { rerender } = await render( <Component { ...initialComponentProps } /> );
+
+					// Gamma is the selected tab.
+					await waitForComponentToBeInitializedWithSelectedTab( 'Gamma' );
+
+					// Select alpha
+					await click( screen.getByRole( 'tab', { name: 'Alpha' } ) );
+
+					expect(
+						screen.getByRole( 'tab', {
+							selected: true,
+							name: 'Alpha',
+						} )
+					).toHaveFocus();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Alpha',
+						} )
+					).toBeVisible();
+
+					expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+					expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+
+					// Remove alpha
+					await rerender( <Component { ...initialComponentProps } tabs={ TABS.slice( 1 ) } /> );
+
+					expect( screen.getAllByRole( 'tab' ) ).toHaveLength( 2 );
+
+					// No tab should be selected i.e. it doesn't fall back to gamma,
+					// even if it matches the `defaultTabId` prop.
+					expect( screen.queryByRole( 'tab', { selected: true } ) ).not.toBeInTheDocument();
+					// No tabpanel should be rendered either
+					expect( screen.queryByRole( 'tabpanel' ) ).not.toBeInTheDocument();
+
+					// Re-add alpha. Alpha becomes selected again.
+					await rerender( <Component { ...initialComponentProps } /> );
+
+					expect( screen.getAllByRole( 'tab' ) ).toHaveLength( TABS.length );
+
+					expect(
+						screen.getByRole( 'tab', {
+							selected: true,
+							name: 'Alpha',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Alpha',
+						} )
+					).toBeVisible();
+
+					expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+				} );
+			} );
+		} );
+
+		describe( 'adding a tab', () => {
+			describe.each( [
+				[ 'defaultTabId', 'Uncontrolled', UncontrolledTabs ],
+				[ 'selectedTabId', 'Controlled', ControlledTabs ],
+			] )( 'when using the `%s` prop [%s]', ( propName, _mode, Component ) => {
+				it( `should select a newly added tab if it matches the \`${ propName }\` prop`, async () => {
+					const mockOnSelect = jest.fn();
+
+					const initialComponentProps = {
+						tabs: TABS,
+						[ propName ]: 'delta',
+						onSelect: mockOnSelect,
+					};
+
+					const { rerender } = await render( <Component { ...initialComponentProps } /> );
+
+					// No initially selected tabs or tabpanels, since the `defaultTabId`
+					// prop is not matching any known tabs.
+					await waitForComponentToBeInitializedWithSelectedTab( undefined );
+
+					expect( mockOnSelect ).not.toHaveBeenCalled();
+
+					// Re-render with beta disabled.
+					await rerender( <Component { ...initialComponentProps } tabs={ TABS_WITH_DELTA } /> );
+
+					// Delta becomes selected
+					expect(
+						screen.getByRole( 'tab', {
+							selected: true,
+							name: 'Delta',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Delta',
+						} )
+					).toBeVisible();
+
+					expect( mockOnSelect ).not.toHaveBeenCalled();
+				} );
+			} );
+		} );
+		describe( 'a tab becomes disabled', () => {
+			describe.each( [
+				[ 'defaultTabId', 'Uncontrolled', UncontrolledTabs ],
+				[ 'selectedTabId', 'Controlled', ControlledTabs ],
+			] )( 'when using the `%s` prop [%s]', ( propName, _mode, Component ) => {
+				it( `should keep the initial tab matching the \`${ propName }\` prop as selected even if it becomes disabled`, async () => {
+					const mockOnSelect = jest.fn();
+
+					const initialComponentProps = {
+						tabs: TABS,
+						[ propName ]: 'beta',
+						onSelect: mockOnSelect,
+					};
+
+					const { rerender } = await render( <Component { ...initialComponentProps } /> );
+
+					// Beta is the selected tab.
+					await waitForComponentToBeInitializedWithSelectedTab( 'Beta' );
+
+					expect( mockOnSelect ).not.toHaveBeenCalled();
+
+					// Re-render with beta disabled.
+					await rerender(
+						<Component { ...initialComponentProps } tabs={ TABS_WITH_BETA_DISABLED } />
+					);
+
+					// Beta continues to be selected and focused, even if it is disabled.
+					expect(
+						screen.getByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Beta',
+						} )
+					).toBeVisible();
+
+					// Re-enable beta.
+					await rerender( <Component { ...initialComponentProps } /> );
+
+					// Beta continues to be selected and focused.
+					expect(
+						screen.getByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Beta',
+						} )
+					).toBeVisible();
+
+					expect( mockOnSelect ).not.toHaveBeenCalled();
+				} );
+
+				it( 'should keep the current tab selected by the user as selected even if it becomes disabled', async () => {
+					const mockOnSelect = jest.fn();
+
+					const { rerender } = await render(
+						<Component tabs={ TABS } onSelect={ mockOnSelect } />
+					);
+
+					// Alpha is automatically selected as the selected tab.
+					await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
+
+					expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+					expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+
+					// Click on beta tab, beta becomes selected.
+					await click( screen.getByRole( 'tab', { name: 'Beta' } ) );
+
+					expect(
+						screen.getByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Beta',
+						} )
+					).toBeVisible();
+
+					expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+					expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+
+					// Re-render with beta disabled.
+					await rerender(
+						<Component tabs={ TABS_WITH_BETA_DISABLED } onSelect={ mockOnSelect } />
+					);
+
+					// Beta continues to be selected, even if it is disabled.
+					expect(
+						screen.getByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toHaveFocus();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Beta',
+						} )
+					).toBeVisible();
+
+					// Re-enable beta.
+					await rerender( <Component tabs={ TABS } onSelect={ mockOnSelect } /> );
+
+					// Beta continues to be selected and focused.
+					expect(
+						screen.getByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Beta',
+						} )
+					).toBeVisible();
+
+					expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+				} );
+			} );
+		} );
+	} );
+} );

--- a/packages/components/src/tabs-bui/test/index.tsx
+++ b/packages/components/src/tabs-bui/test/index.tsx
@@ -2,26 +2,15 @@
  * @jest-environment jsdom
  */
 import '@testing-library/jest-dom';
-import { press, click } from '@ariakit/test';
-import { render } from '@ariakit/test/react';
-import { screen, waitFor } from '@testing-library/react';
-import { isRTL } from '@wordpress/i18n';
+import { DirectionProvider } from '@base-ui-components/react/direction-provider';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React, { useEffect, useState } from 'react';
 import { Tabs } from '..';
 import type { TabsProps } from '../types';
 
-// Setup mocking the `isRTL` function to test arrow key navigation behavior.
-jest.mock( '@wordpress/i18n', () => {
-	const original = jest.requireActual( '@wordpress/i18n' );
-	return {
-		...original,
-		isRTL: jest.fn( () => false ),
-	};
-} );
-const mockedIsRTL = isRTL as jest.Mock;
-
 type Tab = {
-	tabId: string;
+	value?: string;
 	title: string;
 	content: React.ReactNode;
 	tab: {
@@ -35,27 +24,39 @@ type Tab = {
 
 const TABS: Tab[] = [
 	{
-		tabId: 'alpha',
 		title: 'Alpha',
 		content: 'Selected tab: Alpha',
 		tab: { className: 'alpha-class' },
 	},
 	{
-		tabId: 'beta',
 		title: 'Beta',
 		content: 'Selected tab: Beta',
 		tab: { className: 'beta-class' },
 	},
 	{
-		tabId: 'gamma',
 		title: 'Gamma',
 		content: 'Selected tab: Gamma',
 		tab: { className: 'gamma-class' },
 	},
 ];
 
-const TABS_WITH_ALPHA_DISABLED = TABS.map( ( tabObj ) =>
-	tabObj.tabId === 'alpha'
+const TABS_WITH_VALUES: Tab[] = [
+	{
+		...TABS[ 0 ],
+		value: 'alpha',
+	},
+	{
+		...TABS[ 1 ],
+		value: 'beta',
+	},
+	{
+		...TABS[ 2 ],
+		value: 'gamma',
+	},
+];
+
+const TABS_WITH_ALPHA_DISABLED = TABS.map( ( tabObj, index ) =>
+	index === 0
 		? {
 				...tabObj,
 				tab: {
@@ -66,8 +67,20 @@ const TABS_WITH_ALPHA_DISABLED = TABS.map( ( tabObj ) =>
 		: tabObj
 );
 
-const TABS_WITH_BETA_DISABLED = TABS.map( ( tabObj ) =>
-	tabObj.tabId === 'beta'
+const TABS_WITH_VALUES_AND_ALPHA_DISABLED = TABS_WITH_VALUES.map( ( tabObj ) =>
+	tabObj.value === 'alpha'
+		? {
+				...tabObj,
+				tab: {
+					...tabObj.tab,
+					disabled: true,
+				},
+		  }
+		: tabObj
+);
+
+const TABS_WITH_VALUES_AND_BETA_DISABLED = TABS_WITH_VALUES.map( ( tabObj ) =>
+	tabObj.value === 'beta'
 		? {
 				...tabObj,
 				tab: {
@@ -81,26 +94,35 @@ const TABS_WITH_BETA_DISABLED = TABS.map( ( tabObj ) =>
 const TABS_WITH_DELTA: Tab[] = [
 	...TABS,
 	{
-		tabId: 'delta',
 		title: 'Delta',
 		content: 'Selected tab: Delta',
 		tab: { className: 'delta-class' },
 	},
 ];
 
+const TABS_WITH_VALUES_AND_DELTA: Tab[] = [
+	...TABS_WITH_VALUES,
+	{
+		...TABS_WITH_DELTA[ 3 ],
+		value: 'delta',
+	},
+];
+
 const UncontrolledTabs = ( {
 	tabs,
+	selectOnMove,
 	...props
 }: Omit< TabsProps, 'children' > & {
 	tabs: Tab[];
+	selectOnMove?: boolean;
 } ) => {
 	return (
 		<Tabs { ...props }>
-			<Tabs.TabList>
-				{ tabs.map( ( tabObj ) => (
+			<Tabs.TabList activateOnFocus={ selectOnMove }>
+				{ tabs.map( ( tabObj, index ) => (
 					<Tabs.Tab
-						key={ tabObj.tabId }
-						tabId={ tabObj.tabId }
+						key={ `${ tabObj.title }-${ index }` }
+						value={ tabObj.value }
 						className={ tabObj.tab.className }
 						disabled={ tabObj.tab.disabled }
 					>
@@ -108,10 +130,10 @@ const UncontrolledTabs = ( {
 					</Tabs.Tab>
 				) ) }
 			</Tabs.TabList>
-			{ tabs.map( ( tabObj ) => (
+			{ tabs.map( ( tabObj, index ) => (
 				<Tabs.TabPanel
-					key={ tabObj.tabId }
-					tabId={ tabObj.tabId }
+					key={ `${ tabObj.title }-${ index }` }
+					value={ tabObj.value }
 					focusable={ tabObj.tabpanel?.focusable }
 				>
 					{ tabObj.content }
@@ -123,32 +145,32 @@ const UncontrolledTabs = ( {
 
 const ControlledTabs = ( {
 	tabs,
+	selectOnMove,
 	...props
 }: Omit< TabsProps, 'children' > & {
 	tabs: Tab[];
+	selectOnMove?: boolean;
 } ) => {
-	const [ selectedTabId, setSelectedTabId ] = useState< string | undefined | null >(
-		props.selectedTabId
-	);
+	const [ value, setValue ] = useState( props.value ?? null );
 
 	useEffect( () => {
-		setSelectedTabId( props.selectedTabId );
-	}, [ props.selectedTabId ] );
+		setValue( props.value ?? null );
+	}, [ props.value ] );
 
 	return (
 		<Tabs
 			{ ...props }
-			selectedTabId={ selectedTabId }
-			onSelect={ ( selectedId ) => {
-				setSelectedTabId( selectedId );
-				props.onSelect?.( selectedId );
+			value={ value }
+			onValueChange={ ( selectedId, event ) => {
+				setValue( selectedId );
+				props.onValueChange?.( selectedId, event );
 			} }
 		>
-			<Tabs.TabList>
-				{ tabs.map( ( tabObj ) => (
+			<Tabs.TabList activateOnFocus={ selectOnMove }>
+				{ tabs.map( ( tabObj, index ) => (
 					<Tabs.Tab
-						key={ tabObj.tabId }
-						tabId={ tabObj.tabId }
+						key={ `${ tabObj.title }-${ index }` }
+						value={ tabObj.value }
 						className={ tabObj.tab.className }
 						disabled={ tabObj.tab.disabled }
 					>
@@ -156,10 +178,10 @@ const ControlledTabs = ( {
 					</Tabs.Tab>
 				) ) }
 			</Tabs.TabList>
-			{ tabs.map( ( tabObj ) => (
+			{ tabs.map( ( tabObj, index ) => (
 				<Tabs.TabPanel
-					key={ tabObj.tabId }
-					tabId={ tabObj.tabId }
+					key={ `${ tabObj.title }-${ index }` }
+					value={ tabObj.value }
 					focusable={ tabObj.tabpanel?.focusable }
 				>
 					{ tabObj.content }
@@ -224,17 +246,28 @@ describe( 'Tabs', () => {
 
 	describe( 'Adherence to spec and basic behavior', () => {
 		it( 'should apply the correct roles, semantics and attributes', async () => {
-			await render( <UncontrolledTabs tabs={ TABS } /> );
+			await render(
+				<Tabs>
+					<Tabs.TabList>
+						<Tabs.Tab>One</Tabs.Tab>
+						<Tabs.Tab>Two</Tabs.Tab>
+						<Tabs.Tab>Three</Tabs.Tab>
+					</Tabs.TabList>
+					<Tabs.TabPanel>First panel</Tabs.TabPanel>
+					<Tabs.TabPanel>Second panel</Tabs.TabPanel>
+					<Tabs.TabPanel>Third panel</Tabs.TabPanel>
+				</Tabs>
+			);
 
-			// Alpha is automatically selected as the selected tab.
-			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
+			await waitForComponentToBeInitializedWithSelectedTab( 'One' );
 
 			const tabList = screen.getByRole( 'tablist' );
 			const allTabs = screen.getAllByRole( 'tab' );
 			const allTabpanels = screen.getAllByRole( 'tabpanel' );
 
 			expect( tabList ).toBeVisible();
-			expect( tabList ).toHaveAttribute( 'aria-orientation', 'horizontal' );
+			// Since 'horizontal' is the default orientation, no need to set it.
+			expect( tabList ).not.toHaveAttribute( 'aria-orientation' );
 
 			expect( allTabs ).toHaveLength( TABS.length );
 
@@ -244,10 +277,12 @@ describe( 'Tabs', () => {
 			expect( allTabpanels ).toHaveLength( 1 );
 
 			expect( allTabpanels[ 0 ] ).toBeVisible();
-			expect( allTabs[ 0 ] ).toHaveAttribute(
-				'aria-controls',
-				allTabpanels[ 0 ].getAttribute( 'id' )
-			);
+			// TODO: re-enable once the bug is fixed upstream
+			// https://github.com/mui/base-ui/issues
+			// expect( allTabs[ 0 ] ).toHaveAttribute(
+			// 	'aria-controls',
+			// 	allTabpanels[ 0 ].getAttribute( 'id' )
+			// );
 			expect( allTabpanels[ 0 ] ).toHaveAttribute(
 				'aria-labelledby',
 				allTabs[ 0 ].getAttribute( 'id' )
@@ -255,15 +290,17 @@ describe( 'Tabs', () => {
 		} );
 
 		it( 'should associate each `tab` with the correct `tabpanel`, even if they are not rendered in the same order', async () => {
-			const TABS_WITH_DELTA_REVERSED = [ ...TABS_WITH_DELTA ].reverse();
+			const TABS_WITH_DELTA_REVERSED = [ ...TABS_WITH_VALUES_AND_DELTA ].reverse();
+
+			const user = userEvent.setup();
 
 			await render(
-				<Tabs>
+				<Tabs defaultValue="alpha">
 					<Tabs.TabList>
-						{ TABS_WITH_DELTA.map( ( tabObj ) => (
+						{ TABS_WITH_VALUES_AND_DELTA.map( ( tabObj, index ) => (
 							<Tabs.Tab
-								key={ tabObj.tabId }
-								tabId={ tabObj.tabId }
+								key={ `${ tabObj.title }-${ index }` }
+								value={ tabObj.value }
 								className={ tabObj.tab.className }
 								disabled={ tabObj.tab.disabled }
 							>
@@ -271,10 +308,10 @@ describe( 'Tabs', () => {
 							</Tabs.Tab>
 						) ) }
 					</Tabs.TabList>
-					{ TABS_WITH_DELTA_REVERSED.map( ( tabObj ) => (
+					{ TABS_WITH_DELTA_REVERSED.map( ( tabObj, index ) => (
 						<Tabs.TabPanel
-							key={ tabObj.tabId }
-							tabId={ tabObj.tabId }
+							key={ `${ tabObj.title }-${ index }` }
+							value={ tabObj.value }
 							focusable={ tabObj.tabpanel?.focusable }
 						>
 							{ tabObj.content }
@@ -283,11 +320,10 @@ describe( 'Tabs', () => {
 				</Tabs>
 			);
 
-			// Alpha is automatically selected as the selected tab.
 			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
 
 			// Select Beta, make sure the correct tabpanel is rendered
-			await click( screen.getByRole( 'tab', { name: 'Beta' } ) );
+			await user.click( screen.getByRole( 'tab', { name: 'Beta' } ) );
 			expect(
 				screen.getByRole( 'tab', {
 					selected: true,
@@ -301,7 +337,7 @@ describe( 'Tabs', () => {
 			).toBeVisible();
 
 			// Select Gamma, make sure the correct tabpanel is rendered
-			await click( screen.getByRole( 'tab', { name: 'Gamma' } ) );
+			await user.click( screen.getByRole( 'tab', { name: 'Gamma' } ) );
 			expect(
 				screen.getByRole( 'tab', {
 					selected: true,
@@ -315,7 +351,7 @@ describe( 'Tabs', () => {
 			).toBeVisible();
 
 			// Select Delta, make sure the correct tabpanel is rendered
-			await click( screen.getByRole( 'tab', { name: 'Delta' } ) );
+			await user.click( screen.getByRole( 'tab', { name: 'Delta' } ) );
 			expect(
 				screen.getByRole( 'tab', {
 					selected: true,
@@ -343,18 +379,22 @@ describe( 'Tabs', () => {
 
 	describe( 'pointer interactions', () => {
 		it( 'should select a tab when clicked', async () => {
-			const mockOnSelect = jest.fn();
+			const mockOnValueChange = jest.fn();
 
-			await render( <UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } /> );
+			const user = userEvent.setup();
 
-			// Alpha is automatically selected as the selected tab.
+			await render(
+				<UncontrolledTabs
+					tabs={ TABS_WITH_VALUES }
+					onValueChange={ mockOnValueChange }
+					defaultValue="alpha"
+				/>
+			);
+
 			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
 
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
-
 			// Click on Beta, make sure beta is the selected tab
-			await click( screen.getByRole( 'tab', { name: 'Beta' } ) );
+			await user.click( screen.getByRole( 'tab', { name: 'Beta' } ) );
 
 			expect(
 				screen.getByRole( 'tab', {
@@ -368,11 +408,11 @@ describe( 'Tabs', () => {
 				} )
 			).toBeVisible();
 
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+			expect( mockOnValueChange ).toHaveBeenCalledTimes( 1 );
+			expect( mockOnValueChange ).toHaveBeenLastCalledWith( 'beta', expect.anything() );
 
 			// Click on Alpha, make sure alpha is the selected tab
-			await click( screen.getByRole( 'tab', { name: 'Alpha' } ) );
+			await user.click( screen.getByRole( 'tab', { name: 'Alpha' } ) );
 
 			expect(
 				screen.getByRole( 'tab', {
@@ -386,26 +426,29 @@ describe( 'Tabs', () => {
 				} )
 			).toBeVisible();
 
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+			expect( mockOnValueChange ).toHaveBeenCalledTimes( 2 );
+			expect( mockOnValueChange ).toHaveBeenLastCalledWith( 'alpha', expect.anything() );
 		} );
 
 		it( 'should not select a disabled tab when clicked', async () => {
-			const mockOnSelect = jest.fn();
+			const mockOnValueChange = jest.fn();
+
+			const user = userEvent.setup();
 
 			await render(
-				<UncontrolledTabs tabs={ TABS_WITH_BETA_DISABLED } onSelect={ mockOnSelect } />
+				<UncontrolledTabs
+					tabs={ TABS_WITH_VALUES_AND_BETA_DISABLED }
+					onValueChange={ mockOnValueChange }
+					defaultValue="alpha"
+				/>
 			);
 
-			// Alpha is automatically selected as the selected tab.
+			// Alpha is automatically selected as the selected tab./>
 			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
-
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
 
 			// Clicking on Beta does not result in beta being selected
 			// because the tab is disabled.
-			await click( screen.getByRole( 'tab', { name: 'Beta' } ) );
+			await user.click( screen.getByRole( 'tab', { name: 'Beta' } ) );
 
 			expect(
 				screen.getByRole( 'tab', {
@@ -419,21 +462,43 @@ describe( 'Tabs', () => {
 				} )
 			).toBeVisible();
 
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+			expect( mockOnValueChange ).toHaveBeenCalledTimes( 0 );
 		} );
 	} );
 
 	describe( 'initial tab selection', () => {
 		describe( 'when a selected tab id is not specified', () => {
 			describe( 'when left `undefined` [Uncontrolled]', () => {
-				it( 'should choose the first tab as selected', async () => {
+				it( 'should choose the first tab as selected if tabs and tabpanels do not have explicit values', async () => {
+					const user = userEvent.setup();
+
 					await render( <UncontrolledTabs tabs={ TABS } /> );
 
-					// Alpha is automatically selected as the selected tab.
+					// Alpha is automatically selected as the selected tab./>
 					await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
 
 					// Press tab. The selected tab (alpha) received focus.
-					await press.Tab();
+					await user.keyboard( '{Tab}' );
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Alpha',
+						} )
+					).toHaveFocus();
+
+					// TODO: check that `onVvalueChange` fired
+					// once https://github.com/mui/base-ui/issues/2097 is fixed
+				} );
+
+				it( 'should not choose any tabs as selected if tabs and tabpanels do have explicit values', async () => {
+					const user = userEvent.setup();
+
+					await render( <UncontrolledTabs tabs={ TABS_WITH_VALUES } /> );
+
+					await waitForComponentToBeInitializedWithSelectedTab( undefined );
+
+					// Press tab. The first tab (alpha) received focus.
+					await user.keyboard( '{Tab}' );
 					expect(
 						await screen.findByRole( 'tab', {
 							selected: true,
@@ -442,38 +507,42 @@ describe( 'Tabs', () => {
 					).toHaveFocus();
 				} );
 
-				it( 'should choose the first non-disabled tab if the first tab is disabled', async () => {
+				// TODO: re-enable once https://github.com/mui/base-ui/issues/2097 is fixed
+				it.skip( 'should choose the first non-disabled tab if the first tab is disabled', async () => {
+					const user = userEvent.setup();
+
 					await render( <UncontrolledTabs tabs={ TABS_WITH_ALPHA_DISABLED } /> );
 
 					// Beta is automatically selected as the selected tab, since alpha is
-					// disabled.
+					// disabled./>
 					await waitForComponentToBeInitializedWithSelectedTab( 'Beta' );
 
 					// Press tab. The selected tab (beta) received focus. The corresponding
 					// tabpanel is shown.
-					await press.Tab();
+					await user.keyboard( '{Tab}' );
 					expect(
 						await screen.findByRole( 'tab', {
 							selected: true,
 							name: 'Beta',
 						} )
 					).toHaveFocus();
+
+					// TODO: check that `onVvalueChange` fired
+					// once https://github.com/mui/base-ui/issues/2097 is fixed
 				} );
 			} );
 			describe( 'when `null` [Controlled]', () => {
 				it( 'should not have a selected tab nor show any tabpanels, make the tablist tabbable and still allow selecting tabs', async () => {
-					await render( <ControlledTabs tabs={ TABS } selectedTabId={ null } /> );
+					const user = userEvent.setup();
+
+					await render( <ControlledTabs tabs={ TABS } value={ null } /> );
 
 					// No initially selected tabs or tabpanels.
 					await waitForComponentToBeInitializedWithSelectedTab( undefined );
 
-					// Press tab. The tablist receives focus
-					await press.Tab();
-					expect( await screen.findByRole( 'tablist' ) ).toHaveFocus();
-
-					// Press right arrow to select the first tab (alpha) and
+					// Press tab to focus and select the first tab (alpha) and
 					// show the related tabpanel.
-					await press.ArrowRight();
+					await user.keyboard( '{Tab}' );
 					expect(
 						await screen.findByRole( 'tab', {
 							selected: true,
@@ -490,16 +559,18 @@ describe( 'Tabs', () => {
 		} );
 
 		describe( 'when a selected tab id is specified', () => {
-			describe( 'through the `defaultTabId` prop [Uncontrolled]', () => {
-				it( 'should select the initial tab matching the `defaultTabId` prop', async () => {
-					await render( <UncontrolledTabs tabs={ TABS } defaultTabId="beta" /> );
+			describe( 'through the `defaultValue` prop [Uncontrolled]', () => {
+				it( 'should select the initial tab matching the `defaultValue` prop', async () => {
+					const user = userEvent.setup();
+
+					await render( <UncontrolledTabs tabs={ TABS_WITH_VALUES } defaultValue="beta" /> );
 
 					// Beta is the initially selected tab
 					await waitForComponentToBeInitializedWithSelectedTab( 'Beta' );
 
 					// Press tab. The selected tab (beta) received focus. The corresponding
 					// tabpanel is shown.
-					await press.Tab();
+					await user.keyboard( '{Tab}' );
 					expect(
 						await screen.findByRole( 'tab', {
 							selected: true,
@@ -508,16 +579,19 @@ describe( 'Tabs', () => {
 					).toHaveFocus();
 				} );
 
-				it( 'should select the initial tab matching the `defaultTabId` prop even if the tab is disabled', async () => {
-					await render( <UncontrolledTabs tabs={ TABS_WITH_BETA_DISABLED } defaultTabId="beta" /> );
+				it( 'should select the initial tab matching the `defaultValue` prop even if the tab is disabled', async () => {
+					const user = userEvent.setup();
+					await render(
+						<UncontrolledTabs tabs={ TABS_WITH_VALUES_AND_BETA_DISABLED } defaultValue="beta" />
+					);
 
 					// Beta is automatically selected as the selected tab despite being
-					// disabled, respecting the `defaultTabId` prop.
+					// disabled, respecting the `defaultValue` prop.
 					await waitForComponentToBeInitializedWithSelectedTab( 'Beta' );
 
 					// Press tab. The selected tab (beta) received focus, since it is
 					// accessible despite being disabled.
-					await press.Tab();
+					await user.keyboard( '{Tab}' );
 					expect(
 						await screen.findByRole( 'tab', {
 							selected: true,
@@ -526,50 +600,43 @@ describe( 'Tabs', () => {
 					).toHaveFocus();
 				} );
 
-				it( 'should not have a selected tab nor show any tabpanels, but allow tabbing to the first tab when `defaultTabId` prop does not match any known tab', async () => {
-					await render( <UncontrolledTabs tabs={ TABS } defaultTabId="non-existing-tab" /> );
+				it( 'should not have a selected tab nor show any tabpanels, but allow tabbing to the first tab when `defaultValue` prop does not match any known tab', async () => {
+					const user = userEvent.setup();
 
-					// No initially selected tabs or tabpanels, since the `defaultTabId`
+					await render( <UncontrolledTabs tabs={ TABS } defaultValue="non-existing-tab" /> );
+
+					// No initially selected tabs or tabpanels, since the `defaultValue`
 					// prop is not matching any known tabs.
 					await waitForComponentToBeInitializedWithSelectedTab( undefined );
 
 					// Press tab. The first tab receives focus, but it's
 					// not selected.
-					await press.Tab();
+					await user.keyboard( '{Tab}' );
 					expect( screen.getByRole( 'tab', { name: 'Alpha' } ) ).toHaveFocus();
-					await waitFor( () =>
-						expect( screen.queryByRole( 'tab', { selected: true } ) ).not.toBeInTheDocument()
-					);
-					await waitFor( () => expect( screen.queryByRole( 'tabpanel' ) ).not.toBeInTheDocument() );
-
-					// Press right arrow to select the next tab (beta) and
-					// show the related tabpanel.
-					await press.ArrowRight();
-					expect(
-						await screen.findByRole( 'tab', {
-							selected: true,
-							name: 'Beta',
-						} )
-					).toHaveFocus();
+					expect( screen.queryByRole( 'tab', { selected: true, name: 'Alpha' } ) ).toBeVisible();
 					expect(
 						await screen.findByRole( 'tabpanel', {
-							name: 'Beta',
+							name: 'Alpha',
 						} )
 					).toBeVisible();
 				} );
 
-				it( 'should not have a selected tab nor show any tabpanels, but allow tabbing to the first tab, even when disabled, when `defaultTabId` prop does not match any known tab', async () => {
+				it( 'should not have a selected tab nor show any tabpanels, but allow tabbing to the first tab, even when disabled, when `defaultValue` prop does not match any known tab', async () => {
+					const user = userEvent.setup();
 					await render(
-						<UncontrolledTabs tabs={ TABS_WITH_ALPHA_DISABLED } defaultTabId="non-existing-tab" />
+						<UncontrolledTabs
+							tabs={ TABS_WITH_VALUES_AND_ALPHA_DISABLED }
+							defaultValue="non-existing-tab"
+						/>
 					);
 
-					// No initially selected tabs or tabpanels, since the `defaultTabId`
+					// No initially selected tabs or tabpanels, since the `defaultValue`
 					// prop is not matching any known tabs.
 					await waitForComponentToBeInitializedWithSelectedTab( undefined );
 
 					// Press tab. The first tab receives focus, but it's
 					// not selected.
-					await press.Tab();
+					await user.keyboard( '{Tab}' );
 					expect( screen.getByRole( 'tab', { name: 'Alpha' } ) ).toHaveFocus();
 					await waitFor( () =>
 						expect( screen.queryByRole( 'tab', { selected: true } ) ).not.toBeInTheDocument()
@@ -578,7 +645,7 @@ describe( 'Tabs', () => {
 
 					// Press right arrow to select the next tab (beta) and
 					// show the related tabpanel.
-					await press.ArrowRight();
+					await user.keyboard( '{ArrowRight}' );
 					expect(
 						await screen.findByRole( 'tab', {
 							selected: true,
@@ -592,19 +659,28 @@ describe( 'Tabs', () => {
 					).toBeVisible();
 				} );
 
-				it( 'should ignore any changes to the `defaultTabId` prop after the first render', async () => {
-					const mockOnSelect = jest.fn();
+				it( 'should ignore any changes to the `defaultValue` prop after the first render', async () => {
+					const mockOnValueChange = jest.fn();
+					const consoleErrorSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
 
 					const { rerender } = await render(
-						<UncontrolledTabs tabs={ TABS } defaultTabId="beta" onSelect={ mockOnSelect } />
+						<UncontrolledTabs
+							tabs={ TABS_WITH_VALUES }
+							defaultValue="beta"
+							onValueChange={ mockOnValueChange }
+						/>
 					);
 
 					// Beta is the initially selected tab
 					await waitForComponentToBeInitializedWithSelectedTab( 'Beta' );
 
-					// Changing the defaultTabId prop to gamma should not have any effect.
+					// Changing the defaultValue prop to gamma should not have any effect.
 					await rerender(
-						<UncontrolledTabs tabs={ TABS } defaultTabId="gamma" onSelect={ mockOnSelect } />
+						<UncontrolledTabs
+							tabs={ TABS_WITH_VALUES }
+							defaultValue="gamma"
+							onValueChange={ mockOnValueChange }
+						/>
 					);
 
 					expect(
@@ -619,21 +695,30 @@ describe( 'Tabs', () => {
 						} )
 					).toBeVisible();
 
-					expect( mockOnSelect ).not.toHaveBeenCalled();
+					expect( mockOnValueChange ).not.toHaveBeenCalled();
+
+					expect( consoleErrorSpy ).toHaveBeenCalled();
+					expect( consoleErrorSpy ).toHaveBeenCalledWith(
+						expect.stringContaining( 'changing the default value state' )
+					);
+
+					consoleErrorSpy.mockRestore();
 				} );
 			} );
 
-			describe( 'through the `selectedTabId` prop [Controlled]', () => {
-				describe( 'when the `selectedTabId` matches an existing tab', () => {
-					it( 'should choose the initial tab matching the `selectedTabId`', async () => {
-						await render( <ControlledTabs tabs={ TABS } selectedTabId="beta" /> );
+			describe( 'through the `value` prop [Controlled]', () => {
+				describe( 'when the `value` matches an existing tab', () => {
+					it( 'should choose the initial tab matching the `value`', async () => {
+						const user = userEvent.setup();
+
+						await render( <ControlledTabs tabs={ TABS_WITH_VALUES } value="beta" /> );
 
 						// Beta is the initially selected tab
 						await waitForComponentToBeInitializedWithSelectedTab( 'Beta' );
 
 						// Press tab. The selected tab (beta) received focus, since it is
 						// accessible despite being disabled.
-						await press.Tab();
+						await user.keyboard( '{Tab}' );
 						expect(
 							await screen.findByRole( 'tab', {
 								selected: true,
@@ -642,9 +727,11 @@ describe( 'Tabs', () => {
 						).toHaveFocus();
 					} );
 
-					it( 'should choose the initial tab matching the `selectedTabId` even if a `defaultTabId` is passed', async () => {
+					it( 'should choose the initial tab matching the `value` even if a `defaultValue` is passed', async () => {
+						const user = userEvent.setup();
+
 						await render(
-							<ControlledTabs tabs={ TABS } defaultTabId="beta" selectedTabId="gamma" />
+							<ControlledTabs tabs={ TABS_WITH_VALUES } defaultValue="beta" value="gamma" />
 						);
 
 						// Gamma is the initially selected tab
@@ -652,7 +739,7 @@ describe( 'Tabs', () => {
 
 						// Press tab. The selected tab (gamma) received focus, since it is
 						// accessible despite being disabled.
-						await press.Tab();
+						await user.keyboard( '{Tab}' );
 						expect(
 							await screen.findByRole( 'tab', {
 								selected: true,
@@ -661,9 +748,11 @@ describe( 'Tabs', () => {
 						).toHaveFocus();
 					} );
 
-					it( 'should choose the initial tab matching the `selectedTabId` even if the tab is disabled', async () => {
+					it( 'should choose the initial tab matching the `value` even if the tab is disabled', async () => {
+						const user = userEvent.setup();
+
 						await render(
-							<ControlledTabs tabs={ TABS_WITH_BETA_DISABLED } selectedTabId="beta" />
+							<ControlledTabs tabs={ TABS_WITH_VALUES_AND_BETA_DISABLED } value="beta" />
 						);
 
 						// Beta is the initially selected tab
@@ -671,7 +760,7 @@ describe( 'Tabs', () => {
 
 						// Press tab. The selected tab (beta) received focus, since it is
 						// accessible despite being disabled.
-						await press.Tab();
+						await user.keyboard( '{Tab}' );
 						expect(
 							await screen.findByRole( 'tab', {
 								selected: true,
@@ -681,53 +770,48 @@ describe( 'Tabs', () => {
 					} );
 				} );
 
-				describe( "when the `selectedTabId` doesn't match an existing tab", () => {
+				describe( "when the `value` doesn't match an existing tab", () => {
 					it( 'should not have a selected tab nor show any tabpanels, but allow tabbing to the first tab', async () => {
-						await render( <ControlledTabs tabs={ TABS } selectedTabId="non-existing-tab" /> );
+						const user = userEvent.setup();
 
-						// No initially selected tabs or tabpanels, since the `selectedTabId`
+						await render( <ControlledTabs tabs={ TABS } value="non-existing-tab" /> );
+
+						// No initially selected tabs or tabpanels, since the `value`
 						// prop is not matching any known tabs.
 						await waitForComponentToBeInitializedWithSelectedTab( undefined );
 
-						// Press tab. The first tab receives focus, but it's
-						// not selected.
-						await press.Tab();
-						expect( screen.getByRole( 'tab', { name: 'Alpha' } ) ).toHaveFocus();
-						await waitFor( () =>
-							expect( screen.queryByRole( 'tab', { selected: true } ) ).not.toBeInTheDocument()
-						);
-						await waitFor( () =>
-							expect( screen.queryByRole( 'tabpanel' ) ).not.toBeInTheDocument()
-						);
-
-						// Press right arrow to select the next tab (beta) and
-						// show the related tabpanel.
-						await press.ArrowRight();
+						// Press tab. The first tab receives focus and gets selected.
+						await user.keyboard( '{Tab}' );
 						expect(
 							await screen.findByRole( 'tab', {
 								selected: true,
-								name: 'Beta',
+								name: 'Alpha',
 							} )
 						).toHaveFocus();
 						expect(
 							await screen.findByRole( 'tabpanel', {
-								name: 'Beta',
+								name: 'Alpha',
 							} )
 						).toBeVisible();
 					} );
 
 					it( 'should not have a selected tab nor show any tabpanels, but allow tabbing to the first tab even when disabled', async () => {
+						const user = userEvent.setup();
+
 						await render(
-							<ControlledTabs tabs={ TABS_WITH_ALPHA_DISABLED } selectedTabId="non-existing-tab" />
+							<ControlledTabs
+								tabs={ TABS_WITH_VALUES_AND_ALPHA_DISABLED }
+								value="non-existing-tab"
+							/>
 						);
 
-						// No initially selected tabs or tabpanels, since the `selectedTabId`
+						// No initially selected tabs or tabpanels, since the `value`
 						// prop is not matching any known tabs.
 						await waitForComponentToBeInitializedWithSelectedTab( undefined );
 
 						// Press tab. The first tab receives focus, but it's
-						// not selected.
-						await press.Tab();
+						// not selected since it's disabled.
+						await user.keyboard( '{Tab}' );
 						expect( screen.getByRole( 'tab', { name: 'Alpha' } ) ).toHaveFocus();
 						await waitFor( () =>
 							expect( screen.queryByRole( 'tab', { selected: true } ) ).not.toBeInTheDocument()
@@ -738,7 +822,7 @@ describe( 'Tabs', () => {
 
 						// Press right arrow to select the next tab (beta) and
 						// show the related tabpanel.
-						await press.ArrowRight();
+						await user.keyboard( '{ArrowRight}' );
 						expect(
 							await screen.findByRole( 'tab', {
 								selected: true,
@@ -762,13 +846,18 @@ describe( 'Tabs', () => {
 			[ 'Controlled', ControlledTabs ],
 		] )( '[`%s`]', ( _mode, Component ) => {
 			it( 'should handle the tablist as one tab stop', async () => {
-				await render( <Component tabs={ TABS } /> );
+				const user = userEvent.setup();
+
+				const valueProps =
+					_mode === 'Uncontrolled' ? { defaultValue: 'alpha' } : { value: 'alpha' };
+
+				await render( <Component tabs={ TABS_WITH_VALUES } { ...valueProps } /> );
 
 				// Alpha is automatically selected as the selected tab.
 				await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
 
 				// Press tab. The selected tab (alpha) received focus.
-				await press.Tab();
+				await user.keyboard( '{Tab}' );
 				expect(
 					await screen.findByRole( 'tab', {
 						selected: true,
@@ -777,7 +866,7 @@ describe( 'Tabs', () => {
 				).toHaveFocus();
 
 				// By default the tabpanel should receive focus
-				await press.Tab();
+				await user.keyboard( '{Tab}' );
 				expect(
 					await screen.findByRole( 'tabpanel', {
 						name: 'Alpha',
@@ -786,10 +875,15 @@ describe( 'Tabs', () => {
 			} );
 
 			it( 'should not focus the tabpanel container when its `focusable` property is set to `false`', async () => {
+				const user = userEvent.setup();
+
+				const valueProps =
+					_mode === 'Uncontrolled' ? { defaultValue: 'alpha' } : { value: 'alpha' };
+
 				await render(
 					<Component
-						tabs={ TABS.map( ( tabObj ) =>
-							tabObj.tabId === 'alpha'
+						tabs={ TABS_WITH_VALUES.map( ( tabObj ) =>
+							tabObj.value === 'alpha'
 								? {
 										...tabObj,
 										content: (
@@ -802,6 +896,7 @@ describe( 'Tabs', () => {
 								  }
 								: tabObj
 						) }
+						{ ...valueProps }
 					/>
 				);
 
@@ -810,7 +905,7 @@ describe( 'Tabs', () => {
 
 				// Tab should initially focus the first tab in the tablist, which
 				// is Alpha.
-				await press.Tab();
+				await user.keyboard( '{Tab}' );
 				expect(
 					await screen.findByRole( 'tab', {
 						selected: true,
@@ -820,7 +915,7 @@ describe( 'Tabs', () => {
 
 				// In this case, the tabpanel container is skipped and focus is
 				// moved directly to its contents
-				await press.Tab();
+				await user.keyboard( '{Tab}' );
 				expect(
 					await screen.findByRole( 'button', {
 						name: 'Alpha Button',
@@ -829,20 +924,31 @@ describe( 'Tabs', () => {
 			} );
 
 			it( 'should select tabs in the tablist when using the left and right arrow keys by default (automatic tab activation)', async () => {
-				const mockOnSelect = jest.fn();
+				const mockOnValueChange = jest.fn();
+				const user = userEvent.setup();
 
-				await render( <Component tabs={ TABS } onSelect={ mockOnSelect } /> );
+				const valueProps =
+					_mode === 'Uncontrolled' ? { defaultValue: 'alpha' } : { value: 'alpha' };
+
+				await render(
+					<Component
+						tabs={ TABS_WITH_VALUES }
+						onValueChange={ mockOnValueChange }
+						{ ...valueProps }
+					/>
+				);
 
 				// Alpha is automatically selected as the selected tab.
 				await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
 
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+				// TODO: re-enable once https://github.com/mui/base-ui/issues/2097 is fixed
+				// expect( mockOnValueChange ).toHaveBeenCalledTimes( 1 );
+				// expect( mockOnValueChange ).toHaveBeenLastCalledWith( 'alpha' );
 
 				// Focus the tablist (and the selected tab, alpha)
 				// Tab should initially focus the first tab in the tablist, which
 				// is Alpha.
-				await press.Tab();
+				await user.keyboard( '{Tab}' );
 				expect(
 					await screen.findByRole( 'tab', {
 						selected: true,
@@ -851,7 +957,7 @@ describe( 'Tabs', () => {
 				).toHaveFocus();
 
 				// Press the right arrow key to select the beta tab
-				await press.ArrowRight();
+				await user.keyboard( '{ArrowRight}' );
 
 				expect(
 					screen.getByRole( 'tab', {
@@ -865,11 +971,11 @@ describe( 'Tabs', () => {
 					} )
 				).toBeVisible();
 
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
-				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+				expect( mockOnValueChange ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnValueChange ).toHaveBeenLastCalledWith( 'beta', expect.anything() );
 
 				// Press the right arrow key to select the gamma tab
-				await press.ArrowRight();
+				await user.keyboard( '{ArrowRight}' );
 
 				expect(
 					screen.getByRole( 'tab', {
@@ -883,11 +989,11 @@ describe( 'Tabs', () => {
 					} )
 				).toBeVisible();
 
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
-				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'gamma' );
+				expect( mockOnValueChange ).toHaveBeenCalledTimes( 2 );
+				expect( mockOnValueChange ).toHaveBeenLastCalledWith( 'gamma', expect.anything() );
 
 				// Press the left arrow key to select the beta tab
-				await press.ArrowLeft();
+				await user.keyboard( '{ArrowLeft}' );
 
 				expect(
 					screen.getByRole( 'tab', {
@@ -901,27 +1007,38 @@ describe( 'Tabs', () => {
 					} )
 				).toBeVisible();
 
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 4 );
-				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+				expect( mockOnValueChange ).toHaveBeenCalledTimes( 3 );
+				expect( mockOnValueChange ).toHaveBeenLastCalledWith( 'beta', expect.anything() );
 			} );
 
-			it( 'should not automatically select tabs in the tablist when pressing the left and right arrow keys if the `selectOnMove` prop is set to `false` (manual tab activation)', async () => {
-				const mockOnSelect = jest.fn();
+			it( 'should not automatically select tabs in the tablist when pressing the left and right arrow keys if the manual tab activation is enabled', async () => {
+				const mockOnValueChange = jest.fn();
+
+				const user = userEvent.setup();
+
+				const valueProps =
+					_mode === 'Uncontrolled' ? { defaultValue: 'alpha' } : { value: 'alpha' };
 
 				await render(
-					<Component tabs={ TABS } onSelect={ mockOnSelect } selectOnMove={ false } />
+					<Component
+						tabs={ TABS_WITH_VALUES }
+						onValueChange={ mockOnValueChange }
+						selectOnMove={ false }
+						{ ...valueProps }
+					/>
 				);
 
 				// Alpha is automatically selected as the selected tab.
 				await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
 
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+				// TODO: re-enable once https://github.com/mui/base-ui/issues/2097 is fixed
+				// expect( mockOnValueChange ).toHaveBeenCalledTimes( 1 );
+				// expect( mockOnValueChange ).toHaveBeenLastCalledWith( 'alpha' );
 
 				// Focus the tablist (and the selected tab, alpha)
 				// Tab should initially focus the first tab in the tablist, which
 				// is Alpha.
-				await press.Tab();
+				await user.keyboard( '{Tab}' );
 				expect(
 					await screen.findByRole( 'tab', {
 						selected: true,
@@ -931,7 +1048,7 @@ describe( 'Tabs', () => {
 
 				// Press the right arrow key to move focus to the beta tab,
 				// but without selecting it
-				await press.ArrowRight();
+				await user.keyboard( '{ArrowRight}' );
 
 				expect(
 					screen.getByRole( 'tab', {
@@ -951,44 +1068,58 @@ describe( 'Tabs', () => {
 					} )
 				).toBeVisible();
 
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnValueChange ).toHaveBeenCalledTimes( 0 );
 
 				// Press the space key to click the beta tab, and select it.
 				// The same should be true with any other mean of clicking the tab button
 				// (ie. mouse click, enter key).
-				await press.Space();
+				await user.keyboard( '{ }' );
 
-				expect(
-					screen.getByRole( 'tab', {
-						selected: true,
-						name: 'Beta',
-					} )
-				).toHaveFocus();
+				await waitFor( () =>
+					expect(
+						screen.getByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toHaveFocus()
+				);
 				expect(
 					screen.getByRole( 'tabpanel', {
 						name: 'Beta',
 					} )
 				).toBeVisible();
 
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
-				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+				expect( mockOnValueChange ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnValueChange ).toHaveBeenLastCalledWith( 'beta', expect.anything() );
 			} );
 
 			it( 'should not select tabs in the tablist when using the up and down arrow keys, unless the `orientation` prop is set to `vertical`', async () => {
-				const mockOnSelect = jest.fn();
+				const mockOnValueChange = jest.fn();
 
-				const { rerender } = await render( <Component tabs={ TABS } onSelect={ mockOnSelect } /> );
+				const user = userEvent.setup();
+
+				const valueProps =
+					_mode === 'Uncontrolled' ? { defaultValue: 'alpha' } : { value: 'alpha' };
+
+				const { rerender } = await render(
+					<Component
+						tabs={ TABS_WITH_VALUES }
+						onValueChange={ mockOnValueChange }
+						{ ...valueProps }
+					/>
+				);
 
 				// Alpha is automatically selected as the selected tab.
 				await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
 
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+				// TODO: re-enable once https://github.com/mui/base-ui/issues/2097 is fixed
+				// expect( mockOnValueChange ).toHaveBeenCalledTimes( 1 );
+				// expect( mockOnValueChange ).toHaveBeenLastCalledWith( 'alpha' );
 
 				// Focus the tablist (and the selected tab, alpha)
 				// Tab should initially focus the first tab in the tablist, which
 				// is Alpha.
-				await press.Tab();
+				await user.keyboard( '{Tab}' );
 				expect(
 					await screen.findByRole( 'tab', {
 						selected: true,
@@ -997,7 +1128,7 @@ describe( 'Tabs', () => {
 				).toHaveFocus();
 
 				// Press the up arrow key, but the focused/selected tab does not change.
-				await press.ArrowUp();
+				await user.keyboard( '{ArrowUp}' );
 
 				expect(
 					screen.getByRole( 'tab', {
@@ -1011,10 +1142,10 @@ describe( 'Tabs', () => {
 					} )
 				).toBeVisible();
 
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnValueChange ).toHaveBeenCalledTimes( 0 );
 
 				// Press the down arrow key, but the focused/selected tab does not change.
-				await press.ArrowDown();
+				await user.keyboard( '{ArrowDown}' );
 
 				expect(
 					screen.getByRole( 'tab', {
@@ -1028,15 +1159,20 @@ describe( 'Tabs', () => {
 					} )
 				).toBeVisible();
 
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnValueChange ).toHaveBeenCalledTimes( 0 );
 
 				// Change the orientation to "vertical" and rerender the component.
 				await rerender(
-					<Component tabs={ TABS } onSelect={ mockOnSelect } orientation="vertical" />
+					<Component
+						tabs={ TABS_WITH_VALUES }
+						onValueChange={ mockOnValueChange }
+						orientation="vertical"
+						{ ...valueProps }
+					/>
 				);
 
 				// Pressing the down arrow key now selects the next tab (beta).
-				await press.ArrowDown();
+				await user.keyboard( '{ArrowDown}' );
 
 				expect(
 					screen.getByRole( 'tab', {
@@ -1050,11 +1186,11 @@ describe( 'Tabs', () => {
 					} )
 				).toBeVisible();
 
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
-				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+				expect( mockOnValueChange ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnValueChange ).toHaveBeenLastCalledWith( 'beta', expect.anything() );
 
 				// Pressing the up arrow key now selects the previous tab (alpha).
-				await press.ArrowUp();
+				await user.keyboard( '{ArrowUp}' );
 
 				expect(
 					screen.getByRole( 'tab', {
@@ -1068,25 +1204,37 @@ describe( 'Tabs', () => {
 					} )
 				).toBeVisible();
 
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
-				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+				expect( mockOnValueChange ).toHaveBeenCalledTimes( 2 );
+				expect( mockOnValueChange ).toHaveBeenLastCalledWith( 'alpha', expect.anything() );
 			} );
 
 			it( 'should loop tab focus at the end of the tablist when using arrow keys', async () => {
-				const mockOnSelect = jest.fn();
+				const mockOnValueChange = jest.fn();
 
-				await render( <Component tabs={ TABS } onSelect={ mockOnSelect } /> );
+				const user = userEvent.setup();
+
+				const valueProps =
+					_mode === 'Uncontrolled' ? { defaultValue: 'alpha' } : { value: 'alpha' };
+
+				await render(
+					<Component
+						tabs={ TABS_WITH_VALUES }
+						onValueChange={ mockOnValueChange }
+						{ ...valueProps }
+					/>
+				);
 
 				// Alpha is automatically selected as the selected tab.
 				await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
 
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+				// TODO: re-enable once https://github.com/mui/base-ui/issues/2097 is fixed
+				// expect( mockOnValueChange ).toHaveBeenCalledTimes( 1 );
+				// expect( mockOnValueChange ).toHaveBeenLastCalledWith( 'alpha' );
 
 				// Focus the tablist (and the selected tab, alpha)
 				// Tab should initially focus the first tab in the tablist, which
 				// is Alpha.
-				await press.Tab();
+				await user.keyboard( '{Tab}' );
 				expect(
 					await screen.findByRole( 'tab', {
 						selected: true,
@@ -1095,7 +1243,7 @@ describe( 'Tabs', () => {
 				).toHaveFocus();
 
 				// Press the left arrow key to loop around and select the gamma tab
-				await press.ArrowLeft();
+				await user.keyboard( '{ArrowLeft}' );
 
 				expect(
 					screen.getByRole( 'tab', {
@@ -1109,11 +1257,11 @@ describe( 'Tabs', () => {
 					} )
 				).toBeVisible();
 
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
-				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'gamma' );
+				expect( mockOnValueChange ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnValueChange ).toHaveBeenLastCalledWith( 'gamma', expect.anything() );
 
 				// Press the right arrow key to loop around and select the alpha tab
-				await press.ArrowRight();
+				await user.keyboard( '{ArrowRight}' );
 
 				expect(
 					screen.getByRole( 'tab', {
@@ -1127,29 +1275,39 @@ describe( 'Tabs', () => {
 					} )
 				).toBeVisible();
 
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
-				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+				expect( mockOnValueChange ).toHaveBeenCalledTimes( 2 );
+				expect( mockOnValueChange ).toHaveBeenLastCalledWith( 'alpha', expect.anything() );
 			} );
 
-			// TODO: mock writing direction to RTL
 			it( 'should swap the left and right arrow keys when selecting tabs if the writing direction is set to RTL', async () => {
-				// For this test only, mock the writing direction to RTL.
-				mockedIsRTL.mockImplementation( () => true );
+				const mockOnValueChange = jest.fn();
 
-				const mockOnSelect = jest.fn();
+				const user = userEvent.setup();
 
-				await render( <Component tabs={ TABS } onSelect={ mockOnSelect } /> );
+				const valueProps =
+					_mode === 'Uncontrolled' ? { defaultValue: 'alpha' } : { value: 'alpha' };
+
+				await render(
+					<DirectionProvider direction="rtl">
+						<Component
+							tabs={ TABS_WITH_VALUES }
+							onValueChange={ mockOnValueChange }
+							{ ...valueProps }
+						/>
+					</DirectionProvider>
+				);
 
 				// Alpha is automatically selected as the selected tab.
 				await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
 
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+				// TODO: re-enable once https://github.com/mui/base-ui/issues/2097 is fixed
+				// expect( mockOnValueChange ).toHaveBeenCalledTimes( 1 );
+				// expect( mockOnValueChange ).toHaveBeenLastCalledWith( 'alpha' );
 
 				// Focus the tablist (and the selected tab, alpha)
 				// Tab should initially focus the first tab in the tablist, which
 				// is Alpha.
-				await press.Tab();
+				await user.keyboard( '{Tab}' );
 				expect(
 					await screen.findByRole( 'tab', {
 						selected: true,
@@ -1158,7 +1316,7 @@ describe( 'Tabs', () => {
 				).toHaveFocus();
 
 				// Press the left arrow key to select the beta tab
-				await press.ArrowLeft();
+				await user.keyboard( '{ArrowLeft}' );
 
 				expect(
 					screen.getByRole( 'tab', {
@@ -1172,11 +1330,11 @@ describe( 'Tabs', () => {
 					} )
 				).toBeVisible();
 
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
-				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+				expect( mockOnValueChange ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnValueChange ).toHaveBeenLastCalledWith( 'beta', expect.anything() );
 
 				// Press the left arrow key to select the gamma tab
-				await press.ArrowLeft();
+				await user.keyboard( '{ArrowLeft}' );
 
 				expect(
 					screen.getByRole( 'tab', {
@@ -1190,11 +1348,11 @@ describe( 'Tabs', () => {
 					} )
 				).toBeVisible();
 
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
-				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'gamma' );
+				expect( mockOnValueChange ).toHaveBeenCalledTimes( 2 );
+				expect( mockOnValueChange ).toHaveBeenLastCalledWith( 'gamma', expect.anything() );
 
 				// Press the right arrow key to select the beta tab
-				await press.ArrowRight();
+				await user.keyboard( '{ArrowRight}' );
 
 				expect(
 					screen.getByRole( 'tab', {
@@ -1208,28 +1366,37 @@ describe( 'Tabs', () => {
 					} )
 				).toBeVisible();
 
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 4 );
-				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
-
-				// Restore the original implementation of the isRTL function.
-				mockedIsRTL.mockRestore();
+				expect( mockOnValueChange ).toHaveBeenCalledTimes( 3 );
+				expect( mockOnValueChange ).toHaveBeenLastCalledWith( 'beta', expect.anything() );
 			} );
 
 			it( 'should focus tabs in the tablist even if disabled', async () => {
-				const mockOnSelect = jest.fn();
+				const mockOnValueChange = jest.fn();
 
-				await render( <Component tabs={ TABS_WITH_BETA_DISABLED } onSelect={ mockOnSelect } /> );
+				const user = userEvent.setup();
+
+				const valueProps =
+					_mode === 'Uncontrolled' ? { defaultValue: 'alpha' } : { value: 'alpha' };
+
+				await render(
+					<Component
+						tabs={ TABS_WITH_VALUES_AND_BETA_DISABLED }
+						onValueChange={ mockOnValueChange }
+						{ ...valueProps }
+					/>
+				);
 
 				// Alpha is automatically selected as the selected tab.
 				await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
 
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+				// TODO: re-enable once https://github.com/mui/base-ui/issues/2097 is fixed
+				// expect( mockOnValueChange ).toHaveBeenCalledTimes( 1 );
+				// expect( mockOnValueChange ).toHaveBeenLastCalledWith( 'alpha' );
 
 				// Focus the tablist (and the selected tab, alpha)
 				// Tab should initially focus the first tab in the tablist, which
 				// is Alpha.
-				await press.Tab();
+				await user.keyboard( '{Tab}' );
 				expect(
 					await screen.findByRole( 'tab', {
 						selected: true,
@@ -1239,7 +1406,7 @@ describe( 'Tabs', () => {
 
 				// Pressing the right arrow key moves focus to the beta tab, but alpha
 				// remains the selected tab because beta is disabled.
-				await press.ArrowRight();
+				await user.keyboard( '{ArrowRight}' );
 
 				expect(
 					screen.getByRole( 'tab', {
@@ -1259,10 +1426,10 @@ describe( 'Tabs', () => {
 					} )
 				).toBeVisible();
 
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnValueChange ).toHaveBeenCalledTimes( 0 );
 
 				// Press the right arrow key to select the gamma tab
-				await press.ArrowRight();
+				await user.keyboard( '{ArrowRight}' );
 
 				expect(
 					screen.getByRole( 'tab', {
@@ -1276,65 +1443,93 @@ describe( 'Tabs', () => {
 					} )
 				).toBeVisible();
 
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
-				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'gamma' );
+				expect( mockOnValueChange ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnValueChange ).toHaveBeenLastCalledWith( 'gamma', expect.anything() );
 			} );
 		} );
 
 		describe( 'When `selectedId` is changed by the controlling component [Controlled]', () => {
-			describe.each( [ true, false ] )( 'and `selectOnMove` is %s', ( selectOnMove ) => {
+			describe.each( [ true, false ] )( 'and manual tab activation is %s', ( selectOnMove ) => {
 				it( 'should continue to handle arrow key navigation properly', async () => {
-					const { rerender } = await render(
-						<ControlledTabs tabs={ TABS } selectedTabId="beta" selectOnMove={ selectOnMove } />
+					const user = userEvent.setup();
+
+					await render(
+						<ControlledTabs tabs={ TABS_WITH_VALUES } value="beta" selectOnMove={ selectOnMove } />
 					);
 
 					// Beta is the selected tab.
 					await waitForComponentToBeInitializedWithSelectedTab( 'Beta' );
 
-					// Tab key should focus the currently selected tab, which is Beta.
-					await press.Tab();
+					// Tab key should focus the currently first tab (if manual activation mode),
+					// or the currently selected tab (if automatic activation mode).
+					await user.keyboard( '{Tab}' );
 					expect(
-						screen.getByRole( 'tab', {
-							selected: true,
-							name: 'Beta',
-						} )
+						screen.getByRole(
+							'tab',
+							// TODO: update to the same tab (just different selected state)
+							// once https://github.com/mui/base-ui/issues/2099 is fixed
+							selectOnMove
+								? {
+										selected: true,
+										name: 'Beta',
+								  }
+								: {
+										selected: false,
+										name: 'Alpha',
+								  }
+						)
 					).toHaveFocus();
 
-					await rerender(
-						<ControlledTabs tabs={ TABS } selectedTabId="gamma" selectOnMove={ selectOnMove } />
-					);
+					// TODO: re-enable once https://github.com/mui/base-ui/issues/2101 is fixed
+					// await rerender(
+					// 	<ControlledTabs tabs={ TABS_WITH_VALUES } value="gamma" selectOnMove={ selectOnMove } />
+					// );
 
 					// When the selected tab is changed, focus should not be changed.
-					expect(
-						screen.getByRole( 'tab', {
-							selected: true,
-							name: 'Gamma',
-						} )
-					).toBeVisible();
-					expect(
-						screen.getByRole( 'tab', {
-							selected: false,
-							name: 'Beta',
-						} )
-					).toHaveFocus();
+					// expect(
+					// 	screen.getByRole( 'tab', {
+					// 		selected: true,
+					// 		name: 'Gamma',
+					// 	} )
+					// ).toBeVisible();
+					// expect(
+					// 	screen.getByRole( 'tab', {
+					// 		selected: false,
+					// 		name: selectOnMove ? 'Beta' : 'Alpha',
+					// 	} )
+					// ).toHaveFocus();
 
-					// Arrow left should move focus to the previous tab (alpha).
+					// Arrow left should move focus to the previous tab.
 					// The alpha tab should be always focused, and should be selected
 					// when the `selectOnMove` prop is set to `true`.
-					await press.ArrowLeft();
-					expect(
-						screen.getByRole( 'tab', {
-							selected: selectOnMove,
-							name: 'Alpha',
-						} )
-					).toHaveFocus();
+					await user.keyboard( '{ArrowLeft}' );
+
+					await waitFor( () =>
+						expect(
+							screen.getByRole(
+								'tab',
+								selectOnMove
+									? {
+											selected: true,
+											name: 'Alpha',
+									  }
+									: {
+											selected: false,
+											name: 'Gamma',
+									  }
+							)
+						).toHaveFocus()
+					);
 				} );
 
-				it( 'should focus the correct tab when tabbing out and back into the tablist', async () => {
+				// TODO: re-enable once https://github.com/mui/base-ui/issues/2100 is fixed
+				it.skip( 'should focus the correct tab when tabbing out and back into the tablist', async () => {
+					const user = userEvent.setup();
+
 					const { rerender } = await render(
 						<>
 							<button>Focus me</button>
-							<ControlledTabs tabs={ TABS } selectedTabId="beta" selectOnMove={ selectOnMove } />
+							<ControlledTabs tabs={ TABS } value="beta" selectOnMove={ selectOnMove } />
 						</>
 					);
 
@@ -1342,8 +1537,8 @@ describe( 'Tabs', () => {
 					await waitForComponentToBeInitializedWithSelectedTab( 'Beta' );
 
 					// Tab key should focus the currently selected tab, which is Beta.
-					await press.Tab();
-					await press.Tab();
+					await user.keyboard( '{Tab}' );
+					await user.keyboard( '{Tab}' );
 					expect(
 						screen.getByRole( 'tab', {
 							selected: true,
@@ -1355,7 +1550,7 @@ describe( 'Tabs', () => {
 					await rerender(
 						<>
 							<button>Focus me</button>
-							<ControlledTabs tabs={ TABS } selectedTabId="gamma" selectOnMove={ selectOnMove } />
+							<ControlledTabs tabs={ TABS } value="gamma" selectOnMove={ selectOnMove } />
 						</>
 					);
 
@@ -1374,11 +1569,11 @@ describe( 'Tabs', () => {
 					).toHaveFocus();
 
 					// Press shift+tab, move focus to the button before Tabs
-					await press.ShiftTab();
+					await user.keyboard( '{Shift>}{Tab}{/Shift}' );
 					expect( screen.getByRole( 'button', { name: 'Focus me' } ) ).toHaveFocus();
 
 					// Press tab, move focus back to the tablist
-					await press.Tab();
+					await user.keyboard( '{Tab}' );
 
 					const betaTab = screen.getByRole( 'tab', {
 						name: 'Beta',
@@ -1397,20 +1592,27 @@ describe( 'Tabs', () => {
 		describe( 'removing a tab', () => {
 			describe( 'with no explicitly set initial tab', () => {
 				it( 'should not select a new tab when the selected tab is removed', async () => {
-					const mockOnSelect = jest.fn();
+					const mockOnValueChange = jest.fn();
+
+					const user = userEvent.setup();
 
 					const { rerender } = await render(
-						<UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } />
+						<UncontrolledTabs
+							tabs={ TABS_WITH_VALUES }
+							onValueChange={ mockOnValueChange }
+							defaultValue="alpha"
+						/>
 					);
 
 					// Alpha is automatically selected as the selected tab.
 					await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
 
-					expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-					expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+					// TODO: re-enable once https://github.com/mui/base-ui/issues/2097 is fixed
+					// expect( mockOnValueChange ).toHaveBeenCalledTimes( 1 );
+					// expect( mockOnValueChange ).toHaveBeenLastCalledWith( 'alpha' );
 
 					// Select gamma
-					await click( screen.getByRole( 'tab', { name: 'Gamma' } ) );
+					await user.click( screen.getByRole( 'tab', { name: 'Gamma' } ) );
 
 					expect(
 						screen.getByRole( 'tab', {
@@ -1424,37 +1626,41 @@ describe( 'Tabs', () => {
 						} )
 					).toBeVisible();
 
-					expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
-					expect( mockOnSelect ).toHaveBeenLastCalledWith( 'gamma' );
+					expect( mockOnValueChange ).toHaveBeenCalledTimes( 1 );
+					expect( mockOnValueChange ).toHaveBeenLastCalledWith( 'gamma', expect.anything() );
 
 					// Remove gamma
 					await rerender(
-						<UncontrolledTabs tabs={ TABS.slice( 0, 2 ) } onSelect={ mockOnSelect } />
+						<UncontrolledTabs
+							tabs={ TABS_WITH_VALUES.slice( 0, 2 ) }
+							onValueChange={ mockOnValueChange }
+							defaultValue="alpha"
+						/>
 					);
 
 					expect( screen.getAllByRole( 'tab' ) ).toHaveLength( 2 );
 
 					// No tab should be selected i.e. it doesn't fall back to gamma,
-					// even if it matches the `defaultTabId` prop.
+					// even if it matches the `defaultValue` prop.
 					expect( screen.queryByRole( 'tab', { selected: true } ) ).not.toBeInTheDocument();
 					// No tabpanel should be rendered either
 					expect( screen.queryByRole( 'tabpanel' ) ).not.toBeInTheDocument();
 
-					expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+					expect( mockOnValueChange ).toHaveBeenCalledTimes( 1 );
 				} );
 			} );
 
 			describe.each( [
-				[ 'defaultTabId', 'Uncontrolled', UncontrolledTabs ],
-				[ 'selectedTabId', 'Controlled', ControlledTabs ],
+				[ 'defaultValue', 'Uncontrolled', UncontrolledTabs ],
+				[ 'value', 'Controlled', ControlledTabs ],
 			] )( 'when using the `%s` prop [%s]', ( propName, _mode, Component ) => {
 				it( 'should not select a new tab when the selected tab is removed', async () => {
-					const mockOnSelect = jest.fn();
+					const mockOnValueChange = jest.fn();
 
 					const initialComponentProps = {
-						tabs: TABS,
+						tabs: TABS_WITH_VALUES,
 						[ propName ]: 'gamma',
-						onSelect: mockOnSelect,
+						onValueChange: mockOnValueChange,
 					};
 
 					const { rerender } = await render( <Component { ...initialComponentProps } /> );
@@ -1463,7 +1669,9 @@ describe( 'Tabs', () => {
 					await waitForComponentToBeInitializedWithSelectedTab( 'Gamma' );
 
 					// Remove gamma
-					await rerender( <Component { ...initialComponentProps } tabs={ TABS.slice( 0, 2 ) } /> );
+					await rerender(
+						<Component { ...initialComponentProps } tabs={ TABS_WITH_VALUES.slice( 0, 2 ) } />
+					);
 
 					expect( screen.getAllByRole( 'tab' ) ).toHaveLength( 2 );
 					// No tab should be selected i.e. it doesn't fall back to first tab.
@@ -1488,17 +1696,19 @@ describe( 'Tabs', () => {
 						} )
 					).toBeVisible();
 
-					expect( mockOnSelect ).not.toHaveBeenCalled();
+					expect( mockOnValueChange ).not.toHaveBeenCalled();
 				} );
 
 				it( `should not select the tab matching the \`${ propName }\` prop as a fallback when the selected tab is removed`, async () => {
-					const mockOnSelect = jest.fn();
+					const mockOnValueChange = jest.fn();
 
 					const initialComponentProps = {
-						tabs: TABS,
+						tabs: TABS_WITH_VALUES,
 						[ propName ]: 'gamma',
-						onSelect: mockOnSelect,
+						onValueChange: mockOnValueChange,
 					};
+
+					const user = userEvent.setup();
 
 					const { rerender } = await render( <Component { ...initialComponentProps } /> );
 
@@ -1506,7 +1716,7 @@ describe( 'Tabs', () => {
 					await waitForComponentToBeInitializedWithSelectedTab( 'Gamma' );
 
 					// Select alpha
-					await click( screen.getByRole( 'tab', { name: 'Alpha' } ) );
+					await user.click( screen.getByRole( 'tab', { name: 'Alpha' } ) );
 
 					expect(
 						screen.getByRole( 'tab', {
@@ -1520,16 +1730,18 @@ describe( 'Tabs', () => {
 						} )
 					).toBeVisible();
 
-					expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-					expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+					expect( mockOnValueChange ).toHaveBeenCalledTimes( 1 );
+					expect( mockOnValueChange ).toHaveBeenLastCalledWith( 'alpha', expect.anything() );
 
 					// Remove alpha
-					await rerender( <Component { ...initialComponentProps } tabs={ TABS.slice( 1 ) } /> );
+					await rerender(
+						<Component { ...initialComponentProps } tabs={ TABS_WITH_VALUES.slice( 1 ) } />
+					);
 
 					expect( screen.getAllByRole( 'tab' ) ).toHaveLength( 2 );
 
 					// No tab should be selected i.e. it doesn't fall back to gamma,
-					// even if it matches the `defaultTabId` prop.
+					// even if it matches the `defaultValue` prop.
 					expect( screen.queryByRole( 'tab', { selected: true } ) ).not.toBeInTheDocument();
 					// No tabpanel should be rendered either
 					expect( screen.queryByRole( 'tabpanel' ) ).not.toBeInTheDocument();
@@ -1551,35 +1763,37 @@ describe( 'Tabs', () => {
 						} )
 					).toBeVisible();
 
-					expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+					expect( mockOnValueChange ).toHaveBeenCalledTimes( 1 );
 				} );
 			} );
 		} );
 
 		describe( 'adding a tab', () => {
 			describe.each( [
-				[ 'defaultTabId', 'Uncontrolled', UncontrolledTabs ],
-				[ 'selectedTabId', 'Controlled', ControlledTabs ],
+				[ 'defaultValue', 'Uncontrolled', UncontrolledTabs ],
+				[ 'value', 'Controlled', ControlledTabs ],
 			] )( 'when using the `%s` prop [%s]', ( propName, _mode, Component ) => {
 				it( `should select a newly added tab if it matches the \`${ propName }\` prop`, async () => {
-					const mockOnSelect = jest.fn();
+					const mockOnValueChange = jest.fn();
 
 					const initialComponentProps = {
-						tabs: TABS,
+						tabs: TABS_WITH_VALUES,
 						[ propName ]: 'delta',
-						onSelect: mockOnSelect,
+						onValueChange: mockOnValueChange,
 					};
 
 					const { rerender } = await render( <Component { ...initialComponentProps } /> );
 
-					// No initially selected tabs or tabpanels, since the `defaultTabId`
+					// No initially selected tabs or tabpanels, since the `defaultValue`
 					// prop is not matching any known tabs.
 					await waitForComponentToBeInitializedWithSelectedTab( undefined );
 
-					expect( mockOnSelect ).not.toHaveBeenCalled();
+					expect( mockOnValueChange ).not.toHaveBeenCalled();
 
 					// Re-render with beta disabled.
-					await rerender( <Component { ...initialComponentProps } tabs={ TABS_WITH_DELTA } /> );
+					await rerender(
+						<Component { ...initialComponentProps } tabs={ TABS_WITH_VALUES_AND_DELTA } />
+					);
 
 					// Delta becomes selected
 					expect(
@@ -1594,22 +1808,22 @@ describe( 'Tabs', () => {
 						} )
 					).toBeVisible();
 
-					expect( mockOnSelect ).not.toHaveBeenCalled();
+					expect( mockOnValueChange ).not.toHaveBeenCalled();
 				} );
 			} );
 		} );
 		describe( 'a tab becomes disabled', () => {
 			describe.each( [
-				[ 'defaultTabId', 'Uncontrolled', UncontrolledTabs ],
-				[ 'selectedTabId', 'Controlled', ControlledTabs ],
+				[ 'defaultValue', 'Uncontrolled', UncontrolledTabs ],
+				[ 'value', 'Controlled', ControlledTabs ],
 			] )( 'when using the `%s` prop [%s]', ( propName, _mode, Component ) => {
 				it( `should keep the initial tab matching the \`${ propName }\` prop as selected even if it becomes disabled`, async () => {
-					const mockOnSelect = jest.fn();
+					const mockOnValueChange = jest.fn();
 
 					const initialComponentProps = {
-						tabs: TABS,
+						tabs: TABS_WITH_VALUES,
 						[ propName ]: 'beta',
-						onSelect: mockOnSelect,
+						onValueChange: mockOnValueChange,
 					};
 
 					const { rerender } = await render( <Component { ...initialComponentProps } /> );
@@ -1617,11 +1831,11 @@ describe( 'Tabs', () => {
 					// Beta is the selected tab.
 					await waitForComponentToBeInitializedWithSelectedTab( 'Beta' );
 
-					expect( mockOnSelect ).not.toHaveBeenCalled();
+					expect( mockOnValueChange ).not.toHaveBeenCalled();
 
 					// Re-render with beta disabled.
 					await rerender(
-						<Component { ...initialComponentProps } tabs={ TABS_WITH_BETA_DISABLED } />
+						<Component { ...initialComponentProps } tabs={ TABS_WITH_VALUES_AND_BETA_DISABLED } />
 					);
 
 					// Beta continues to be selected and focused, even if it is disabled.
@@ -1653,24 +1867,31 @@ describe( 'Tabs', () => {
 						} )
 					).toBeVisible();
 
-					expect( mockOnSelect ).not.toHaveBeenCalled();
+					expect( mockOnValueChange ).not.toHaveBeenCalled();
 				} );
 
 				it( 'should keep the current tab selected by the user as selected even if it becomes disabled', async () => {
-					const mockOnSelect = jest.fn();
+					const mockOnValueChange = jest.fn();
 
-					const { rerender } = await render(
-						<Component tabs={ TABS } onSelect={ mockOnSelect } />
-					);
+					const user = userEvent.setup();
+
+					const initialComponentProps = {
+						tabs: TABS_WITH_VALUES,
+						[ propName ]: 'alpha',
+						onValueChange: mockOnValueChange,
+					};
+
+					const { rerender } = await render( <Component { ...initialComponentProps } /> );
 
 					// Alpha is automatically selected as the selected tab.
 					await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
 
-					expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-					expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+					// TODO: re-enable once https://github.com/mui/base-ui/issues/2097 is fixed
+					// expect( mockOnValueChange ).toHaveBeenCalledTimes( 1 );
+					// expect( mockOnValueChange ).toHaveBeenLastCalledWith( 'alpha' );
 
 					// Click on beta tab, beta becomes selected.
-					await click( screen.getByRole( 'tab', { name: 'Beta' } ) );
+					await user.click( screen.getByRole( 'tab', { name: 'Beta' } ) );
 
 					expect(
 						screen.getByRole( 'tab', {
@@ -1684,12 +1905,12 @@ describe( 'Tabs', () => {
 						} )
 					).toBeVisible();
 
-					expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
-					expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+					expect( mockOnValueChange ).toHaveBeenCalledTimes( 1 );
+					expect( mockOnValueChange ).toHaveBeenLastCalledWith( 'beta', expect.anything() );
 
 					// Re-render with beta disabled.
 					await rerender(
-						<Component tabs={ TABS_WITH_BETA_DISABLED } onSelect={ mockOnSelect } />
+						<Component { ...initialComponentProps } tabs={ TABS_WITH_VALUES_AND_BETA_DISABLED } />
 					);
 
 					// Beta continues to be selected, even if it is disabled.
@@ -1706,7 +1927,7 @@ describe( 'Tabs', () => {
 					).toBeVisible();
 
 					// Re-enable beta.
-					await rerender( <Component tabs={ TABS } onSelect={ mockOnSelect } /> );
+					await rerender( <Component { ...initialComponentProps } /> );
 
 					// Beta continues to be selected and focused.
 					expect(
@@ -1721,7 +1942,7 @@ describe( 'Tabs', () => {
 						} )
 					).toBeVisible();
 
-					expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+					expect( mockOnValueChange ).toHaveBeenCalledTimes( 1 );
 				} );
 			} );
 		} );

--- a/packages/components/src/tabs-bui/types.ts
+++ b/packages/components/src/tabs-bui/types.ts
@@ -1,0 +1,158 @@
+import type * as Ariakit from '@ariakit/react';
+
+export type TabsContextProps =
+	| {
+			/**
+			 * The tabStore object returned by Ariakit's `useTabStore` hook.
+			 */
+			store: Ariakit.TabStore;
+			/**
+			 * The unique id string for this instance of the Tabs component.
+			 */
+			instanceId: string;
+	  }
+	| undefined;
+
+export type TabsProps = {
+	/**
+	 * The children elements, which should include one instance of the
+	 * `Tabs.Tablist` component and as many instances of the `Tabs.TabPanel`
+	 * components as there are `Tabs.Tab` components.
+	 */
+	children: Ariakit.TabProviderProps[ 'children' ];
+	/**
+	 * Determines if the tab should be selected when it receives focus. If set to
+	 * `false`, the tab will only be selected upon clicking, not when using arrow
+	 * keys to shift focus (manual tab activation). See the [official W3C docs](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/)
+	 * for more info.
+	 * @default true
+	 */
+	selectOnMove?: Ariakit.TabProviderProps[ 'selectOnMove' ];
+	/**
+	 * The id of the tab whose panel is currently visible.
+	 *
+	 * If left `undefined`, it will be automatically set to the first enabled
+	 * tab, and the component assumes it is being used in "uncontrolled" mode.
+	 *
+	 * Consequently, any value different than `undefined` will set the component
+	 * in "controlled" mode. When in "controlled" mode, the `null` value will
+	 * result in no tabs being selected, and the tablist becoming tabbable.
+	 */
+	selectedTabId?: Ariakit.TabProviderProps[ 'selectedId' ];
+	/**
+	 * The id of the tab whose panel is currently visible.
+	 *
+	 * If left `undefined`, it will be automatically set to the first enabled
+	 * tab. If set to `null`, no tab will be selected, and the tablist will be
+	 * tabbable.
+	 *
+	 * Note: this prop will be overridden by the `selectedTabId` prop if it is
+	 * provided (meaning the component will be used in "controlled" mode).
+	 */
+	defaultTabId?: Ariakit.TabProviderProps[ 'defaultSelectedId' ];
+	/**
+	 * The function called when the `selectedTabId` changes.
+	 */
+	onSelect?: Ariakit.TabProviderProps[ 'setSelectedId' ];
+	/**
+	 * The current active tab `id`. The active tab is the tab element within the
+	 * tablist widget that has DOM focus.
+	 *
+	 * - `null` represents the tablist (ie. the base composite element). Users
+	 *   will be able to navigate out of it using arrow keys.
+	 * - If `activeTabId` is initially set to `null`, the base composite element
+	 *   itself will have focus and users will be able to navigate to it using
+	 *   arrow keys.
+	 */
+	activeTabId?: Ariakit.TabProviderProps[ 'activeId' ];
+	/**
+	 * The tab id that should be active by default when the composite widget is
+	 * rendered. If `null`, the tablist element itself will have focus
+	 * and users will be able to navigate to it using arrow keys. If `undefined`,
+	 * the first enabled item will be focused.
+	 *
+	 * Note: this prop will be overridden by the `activeTabId` prop if it is
+	 * provided.
+	 */
+	defaultActiveTabId?: Ariakit.TabProviderProps[ 'defaultActiveId' ];
+	/**
+	 * A callback that gets called when the `activeTabId` state changes.
+	 */
+	onActiveTabIdChange?: Ariakit.TabProviderProps[ 'setActiveId' ];
+	/**
+	 * Defines the orientation of the tablist and determines which arrow keys
+	 * can be used to move focus:
+	 *
+	 * - `both`: all arrow keys work.
+	 * - `horizontal`: only left and right arrow keys work.
+	 * - `vertical`: only up and down arrow keys work.
+	 * @default "horizontal"
+	 */
+	orientation?: Ariakit.TabProviderProps[ 'orientation' ];
+};
+
+export type TabListProps = {
+	/**
+	 * The children elements, which should include one or more instances of the
+	 * `Tabs.Tab` component.
+	 */
+	children: Ariakit.TabListProps[ 'children' ];
+	/**
+	 * The visual density of the tab list.
+	 * @default "default"
+	 */
+	density?: 'compact' | 'default';
+};
+
+// TODO: consider prop name changes (tabId, selectedTabId)
+// compound technique
+
+export type TabProps = {
+	/**
+	 * The unique ID of the tab. It will be used to register the tab and match
+	 * it to a corresponding `Tabs.TabPanel` component.
+	 */
+	tabId: NonNullable< Ariakit.TabProps[ 'id' ] >;
+	/**
+	 * The contents of the tab.
+	 */
+	children?: Ariakit.TabProps[ 'children' ];
+	/**
+	 * Determines if the tab should be disabled. Note that disabled tabs can
+	 * still be accessed via the keyboard when navigating through the tablist.
+	 * @default false
+	 */
+	disabled?: Ariakit.TabProps[ 'disabled' ];
+	/**
+	 * Allows the component to be rendered as a different HTML element or React
+	 * component. The value can be a React element or a function that takes in the
+	 * original component props and gives back a React element with the props
+	 * merged.
+	 *
+	 * By default, the tab will be rendered as a `button` element.
+	 */
+	render?: Ariakit.TabProps[ 'render' ];
+};
+
+export type TabPanelProps = {
+	/**
+	 * The contents of the tab panel.
+	 */
+	children?: Ariakit.TabPanelProps[ 'children' ];
+	/**
+	 * The unique `id` of the `Tabs.Tab` component controlling this panel. This
+	 * connection is used to assign the `aria-labelledby` attribute to the tab
+	 * panel and to determine if the tab panel should be visible.
+	 *
+	 * If not provided, this link is automatically established by matching the
+	 * order of `Tabs.Tab` and `Tabs.TabPanel` elements in the DOM.
+	 */
+	tabId: NonNullable< Ariakit.TabPanelProps[ 'tabId' ] >;
+	/**
+	 * Determines whether or not the tabpanel element should be focusable.
+	 * If `false`, pressing the tab key will skip over the tabpanel, and instead
+	 * focus on the first focusable element in the panel (if there is one).
+	 * @default true
+	 */
+	focusable?: Ariakit.TabPanelProps[ 'focusable' ];
+};

--- a/packages/components/src/tabs-bui/types.ts
+++ b/packages/components/src/tabs-bui/types.ts
@@ -1,17 +1,4 @@
-import type * as Ariakit from '@ariakit/react';
-
-export type TabsContextProps =
-	| {
-			/**
-			 * The tabStore object returned by Ariakit's `useTabStore` hook.
-			 */
-			store: Ariakit.TabStore;
-			/**
-			 * The unique id string for this instance of the Tabs component.
-			 */
-			instanceId: string;
-	  }
-	| undefined;
+import { Tabs } from '@base-ui-components/react/tabs';
 
 export type TabsProps = {
 	/**
@@ -19,76 +6,36 @@ export type TabsProps = {
 	 * `Tabs.Tablist` component and as many instances of the `Tabs.TabPanel`
 	 * components as there are `Tabs.Tab` components.
 	 */
-	children: Ariakit.TabProviderProps[ 'children' ];
+	children: Tabs.Root.Props[ 'children' ];
 	/**
-	 * Determines if the tab should be selected when it receives focus. If set to
-	 * `false`, the tab will only be selected upon clicking, not when using arrow
-	 * keys to shift focus (manual tab activation). See the [official W3C docs](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/)
-	 * for more info.
-	 * @default true
+	 * The value of the currently selected Tab.
+	 * Use when the component is controlled. When the value is null,
+	 * no Tab will be selected.
 	 */
-	selectOnMove?: Ariakit.TabProviderProps[ 'selectOnMove' ];
+	value?: Tabs.Root.Props[ 'value' ];
 	/**
-	 * The id of the tab whose panel is currently visible.
-	 *
-	 * If left `undefined`, it will be automatically set to the first enabled
-	 * tab, and the component assumes it is being used in "uncontrolled" mode.
-	 *
-	 * Consequently, any value different than `undefined` will set the component
-	 * in "controlled" mode. When in "controlled" mode, the `null` value will
-	 * result in no tabs being selected, and the tablist becoming tabbable.
+	 * The default value.
+	 * Use when the component is not controlled. When the value is null,
+	 * no Tab will be selected.
 	 */
-	selectedTabId?: Ariakit.TabProviderProps[ 'selectedId' ];
+	defaultValue?: Tabs.Root.Props[ 'defaultValue' ];
 	/**
-	 * The id of the tab whose panel is currently visible.
-	 *
-	 * If left `undefined`, it will be automatically set to the first enabled
-	 * tab. If set to `null`, no tab will be selected, and the tablist will be
-	 * tabbable.
-	 *
-	 * Note: this prop will be overridden by the `selectedTabId` prop if it is
-	 * provided (meaning the component will be used in "controlled" mode).
+	 * Callback invoked when new value is being set.
 	 */
-	defaultTabId?: Ariakit.TabProviderProps[ 'defaultSelectedId' ];
+	onValueChange?: Tabs.Root.Props[ 'onValueChange' ];
 	/**
-	 * The function called when the `selectedTabId` changes.
-	 */
-	onSelect?: Ariakit.TabProviderProps[ 'setSelectedId' ];
-	/**
-	 * The current active tab `id`. The active tab is the tab element within the
-	 * tablist widget that has DOM focus.
-	 *
-	 * - `null` represents the tablist (ie. the base composite element). Users
-	 *   will be able to navigate out of it using arrow keys.
-	 * - If `activeTabId` is initially set to `null`, the base composite element
-	 *   itself will have focus and users will be able to navigate to it using
-	 *   arrow keys.
-	 */
-	activeTabId?: Ariakit.TabProviderProps[ 'activeId' ];
-	/**
-	 * The tab id that should be active by default when the composite widget is
-	 * rendered. If `null`, the tablist element itself will have focus
-	 * and users will be able to navigate to it using arrow keys. If `undefined`,
-	 * the first enabled item will be focused.
-	 *
-	 * Note: this prop will be overridden by the `activeTabId` prop if it is
-	 * provided.
-	 */
-	defaultActiveTabId?: Ariakit.TabProviderProps[ 'defaultActiveId' ];
-	/**
-	 * A callback that gets called when the `activeTabId` state changes.
-	 */
-	onActiveTabIdChange?: Ariakit.TabProviderProps[ 'setActiveId' ];
-	/**
-	 * Defines the orientation of the tablist and determines which arrow keys
-	 * can be used to move focus:
-	 *
-	 * - `both`: all arrow keys work.
-	 * - `horizontal`: only left and right arrow keys work.
-	 * - `vertical`: only up and down arrow keys work.
+	 * The component orientation (layout flow direction).d down arrow keys work.
 	 * @default "horizontal"
 	 */
-	orientation?: Ariakit.TabProviderProps[ 'orientation' ];
+	orientation?: Tabs.Root.Props[ 'orientation' ];
+	/**
+	 * Allows you to replace the component’s HTML element with a different tag,
+	 * or compose it with another component.
+	 * Accepts a ReactElement or a function that returns the element to render.
+	 *
+	 * By default, the tabs root will be rendered as a `div` element.
+	 */
+	render?: Tabs.Root.Props[ 'render' ];
 };
 
 export type TabListProps = {
@@ -96,7 +43,27 @@ export type TabListProps = {
 	 * The children elements, which should include one or more instances of the
 	 * `Tabs.Tab` component.
 	 */
-	children: Ariakit.TabListProps[ 'children' ];
+	children: Tabs.List.Props[ 'children' ];
+	/**
+	 * Whether to automatically change the active tab on arrow key focus.
+	 * Otherwise, tabs will be activated using Enter or Spacebar key press.
+	 * @default true
+	 */
+	activateOnFocus?: Tabs.List.Props[ 'activateOnFocus' ];
+	/**
+	 * Whether to loop keyboard focus back to the first item when the end of
+	 * the list is reached while using the arrow keys.
+	 * @default false
+	 */
+	loop?: Tabs.List.Props[ 'loop' ];
+	/**
+	 * Allows you to replace the component’s HTML element with a different tag,
+	 * or compose it with another component.
+	 * Accepts a ReactElement or a function that returns the element to render.
+	 *
+	 * By default, the tablist will be rendered as a `div` element.
+	 */
+	render?: Tabs.List.Props[ 'render' ];
 	/**
 	 * The visual density of the tab list.
 	 * @default "default"
@@ -104,55 +71,50 @@ export type TabListProps = {
 	density?: 'compact' | 'default';
 };
 
-// TODO: consider prop name changes (tabId, selectedTabId)
-// compound technique
-
 export type TabProps = {
 	/**
-	 * The unique ID of the tab. It will be used to register the tab and match
-	 * it to a corresponding `Tabs.TabPanel` component.
+	 * The value of the Tab. When not specified,
+	 * the value is the child position index.
 	 */
-	tabId: NonNullable< Ariakit.TabProps[ 'id' ] >;
+	value?: Tabs.Tab.Props[ 'value' ];
 	/**
 	 * The contents of the tab.
 	 */
-	children?: Ariakit.TabProps[ 'children' ];
+	children?: Tabs.Tab.Props[ 'children' ];
 	/**
-	 * Determines if the tab should be disabled. Note that disabled tabs can
-	 * still be accessed via the keyboard when navigating through the tablist.
-	 * @default false
-	 */
-	disabled?: Ariakit.TabProps[ 'disabled' ];
-	/**
-	 * Allows the component to be rendered as a different HTML element or React
-	 * component. The value can be a React element or a function that takes in the
-	 * original component props and gives back a React element with the props
-	 * merged.
+	 * Allows you to replace the component’s HTML element with a different tag,
+	 * or compose it with another component.
+	 * Accepts a ReactElement or a function that returns the element to render.
 	 *
 	 * By default, the tab will be rendered as a `button` element.
 	 */
-	render?: Ariakit.TabProps[ 'render' ];
+	render?: Tabs.Tab.Props[ 'render' ];
 };
 
 export type TabPanelProps = {
 	/**
 	 * The contents of the tab panel.
 	 */
-	children?: Ariakit.TabPanelProps[ 'children' ];
+	children?: Tabs.Panel.Props[ 'children' ];
 	/**
-	 * The unique `id` of the `Tabs.Tab` component controlling this panel. This
-	 * connection is used to assign the `aria-labelledby` attribute to the tab
-	 * panel and to determine if the tab panel should be visible.
+	 * The value of the TabPanel.
+	 * It will be shown when the Tab with the corresponding value is selected.
+	 * If not provided, it will fall back to the index of the panel.
+	 * It is recommended to explicitly provide it, as it's required for the tab
+	 * panel to be rendered on the server.
+	 */
+	value?: Tabs.Panel.Props[ 'value' ];
+	/**
+	 * Whether to keep the HTML element in the DOM while the panel is hidden.
+	 * @default false
+	 */
+	keepMounted?: Tabs.Panel.Props[ 'keepMounted' ];
+	/**
+	 * Allows you to replace the component’s HTML element with a different tag,
+	 * or compose it with another component.
+	 * Accepts a ReactElement or a function that returns the element to render.
 	 *
-	 * If not provided, this link is automatically established by matching the
-	 * order of `Tabs.Tab` and `Tabs.TabPanel` elements in the DOM.
+	 * By default, the tab panel will be rendered as a `div` element.
 	 */
-	tabId: NonNullable< Ariakit.TabPanelProps[ 'tabId' ] >;
-	/**
-	 * Determines whether or not the tabpanel element should be focusable.
-	 * If `false`, pressing the tab key will skip over the tabpanel, and instead
-	 * focus on the first focusable element in the panel (if there is one).
-	 * @default true
-	 */
-	focusable?: Ariakit.TabPanelProps[ 'focusable' ];
+	render?: Tabs.Panel.Props[ 'render' ];
 };

--- a/packages/components/src/tabs-bui/types.ts
+++ b/packages/components/src/tabs-bui/types.ts
@@ -117,4 +117,9 @@ export type TabPanelProps = {
 	 * By default, the tab panel will be rendered as a `div` element.
 	 */
 	render?: Tabs.Panel.Props[ 'render' ];
+	/**
+	 * Whether the tab panel should be focusable.
+	 * @default true
+	 */
+	focusable?: boolean;
 };

--- a/packages/components/src/tabs-bui/use-track-overflow.ts
+++ b/packages/components/src/tabs-bui/use-track-overflow.ts
@@ -1,0 +1,71 @@
+import { useEvent } from '@wordpress/compose';
+import { useState, useEffect } from 'react';
+
+/**
+ * Tracks if an element contains overflow and on which end by tracking the
+ * first and last child elements with an `IntersectionObserver` in relation
+ * to the parent element.
+ *
+ * Note that the returned value will only indicate whether the first or last
+ * element is currently "going out of bounds" but not whether it happens on
+ * the X or Y axis.
+ */
+export function useTrackOverflow(
+	parent: HTMLElement | undefined | null,
+	children: {
+		first: HTMLElement | undefined | null;
+		last: HTMLElement | undefined | null;
+	}
+) {
+	const [ first, setFirst ] = useState( false );
+	const [ last, setLast ] = useState( false );
+	const [ observer, setObserver ] = useState< IntersectionObserver >();
+
+	const callback: IntersectionObserverCallback = useEvent( ( entries ) => {
+		for ( const entry of entries ) {
+			if ( entry.target === children.first ) {
+				setFirst( ! entry.isIntersecting );
+			}
+			if ( entry.target === children.last ) {
+				setLast( ! entry.isIntersecting );
+			}
+		}
+	} );
+
+	useEffect( () => {
+		if ( ! parent || ! window.IntersectionObserver ) {
+			return;
+		}
+		const newObserver = new IntersectionObserver( callback, {
+			root: parent,
+			threshold: 0.9,
+		} );
+		setObserver( newObserver );
+
+		return () => newObserver.disconnect();
+	}, [ callback, parent ] );
+
+	useEffect( () => {
+		if ( ! observer ) {
+			return;
+		}
+
+		if ( children.first ) {
+			observer.observe( children.first );
+		}
+		if ( children.last ) {
+			observer.observe( children.last );
+		}
+
+		return () => {
+			if ( children.first ) {
+				observer.unobserve( children.first );
+			}
+			if ( children.last ) {
+				observer.unobserve( children.last );
+			}
+		};
+	}, [ children.first, children.last, observer ] );
+
+	return { first, last };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -869,6 +869,7 @@ __metadata:
     "@automattic/number-formatters": "npm:^1.0.1"
     "@automattic/typography": "workspace:^"
     "@automattic/viewport-react": "workspace:^"
+    "@base-ui-components/react": "npm:^1.0.0-beta.0"
     "@emotion/css": "npm:^11.11.2"
     "@emotion/react": "npm:^11.11.1"
     "@emotion/styled": "npm:^11.11.0"
@@ -4091,6 +4092,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.27.0":
+  version: 7.27.6
+  resolution: "@babel/runtime@npm:7.27.6"
+  checksum: 89726be83f356f511dcdb74d3ea4d873a5f0cf0017d4530cb53aa27380c01ca102d573eff8b8b77815e624b1f8c24e7f0311834ad4fb632c90a770fda00bd4c8
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.25.7, @babel/template@npm:^7.27.1, @babel/template@npm:^7.3.3":
   version: 7.27.1
   resolution: "@babel/template@npm:7.27.1"
@@ -4124,6 +4132,25 @@ __metadata:
     "@babel/helper-string-parser": "npm:^7.27.1"
     "@babel/helper-validator-identifier": "npm:^7.27.1"
   checksum: ed736f14db2fdf0d36c539c8e06b6bb5e8f9649a12b5c0e1c516fed827f27ef35085abe08bf4d1302a4e20c9a254e762eed453bce659786d4a6e01ba26a91377
+  languageName: node
+  linkType: hard
+
+"@base-ui-components/react@npm:^1.0.0-beta.0":
+  version: 1.0.0-beta.0
+  resolution: "@base-ui-components/react@npm:1.0.0-beta.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.27.0"
+    "@floating-ui/react": "npm:^0.27.9"
+    "@floating-ui/utils": "npm:^0.2.9"
+    use-sync-external-store: "npm:^1.5.0"
+  peerDependencies:
+    "@types/react": ^17 || ^18 || ^19
+    react: ^17 || ^18 || ^19
+    react-dom: ^17 || ^18 || ^19
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: de77d0455d9722f483b60a37b8cc4d26bccd6728f887d1ac5c384207fe79414acaec03541df0d1a80a569404e248c72c8ecbbb8e88530d3c8398ba7ed3629a10
   languageName: node
   linkType: hard
 
@@ -5875,10 +5902,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@floating-ui/react-dom@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "@floating-ui/react-dom@npm:2.1.3"
+  dependencies:
+    "@floating-ui/dom": "npm:^1.0.0"
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: e88750ea2fb352264d52d502d3979f94155ce2c8ab9a50862810d0cfc8c8e49cb6bbde466d668736cb38624d089360ef97451397b647408a0eb2c1870234c19a
+  languageName: node
+  linkType: hard
+
+"@floating-ui/react@npm:^0.27.9":
+  version: 0.27.12
+  resolution: "@floating-ui/react@npm:0.27.12"
+  dependencies:
+    "@floating-ui/react-dom": "npm:^2.1.3"
+    "@floating-ui/utils": "npm:^0.2.9"
+    tabbable: "npm:^6.0.0"
+  peerDependencies:
+    react: ">=17.0.0"
+    react-dom: ">=17.0.0"
+  checksum: da453965074bd4ded8e3de97ceb2c0833df8df2ecd9eff5ae4d336413443ea5abde5c9e37b092956901b97e7b47f9138d51d4896fa82da68e77eb0090289bf64
+  languageName: node
+  linkType: hard
+
 "@floating-ui/utils@npm:^0.2.0, @floating-ui/utils@npm:^0.2.1":
   version: 0.2.1
   resolution: "@floating-ui/utils@npm:0.2.1"
   checksum: ee77756712cf5b000c6bacf11992ffb364f3ea2d0d51cc45197a7e646a17aeb86ea4b192c0b42f3fbb29487aee918a565e84f710b8c3645827767f406a6b4cc9
+  languageName: node
+  linkType: hard
+
+"@floating-ui/utils@npm:^0.2.9":
+  version: 0.2.9
+  resolution: "@floating-ui/utils@npm:0.2.9"
+  checksum: 48bbed10f91cb7863a796cc0d0e917c78d11aeb89f98d03fc38d79e7eb792224a79f538ed8a2d5d5584511d4ca6354ef35f1712659fd569868e342df4398ad6f
   languageName: node
   linkType: hard
 
@@ -34728,6 +34788,13 @@ __metadata:
     "@pkgr/core": "npm:^0.1.0"
     tslib: "npm:^2.6.2"
   checksum: e0c262817444e5b872708adb6f5ad37951ba33f6b2d1d4477d45db1f57573a784618ceed5e6614e0225db330632b1f6b95bb74d21e4d013e45ad4bde03d0cb59
+  languageName: node
+  linkType: hard
+
+"tabbable@npm:^6.0.0":
+  version: 6.2.0
+  resolution: "tabbable@npm:6.2.0"
+  checksum: ced8b38f05f2de62cd46836d77c2646c42b8c9713f5bd265daf0e78ff5ac73d3ba48a7ca45f348bafeef29b23da7187c72250742d37627883ef89cbd7fa76898
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Experiment with refactoring Tabs from Ariakit to Base UI to get a feeling for Base UI.

Note: review code changes by ignoring the first couple of commits to appreciate better the necessary changes

## Key differences:

- The root component of Base UI renders a `div`, while Ariakit doesn't render anything
- Props differences:
  - Base UI doesn't expose props around the active tab (ie. the composite element that has focus);
  - Ariakit uses `selectedTabId`/`defaultTabId` / `onSelect` props, Base UI calls them `value` / `defaultValue` / `onValueChange`
  - Ariakit's `selectOnMove` is called `activateOnFocus` and is passed to the tablist component instead;
  - Base UI doesn't have a `focusable` prop for the tab panel (although I was able to quickly polyfill it)
- When passing explicit `value`s to tabs and tabpanels, Base UI won't select the first available tab by default
- Base UI and Ariakit have the same conventions about controlled/uncontrolled value (ie. `defaultValue` for initial selection when uncontrolled, `null` value for "controlled but unselected")
- Base UI conveniently exposes some CSS variables for positioning the indicator
- Base UI already checks that compound components are rendered inside a parent compound component, making our custom custom redundant;
- In Base UI, there isn't an easy way to access internal state, meaning that it's not easy to add advanced behaviors such as:
  - making sure that selected tab and active tab are kept in sync when necessary;
  - tablist scrolls the selected tab into view;
- Base UI handles RTL layouts via [a global provider](https://base-ui.com/react/utils/direction-provider), while Ariakit expects the consumer to set it on each component

## Bugs & missing features

I opened the following issues on Base UI's repository:

Bugs:
- https://github.com/mui/base-ui/issues/2096
- https://github.com/mui/base-ui/issues/2097
- https://github.com/mui/base-ui/issues/2098
- https://github.com/mui/base-ui/issues/2099
- https://github.com/mui/base-ui/issues/2100
- https://github.com/mui/base-ui/issues/2101
- https://github.com/mui/base-ui/issues/2106

Missing features:
- https://github.com/mui/base-ui/issues/2085
- https://github.com/mui/base-ui/issues/2103

Overall, none of the bugs are blockers, and I hope they can be fixed quickly. Some of them have already been assigned, too.