### PR TITLE
Purchases: Always call getSitePurchases for site-level even if loading

### DIFF
--- a/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
+++ b/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
@@ -94,9 +94,7 @@ export default function SubscriptionsContentWrapper() {
 	const hasLoadedPurchases = useSelector( hasLoadedSitePurchasesFromServer );
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const selectedSite = useSelector( getSelectedSite );
-	const purchases = useSelector( ( state ) =>
-		isFetchingPurchases || ! hasLoadedPurchases ? [] : getSitePurchases( state, selectedSiteId )
-	);
+	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSiteId ) );
 	const sites = useSelector( getSites ).filter( isValueTruthy );
 
 	if ( config.isEnabled( 'purchases/purchase-list-dataview' ) ) {


### PR DESCRIPTION
## Proposed Changes

This fixes a regression caused by https://github.com/Automattic/wp-calypso/pull/103966 to the site-level purchases list page.

When that PR was made I noticed the console warning:

```
Selector unknown returned a different result when called with the same parameters. This can lead to unnecessary rerenders.
Selectors that return a new reference (such as an object or an array) should be memoized
```

This happens because fetching the list of purchases returns no data when it hasn't loaded, but then returns the correct data once it has loaded. To fix this warning, I prevented calling the Redux selector until the data had loaded. However, this had an unintentional side effect of creating an infinite loading loop on the page.

In this PR I revert that guard. The warning is probably fine. Eventually fetching purchases should be made to work via useQuery instead.

## Testing Instructions

Because the DataViews version of the purchases list is shown in calypso.localhost, in order to see this you'll need to disable the feature flag `purchases/purchase-list-dataview` in development or just disable [the block here](https://github.com/Automattic/wp-calypso/blob/dc6a98cadb7492a04268c2c3f67678786474a90c/client/my-sites/purchases/subscriptions/subscriptions-content.tsx#L100).

- Visit http://calypso.localhost:3000/purchases/subscriptions/your-site-here
- Verify that the page loads.