### PR TITLE
Newsletter importer: Improve file upload error

### DIFF
--- a/client/my-sites/importer/error-pane.jsx
+++ b/client/my-sites/importer/error-pane.jsx
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { localize, fixMe } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { WPImportError, FileTooLarge } from 'calypso/blocks/importer/wordpress/types';
@@ -98,31 +98,27 @@ class ImporterError extends PureComponent {
 		}
 
 		if ( this.props.importerEngine === 'substack' ) {
-			return fixMe( {
-				text: '%(errorDescription)s{{br/}}Make sure you are using {{doc}}a valid export file{{/doc}} in XML or ZIP format.{{br/}}{{cs}}Still need help{{/cs}}?',
-				newCopy: this.props.translate(
-					'%(errorDescription)s{{br/}}Make sure you are using {{doc}}a valid export file{{/doc}} in XML or ZIP format.{{br/}}{{cs}}Still need help{{/cs}}?',
-					{
-						args: {
-							errorDescription: description.length ? description : defaultError,
-						},
-						components: {
-							br: <br />,
-							cs: helpButton,
-							doc: (
-								<InlineSupportLink
-									showIcon={ false }
-									supportLink={ localizeUrl(
-										'https://wordpress.com/support/import-from-substack/import-content/'
-									) }
-									supportPostId={ 400434 }
-								/>
-							),
-						},
-					}
-				),
-				oldCopy: generalMessage,
-			} );
+			return this.props.translate(
+				'%(errorDescription)s{{br/}}Make sure you are using {{doc}}a valid export file{{/doc}} in XML or ZIP format.{{br/}}{{cs}}Still need help{{/cs}}?',
+				{
+					args: {
+						errorDescription: description.length ? description : defaultError,
+					},
+					components: {
+						br: <br />,
+						cs: helpButton,
+						doc: (
+							<InlineSupportLink
+								showIcon={ false }
+								supportLink={ localizeUrl(
+									'https://wordpress.com/support/import-from-substack/import-content/'
+								) }
+								supportPostId={ 400434 }
+							/>
+						),
+					},
+				}
+			);
 		}
 
 		return generalMessage;

--- a/client/my-sites/importer/error-pane.jsx
+++ b/client/my-sites/importer/error-pane.jsx
@@ -5,6 +5,7 @@ import { localize, fixMe } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { WPImportError, FileTooLarge } from 'calypso/blocks/importer/wordpress/types';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Notice from 'calypso/components/notice';
 import { addQueryArgs } from 'calypso/lib/route';
 
@@ -109,12 +110,12 @@ class ImporterError extends PureComponent {
 							br: <br />,
 							cs: helpButton,
 							doc: (
-								<a
-									href={ localizeUrl(
+								<InlineSupportLink
+									showIcon={ false }
+									supportLink={ localizeUrl(
 										'https://wordpress.com/support/import-from-substack/import-content/'
 									) }
-									target="_blank"
-									rel="noreferrer"
+									supportPostId={ 400434 }
 								/>
 							),
 						},

--- a/client/my-sites/importer/error-pane.jsx
+++ b/client/my-sites/importer/error-pane.jsx
@@ -29,7 +29,7 @@ class ImporterError extends PureComponent {
 	contactSupport = ( event ) => {
 		event.preventDefault();
 		event.stopPropagation();
-		window.location.href = '/help';
+		window.open( '/help', '_blank', 'noopener,noreferrer' );
 	};
 
 	installPlugin = ( event ) => {

--- a/client/my-sites/importer/importer-action-buttons/close-button.jsx
+++ b/client/my-sites/importer/importer-action-buttons/close-button.jsx
@@ -20,6 +20,7 @@ export class ImporterCloseButton extends PureComponent {
 			ID: PropTypes.number.isRequired,
 		} ),
 		isEnabled: PropTypes.bool.isRequired,
+		label: PropTypes.string,
 	};
 
 	handleClick = () => {
@@ -42,13 +43,14 @@ export class ImporterCloseButton extends PureComponent {
 			isEnabled,
 			isUploading,
 			translate,
+			label,
 		} = this.props;
 
 		const disabled = ! isEnabled || isUploading || appStates.UPLOADING === importerState;
 
 		return (
 			<ImporterActionButton disabled={ disabled } onClick={ this.handleClick }>
-				{ translate( 'Cancel', { context: 'verb, to Cancel an operation' } ) }
+				{ label || translate( 'Cancel', { context: 'verb, to Cancel an operation' } ) }
 			</ImporterActionButton>
 		);
 	}

--- a/client/my-sites/importer/newsletter/content-upload/importing-pane.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/importing-pane.jsx
@@ -202,9 +202,17 @@ export class ImportingPane extends PureComponent {
 						</ImporterActionButton>
 					</ImporterActionButtonContainer>
 				) }
-				{ showFallbackButton && (
-					<ImporterCloseButton importerStatus={ importerStatus } site={ site } isEnabled />
-				) }
+				{ showFallbackButton &&
+					( isError ? (
+						<ImporterCloseButton
+							importerStatus={ importerStatus }
+							site={ site }
+							isEnabled
+							label={ this.props.translate( 'Try again' ) }
+						/>
+					) : (
+						<ImporterCloseButton importerStatus={ importerStatus } site={ site } isEnabled />
+					) ) }
 			</ImporterActionButtonContainer>
 		);
 	};

