### PR TITLE
Fix link contrast on Jetpack Cloud login page

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -382,10 +382,10 @@ a.calypso-notice__action {
 			a,
 			a:visited,
 			button.is-link {
-				color: var(--color-link);
+				color: var(--color-link-dark);
 
 				&:hover {
-					color: var(--color-link);
+					color: var(--color-link-dark);
 				}
 			}
 		}

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -611,7 +611,7 @@
 }
 
 .jetpack-cloud {
-	--color-link: var(--studio-jetpack-green-40);
+	--color-link: var(--studio-jetpack-green-50);
 	--color-link-dark: var(--studio-jetpack-green-60);
 
 	input:focus:hover[type],


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13185

## Proposed Changes

* I propose to fix link contrast on Jetpack Cloud login page for links like ToS or Privacy Policy, and for links in locale suggestions box.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To meet accessibility standards.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start Jetpack Clou (`yarn start-jetpack-cloud`) or use live link
2. Use Chrome Dev Tools Sensor settings to change location/locale to display locale suggestions.
3. As logged out user, access https://cloud.jetpack.com/dashboard
4. Run axe Dev Tools scan and confirm there are not issues with elements contrast

![Screenshot 2025-06-11 at 14 10 05](https://github.com/user-attachments/assets/1665699a-52fd-4c68-b89c-105977941c54)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
