### PR TITLE
Connect Refresh: Migrate VIP to unified Login

### DIFF
--- a/client/blocks/login/login-header.tsx
+++ b/client/blocks/login/login-header.tsx
@@ -12,6 +12,7 @@ import {
 	isGravatarFlowOAuth2Client,
 	isPartnerPortalOAuth2Client,
 	isGravatarOAuth2Client,
+	isVIPOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import './login-header.scss';
 
@@ -82,6 +83,8 @@ export function getHeaderText(
 			clientName = 'Jetpack';
 		} else if ( isWCCOM ) {
 			headerText = translate( 'Log in to Woo with WordPress.com' );
+		} else if ( isVIPOAuth2Client( oauth2Client ) ) {
+			clientName = 'VIP';
 		}
 
 		headerText = clientName

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -30,6 +30,7 @@ import {
 	isBlazeProOAuth2Client,
 	isPartnerPortalOAuth2Client,
 	isStudioAppOAuth2Client,
+	isVIPOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { createAccountUrl } from 'calypso/lib/paths';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
@@ -346,6 +347,7 @@ export default withCurrentRoute(
 			const isStudioClient = isStudioAppOAuth2Client( oauth2Client );
 			const isCrowdsignalClient = isCrowdsignalOAuth2Client( oauth2Client );
 			const isA4AClient = isA4AOAuth2Client( oauth2Client );
+			const isVipClient = isVIPOAuth2Client( oauth2Client );
 			const isWhiteLogin =
 				( currentRoute.startsWith( '/log-in' ) &&
 					( ( Boolean( currentQuery?.client_id ) === false &&
@@ -356,7 +358,8 @@ export default withCurrentRoute(
 						isA4AClient ||
 						isWoo ||
 						isJetpackCloudClient ||
-						isJetpackLogin ) ) ||
+						isJetpackLogin ||
+						isVipClient ) ) ||
 				isPartnerPortal;
 
 			const noMasterbarForRoute =

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -347,7 +347,7 @@ export default withCurrentRoute(
 			const isStudioClient = isStudioAppOAuth2Client( oauth2Client );
 			const isCrowdsignalClient = isCrowdsignalOAuth2Client( oauth2Client );
 			const isA4AClient = isA4AOAuth2Client( oauth2Client );
-			const isVipClient = isVIPOAuth2Client( oauth2Client );
+			const isVIPClient = isVIPOAuth2Client( oauth2Client );
 			const isWhiteLogin =
 				( currentRoute.startsWith( '/log-in' ) &&
 					( ( Boolean( currentQuery?.client_id ) === false &&
@@ -359,7 +359,7 @@ export default withCurrentRoute(
 						isWoo ||
 						isJetpackCloudClient ||
 						isJetpackLogin ||
-						isVipClient ) ) ||
+						isVIPClient ) ) ||
 				isPartnerPortal;
 
 			const noMasterbarForRoute =

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -74,7 +74,7 @@ const enhanceContextWithLogin = ( context ) => {
 	const isA4AClient = isA4AOAuth2Client( oauth2Client );
 	const isJetpackLogin = isJetpack === 'jetpack';
 	const isJetpackCloudClient = isJetpackCloudOAuth2Client( oauth2Client );
-	const isVipClient = isVIPOAuth2Client( oauth2Client );
+	const isVIPClient = isVIPOAuth2Client( oauth2Client );
 
 	const isWhiteLogin =
 		( Boolean( clientId ) === false && Boolean( oauth2ClientId ) === false ) ||
@@ -86,7 +86,7 @@ const enhanceContextWithLogin = ( context ) => {
 		isJetpackCloudClient ||
 		isJetpackLogin ||
 		isWoo ||
-		isVipClient;
+		isVIPClient;
 
 	context.primary = (
 		<WPLogin

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -9,6 +9,7 @@ import {
 	isCrowdsignalOAuth2Client,
 	isA4AOAuth2Client,
 	isJetpackCloudOAuth2Client,
+	isVIPOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { DesktopLoginStart, DesktopLoginFinalize } from 'calypso/login/desktop-login';
 import { SOCIAL_HANDOFF_CONNECT_ACCOUNT } from 'calypso/state/action-types';
@@ -73,6 +74,7 @@ const enhanceContextWithLogin = ( context ) => {
 	const isA4AClient = isA4AOAuth2Client( oauth2Client );
 	const isJetpackLogin = isJetpack === 'jetpack';
 	const isJetpackCloudClient = isJetpackCloudOAuth2Client( oauth2Client );
+	const isVipClient = isVIPOAuth2Client( oauth2Client );
 
 	const isWhiteLogin =
 		( Boolean( clientId ) === false && Boolean( oauth2ClientId ) === false ) ||
@@ -83,7 +85,8 @@ const enhanceContextWithLogin = ( context ) => {
 		isA4AClient ||
 		isJetpackCloudClient ||
 		isJetpackLogin ||
-		isWoo;
+		isWoo ||
+		isVipClient;
 
 	context.primary = (
 		<WPLogin

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -27,6 +27,7 @@ import {
 	isCrowdsignalOAuth2Client,
 	isGravatarFlowOAuth2Client,
 	isGravatarOAuth2Client,
+	isVIPOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login, lostPassword } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -655,7 +656,8 @@ export default connect(
 				! isJetpackCloudOAuth2Client( oauth2Client ) &&
 				! isWooOAuth2Client( oauth2Client ) &&
 				! isCrowdsignalOAuth2Client( oauth2Client ) &&
-				! isStudioAppOAuth2Client( oauth2Client ),
+				! isStudioAppOAuth2Client( oauth2Client ) &&
+				! isVIPOAuth2Client( oauth2Client ),
 			currentRoute,
 			currentQuery,
 			redirectTo: getRedirectToOriginal( state ),

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -582,7 +582,8 @@ export class Login extends Component {
 			isBlazePro ||
 			isJetpack ||
 			isJetpackCloudOAuth2Client( oauth2Client ) ||
-			isWoo;
+			isWoo ||
+			isVIPOAuth2Client( oauth2Client );
 
 		return (
 			<>

--- a/client/login/wp-login/login-footer.tsx
+++ b/client/login/wp-login/login-footer.tsx
@@ -1,7 +1,8 @@
-import { useTranslate } from 'i18n-calypso';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useSelector } from 'react-redux';
 import SocialTos from 'calypso/blocks/authentication/social/social-tos';
-import { isGravPoweredOAuth2Client } from 'calypso/lib/oauth2-clients';
+import LoggedOutFormBackLink from 'calypso/components/logged-out-form/back-link';
+import { isVIPOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 
 interface LoginFooterProps {
@@ -9,11 +10,13 @@ interface LoginFooterProps {
 	shouldRenderTos: boolean;
 }
 
+const recordBackToWpcomLinkClick = () => {
+	recordTracksEvent( 'calypso_login_back_to_wpcom_link_click' );
+};
+
 const LoginFooter = ( { lostPasswordLink, shouldRenderTos }: LoginFooterProps ) => {
-	const translate = useTranslate();
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
-	const isGravPoweredClient = isGravPoweredOAuth2Client( oauth2Client );
-	const showGravHelperDocs = isGravPoweredClient && false;
+	const isVIPClient = isVIPOAuth2Client( oauth2Client );
 
 	if ( ! lostPasswordLink && ! shouldRenderTos ) {
 		return null;
@@ -23,14 +26,14 @@ const LoginFooter = ( { lostPasswordLink, shouldRenderTos }: LoginFooterProps ) 
 		<div className="wp-login__main-footer">
 			{ shouldRenderTos && <SocialTos /> }
 			{ lostPasswordLink }
-			{ showGravHelperDocs && (
-				<div className="wp-login__main-footer-help-docs">
-					{ translate( 'Any question? {{a}}Check our help docs{{/a}}.', {
-						components: {
-							a: <a href="https://gravatar.com/support" target="_blank" rel="noreferrer" />,
-						},
-					} ) }
-				</div>
+			{ isVIPClient && (
+				<LoggedOutFormBackLink
+					classes={ {
+						'wp-login__main-footer-back-link': true,
+					} }
+					oauth2Client={ oauth2Client }
+					recordClick={ recordBackToWpcomLinkClick }
+				/>
 			) }
 		</div>
 	);

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -533,18 +533,21 @@ $image-height: 47px;
 		align-self: center;
 		max-width: var(--login-form-column-max-width);
 
-		.wp-login__main-footer-help-docs {
+		.wp-login__main-footer-help-docs,
+		.wp-login__main-footer-back-link {
 			margin-top: 16px;
 		}
 
 		.wp-login__main-footer-help-docs,
-		.login__lost-password-link {
+		.login__lost-password-link,
+		.wp-login__main-footer-back-link {
 			font-size: $font-body-small;
 			display: block;
 		}
 
 		.login__lost-password-link,
-		.wp-login__main-footer-help-docs a {
+		.wp-login__main-footer-help-docs a,
+		a.wp-login__main-footer-back-link {
 			color: var(--studio-gray-90, #1d2327);
 			font-weight: 500;
 			text-align: center;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13403/vip
Part of https://linear.app/a8c/issue/DOTCOM-13391/vip

## Proposed Changes

Migrates VIP client Authentication to unified Login

## Media

| Before | After |
|--------|--------|
| <img width="1183" alt="Screenshot 2025-06-10 at 6 28 02 PM" src="https://github.com/user-attachments/assets/5f24d4f5-e46e-448a-9c27-5e385b2f659a" /> | <img width="1091" alt="Screenshot 2025-06-10 at 6 22 50 PM" src="https://github.com/user-attachments/assets/1a0e2c28-ed2b-4129-860d-ceb77cc2a4f8" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13403/vip
Part of https://linear.app/a8c/issue/DOTCOM-13391/vip

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go to [VIP Login](https://linear.app/a8c/issue/DOTCOM-13220/calypso-make-the-two-columnwhite-layout-the-default-across-all) and confirm media
Go to [WP Login](http://calypso.localhost:3000/log-in) and confirm no changes
Go to any of the [other OAuth client Login screens](https://linear.app/a8c/issue/DOTCOM-13220/calypso-make-the-two-columnwhite-layout-the-default-across-all) and confirm no changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
