### PR TITLE
Connect Refresh: Migrate A4A to unified Login

### DIFF
--- a/client/blocks/login/login-header.tsx
+++ b/client/blocks/login/login-header.tsx
@@ -1,6 +1,5 @@
 import { useTranslate, TranslateResult, fixMe } from 'i18n-calypso';
 import { capitalize } from 'lodash';
-import A4APlusWpComLogo from 'calypso/a8c-for-agencies/components/a4a-plus-wpcom-logo';
 import VisitSite from 'calypso/blocks/visit-site';
 import GravatarLoginLogo from 'calypso/components/gravatar-login-logo';
 import JetpackPlusWpComLogo from 'calypso/components/jetpack-plus-wpcom-logo';
@@ -78,6 +77,8 @@ export function getHeaderText(
 			clientName = 'Akismet';
 		} else if ( isBlazeProOAuth2Client( oauth2Client ) ) {
 			clientName = 'Blaze Pro';
+		} else if ( isA4AOAuth2Client( oauth2Client ) ) {
+			clientName = 'Automattic for Agencies';
 		}
 
 		headerText = clientName
@@ -142,16 +143,6 @@ export function getHeaderText(
 
 		if ( isJetpackCloudOAuth2Client( oauth2Client ) ) {
 			headerText = translate( 'Howdy! Log in to Jetpack.com with your WordPress.com account.' );
-		}
-
-		if ( isA4AOAuth2Client( oauth2Client ) ) {
-			headerText = translate(
-				'Howdy! Log in to Automattic for Agencies with your WordPress.com{{nbsp/}}account.',
-				{
-					components: { nbsp: <>&nbsp;</> },
-					comment: 'The {{nbsp/}} is a non-breaking space',
-				}
-			);
 		}
 
 		if ( isPartnerPortalOAuth2Client( oauth2Client ) ) {
@@ -336,14 +327,6 @@ export function LoginHeader( {
 			preHeader = (
 				<div>
 					<JetpackPlusWpComLogo className="login__jetpack-plus-wpcom-logo" size={ 24 } />
-				</div>
-			);
-		}
-
-		if ( isA4AOAuth2Client( oauth2Client ) ) {
-			preHeader = (
-				<div>
-					<A4APlusWpComLogo className="login__a4a-plus-wpcom-logo" size={ 32 } />
 				</div>
 			);
 		}

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -348,8 +348,7 @@ $breakpoint-mobile: 782px; //Mobile size.
 	}
 }
 
-.login__jetpack-plus-wpcom-logo,
-.login__a4a-plus-wpcom-logo {
+.login__jetpack-plus-wpcom-logo {
 	margin: 40px 0 16px;
 }
 

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -341,6 +341,7 @@ export default withCurrentRoute(
 
 			const isStudioClient = isStudioAppOAuth2Client( oauth2Client );
 			const isCrowdsignalClient = isCrowdsignalOAuth2Client( oauth2Client );
+			const isA4AClient = isA4AOAuth2Client( oauth2Client );
 			const isWhiteLogin =
 				( currentRoute.startsWith( '/log-in' ) &&
 					( ( ! isJetpackLogin &&
@@ -349,7 +350,8 @@ export default withCurrentRoute(
 						! isWooJPC ) ||
 						isStudioClient ||
 						isCrowdsignalClient ||
-						isBlazePro ) ) ||
+						isBlazePro ||
+						isA4AClient ) ) ||
 				isPartnerPortal;
 
 			const noMasterbarForRoute =

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -113,7 +113,6 @@ const LayoutLoggedOut = ( {
 		! isJetpackLogin &&
 		! hasGravPoweredClientClass &&
 		! isJetpackCloudOAuth2Client( oauth2Client ) &&
-		! isA4AOAuth2Client( oauth2Client ) &&
 		! isWooOAuth2Client( oauth2Client );
 
 	const loadHelpCenter =

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -9,7 +9,6 @@ import {
 	isGravatarOAuth2Client,
 	isGravPoweredOAuth2Client,
 	isJetpackCloudOAuth2Client,
-	isA4AOAuth2Client,
 	isWooOAuth2Client,
 	isIntenseDebateOAuth2Client,
 	isStudioAppOAuth2Client,
@@ -183,11 +182,6 @@ export const canDoMagicLogin = ( twoFactorAuthType, oauth2Client ) => {
 
 	// jetpack cloud cannot have users being sent to WordPress.com
 	if ( isJetpackCloudOAuth2Client( oauth2Client ) ) {
-		return false;
-	}
-
-	// Automattic for Agencies cannot have users being sent to WordPress.com
-	if ( isA4AOAuth2Client( oauth2Client ) ) {
 		return false;
 	}
 

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -7,6 +7,7 @@ import {
 	isPartnerPortalOAuth2Client,
 	isStudioAppOAuth2Client,
 	isCrowdsignalOAuth2Client,
+	isA4AOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { DesktopLoginStart, DesktopLoginFinalize } from 'calypso/login/desktop-login';
 import { SOCIAL_HANDOFF_CONNECT_ACCOUNT } from 'calypso/state/action-types';
@@ -68,6 +69,7 @@ const enhanceContextWithLogin = ( context ) => {
 	const isBlazePro = getIsBlazePro( currentState );
 	const isStudioLogin = isStudioAppOAuth2Client( oauth2Client );
 	const isCrowdsignalLogin = isCrowdsignalOAuth2Client( oauth2Client );
+	const isA4AClient = isA4AOAuth2Client( oauth2Client );
 
 	const isWhiteLogin =
 		( ! isJetpackLogin &&
@@ -77,7 +79,8 @@ const enhanceContextWithLogin = ( context ) => {
 		isPartnerPortalClient ||
 		isStudioLogin ||
 		isCrowdsignalLogin ||
-		isBlazePro;
+		isBlazePro ||
+		isA4AClient;
 
 	context.primary = (
 		<WPLogin

--- a/client/login/wp-login/components/heading-logo.tsx
+++ b/client/login/wp-login/components/heading-logo.tsx
@@ -1,3 +1,4 @@
+import A4APlusWpComLogo from 'calypso/a8c-for-agencies/components/a4a-plus-wpcom-logo';
 import blazeProLogo from 'calypso/assets/images/blaze/blaze-pro-logo.png';
 import akismetLogo from 'calypso/assets/images/icons/akismet-logo.svg';
 import crowdsignalLogo from 'calypso/assets/images/icons/crowdsignal.svg';
@@ -10,6 +11,7 @@ import {
 	isStudioAppOAuth2Client,
 	isWPJobManagerOAuth2Client,
 	isBlazeProOAuth2Client,
+	isA4AOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { useSelector } from 'calypso/state';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
@@ -32,6 +34,8 @@ const HeadingLogo = ( { isFromAkismet }: Props ) => {
 		logo = <img src={ wpJobManagerLogo } alt="WP Job Manager Logo" />;
 	} else if ( isBlazeProOAuth2Client( oauth2Client ) ) {
 		logo = <img src={ blazeProLogo } alt="Blaze Pro Logo" />;
+	} else if ( isA4AOAuth2Client( oauth2Client ) ) {
+		logo = <A4APlusWpComLogo size={ 32 } />;
 	} else if ( isGravPoweredOAuth2Client( oauth2Client ) ) {
 		/**
 		 * Leave last to avoid overriding other grav-powered client logos.

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -346,10 +346,7 @@ export class Login extends Component {
 			return null;
 		}
 
-		if (
-			( isJetpackCloudOAuth2Client( oauth2Client ) || isA4AOAuth2Client( oauth2Client ) ) &&
-			'/log-in/authenticator' !== currentRoute
-		) {
+		if ( isJetpackCloudOAuth2Client( oauth2Client ) && '/log-in/authenticator' !== currentRoute ) {
 			return null;
 		}
 

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -14,7 +14,6 @@ import { canDoMagicLogin, getLoginLinkPageUrl } from 'calypso/lib/login';
 import {
 	isCrowdsignalOAuth2Client,
 	isJetpackCloudOAuth2Client,
-	isA4AOAuth2Client,
 	isGravPoweredOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
@@ -113,7 +112,6 @@ export class LoginLinks extends Component {
 		if (
 			isCrowdsignalOAuth2Client( this.props.oauth2Client ) ||
 			isJetpackCloudOAuth2Client( this.props.oauth2Client ) ||
-			isA4AOAuth2Client( this.props.oauth2Client ) ||
 			this.props.isWhiteLogin
 		) {
 			return null;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13400/a4a
Part of https://linear.app/a8c/issue/DOTCOM-13388/a4a

## Proposed Changes

This PR migrates the A4A Login screen to the unified layout.

### Needs confirmations

- [x] There is an attempt here to introduce magic-login (discussions in Slack: p1749547183535789-slack-C06EV8FF09J)

## Media

| Before | After |
|--------|--------|
| <img width="1132" alt="Screenshot 2025-06-10 at 12 35 00 PM" src="https://github.com/user-attachments/assets/b7cc3a58-d39a-4d02-80ec-390c80e76221" /> | <img width="1139" alt="Screenshot 2025-06-10 at 12 34 13 PM" src="https://github.com/user-attachments/assets/c3ed0173-e1ea-4a80-b4c5-87597a474342" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13400/a4a
Part of https://linear.app/a8c/issue/DOTCOM-13388/a4a

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to [A4A Login](https://linear.app/a8c/issue/DOTCOM-13220/calypso-make-the-two-columnwhite-layout-the-default-across-all) and confirm media
- Go to [WP Login](http://calypso.localhost:3000/log-in) and confirm no changes
- Go to any of the [other OAuth client Login screens](https://linear.app/a8c/issue/DOTCOM-13220/calypso-make-the-two-columnwhite-layout-the-default-across-all) and confirm no changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?