### PR TITLE
read assistant messages on reply

### DIFF
--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -163,10 +163,18 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 				className={ clx( 'chatbox-messages', {
 					'force-email-support': forceEmailSupport && chat.provider === 'zendesk',
 				} ) }
-				aria-live="polite"
-				aria-atomic="false"
 				ref={ messagesContainerRef }
 			>
+				<div
+					className="screen-reader-text"
+					aria-live="polite"
+					aria-atomic="false"
+					aria-relevant="additions"
+				>
+					{ chat.messages.map( ( message ) => (
+						<div key={ message.created_at }>{ message.role === 'bot' && message.content }</div>
+					) ) }
+				</div>
 				<ChatDate chat={ chat } />
 				{ ! chatMessagesLoaded ? (
 					<LoadingChatSpinner />

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -163,6 +163,8 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 				className={ clx( 'chatbox-messages', {
 					'force-email-support': forceEmailSupport && chat.provider === 'zendesk',
 				} ) }
+				aria-live="polite"
+				aria-atomic="false"
 				ref={ messagesContainerRef }
 			>
 				<ChatDate chat={ chat } />

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -172,7 +172,9 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 					aria-relevant="additions"
 				>
 					{ chat.messages.map( ( message ) => (
-						<div key={ message.created_at }>{ message.role === 'bot' && message.content }</div>
+						<div key={ message.created_at }>
+							{ [ 'bot', 'business' ].includes( message.role ) && message.content }
+						</div>
 					) ) }
 				</div>
 				<ChatDate chat={ chat } />


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-13509

## Proposed Changes

* Added `aria-live` to chat messages container

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Currently screen reader users do not know there's a response from the AI Assistant.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Help Center on WordPress.com.
* Click on theStill need help? button.
* Enable VoiceOver.
* Ask a question and submit it to the assistant.
* Confirm the message is read as it is received

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
