### PR TITLE
Help Center / Zendesk: Fix event parameters format

### DIFF
--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -107,8 +107,8 @@ export const useGetCombinedChat = (
 				} );
 			} catch ( error ) {
 				recordTracksEvent( 'calypso_odie_zendesk_conversation_not_found', {
-					conversationId,
-					odieId,
+					conversation_id: conversationId,
+					odie_id: odieId,
 				} );
 
 				startNewInteraction( {
@@ -128,6 +128,7 @@ export const useGetCombinedChat = (
 		canConnectToZendesk,
 		getZendeskConversation,
 		startNewInteraction,
+		isLoadingCanConnectToZendesk,
 	] );
 
 	return { mainChatState, setMainChatState };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* `calypso_odie_zendesk_conversation_not_found` had malformed parameters and so it was not triggered.

conversationId => conversation_id
odieId => odie_id
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check the code