### PR TITLE
Plans: update support link for upgrade credits

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -472,6 +472,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/domains/transfer-domain-registration/',
 		post_id: 41298,
 	},
+	'plans-upgrade-credit': {
+		link: 'https://wordpress.com/support/manage-purchases/upgrade-your-plan/#upgrade-credit',
+		post_id: 267100,
+	},
 };
 
 export default contextLinks;

--- a/client/my-sites/plans-features-main/components/plan-notice-domain-to-plan-credit.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice-domain-to-plan-credit.tsx
@@ -1,4 +1,3 @@
-import { localizeUrl } from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useTranslate } from 'i18n-calypso';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
@@ -26,9 +25,6 @@ const PlanNoticeDomainToPlanCredit = ( {
 	const showNotice = domainToPlanCreditsApplicable !== null && domainToPlanCreditsApplicable > 0;
 	const translate = useTranslate();
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
-	const upgradeCreditDocsUrl = localizeUrl(
-		'https://wordpress.com/support/manage-purchases/upgrade-your-plan/#upgrade-credit'
-	);
 
 	return (
 		<>
@@ -54,7 +50,7 @@ const PlanNoticeDomainToPlanCredit = ( {
 							},
 							components: {
 								b: <strong />,
-								a: <InlineSupportLink supportLink={ upgradeCreditDocsUrl } />,
+								a: <InlineSupportLink supportContext="plans-upgrade-credit" showIcon={ false } />,
 							},
 						}
 					) }

--- a/client/my-sites/plans-features-main/components/plan-notice-plan-to-higher-plan-credit.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice-plan-to-higher-plan-credit.tsx
@@ -1,4 +1,3 @@
-import { localizeUrl } from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useTranslate } from 'i18n-calypso';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
@@ -26,10 +25,6 @@ const PlanNoticePlanToHigherPlanCredit = ( {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 
 	const planUpgradeCreditsApplicable = usePlanUpgradeCreditsApplicable( siteId, visiblePlans );
-
-	const upgradeCreditDocsUrl = localizeUrl(
-		'https://wordpress.com/support/manage-purchases/upgrade-your-plan/#upgrade-credit'
-	);
 
 	const showNotice =
 		visiblePlans &&
@@ -63,7 +58,7 @@ const PlanNoticePlanToHigherPlanCredit = ( {
 							},
 							components: {
 								b: <strong />,
-								a: <InlineSupportLink supportLink={ upgradeCreditDocsUrl } />,
+								a: <InlineSupportLink supportContext="plans-upgrade-credit" showIcon={ false } />,
 							},
 						}
 					) }

--- a/client/my-sites/plans-features-main/components/test/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/test/plan-notice.tsx
@@ -152,7 +152,7 @@ describe( '<PlanNotice /> Tests', () => {
 			/>
 		);
 		expect( screen.getByRole( 'status' ).textContent ).toBe(
-			'You have $100.00 in upgrade credits(opens in a new tab) available from your current plan. This credit will be applied to the pricing below at checkout if you upgrade today!'
+			'You have $100.00 in upgrade credits available from your current plan. This credit will be applied to the pricing below at checkout if you upgrade today!'
 		);
 	} );
 
@@ -169,7 +169,7 @@ describe( '<PlanNotice /> Tests', () => {
 			/>
 		);
 		expect( screen.getByRole( 'status' ).textContent ).toBe(
-			'You have $10.00 in upgrade credits(opens in a new tab) available from your current domain. This credit will be applied to the pricing below at checkout if you purchase a plan today!'
+			'You have $10.00 in upgrade credits available from your current domain. This credit will be applied to the pricing below at checkout if you purchase a plan today!'
 		);
 	} );
 

--- a/client/my-sites/plans-features-main/components/test/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/test/plan-notice.tsx
@@ -137,42 +137,6 @@ describe( '<PlanNotice /> Tests', () => {
 		expect( screen.getByRole( 'status' ).textContent ).toBe( discount.plansPageNoticeText );
 	} );
 
