### PR TITLE
Purchases: Update DataViews version to implement design feedback, third pass

### DIFF
--- a/client/me/purchases/add-new-payment-method/index.tsx
+++ b/client/me/purchases/add-new-payment-method/index.tsx
@@ -25,8 +25,10 @@ import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { PaymentMethodSelectorSubmitButtonContent } from '../manage-purchase/payment-method-selector/payment-method-selector-submit-button-content';
 
-function AddNewPaymentMethod() {
-	const goToPaymentMethods = () => page( paymentMethods );
+function AddNewPaymentMethod( { purchaseListUrl }: { purchaseListUrl?: string | undefined } ) {
+	const goToPaymentMethods = () => {
+		page( purchaseListUrl ?? paymentMethods );
+	};
 	const addPaymentMethodTitle = String( titles.addPaymentMethod );
 	const currency = useSelector( getCurrentUserCurrencyCode );
 	const translate = useTranslate();
@@ -85,7 +87,11 @@ function AddNewPaymentMethod() {
 	);
 }
 
-export default function AccountLevelAddNewPaymentMethodWrapper() {
+export default function AccountLevelAddNewPaymentMethodWrapper( {
+	purchaseListUrl,
+}: {
+	purchaseListUrl?: string | undefined;
+} ) {
 	const locale = useSelector( getCurrentUserLocale );
 
 	return (
@@ -99,7 +105,7 @@ export default function AccountLevelAddNewPaymentMethodWrapper() {
 				<QueryProducts
 					productSlugList={ [ 'value_bundle', 'personal-bundle', 'business-bundle' ] }
 				/>
-				<AddNewPaymentMethod />
+				<AddNewPaymentMethod purchaseListUrl={ purchaseListUrl } />
 			</RazorpayHookProvider>
 		</StripeHookProvider>
 	);

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -39,6 +39,19 @@ import useVatDetails from './vat-info/use-vat-details';
 
 const useDataViewPurchasesList = config.isEnabled( 'purchases/purchase-list-dataview' );
 
+/**
+ * Returns the previous page URL if it is one of the two purchases lists
+ * (account-level or site-level), including query strings.
+ * @returns string|undefined
+ */
+function usePreviousUrlIfPurchasesList() {
+	const previousRoute = useSelector( getPreviousRoute );
+	return /\/me\/purchases\/?[^/]*$/.test( previousRoute ) ||
+		/\/purchases\/subscriptions\/?[^/]*$/.test( previousRoute )
+		? previousRoute
+		: undefined;
+}
+
 function useLogPurchasesError( message ) {
 	return useCallback(
 		( error ) => {
@@ -199,8 +212,7 @@ export function vatDetails( context, next ) {
 export function managePurchase( context, next ) {
 	const ManagePurchasesWrapper = localize( () => {
 		const classes = 'manage-purchase';
-		const previousRoute = useSelector( getPreviousRoute );
-		const purchaseListUrl = previousRoute.includes( '/purchases' ) ? previousRoute : undefined;
+		const purchaseListUrl = usePreviousUrlIfPurchasesList();
 
 		return (
 			<PurchasesWrapper title={ titles.managePurchase }>
@@ -247,7 +259,11 @@ export function managePurchaseByOwnership( context, next ) {
 }
 
 export function addNewPaymentMethod( context, next ) {
-	context.primary = <AddNewPaymentMethod />;
+	const AddNewPaymentMethodTopWrapper = () => {
+		const purchaseListUrl = usePreviousUrlIfPurchasesList();
+		return <AddNewPaymentMethod purchaseListUrl={ purchaseListUrl } />;
+	};
+	context.primary = <AddNewPaymentMethodTopWrapper />;
 	next();
 }
 

--- a/client/me/purchases/purchase-item/index.tsx
+++ b/client/me/purchases/purchase-item/index.tsx
@@ -629,11 +629,15 @@ export function PurchaseItemPaymentMethod( {
 		);
 	}
 
-	const goToAddPaymentMethod = ( e: React.MouseEvent< HTMLButtonElement >, siteId: number ) => {
+	const goToAddPaymentMethod = (
+		e: React.MouseEvent< HTMLButtonElement >,
+		siteSlug: string | number,
+		purchaseId: number
+	) => {
 		e.preventDefault();
 		e.stopPropagation();
 
-		page( `/me/purchases/add-payment-method/${ siteId }/payment-method/add` );
+		page( `/me/purchases/${ siteSlug }/${ purchaseId }/payment-method/add` );
 	};
 
 	if (
@@ -650,7 +654,7 @@ export function PurchaseItemPaymentMethod( {
 						variant="link"
 						size="compact"
 						onClick={ ( e: React.MouseEvent< HTMLButtonElement > ) =>
-							goToAddPaymentMethod( e, purchase.id )
+							goToAddPaymentMethod( e, purchase.siteId, purchase.id )
 						}
 					>
 						{ translate( 'Add payment method' ) }

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -122,7 +122,7 @@ export function getPurchasesFieldDefinitions( {
 					return { value: String( site.ID ), label: `${ site.name } (${ site.domain })` };
 				} );
 			} )(),
-			filterBy: { operators: [ 'is' ] },
+			filterBy: { operators: [ 'isAny' ] },
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
 				// getValue must return a string because the DataViews search feature calls `trim()` on it.
 				return String( item.siteId );

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -189,6 +189,8 @@ export function getPurchasesFieldDefinitions( {
 		{
 			id: 'type',
 			label: translate( 'Type' ),
+			enableHiding: false,
+			enableSorting: true,
 			type: 'text',
 			elements: [
 				{ value: 'domain', label: translate( 'Domains' ) },
@@ -208,6 +210,8 @@ export function getPurchasesFieldDefinitions( {
 		},
 		{
 			id: 'expiring-soon',
+			enableHiding: false,
+			enableSorting: true,
 			label: translate( 'Expiring soon' ),
 			type: 'text',
 			elements: [

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -194,7 +194,7 @@ export function getPurchasesFieldDefinitions( {
 			type: 'text',
 			elements: [
 				{ value: 'domain', label: translate( 'Domains' ) },
-				{ value: 'plan', label: translate( 'Plan' ) },
+				{ value: 'plan', label: translate( 'Plans' ) },
 				{ value: 'other', label: translate( 'Other' ) },
 			],
 			filterBy: { operators: [ 'is' ] },

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -239,7 +239,7 @@ export function getPurchasesFieldDefinitions( {
 		},
 		{
 			id: 'status',
-			label: translate( 'Status' ),
+			label: translate( 'Expires/Renews on' ),
 			type: 'text',
 			enableGlobalSearch: true,
 			enableSorting: true,

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -44,7 +44,7 @@ export const purchasesDataView: View = {
 function alterUrlForViewProp(
 	url: URL,
 	urlKey: string,
-	currentViewPropValue: string | number | undefined,
+	currentViewPropValue: string | number | string[] | number[] | undefined,
 	defaultValue?: string | number | undefined
 ): void {
 	if ( currentViewPropValue && defaultValue && currentViewPropValue !== defaultValue ) {
@@ -97,7 +97,7 @@ function usePreservePurchasesViewInUrl( {
 			url.searchParams.get( urlSortDirection ) === 'asc' ? 'asc' : 'desc'
 		) as SortDirection;
 		if ( siteFilterValue ) {
-			filters.push( { value: siteFilterValue, operator: 'is', field: 'site' } );
+			filters.push( { value: siteFilterValue.split( ',' ), operator: 'isAny', field: 'site' } );
 		}
 		if ( expiringSoonValue ) {
 			filters.push( { value: expiringSoonValue, operator: 'is', field: 'expiring-soon' } );


### PR DESCRIPTION
## Proposed Changes

This PR updates the UI and UX of the DataViews version of the purchases page to implement some additional design feedback from its Call for Testing (see pdtkmj-3Go-p2#comment-7107).

The main points from this PR:

- Prevent making "Type" or "Expiring soon" fields visible. (https://linear.app/a8c/issue/CHE-195/mobile-view-feedback)
- Fix back button from "Add payment method" (https://linear.app/a8c/issue/CHE-185/unable-to-come-back-to-the-active-upgrades-section-after-clicking-on)
- Pluralize "Plans" filter to match "Domains". (https://linear.app/a8c/issue/CHE-194/feedback-on-the-filtering-options-for-the-type-filter)
- Change "Status" header to be "Expires/Renews on" to match domains table. (https://linear.app/a8c/issue/CHE-187/expiring-soon-filter-could-be-more-valuable-with-a-sort-option)
- Allow filtering by multiple sites at once (https://linear.app/a8c/issue/CHE-188/filter-by-multiple-values)

Part of https://linear.app/a8c/project/replace-calypsos-active-upgrades-subscriptions-with-dataviews-a7b39dea5417/overview / https://github.com/Automattic/wp-calypso/issues/86616

Tracked by https://linear.app/a8c/issue/CHE-177/purchases-update-dataviews-version-to-implement-design-feedback

## Testing Instructions

- Use calypso.localhost because the DataViews layout is only available there.
- View /me/purchases and verify that everything looks and works as expected.