### PR TITLE
Record impression and click events for settings callouts

### DIFF
--- a/client/dashboard/sites/settings-caching/index.tsx
+++ b/client/dashboard/sites/settings-caching/index.tsx
@@ -126,7 +126,7 @@ export default function CachingSettings( { siteSlug }: { siteSlug: string } ) {
 	};
 
 	const renderCallout = () => {
-		return <SettingsCallout siteSlug={ siteSlug } />;
+		return <SettingsCallout siteSlug={ siteSlug } tracksId="caching" />;
 	};
 
 	const renderForm = () => {

--- a/client/dashboard/sites/settings-callout/index.tsx
+++ b/client/dashboard/sites/settings-callout/index.tsx
@@ -2,15 +2,17 @@ import { __experimentalText as Text, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { settings } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
+import { useEffect, type ReactNode } from 'react';
+import { useAnalytics } from '../../app/analytics';
 import { Callout } from '../../components/callout';
 import calloutIllustrationUrl from './callout-illustration.svg';
 import type { CalloutProps } from '../../components/callout/types';
-import type { ReactNode } from 'react';
 
 interface SettingsCalloutProps extends Omit< CalloutProps, 'title' | 'description' > {
 	siteSlug: string;
 	title?: string;
 	description?: ReactNode;
+	tracksId: string;
 }
 
 export default function SettingsCallout( {
@@ -19,8 +21,20 @@ export default function SettingsCallout( {
 	image,
 	title,
 	description,
+	tracksId,
 }: SettingsCalloutProps ) {
+	const { recordTracksEvent } = useAnalytics();
+	useEffect( () => {
+		recordTracksEvent( 'calypso_settings_callout_impression', {
+			callout_id: tracksId,
+		} );
+	}, [ recordTracksEvent, tracksId ] );
+
 	const handleUpgradePlan = () => {
+		recordTracksEvent( 'calypso_settings_callout_click', {
+			callout_id: tracksId,
+		} );
+
 		const backUrl = window.location.href.replace( window.location.origin, '' );
 
 		window.location.href = addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }/business`, {

--- a/client/dashboard/sites/settings-database/index.tsx
+++ b/client/dashboard/sites/settings-database/index.tsx
@@ -55,6 +55,7 @@ export default function SiteDatabaseSettings( { siteSlug }: { siteSlug: string }
 					description={ __(
 						'Access your site’s database with phpMyAdmin—perfect for inspecting data, running queries, and quick debugging.'
 					) }
+					tracksId="database"
 				/>
 			</PageLayout>
 		);

--- a/client/dashboard/sites/settings-php/index.tsx
+++ b/client/dashboard/sites/settings-php/index.tsx
@@ -42,7 +42,7 @@ export default function PHPVersionSettings( { siteSlug }: { siteSlug: string } )
 	if ( ! canUpdate ) {
 		return (
 			<PageLayout size="small" header={ <SettingsPageHeader title="PHP" /> }>
-				<SettingsCallout siteSlug={ siteSlug } />
+				<SettingsCallout siteSlug={ siteSlug } tracksId="php" />
 			</PageLayout>
 		);
 	}

--- a/client/dashboard/sites/settings-sftp-ssh/index.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/index.tsx
@@ -40,6 +40,7 @@ export default function SftpSshSettings( { siteSlug }: { siteSlug: string } ) {
 					description={ __(
 						'SFTP and SSH give you secure, direct access to your site’s filesystem—fast, reliable, and built for your workflow.'
 					) }
+					tracksId="sftp-ssh"
 				/>
 			</PageLayout>
 		);

--- a/client/dashboard/sites/settings-static-file-404/index.tsx
+++ b/client/dashboard/sites/settings-static-file-404/index.tsx
@@ -74,7 +74,7 @@ export default function SiteStaticFile404Settings( { siteSlug }: { siteSlug: str
 				size="small"
 				header={ <SettingsPageHeader title={ __( 'Handling requests for nonexistent assets' ) } /> }
 			>
-				<SettingsCallout siteSlug={ siteSlug } />
+				<SettingsCallout siteSlug={ siteSlug } tracksId="static-file-404" />
 			</PageLayout>
 		);
 	}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-13478

## Proposed Changes

- Record `calypso_settings_callout_impression` when a callout is rendered
- Record `calypso_settings_callout_click` when a callout action button is clicked

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Help measure performance of the settings backport

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Enable `dashboard/v2/backport/site-settings` flag
- Load up `/sites/settings/v2/{{ site slug }}` with a simple site
- View SSH or PHP settings
- Confirm impression event is sent
- Click button, and confirm event is sent

Event will be recorded in the v2 dashboard too.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
