### PR TITLE
Login: Extend tracking for magic codes + readme

### DIFF
--- a/client/login/LOGIN_ANALYTICS_EVENTS.md
+++ b/client/login/LOGIN_ANALYTICS_EVENTS.md
@@ -1,0 +1,95 @@
+# Login Analytics Events
+
+This document outlines all the analytics events tracked during the login process, particularly for magic login flows.
+
+## Magic Login Authentication Events
+
+### `calypso_login_magic_authenticate_attempt`
+**Description**: Tracks when a magic login authentication is attempted (either code or link)
+
+**Properties**:
+- `flow` (string|null): The client's login flow (e.g., gravatar flows)
+- `token_type` (string): Either "code" or "link"
+
+### `calypso_login_magic_authenticate_success`
+**Description**: Tracks successful magic login authentication
+
+**Properties**:
+- `flow` (string|null): The client's login flow
+- `token_type` (string): Either "code" or "link"
+
+### `calypso_login_magic_authenticate_failure`
+**Description**: Tracks failed magic login authentication attempts
+
+**Properties**:
+- `flow` (string|null): The client's login flow
+- `token_type` (string): Either "code" or "link"
+- `error_code` (number): HTTP status code of the error
+- `error_message` (string): Error type/message
+
+## Magic Code Verification Events
+
+### `calypso_login_magic_code_submit`
+**Description**: Tracks when user submits a magic code for verification
+
+**Properties**:
+- `code_length` (number): Length of the submitted verification code
+
+## Email Link Events
+
+### `calypso_login_email_link_submit`
+**Description**: Tracks when user requests a magic login email
+
+**Properties**:
+- `flow` (string|null): The client's login flow
+- `token_type` (string): Always "link" for email requests
+- `is_jetpack` (boolean): Whether this is a Jetpack login
+- `is_magic_code` (boolean): Whether magic code is being used
+
+### `calypso_login_email_link_success`
+**Description**: Tracks successful email link request
+
+**Properties**:
+- `flow` (string|null): The client's login flow
+- `token_type` (string): Always "link"
+- `is_jetpack` (boolean): Whether this is a Jetpack login
+- `is_magic_code` (boolean): Whether magic code is being used
+
+### `calypso_login_email_link_failure`
+**Description**: Tracks failed email link requests
+
+**Properties**:
+- `flow` (string|null): The client's login flow
+- `token_type` (string): Always "link"
+- `is_jetpack` (boolean): Whether this is a Jetpack login
+- `is_magic_code` (boolean): Whether magic code is being used
+
+### `calypso_login_email_link_handle_click_view`
+**Description**: Tracks when user views the email link handling page
+
+**Properties**: None
+
+## General Login Events
+
+### `calypso_login_success`
+**Description**: Tracks overall successful login completion
+
+**Properties**:
+- `is_jetpack` (boolean): Whether this is a Jetpack login
+- `is_magic_login` (boolean): Whether magic login was used
+- `login_method` (string): The method used for login
+
+## Event Flow
+
+1. **Email Request**: `calypso_login_email_link_submit` → `calypso_login_email_link_success`/`calypso_login_email_link_failure`
+2. **Link Click**: `calypso_login_email_link_handle_click_view`
+3. **Code Entry** (if applicable): `calypso_login_magic_code_submit`
+4. **Authentication**: `calypso_login_magic_authenticate_attempt` → `calypso_login_magic_authenticate_success`/`calypso_login_magic_authenticate_failure`
+5. **Final Success**: `calypso_login_success`
+
+## Implementation Files
+
+- **Email requests**: `client/state/data-layer/wpcom/auth/send-login-email/index.js`
+- **Authentication**: `client/state/login/magic-login/actions.js`
+- **Code verification**: `client/login/magic-login/verify-login-code.jsx`
+- **Final login**: `client/state/login/actions/reboot-after-login.ts` 

--- a/client/login/LOGIN_ANALYTICS_EVENTS.md
+++ b/client/login/LOGIN_ANALYTICS_EVENTS.md
@@ -42,27 +42,23 @@ This document outlines all the analytics events tracked during the login process
 
 **Properties**:
 - `flow` (string|null): The client's login flow
-- `token_type` (string): Always "link" for email requests
-- `is_jetpack` (boolean): Whether this is a Jetpack login
-- `is_magic_code` (boolean): Whether magic code is being used
+- `token_type` (string): Token type being requested
 
 ### `calypso_login_email_link_success`
 **Description**: Tracks successful email link request
 
 **Properties**:
 - `flow` (string|null): The client's login flow
-- `token_type` (string): Always "link"
-- `is_jetpack` (boolean): Whether this is a Jetpack login
-- `is_magic_code` (boolean): Whether magic code is being used
+- `token_type` (string): Token type that was requested
 
 ### `calypso_login_email_link_failure`
 **Description**: Tracks failed email link requests
 
 **Properties**:
 - `flow` (string|null): The client's login flow
-- `token_type` (string): Always "link"
-- `is_jetpack` (boolean): Whether this is a Jetpack login
-- `is_magic_code` (boolean): Whether magic code is being used
+- `token_type` (string): Token type that was requested
+- `error_code` (string): Error code from the API
+- `error_message` (string): Error message from the API
 
 ### `calypso_login_email_link_handle_click_view`
 **Description**: Tracks when user views the email link handling page

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -543,7 +543,8 @@ class MagicLogin extends Component {
 		this.props.fetchMagicLoginAuthenticate(
 			`${ publicToken }:${ btoa( verificationCodeInputValue ) }`,
 			query?.redirect_to,
-			getGravatarOAuth2Flow( oauth2Client )
+			getGravatarOAuth2Flow( oauth2Client ),
+			true
 		);
 	};
 

