### PR TITLE
Purchases: Add hard-coded "Expiring soon" filter keys to DataViews

### DIFF
--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -215,24 +215,50 @@ export function getPurchasesFieldDefinitions( {
 			label: translate( 'Expiring soon' ),
 			type: 'text',
 			elements: [
-				{ value: 'expiring-soon', label: translate( 'Expiring soon' ) },
-				{ value: 'not-expiring-soon', label: translate( 'Other' ) },
+				{
+					value: '7',
+					label: translate( 'Expires in %(days)d days', { textOnly: true, args: { days: 7 } } ),
+				},
+				{
+					value: '14',
+					label: translate( 'Expires in %(days)d days', { textOnly: true, args: { days: 14 } } ),
+				},
+				{
+					value: '30',
+					label: translate( 'Expires in %(days)d days', { textOnly: true, args: { days: 30 } } ),
+				},
+				{
+					value: '60',
+					label: translate( 'Expires in %(days)d days', { textOnly: true, args: { days: 60 } } ),
+				},
+				{
+					value: '365',
+					label: translate( 'Expires in %(days)d days', { textOnly: true, args: { days: 365 } } ),
+				},
 			],
 			filterBy: { operators: [ 'is' ] },
 			getValue: ( { item } ) => {
-				const expiryDate = Date.parse( item.expiryDate );
 				const now = Date.now();
+				const expiryDate = Date.parse( item.expiryDate );
+				if ( ! item.isRenewable || ! expiryDate || expiryDate < now ) {
+					return 'not-expiring-soon';
+				}
 				const msPerDay = 86_400_000;
-				// @todo: this should be updated to be product-specific since
-				// some products renew 30 days in advance.
-				const expireSoonMs = msPerDay * 7;
-				if (
-					item.isRenewable &&
-					expiryDate &&
-					expiryDate > now &&
-					expiryDate - now < expireSoonMs
-				) {
-					return 'expiring-soon';
+				const msTilExpiry = expiryDate - now;
+				if ( msTilExpiry <= 7 * msPerDay ) {
+					return '7';
+				}
+				if ( msTilExpiry <= 14 * msPerDay ) {
+					return '14';
+				}
+				if ( msTilExpiry <= 30 * msPerDay ) {
+					return '30';
+				}
+				if ( msTilExpiry <= 60 * msPerDay ) {
+					return '60';
+				}
+				if ( msTilExpiry <= 365 * msPerDay ) {
+					return '365';
 				}
 				return 'not-expiring-soon';
 			},


### PR DESCRIPTION
## Proposed Changes

This PR changes the "Expiring soon" filter in the DataViews version of the purchases list to use a hard-coded list of day ranges instead of the vague concept of "soon".

Before             |  After
:-------------------------:|:-------------------------:
<img width="297" alt="Screenshot 2025-06-11 at 10 38 16 AM" src="https://github.com/user-attachments/assets/0d5d93d6-b228-4b4f-9ca2-26b9f33f5b28" /> | <img width="302" alt="Screenshot 2025-06-11 at 10 34 59 AM" src="https://github.com/user-attachments/assets/c07eb48f-3f81-4423-8dbb-0f40782df100" />

Part of https://linear.app/a8c/project/replace-calypsos-active-upgrades-subscriptions-with-dataviews-a7b39dea5417/overview / https://github.com/Automattic/wp-calypso/issues/86616

Tracked by https://linear.app/a8c/issue/CHE-186/filtering-for-expiring-soon-with-a-value-results-in-expiring-soon-is

## Testing Instructions

- Use calypso.localhost because the DataViews layout is only available there.
- View /me/purchases.
- Apply the "Expiring soon" filter from the filters drop-down next to the search field.
- Verify that the filter includes/excludes purchases as you'd expect.