### PR TITLE
Add missing parent aria role for menu items on themes page

### DIFF
--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -47,8 +47,8 @@ const UniversalNavbarHeader = ( {
 					<div className="masterbar-menu">
 						<div className="masterbar">
 							<nav className="x-nav" aria-label="WordPress.com">
-								<ul className="x-nav-list x-nav-list__left">
-									<li className="x-nav-item">
+								<ul className="x-nav-list x-nav-list__left" role="menu">
+									<li className="x-nav-item" role="none">
 										<a
 											role="menuitem"
 											className="x-nav-link x-nav-link__logo x-link"
@@ -68,7 +68,7 @@ const UniversalNavbarHeader = ( {
 									</li>
 									{ variant !== 'minimal' ? (
 										<>
-											<li className="x-nav-item x-nav-item__wide">
+											<li className="x-nav-item x-nav-item__wide" role="none">
 												<NonClickableItem
 													className="x-nav-link x-link"
 													content={ __( 'Products', __i18n_text_domain__ ) }
@@ -167,7 +167,7 @@ const UniversalNavbarHeader = ( {
 													</ul>
 												</div>
 											</li>
-											<li className="x-nav-item x-nav-item__wide">
+											<li className="x-nav-item x-nav-item__wide" role="none">
 												<NonClickableItem
 													className="x-nav-link x-link"
 													content={ __( 'Features', __i18n_text_domain__ ) }
@@ -233,7 +233,7 @@ const UniversalNavbarHeader = ( {
 													</ul>
 												</div>
 											</li>
-											<li className="x-nav-item x-nav-item__wide">
+											<li className="x-nav-item x-nav-item__wide" role="none">
 												<NonClickableItem
 													className="x-nav-link x-link"
 													content={ __( 'Resources', __i18n_text_domain__ ) }
@@ -315,7 +315,7 @@ const UniversalNavbarHeader = ( {
 										</>
 									) : null }
 								</ul>
-								<ul className="x-nav-list x-nav-list__right">
+								<ul className="x-nav-list x-nav-list__right" role="menu">
 									{ ! isLoggedIn && (
 										<ClickableItem
 											className="x-nav-item x-nav-item__wide"
@@ -338,7 +338,7 @@ const UniversalNavbarHeader = ( {
 											typeClassName="x-nav-link x-nav-link__primary x-link cta-btn-nav"
 										/>
 									) }
-									<li className="x-nav-item x-nav-item__narrow">
+									<li className="x-nav-item x-nav-item__narrow" role="none">
 										<button
 											role="menuitem"
 											className="x-nav-link x-nav-link__menu x-link"

--- a/packages/wpcom-template-parts/src/universal-header-navigation/menu-items.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/menu-items.tsx
@@ -73,7 +73,7 @@ export const ClickableItem = ( {
 		clickNavLinkEvent( target );
 	};
 	return (
-		<li className={ liClassName }>
+		<li className={ liClassName } role="none">
 			<a
 				role="menuitem"
 				className={ typeClassName ? typeClassName : `x-${ type }-link x-link` }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13273

## Proposed Changes

* I propose to add missing parent aria role for menu items on themes page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To fix axe Dev Tools findings, improving accessibility tools compatibility.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open `/themes` page
2. Use axe Dev Tools to confirm it doesn't complain about missing parent roles for `role="menuitem"` items.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