--- a/client/login/magic-login/verify-login-code.jsx
+++ b/client/login/magic-login/verify-login-code.jsx
@@ -8,6 +8,7 @@ import FormButton from 'calypso/components/forms/form-button';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import LoggedOutForm from 'calypso/components/logged-out-form';
 import { navigate } from 'calypso/lib/navigate';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { fetchMagicLoginAuthenticate } from 'calypso/state/login/magic-login/actions';
 import { getRedirectToOriginal } from 'calypso/state/login/selectors';
 import getMagicLoginAuthSuccessData from 'calypso/state/selectors/get-magic-login-auth-success-data';
@@ -141,10 +142,15 @@ const VerifyLoginCode = ( {
 			return;
 		}
 
+		// Track magic code verification attempt
+		recordTracksEvent( 'calypso_login_magic_code_submit', {
+			code_length: verificationCode.length,
+		} );
+
 		// Format: publicToken:code
 		const loginToken = `${ publicToken }:${ btoa( verificationCode ) }`;
 
-		authenticate( loginToken, redirectTo );
+		authenticate( loginToken, redirectTo, null, true );
 	};
 
 	const isDisabled = isValidating || isRedirecting;
@@ -262,6 +268,7 @@ const mapState = ( state ) => ( {
 
 const mapDispatch = {
 	fetchMagicLoginAuthenticate,
+	recordTracksEvent,
 };
 
 export default connect( mapState, mapDispatch )( localize( VerifyLoginCode ) );

--- a/client/state/data-layer/wpcom/auth/send-login-email/index.js
+++ b/client/state/data-layer/wpcom/auth/send-login-email/index.js
@@ -44,15 +44,29 @@ export const sendLoginEmail = ( action ) => {
 			? [ { type: MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_FETCH } ]
 			: [] ),
 		...( requestLoginEmailFormFlow
-			? [ recordTracksEventWithClientId( 'calypso_login_email_link_submit' ) ]
+			? [
+					recordTracksEventWithClientId( 'calypso_login_email_link_submit', {
+						token_type: tokenType,
+						flow: flow,
+					} ),
+			  ]
 			: [] ),
 		...( loginFormFlow
-			? [ recordTracksEventWithClientId( 'calypso_login_block_login_form_send_magic_link' ) ]
+			? [
+					recordTracksEventWithClientId( 'calypso_login_block_login_form_send_magic_link', {
+						token_type: tokenType,
+						flow: flow,
+					} ),
+			  ]
 			: [] ),
 		...( createAccount
 			? [
 					recordTracksEventWithClientId(
-						'calypso_login_block_login_form_send_account_create_magic_link'
+						'calypso_login_block_login_form_send_account_create_magic_link',
+						{
+							token_type: tokenType,
+							flow: flow,
+						}
 					),
 			  ]
 			: [] ),
@@ -86,7 +100,15 @@ export const sendLoginEmail = ( action ) => {
 };
 
 export const onSuccess = (
-	{ email, showGlobalNotices, infoNoticeId = null, loginFormFlow, requestLoginEmailFormFlow },
+	{
+		email,
+		showGlobalNotices,
+		infoNoticeId = null,
+		loginFormFlow,
+		requestLoginEmailFormFlow,
+		tokenType,
+		flow,
+	},
 	response
 ) => [
 	...( loginFormFlow || requestLoginEmailFormFlow
@@ -96,10 +118,20 @@ export const onSuccess = (
 		  ]
 		: [] ),
 	...( requestLoginEmailFormFlow
-		? [ recordTracksEventWithClientId( 'calypso_login_email_link_success' ) ]
+		? [
+				recordTracksEventWithClientId( 'calypso_login_email_link_success', {
+					token_type: tokenType,
+					flow: flow,
+				} ),
+		  ]
 		: [] ),
 	...( loginFormFlow
-		? [ recordTracksEventWithClientId( 'calypso_login_block_login_form_send_magic_link_success' ) ]
+		? [
+				recordTracksEventWithClientId( 'calypso_login_block_login_form_send_magic_link_success', {
+					token_type: tokenType,
+					flow: flow,
+				} ),
+		  ]
 		: [] ),
 	// Default Global Notice Handling
 	...( showGlobalNotices
@@ -113,7 +145,14 @@ export const onSuccess = (
 ];
 
 export const onError = (
-	{ showGlobalNotices, infoNoticeId = null, loginFormFlow, requestLoginEmailFormFlow },
+	{
+		showGlobalNotices,
+		infoNoticeId = null,
+		loginFormFlow,
+		requestLoginEmailFormFlow,
+		tokenType,
+		flow,
+	},
 	error
 ) => [
 	...( loginFormFlow || requestLoginEmailFormFlow
@@ -129,6 +168,8 @@ export const onError = (
 				recordTracksEventWithClientId( 'calypso_login_email_link_failure', {
 					error_code: error.error,
 					error_message: error.message,
+					token_type: tokenType,
+					flow: flow,
 				} ),
 		  ]
 		: [] ),
@@ -137,6 +178,8 @@ export const onError = (
 				recordTracksEventWithClientId( 'calypso_login_block_login_form_send_magic_link_failure', {
 					error_code: error.error,
 					error_message: error.message,
+					token_type: tokenType,
+					flow: flow,
 				} ),
 		  ]
 		: [] ),


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Adds extended tracking for the login flow, to detect magic login as well

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To have better metrics for the magic code login

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `localStorage.setItem('debug', 'dops:analytics');` in the console
* Test the login flow
* Check that the events are being recorded in Tracks

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
