### PR TITLE
A4A: Update the overview page to complement the unified onboarding tour flow.

### DIFF
--- a/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour-sections.tsx
+++ b/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour-sections.tsx
@@ -19,7 +19,7 @@ import {
 	A4A_MIGRATIONS_LINK,
 	A4A_OVERVIEW_LINK,
 	A4A_PURCHASES_LINK,
-	A4A_REFERRALS_LINK,
+	A4A_REFERRALS_DASHBOARD,
 	A4A_SITES_LINK,
 	A4A_AGENCY_TIER_LINK,
 	A4A_TEAM_LINK,
@@ -209,7 +209,7 @@ export default function useOnboardingTourSections() {
 						{
 							label: translate( 'View Referrals Dashboard' ),
 							variant: 'secondary',
-							href: A4A_REFERRALS_LINK,
+							href: A4A_REFERRALS_DASHBOARD,
 							onClick: () => onExplore( 'referrals', onClose ),
 						},
 						{

--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/celebration-modal/feature-announcement.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/celebration-modal/feature-announcement.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import EmergingPartnerBackground from 'calypso/assets/images/a8c-for-agencies/agency-tier/announcement-background.svg';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -32,7 +33,8 @@ const AgencyTierFeatureAnnouncement = () => {
 		dispatch( recordTracksEvent( 'calypso_a8c_agency_tier_announcement_modal_cta_click' ) );
 	};
 
-	if ( isDismissed ) {
+	// If the new unified onboarding tour is enabled, we do not need to show the modal.
+	if ( isDismissed || isEnabled( 'a4a-unified-onboarding-tour' ) ) {
 		return null;
 	}
 

--- a/client/a8c-for-agencies/sections/overview/sidebar/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/index.tsx
@@ -7,13 +7,19 @@ import OverviewSidebarQuickLinks from './quick-links';
 import OverviewSidebarRelaunchWelcomeTour from './relaunch-welcome-tour';
 
 const OverviewSidebar = () => {
+	const isNewArrangement = isEnabled( 'a4a-unified-onboarding-tour' );
 	return (
 		<div className="overview-sidebar">
-			{ isEnabled( 'a4a-unified-onboarding-tour' ) && <OverviewSidebarRelaunchWelcomeTour /> }
+			{ isNewArrangement && (
+				<>
+					<OverviewSidebarRelaunchWelcomeTour />
+					<OverviewSidebarGrowthAccelerator />
+				</>
+			) }
 			{ isEnabled( 'a8c-for-agencies-agency-tier' ) && <OverviewSidebarAgencyTier /> }
-			<OverviewSidebarQuickLinks />
+			{ ! isNewArrangement && <OverviewSidebarQuickLinks /> }
 			<OverviewSidebarFeaturedWooPayments />
-			<OverviewSidebarGrowthAccelerator />
+			{ ! isNewArrangement && <OverviewSidebarGrowthAccelerator /> }
 			<OverviewSidebarContactSupport />
 		</div>
 	);

--- a/client/a8c-for-agencies/sections/signup/primary/agency-signup-finish/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/primary/agency-signup-finish/index.tsx
@@ -1,8 +1,10 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { APIError } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import A4ALogo, { LOGO_COLOR_SECONDARY_ALT } from 'calypso/a8c-for-agencies/components/a4a-logo';
+import { ONBOARDING_TOUR_HASH } from 'calypso/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour';
 import {
 	A4A_OVERVIEW_LINK,
 	A4A_SIGNUP_LINK,
@@ -47,7 +49,12 @@ export default function AgencySignupFinish() {
 	useEffect( () => {
 		if ( agency ) {
 			// Redirect to the sites page if the user already has an agency record.
-			page.redirect( A4A_OVERVIEW_LINK );
+
+			if ( isEnabled( 'a4a-unified-onboarding-tour' ) ) {
+				page.redirect( `${ A4A_OVERVIEW_LINK }${ ONBOARDING_TOUR_HASH }` );
+			} else {
+				page.redirect( A4A_OVERVIEW_LINK );
+			}
 		}
 	}, [ agency ] );
 


### PR DESCRIPTION
This PR introduces several changes that update the overview page to complement the new onboarding tour flow.

Depends on https://github.com/Automattic/wp-calypso/pull/103931
Closes https://linear.app/a8c/issue/A4A-1055/overview-page-remove-redundant-elements
Closes https://linear.app/a8c/issue/A4A-1069/signup-auto-display-onboarding-tour-modal-after-signup

## Proposed Changes

| | Description | Screenshot |
|--------|--------|--------|
| 1 | This PR reorganizes the sidebar menu on the overview page. The Growth call card is now positioned above the Agency tier card, and the quick links have been eliminated. | <img width="895" alt="Screenshot 2025-06-10 at 7 53 06 PM" src="https://github.com/user-attachments/assets/a210188c-907f-4517-975e-1108361e88c1" /> |
| 2 | The announcement regarding the Agency Tier has been suppressed and will no longer appear. | <img width="962" alt="Screenshot 2025-06-10 at 7 54 19 PM" src="https://github.com/user-attachments/assets/0ce5eb0e-1e0a-4360-8013-6beb8f7294ee" /> |
| 3 | Signup will now redirect the user to the onboarding tour right after completing the signup. | <img width="919" alt="Screenshot 2025-06-10 at 7 55 29 PM" src="https://github.com/user-attachments/assets/32ff7029-5104-4c44-bd31-826ccd0f37a7" /> | 

## Why are these changes being made?
* This is part of the Agency onboarding improvement part 2 project.

## Testing Instructions

### Test 1 (Overview page)
* Use the A4A live link and navigate to `/overview`.
* Confirm that the sidebar is arranged correctly. See screenshot above.

### Test 2 (Agency Tier announcement)
* Make sure you clear the `a4a-agency-tier-announcement-modal-dismissed` preference before testing.
* Use the A4A live link and navigate to `/overview`.
* Confirm that the announcement no longer appears.

### Test 3 (Signup)
* Spin up this branch locally.
* Navigate to http://agencies.localhost:3000/signup
* Complete a signup.
* Confirm you are redirected to the Unified Onboarding tour. `/overview#onboarding-tour`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
