### PR TITLE
Admin color: treat sites without admin color to have default one

### DIFF
--- a/client/state/admin-color/reducer.js
+++ b/client/state/admin-color/reducer.js
@@ -3,12 +3,14 @@ import { ADMIN_COLOR_RECEIVE, ADMIN_COLOR_REQUEST_FAILURE } from 'calypso/state/
 import { keyedReducer, withPersistence } from 'calypso/state/utils';
 import 'calypso/state/data-layer/wpcom/sites/admin-color';
 
+const fallbackAdminColor = 'default'; // packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+
 const adminColorReducer = ( state = [], action ) => {
 	switch ( action.type ) {
 		case ADMIN_COLOR_RECEIVE:
-			return action.adminColor;
+			return action.adminColor || fallbackAdminColor;
 		case ADMIN_COLOR_REQUEST_FAILURE:
-			return 'default'; // fallback color scheme: packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+			return fallbackAdminColor;
 		default:
 			return state;
 	}


### PR DESCRIPTION
Fixes p1749632519763519/1749218797.851879-slack-C0761SX4K

## Proposed Changes

In some migrated sites, the `/wpcom/v2/sites/:siteId/admin-color` returns `{ admin_color: false }`, so the logic from this PR: 

- https://github.com/Automattic/wp-calypso/pull/102929

will never render Calypso page.

This PR fixes that by coalescing that value with `default`.

## Testing Instructions

Smoke test Calypso nav-unified pages (e.g. /home) on various sites and make sure they still load the site's correct admin color scheme.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?