### PR TITLE
Site settings backport: Fix issue where the SFTP/SSH panel toggle button is center aligned

### DIFF
--- a/client/sites/settings/v2/style.scss
+++ b/client/sites/settings/v2/style.scss
@@ -24,6 +24,10 @@
 		min-height: 0;
 	}
 
+	.components-panel__body-toggle {
+		justify-content: unset;
+	}
+
 	.site-preview-pane:has( & .dashboard-snackbars ) {
 		z-index: 176;
 	}


### PR DESCRIPTION
Ref pdtkmj-3H1-p2#comment-7106 

## Proposed Changes

| Before | After |
| --- | --- |
| <img width="650" alt="Screenshot 2025-06-11 at 10 07 44 PM" src="https://github.com/user-attachments/assets/d362f2bc-57e1-412f-9e66-2c6e1905fc58" /> | <img width="647" alt="Screenshot 2025-06-11 at 10 07 34 PM" src="https://github.com/user-attachments/assets/e56b458c-aca9-412b-99ae-171540556f16" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Ensure that the UI is updated as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?