### PR TITLE
Adjust environment switcher display condition

### DIFF
--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -9,7 +9,7 @@ import { useSetTabBreadcrumb } from 'calypso/sites/hooks/breadcrumbs/use-set-tab
 import HostingFeaturesIcon from 'calypso/sites/hosting/components/hosting-features-icon';
 import { useStagingSite } from 'calypso/sites/staging-site/hooks/use-staging-site';
 import { useSelector } from 'calypso/state';
-import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import { canCurrentUserManageEnvironmentOptions } from 'calypso/state/sites/selectors/can-current-user-manage-environment-options';
 import { StagingSiteStatus } from 'calypso/state/staging-site/constants';
 import { getStagingSiteStatus } from 'calypso/state/staging-site/selectors';
 import { useBreadcrumbs } from '../../hooks/breadcrumbs/use-breadcrumbs';
@@ -191,15 +191,9 @@ const DotcomPreviewPane = ( {
 		stagingStatus === StagingSiteStatus.NONE ||
 		stagingStatus === StagingSiteStatus.UNSET;
 
-	const hasEnvironmentPermission = useSelector( ( state ) => {
-		if ( site.is_wpcom_staging_site ) {
-			return canCurrentUser( state, site.options?.wpcom_production_blog_id, 'manage_options' );
-		}
-		return (
-			canCurrentUser( state, site.options?.wpcom_staging_blog_ids?.[ 0 ], 'manage_options' ) ??
-			false
-		);
-	} );
+	const hasEnvironmentPermission = useSelector( ( state ) =>
+		canCurrentUserManageEnvironmentOptions( state, site )
+	);
 
 	const { breadcrumbs, shouldShowBreadcrumbs } = useBreadcrumbs();
 	useSetTabBreadcrumb( {

--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -9,7 +9,7 @@ import { useSetTabBreadcrumb } from 'calypso/sites/hooks/breadcrumbs/use-set-tab
 import HostingFeaturesIcon from 'calypso/sites/hosting/components/hosting-features-icon';
 import { useStagingSite } from 'calypso/sites/staging-site/hooks/use-staging-site';
 import { useSelector } from 'calypso/state';
-import { canCurrentUserManageEnvironmentOptions } from 'calypso/state/sites/selectors/can-current-user-manage-environment-options';
+import { canCurrentUserSwitchEnvironment } from 'calypso/state/sites/selectors/can-current-user-switch-environment';
 import { StagingSiteStatus } from 'calypso/state/staging-site/constants';
 import { getStagingSiteStatus } from 'calypso/state/staging-site/selectors';
 import { useBreadcrumbs } from '../../hooks/breadcrumbs/use-breadcrumbs';
@@ -192,7 +192,7 @@ const DotcomPreviewPane = ( {
 		stagingStatus === StagingSiteStatus.UNSET;
 
 	const hasEnvironmentPermission = useSelector( ( state ) =>
-		canCurrentUserManageEnvironmentOptions( state, site )
+		canCurrentUserSwitchEnvironment( state, site )
 	);
 
 	const { breadcrumbs, shouldShowBreadcrumbs } = useBreadcrumbs();

--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -195,7 +195,10 @@ const DotcomPreviewPane = ( {
 		if ( site.is_wpcom_staging_site ) {
 			return canCurrentUser( state, site.options?.wpcom_production_blog_id, 'manage_options' );
 		}
-		return stagingSites?.[ 0 ]?.user_has_permission ?? false;
+		return (
+			canCurrentUser( state, site.options?.wpcom_staging_blog_ids?.[ 0 ], 'manage_options' ) ??
+			false
+		);
 	} );
 
 	const { breadcrumbs, shouldShowBreadcrumbs } = useBreadcrumbs();

--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -191,16 +191,11 @@ const DotcomPreviewPane = ( {
 		stagingStatus === StagingSiteStatus.NONE ||
 		stagingStatus === StagingSiteStatus.UNSET;
 
-	const hasStagingSitePermission = stagingSites?.some(
-		( stagingSite ) => stagingSite.user_has_permission
-	);
-
-	const hasManageOptionsPermission = useSelector( ( state ) => {
+	const hasEnvironmentPermission = useSelector( ( state ) => {
 		if ( site.is_wpcom_staging_site ) {
 			return canCurrentUser( state, site.options?.wpcom_production_blog_id, 'manage_options' );
 		}
-
-		return canCurrentUser( state, site.ID, 'manage_options' );
+		return stagingSites?.[ 0 ]?.user_has_permission ?? false;
 	} );
 
 	const { breadcrumbs, shouldShowBreadcrumbs } = useBreadcrumbs();
@@ -226,12 +221,7 @@ const DotcomPreviewPane = ( {
 						return <SiteStatus site={ site } />;
 					}
 
-					if (
-						( hasStagingSitePermission &&
-							! site.is_wpcom_staging_site &&
-							isStagingStatusFinished ) ||
-						( hasManageOptionsPermission && site.is_wpcom_staging_site )
-					) {
+					if ( hasEnvironmentPermission && isStagingStatusFinished ) {
 						return <SiteEnvironmentSwitcher onChange={ changeSitePreviewPane } site={ site } />;
 					}
 				},

--- a/client/state/sites/selectors/can-current-user-manage-environment-options.ts
+++ b/client/state/sites/selectors/can-current-user-manage-environment-options.ts
@@ -1,0 +1,28 @@
+import { createSelector } from '@automattic/state-utils';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import type { SiteExcerptData } from '@automattic/sites';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Returns whether the current user has manage_options capability for the other environment site.
+ * For staging sites, checks production site permissions.
+ * For production sites, checks staging site permissions.
+ * @param {Object} state Global state tree
+ * @param {SiteExcerptData} site Site data
+ * @returns {boolean} Whether the user has manage_options capability
+ */
+export const canCurrentUserManageEnvironmentOptions = createSelector(
+	( state: AppState, site: SiteExcerptData ) => {
+		const otherEnvironmentSiteID = site.is_wpcom_staging_site
+			? site.options?.wpcom_production_blog_id
+			: site.options?.wpcom_staging_blog_ids?.[ 0 ];
+
+		return canCurrentUser( state, otherEnvironmentSiteID, 'manage_options' ) ?? false;
+	},
+	( state: AppState, site: SiteExcerptData ) => [
+		state.currentUser.capabilities,
+		site.is_wpcom_staging_site,
+		site.options?.wpcom_production_blog_id,
+		site.options?.wpcom_staging_blog_ids,
+	]
+);

--- a/client/state/sites/selectors/can-current-user-switch-environment.ts
+++ b/client/state/sites/selectors/can-current-user-switch-environment.ts
@@ -11,7 +11,7 @@ import type { AppState } from 'calypso/types';
  * @param {SiteExcerptData} site Site data
  * @returns {boolean} Whether the user has manage_options capability
  */
-export const canCurrentUserManageEnvironmentOptions = createSelector(
+export const canCurrentUserSwitchEnvironment = createSelector(
 	( state: AppState, site: SiteExcerptData ) => {
 		const otherEnvironmentSiteID = site.is_wpcom_staging_site
 			? site.options?.wpcom_production_blog_id


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDEV-131

## Proposed Changes

* Created a new selector to check for permission to swap environment
* Uses the same selector for staging and production site that will be used in the existing `SiteEnvironmentSwitcher` component so we can be sure the permission matches the site 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This PR aims to fix the reported issue where the environment switcher is displayed up for users without proper permissions on a specific condition mentioned here: https://github.com/Automattic/wp-calypso/pull/103438#issuecomment-2962388915

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site
* Create a staging site
* Invite another user to staging site
* Log in with the test user and confirm the environment switcher is not displayed
* Log back in to the site owner and invite the user to the production site
*  Log in with the test user and confirm the environment switcher is now displayed
*  Test the same scenario with reverse order - invite to production first and staging after


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
- [ ] 