### PR TITLE
A4A: Add Swipe gesture on the Onboard tour mobile navigation.

### DIFF
--- a/client/a8c-for-agencies/components/onboarding-tour-modal/index.tsx
+++ b/client/a8c-for-agencies/components/onboarding-tour-modal/index.tsx
@@ -14,6 +14,7 @@ import {
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { ONBOARDING_TOUR_HASH } from '../hoc/with-onboarding-tour/hooks/use-onboarding-tour';
+import OnboardingTourModalMobileNavigation from './mobile-navigation';
 import OnboardingTourModalSection, {
 	ActionProps,
 	OnboardingTourModalSectionProps,
@@ -163,31 +164,19 @@ function OnboardingTourModal( { onClose, children }: OnboardingTourModalProps ) 
 						<div className="onboarding-tour-modal__main-content-footer">
 							{ actions }
 
-							<div className="onboarding-tour-modal__main-content-footer-navigation">
-								{ menuItems.map( ( menuItem ) => (
-									<button
-										className={ clsx(
-											'onboarding-tour-modal__main-content-footer-navigation-button',
-											{
-												'is-active': menuItem.id === currentSectionId,
-											}
-										) }
-										key={ menuItem.id }
-										onClick={ () => {
-											setCurrentSectionId( menuItem.id );
-											dispatch(
-												recordTracksEvent(
-													'calypso_onboarding_tour_modal_section_menu_item_click',
-													{
-														section: menuItem.id,
-													}
-												)
-											);
-										} }
-										aria-label={ menuItem.label }
-									/>
-								) ) }
-							</div>
+							<OnboardingTourModalMobileNavigation
+								menuItems={ menuItems }
+								currentSectionId={ currentSectionId }
+								setCurrentSectionId={ ( sectionId ) => {
+									setCurrentSectionId( sectionId );
+									window.location.hash = `${ ONBOARDING_TOUR_HASH }-${ sectionId }`;
+									dispatch(
+										recordTracksEvent( 'calypso_onboarding_tour_modal_section_menu_item_swipe', {
+											section: sectionId,
+										} )
+									);
+								} }
+							/>
 						</div>
 					</div>
 				</div>

--- a/client/a8c-for-agencies/components/onboarding-tour-modal/mobile-navigation.tsx
+++ b/client/a8c-for-agencies/components/onboarding-tour-modal/mobile-navigation.tsx
@@ -1,0 +1,66 @@
+import clsx from 'clsx';
+import { useCallback } from 'react';
+
+type Props = {
+	menuItems: {
+		id: string;
+		label: string;
+	}[];
+	currentSectionId: string | null;
+	setCurrentSectionId: ( sectionId: string ) => void;
+};
+
+export default function OnboardingTourModalMobileNavigation( {
+	menuItems,
+	currentSectionId,
+	setCurrentSectionId,
+}: Props ) {
+	const onSwipe = useCallback(
+		( e ) => {
+			// Prevent scrolling while touching navigation
+			e.preventDefault();
+
+			// Get touch location
+			const touch = e.touches[ 0 ];
+
+			// Get navigation element bounds
+			const navBounds = e.currentTarget.getBoundingClientRect();
+
+			// Calculate which button is being touched based on x position
+			const buttonWidth = navBounds.width / menuItems.length;
+			const touchX = touch.clientX - navBounds.left;
+			const buttonIndex = Math.floor( touchX / buttonWidth );
+
+			// Ensure valid index and change section if needed
+			if ( buttonIndex >= 0 && buttonIndex < menuItems.length ) {
+				const sectionId = menuItems[ buttonIndex ].id;
+				if ( sectionId !== currentSectionId ) {
+					setCurrentSectionId( sectionId );
+				}
+			}
+		},
+		[ currentSectionId, menuItems, setCurrentSectionId ]
+	);
+
+	return (
+		<div className="onboarding-tour-modal__main-content-footer-navigation-wrapper">
+			<div
+				className="onboarding-tour-modal__main-content-footer-navigation"
+				onTouchMove={ onSwipe }
+			>
+				{ menuItems.map( ( menuItem ) => (
+					<button
+						className={ clsx( 'onboarding-tour-modal__main-content-footer-navigation-button', {
+							'is-active': menuItem.id === currentSectionId,
+						} ) }
+						key={ menuItem.id }
+						onClick={ () => {
+							setCurrentSectionId( menuItem.id );
+						} }
+						aria-label={ menuItem.label }
+					/>
+				) ) }
+			</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/components/onboarding-tour-modal/mobile-navigation.tsx
+++ b/client/a8c-for-agencies/components/onboarding-tour-modal/mobile-navigation.tsx
@@ -16,7 +16,7 @@ export default function OnboardingTourModalMobileNavigation( {
 	setCurrentSectionId,
 }: Props ) {
 	const onSwipe = useCallback(
-		( e ) => {
+		( e: React.TouchEvent< HTMLDivElement > ) => {
 			// Prevent scrolling while touching navigation
 			e.preventDefault();
 

--- a/client/a8c-for-agencies/components/onboarding-tour-modal/style.scss
+++ b/client/a8c-for-agencies/components/onboarding-tour-modal/style.scss
@@ -123,8 +123,14 @@ $mobile-footer-height: 150px;
 	}
 }
 
+.onboarding-tour-modal__main-content-footer-navigation-wrapper {
+	text-align: center;
+	margin: 0;
+	padding: 0;
+}
+
 .onboarding-tour-modal__main-content-footer-navigation {
-	display: flex;
+	display: inline-flex;
 	align-items: center;
 	justify-content: center;
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/54d6d621-de84-4267-8549-d7347de69e71

Depends on https://github.com/Automattic/wp-calypso/pull/104035
Closes https://linear.app/a8c/issue/A4A-1057/welcome-tour-implement-swipe-gesture-on-mobile-view

## Proposed Changes

* Add an onTouch event listener on the navigation menu container.

## Why are these changes being made?

This is part of the Agency onboarding improvement part 2 project.

## Testing Instructions

* Use the A4A live link and navigate to `/overview#onboarding-tour`
* Set your browser to mobile view.
* Do a swipe movement on the mobile navigation menu and verify it is working.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
