### PR TITLE
Better defaults for untyped fields

### DIFF
--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- Update the field type definitions to declare the default and valid operators they support.
+- Update the field type definitions to declare the default and valid operators they support. Fields with no `type` property can use all operators and, if none is provided in the field's config, they'll display `is` and `isNot`.
 - Add a story for each FieldTypeDefinition.
 
 ## 0.2.1

--- a/packages/dataviews/src/constants.ts
+++ b/packages/dataviews/src/constants.ts
@@ -24,7 +24,7 @@ export const OPERATOR_CONTAINS = 'contains';
 export const OPERATOR_NOT_CONTAINS = 'notContains';
 export const OPERATOR_STARTS_WITH = 'startsWith';
 
-export const ALL_OPERATORS = [
+export const ALL_OPERATORS: Operator[] = [
 	OPERATOR_IS,
 	OPERATOR_IS_NOT,
 	OPERATOR_IS_ANY,
@@ -38,9 +38,9 @@ export const ALL_OPERATORS = [
 	OPERATOR_CONTAINS,
 	OPERATOR_NOT_CONTAINS,
 	OPERATOR_STARTS_WITH,
-] satisfies Operator[];
+];
 
-export const SINGLE_SELECTION_OPERATORS = [
+export const SINGLE_SELECTION_OPERATORS: Operator[] = [
 	OPERATOR_IS,
 	OPERATOR_IS_NOT,
 	OPERATOR_LESS_THAN,
@@ -50,7 +50,7 @@ export const SINGLE_SELECTION_OPERATORS = [
 	OPERATOR_CONTAINS,
 	OPERATOR_NOT_CONTAINS,
 	OPERATOR_STARTS_WITH,
-] satisfies Operator[];
+];
 
 export const OPERATORS: Record< Operator, { key: string; label: string } > = {
 	[ OPERATOR_IS ]: {

--- a/packages/dataviews/src/constants.ts
+++ b/packages/dataviews/src/constants.ts
@@ -38,7 +38,7 @@ export const ALL_OPERATORS = [
 	OPERATOR_CONTAINS,
 	OPERATOR_NOT_CONTAINS,
 	OPERATOR_STARTS_WITH,
-];
+] satisfies Operator[];
 
 export const SINGLE_SELECTION_OPERATORS = [
 	OPERATOR_IS,
@@ -50,7 +50,7 @@ export const SINGLE_SELECTION_OPERATORS = [
 	OPERATOR_CONTAINS,
 	OPERATOR_NOT_CONTAINS,
 	OPERATOR_STARTS_WITH,
-];
+] satisfies Operator[];
 
 export const OPERATORS: Record< Operator, { key: string; label: string } > = {
 	[ OPERATOR_IS ]: {

--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -15,6 +15,7 @@ import { default as datetime } from './datetime';
 import { default as boolean } from './boolean';
 import { default as media } from './media';
 import { renderFromElements } from '../utils';
+import { ALL_OPERATORS, OPERATOR_IS, OPERATOR_IS_NOT } from '../constants';
 
 /**
  *
@@ -78,6 +79,9 @@ export default function getFieldTypeDefinition< Item >(
 				: field.getValue( { item } );
 		},
 		enableSorting: true,
-		filterBy: false,
+		filterBy: {
+			defaultOperators: [ OPERATOR_IS, OPERATOR_IS_NOT ],
+			validOperators: ALL_OPERATORS,
+		},
 	};
 }

--- a/packages/dataviews/src/test/normalize-fields.ts
+++ b/packages/dataviews/src/test/normalize-fields.ts
@@ -51,7 +51,7 @@ describe( 'normalizeFields: default getValue', () => {
 			];
 			const normalizedFields = normalizeFields( fields );
 			const result = normalizedFields[ 0 ].filterBy;
-			expect( result ).toBe( false );
+			expect( result ).toStrictEqual( { operators: [ 'is', 'isNot' ] } );
 		} );
 
 		it( 'returns the field type definition for typed fields', () => {


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/103949

## What?

Update how filters behave for fields with no `type` prop. By default, it provides two filters (`is`, `isNot`) and allows all registered filters to be used in the field.

## Why?

To provide better defaults.

## How?

By updating the `filterBy` config of the default field type definition.

## Testing Instructions

- Go to the sites-dataviews component ([permalink](https://github.com/Automattic/wp-calypso/blob/c4cc72afa6e59e9f23e3730923c7a2abe5b67572/client/sites/components/sites-dataviews/index.tsx#L196)) and remove the `filterBy` config for the `is_a8c` field.
- `yarn && yarn start`
- Visit http://calypso.localhost:3000/sites

The expected result is that the filter for "is a8c site" is displayed and users can select two operators: "is" and "is not". In trunk, there won't be any filter displayed for the field.

<img width="412" alt="Screenshot 2025-06-09 at 17 34 52" src="https://github.com/user-attachments/assets/247c94ca-ce2e-4491-8c99-c7032021275a" />
