### PR TITLE
Reader lists - fix scrolling and frame for lists add and manage pages.

### DIFF
--- a/client/reader/list-manage/index.jsx
+++ b/client/reader/list-manage/index.jsx
@@ -6,12 +6,12 @@ import { READER_EXPORT_TYPE_LIST } from 'calypso/blocks/reader-export-button/con
 import QueryReaderList from 'calypso/components/data/query-reader-list';
 import QueryReaderListItems from 'calypso/components/data/query-reader-list-items';
 import EmptyContent from 'calypso/components/empty-content';
-import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import { preventWidows } from 'calypso/lib/formatting';
+import ReaderMain from 'calypso/reader/components/reader-main';
 import Missing from 'calypso/reader/list-stream/missing';
 import { createReaderList, updateReaderList } from 'calypso/state/reader/lists/actions';
 import {
@@ -91,14 +91,14 @@ function ReaderListCreate() {
 	const isCreatingList = useSelector( isCreatingListSelector );
 
 	return (
-		<Main>
+		<ReaderMain>
 			<NavigationHeader title={ translate( 'Create List' ) } />
 			<ListForm
 				isCreateForm
 				isSubmissionDisabled={ isCreatingList }
 				onSubmit={ ( list ) => dispatch( createReaderList( list ) ) }
 			/>
-		</Main>
+		</ReaderMain>
 	);
 }
 
@@ -132,7 +132,7 @@ function ReaderListEdit( props ) {
 		<>
 			{ ! list && <QueryReaderList owner={ props.owner } slug={ props.slug } /> }
 			{ ! listItems && list && <QueryReaderListItems owner={ props.owner } slug={ props.slug } /> }
-			<Main>
+			<ReaderMain>
 				<NavigationHeader
 					title={ translate( 'Manage %(listName)s', {
 						args: { listName: list?.title || decodeURIComponent( props.slug ) },
@@ -179,7 +179,7 @@ function ReaderListEdit( props ) {
 						{ selectedSection === 'delete' && <ListDelete { ...sectionProps } /> }
 					</>
 				) }
-			</Main>
+			</ReaderMain>
 		</>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/CML-553/recommended-blogs-fix-scrolling-on-edit-page

## Proposed Changes

* Uses the `ReaderMain` component instead of the general `Main` component for the add and manage pages for lists.
    * This adds the extra div and styles to show the reader content frame and enable scrolling. 

BEFORE (no content frame or scrolling)
![lists-before](https://github.com/user-attachments/assets/9a5eca69-0ba8-44c0-82fc-774dafe12ff5)


AFTER (content frame and scrolling)
![create-list-after](https://github.com/user-attachments/assets/38d9ea35-ef0e-452f-9496-732c381b446d)
![manage-list-after](https://github.com/user-attachments/assets/ce25bd54-79f4-4132-bc53-22e09986f007)




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Can't scroll on the add or manage page of any list.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the reader -> lists
* go to add new, verify you can scroll the page when the height does not contain the content.
* add the list, or go to manage an existing one by the "edit" button in the top right of the list page. verify you can scroll this as well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
