### PR TITLE
Connect Refresh: Migrate Jetpack and Jetpack Cloud to unified Login

### DIFF
--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -44,9 +44,17 @@
 	--wp-components-color-accent: var(--color-accent);
 }
 
-/* Jetpack */
-.layout.is-jetpack-login:not(.is-wccom-oauth-flow):not(.is-woocommerce-core-profiler-flow) {
-	.components-button:not(.is-destructive) {
+/*
+ * Jetpack
+ * --------------------------------------------------------------------------------
+ * Note: The increased specificity here overrides the is-link button styles
+ * added by Stepper and other components. It is not always the desired behavior.
+ * In login, we want to use the Jetpack green color for buttons, but not for links.
+ * We therefore apply :not(.is-link) to avoid overriding the is-link styles.
+ * --------------------------------------------------------------------------------
+ */
+.is-jetpack-login:not(.is-wccom-oauth-flow):not(.is-woocommerce-core-profiler-flow) {
+	.components-button:not(.is-link):not(.is-destructive) {
 		--wp-components-color-accent: var(--studio-jetpack-green-50);
 		--wp-components-color-accent-darker-10: var(--studio-jetpack-green-60);
 		--wp-components-color-accent-darker-20: var(--studio-jetpack-green-60);

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -993,34 +993,6 @@ export class LoginForm extends Component {
 							/>
 						</div>
 
-						{ ! isBlazePro && isJetpack && (
-							<p className="login__form-jetpack-terms">
-								{ this.props.translate(
-									'By continuing you agree to our {{tosLink}}Terms of Service{{/tosLink}} and ' +
-										'to {{privacyLink}}sync your site’s data{{/privacyLink}} with us. We’ll check if that ' +
-										'email is linked to an existing WordPress.com account or create a new one instantly. ',
-									{
-										components: {
-											tosLink: (
-												<a
-													href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-													target="_blank"
-													rel="noopener noreferrer"
-												/>
-											),
-											privacyLink: (
-												<a
-													href={ localizeUrl( 'https://automattic.com/privacy/' ) }
-													target="_blank"
-													rel="noopener noreferrer"
-												/>
-											),
-										},
-									}
-								) }
-							</p>
-						) }
-
 						{ ! hideSignupLink && isOauthLogin && (
 							<p className={ clsx( 'login__form-signup-link' ) }>
 								{ this.props.translate(
@@ -1040,7 +1012,7 @@ export class LoginForm extends Component {
 	}
 
 	renderLoginOptions() {
-		const { oauth2Client, currentQuery, isWoo, isWooJPC, isSocialFirst, isJetpack } = this.props;
+		const { oauth2Client, currentQuery, isWoo, isWooJPC, isSocialFirst } = this.props;
 
 		const { lastUsedAuthenticationMethod } = this.state;
 
@@ -1071,35 +1043,6 @@ export class LoginForm extends Component {
 			! isFromGravatar3rdPartyApp &&
 			! isFromGravatarQuickEditor &&
 			! isGravatarFlowWithEmail;
-
-		if ( isJetpack ) {
-			return (
-				<div className="login__form-jetpack">
-					{ shouldShowSocialLoginForm && (
-						<SocialLoginForm
-							lastUsedAuthenticationMethod={
-								showLastUsedAuthenticationMethod ? this.state.lastUsedAuthenticationMethod : ''
-							}
-							handleLogin={ this.handleSocialLogin }
-							trackLoginAndRememberRedirect={ this.trackLoginAndRememberRedirect }
-							resetLastUsedAuthenticationMethod={ this.resetLastUsedAuthenticationMethod }
-							socialServiceResponse={ this.props.socialServiceResponse }
-							shouldRenderToS={ false }
-							isWoo={ isWoo }
-							isSocialFirst={
-								isSocialFirst || ( isJetpack && ! this.props.isFromAutomatticForAgenciesPlugin )
-							}
-							magicLoginLink={ null }
-							qrLoginLink={ this.getQrLoginLink() }
-						/>
-					) }
-
-					<FormDivider />
-
-					{ this.renderLoginCard() }
-				</div>
-			);
-		}
 
 		return (
 			<>

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -507,6 +507,7 @@ export class LoginForm extends Component {
 									handleLogin={ this.handleSocialLogin }
 									trackLoginAndRememberRedirect={ this.trackLoginAndRememberRedirect }
 									socialServiceResponse={ this.props.socialServiceResponse }
+									isJetpack={ this.props.isJetpack }
 								/>
 							</div>
 						) }
@@ -1012,7 +1013,7 @@ export class LoginForm extends Component {
 	}
 
 	renderLoginOptions() {
-		const { oauth2Client, currentQuery, isWoo, isWooJPC, isSocialFirst } = this.props;
+		const { oauth2Client, currentQuery, isWoo, isWooJPC, isSocialFirst, isJetpack } = this.props;
 
 		const { lastUsedAuthenticationMethod } = this.state;
 
@@ -1064,6 +1065,7 @@ export class LoginForm extends Component {
 							isSocialFirst={ isSocialFirst }
 							magicLoginLink={ ! isWooJPC ? this.getMagicLoginPageLink() : null }
 							qrLoginLink={ this.getQrLoginLink() }
+							isJetpack={ isJetpack }
 						/>
 					</Fragment>
 				) }
@@ -1080,6 +1082,7 @@ export class LoginForm extends Component {
 			isWoo,
 			isBlazePro,
 			isSocialFirst,
+			isJetpack,
 		} = this.props;
 
 		const socialToS = this.props.translate(
@@ -1116,6 +1119,7 @@ export class LoginForm extends Component {
 						trackLoginAndRememberRedirect={ this.trackLoginAndRememberRedirect }
 						socialServiceResponse={ this.props.socialServiceResponse }
 						shouldRenderToS
+						isJetpack={ isJetpack }
 					/>
 				</Fragment>
 			) : null;

--- a/client/blocks/login/login-header.tsx
+++ b/client/blocks/login/login-header.tsx
@@ -79,6 +79,10 @@ export function getHeaderText(
 			clientName = 'Blaze Pro';
 		} else if ( isA4AOAuth2Client( oauth2Client ) ) {
 			clientName = 'Automattic for Agencies';
+		} else if ( isJetpackCloudOAuth2Client( oauth2Client ) ) {
+			clientName = 'Jetpack Cloud';
+		} else if ( isJetpack ) {
+			clientName = 'Jetpack';
 		}
 
 		headerText = clientName
@@ -141,17 +145,9 @@ export function getHeaderText(
 			headerText = translate( 'Log in to your account' );
 		}
 
-		if ( isJetpackCloudOAuth2Client( oauth2Client ) ) {
-			headerText = translate( 'Howdy! Log in to Jetpack.com with your WordPress.com account.' );
-		}
-
 		if ( isPartnerPortalOAuth2Client( oauth2Client ) ) {
 			if ( document.location.search?.includes( 'wpcloud' ) ) {
 				headerText = translate( 'Log in to WP Cloud with WordPress.com' );
-			} else if ( document.location.search?.includes( 'jetpack' ) ) {
-				headerText = translate(
-					'Howdy! Log into the Jetpack Partner Portal with your WordPress.com account.'
-				);
 			} else {
 				headerText = translate(
 					'Howdy! Log into the Automattic Partner Portal with your WordPress.com account.'
@@ -173,10 +169,6 @@ export function getHeaderText(
 		} else {
 			headerText = translate( 'Log in to your account' );
 		}
-	} else if ( isJetpack && ! isFromAutomatticForAgenciesPlugin ) {
-		headerText = translate(
-			'Log in or create a WordPress.com account to supercharge your site with powerful growth, performance, and security tools.'
-		);
 	}
 
 	if ( isFromAutomatticForAgenciesPlugin ) {
@@ -323,14 +315,6 @@ export function LoginHeader( {
 			}
 		}
 
-		if ( isJetpackCloudOAuth2Client( oauth2Client ) ) {
-			preHeader = (
-				<div>
-					<JetpackPlusWpComLogo className="login__jetpack-plus-wpcom-logo" size={ 24 } />
-				</div>
-			);
-		}
-
 		if ( isPartnerPortalOAuth2Client( oauth2Client ) ) {
 			if ( document.location.search?.includes( 'wpcloud' ) ) {
 				preHeader = (
@@ -434,13 +418,11 @@ export function LoginHeader( {
 			);
 		}
 		postHeader = <p className="login__header-subtitle">{ subtitle }</p>;
-	} else if ( isJetpack && ! isFromAutomatticForAgenciesPlugin ) {
-		preHeader = <p className="login__jetpack-pre-header">{ translate( 'Log in or sign up' ) }</p>;
-		header = <p className="login__jetpack-header">{ headerText }</p>;
 	} else if ( fromSite ) {
 		// if redirected from Calypso URL with a site slug, offer a link to that site's frontend
 		postHeader = <VisitSite siteSlug={ fromSite } />;
 	}
+
 	if ( isFromAutomatticForAgenciesPlugin ) {
 		preHeader = (
 			<svg

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -25,6 +25,7 @@ class SocialLoginForm extends Component {
 		isSocialFirst: PropTypes.bool,
 		lastUsedAuthenticationMethod: PropTypes.string,
 		resetLastUsedAuthenticationMethod: PropTypes.func,
+		isJetpack: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -70,7 +71,11 @@ class SocialLoginForm extends Component {
 		{
 			service: 'magic-login',
 			button: ( this.props.isSocialFirst || this.props.isWoo ) && this.props.magicLoginLink && (
-				<MagicLoginButton loginUrl={ this.props.magicLoginLink } key={ 4 } />
+				<MagicLoginButton
+					loginUrl={ this.props.magicLoginLink }
+					key={ 4 }
+					isJetpack={ this.props.isJetpack }
+				/>
 			),
 		},
 		{

--- a/client/blocks/login/utils/should-use-magic-code.ts
+++ b/client/blocks/login/utils/should-use-magic-code.ts
@@ -4,7 +4,7 @@ type ShouldUseMagicCodeProps = {
 	/**
 	 * Whether the login is for a Jetpack site.
 	 */
-	isJetpack: boolean;
+	isJetpack?: boolean;
 };
 
 /**

--- a/client/components/social-buttons/magic-login.tsx
+++ b/client/components/social-buttons/magic-login.tsx
@@ -1,6 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { shouldUseMagicCode } from 'calypso/blocks/login/utils/should-use-magic-code';
 import MailIcon from 'calypso/components/social-icons/mail';
 import { useSelector, useDispatch } from 'calypso/state';
 import { resetMagicLoginRequestForm } from 'calypso/state/login/magic-login/actions';
@@ -11,12 +12,14 @@ import './style.scss';
 
 type MagicLoginButtonProps = {
 	loginUrl: string;
+	isJetpack?: boolean;
 };
 
-export const MagicLoginButton = ( { loginUrl }: MagicLoginButtonProps ) => {
+export const MagicLoginButton = ( { loginUrl, isJetpack }: MagicLoginButtonProps ) => {
 	const translate = useTranslate();
 	const isDisabled = useSelector( isFormDisabled );
 	const dispatch = useDispatch();
+	const isMagicCodeEnabled = shouldUseMagicCode( { isJetpack } );
 
 	const handleClick = () => {
 		recordTracksEvent( 'calypso_login_magic_login_request_click', {
@@ -38,7 +41,11 @@ export const MagicLoginButton = ( { loginUrl }: MagicLoginButtonProps ) => {
 			__next40pxDefaultSize
 		>
 			<MailIcon width="20" height="20" isDisabled={ isDisabled } />
-			<span className="social-buttons__service-name">{ translate( 'Email me a login link' ) }</span>
+			<span className="social-buttons__service-name">
+				{ isMagicCodeEnabled
+					? translate( 'Email me a login code' )
+					: translate( 'Email me a login link' ) }
+			</span>
 		</Button>
 	);
 };

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -327,7 +327,6 @@ export default withCurrentRoute(
 			const isAkismet = isAkismetRedirect(
 				new URLSearchParams( getRedirectToOriginal( state )?.split( '?' )[ 1 ] ).get( 'back' )
 			);
-			const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
 			const isInvitationURL = currentRoute.startsWith( '/accept-invite' );
 			const isJetpackWooDnaFlow = wooDnaConfig( getInitialQueryArguments( state ) ).isWooDnaFlow();
 			const oauth2Client = getCurrentOAuth2Client( state );
@@ -337,27 +336,27 @@ export default withCurrentRoute(
 			const isGravPoweredClient = isGravPoweredOAuth2Client( oauth2Client );
 			const isPartnerPortal = isPartnerPortalOAuth2Client( oauth2Client );
 			const isWooJPC = isWooJPCFlow( state );
+			const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
+			const isJetpackCloudClient = isJetpackCloudOAuth2Client( oauth2Client );
 
 			const isStudioClient = isStudioAppOAuth2Client( oauth2Client );
 			const isCrowdsignalClient = isCrowdsignalOAuth2Client( oauth2Client );
 			const isA4AClient = isA4AOAuth2Client( oauth2Client );
 			const isWhiteLogin =
 				( currentRoute.startsWith( '/log-in' ) &&
-					( ( ! isJetpackLogin &&
-						Boolean( currentQuery?.client_id ) === false &&
+					( ( Boolean( currentQuery?.client_id ) === false &&
 						Boolean( currentQuery?.oauth2_client_id ) === false &&
 						! isWooJPC ) ||
 						isStudioClient ||
 						isCrowdsignalClient ||
 						isBlazePro ||
-						isA4AClient ) ) ||
+						isA4AClient ||
+						isJetpackCloudClient ||
+						isJetpackLogin ) ) ||
 				isPartnerPortal;
 
 			const noMasterbarForRoute =
-				isJetpackLogin ||
-				( isWhiteLogin && ! isBlazePro ) ||
-				isJetpackWooDnaFlow ||
-				isInvitationURL;
+				( isWhiteLogin && ! isBlazePro ) || isJetpackWooDnaFlow || isInvitationURL;
 			const isPopup = '1' === currentQuery?.is_popup;
 			const noMasterbarForSection =
 				! isWooOAuth2Client( oauth2Client ) &&

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -146,6 +146,7 @@ const LayoutLoggedOut = ( {
 		'two-factor-auth-enabled': twoFactorEnabled,
 		'is-woo-com-oauth': isWooOAuth2Client( oauth2Client ),
 		'feature-flag-woocommerce-core-profiler-passwordless-auth': true,
+		'jetpack-cloud': isJetpackCloudOAuth2Client( oauth2Client ),
 	};
 
 	let masterbar = null;

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -550,45 +550,6 @@
 		padding-top: 90px;
 	}
 
-	main.wp-login__main.main {
-		background: var(--studio-white);
-		padding-bottom: 0;
-		max-width: 640px;
-		border: 1px solid var(--studio-gray-5);
-
-		.card.login__form,
-		.card.auth-form__social {
-			box-shadow: none;
-		}
-
-		.wp-login__container {
-			display: flex;
-			flex-direction: column;
-			align-items: center;
-		}
-
-		.login__form {
-			display: flex;
-			flex-direction: column;
-
-			.login__form-userdata {
-				order: 1;
-			}
-
-			.login__form-terms {
-				order: 2;
-			}
-
-			.login__form-action {
-				order: 3;
-			}
-
-			.login__form-signup-link {
-				order: 4;
-			}
-		}
-	}
-
 	.login__social-tos {
 		font-size: $font-body-small;
 		line-height: 24px;

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -447,31 +447,8 @@
 
 	}
 
-	// primary text rules
-	.login__form-header,
-	.signup-form__wrapper h3 {
-		font-weight: 600;
-		font-size: $font-title-small;
-		line-height: 32px;
-		margin-block: 8px;
-		text-align: center;
-	}
-
 	.login__form-post-header {
 		margin-top: 24px;
-	}
-
-	.login__form-header-wrapper,
-	.signup-form__wrapper {
-		padding: 32px 0 0;
-		display: flex;
-		align-items: center;
-		flex-direction: column;
-		width: 100%;
-
-		>* {
-			max-width: 375px;
-		}
 	}
 
 	.wp-login__links,

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -8,6 +8,7 @@ import {
 	isStudioAppOAuth2Client,
 	isCrowdsignalOAuth2Client,
 	isA4AOAuth2Client,
+	isJetpackCloudOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { DesktopLoginStart, DesktopLoginFinalize } from 'calypso/login/desktop-login';
 import { SOCIAL_HANDOFF_CONNECT_ACCOUNT } from 'calypso/state/action-types';
@@ -59,7 +60,6 @@ const enhanceContextWithLogin = ( context ) => {
 	const socialServiceResponse = client_id
 		? { client_id, user_email, user_name, id_token, state }
 		: null;
-	const isJetpackLogin = isJetpack === 'jetpack';
 	const clientId = query?.client_id;
 	const oauth2ClientId = query?.oauth2_client_id;
 	const oauth2Client = getOAuth2Client( currentState, Number( clientId || oauth2ClientId ) ) || {};
@@ -70,17 +70,18 @@ const enhanceContextWithLogin = ( context ) => {
 	const isStudioLogin = isStudioAppOAuth2Client( oauth2Client );
 	const isCrowdsignalLogin = isCrowdsignalOAuth2Client( oauth2Client );
 	const isA4AClient = isA4AOAuth2Client( oauth2Client );
+	const isJetpackLogin = isJetpack === 'jetpack';
+	const isJetpackCloudClient = isJetpackCloudOAuth2Client( oauth2Client );
 
 	const isWhiteLogin =
-		( ! isJetpackLogin &&
-			Boolean( clientId ) === false &&
-			Boolean( oauth2ClientId ) === false &&
-			! isWooJPC ) ||
+		( Boolean( clientId ) === false && Boolean( oauth2ClientId ) === false && ! isWooJPC ) ||
 		isPartnerPortalClient ||
 		isStudioLogin ||
 		isCrowdsignalLogin ||
 		isBlazePro ||
-		isA4AClient;
+		isA4AClient ||
+		isJetpackCloudClient ||
+		isJetpackLogin;
 
 	context.primary = (
 		<WPLogin

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -115,12 +115,6 @@
 		}
 	}
 
-	#content.layout__content {
-		@include break-mobile {
-			padding-top: 10rem;
-		}
-	}
-
 	.magic-login__link-expired {
 		padding-inline: 1rem;
 		padding-top: 0;

--- a/client/login/wp-login/components/heading-logo.tsx
+++ b/client/login/wp-login/components/heading-logo.tsx
@@ -5,6 +5,8 @@ import crowdsignalLogo from 'calypso/assets/images/icons/crowdsignal.svg';
 import gravatarLogo from 'calypso/assets/images/icons/gravatar.svg';
 import studioAppLogo from 'calypso/assets/images/icons/studio-app-logo.svg';
 import wpJobManagerLogo from 'calypso/assets/images/icons/wp-job-manager.png';
+import JetpackLogo from 'calypso/components/jetpack-logo';
+import JetpackPlusWpComLogo from 'calypso/components/jetpack-plus-wpcom-logo';
 import {
 	isCrowdsignalOAuth2Client,
 	isGravPoweredOAuth2Client,
@@ -12,15 +14,17 @@ import {
 	isWPJobManagerOAuth2Client,
 	isBlazeProOAuth2Client,
 	isA4AOAuth2Client,
+	isJetpackCloudOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { useSelector } from 'calypso/state';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 
 interface Props {
 	isFromAkismet?: boolean;
+	isJetpack?: boolean;
 }
 
-const HeadingLogo = ( { isFromAkismet }: Props ) => {
+const HeadingLogo = ( { isFromAkismet, isJetpack }: Props ) => {
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
 
 	let logo = null;
@@ -36,6 +40,10 @@ const HeadingLogo = ( { isFromAkismet }: Props ) => {
 		logo = <img src={ blazeProLogo } alt="Blaze Pro Logo" />;
 	} else if ( isA4AOAuth2Client( oauth2Client ) ) {
 		logo = <A4APlusWpComLogo size={ 32 } />;
+	} else if ( isJetpack ) {
+		logo = <JetpackLogo size={ 64 } />;
+	} else if ( isJetpackCloudOAuth2Client( oauth2Client ) ) {
+		logo = <JetpackPlusWpComLogo size={ 32 } />;
 	} else if ( isGravPoweredOAuth2Client( oauth2Client ) ) {
 		/**
 		 * Leave last to avoid overriding other grav-powered client logos.

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -139,10 +139,10 @@ export class Login extends Component {
 	}
 
 	renderFooter() {
-		const { isJetpack, isWhiteLogin, translate } = this.props;
+		const { isWhiteLogin, translate } = this.props;
 		const isOauthLogin = !! this.props.oauth2Client;
 
-		if ( isJetpack || isWhiteLogin ) {
+		if ( isWhiteLogin ) {
 			return null;
 		}
 
@@ -346,10 +346,6 @@ export class Login extends Component {
 			return null;
 		}
 
-		if ( isJetpackCloudOAuth2Client( oauth2Client ) && '/log-in/authenticator' !== currentRoute ) {
-			return null;
-		}
-
 		// use '?signup_url' if explicitly passed as URL query param
 		const signupUrl = this.props.signupUrl
 			? window.location.origin + pathWithLeadingSlash( this.props.signupUrl )
@@ -378,7 +374,6 @@ export class Login extends Component {
 
 	renderLoginBlockFooter( { isGravPoweredLoginPage, isSocialFirst } ) {
 		const {
-			isJetpack,
 			isWhiteLogin,
 			isGravPoweredClient,
 			socialConnect,
@@ -414,8 +409,7 @@ export class Login extends Component {
 			return <LoginFooter lostPasswordLink={ this.getLostPasswordLink() } />;
 		}
 
-		const shouldRenderFooter =
-			! socialConnect && ! isJetpack && ! isWCCOM && ! isBlazePro && ! isWooJPC;
+		const shouldRenderFooter = ! socialConnect && ! isWCCOM && ! isBlazePro && ! isWooJPC;
 
 		if ( shouldRenderFooter ) {
 			return (
@@ -516,23 +510,6 @@ export class Login extends Component {
 		const canonicalUrl = localizeUrl( 'https://wordpress.com/log-in', locale );
 		const isSocialFirst = isWhiteLogin && ! isGravPoweredClient && ! isWoo;
 
-		const jetpackLogo = (
-			<div className="magic-login__gutenboarding-wordpress-logo">
-				<svg
-					xmlns="http://www.w3.org/2000/svg"
-					width="24"
-					height="24"
-					viewBox="0 0 24 24"
-					fill="none"
-				>
-					<path
-						d="M12 0C9.62663 0 7.30655 0.703788 5.33316 2.02236C3.35977 3.34094 1.8217 5.21508 0.913451 7.4078C0.00519938 9.60051 -0.232441 12.0133 0.230582 14.3411C0.693605 16.6689 1.83649 18.807 3.51472 20.4853C5.19295 22.1635 7.33115 23.3064 9.65892 23.7694C11.9867 24.2324 14.3995 23.9948 16.5922 23.0865C18.7849 22.1783 20.6591 20.6402 21.9776 18.6668C23.2962 16.6934 24 14.3734 24 12C24 8.8174 22.7357 5.76515 20.4853 3.51472C18.2348 1.26428 15.1826 0 12 0ZM11.3684 13.9895H5.40632L11.3684 2.35579V13.9895ZM12.5811 21.6189V9.98526H18.5621L12.5811 21.6189Z"
-						fill="#069E08"
-					/>
-				</svg>
-			</div>
-		);
-
 		const mainContent = (
 			<Main
 				className={ clsx( 'wp-login__main', {
@@ -601,7 +578,9 @@ export class Login extends Component {
 			isStudioAppOAuth2Client( oauth2Client ) ||
 			isFromAkismet ||
 			isCrowdsignalOAuth2Client( oauth2Client ) ||
-			isBlazePro;
+			isBlazePro ||
+			isJetpack ||
+			isJetpackCloudOAuth2Client( oauth2Client );
 
 		return (
 			<>
@@ -616,7 +595,7 @@ export class Login extends Component {
 							<Step.Heading
 								text={
 									<>
-										<HeadingLogo isFromAkismet={ isFromAkismet } />
+										<HeadingLogo isFromAkismet={ isFromAkismet } isJetpack={ isJetpack } />
 										<div className="wp-login__heading-text">{ headerText }</div>
 									</>
 								}
@@ -633,7 +612,6 @@ export class Login extends Component {
 						{ mainContent }
 					</Step.CenteredColumnLayout>
 				) }
-				{ ! isWooJPC && isJetpack && ! this.props.isFromAutomatticForAgenciesPlugin && jetpackLogo }
 				{ ! isWhiteLogin && mainContent }
 				{ this.renderFooter() }
 			</>

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -11,11 +11,7 @@ import { connect } from 'react-redux';
 import LoggedOutFormBackLink from 'calypso/components/logged-out-form/back-link';
 import { isDomainConnectAuthorizePath } from 'calypso/lib/domains/utils';
 import { canDoMagicLogin, getLoginLinkPageUrl } from 'calypso/lib/login';
-import {
-	isCrowdsignalOAuth2Client,
-	isJetpackCloudOAuth2Client,
-	isGravPoweredOAuth2Client,
-} from 'calypso/lib/oauth2-clients';
+import { isGravPoweredOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -109,11 +105,7 @@ export class LoginLinks extends Component {
 	};
 
 	renderBackLink() {
-		if (
-			isCrowdsignalOAuth2Client( this.props.oauth2Client ) ||
-			isJetpackCloudOAuth2Client( this.props.oauth2Client ) ||
-			this.props.isWhiteLogin
-		) {
+		if ( this.props.isWhiteLogin ) {
 			return null;
 		}
 

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -62,6 +62,22 @@ $image-height: 47px;
 		}
 	}
 	/* End: Blaze Pro OAuth client font styles for login page */
+
+	/* Start: Jetpack font styles for login page */
+	&.is-jetpack-login {
+		.wp-login__heading-text {
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif
+		}
+	}
+	/* End: Jetpack font styles for login page */
+
+	/* Start: Jetpack Cloud font styles for login page */
+	&.jetpack-cloud {
+		.wp-login__heading-text {
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif
+		}
+	}
+	/* End: Jetpack Cloud font styles for login page */
 }
 
 .wp-login__heading-logo {

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -83,20 +83,6 @@ $image-height: 47px;
 	}
 }
 
-.wp-login__main.main {
-	max-width: 400px;
-
-	&.is-jetpack {
-		max-width: 450px;
-
-		// This is margin based on the layout + padding height.
-		margin-top: calc(96px - 48px);
-		@include break-small {
-			margin-top: calc(170px - 48px);
-		}
-	}
-}
-
 .wp-login__header {
 	color: var(--color-neutral-40);
 	font-size: $font-body;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13396/jetpack-cloud
Part of https://linear.app/a8c/issue/DOTCOM-13382/jetpack-cloud
Part of https://linear.app/a8c/issue/DOTCOM-13601/jetpack

## Proposed Changes

- Updates Jetpack and Jetpack Cloud Login screens to the unified layout.
- The two could have been handled separately, they different contexts (Jetpack Cloud is OAuth). I started the refactor not knowing that, so they ended up being done together.

### May need confirming

- [ ] The PR also adds the "Email a login link" CTA to the Jetpack login form (not the Jetpack Cloud one - that's to be done separately, as I'm not sure if applicable). TODO below to update the text to "code" instead of "link"

### TODO

- [x] Update the button colors for the JP Cloud unified screen
- [x] Update the fonts to adapt to the client defined
- [x] Update the "Email me a login link" to "Email me a login code" for Jetpack Login if we keep it enabled

### Media

| Before | After |
|--------|--------|
| <img width="1208" alt="Screenshot 2025-06-11 at 5 46 54 PM" src="https://github.com/user-attachments/assets/901b8f32-7891-4d3e-8e60-2c9305bd36cf" /> | <img width="1154" alt="Screenshot 2025-06-17 at 8 45 07 PM" src="https://github.com/user-attachments/assets/d1bbb4f5-530a-4245-ae24-711859ad4a86" /> |
| <img width="1271" alt="Screenshot 2025-06-11 at 5 47 41 PM" src="https://github.com/user-attachments/assets/196618d9-fff2-4923-a9c6-9789dbef486a" /> | <img width="1172" alt="Screenshot 2025-06-17 at 8 45 13 PM" src="https://github.com/user-attachments/assets/93c78636-d417-4e0b-9eb5-0cc319e8b466" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


Part of https://linear.app/a8c/issue/DOTCOM-13396/jetpack-cloud
Part of https://linear.app/a8c/issue/DOTCOM-13382/jetpack-cloud
Part of https://linear.app/a8c/issue/DOTCOM-13601/jetpack

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Got to [Jetpack Cloud Login](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D69040%26redirect_uri%3Dhttps%253A%252F%252Fcloud.jetpack.com%252Fconnect%252Foauth%252Ftoken%253Fnext%253D%25252F%26scope%3Dglobal%26blog_id%3D0%26from-calypso%3D1&client_id=69040&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D69040%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%253Fresponse_type%253Dtoken%2526client_id%253D69040%2526redirect_uri%253Dhttps%25253A%25252F%25252Fcloud.jetpack.com%25252Fconnect%25252Foauth%25252Ftoken%25253Fnext%25253D%2525252F%2526scope%253Dglobal%2526blog_id%253D0%2526from-calypso%253D1) and confirm
- Go to [Jetpack Login](http://calypso.localhost:3000/log-in/jetpack) and confirm
- Go to any of the [other client or default Login](https://linear.app/a8c/issue/DOTCOM-13220/calypso-make-the-two-columnwhite-layout-the-default-across-all) screens and confirm no changes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
