### PR TITLE
Update Cancellation Survey and Expand Questions

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
@@ -221,26 +221,26 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 	{
 		value: 'domain',
 		get label() {
-			return translate( 'Domain' );
+			return translate( 'Problems with domain' );
 		},
 		selectOptions: [
 			PLACEHOLDER,
 			{
-				value: 'didNotGetFreeDomain',
+				value: 'troubleConnectingOrTransferring',
 				get label() {
-					return translate( 'I didn’t get a free domain.' );
+					return translate( 'Trouble connecting or transferring my existing domain.' );
 				},
 			},
 			{
-				value: 'otherDomainIssues',
+				value: 'confusedAboutDomains',
 				get label() {
-					return translate( 'Other domain issues' );
+					return translate( 'Confused about how domains work with the WordPress.com plan.' );
 				},
 			},
 			{
-				value: 'domainConnection',
+				value: 'domainIncorrect',
 				get label() {
-					return translate( 'Problem connecting my domain' );
+					return translate( 'Didn’t get the domain name I expected / My domain is incorrect.' );
 				},
 			},
 		],

--- a/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
@@ -108,7 +108,7 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 			{
 				value: 'otherPriceValue',
 				get label() {
-					return translate( 'Something else related to price/value' );
+					return translate( 'Something else related to price/value.' );
 				},
 				get textPlaceholder() {
 					return translate( 'Please tell us more about your price/value concern' );

--- a/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
@@ -147,6 +147,15 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 					return translate( 'Onboarding or tutorials were not helpful enough.' );
 				},
 			},
+			{
+				value: 'otherTooHardToUse',
+				get label() {
+					return translate( 'Something else related to too hard to use.' );
+				},
+				get textPlaceholder() {
+					return translate( 'Please tell us more' );
+				},
+			},
 		],
 	},
 	{
@@ -192,6 +201,15 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 					return translate( 'Core features I expected are only available on a much higher plan.' );
 				},
 			},
+			{
+				value: 'otherMissingFeatures',
+				get label() {
+					return translate( 'Something else related to features/flexibility.' );
+				},
+				get textPlaceholder() {
+					return translate( 'Please tell us more' );
+				},
+			},
 		],
 	},
 	{
@@ -225,6 +243,15 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 					return translate( 'Site was down or inaccessible.' );
 				},
 			},
+			{
+				value: 'otherTechnicalIssues',
+				get label() {
+					return translate( 'Something else related to technical problems.' );
+				},
+				get textPlaceholder() {
+					return translate( 'Please tell us more' );
+				},
+			},
 		],
 	},
 	{
@@ -250,6 +277,15 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 				value: 'domainIncorrect',
 				get label() {
 					return translate( 'Didn’t get the domain name I expected / My domain is incorrect.' );
+				},
+			},
+			{
+				value: 'otherDomain',
+				get label() {
+					return translate( 'Something else related to domains.' );
+				},
+				get textPlaceholder() {
+					return translate( 'Please tell us more' );
 				},
 			},
 		],
@@ -279,6 +315,15 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 					return translate( 'The plan I chose didn’t match what I thought I was buying.' );
 				},
 			},
+			{
+				value: 'otherWrongPlanOrSite',
+				get label() {
+					return translate( 'Something else related to an accidental purchase.' );
+				},
+				get textPlaceholder() {
+					return translate( 'Please tell us more' );
+				},
+			},
 		],
 	},
 	{
@@ -304,6 +349,15 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 				value: 'AIInsufficient',
 				get label() {
 					return translate( 'AI/automated support was not sufficient for my issue.' );
+				},
+			},
+			{
+				value: 'otherBadSupport',
+				get label() {
+					return translate( 'Something else related to support.' );
+				},
+				get textPlaceholder() {
+					return translate( 'Please tell us more' );
 				},
 			},
 		],