-	test( 'A plan upgrade credit <PlanNotice /> should be shown in a site where a plan is purchased, without other active discounts, has upgradeable plan and, the site owner is logged in', () => {
-		jest.mocked( isCurrentUserCurrentPlanOwner ).mockReturnValue( true );
-		jest.mocked( isCurrentPlanPaid ).mockReturnValue( true );
-		jest.mocked( getDiscountByName ).mockReturnValue( false );
-		jest.mocked( usePlanUpgradeCreditsApplicable ).mockReturnValue( 10000 );
-
-		renderWithProvider(
-			<PlanNotice
-				discountInformation={ { coupon: 'test', discountEndDate: new Date() } }
-				visiblePlans={ plansList }
-				isInSignup={ false }
-				siteId={ 32234 }
-			/>
-		);
-		expect( screen.getByRole( 'status' ).textContent ).toBe(
-			'You have $100.00 in upgrade credits available from your current plan. This credit will be applied to the pricing below at checkout if you upgrade today!'
-		);
-	} );
-
-	test( 'A domain-to-plan credit <PlanNotice /> should be shown in a site where a domain has been purchased without a paid plan', () => {
-		jest.mocked( usePlanUpgradeCreditsApplicable ).mockReturnValue( null );
-		jest.mocked( useDomainToPlanCreditsApplicable ).mockReturnValue( 1000 );
-
-		renderWithProvider(
-			<PlanNotice
-				discountInformation={ { coupon: 'test', discountEndDate: new Date() } }
-				visiblePlans={ plansList }
-				isInSignup={ false }
-				siteId={ 32234 }
-			/>
-		);
-		expect( screen.getByRole( 'status' ).textContent ).toBe(
-			'You have $10.00 in upgrade credits available from your current domain. This credit will be applied to the pricing below at checkout if you purchase a plan today!'
-		);
-	} );
-
 	test( 'A marketing message <PlanNotice /> when no other notices are available and marketing messages are available and the user is not in signup', () => {
 		jest.mocked( isCurrentUserCurrentPlanOwner ).mockReturnValue( true );
 		jest.mocked( isCurrentPlanPaid ).mockReturnValue( true );

--- a/client/sites/overview/components/plan-credit-notice.tsx
+++ b/client/sites/overview/components/plan-credit-notice.tsx
@@ -1,4 +1,3 @@
-import { localizeUrl } from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
 import { Notice } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -17,9 +16,6 @@ const PlanCreditNotice = () => {
 	const showNotice = domainToPlanCreditsApplicable !== null && domainToPlanCreditsApplicable > 0;
 	const translate = useTranslate();
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
-	const upgradeCreditDocsUrl = localizeUrl(
-		'https://wordpress.com/support/manage-purchases/upgrade-your-plan/#upgrade-credit'
-	);
 
 	if ( ! siteId ) {
 		return null;
@@ -48,7 +44,7 @@ const PlanCreditNotice = () => {
 							},
 							components: {
 								b: <strong />,
-								a: <InlineSupportLink supportLink={ upgradeCreditDocsUrl } />,
+								a: <InlineSupportLink supportContext="plans-upgrade-credit" showIcon={ false } />,
 							},
 						}
 					) }


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/DOTCOM-1672/update-support-link-for-upgrade-credits

This changes the support link attached to `upgrade credits` open in the inline Help Center instead of a new tab.

Note: the unit tests for these `PlanNotice` components was broken before this change... I tried to fix it but couldn't solve easily. Will revisit.

Here's the result:

**Before**
![Screenshot 2025-06-11 at 14 20 56](https://github.com/user-attachments/assets/fc2749e1-8d64-4b85-b1a2-3261e22e5fc8)

**After**
![Screenshot 2025-06-11 at 14 21 03](https://github.com/user-attachments/assets/26d404d7-3bea-48b1-815a-c38e125a030c)

**After with inline Help open**
![Screenshot 2025-06-11 at 15 16 00](https://github.com/user-attachments/assets/81575db3-9bcd-4301-847d-43af65d6464b)
