### PR TITLE
Fix contrast issue on Blaze Pro Oauth page

### DIFF
--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -173,9 +173,9 @@
 .blaze-pro,
 .is-blaze-pro {
 	.components-button:not(.is-destructive) {
-		--color-blaze-pro-darker: color-mix(in srgb, var(--color-blaze-pro), #000 13%);
+		--color-blaze-pro-darker: color-mix(in srgb, var(--color-blaze-pro), #000 23%);
 
-		--wp-components-color-accent: var(--color-blaze-pro);
+		--wp-components-color-accent: var(--color-blaze-pro-darker);
 		--wp-components-color-accent-darker-10: var(--color-blaze-pro-darker);
 		--wp-components-color-accent-darker-20: var(--color-blaze-pro-darker);
 	}

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -173,11 +173,17 @@
 .blaze-pro,
 .is-blaze-pro {
 	.components-button:not(.is-destructive) {
-		--color-blaze-pro-darker: color-mix(in srgb, var(--color-blaze-pro), #000 23%);
+		--color-blaze-pro-darker: color-mix(in srgb, var(--color-blaze-pro), #000 13%);
 
-		--wp-components-color-accent: var(--color-blaze-pro-darker);
+		--wp-components-color-accent: var(--color-blaze-pro);
+		--wp-components-color-accent-inverted: var(--studio-black);
 		--wp-components-color-accent-darker-10: var(--color-blaze-pro-darker);
 		--wp-components-color-accent-darker-20: var(--color-blaze-pro-darker);
+	}
+
+	.components-button.is-tertiary {
+		--wp-components-color-accent: var(--studio-gray-60);
+		--wp-components-color-accent-darker-20: var(--studio-gray-80);
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13184

## Proposed Changes

* I propose to make the accent color darker to fix the contrast issue on the Blaze Pro Oauth page.

|**Before**|**After**|
|---|---|
| ![Screenshot 2025-06-11 at 17 09 00](https://github.com/user-attachments/assets/0eedf59a-aab5-4a89-9824-92d39864edb1) | ![Screenshot 2025-06-12 at 12 13 44](https://github.com/user-attachments/assets/236c53ce-7b85-4b61-8fea-4fd0f8116455) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To meet accessibility standards.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run Calypso locally or use live link
2. Open https://blazepro.com/
3. Click Get Started and the Log in to Blaze Pro
4. Replace wordpress.com domain in the URL with local Calypso link or live link
5. Use axe Dev Tools to confirm contrast issue is gone

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
