### PR TITLE
Stats: Align the visitors and views selector correctly

### DIFF
--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -326,9 +326,12 @@ $y-axis-padding: 0 20px;
 
 
 	&.form-label {
-		display: inline-block;
-		margin-bottom: 0;
-		font-weight: 400;
+		&,
+		&.is-selectable {
+			display: inline-block;
+			margin-bottom: 0;
+			font-weight: 400;
+		}
 	}
 
 	&.is-selectable {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Increase the CSS specificity for `.form-label` selector on my stats page
* The PR https://github.com/Automattic/wp-calypso/pull/103616/files#diff-3234c129bad8ca596afa303bb15e52f1ece076c1ddfb1a455a071c41fe903877L4-R5 seems to increase CSS specificity because of the `:not` selector which is overriding some of the overrides for the form-label selector
* Add more more class to increase the specificity of stats CSS changes

Before

![Arc -2025-06-11 at 14 22 50@2x](https://github.com/user-attachments/assets/5dd0316b-b77c-4347-8b13-f9336a9db03f)


After

![Arc -2025-06-11 at 14 23 33@2x](https://github.com/user-attachments/assets/e72d3fee-8931-40d9-a310-747b45c91a56)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (CYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
