### PR TITLE
Subscribers imports - Add notice to clarify free plan limit.

### DIFF
--- a/client/my-sites/importer/newsletter/subscribers/step-initial.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-initial.tsx
@@ -7,8 +7,7 @@ import { external } from '@wordpress/icons';
 import { useTranslate, fixMe } from 'i18n-calypso';
 import { useEffect, useRef } from 'react';
 import InlineSupportLink from 'calypso/components/inline-support-link';
-import { useSelector } from 'calypso/state';
-import isSiteOnFreePlan from 'calypso/state/selectors/is-site-on-free-plan';
+import SubscriberImportLimitNotice from 'calypso/my-sites/subscribers/components/subscriber-import-limit-notice';
 import { SubscribersStepProps } from '../types';
 import { normalizeFromSite } from '../utils';
 import SubscriberUploadForm from './upload-form';
@@ -37,8 +36,6 @@ export default function StepInitial( {
 		}
 		prevInProgress.current = importSelector?.inProgress;
 	}, [ importSelector?.inProgress, setAutoFetchData ] );
-
-	const isOnFreePlan = useSelector( ( state ) => isSiteOnFreePlan( state, selectedSite.ID ) );
 
 	return (
 		<Card>
@@ -74,31 +71,7 @@ export default function StepInitial( {
 					),
 				} ) }
 			</p>
-			{ isOnFreePlan && (
-				<p>
-					{ fixMe( {
-						text: 'Note: On the free plan, you can import up to 100 subscribers.',
-						newCopy: translate(
-							'Note: On the free plan, {{supportLink}}you can import up to 100 subscribers.{{/supportLink}}',
-							{
-								components: {
-									supportLink: (
-										<InlineSupportLink
-											noWrap={ false }
-											showIcon={ false }
-											supportLink={ localizeUrl(
-												'https://wordpress.com/support/import-subscribers-to-a-newsletter/#import-limits'
-											) }
-											supportPostId={ 220199 }
-										/>
-									),
-								},
-							}
-						),
-						oldCopy: '',
-					} ) }
-				</p>
-			) }
+
 			<Button
 				href={ `https://${ normalizeFromSite( fromSite ) }/publish/subscribers` }
 				target="_blank"
@@ -111,6 +84,7 @@ export default function StepInitial( {
 			</Button>
 			<hr />
 			<h2>{ translate( 'Step 2: Import your subscribers' ) }</h2>
+			<SubscriberImportLimitNotice />
 			{ selectedSite.ID && (
 				<SubscriberUploadForm
 					siteId={ selectedSite.ID }

--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -23,6 +23,7 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
+import SubscriberImportLimitNotice from '../subscriber-import-limit-notice';
 import { StaleImportJobsNotice } from './stale-job-notice';
 
 import './style.scss';
@@ -180,6 +181,7 @@ const AddSubscribersModal = ( {
 							</span>
 						</Notice>
 					) }
+					<SubscriberImportLimitNotice />
 					{ ! isUploading && isImportInProgress && hasStaleImportJobs && (
 						<StaleImportJobsNotice isJetpack={ isJetpack } siteId={ site?.ID || null } />
 					) }
@@ -228,6 +230,7 @@ const AddSubscribersModal = ( {
 							</span>
 						</Notice>
 					) }
+					<SubscriberImportLimitNotice />
 					{ ! isUploading && isImportInProgress && hasStaleImportJobs && (
 						<StaleImportJobsNotice isJetpack={ isJetpack } siteId={ site?.ID || null } />
 					) }

--- a/client/my-sites/subscribers/components/subscriber-import-limit-notice/index.tsx
+++ b/client/my-sites/subscribers/components/subscriber-import-limit-notice/index.tsx
@@ -1,16 +1,19 @@
+import { isJetpackFreePlan, isFreePlan } from '@automattic/calypso-products';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Notice } from '@wordpress/components';
 import { useTranslate, fixMe } from 'i18n-calypso';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useSelector } from 'calypso/state';
-import isSiteOnFreePlan from 'calypso/state/selectors/is-site-on-free-plan';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import './style.scss';
 
 export default function SubscriberImportLimitNotice() {
 	const translate = useTranslate();
 	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) ) || { ID: 0, slug: '' };
-	const isOnFreePlan = useSelector( ( state ) => isSiteOnFreePlan( state, selectedSite.ID ) );
+	const currentPlan = useSelector( ( state ) => getCurrentPlan( state, selectedSite.ID ) );
+	const isOnFreePlan =
+		isFreePlan( currentPlan?.productSlug ) || isJetpackFreePlan( currentPlan?.productSlug );
 
 	if ( ! isOnFreePlan || ! selectedSite.ID ) {
 		return null;

--- a/client/my-sites/subscribers/components/subscriber-import-limit-notice/index.tsx
+++ b/client/my-sites/subscribers/components/subscriber-import-limit-notice/index.tsx
@@ -1,0 +1,61 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { Notice } from '@wordpress/components';
+import { useTranslate, fixMe } from 'i18n-calypso';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import { useSelector } from 'calypso/state';
+import isSiteOnFreePlan from 'calypso/state/selectors/is-site-on-free-plan';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import './styles.scss';
+
+export default function SubscriberImportLimitNotice() {
+	const translate = useTranslate();
+	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) ) || { ID: 0, slug: '' };
+	const isOnFreePlan = useSelector( ( state ) => isSiteOnFreePlan( state, selectedSite.ID ) );
+
+	if ( ! isOnFreePlan || ! selectedSite.ID ) {
+		return null;
+	}
+
+	return (
+		<Notice status="info" isDismissible={ false } className="subscribers-import-limit-notice">
+			{ fixMe( {
+				text: 'Note: On the free plan, you can import up to 100 subscribers.',
+				newCopy: translate(
+					'Import {{supportLink}}up to 100 subscribers{{/supportLink}} on the Free plan. {{upgradeLink}}Upgrade{{/upgradeLink}} to add more.',
+					{
+						components: {
+							supportLink: (
+								<InlineSupportLink
+									noWrap={ false }
+									showIcon={ false }
+									supportLink={ localizeUrl(
+										'https://wordpress.com/support/import-subscribers-to-a-newsletter/#import-limits'
+									) }
+									supportPostId={ 220199 }
+								/>
+							),
+							upgradeLink: <a href={ `/plans/${ selectedSite.slug }` } />,
+						},
+					}
+				),
+				oldCopy: translate(
+					'Note: On the free plan, {{supportLink}}you can import up to 100 subscribers.{{/supportLink}}',
+					{
+						components: {
+							supportLink: (
+								<InlineSupportLink
+									noWrap={ false }
+									showIcon={ false }
+									supportLink={ localizeUrl(
+										'https://wordpress.com/support/import-subscribers-to-a-newsletter/#import-limits'
+									) }
+									supportPostId={ 220199 }
+								/>
+							),
+						},
+					}
+				),
+			} ) }
+		</Notice>
+	);
+}

