### PR TITLE
DS Site: Tweak guidance for calendar components

### DIFF
--- a/apps/design-system-docs/docs/components/packages/wp-components/data.ts
+++ b/apps/design-system-docs/docs/components/packages/wp-components/data.ts
@@ -234,7 +234,7 @@ export const data: ComponentData[] = [
 		status: 'use-with-caution',
 		docs: 'https://wordpress.github.io/gutenberg/?path=/docs/components-datetimepicker--docs',
 		notes:
-			'If possible, use `DateCalendar` from `@automattic/components` instead. For the input fields, consider using an `InputControl` with `type="datetime-local"`.',
+			'If possible, use `DateCalendar` from `@automattic/components` instead. For the input fields, consider using an `TextControl` with `type="date"` or `type="datetime-local"`.',
 	},
 	{
 		id: 'disabled',
@@ -792,7 +792,7 @@ export const data: ComponentData[] = [
 		figma:
 			'https://www.figma.com/design/804HN2REV2iap2ytjRQ055/WordPress-Design-System?node-id=16530-21978',
 		docs: 'https://wordpress.github.io/gutenberg/?path=/docs/components-timepicker--docs',
-		notes: 'Consider using an `InputControl` with `type="datetime-local"` instead.',
+		notes: 'Consider using an `TextControl` with `type="date"` or `type="datetime-local"` instead.',
 	},
 	{
 		id: 'tip',


### PR DESCRIPTION
## Proposed Changes

Tweaks some of the guidance we give for calendar components in `@wordpress/components`.

## Why are these changes being made?

Prompted by a question in p1749574515153339-slack-CNGQYA3B9

I remembered that `<InputControl type="date">` has styling issues in Safari, so `TextControl` works better for that at the moment. I also remembered that wanting to hide the time part is also a somewhat common request.

## Testing Instructions

See the live link for the DS site and go to the `@wordpress/components` section.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?