### PR TITLE
SupportHeader: Button only display for search

### DIFF
--- a/apps/happy-blocks/block-library/education-header/index.php
+++ b/apps/happy-blocks/block-library/education-header/index.php
@@ -20,17 +20,12 @@ $happy_blocks_current_page = $args['active_page'];
 
 if ( isset( $args['button_only'] ) && $args['button_only'] ) : ?>
 <div class="happy-blocks_navigation_search">
-	<div></div>
-	<form class="happy-blocks_inner_search_form" role="search" method="get" action="">
-		<input type="search" name="s" value="" placeholder="<?php echo esc_html( $args['search_placeholder'] ); ?>">
-			<button type="submit" class="search-submit-button" aria-label="<?php echo esc_attr( __( 'Search', 'happy-blocks' ) ); ?>">
-				<svg xmlns="http://www.w3.org/2000/svg" class="search-icon" width="24" height="24" viewBox="0 0 24 24" fill="#1E1E1E">
-					<path d="M13 5C9.7 5 7 7.7 7 11C7 12.4 7.5 13.7 8.3 14.7L4.5 18.5L5.6 19.6L9.4 15.8C10.4 16.6 11.7 17.1 13.1 17.1C16.4 17.1 19.1 14.4 19.1 11.1C19.1 7.8 16.3 5 13 5ZM13 15.5C10.5 15.5 8.5 13.5 8.5 11C8.5 8.5 10.5 6.5 13 6.5C15.5 6.5 17.5 8.5 17.5 11C17.5 13.5 15.5 15.5 13 15.5Z"/>
-				</svg>
-				<?php echo esc_html( __( 'Search', 'happy-blocks' ) ); ?>
-			</button>
-		</div>
-	</form>
+	<a class="jetpack-search-filter__link" href="#">
+		<svg xmlns="http://www.w3.org/2000/svg" class="search-icon" width="24" height="24" viewBox="0 0 24 24" fill="#1E1E1E">
+			<path d="M13 5C9.7 5 7 7.7 7 11C7 12.4 7.5 13.7 8.3 14.7L4.5 18.5L5.6 19.6L9.4 15.8C10.4 16.6 11.7 17.1 13.1 17.1C16.4 17.1 19.1 14.4 19.1 11.1C19.1 7.8 16.3 5 13 5ZM13 15.5C10.5 15.5 8.5 13.5 8.5 11C8.5 8.5 10.5 6.5 13 6.5C15.5 6.5 17.5 8.5 17.5 11C17.5 13.5 15.5 15.5 13 15.5Z"/>
+		</svg>
+		<?php echo esc_html( __( 'Search', 'happy-blocks' ) ); ?>
+	</a>
 </div>
 <?php else : ?>
 <div class="happy-blocks-mini-search happy-blocks-header is-<?php echo esc_html( $happy_blocks_current_page ); ?>">

