### PR TITLE
Accessibility add aria-selected to item variation list items

### DIFF
--- a/client/my-sites/checkout/src/components/item-variation-picker/item-variation-dropdown.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/item-variation-dropdown.tsx
@@ -263,6 +263,7 @@ function ItemVariantOption( {
 			id={ productId.toString() }
 			className={ isSelected ? 'item-variant-option--selected' : undefined }
 			aria-label={ variantLabel.noun }
+			aria-selected={ isSelected }
 			data-product-slug={ productSlug }
 			role="option"
 			onClick={ onSelect }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DOTCOM-13285

## Proposed Changes

* Add `aria-selected` to the list of item variation in Checkout screen


https://github.com/user-attachments/assets/b56a0caf-c2f7-40e4-840d-1cc5d4c8e0e0



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve the accessibility

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* For one site, purchase something, for example a domain
* Navigate to the checkout screen 
* Activate VoiceOver and navigate to the item variation dropdown, where you can change the period of the purchased item.
* Open the dropdown by clicking `ctrl+option+space`
* Enter the list by clicking on `ctrl+option+right arrow`
* Navigate through the items by clicking on `ctrl+option+right/left arrows`
* Ensure you can hear the value of the items, e.g. Five years
* Select an item by clicking `ctrl+option+space`
* Check the item is selected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
