### PR TITLE
Unsubscribe clean up 

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -680,7 +680,10 @@ class PostCommentList extends Component {
 										post={ this.props.post }
 										followSource={ followSource }
 										followIcon={ ReaderFollowConversationIcon( { iconSize: 24 } ) }
-										followingIcon={ ReaderFollowingConversationIcon( { iconSize: 24 } ) }
+										followingIcon={ ReaderFollowingConversationIcon( {
+											iconSize: 24,
+											className: 'reader-following-conversation',
+										} ) }
 									/>
 								) }
 							</div>

--- a/client/blocks/reader-feed-header/follow.jsx
+++ b/client/blocks/reader-feed-header/follow.jsx
@@ -80,7 +80,7 @@ export default function ReaderFeedHeaderFollow( props ) {
 							hasButtonStyle
 							iconSize={ 24 }
 							onFollowToggle={ openSuggestedFollowsModal }
-							followingLabel={ translate( 'Unsubscribe' ) }
+							followingLabel={ translate( 'Subscribed' ) }
 						/>
 					</div>
 				) }

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -70,7 +70,7 @@ const CompactPost = ( props ) => {
 					siteUrl={ post.feed_URL || post.site_URL }
 					followSource={ READER_DISCOVER }
 					iconSize={ 20 }
-					followingLabel={ translate( 'Unsubscribe' ) }
+					followingLabel={ translate( 'Subscribed' ) }
 				/>
 			) }
 			<ReaderPostEllipsisMenu

--- a/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
+++ b/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
@@ -314,7 +314,10 @@ class ReaderPostEllipsisMenu extends Component {
 						post={ post }
 						followSource={ followSource }
 						followIcon={ ReaderFollowConversationIcon( { iconSize: 24 } ) }
-						followingIcon={ ReaderFollowingConversationIcon( { iconSize: 24 } ) }
+						followingIcon={ ReaderFollowingConversationIcon( {
+							iconSize: 24,
+							className: 'reader-following-conversation',
+						} ) }
 					/>
 				) }
 

--- a/client/landing/subscriptions/components/settings/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings/site-settings/site-settings.tsx
@@ -4,9 +4,9 @@ import { Icon, seen } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useRecordViewFeedButtonClicked } from 'calypso/landing/subscriptions/tracks';
+import ReaderFollowingConversationIcon from 'calypso/reader/components/icons/following-conversation-icon';
 import { getFeedUrl } from 'calypso/reader/route';
 import { SubscriptionsEllipsisMenu } from '../../subscriptions-ellipsis-menu';
-import UnsubscribeIcon from '../icons/unsubscribe-icon';
 import DeliveryFrequencyInput from './delivery-frequency-input';
 import EmailMeNewCommentsToggle from './email-me-new-comments-toggle';
 import EmailMeNewPostsToggle from './email-me-new-posts-toggle';
@@ -116,13 +116,16 @@ export const SiteSettingsPopover = ( {
 							'is-loading': unsubscribing,
 						} ) }
 						disabled={ unsubscribing }
-						icon={ <UnsubscribeIcon className="subscriptions-ellipsis-menu__item-icon" /> }
+						icon={ ReaderFollowingConversationIcon( {
+							iconSize: 24,
+							className: 'subscriptions-ellipsis-menu__item-icon',
+						} ) }
 						onClick={ () => {
 							onUnsubscribe();
 							close();
 						} }
 					>
-						{ translate( 'Unsubscribe' ) }
+						{ translate( 'Subscribed' ) }
 					</Button>
 
 					<hr className="subscriptions__separator" />

--- a/client/landing/subscriptions/components/subscriptions-ellipsis-menu/subscriptions-ellipsis-menu.tsx
+++ b/client/landing/subscriptions/components/subscriptions-ellipsis-menu/subscriptions-ellipsis-menu.tsx
@@ -1,5 +1,6 @@
-import { Gridicon, Popover } from '@automattic/components';
-import { Button } from '@wordpress/components';
+import { Popover } from '@automattic/components';
+import { Button, Icon } from '@wordpress/components';
+import { moreVertical } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useRef } from 'react';
 import usePopoverToggle from 'calypso/landing/subscriptions/hooks/use-popover-toggle';
@@ -31,7 +32,7 @@ const SubscriptionsEllipsisMenu = ( {
 				onClick={ onToggle }
 				ref={ buttonRef }
 				title={ toggleTitle }
-				icon={ <Gridicon icon="ellipsis" size={ 24 } /> }
+				icon={ <Icon icon={ moreVertical } size={ 24 } /> }
 			/>
 
 			<Popover

--- a/client/reader/components/icons/following-conversation-icon.jsx
+++ b/client/reader/components/icons/following-conversation-icon.jsx
@@ -1,4 +1,4 @@
-export default function ReaderFollowingConversationIcon( { iconSize } ) {
+export default function ReaderFollowingConversationIcon( { iconSize, className } ) {
 	return (
 		<svg
 			key="following-conversation"
@@ -6,7 +6,7 @@ export default function ReaderFollowingConversationIcon( { iconSize } ) {
 			viewBox="0 0 24 24"
 			width={ iconSize }
 			height={ iconSize }
-			className="reader-following-conversation"
+			className={ className }
 			xmlns="http://www.w3.org/2000/svg"
 		>
 			<path


### PR DESCRIPTION
## Description

In https://github.com/Automattic/wp-calypso/pull/103809 we started the process of cleaning up icons in the reader. At the bottom of that PR [I noted](https://github.com/Automattic/wp-calypso/pull/103809#issuecomment-2932383453) that I planned to do a clean up of other instances of "Unsubscribe" in the reader in a separate PR.

## Preview

### Feed page

| **Before** | **After** |
|--------|-------|
| ![feed-page-before](https://github.com/user-attachments/assets/04b84d51-a350-4ff6-8fad-1882e9e56a16) | ![feed-page-after](https://github.com/user-attachments/assets/6d064be1-f5ac-46d1-bd26-7edaadc174d1) |

### Discovery

| **Before** | **After** |
|--------|-------|
| ![discover-before](https://github.com/user-attachments/assets/b7685d45-d26a-4c7e-bd11-70fe2f633133) | ![discover-after](https://github.com/user-attachments/assets/2720b5b3-78c3-407b-88fb-e7e8121dea8e) |

### Manage Subscriptions

I decided to keep this button labeled "Unsubscribe". It felt weird to chang it to "Subscribed" with the **Action** table header above it:

![manage-subs-unsub](https://github.com/user-attachments/assets/6e963cde-3d2a-48d6-afa6-67bd2f17e774)

I updated the toggle icon to match the toggle we're using in other cards:

![manage-subs-toggle](https://github.com/user-attachments/assets/7d80cc61-5622-4e22-b620-d3e2d24430bb)

I then updated the Unsub link inside the toggle:

| **Before** | **After** |
|--------|-------|
| ![managed-subs-menu-before](https://github.com/user-attachments/assets/f0b7070e-f630-4eb7-bfb8-5f96d7bcd2cc) | ![managed-subs-menu-after](https://github.com/user-attachments/assets/aa9f26c8-5cdb-4d8a-84af-70c93a062eb3) |

## Testing instructions

- Apply this PR
- Test http://calypso.localhost:3000/reader/feeds/116494, http://calypso.localhost:3000/reader/subscriptions, http://calypso.localhost:3000/discover/