--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -129,9 +129,15 @@ export default function Content( {
 					<h2>{ __( 'Step 2: Import your content to WordPress.com' ) }</h2>
 					<p>
 						{ createInterpolateElement(
-							__(
-								'Your posts may be added to your homepage by default. If you prefer your posts to load on a separate page, first go to <a>Reading Settings</a>, and change "Your homepage displays" to a static page.'
-							),
+							( fixMe( {
+								text: 'Your posts may be added to your homepage by default. If you prefer your posts to load on a separate page, first go to <a>Reading settings</a>, and change "Your homepage displays" to a static page.',
+								newCopy: __(
+									'Your posts may be added to your homepage by default. If you prefer your posts to load on a separate page, first go to <a>Reading settings</a>, and change "Your homepage displays" to a static page.'
+								),
+								oldCopy: __(
+									'Your posts may be added to your homepage by default. If you prefer your posts to load on a separate page, first go to <a>Reading Settings</a>, and change "Your homepage displays" to a static page.'
+								),
+							} ) || '' ) as string,
 							{
 								a: (
 									<a

--- a/client/my-sites/importer/newsletter/importer.scss
+++ b/client/my-sites/importer/newsletter/importer.scss
@@ -41,6 +41,12 @@ $newsletter_importer_line-height: 20px;
 		padding: 0;
 		margin: 0;
 		box-shadow: none;
+
+		.calypso-notice.is-error {
+			a, .button.is-link {
+				text-decoration: underline;
+			}
+		}
 	}
 
 	.summary__content {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/CML-275/substack-importer-fix-random-zip-file-errors

## Proposed Changes

* Change the "Cancel" button text to "Try again".
* Change the support link in the error message to an `InlineSupportLink` and open the "Still need help?" link in a new tab.
* Remove `fixMe` that's no longer needed.
* Change "Reading Settings" to "Reading settings" (sentence case). 
* Add back `text-decoration: underline`. 

Before | After
---- | ----
<img width="756" alt="Screenshot 2025-06-10 at 3 32 17 PM" src="https://github.com/user-attachments/assets/c5bb7aad-410c-4f8c-842f-6f8562437501" /> | <img width="733" alt="Screenshot 2025-06-11 at 10 15 37 AM" src="https://github.com/user-attachments/assets/ce67e73b-8659-484f-a582-de23cc82e519" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To make the error and next step clearer to the user.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /import/newsletter/substack/
* Pick a site
* Enter a Substack url like https://airfryerburrito.substack.com
* On the content step, import any zip file
* Confirm that you can click the links in the error message and that they open a support doc or /help in a new tab.
* Click "Try again" and confirm that you can upload another file
* Switch locales and verify that all copy is translated. The only exception might be "The export file is not a valid Substack export, no posts.csv was found in the archive." That back-end translation wasn't being returned from the import endpoint for me when testing.

Note the content import e2e test is failing with and without these changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
