### PR TITLE
Accessibility: Add ARIA label for selected item in token component

### DIFF
--- a/client/components/token-field/test/__snapshots__/index.jsx.snap
+++ b/client/components/token-field/test/__snapshots__/index.jsx.snap
@@ -9,8 +9,10 @@ exports[`TokenField render should render tokens 1`] = `
       class="token-field__input-container"
     >
       <button
+        aria-checked="true"
         aria-label="Deselect foo"
         class="token-field__token"
+        tabindex="0"
         type="button"
       >
         <span
@@ -31,8 +33,10 @@ exports[`TokenField render should render tokens 1`] = `
         </svg>
       </button>
       <button
+        aria-checked="true"
         aria-label="Deselect bar"
         class="token-field__token"
+        tabindex="0"
         type="button"
       >
         <span

--- a/client/components/token-field/test/__snapshots__/index.jsx.snap
+++ b/client/components/token-field/test/__snapshots__/index.jsx.snap
@@ -8,9 +8,10 @@ exports[`TokenField render should render tokens 1`] = `
     <div
       class="token-field__input-container"
     >
-      <span
+      <button
+        aria-label="Deselect foo"
         class="token-field__token"
-        tabindex="-1"
+        type="button"
       >
         <span
           class="token-field__token-text"
@@ -28,10 +29,11 @@ exports[`TokenField render should render tokens 1`] = `
             xlink:href="gridicons.svg#gridicons-cross-small"
           />
         </svg>
-      </span>
-      <span
+      </button>
+      <button
+        aria-label="Deselect bar"
         class="token-field__token"
-        tabindex="-1"
+        type="button"
       >
         <span
           class="token-field__token-text"
@@ -49,7 +51,7 @@ exports[`TokenField render should render tokens 1`] = `
             xlink:href="gridicons.svg#gridicons-cross-small"
           />
         </svg>
-      </span>
+      </button>
       <input
         aria-activedescendant="option-undefined"
         aria-controls="options-list"

--- a/client/components/token-field/test/__snapshots__/index.jsx.snap
+++ b/client/components/token-field/test/__snapshots__/index.jsx.snap
@@ -9,7 +9,6 @@ exports[`TokenField render should render tokens 1`] = `
       class="token-field__input-container"
     >
       <button
-        aria-checked="true"
         aria-label="Deselect foo"
         class="token-field__token"
         tabindex="0"
@@ -33,7 +32,6 @@ exports[`TokenField render should render tokens 1`] = `
         </svg>
       </button>
       <button
-        aria-checked="true"
         aria-label="Deselect bar"
         class="token-field__token"
         tabindex="0"

--- a/client/components/token-field/token.jsx
+++ b/client/components/token-field/token.jsx
@@ -33,6 +33,7 @@ export default class extends PureComponent {
 			'is-disabled': this.props.disabled,
 		} );
 
+		/* translators: %(item)s is the selected item */
 		const ariaLabel = translate( 'Deselect %(item)s', {
 			args: {
 				item: displayTransform( value ),

--- a/client/components/token-field/token.jsx
+++ b/client/components/token-field/token.jsx
@@ -1,5 +1,6 @@
 import { Gridicon, Tooltip } from '@automattic/components';
 import clsx from 'clsx';
+import { translate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
@@ -32,12 +33,20 @@ export default class extends PureComponent {
 			'is-disabled': this.props.disabled,
 		} );
 
+		const ariaLabel = translate( 'Deselect %(item)s', {
+			args: {
+				item: displayTransform( value ),
+			},
+		} );
+
 		return (
-			<span
+			<button
+				type="button"
 				className={ tokenClasses }
-				tabIndex="-1"
 				onMouseEnter={ this.props.onMouseEnter }
 				onMouseLeave={ this.props.onMouseLeave }
+				disabled={ this.props.disabled }
+				aria-label={ ariaLabel }
 			>
 				<span className="token-field__token-text">{ displayTransform( value ) }</span>
 				<Gridicon
@@ -51,7 +60,7 @@ export default class extends PureComponent {
 						{ tooltip }
 					</Tooltip>
 				) }
-			</span>
+			</button>
 		);
 	}
 

--- a/client/components/token-field/token.jsx
+++ b/client/components/token-field/token.jsx
@@ -46,6 +46,8 @@ export default class extends PureComponent {
 				className={ tokenClasses }
 				onMouseEnter={ this.props.onMouseEnter }
 				onMouseLeave={ this.props.onMouseLeave }
+				onClick={ ! this.props.disabled ? this._onClickRemove : null }
+				tabIndex={ 0 }
 				disabled={ this.props.disabled }
 				aria-label={ ariaLabel }
 			>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13528

## Proposed Changes

* Add appropriate aria label to selected item for screen readers. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* They are currently not selectable or announced correctly by screen reader.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Visit `/setup/onboarding/domains?source=sites-dashboard` URL
* Search for the domain
* Enable VoiceOver
* Navigate through using `Control + Option + Arrow keys`
* Select item
* Try to navigate to selected item
* Make sure it announces as "Deselect ..." 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
