### PR TITLE
Purchases: refactor primary fields for DataViews

### DIFF
--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -120,6 +120,7 @@ export function getPurchasesFieldDefinitions( {
 				const site = { ID: item.siteId };
 				return (
 					<Button
+						className="purchase-item__icon"
 						variant="link"
 						title={ translate( 'Manage purchase', { textOnly: true } ) }
 						label={ translate( 'Manage purchase', { textOnly: true } ) }

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -95,18 +95,6 @@ export function getPurchasesFieldDefinitions( {
 
 	const fields: Fields< Purchases.Purchase > = [
 		{
-			id: 'purchase-id',
-			label: 'Purchase ID',
-			type: 'text',
-			enableGlobalSearch: false,
-			enableSorting: false,
-			enableHiding: false,
-			getValue: ( { item }: { item: Purchases.Purchase } ) => {
-				// getValue must return a string because the DataViews search feature calls `trim()` on it.
-				return String( item.id );
-			},
-		},
-		{
 			id: 'site',
 			label: translate( 'Site' ),
 			type: 'text',

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -155,7 +155,7 @@ export function getPurchasesFieldDefinitions( {
 			},
 			render: ( { item }: { item: Purchases.Purchase } ) => {
 				return (
-					<div className="purchase-item__information purchases-layout__information">
+					<div className="purchase-item__information">
 						<div className="purchase-item__title">
 							<Button
 								variant="link"
@@ -185,8 +185,10 @@ export function getPurchasesFieldDefinitions( {
 			},
 			render: ( { item }: { item: Purchases.Purchase } ) => {
 				return (
-					<div className="purchase-item__information purchases-layout__information">
-						<PurchaseItemRowProduct purchase={ item } translate={ translate } />
+					<div className="purchase-item__information">
+						<div className="purchase-item__purchase-type">
+							<PurchaseItemRowProduct purchase={ item } translate={ translate } />
+						</div>
 					</div>
 				);
 			},
@@ -358,16 +360,15 @@ export function getMembershipsFieldDefinitions( {
 			// Render the site icon
 			render: ( { item }: { item: MembershipSubscription } ) => {
 				return (
-					<div className="membership-item__site purchases-layout__site">
-						<Button
-							variant="link"
-							title={ translate( 'Manage purchase', { textOnly: true } ) }
-							label={ translate( 'Manage purchase', { textOnly: true } ) }
-							onClick={ () => goToPurchase( item ) }
-						>
-							<Icon subscription={ item } />
-						</Button>
-					</div>
+					<Button
+						className="purchase-item__icon"
+						variant="link"
+						title={ translate( 'Manage purchase', { textOnly: true } ) }
+						label={ translate( 'Manage purchase', { textOnly: true } ) }
+						onClick={ () => goToPurchase( item ) }
+					>
+						<Icon subscription={ item } />
+					</Button>
 				);
 			},
 		},
@@ -383,7 +384,7 @@ export function getMembershipsFieldDefinitions( {
 			},
 			render: ( { item }: { item: MembershipSubscription } ) => {
 				return (
-					<div className="membership-item__information purchase-item__information purchases-layout__information">
+					<div className="membership-item__information purchase-item__information">
 						<div className="membership-item__title purchase-item__title">
 							<Button
 								variant="link"
@@ -394,6 +395,23 @@ export function getMembershipsFieldDefinitions( {
 								{ item.title }
 							</Button>
 						</div>
+					</div>
+				);
+			},
+		},
+		{
+			id: 'description',
+			label: translate( 'Product Description' ),
+			type: 'text',
+			enableGlobalSearch: true,
+			enableSorting: true,
+			enableHiding: false,
+			getValue: ( { item }: { item: MembershipSubscription } ) => {
+				return item.title + ' ' + item.site_title + ' ' + item.site_url;
+			},
+			render: ( { item }: { item: MembershipSubscription } ) => {
+				return (
+					<div className="membership-item__information purchase-item__information">
 						<div className="membership-item__purchase-type purchase-item__purchase-type">
 							<MembershipType subscription={ item } />
 						</div>
@@ -413,7 +431,7 @@ export function getMembershipsFieldDefinitions( {
 			},
 			render: ( { item }: { item: MembershipSubscription } ) => {
 				return (
-					<div className="membership-item__status purchase-item__status purchases-layout__status">
+					<div className="membership-item__status purchase-item__status">
 						<MembershipTerms subscription={ item } />
 					</div>
 				);

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -176,12 +176,28 @@ export function getPurchasesFieldDefinitions( {
 							>
 								{ getDisplayName( item ) }
 							</Button>
-							&nbsp;
 							<OwnerInfo purchase={ item } />
 						</div>
-						<div className="purchase-item__purchase-type">
-							<PurchaseItemRowProduct purchase={ item } translate={ translate } />
-						</div>
+					</div>
+				);
+			},
+		},
+		{
+			id: 'description',
+			label: translate( 'Description' ),
+			type: 'text',
+			enableGlobalSearch: true,
+			enableSorting: true,
+			enableHiding: false,
+			getValue: ( { item }: { item: Purchases.Purchase } ) => {
+				// Render a bunch of things to make this easily searchable.
+				const site = sites.find( ( site ) => site.ID === item.siteId );
+				return item.siteName + ' ' + item.domain + ' ' + site?.URL;
+			},
+			render: ( { item }: { item: Purchases.Purchase } ) => {
+				return (
+					<div className="purchase-item__information purchases-layout__information">
+						<PurchaseItemRowProduct purchase={ item } translate={ translate } />
 					</div>
 				);
 			},

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -22,9 +22,9 @@ import {
 
 import './style.scss';
 
-const purchasesWideFields = [ 'site', 'product', 'status', 'payment-method' ];
-const purchasesDesktopFields = [ 'site', 'product', 'status' ];
-const purchasesMobileFields = [ 'product' ];
+const purchasesWideFields = [ 'status', 'payment-method' ];
+const purchasesDesktopFields = [ 'status' ];
+const purchasesMobileFields: string[] = [];
 const defaultPerPage = 10;
 const defaultSort = {
 	field: 'site',
@@ -34,8 +34,12 @@ export const purchasesDataView: View = {
 	type: 'table',
 	page: 1,
 	perPage: defaultPerPage,
-	titleField: 'purchase-id',
-	showTitle: false,
+	titleField: 'product',
+	showTitle: true,
+	mediaField: 'site',
+	showMedia: true,
+	descriptionField: 'description',
+	showDescription: true,
 	fields: purchasesDesktopFields,
 	sort: defaultSort,
 	layout: {},

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -284,14 +284,18 @@ export function PurchasesDataViews( {
 	);
 }
 
-const membershipsDesktopFields = [ 'site', 'product', 'status' ];
-const membershipsMobileFields = [ 'product' ];
+const membershipsDesktopFields = [ 'status' ];
+const membershipsMobileFields: string[] = [];
 export const membershipDataView: View = {
 	type: 'table',
 	page: 1,
 	perPage: defaultPerPage,
-	titleField: 'purchase-id',
-	showTitle: false,
+	titleField: 'product',
+	showTitle: true,
+	mediaField: 'site',
+	showMedia: true,
+	descriptionField: 'description',
+	showDescription: true,
 	fields: membershipsDesktopFields,
 	sort: {
 		field: 'product',

--- a/client/me/purchases/purchases-list-in-dataviews/style.scss
+++ b/client/me/purchases/purchases-list-in-dataviews/style.scss
@@ -77,6 +77,7 @@
 	.purchase-item__information {
 		margin-right: 16px;
 		max-width: 250px;
+		flex: auto;
 
 		@include breakpoint-deprecated( ">480px" ) {
 			max-width: 400px;

--- a/client/me/purchases/purchases-list-in-dataviews/style.scss
+++ b/client/me/purchases/purchases-list-in-dataviews/style.scss
@@ -16,6 +16,29 @@
 
 	.dataviews-wrapper .dataviews-view-table__row .dataviews-view-table__actions-column {
 		text-align: right;
+		position: sticky;
+		right: 0;
+		background-color: var( --studio-white );
+
+		::after {
+			background-color: var( --color-border-subtle );
+			bottom: 0;
+			content: "";
+			display: block;
+			left: 0;
+			position: absolute;
+			top: 0;
+			width: 1px;
+		}
+
+		@include breakpoint-deprecated( ">480px" ) {
+			position: relative;
+			background-color: transparent;
+
+			::after {
+				display: none;
+			}
+		}
 	}
 
 	.dataviews-view-table__row {

--- a/client/me/purchases/purchases-list-in-dataviews/style.scss
+++ b/client/me/purchases/purchases-list-in-dataviews/style.scss
@@ -64,19 +64,23 @@
 	.dataviews-view-table tr td:first-child,
 	.dataviews-view-table tr th:first-child {
 		padding-left: 24px;
-		max-width: 250px;
 	}
 
-	.dataviews-view-table__cell-content-wrapper .purchase-item__site {
-		margin-right: 16px;
+	.dataviews-view-table__cell-content-wrapper.dataviews-column-primary__media {
+		display: none;
 
-		.purchase-item__static-icon {
-			width: 36px;
+		@include breakpoint-deprecated( ">480px" ) {
+			display: flex;
 		}
 	}
 
-	.dataviews-view-table__cell-content-wrapper .purchase-item__information {
+	.purchase-item__information {
 		margin-right: 16px;
+		max-width: 250px;
+
+		@include breakpoint-deprecated( ">480px" ) {
+			max-width: 400px;
+		}
 
 		.purchase-item__title {
 			font-size: 16px;
@@ -89,10 +93,6 @@
 			text-decoration: none;
 		}
 
-		div {
-			max-width: 462px;
-		}
-
 		.purchase-item__purchase-type,
 		.purchase-item__purchase-type a.purchase-item__link {
 			overflow: hidden;
@@ -100,15 +100,15 @@
 	}
 
 	.dataviews-view-table__cell-content-wrapper .purchase-item__status {
-		flex: 0 1 300px;
 		margin-right: 16px;
+		max-width: 250px;
 	}
 
 	.dataviews-view-table__cell-content-wrapper .purchase-item__payment-method {
-		flex: 0 0 200px;
 		display: flex;
 		align-items: center;
 		flex-wrap: wrap;
+		min-width: 175px;
 
 		.purchase-item__payment-method-card {
 			margin-right: 8px;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: https://linear.app/a8c/issue/CHE-184/long-site-urls-cut-off-or-overlap-in-various-places

## Proposed Changes

This slightly refactors some of the fields for the Purchase Management DataViews component to better align with Core's `title`, `media`, and `description` fields.

## Why are these changes being made?

Currently, we're using a hidden field, `purchases-id`, along with separate fields for the site icon (`site`) and both the product description and site name (`product`) to create a look similar to Core's special treatment of the DataView's `title`, `media`, and `description` fields. Our version introduces some small layout issues related to being able to rearrange those unlocked fields, whereas Core's version (also used by the Sites and Domains DataViews) locks those fields and combines them into a single column in the table.

| Before | After |
| ----------- | ----------- |
| <img width="1608" alt="Screenshot 2025-06-12 at 2 22 22 PM" src="https://github.com/user-attachments/assets/ec5d0421-6e13-4b52-996f-b41d60713b54" /> | <img width="1608" alt="Screenshot 2025-06-12 at 2 22 09 PM" src="https://github.com/user-attachments/assets/fd784bee-c32a-4331-a973-e8d83e2cb760" /> |
| <img width="385" alt="Screenshot 2025-06-12 at 2 22 42 PM" src="https://github.com/user-attachments/assets/73b9974c-d82f-40b5-b96d-43a06fc4e92a" /> | <img width="384" alt="Screenshot 2025-06-12 at 2 22 59 PM" src="https://github.com/user-attachments/assets/9a2a471f-b69e-4de9-9a7a-df06dda3c861" /> |

## Testing Instructions

* For a user with many purchases, visit Me > Purchases
* Verify that the table layout is correct at various widths
* Verify that filtering, sorting, and searching works as expected
* Verify the primary fields (site, product, and description) are locked