--- a/apps/happy-blocks/block-library/education-header/index.php
+++ b/apps/happy-blocks/block-library/education-header/index.php
@@ -18,7 +18,21 @@ if ( ! isset( $args ) ) {
 
 $happy_blocks_current_page = $args['active_page'];
 
-?>
+if ( isset( $args['button_only'] ) && $args['button_only'] ) : ?>
+<div class="happy-blocks_navigation_search">
+	<div></div>
+	<form class="happy-blocks_inner_search_form" role="search" method="get" action="">
+		<input type="search" name="s" value="" placeholder="<?php echo esc_html( $args['search_placeholder'] ); ?>">
+			<button type="submit" class="search-submit-button" aria-label="<?php echo esc_attr( __( 'Search', 'happy-blocks' ) ); ?>">
+				<svg xmlns="http://www.w3.org/2000/svg" class="search-icon" width="24" height="24" viewBox="0 0 24 24" fill="#1E1E1E">
+					<path d="M13 5C9.7 5 7 7.7 7 11C7 12.4 7.5 13.7 8.3 14.7L4.5 18.5L5.6 19.6L9.4 15.8C10.4 16.6 11.7 17.1 13.1 17.1C16.4 17.1 19.1 14.4 19.1 11.1C19.1 7.8 16.3 5 13 5ZM13 15.5C10.5 15.5 8.5 13.5 8.5 11C8.5 8.5 10.5 6.5 13 6.5C15.5 6.5 17.5 8.5 17.5 11C17.5 13.5 15.5 15.5 13 15.5Z"/>
+				</svg>
+				<?php echo esc_html( __( 'Search', 'happy-blocks' ) ); ?>
+			</button>
+		</div>
+	</form>
+</div>
+<?php else : ?>
 <div class="happy-blocks-mini-search happy-blocks-header is-<?php echo esc_html( $happy_blocks_current_page ); ?>">
 	<div class="happy-blocks-search-container">
 		<div class="happy-blocks-global-header-site__title">
@@ -37,3 +51,4 @@ $happy_blocks_current_page = $args['active_page'];
 		</div>
 	</div>
 </div>
+<?php endif; ?>

--- a/apps/happy-blocks/block-library/education-header/style.scss
+++ b/apps/happy-blocks/block-library/education-header/style.scss
@@ -21,7 +21,7 @@ body.archive {
 }
 .happy-blocks_navigation_search {
 	display: flex;
-	justify-content: space-between;
+	justify-content: end;
 	padding: 16px 24px;
 	margin-bottom: 32px;
 
@@ -30,20 +30,15 @@ body.archive {
 		margin-bottom: 16px;
 	}
 
-	.happy-blocks_inner_search_form {
-		input {
-			display: none;
-		}
-
-		.search-submit-button {
-			height: 24px;
-			display: flex;
-			align-items: center;
-			gap: 4px;
-			border: none;
-			background: #fff;
-			cursor: pointer;
-		}
+	a.jetpack-search-filter__link {
+		height: 24px;
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		border: none;
+		background: #fff;
+		color: #1e1e1e;
+		text-decoration: none;
 	}
 }
 

--- a/apps/happy-blocks/block-library/education-header/style.scss
+++ b/apps/happy-blocks/block-library/education-header/style.scss
@@ -19,6 +19,33 @@ body.archive {
 		}
 	}
 }
+.happy-blocks_navigation_search {
+	display: flex;
+	justify-content: space-between;
+	padding: 16px 24px;
+	margin-bottom: 32px;
+
+	@media only screen and (max-width: $breakpoint-mobile) {
+		padding: 16px;
+		margin-bottom: 16px;
+	}
+
+	.happy-blocks_inner_search_form {
+		input {
+			display: none;
+		}
+
+		.search-submit-button {
+			height: 24px;
+			display: flex;
+			align-items: center;
+			gap: 4px;
+			border: none;
+			background: #fff;
+			cursor: pointer;
+		}
+	}
+}
 
 .happy-blocks_inner_search {
 	height: 0;

--- a/apps/happy-blocks/block-library/support-content-footer/index.php
+++ b/apps/happy-blocks/block-library/support-content-footer/index.php
@@ -117,7 +117,7 @@ if ( 'home' === $current_page_slug ) {
 	<?php
 } elseif ( 'contact' === $current_page_slug ) {
 	?>
-	<div class="happy-blocks-new-support-content-footer">
+	<div class="happy-blocks-new-support-content-footer contact-page">
 		<div class="support-content-resources">
 			<a href="<?php echo esc_url( localized_wpcom_url( 'https://wordpress.com/sites?help-center=wapuu' ) ); ?>" class="support-content-resource">
 				<div class="support-content-resource__content">


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->
Figma: RgA5dOmf6lXrC75C8yro6Q-fi-470_8549

| Before  | After |
| ------------- | ------------- |
|  <img width="1489" alt="Screenshot 2025-06-10 at 10 37 42" src="https://github.com/user-attachments/assets/8b6e199b-0e76-4e25-852e-20d154eb3a40" /> |  <img width="1487" alt="Screenshot 2025-06-10 at 10 36 50" src="https://github.com/user-attachments/assets/60981ce3-d9e2-4364-88ab-571a6b5be68b" /> |
| <img width="376" alt="Screenshot 2025-06-10 at 10 37 29" src="https://github.com/user-attachments/assets/7e4b70bb-f481-4e2b-989b-a1b5afff9767" /> | <img width="382" alt="Screenshot 2025-06-10 at 10 37 13" src="https://github.com/user-attachments/assets/d26e41fd-d949-4131-9dd3-8e30109fcba4" /> |



Part of #HAPD-1690

## Proposed Changes

* Change header to show only search button for inner pages

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To align with the new design

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR
* cd to app/happy-blocks
* run `yarn dev --sync`
* Sandbox wordpress.com and en.support.wordpress.com
* Open a support guide. Example: https://wordpress.com/support/domains/https-ssl/
* Compare the search with the design

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?