### PR TITLE
DOTCON-82: Treat migration-in-progress sites as DIFM migrations

### DIFF
--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -102,6 +102,10 @@ export const getMigrationType = ( site: SiteExcerptData ): 'diy' | 'difm' | unde
 		return undefined;
 	}
 
+	if ( migrationStatus === 'migration-in-progress' ) {
+		return 'difm';
+	}
+
 	const type = migrationStatus.split( '-' )[ 2 ];
 
 	if ( ! [ 'difm', 'diy' ].includes( type ) ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCON-82

## Proposed Changes

The `getMigrationStatus` method (which is used to determine which type of Migration overview to display on the site overview) had an issue where sites with `migration-in-progress` but not `migration-started-difm` showed a blank overview.

This updates makes `getMigrationStatus` return `difm` if `migration-in-progress` is set since that sticker is only added by DAMS doing DIFM migrations.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply locally or use the calypso.live url.
* Got through `/setup/site-migration` and choose a DIFM migration.
* Once you reach the site overview, add the `migration-in-progress` sticker and remove the `migration-started-difm` sticker.
* Verify that the site overview still appears.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