--- a/client/my-sites/subscribers/components/subscriber-import-limit-notice/index.tsx
+++ b/client/my-sites/subscribers/components/subscriber-import-limit-notice/index.tsx
@@ -4,18 +4,16 @@ import { Notice } from '@wordpress/components';
 import { useTranslate, fixMe } from 'i18n-calypso';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useSelector } from 'calypso/state';
-import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import './style.scss';
 
 export default function SubscriberImportLimitNotice() {
 	const translate = useTranslate();
-	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) ) || { ID: 0, slug: '' };
-	const currentPlan = useSelector( ( state ) => getCurrentPlan( state, selectedSite.ID ) );
-	const isOnFreePlan =
-		isFreePlan( currentPlan?.productSlug ) || isJetpackFreePlan( currentPlan?.productSlug );
+	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
+	const currentPlan = selectedSite?.plan?.product_slug || '';
+	const isOnFreePlan = isFreePlan( currentPlan ) || isJetpackFreePlan( currentPlan );
 
-	if ( ! isOnFreePlan || ! selectedSite.ID ) {
+	if ( ! isOnFreePlan || ! selectedSite?.ID ) {
 		return null;
 	}
 

--- a/client/my-sites/subscribers/components/subscriber-import-limit-notice/index.tsx
+++ b/client/my-sites/subscribers/components/subscriber-import-limit-notice/index.tsx
@@ -20,7 +20,7 @@ export default function SubscriberImportLimitNotice() {
 	return (
 		<Notice status="info" isDismissible={ false } className="subscribers-import-limit-notice">
 			{ fixMe( {
-				text: 'Note: On the free plan, you can import up to 100 subscribers.',
+				text: 'Import up to 100 subscribers on the Free plan. Upgrade to add more.',
 				newCopy: translate(
 					'Import {{supportLink}}up to 100 subscribers{{/supportLink}} on the Free plan. {{upgradeLink}}Upgrade{{/upgradeLink}} to add more.',
 					{

--- a/client/my-sites/subscribers/components/subscriber-import-limit-notice/index.tsx
+++ b/client/my-sites/subscribers/components/subscriber-import-limit-notice/index.tsx
@@ -5,7 +5,7 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useSelector } from 'calypso/state';
 import isSiteOnFreePlan from 'calypso/state/selectors/is-site-on-free-plan';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import './styles.scss';
+import './style.scss';
 
 export default function SubscriberImportLimitNotice() {
 	const translate = useTranslate();

--- a/client/my-sites/subscribers/components/subscriber-import-limit-notice/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-import-limit-notice/style.scss
@@ -1,0 +1,3 @@
+.subscribers-import-limit-notice {
+	margin-bottom: 16px;
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/CML-450/enhancement-clear-notification-for-subscriber-import-limit-exceeded / https://github.com/Automattic/jetpack/issues/38657

## Proposed Changes

* Creates a shared notice component for the subscribers import limit that only renders if the site is on a free (or jetpack free) plan.
* Adds this notice to both the add and upload subscribers modals (shown in calypso and jetpack cloud).
* Removes the previous copy about this in the substack import subscribers step, and adds the notice to the import section below.


AFTER

<img width="600" src="https://github.com/user-attachments/assets/412096d9-44ec-46c2-ac32-bf91bd2b2486" />

![Screenshot 2025-06-10 at 7 42 03 AM](https://github.com/user-attachments/assets/1d6fd28b-6432-4d85-a9d9-ddf632a708f4)

![Screenshot 2025-06-10 at 8 05 48 AM](https://github.com/user-attachments/assets/fa091530-69a7-4d99-b09a-39d1150ce2a6)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve clarity on import limit.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Calypso
* Goto calypso with a free plan site.
* In users -> subscribers, verify that the add modal and upload modal both contain the notice as shown above.
* Verify the first link opens the help center to the info about the subscribers limit.
* Verify the second link opens plans page.
* Go to the substack importer and skip to the upload subscribers step, verify the notice is shown in the bottom import section.
* Repeat on a site with a paid plan, verify the notices are not visible.

Jetpack cloud
* Goto jetpack cloud with a free jetpack site.
* In subscribers, verify the add and upload modals both show the notice.
* Verify the first link opens the help center to the info about the subscribers limit.
* Verify the second link opens plans page.
* For import, you will need to use your jetpack site slug in the URL with the calypso build you used above (clicking it from cloud will take you to production calypso). Verify the notice is present.
* Purchase a jetpack plan or use a site with one, repeat the above. Verify the notices are not present.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
