### PR TITLE
Add site-specific props to tracks events when possible

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -43,6 +43,7 @@ module.exports = {
 							'!@automattic/calypso-analytics',
 							'!@automattic/dataviews',
 							'!@automattic/number-formatters',
+							'!@automattic/viewport',
 							// Please do not add exceptions unless agreed on
 							// with the #architecture group.
 						],

--- a/client/dashboard/app/analytics/super-props.ts
+++ b/client/dashboard/app/analytics/super-props.ts
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { SITE_FIELDS, SITE_OPTIONS } from '../../data/constants';
+import { siteQuery, sitesQuery } from '../queries';
 import type { User, Site } from '../../data/types';
 import type { QueryClient } from '@tanstack/react-query';
 import type { AnyRouter } from '@tanstack/react-router';
@@ -48,11 +48,11 @@ export const getSuperProps = ( user: User, router: AnyRouter, queryClient: Query
  * both caches represents a "best effort" attempt.
  */
 function getSiteFromCache( queryClient: QueryClient, siteSlug: string ): Site | undefined {
-	const site = queryClient.getQueryData< Site >( [ 'site', siteSlug, SITE_FIELDS, SITE_OPTIONS ] );
+	const site = queryClient.getQueryData< Site >( siteQuery( siteSlug ).queryKey );
 	if ( site ) {
 		return site;
 	}
 
-	const sites = queryClient.getQueryData< Site[] >( [ 'sites', SITE_FIELDS, SITE_OPTIONS ] );
+	const sites = queryClient.getQueryData< Site[] >( sitesQuery().queryKey );
 	return sites?.find( ( s ) => s.slug === siteSlug );
 }

--- a/client/dashboard/app/analytics/super-props.ts
+++ b/client/dashboard/app/analytics/super-props.ts
@@ -39,6 +39,14 @@ export const getSuperProps = ( user: User, router: AnyRouter, queryClient: Query
 	};
 };
 
+/**
+ * Attempts to retrieve the site information from the tanstack cache.
+ *
+ * It looks for the site slug in both the "site" and "sites" caches. Perhaps it's
+ * overkill to search in both places. But this whole thing is a heuristic - we're
+ * hoping to attach site info if it happens to be available. So I think checking
+ * both caches represents a "best effort" attempt.
+ */
 function getSiteFromCache( queryClient: QueryClient, siteSlug: string ): Site | undefined {
 	const site = queryClient.getQueryData< Site >( [ 'site', siteSlug, SITE_FIELDS, SITE_OPTIONS ] );
 	if ( site ) {

--- a/client/dashboard/app/analytics/super-props.ts
+++ b/client/dashboard/app/analytics/super-props.ts
@@ -1,0 +1,50 @@
+import config from '@automattic/calypso-config';
+import { SITE_FIELDS, SITE_OPTIONS } from '../../data/constants';
+import type { User, Site } from '../../data/types';
+import type { QueryClient } from '@tanstack/react-query';
+import type { AnyRouter } from '@tanstack/react-router';
+
+export const getSuperProps = ( user: User, router: AnyRouter, queryClient: QueryClient ) => () => {
+	const superProps = {
+		environment: process.env.NODE_ENV,
+		environment_id: config( 'env_id' ),
+		site_count: user.site_count,
+		site_id_label: 'wpcom',
+		client: config( 'client_slug' ),
+	};
+
+	if ( typeof window !== 'undefined' ) {
+		Object.assign( superProps, {
+			vph: window.innerHeight,
+			vpw: window.innerWidth,
+		} );
+	}
+
+	const siteSlug = router.state.matches.at( -1 )?.params?.siteSlug;
+	if ( ! siteSlug ) {
+		return superProps;
+	}
+
+	const site = getSiteFromCache( queryClient, siteSlug );
+	if ( ! site ) {
+		return superProps;
+	}
+
+	return {
+		...superProps,
+		blog_id: site.ID,
+		blog_lang: site.lang,
+		site_id_label: site.jetpack ? 'jetpack' : 'wpcom',
+		site_plan_id: site.plan?.product_id ?? null,
+	};
+};
+
+function getSiteFromCache( queryClient: QueryClient, siteSlug: string ): Site | undefined {
+	const site = queryClient.getQueryData< Site >( [ 'site', siteSlug, SITE_FIELDS, SITE_OPTIONS ] );
+	if ( site ) {
+		return site;
+	}
+
+	const sites = queryClient.getQueryData< Site[] >( [ 'sites', SITE_FIELDS, SITE_OPTIONS ] );
+	return sites?.find( ( s ) => s.slug === siteSlug );
+}

--- a/client/dashboard/app/analytics/super-props.ts
+++ b/client/dashboard/app/analytics/super-props.ts
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
-import { siteQuery, sitesQuery } from '../queries';
+import { siteBySlugQuery } from '../queries/site';
+import { sitesQuery } from '../queries/sites';
 import type { User, Site } from '../../data/types';
 import type { QueryClient } from '@tanstack/react-query';
 import type { AnyRouter } from '@tanstack/react-router';
@@ -48,7 +49,7 @@ export const getSuperProps = ( user: User, router: AnyRouter, queryClient: Query
  * both caches represents a "best effort" attempt.
  */
 function getSiteFromCache( queryClient: QueryClient, siteSlug: string ): Site | undefined {
-	const site = queryClient.getQueryData< Site >( siteQuery( siteSlug ).queryKey );
+	const site = queryClient.getQueryData< Site >( siteBySlugQuery( siteSlug ).queryKey );
 	if ( site ) {
 		return site;
 	}

--- a/client/dashboard/data/site.ts
+++ b/client/dashboard/data/site.ts
@@ -16,6 +16,7 @@ export const SITE_FIELDS = [
 	'is_private',
 	'is_wpcom_atomic',
 	'is_wpcom_staging_site',
+	'lang',
 	'launch_status',
 	'site_migration',
 	'site_owner',
@@ -53,6 +54,7 @@ export interface SiteDomain {
 }
 
 export interface SitePlan {
+	product_id: number;
 	product_slug: string;
 	product_name: string;
 	product_name_short: string;
@@ -98,6 +100,7 @@ export interface Site {
 	is_wpcom_atomic: boolean;
 	is_wpcom_staging_site: boolean;
 	is_vip: boolean;
+	lang: string;
 	launch_status: string | boolean;
 	site_migration: {
 		migration_status?: string;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-13477

## Proposed Changes

* Use `@automattic/calypso-analytics`’s "super props" feature to attach properties to every tracks event.
* Lift `router` up out of `<RouterProviderWithAuth>` and into `<Layout>`, because the analytics client needs access to the current router state.
* On each event, make an effort to find the currently "selected" site, so we can send the standard props.
* Attach the `device_type` property to the `calypso_page_view` event.

**Note**: Calypso also attaches a `global_site_view_enabled` to all `calypso_page_view` events. It’s not relevant for us though because this reviews to the "admin style" user preference. It’s not part of v2.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Replicating the base tracks features that Calypso has.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test `/v2/sites`
  * Check the `t.gif` data in network tools which sends the tracks event
  * There's no "selected site" so it doesn't contain any site-specific properties
  * It does contain the `device_type` property
* Test `/v2/sites/{{ site slug }}`
  * Check the `t.gif` data in network tools which sends the tracks event
  * Check for the site-specific properties: e.g. `blog_id`, `product_id`, etc.
  * It does contain the `device_type` property

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