@@ -337,6 +391,15 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 				value: 'mayReturn',
 				get label() {
 					return translate( 'Temporary cancellation, I might return.' );
+				},
+			},
+			{
+				value: 'otherNoLongerNeedSite',
+				get label() {
+					return translate( 'Something else related to changed needs.' );
+				},
+				get textPlaceholder() {
+					return translate( 'Please tell us more' );
 				},
 			},
 		],

--- a/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
@@ -273,40 +273,61 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 		],
 	},
 	{
-		value: 'couldNotFinish',
+		value: 'badSupport',
 		get label() {
-			return translate( 'Couldn’t finish my site' );
+			return translate( 'Bad support experience' );
 		},
 		selectOptions: [
 			PLACEHOLDER,
 			{
-				value: 'noTime',
+				value: 'slowOrUnhelpful',
 				get label() {
-					return translate( 'I don’t have time.' );
+					return translate( 'Support was unhelpful or slow to respond.' );
 				},
 			},
 			{
-				value: 'needProfessionalHelp',
+				value: 'noHumanSupport',
 				get label() {
-					return translate( 'Need professional help to build my site.' );
+					return translate( 'Could not easily reach a human support agent.' );
 				},
 			},
 			{
-				value: 'siteIsNotReady',
+				value: 'AIInsufficient',
 				get label() {
-					return translate( 'My site is not ready.' );
+					return translate( 'AI/automated support was not sufficient for my issue.' );
+				},
+			},
+		],
+	},
+	{
+		value: 'noLongerNeedSite',
+		get label() {
+			return translate( 'No longer need a site' );
+		},
+		selectOptions: [
+			PLACEHOLDER,
+			{
+				value: 'projectChanged',
+				get label() {
+					return translate( 'My project/business plans have changed.' );
 				},
 			},
 			{
-				value: 'cannotFindWhatIWanted',
+				value: 'justExploring',
 				get label() {
-					return translate( 'Couldn’t find what I wanted.' );
+					return translate( 'I was just exploring/testing the platform.' );
 				},
 			},
 			{
-				value: 'tooComplicated',
+				value: 'noLongerNeedSite',
 				get label() {
-					return translate( 'It’s too complicated for me.' );
+					return translate( 'I no longer need this website/service.' );
+				},
+			},
+			{
+				value: 'mayReturn',
+				get label() {
+					return translate( 'Temporary cancellation, I might return.' );
 				},
 			},
 		],

--- a/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
@@ -71,26 +71,71 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 	{
 		value: 'price/budget',
 		get label() {
-			return translate( 'Price/Budget' );
+			return translate( 'Too expensive' );
 		},
 		selectOptions: [
 			PLACEHOLDER,
 			{
 				value: 'tooExpensive',
 				get label() {
-					return translate( 'It’s too expensive.' );
+					return translate( 'The plan is too expensive for the features offered.' );
 				},
 			},
 			{
-				value: 'wantCheaperPlan',
+				value: 'lackOfCustomization',
 				get label() {
-					return translate( 'I want a cheaper plan.' );
+					return translate( 'Lack of customization features (e.g., colors, fonts, themes).' );
 				},
 			},
 			{
 				value: 'freeIsGoodEnough',
 				get label() {
-					return translate( 'Free is good enough for me.' );
+					return translate( 'The free plan is sufficient for my current needs.' );
+				},
+			},
+			{
+				value: 'foundBetterValue',
+				get label() {
+					return translate( 'I found a competitor with better pricing/value.' );
+				},
+			},
+			{
+				value: 'budgetConstraints',
+				get label() {
+					return translate( 'Budget constraints / Can no longer afford it.' );
+				},
+			},
+		],
+	},
+	{
+		value: 'tooHardToUse',
+		get label() {
+			return translate( 'Too hard to use' );
+		},
+		selectOptions: [
+			PLACEHOLDER,
+			{
+				value: 'complicatedDashboard',
+				get label() {
+					return translate( 'The platform/dashboard is too complicated or confusing to navigate.' );
+				},
+			},
+			{
+				value: 'difficultEditor',
+				get label() {
+					return translate( 'The website editor is difficult or unintuitive to use.' );
+				},
+			},
+			{
+				value: 'tooMuchTimeToLearn',
+				get label() {
+					return translate( 'It takes too much time to learn how to use the platform.' );
+				},
+			},
+			{
+				value: 'inadequateOnboarding',
+				get label() {
+					return translate( 'Onboarding or tutorials were not helpful enough.' );
 				},
 			},
 		],

--- a/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
@@ -40,7 +40,7 @@ export interface CancellationReason extends CancellationReasonBase {
 	/**
 	 * Options for the sub category select
 	 */
-	selectOptions?: CancellationReasonBase[];
+	selectOptions?: CancellationReason[];
 }
 
 /**
@@ -103,6 +103,15 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 				value: 'budgetConstraints',
 				get label() {
 					return translate( 'Budget constraints / Can no longer afford it.' );
+				},
+			},
+			{
+				value: 'otherPriceValue',
+				get label() {
+					return translate( 'Something else related to price/value' );
+				},
+				get textPlaceholder() {
+					return translate( 'Please tell us more about your price/value concern' );
 				},
 			},
 		],

--- a/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
@@ -246,6 +246,33 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 		],
 	},
 	{
+		value: 'wrongPlanOrSite',
+		get label() {
+			return translate( 'Wrong plan or site' );
+		},
+		selectOptions: [
+			PLACEHOLDER,
+			{
+				value: 'wrongPlan',
+				get label() {
+					return translate( 'I purchased this plan by mistake.' );
+				},
+			},
+			{
+				value: 'wrongSite',
+				get label() {
+					return translate( 'I meant to upgrade a different website or account.' );
+				},
+			},
+			{
+				value: 'noMatch',
+				get label() {
+					return translate( 'The plan I chose didn’t match what I thought I was buying.' );
+				},
+			},
+		],
+	},
+	{
 		value: 'couldNotFinish',
 		get label() {
 			return translate( 'Couldn’t finish my site' );

--- a/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
@@ -141,6 +141,78 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 		],
 	},
 	{
+		value: 'missingFeatures',
+		get label() {
+			return translate( 'Missing features' );
+		},
+		selectOptions: [
+			PLACEHOLDER,
+			{
+				value: 'cannotInstallPlugins',
+				get label() {
+					return translate(
+						'Cannot install desired plugins (e.g., from WordPress.org or third-party).'
+					);
+				},
+			},
+			{
+				value: 'cannotUploadThemes',
+				get label() {
+					return translate( 'Cannot upload custom themes.' );
+				},
+			},
+			{
+				value: 'limitedCustomization',
+				get label() {
+					return translate(
+						'Limited design or customization options (e.g., layout, specific elements).'
+					);
+				},
+			},
+			{
+				value: 'missingFunctionality',
+				get label() {
+					return translate(
+						'Lacking specific functionality I need (e.g., e-commerce, specific integrations, advanced SEO tools).'
+					);
+				},
+			},
+			{
+				value: 'coreFeaturesMissing',
+				get label() {
+					return translate( 'Core features I expected are only available on a much higher plan.' );
+				},
+			},
+		],
+	},
+	{
+		value: 'technicalIssues',
+		get label() {
+			return translate( 'Technical issues' );
+		},
+		selectOptions: [
+			PLACEHOLDER,
+			{
+				value: 'tooComplicated',
+				get label() {
+					return translate( 'It’s too complicated for me.' );
+				},
+			},
+			{
+				value: 'seoIssues',
+				get label() {
+					return translate( 'SEO issues' );
+				},
+			},
+			{
+				value: 'loadingTime',
+				get label() {
+					return translate( 'Loading time' );
+				},
+			},
+		],
+	},
+	{
 		value: 'couldNotFinish',
 		get label() {
 			return translate( 'Couldn’t finish my site' );
@@ -175,78 +247,6 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 				value: 'tooComplicated',
 				get label() {
 					return translate( 'It’s too complicated for me.' );
-				},
-			},
-		],
-	},
-	{
-		value: 'missingFeatures',
-		get label() {
-			return translate( 'Missing features' );
-		},
-		selectOptions: [
-			PLACEHOLDER,
-			{
-				value: 'otherFeatures',
-				get label() {
-					return translate( 'Other features' );
-				},
-			},
-			{
-				value: 'eCommerceFeatures',
-				get label() {
-					return translate( 'eCommerce features' );
-				},
-			},
-			{
-				value: 'customization',
-				get label() {
-					return translate( 'Customization / CSS' );
-				},
-			},
-			{
-				value: 'cannotUsePlugin',
-				get label() {
-					return translate( 'Can’t use a plugin' );
-				},
-			},
-			{
-				value: 'cannotUseTheme',
-				get label() {
-					return translate( 'Can’t use a theme' );
-				},
-			},
-			{
-				value: 'loadingTime',
-				get label() {
-					return translate( 'Loading time' );
-				},
-			},
-		],
-	},
-	{
-		value: 'technicalIssues',
-		get label() {
-			return translate( 'Technical issues' );
-		},
-		selectOptions: [
-			PLACEHOLDER,
-			{
-				value: 'tooComplicated',
-				get label() {
-					return translate( 'It’s too complicated for me.' );
-				},
-			},
-			{
-				value: 'seoIssues',
-				get label() {
-					return translate( 'SEO issues' );
-				},
-			},
-			{
-				value: 'loadingTime',
-				get label() {
-					return translate( 'Loading time' );
 				},
 			},
 		],

--- a/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
@@ -188,26 +188,59 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 	{
 		value: 'technicalIssues',
 		get label() {
-			return translate( 'Technical issues' );
+			return translate( 'Technical problems' );
 		},
 		selectOptions: [
 			PLACEHOLDER,
 			{
-				value: 'tooComplicated',
+				value: 'tooSlow',
 				get label() {
-					return translate( 'It’s too complicated for me.' );
+					return translate( 'Site is slow or experiences performance issues.' );
 				},
 			},
 			{
-				value: 'seoIssues',
+				value: 'bugsOrGlitches',
 				get label() {
-					return translate( 'SEO issues' );
+					return translate( 'Encountered bugs, errors, or glitches.' );
 				},
 			},
 			{
-				value: 'loadingTime',
+				value: 'migrationProblems',
 				get label() {
-					return translate( 'Loading time' );
+					return translate( 'Problems migrating my existing site or content.' );
+				},
+			},
+			{
+				value: 'downtime',
+				get label() {
+					return translate( 'Site was down or inaccessible.' );
+				},
+			},
+		],
+	},
+	{
+		value: 'domain',
+		get label() {
+			return translate( 'Domain' );
+		},
+		selectOptions: [
+			PLACEHOLDER,
+			{
+				value: 'didNotGetFreeDomain',
+				get label() {
+					return translate( 'I didn’t get a free domain.' );
+				},
+			},
+			{
+				value: 'otherDomainIssues',
+				get label() {
+					return translate( 'Other domain issues' );
+				},
+			},
+			{
+				value: 'domainConnection',
+				get label() {
+					return translate( 'Problem connecting my domain' );
 				},
 			},
 		],
@@ -247,33 +280,6 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 				value: 'tooComplicated',
 				get label() {
 					return translate( 'It’s too complicated for me.' );
-				},
-			},
-		],
-	},
-	{
-		value: 'domain',
-		get label() {
-			return translate( 'Domain' );
-		},
-		selectOptions: [
-			PLACEHOLDER,
-			{
-				value: 'didNotGetFreeDomain',
-				get label() {
-					return translate( 'I didn’t get a free domain.' );
-				},
-			},
-			{
-				value: 'otherDomainIssues',
-				get label() {
-					return translate( 'Other domain issues' );
-				},
-			},
-			{
-				value: 'domainConnection',
-				get label() {
-					return translate( 'Problem connecting my domain' );
 				},
 			},
 		],

--- a/client/components/marketing-survey/cancel-purchase-form/get-upsell-type.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/get-upsell-type.ts
@@ -48,7 +48,7 @@ export function getUpsellType( reason: string, opts: UpsellOptions ): UpsellType
 
 	switch ( reason ) {
 		case 'tooExpensive':
-		case 'wantCheaperPlan':
+		case 'budgetConstraints':
 			if ( ! canDowngrade ) {
 				return '';
 			}
@@ -67,43 +67,40 @@ export function getUpsellType( reason: string, opts: UpsellOptions ): UpsellType
 
 			break;
 
-		case 'noTime':
-		case 'siteIsNotReady':
+		case 'freeIsGoodEnough':
+		case 'foundBetterValue':
+		case 'tooMuchTimeToLearn':
+		case 'inadequateOnboarding':
 			if ( isWpComMonthlyPlan( productSlug ) && canOfferFreeMonth ) {
 				return 'free-month-offer';
 			}
 			return 'built-by';
 
-		case 'needProfessionalHelp':
-		case 'tooComplicated':
+		case 'limitedCustomization':
+		case 'lackOfCustomization':
 		case 'customization':
 			return 'built-by';
 
-		case 'eCommerceFeatures':
-			return liveChatSupported ? 'live-chat:plugins' : '';
-
-		case 'cannotFindWhatIWanted':
-		case 'otherFeatures':
+		case 'missingFunctionality':
+		case 'coreFeaturesMissing':
+		case 'otherMissingFeatures':
 			return liveChatSupported ? 'live-chat:plans' : '';
 
-		case 'cannotUsePlugin':
-		case 'cannotUseTheme':
+		case 'cannotInstallPlugins':
+		case 'cannotUploadThemes':
 			if ( isWpComBusinessPlan( productSlug ) || isWpComEcommercePlan( productSlug ) ) {
 				if ( liveChatSupported ) {
-					return reason === 'cannotUsePlugin' ? 'live-chat:plugins' : 'live-chat:themes';
+					return reason === 'cannotInstallPlugins' ? 'live-chat:plugins' : 'live-chat:themes';
 				}
 				return '';
 			}
 			return 'upgrade-atomic';
-		case 'seoIssues':
-			return 'education:seo';
-		case 'loadingTime':
+		case 'tooSlow':
+		case 'downtime':
 			return 'education:loading-time';
-		case 'didNotGetFreeDomain':
-			return 'education:free-domain';
-		case 'domainConnection':
+		case 'troubleConnectingOrTransferring':
 			return 'education:domain-connection';
-		case 'otherDomainIssues':
+		case 'otherDomain':
 			return liveChatSupported ? 'live-chat:domains' : '';
 	}
 

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -262,8 +262,8 @@ class CancelPurchaseForm extends Component {
 				isSubmitting: true,
 			} );
 
-			const useSubOption = this.state.questionOneDetails && this.state.questionOneText;
-			const responseValue = useSubOption
+			const hasSubOption = this.state.questionOneDetails && this.state.questionOneText;
+			const responseValue = hasSubOption
 				? this.state.questionOneDetails
 				: this.state.questionOneRadio;
 

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -174,12 +174,13 @@ class CancelPurchaseForm extends Component {
 		this.setState( newState );
 	};
 
-	onTextOneChange = ( eventOrValue ) => {
+	onTextOneChange = ( eventOrValue, detailsValue ) => {
 		const value = eventOrValue?.currentTarget?.value ?? eventOrValue;
 		const { purchaseIsAlreadyExtended } = this.state;
 		const newState = {
 			...this.state,
 			questionOneText: value,
+			questionOneDetails: detailsValue || this.state.questionOneDetails,
 			upsell:
 				getUpsellType( value, {
 					productSlug: this.props.purchase?.productSlug || '',

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -139,6 +139,7 @@ class CancelPurchaseForm extends Component {
 			atomicRevertCheckOne: false,
 			atomicRevertCheckTwo: false,
 			purchaseIsAlreadyExtended: false,
+			nextAdventureValidation: true,
 		};
 	}
 
@@ -229,6 +230,10 @@ class CancelPurchaseForm extends Component {
 			importQuestionRadio: value,
 		};
 		this.setState( newState );
+	};
+
+	onNextAdventureValidationChange = ( isValid ) => {
+		this.setState( { nextAdventureValidation: isValid } );
 	};
 
 	// Because of the legacy reason, we can't just use `flowType` here.
@@ -405,6 +410,7 @@ class CancelPurchaseForm extends Component {
 					onSelectNextAdventure={ this.onRadioTwoChange }
 					onChangeNextAdventureDetails={ this.onTextTwoChange }
 					onChangeText={ this.onTextThreeChange }
+					onValidationChange={ this.onNextAdventureValidationChange }
 				/>
 			);
 		}
@@ -513,6 +519,11 @@ class CancelPurchaseForm extends Component {
 
 		if ( surveyStep === NEXT_ADVENTURE_STEP ) {
 			if ( this.state.questionTwoRadio === 'anotherReasonTwo' && ! this.state.questionTwoText ) {
+				return false;
+			}
+
+			// For plan cancellations, require a valid selection from the adventure dropdown
+			if ( ! this.state.nextAdventureValidation ) {
 				return false;
 			}
 

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -261,9 +261,14 @@ class CancelPurchaseForm extends Component {
 				isSubmitting: true,
 			} );
 
+			const useSubOption = this.state.questionOneDetails && this.state.questionOneText;
+			const responseValue = useSubOption
+				? this.state.questionOneDetails
+				: this.state.questionOneRadio;
+
 			const surveyData = {
 				'why-cancel': {
-					response: this.state.questionOneRadio,
+					response: responseValue,
 					text: this.state.questionOneText,
 				},
 				'next-adventure': {

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -139,7 +139,7 @@ class CancelPurchaseForm extends Component {
 			atomicRevertCheckOne: false,
 			atomicRevertCheckTwo: false,
 			purchaseIsAlreadyExtended: false,
-			nextAdventureValidation: true,
+			isNextAdventureValid: true,
 		};
 	}
 
@@ -234,7 +234,7 @@ class CancelPurchaseForm extends Component {
 	};
 
 	onNextAdventureValidationChange = ( isValid ) => {
-		this.setState( { nextAdventureValidation: isValid } );
+		this.setState( { isNextAdventureValid: isValid } );
 	};
 
 	// Because of the legacy reason, we can't just use `flowType` here.
@@ -529,7 +529,7 @@ class CancelPurchaseForm extends Component {
 			}
 
 			// For plan cancellations, require a valid selection from the adventure dropdown
-			if ( ! this.state.nextAdventureValidation ) {
+			if ( ! this.state.isNextAdventureValid ) {
 				return false;
 			}
 

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/feedback-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/feedback-step.tsx
@@ -48,7 +48,6 @@ function CancellationReason( { purchase, reasonCodes, ...props }: CancellationRe
 					options={ reasons.map( toSelectOption ) }
 					onChange={ ( val ) => {
 						onDetailsChange( '' );
-						setFeedbackValue( '' );
 						setValue( val );
 						props.onChange( val );
 					} }

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/feedback-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/feedback-step.tsx
@@ -35,7 +35,7 @@ function CancellationReason( { purchase, reasonCodes, ...props }: CancellationRe
 
 	const onTextAreaChange = ( val: string ) => {
 		setTextAreaValue( val );
-		props.onDetailsChange( val );
+		props.onDetailsChange( val, details );
 	};
 
 	return (

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/feedback-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/feedback-step.tsx
@@ -29,7 +29,7 @@ function CancellationReason( { purchase, reasonCodes, ...props }: CancellationRe
 
 	const onDetailsChange = ( val: string ) => {
 		setDetails( val );
-		setTextAreaValue( '' ); // Reset textarea when changing sub-option
+		setTextAreaValue( '' );
 		props.onDetailsChange( val );
 	};
 
@@ -58,8 +58,8 @@ function CancellationReason( { purchase, reasonCodes, ...props }: CancellationRe
 					<TextareaControl
 						label={ translate( 'Can you please specify?' ) }
 						placeholder={ String( selectedReason.textPlaceholder ) }
-						value={ textAreaValue }
-						onChange={ onTextAreaChange }
+						value={ details }
+						onChange={ onDetailsChange }
 					/>
 				</div>
 			) }

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/feedback-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/feedback-step.tsx
@@ -21,7 +21,7 @@ function CancellationReason( { purchase, reasonCodes, ...props }: CancellationRe
 	const translate = useTranslate();
 	const [ value, setValue ] = useState( '' );
 	const [ details, setDetails ] = useState( '' );
-	const [ textAreaValue, setTextAreaValue ] = useState( '' );
+	const [ feedbackValue, setFeedbackValue ] = useState( '' );
 	const reasons = getCancellationReasons( reasonCodes, { productSlug: purchase.productSlug } );
 	const selectedReason = reasons.find( ( reason ) => reason.value === value );
 	const selectedSubOption = selectedReason?.selectOptions?.find(
@@ -30,12 +30,12 @@ function CancellationReason( { purchase, reasonCodes, ...props }: CancellationRe
 
 	const onDetailsChange = ( val: string ) => {
 		setDetails( val );
-		setTextAreaValue( '' );
+		setFeedbackValue( '' );
 		props.onDetailsChange( val );
 	};
 
 	const onTextAreaChange = ( val: string ) => {
-		setTextAreaValue( val );
+		setFeedbackValue( val );
 		props.onDetailsChange( val, details );
 	};
 
@@ -48,7 +48,7 @@ function CancellationReason( { purchase, reasonCodes, ...props }: CancellationRe
 					options={ reasons.map( toSelectOption ) }
 					onChange={ ( val ) => {
 						onDetailsChange( '' );
-						setTextAreaValue( '' );
+						setFeedbackValue( '' );
 						setValue( val );
 						props.onChange( val );
 					} }
@@ -79,7 +79,7 @@ function CancellationReason( { purchase, reasonCodes, ...props }: CancellationRe
 					<TextareaControl
 						label={ translate( 'Can you please specify?' ) }
 						placeholder={ String( selectedSubOption.textPlaceholder ) }
-						value={ textAreaValue }
+						value={ feedbackValue }
 						onChange={ onTextAreaChange }
 					/>
 				</div>

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/feedback-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/feedback-step.tsx
@@ -8,12 +8,13 @@ import { toSelectOption } from '../to-select-options';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
 type ChangeCallback = ( value: string ) => void;
+type DetailsChangeCallback = ( value: string, details?: string ) => void;
 
 type CancellationReasonProps = {
 	purchase: Purchase;
 	reasonCodes: string[];
 	onChange: ChangeCallback;
-	onDetailsChange: ChangeCallback;
+	onDetailsChange: DetailsChangeCallback;
 };
 
 function CancellationReason( { purchase, reasonCodes, ...props }: CancellationReasonProps ) {

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/feedback-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/feedback-step.tsx
@@ -20,11 +20,21 @@ function CancellationReason( { purchase, reasonCodes, ...props }: CancellationRe
 	const translate = useTranslate();
 	const [ value, setValue ] = useState( '' );
 	const [ details, setDetails ] = useState( '' );
+	const [ textAreaValue, setTextAreaValue ] = useState( '' );
 	const reasons = getCancellationReasons( reasonCodes, { productSlug: purchase.productSlug } );
 	const selectedReason = reasons.find( ( reason ) => reason.value === value );
+	const selectedSubOption = selectedReason?.selectOptions?.find(
+		( option ) => option.value === details
+	);
 
 	const onDetailsChange = ( val: string ) => {
 		setDetails( val );
+		setTextAreaValue( '' ); // Reset textarea when changing sub-option
+		props.onDetailsChange( val );
+	};
+
+	const onTextAreaChange = ( val: string ) => {
+		setTextAreaValue( val );
 		props.onDetailsChange( val );
 	};
 
@@ -37,6 +47,7 @@ function CancellationReason( { purchase, reasonCodes, ...props }: CancellationRe
 					options={ reasons.map( toSelectOption ) }
 					onChange={ ( val ) => {
 						onDetailsChange( '' );
+						setTextAreaValue( '' );
 						setValue( val );
 						props.onChange( val );
 					} }
@@ -47,8 +58,8 @@ function CancellationReason( { purchase, reasonCodes, ...props }: CancellationRe
 					<TextareaControl
 						label={ translate( 'Can you please specify?' ) }
 						placeholder={ String( selectedReason.textPlaceholder ) }
-						value={ details }
-						onChange={ onDetailsChange }
+						value={ textAreaValue }
+						onChange={ onTextAreaChange }
 					/>
 				</div>
 			) }
@@ -59,6 +70,16 @@ function CancellationReason( { purchase, reasonCodes, ...props }: CancellationRe
 						value={ details }
 						options={ selectedReason.selectOptions.map( toSelectOption ) }
 						onChange={ onDetailsChange }
+					/>
+				</div>
+			) }
+			{ selectedSubOption?.textPlaceholder && (
+				<div className="cancel-purchase-form__feedback-question">
+					<TextareaControl
+						label={ translate( 'Can you please specify?' ) }
+						placeholder={ String( selectedSubOption.textPlaceholder ) }
+						value={ textAreaValue }
+						onChange={ onTextAreaChange }
 					/>
 				</div>
 			) }

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/next-adventure-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/next-adventure-step.tsx
@@ -1,6 +1,6 @@
 import { TextareaControl, TextControl, SelectControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { toSelectOption } from '../to-select-options';
 
@@ -10,10 +10,12 @@ interface Props {
 	onChangeText?: ( text: string ) => void;
 	onSelectNextAdventure?: ( nextAdventure: string ) => void;
 	onChangeNextAdventureDetails?: ( details: string ) => void;
+	onValidationChange?: ( isValid: boolean ) => void;
 }
 
 export default function NextAdventureStep( props: Props ) {
 	const translate = useTranslate();
+	const { isPlan, onValidationChange } = props;
 	const [ text, setText ] = useState( '' );
 	const [ nextAdventure, setNextAdventure ] = useState( '' );
 	const [ nextAdventureDetails, setNextAdventureDetails ] = useState( '' );
@@ -70,6 +72,15 @@ export default function NextAdventureStep( props: Props ) {
 		props.onChangeNextAdventureDetails?.( details );
 	};
 
+	// Validation logic for plan cancellations
+	useEffect( () => {
+		if ( isPlan && onValidationChange ) {
+			// For plans, require a selection from the adventure dropdown (not the placeholder)
+			const isValid = nextAdventure !== '';
+			onValidationChange( isValid );
+		}
+	}, [ nextAdventure, isPlan, onValidationChange ] );
+
 	return (
 		<div className="cancel-purchase-form__feedback">
 			<FormattedHeader
@@ -93,7 +104,7 @@ export default function NextAdventureStep( props: Props ) {
 						id="improvementInput"
 					/>
 				</div>
-				{ props.isPlan && (
+				{ isPlan && (
 					<div className="cancel-purchase-form__feedback-question">
 						<SelectControl
 							label={ translate( 'Where is your next adventure taking you?' ) }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Update the cancellation survey based on the work by @bohdankit07 on p58i-lsX-p2
* Introduce many new questions
* Introduce other options with textareas

## Why are these changes being made?

* Step one of compliance changes coming up next week

## Testing Instructions

* Turn on the store sandbox
* Switch locale to English
* Buy a plan
* Cancel it
* Switch locale to any non-English locale
* Ensure the old survey is still there and functioning

A sample of how I tested it:
https://github.com/user-attachments/assets/c6fdc9a8-4313-427a-a144-2804f2fe100d

Then I confirmed the expected structure with wpsh 38242-pb

```
    [why-cancel] => Array
        (
            [response] => otherDomain
            [text] => asdf
        )
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
