### PR TITLE
Backup: fix finished screen on granular restores

### DIFF
--- a/client/my-sites/backup/rewind-flow/granular-restore.tsx
+++ b/client/my-sites/backup/rewind-flow/granular-restore.tsx
@@ -154,6 +154,7 @@ const BackupGranularRestoreFlow: FunctionComponent< Props > = ( {
 
 	const [ userHasRequestedRestore, setUserHasRequestedRestore ] = useState( false );
 	const [ restoreInitiated, setRestoreInitiated ] = useState( false );
+	const [ isFinished, setIsFinished ] = useState( false );
 
 	const rewindState = useSelector( ( state ) => getRewindState( state, siteId ) ) as RewindState;
 	const inProgressRewindStatus = useSelector( ( state ) =>
@@ -233,6 +234,7 @@ const BackupGranularRestoreFlow: FunctionComponent< Props > = ( {
 
 		// Mark that the user has requested a restore
 		setUserHasRequestedRestore( true );
+		setIsFinished( false );
 
 		// Track the restore confirmation event.
 		dispatch(
@@ -589,13 +591,18 @@ const BackupGranularRestoreFlow: FunctionComponent< Props > = ( {
 		</Error>
 	);
 
-	const isFinished = inProgressRewindStatus !== null && inProgressRewindStatus === 'finished';
 	const isInProgress =
 		( ! inProgressRewindStatus && userHasRequestedRestore ) ||
 		( inProgressRewindStatus && [ 'queued', 'running' ].includes( inProgressRewindStatus ) ) ||
 		( restoreInitiated && userHasRequestedRestore );
 
 	const shouldRenderConfirmation = ( ! isInProgress || ! isFinished ) && ! restoreInitiated;
+
+	useEffect( () => {
+		if ( inProgressRewindStatus === 'finished' ) {
+			setIsFinished( true );
+		}
+	}, [ dispatch, inProgressRewindStatus ] );
 
 	useEffect( () => {
 		if ( isInProgress && ! userHasRequestedRestore ) {

--- a/client/my-sites/backup/rewind-flow/granular-restore.tsx
+++ b/client/my-sites/backup/rewind-flow/granular-restore.tsx
@@ -155,14 +155,18 @@ const BackupGranularRestoreFlow: FunctionComponent< Props > = ( {
 	const [ userHasRequestedRestore, setUserHasRequestedRestore ] = useState( false );
 	const [ restoreInitiated, setRestoreInitiated ] = useState( false );
 	const [ isFinished, setIsFinished ] = useState( false );
+	const [ percent, setPercent ] = useState( 0 );
 
 	const rewindState = useSelector( ( state ) => getRewindState( state, siteId ) ) as RewindState;
 	const inProgressRewindStatus = useSelector( ( state ) =>
 		getInProgressRewindStatus( state, siteId, rewindId )
 	);
-	const { message, percent, currentEntry, status } = useSelector(
-		( state ) => getRestoreProgress( state, siteId ) || ( {} as RestoreProgress )
-	);
+	const {
+		message,
+		percent: restorePercent,
+		currentEntry,
+		status,
+	} = useSelector( ( state ) => getRestoreProgress( state, siteId ) || ( {} as RestoreProgress ) );
 
 	const browserCheckList = useSelector( ( state ) => getBackupBrowserCheckList( state, siteId ) );
 	const browserSelectedList = useSelector( ( state ) =>
@@ -235,6 +239,7 @@ const BackupGranularRestoreFlow: FunctionComponent< Props > = ( {
 		// Mark that the user has requested a restore
 		setUserHasRequestedRestore( true );
 		setIsFinished( false );
+		setPercent( 0 );
 
 		// Track the restore confirmation event.
 		dispatch(
@@ -603,6 +608,10 @@ const BackupGranularRestoreFlow: FunctionComponent< Props > = ( {
 			setIsFinished( true );
 		}
 	}, [ dispatch, inProgressRewindStatus ] );
+
+	useEffect( () => {
+		setPercent( restorePercent );
+	}, [ dispatch, restorePercent ] );
 
 	useEffect( () => {
 		if ( isInProgress && ! userHasRequestedRestore ) {

--- a/client/my-sites/backup/rewind-flow/progress-bar.tsx
+++ b/client/my-sites/backup/rewind-flow/progress-bar.tsx
@@ -31,7 +31,7 @@ const RewindFlowProgressBar: FunctionComponent< Props > = ( {
 					{ translate( '%(filteredPercent)d%% complete', { args: { filteredPercent } } ) }
 				</p>
 			</div>
-			<ProgressBar value={ filteredPercent } total={ 100 } />
+			<ProgressBar value={ filteredPercent } total={ 100 } canGoBackwards />
 			<p className="rewind-flow__progress-bar-entry">
 				{ isReady &&
 					entry &&


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [BACKUP-54][1].

## Proposed Changes

Fixes the "finished" screen appearing when a new granular restore is started.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The goal is to present a smoother granular restore process, without unintended screens appearing at the wrong stage of the process.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Access the `Jetpack Cloud live` link provided by GitHub Actions below.
- Select a site that has a working backup.
- Go to `VaultPress Backup`, click on the arrow besides `Restore to this point` and then `View files`:
  - <img width="380" alt="image" src="https://github.com/user-attachments/assets/e8c5613e-9a1d-407c-a4bb-a2c998afe213" />
- Select any file, click on `Restore selected files`.
- When the restore finishes, click on the `Go back` button and repeat the process.
- The success screen should only appear at the end of the process, not at the start.

### Before

https://github.com/user-attachments/assets/d83d00e3-e350-4c4c-9149-19b7f08b9dcc

### After

https://github.com/user-attachments/assets/26d88585-5358-430a-9685-01ba284456f5

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

[1]: https://linear.app/a8c/issue/BACKUP-54/initiating-a-new-granular-restore-after-a-successful-one-with-the-same