### PR TITLE
Accessibility: Improve the VoiceOver on domains filter

### DIFF
--- a/client/components/domains/search-filters/dropdown-filters.jsx
+++ b/client/components/domains/search-filters/dropdown-filters.jsx
@@ -98,6 +98,21 @@ export class DropdownFilters extends Component {
 
 	render() {
 		const hasFilterValues = this.getFiltercounts() > 0;
+		const { translate } = this.props;
+
+		let ariaLabel = '';
+		if ( hasFilterValues ) {
+			ariaLabel = translate(
+				'Filter, %(filterCount)s filter applied',
+				'Filter, %(filterCount)s filters applied',
+				{
+					count: this.getFiltercounts(),
+					args: { filterCount: this.getFiltercounts() },
+				}
+			);
+		} else {
+			ariaLabel = translate( 'Filter, no filters applied' );
+		}
 
 		return (
 			<div
@@ -113,8 +128,8 @@ export class DropdownFilters extends Component {
 					ref={ this.button }
 					onClick={ this.togglePopover }
 				>
-					<span className="search-filters__dropdown-filters-button-text">
-						{ this.props.translate( 'Filter' ) }
+					<span className="search-filters__dropdown-filters-button-text" aria-label={ ariaLabel }>
+						{ translate( 'Filter' ) }
 						{ hasFilterValues && <Count primary count={ this.getFiltercounts() } /> }
 					</span>
 				</Button>

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -175,8 +175,6 @@ class TokenField extends PureComponent {
 					items: this.props.value.map( this.props.displayTransform ).join( ', ' ),
 				},
 			} );
-		} else {
-			ariaLabel = translate( 'Search to add items' );
 		}
 
 		let props = {

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -92,9 +92,6 @@ class TokenField extends PureComponent {
 		let tokenFieldProps = {
 			ref: 'main',
 			className: classes,
-			tabIndex: '-1',
-			'aria-haspopup': 'listbox',
-			'aria-owns': 'options-list',
 		};
 
 		if ( ! this.props.disabled ) {
@@ -107,13 +104,12 @@ class TokenField extends PureComponent {
 
 		return (
 			<div { ...tokenFieldProps }>
+				{ /* eslint-disable jsx-a11y/no-static-element-interactions */ }
 				<div
 					ref={ this.setTokensAndInput }
 					className="token-field__input-container"
-					tabIndex="-1"
 					onMouseDown={ this._onContainerTouched }
 					onTouchStart={ this._onContainerTouched }
-					role="listbox"
 				>
 					{ this._renderTokensAndInput() }
 				</div>
@@ -194,7 +190,7 @@ class TokenField extends PureComponent {
 			onBlur: this._onBlur,
 			spellCheck,
 			value: this.state.incompleteTokenValue,
-			role: 'textbox',
+			'aria-owns': 'options-list',
 			'aria-controls': 'options-list',
 			'aria-activedescendant': `option-${ this._getSelectedSuggestion() }`,
 			'aria-label': ariaLabel,

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import debugFactory from 'debug';
+import { translate } from 'i18n-calypso';
 import { difference } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
@@ -92,6 +93,8 @@ class TokenField extends PureComponent {
 			ref: 'main',
 			className: classes,
 			tabIndex: '-1',
+			'aria-haspopup': 'listbox',
+			'aria-owns': 'options-list',
 		};
 
 		if ( ! this.props.disabled ) {
@@ -110,7 +113,7 @@ class TokenField extends PureComponent {
 					tabIndex="-1"
 					onMouseDown={ this._onContainerTouched }
 					onTouchStart={ this._onContainerTouched }
-					role="textbox"
+					role="listbox"
 				>
 					{ this._renderTokensAndInput() }
 				</div>
@@ -168,6 +171,18 @@ class TokenField extends PureComponent {
 			value,
 		} = this.props;
 
+		let ariaLabel = '';
+		if ( this.props.value.length > 0 ) {
+			/* translators: %(items)s is a comma-separated list of selected items */
+			ariaLabel = translate( 'Selected: %(items)s. Search to add more.', {
+				args: {
+					items: this.props.value.map( this.props.displayTransform ).join( ', ' ),
+				},
+			} );
+		} else {
+			ariaLabel = translate( 'Search to add items' );
+		}
+
 		let props = {
 			autoCapitalize,
 			autoComplete,
@@ -179,6 +194,10 @@ class TokenField extends PureComponent {
 			onBlur: this._onBlur,
 			spellCheck,
 			value: this.state.incompleteTokenValue,
+			role: 'textbox',
+			'aria-controls': 'options-list',
+			'aria-activedescendant': `option-${ this._getSelectedSuggestion() }`,
+			'aria-label': ariaLabel,
 		};
 
 		if ( value.length === 0 && placeholder ) {

--- a/client/components/token-field/suggestions-list.jsx
+++ b/client/components/token-field/suggestions-list.jsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import { translate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { createRef, PureComponent } from 'react';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
@@ -72,12 +73,15 @@ class SuggestionsList extends PureComponent {
 			'is-expanded': this.props.isExpanded && this.props.suggestions.length > 0,
 		} );
 
-		// We set `tabIndex` here because otherwise Firefox sets focus on this
-		// div when tabbing off of the input in `TokenField` -- not really sure
-		// why, since usually a div isn't focusable by default
-		// TODO does this still apply now that it's a <ul> and not a <div>?
 		return (
-			<ul ref={ this.listRef } className={ classes } tabIndex="-1">
+			<ul
+				id="options-list"
+				ref={ this.listRef }
+				className={ classes }
+				role="listbox"
+				tabindex="0"
+				aria-label={ translate( 'Options' ) }
+			>
 				{ this._renderSuggestions() }
 			</ul>
 		);
@@ -112,7 +116,13 @@ class SuggestionsList extends PureComponent {
 
 			if ( isLabel ) {
 				return (
-					<li className={ classes } key={ `label_${ suggestion.label }` }>
+					<li
+						id={ `option-${ index }` }
+						className={ classes }
+						key={ `label_${ suggestion.label }` }
+						role="presentation"
+						aria-hidden="true"
+					>
 						{ suggestion.label }
 					</li>
 				);
@@ -123,11 +133,21 @@ class SuggestionsList extends PureComponent {
 			return (
 				// eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-noninteractive-element-interactions
 				<li
+					id={ `option-${ suggestion }` }
 					className={ classes }
 					key={ suggestion }
 					onMouseDown={ this._handleMouseDown }
 					onClick={ this._handleClick( suggestion ) }
 					onMouseEnter={ this._handleHover( suggestion ) }
+					role="option"
+					aria-selected={ index === this.props.selectedIndex }
+					onKeyDown={ this._handleKeyDown( suggestion ) }
+					/* translators: %(item)s is the option that can be selected */
+					aria-label={ translate( 'Option %(item)s', {
+						args: {
+							item: this.props.displayTransform( suggestion ),
+						},
+					} ) }
 				>
 					{ match ? (
 						<span>
@@ -161,6 +181,15 @@ class SuggestionsList extends PureComponent {
 		// By preventing default here, we will not lose focus of <input> when clicking a suggestion
 		e.preventDefault();
 	};
+
+	_handleKeyDown( suggestion ) {
+		return ( event ) => {
+			if ( event.key === 'Enter' || event.key === ' ' ) {
+				event.preventDefault();
+				this.props.onSelect( suggestion );
+			}
+		};
+	}
 }
 
 export default SuggestionsList;

--- a/client/components/token-field/suggestions-list.jsx
+++ b/client/components/token-field/suggestions-list.jsx
@@ -79,7 +79,7 @@ class SuggestionsList extends PureComponent {
 				ref={ this.listRef }
 				className={ classes }
 				role="listbox"
-				tabindex="0"
+				tabIndex="0"
 				aria-label={ translate( 'Options' ) }
 			>
 				{ this._renderSuggestions() }

--- a/client/components/token-field/test/__snapshots__/index.jsx.snap
+++ b/client/components/token-field/test/__snapshots__/index.jsx.snap
@@ -4,12 +4,9 @@ exports[`TokenField render should render tokens 1`] = `
 <div>
   <div
     class="token-field"
-    tabindex="-1"
   >
     <div
       class="token-field__input-container"
-      role="textbox"
-      tabindex="-1"
     >
       <span
         class="token-field__token"
@@ -54,6 +51,10 @@ exports[`TokenField render should render tokens 1`] = `
         </svg>
       </span>
       <input
+        aria-activedescendant="option-undefined"
+        aria-controls="options-list"
+        aria-label="Selected: foo, bar. Search to add more."
+        aria-owns="options-list"
         class="form-text-input token-field__input"
         placeholder=""
         size="1"
@@ -62,176 +63,315 @@ exports[`TokenField render should render tokens 1`] = `
       />
     </div>
     <ul
+      aria-label="Options"
       class="token-field__suggestions-list"
-      tabindex="-1"
+      id="options-list"
+      role="listbox"
+      tabindex="0"
     >
       <li
+        aria-label="Option the"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-the"
+        role="option"
       >
         the
       </li>
       <li
+        aria-label="Option of"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-of"
+        role="option"
       >
         of
       </li>
       <li
+        aria-label="Option and"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-and"
+        role="option"
       >
         and
       </li>
       <li
+        aria-label="Option to"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-to"
+        role="option"
       >
         to
       </li>
       <li
+        aria-label="Option a"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-a"
+        role="option"
       >
         a
       </li>
       <li
+        aria-label="Option in"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-in"
+        role="option"
       >
         in
       </li>
       <li
+        aria-label="Option for"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-for"
+        role="option"
       >
         for
       </li>
       <li
+        aria-label="Option is"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-is"
+        role="option"
       >
         is
       </li>
       <li
+        aria-label="Option on"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-on"
+        role="option"
       >
         on
       </li>
       <li
+        aria-label="Option that"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-that"
+        role="option"
       >
         that
       </li>
       <li
+        aria-label="Option by"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-by"
+        role="option"
       >
         by
       </li>
       <li
+        aria-label="Option this"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-this"
+        role="option"
       >
         this
       </li>
       <li
+        aria-label="Option with"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-with"
+        role="option"
       >
         with
       </li>
       <li
+        aria-label="Option i"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-i"
+        role="option"
       >
         i
       </li>
       <li
+        aria-label="Option you"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-you"
+        role="option"
       >
         you
       </li>
       <li
+        aria-label="Option it"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-it"
+        role="option"
       >
         it
       </li>
       <li
+        aria-label="Option not"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-not"
+        role="option"
       >
         not
       </li>
       <li
+        aria-label="Option or"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-or"
+        role="option"
       >
         or
       </li>
       <li
+        aria-label="Option be"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-be"
+        role="option"
       >
         be
       </li>
       <li
+        aria-label="Option are"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-are"
+        role="option"
       >
         are
       </li>
       <li
+        aria-label="Option from"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-from"
+        role="option"
       >
         from
       </li>
       <li
+        aria-label="Option at"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-at"
+        role="option"
       >
         at
       </li>
       <li
+        aria-label="Option as"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-as"
+        role="option"
       >
         as
       </li>
       <li
+        aria-label="Option your"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-your"
+        role="option"
       >
         your
       </li>
       <li
+        aria-label="Option all"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-all"
+        role="option"
       >
         all
       </li>
       <li
+        aria-label="Option have"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-have"
+        role="option"
       >
         have
       </li>
       <li
+        aria-label="Option new"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-new"
+        role="option"
       >
         new
       </li>
       <li
+        aria-label="Option more"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-more"
+        role="option"
       >
         more
       </li>
       <li
+        aria-label="Option an"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-an"
+        role="option"
       >
         an
       </li>
       <li
+        aria-label="Option was"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-was"
+        role="option"
       >
         was
       </li>
       <li
+        aria-label="Option we"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-we"
+        role="option"
       >
         we
       </li>
       <li
+        aria-label="Option snake"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-snake"
+        role="option"
       >
         snake
       </li>
       <li
+        aria-label="Option pipes"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-pipes"
+        role="option"
       >
         pipes
       </li>
       <li
+        aria-label="Option sound"
+        aria-selected="false"
         class="token-field__suggestion"
+        id="option-sound"
+        role="option"
       >
         sound
       </li>

--- a/client/components/token-field/test/index.jsx
+++ b/client/components/token-field/test/index.jsx
@@ -34,7 +34,7 @@ describe( 'TokenField', () => {
 	async function setText( text ) {
 		const user = userEvent.setup();
 
-		const field = screen.getAllByRole( 'textbox' )[ 0 ];
+		const field = screen.getByRole( 'textbox' );
 		await user.clear( field );
 		if ( text.length ) {
 			await user.type( field, text );
@@ -42,14 +42,14 @@ describe( 'TokenField', () => {
 	}
 
 	function sendKeyDown( keyCode, shiftKey ) {
-		fireEvent.keyDown( screen.getAllByRole( 'textbox' )[ 0 ], {
+		fireEvent.keyDown( screen.getByRole( 'textbox' ), {
 			keyCode,
 			shiftKey: !! shiftKey,
 		} );
 	}
 
 	function sendKeyPress( charCode ) {
-		fireEvent.keyPress( screen.getAllByRole( 'textbox' )[ 0 ], {
+		fireEvent.keyPress( screen.getByRole( 'textbox' ), {
 			charCode,
 		} );
 	}
@@ -286,7 +286,7 @@ describe( 'TokenField', () => {
 			sendKeyDown( keyCodes.tab );
 
 			expect( getTokensHTML( container ) ).toEqual( [ 'foo', 'bar', 'baz' ] );
-			expect( screen.getAllByRole( 'textbox' )[ 0 ] ).toHaveAttribute( 'value', '' );
+			expect( screen.getByRole( 'textbox' ) ).toHaveAttribute( 'value', '' );
 		} );
 
 		test( 'should not allow adding blank tokens with Tab', () => {
@@ -315,7 +315,7 @@ describe( 'TokenField', () => {
 			sendKeyDown( keyCodes.enter );
 
 			expect( getTokensHTML( container ) ).toEqual( [ 'foo', 'bar', 'baz' ] );
-			expect( screen.getAllByRole( 'textbox' )[ 0 ] ).toHaveAttribute( 'value', '' );
+			expect( screen.getByRole( 'textbox' ) ).toHaveAttribute( 'value', '' );
 		} );
 
 		test( 'should not allow adding blank tokens with Enter', () => {
@@ -366,7 +366,7 @@ describe( 'TokenField', () => {
 			expect( getTokensHTML( container ) ).toEqual( [ 'foo', 'bar' ] );
 
 			// The text input does not register the < keypress when it is sent this way.
-			expect( screen.getAllByRole( 'textbox' )[ 0 ] ).toHaveAttribute( 'value', 'baz' );
+			expect( screen.getByRole( 'textbox' ) ).toHaveAttribute( 'value', 'baz' );
 		} );
 
 		test( 'should trim token values when adding', async () => {
@@ -397,12 +397,12 @@ describe( 'TokenField', () => {
 
 			function testSavedState( isActive ) {
 				expect( getTokensHTML( container ) ).toEqual( expectedTokens );
-				expect( screen.getAllByRole( 'textbox' )[ 0 ] ).toHaveAttribute( 'value', '' );
+				expect( screen.getByRole( 'textbox' ) ).toHaveAttribute( 'value', '' );
 				expect( getSelectedSuggestion( container ) ).toBeNull();
 				expect( container.querySelectorAll( '.is-active' ).length === 1 ).toBe( isActive );
 			}
 
-			const input = screen.getAllByRole( 'textbox' )[ 0 ];
+			const input = screen.getByRole( 'textbox' );
 			fireEvent.blur( input );
 			testSavedState( false );
 			fireEvent.focus( input );
@@ -450,7 +450,7 @@ describe( 'TokenField', () => {
 			const user = userEvent.setup();
 			const { container } = render( <TokenFieldWrapper /> );
 
-			screen.getAllByRole( 'textbox' )[ 0 ].focus();
+			screen.getByRole( 'textbox' ).focus();
 
 			const firstSuggestion = container.querySelectorAll( '.token-field__suggestion' )[ 0 ];
 
@@ -567,12 +567,12 @@ describe( 'TokenField', () => {
 
 			expect( getTokensHTML( container ) ).toEqual( [ 'foo', 'bar', 'baz', 'quux' ] );
 
-			expect( screen.getAllByRole( 'textbox' )[ 0 ] ).toHaveAttribute( 'value', ' wut' );
+			expect( screen.getByRole( 'textbox' ) ).toHaveAttribute( 'value', ' wut' );
 
 			await setText( 'wut,' );
 
 			expect( getTokensHTML( container ) ).toEqual( [ 'foo', 'bar', 'baz', 'quux', 'wut' ] );
-			expect( screen.getAllByRole( 'textbox' )[ 0 ] ).toHaveAttribute( 'value', '' );
+			expect( screen.getByRole( 'textbox' ) ).toHaveAttribute( 'value', '' );
 		} );
 
 		test( 'should add multiple tab-separated tokens when pasting', async () => {
@@ -581,7 +581,7 @@ describe( 'TokenField', () => {
 			await setText( 'baz\tquux\twut' );
 
 			expect( getTokensHTML( container ) ).toEqual( [ 'foo', 'bar', 'baz', 'quux' ] );
-			expect( screen.getAllByRole( 'textbox' )[ 0 ] ).toHaveAttribute( 'value', 'wut' );
+			expect( screen.getByRole( 'textbox' ) ).toHaveAttribute( 'value', 'wut' );
 		} );
 
 		test( 'should not duplicate tokens when pasting', async () => {
@@ -590,7 +590,7 @@ describe( 'TokenField', () => {
 			await setText( 'baz \tbaz,  quux \tquux,quux , wut  \twut, wut' );
 
 			expect( getTokensHTML( container ) ).toEqual( [ 'foo', 'bar', 'baz', 'quux', 'wut' ] );
-			expect( screen.getAllByRole( 'textbox' )[ 0 ] ).toHaveAttribute( 'value', ' wut' );
+			expect( screen.getByRole( 'textbox' ) ).toHaveAttribute( 'value', ' wut' );
 		} );
 
 		test( 'should skip empty tokens at the beginning of a paste', async () => {
@@ -599,7 +599,7 @@ describe( 'TokenField', () => {
 			await setText( ',  ,\t \t  ,,baz, quux' );
 
 			expect( getTokensHTML( container ) ).toEqual( [ 'foo', 'bar', 'baz' ] );
-			expect( screen.getAllByRole( 'textbox' )[ 0 ] ).toHaveAttribute( 'value', ' quux' );
+			expect( screen.getByRole( 'textbox' ) ).toHaveAttribute( 'value', ' quux' );
 		} );
 
 		test( 'should skip empty tokens in the middle of a paste', async () => {
@@ -608,7 +608,7 @@ describe( 'TokenField', () => {
 			await setText( 'baz,  ,\t \t  ,,quux' );
 
 			expect( getTokensHTML( container ) ).toEqual( [ 'foo', 'bar', 'baz' ] );
-			expect( screen.getAllByRole( 'textbox' )[ 0 ] ).toHaveAttribute( 'value', '  quux' );
+			expect( screen.getByRole( 'textbox' ) ).toHaveAttribute( 'value', '  quux' );
 		} );
 
 		test( 'should skip empty tokens at the end of a paste', async () => {
@@ -617,7 +617,7 @@ describe( 'TokenField', () => {
 			await setText( 'baz, quux,  ,\t \t  ,,   ' );
 
 			expect( getTokensHTML( container ) ).toEqual( [ 'foo', 'bar', 'baz', 'quux' ] );
-			expect( screen.getAllByRole( 'textbox' )[ 0 ] ).toHaveAttribute( 'value', '     ' );
+			expect( screen.getByRole( 'textbox' ) ).toHaveAttribute( 'value', '     ' );
 		} );
 	} );
 
@@ -626,7 +626,7 @@ describe( 'TokenField', () => {
 			const user = userEvent.setup();
 			const { container } = render( <TokenFieldWrapper /> );
 
-			screen.getAllByRole( 'textbox' )[ 0 ].focus();
+			screen.getByRole( 'textbox' ).focus();
 
 			await user.click( container.querySelectorAll( '.token-field__remove-token' )[ 0 ] );
 
@@ -636,7 +636,7 @@ describe( 'TokenField', () => {
 		test( 'should remove the token to the left when backspace pressed', () => {
 			const { container } = render( <TokenFieldWrapper />, { legacyRoot: true } );
 
-			screen.getAllByRole( 'textbox' )[ 0 ].focus();
+			screen.getByRole( 'textbox' ).focus();
 
 			sendKeyDown( keyCodes.backspace );
 
@@ -646,7 +646,7 @@ describe( 'TokenField', () => {
 		test( 'should remove the token to the right when delete pressed', () => {
 			const { container } = render( <TokenFieldWrapper /> );
 
-			screen.getAllByRole( 'textbox' )[ 0 ].focus();
+			screen.getByRole( 'textbox' ).focus();
 
 			sendKeyDown( keyCodes.leftArrow );
 			sendKeyDown( keyCodes.leftArrow );

--- a/client/components/token-field/test/index.jsx
+++ b/client/components/token-field/test/index.jsx
@@ -34,7 +34,7 @@ describe( 'TokenField', () => {
 	async function setText( text ) {
 		const user = userEvent.setup();
 
-		const field = screen.getAllByRole( 'textbox' )[ 1 ];
+		const field = screen.getAllByRole( 'textbox' )[ 0 ];
 		await user.clear( field );
 		if ( text.length ) {
 			await user.type( field, text );
@@ -42,14 +42,14 @@ describe( 'TokenField', () => {
 	}
 
 	function sendKeyDown( keyCode, shiftKey ) {
-		fireEvent.keyDown( screen.getAllByRole( 'textbox' )[ 1 ], {
+		fireEvent.keyDown( screen.getAllByRole( 'textbox' )[ 0 ], {
 			keyCode,
 			shiftKey: !! shiftKey,
 		} );
 	}
 
 	function sendKeyPress( charCode ) {
-		fireEvent.keyPress( screen.getAllByRole( 'textbox' )[ 1 ], {
+		fireEvent.keyPress( screen.getAllByRole( 'textbox' )[ 0 ], {
 			charCode,
 		} );
 	}
@@ -286,7 +286,7 @@ describe( 'TokenField', () => {
 			sendKeyDown( keyCodes.tab );
 
 			expect( getTokensHTML( container ) ).toEqual( [ 'foo', 'bar', 'baz' ] );
-			expect( screen.getAllByRole( 'textbox' )[ 1 ] ).toHaveAttribute( 'value', '' );
+			expect( screen.getAllByRole( 'textbox' )[ 0 ] ).toHaveAttribute( 'value', '' );
 		} );
 
 		test( 'should not allow adding blank tokens with Tab', () => {
@@ -315,7 +315,7 @@ describe( 'TokenField', () => {
 			sendKeyDown( keyCodes.enter );
 
 			expect( getTokensHTML( container ) ).toEqual( [ 'foo', 'bar', 'baz' ] );
-			expect( screen.getAllByRole( 'textbox' )[ 1 ] ).toHaveAttribute( 'value', '' );
+			expect( screen.getAllByRole( 'textbox' )[ 0 ] ).toHaveAttribute( 'value', '' );
 		} );
 
 		test( 'should not allow adding blank tokens with Enter', () => {
@@ -366,7 +366,7 @@ describe( 'TokenField', () => {
 			expect( getTokensHTML( container ) ).toEqual( [ 'foo', 'bar' ] );
 
 			// The text input does not register the < keypress when it is sent this way.
-			expect( screen.getAllByRole( 'textbox' )[ 1 ] ).toHaveAttribute( 'value', 'baz' );
+			expect( screen.getAllByRole( 'textbox' )[ 0 ] ).toHaveAttribute( 'value', 'baz' );
 		} );
 
 		test( 'should trim token values when adding', async () => {
@@ -397,12 +397,12 @@ describe( 'TokenField', () => {
 
 			function testSavedState( isActive ) {
 				expect( getTokensHTML( container ) ).toEqual( expectedTokens );
-				expect( screen.getAllByRole( 'textbox' )[ 1 ] ).toHaveAttribute( 'value', '' );
+				expect( screen.getAllByRole( 'textbox' )[ 0 ] ).toHaveAttribute( 'value', '' );
 				expect( getSelectedSuggestion( container ) ).toBeNull();
 				expect( container.querySelectorAll( '.is-active' ).length === 1 ).toBe( isActive );
 			}
 
-			const input = screen.getAllByRole( 'textbox' )[ 1 ];
+			const input = screen.getAllByRole( 'textbox' )[ 0 ];
 			fireEvent.blur( input );
 			testSavedState( false );
 			fireEvent.focus( input );
@@ -450,7 +450,7 @@ describe( 'TokenField', () => {
 			const user = userEvent.setup();
 			const { container } = render( <TokenFieldWrapper /> );
 
-			screen.getAllByRole( 'textbox' )[ 1 ].focus();
+			screen.getAllByRole( 'textbox' )[ 0 ].focus();
 
 			const firstSuggestion = container.querySelectorAll( '.token-field__suggestion' )[ 0 ];
 
@@ -567,12 +567,12 @@ describe( 'TokenField', () => {
 
 			expect( getTokensHTML( container ) ).toEqual( [ 'foo', 'bar', 'baz', 'quux' ] );
 
-			expect( screen.getAllByRole( 'textbox' )[ 1 ] ).toHaveAttribute( 'value', ' wut' );
+			expect( screen.getAllByRole( 'textbox' )[ 0 ] ).toHaveAttribute( 'value', ' wut' );
 
 			await setText( 'wut,' );
 
 			expect( getTokensHTML( container ) ).toEqual( [ 'foo', 'bar', 'baz', 'quux', 'wut' ] );
-			expect( screen.getAllByRole( 'textbox' )[ 1 ] ).toHaveAttribute( 'value', '' );
+			expect( screen.getAllByRole( 'textbox' )[ 0 ] ).toHaveAttribute( 'value', '' );
 		} );
 
 		test( 'should add multiple tab-separated tokens when pasting', async () => {
@@ -581,7 +581,7 @@ describe( 'TokenField', () => {
 			await setText( 'baz\tquux\twut' );
 
 			expect( getTokensHTML( container ) ).toEqual( [ 'foo', 'bar', 'baz', 'quux' ] );
-			expect( screen.getAllByRole( 'textbox' )[ 1 ] ).toHaveAttribute( 'value', 'wut' );
+			expect( screen.getAllByRole( 'textbox' )[ 0 ] ).toHaveAttribute( 'value', 'wut' );
 		} );
 
 		test( 'should not duplicate tokens when pasting', async () => {
@@ -590,7 +590,7 @@ describe( 'TokenField', () => {
 			await setText( 'baz \tbaz,  quux \tquux,quux , wut  \twut, wut' );
 
 			expect( getTokensHTML( container ) ).toEqual( [ 'foo', 'bar', 'baz', 'quux', 'wut' ] );
-			expect( screen.getAllByRole( 'textbox' )[ 1 ] ).toHaveAttribute( 'value', ' wut' );
+			expect( screen.getAllByRole( 'textbox' )[ 0 ] ).toHaveAttribute( 'value', ' wut' );
 		} );
 
 		test( 'should skip empty tokens at the beginning of a paste', async () => {
@@ -599,7 +599,7 @@ describe( 'TokenField', () => {
 			await setText( ',  ,\t \t  ,,baz, quux' );
 
 			expect( getTokensHTML( container ) ).toEqual( [ 'foo', 'bar', 'baz' ] );
-			expect( screen.getAllByRole( 'textbox' )[ 1 ] ).toHaveAttribute( 'value', ' quux' );
+			expect( screen.getAllByRole( 'textbox' )[ 0 ] ).toHaveAttribute( 'value', ' quux' );
 		} );
 
 		test( 'should skip empty tokens in the middle of a paste', async () => {
@@ -608,7 +608,7 @@ describe( 'TokenField', () => {
 			await setText( 'baz,  ,\t \t  ,,quux' );
 
 			expect( getTokensHTML( container ) ).toEqual( [ 'foo', 'bar', 'baz' ] );
-			expect( screen.getAllByRole( 'textbox' )[ 1 ] ).toHaveAttribute( 'value', '  quux' );
+			expect( screen.getAllByRole( 'textbox' )[ 0 ] ).toHaveAttribute( 'value', '  quux' );
 		} );
 
 		test( 'should skip empty tokens at the end of a paste', async () => {
@@ -617,7 +617,7 @@ describe( 'TokenField', () => {
 			await setText( 'baz, quux,  ,\t \t  ,,   ' );
 
 			expect( getTokensHTML( container ) ).toEqual( [ 'foo', 'bar', 'baz', 'quux' ] );
-			expect( screen.getAllByRole( 'textbox' )[ 1 ] ).toHaveAttribute( 'value', '     ' );
+			expect( screen.getAllByRole( 'textbox' )[ 0 ] ).toHaveAttribute( 'value', '     ' );
 		} );
 	} );
 
@@ -626,7 +626,7 @@ describe( 'TokenField', () => {
 			const user = userEvent.setup();
 			const { container } = render( <TokenFieldWrapper /> );
 
-			screen.getAllByRole( 'textbox' )[ 1 ].focus();
+			screen.getAllByRole( 'textbox' )[ 0 ].focus();
 
 			await user.click( container.querySelectorAll( '.token-field__remove-token' )[ 0 ] );
 
@@ -636,7 +636,7 @@ describe( 'TokenField', () => {
 		test( 'should remove the token to the left when backspace pressed', () => {
 			const { container } = render( <TokenFieldWrapper />, { legacyRoot: true } );
 
-			screen.getAllByRole( 'textbox' )[ 1 ].focus();
+			screen.getAllByRole( 'textbox' )[ 0 ].focus();
 
 			sendKeyDown( keyCodes.backspace );
 
@@ -646,7 +646,7 @@ describe( 'TokenField', () => {
 		test( 'should remove the token to the right when delete pressed', () => {
 			const { container } = render( <TokenFieldWrapper /> );
 
-			screen.getAllByRole( 'textbox' )[ 1 ].focus();
+			screen.getAllByRole( 'textbox' )[ 0 ].focus();
 
 			sendKeyDown( keyCodes.leftArrow );
 			sendKeyDown( keyCodes.leftArrow );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13528

## Proposed Changes

* Make the domain TLD search filter pop-up accessible by adding appropriate ARIA labels and keyboard navigation handling. 

> [!NOTE]
> This PR doesn't handle deleting the focused item using the keyboard. You can still delete them by using the backspace key. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The current pop-up component is not accessible by the screen readers.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Visit `/setup/onboarding/domains?source=sites-dashboard` URL
* Search for the domain
* Enable VoiceOver
* Navigate through the popup using `Control + Option + Arrow keys`
* Ensure the following things look correct.
    * It announces list items correctly.
    * When you select an item, it correctly announces the selected items
    * It correctly announces a number of filters currently applied.
    * Make sure you can skip the number of items and go to the clear and apply buttons using keys. 



https://github.com/user-attachments/assets/5dc46614-4633-485d-82c4-4b33cec80f0c


Images for translators. These strings are to be used as ARIA labels in the rendered component. 

![CleanShot 2025-06-12 at 10 23 49@2x](https://github.com/user-attachments/assets/4e9f597f-f5c4-482a-97c1-88fbaacfbc80)
![CleanShot 2025-06-12 at 10 24 08@2x](https://github.com/user-attachments/assets/b6850927-52e8-4552-81c9-416e1196ad39)
![CleanShot 2025-06-12 at 10 22 48@2x](https://github.com/user-attachments/assets/75559fc9-6dc8-4e27-b1ef-3a47a507320f)
![CleanShot 2025-06-12 at 10 22 32@2x](https://github.com/user-attachments/assets/b8dc7136-0d53-49b2-8324-b873c9efa17b)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
