### PR TITLE
Help Center: Only init Smooch once

### DIFF
--- a/packages/help-center/src/components/help-center-smooch.tsx
+++ b/packages/help-center/src/components/help-center-smooch.tsx
@@ -154,7 +154,7 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 			clearTimeout( retryTimeout );
 			destroy();
 		};
-	}, [ isMessagingScriptLoaded, authData, setIsChatLoaded ] );
+	}, [ isMessagingScriptLoaded, authData, setIsChatLoaded, isChatLoaded ] );
 
 	useEffect( () => {
 		if ( isChatLoaded && getZendeskConversations ) {

--- a/packages/help-center/src/components/help-center-smooch.tsx
+++ b/packages/help-center/src/components/help-center-smooch.tsx
@@ -114,6 +114,7 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 	// Initialize Smooch which communicates with Zendesk
 	useEffect( () => {
 		if (
+			isChatLoaded ||
 			! isMessagingScriptLoaded ||
 			! authData?.isLoggedIn ||
 			! authData?.jwt ||


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Context: p1749483394248389-slack-C04DZ8M0GHW

## Proposed Changes

If the chat is loaded, there is no need to try and initialize Smooch again. So we add the check.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Looking at data, we saw a lot of `calypso_smooch_messenger_init` events being fired with the message `Web Messenger is already initialized. Call `destroy()` first before calling `init()` again.`.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Help Center.
* You should be able to contact an Happiness Engineer.
