### PR TITLE
Help Center: Add error to calypso_odie_zendesk_conversation_not_found

### DIFF
--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -109,6 +109,7 @@ export const useGetCombinedChat = (
 				recordTracksEvent( 'calypso_odie_zendesk_conversation_not_found', {
 					conversation_id: conversationId,
 					odie_id: odieId,
+					error: error instanceof Error ? error.message : String( error ),
 				} );
 
 				startNewInteraction( {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-13578/add-error-to-calypso-odie-zendesk-conversation-not-found

## Proposed Changes

Add error to `calypso_odie_zendesk_conversation_not_found`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check the code