### PR TITLE
JP Login: Redirect to fallback if there is no redirect_to provided

### DIFF
--- a/client/login/magic-login/verify-login-code.jsx
+++ b/client/login/magic-login/verify-login-code.jsx
@@ -9,6 +9,7 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import LoggedOutForm from 'calypso/components/logged-out-form';
 import { navigate } from 'calypso/lib/navigate';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { rebootAfterLogin } from 'calypso/state/login/actions';
 import { fetchMagicLoginAuthenticate } from 'calypso/state/login/magic-login/actions';
 import { getRedirectToOriginal } from 'calypso/state/login/selectors';
 import getMagicLoginAuthSuccessData from 'calypso/state/selectors/get-magic-login-auth-success-data';
@@ -41,7 +42,15 @@ const VerifyLoginCode = ( {
 	useEffect( () => {
 		if ( isAuthenticated && authSuccessData ) {
 			setIsRedirecting( true );
-			navigate( authSuccessData.redirect_to );
+
+			const redirectUrl = authSuccessData.redirect_to;
+
+			if ( redirectUrl ) {
+				navigate( redirectUrl );
+			} else {
+				// Fall back to rebootAfterLogin which handles the default redirect to '/' and other edge cases
+				rebootAfterLogin( { magic_login: 1 } );
+			}
 		}
 	}, [ isAuthenticated, authSuccessData ] );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Adds a fallback redirect so we get redirected to home even without a URI param

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix a prod issue where the default redirection is not working the same as on staging

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Just test that the login flow on `log-in/jetpack` works as before with the codes with and without a param

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
