### PR TITLE
Reduce specificity of form label selector

### DIFF
--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -326,12 +326,9 @@ $y-axis-padding: 0 20px;
 
 
 	&.form-label {
-		&,
-		&.is-selectable {
-			display: inline-block;
-			margin-bottom: 0;
-			font-weight: 400;
-		}
+		display: inline-block;
+		margin-bottom: 0;
+		font-weight: 400;
 	}
 
 	&.is-selectable {

--- a/packages/components/src/forms/README.md
+++ b/packages/components/src/forms/README.md
@@ -31,7 +31,16 @@ The `FormInputValidation` component is used to display a validation notice to th
 
 ### FormLabel
 
-The `FormLabel` component is a light wrapper around the traditional HTML label. It provides standardized styling and the ability to display "optional" and "required" subtext alongside the label.
+The `FormLabel` component is a light wrapper around the traditional HTML label. It provides standardized styling and the ability to display "optional" and "required" subtext alongside the label. It also has options to enable styling like @wordpress/component labels.
+
+#### Props
+
+| Prop                  | Type    | Default | Description                                                                                                                          |
+| --------------------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `optional`            | boolean | false   | Displays an "Optional" subtext next to the label.                                                                                    |
+| `required`            | boolean | false   | Displays a "Required" subtext next to the label.                                                                                     |
+| `hasCoreStyles`       | boolean | false   | Applies label styles matching those for core @wordpress/components labels, including uppercase text, lighter font weight, and color. |
+| `hasCoreStylesNoCaps` | boolean | false   | Applies core label styles but keeps the label text in its original case (not uppercase).                                             |
 
 ### General guidelines
 

--- a/packages/components/src/forms/form-label/style.scss
+++ b/packages/components/src/forms/form-label/style.scss
@@ -1,12 +1,10 @@
 @import "@automattic/typography/styles/variables";
 
 .form-label {
-	&:not(.form-label-core-styles) {
-		display: block;
-		font-size: $font-body-small;
-		font-weight: 600;
-		margin-bottom: 5px;
-	}
+	display: block;
+	font-size: $font-body-small;
+	font-weight: 600;
+	margin-bottom: 5px;
 
 	.form-label__required {
 		color: var(--color-error);
@@ -27,8 +25,6 @@
 }
 
 .form-label-core-styles {
-	display: block;
-	font-size: $font-body-small;
 	font-weight: 500;
 	line-height: 1.4;
 	color: var(--color-neutral-100);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DSGCOM-95: Update text fields on login](https://linear.app/a8c/issue/DSGCOM-95/update-text-fields-on-login)

## Proposed Changes

* Reduce the specificity of the form label selector

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The increased specificity of the selector introduced in https://github.com/Automattic/wp-calypso/pull/103616 led to regressions like https://github.com/Automattic/wp-calypso/pull/104127 where existing rules were overridden

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the [log in page](http://calypso.localhost:3000/log-in)
* Check that the username or email field label is still styled like a core no caps label (`font-weight: 500; line-height: 1.4; color: var(--color-neutral-100); margin-bottom: 6px;`)
* Log in and view my stats for a site
* Check that the labels for 'Views' and 'Visitors' in the chart are sitting side-by-side and not stacked
 
![calypso localhost_3000_log-in(2 1366x768)](https://github.com/user-attachments/assets/ee9afee1-1b56-4aec-986a-10807bee2655)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
