### PR TITLE
Dashboard v2: fix siteId type: string => number

### DIFF
--- a/client/dashboard/app/queries/p2.ts
+++ b/client/dashboard/app/queries/p2.ts
@@ -1,6 +1,6 @@
 import { fetchP2HubP2s } from '../../data/p2';
 
-export const p2HubP2sQuery = ( siteId: string, options: { limit?: number } = {} ) => ( {
+export const p2HubP2sQuery = ( siteId: number, options: { limit?: number } = {} ) => ( {
 	queryKey: [ 'p2-hub', siteId, 'p2s', options ],
 	queryFn: () => fetchP2HubP2s( siteId, options ),
 } );

--- a/client/dashboard/app/queries/site-agency.ts
+++ b/client/dashboard/app/queries/site-agency.ts
@@ -1,6 +1,6 @@
 import { fetchAgencyBlog } from '../../data/agency';
 
-export const siteAgencyBlogQuery = ( siteId: string ) => ( {
+export const siteAgencyBlogQuery = ( siteId: number ) => ( {
 	queryKey: [ 'site', siteId, 'agency-blog' ],
 	queryFn: () => {
 		return fetchAgencyBlog( siteId );

--- a/client/dashboard/app/queries/site-cache.ts
+++ b/client/dashboard/app/queries/site-cache.ts
@@ -6,20 +6,20 @@ import {
 } from '../../data/site-hosting-edge-cache';
 import { queryClient } from '../query-client';
 
-export const siteObjectCacheClearMutation = ( siteId: string ) => ( {
+export const siteObjectCacheClearMutation = ( siteId: number ) => ( {
 	mutationFn: ( reason: string ) => clearObjectCache( siteId, reason ),
 } );
 
-export const siteEdgeCacheClearMutation = ( siteId: string ) => ( {
+export const siteEdgeCacheClearMutation = ( siteId: number ) => ( {
 	mutationFn: () => clearEdgeCache( siteId ),
 } );
 
-export const siteEdgeCacheStatusQuery = ( siteId: string ) => ( {
+export const siteEdgeCacheStatusQuery = ( siteId: number ) => ( {
 	queryKey: [ 'site', siteId, 'edge-cache' ],
 	queryFn: () => fetchEdgeCacheStatus( siteId ),
 } );
 
-export const siteEdgeCacheStatusMutation = ( siteId: string ) => ( {
+export const siteEdgeCacheStatusMutation = ( siteId: number ) => ( {
 	mutationFn: ( active: boolean ) => updateEdgeCacheStatus( siteId, active ),
 	onSuccess: ( active: boolean ) => {
 		queryClient.setQueryData( siteEdgeCacheStatusQuery( siteId ).queryKey, active );

--- a/client/dashboard/app/queries/site-defensive-mode.ts
+++ b/client/dashboard/app/queries/site-defensive-mode.ts
@@ -8,12 +8,12 @@ import type {
 	DefensiveModeSettingsUpdate,
 } from '../../data/site-hosting-edge-cache';
 
-export const siteDefensiveModeSettingsQuery = ( siteId: string ) => ( {
+export const siteDefensiveModeSettingsQuery = ( siteId: number ) => ( {
 	queryKey: [ 'site', siteId, 'defensive-mode' ],
 	queryFn: () => fetchEdgeCacheDefensiveModeSettings( siteId ),
 } );
 
-export const siteDefensiveModeSettingsMutation = ( siteId: string ) => ( {
+export const siteDefensiveModeSettingsMutation = ( siteId: number ) => ( {
 	mutationFn: ( data: DefensiveModeSettingsUpdate ) =>
 		updateEdgeCacheDefensiveModeSettings( siteId, data ),
 	onSuccess: ( data: DefensiveModeSettings ) => {

--- a/client/dashboard/app/queries/site-media-storage.ts
+++ b/client/dashboard/app/queries/site-media-storage.ts
@@ -1,6 +1,6 @@
 import { fetchSiteMediaStorage } from '../../data/site-media-storage';
 
-export const siteMediaStorageQuery = ( siteId: string ) => ( {
+export const siteMediaStorageQuery = ( siteId: number ) => ( {
 	queryKey: [ 'site', siteId, 'media-storage' ],
 	queryFn: () => fetchSiteMediaStorage( siteId ),
 } );

--- a/client/dashboard/app/queries/site-owner-transfer.ts
+++ b/client/dashboard/app/queries/site-owner-transfer.ts
@@ -7,16 +7,16 @@ import { queryClient } from '../query-client';
 import { siteByIdQuery } from './site';
 import type { SiteOwnerTransferConfirmation } from '../../data/site-owner-transfer';
 
-export const siteOwnerTransferMutation = ( siteId: string ) => ( {
+export const siteOwnerTransferMutation = ( siteId: number ) => ( {
 	mutationFn: ( data: { new_site_owner: string } ) => startSiteOwnerTransfer( siteId, data ),
 } );
 
-export const siteOwnerTransferEligibilityCheckMutation = ( siteId: string ) => ( {
+export const siteOwnerTransferEligibilityCheckMutation = ( siteId: number ) => ( {
 	mutationFn: ( data: { new_site_owner: string } ) =>
 		checkSiteOwnerTransferEligibility( siteId, data ),
 } );
 
-export const siteOwnerTransferConfirmMutation = ( siteId: string ) => ( {
+export const siteOwnerTransferConfirmMutation = ( siteId: number ) => ( {
 	mutationFn: ( data: { hash: string } ) => confirmSiteOwnerTransfer( siteId, data ),
 	onSuccess: ( { transfer }: SiteOwnerTransferConfirmation ) => {
 		if ( transfer ) {

--- a/client/dashboard/app/queries/site-php-version.ts
+++ b/client/dashboard/app/queries/site-php-version.ts
@@ -1,12 +1,12 @@
 import { fetchPHPVersion, updatePHPVersion } from '../../data/site-hosting';
 import { queryClient } from '../query-client';
 
-export const sitePHPVersionQuery = ( siteId: string ) => ( {
+export const sitePHPVersionQuery = ( siteId: number ) => ( {
 	queryKey: [ 'site', siteId, 'php-version' ],
 	queryFn: () => fetchPHPVersion( siteId ),
 } );
 
-export const sitePHPVersionMutation = ( siteId: string ) => ( {
+export const sitePHPVersionMutation = ( siteId: number ) => ( {
 	mutationFn: ( version: string ) => updatePHPVersion( siteId, version ),
 	onSuccess: () => {
 		queryClient.invalidateQueries( sitePHPVersionQuery( siteId ) );

--- a/client/dashboard/app/queries/site-plans.ts
+++ b/client/dashboard/app/queries/site-plans.ts
@@ -1,11 +1,11 @@
 import { restoreSitePlanSoftware } from '../../data/site-hosting';
 import { fetchCurrentSitePlan } from '../../data/site-plans';
 
-export const siteCurrentPlanQuery = ( siteId: string ) => ( {
+export const siteCurrentPlanQuery = ( siteId: number ) => ( {
 	queryKey: [ 'site', siteId, 'plans', 'current' ],
 	queryFn: () => fetchCurrentSitePlan( siteId ),
 } );
 
-export const sitePlanSoftwareRestoreMutation = ( siteId: string ) => ( {
+export const sitePlanSoftwareRestoreMutation = ( siteId: number ) => ( {
 	mutationFn: () => restoreSitePlanSoftware( siteId ),
 } );

--- a/client/dashboard/app/queries/site-preview-links.ts
+++ b/client/dashboard/app/queries/site-preview-links.ts
@@ -6,21 +6,21 @@ import {
 import { queryClient } from '../query-client';
 import type { SitePreviewLink } from '../../data/site-preview-links';
 
-export const sitePreviewLinksQuery = ( siteId: string ) => ( {
+export const sitePreviewLinksQuery = ( siteId: number ) => ( {
 	queryKey: [ 'site', siteId, 'preview-links' ],
 	queryFn: () => {
 		return fetchSitePreviewLinks( siteId );
 	},
 } );
 
-export const sitePreviewLinkCreateMutation = ( siteId: string ) => ( {
+export const sitePreviewLinkCreateMutation = ( siteId: number ) => ( {
 	mutationFn: () => createSitePreviewLink( siteId ),
 	onSuccess: ( data: SitePreviewLink ) => {
 		queryClient.setQueryData( sitePreviewLinksQuery( siteId ).queryKey, [ data ] );
 	},
 } );
 
-export const sitePreviewLinkDeleteMutation = ( siteId: string ) => ( {
+export const sitePreviewLinkDeleteMutation = ( siteId: number ) => ( {
 	mutationFn: ( code: string ) => deleteSitePreviewLink( siteId, code ),
 	onSuccess: () => {
 		queryClient.removeQueries( sitePreviewLinksQuery( siteId ) );

--- a/client/dashboard/app/queries/site-primary-data-center.ts
+++ b/client/dashboard/app/queries/site-primary-data-center.ts
@@ -1,6 +1,6 @@
 import { fetchPrimaryDataCenter } from '../../data/site-hosting';
 
-export const sitePrimaryDataCenterQuery = ( siteId: string ) => ( {
+export const sitePrimaryDataCenterQuery = ( siteId: number ) => ( {
 	queryKey: [ 'site', siteId, 'primary-data-center' ],
 	queryFn: () => fetchPrimaryDataCenter( siteId ),
 } );

--- a/client/dashboard/app/queries/site-purchases.ts
+++ b/client/dashboard/app/queries/site-purchases.ts
@@ -1,7 +1,7 @@
 import { fetchSitePurchases } from '../../data/site-purchases';
 import type { Purchase } from '../../data/site-purchases';
 
-export const siteHasCancelablePurchasesQuery = ( siteId: string, userId: number ) => ( {
+export const siteHasCancelablePurchasesQuery = ( siteId: number, userId: number ) => ( {
 	queryKey: [ 'site', siteId, 'purchases', 'has-cancelable' ],
 	queryFn: () => fetchSitePurchases( siteId ),
 	select: ( purchases: Purchase[] ) => {

--- a/client/dashboard/app/queries/site-reset.ts
+++ b/client/dashboard/app/queries/site-reset.ts
@@ -4,16 +4,16 @@ import {
 	fetchSiteResetStatus,
 } from '../../data/site-reset';
 
-export const siteResetContentSummaryQuery = ( siteId: string ) => ( {
+export const siteResetContentSummaryQuery = ( siteId: number ) => ( {
 	queryKey: [ 'site', siteId, 'reset', 'content-summary' ],
 	queryFn: () => fetchSiteResetContentSummary( siteId ),
 } );
 
-export const siteResetMutation = ( siteId: string ) => ( {
+export const siteResetMutation = ( siteId: number ) => ( {
 	mutationFn: () => resetSite( siteId ),
 } );
 
-export const siteResetStatusQuery = ( siteId: string ) => ( {
+export const siteResetStatusQuery = ( siteId: number ) => ( {
 	queryKey: [ 'site', siteId, 'reset', 'status' ],
 	queryFn: () => fetchSiteResetStatus( siteId ),
 } );

--- a/client/dashboard/app/queries/site-settings.ts
+++ b/client/dashboard/app/queries/site-settings.ts
@@ -3,12 +3,12 @@ import { queryClient } from '../query-client';
 import { siteByIdQuery } from './site';
 import type { SiteSettings } from '../../data/site-settings';
 
-export const siteSettingsQuery = ( siteId: string ) => ( {
+export const siteSettingsQuery = ( siteId: number ) => ( {
 	queryKey: [ 'site', siteId, 'settings' ],
 	queryFn: () => fetchSiteSettings( siteId ),
 } );
 
-export const siteSettingsMutation = ( siteId: string ) => ( {
+export const siteSettingsMutation = ( siteId: number ) => ( {
 	mutationFn: ( data: Partial< SiteSettings > ) => updateSiteSettings( siteId, data ),
 	onSuccess: ( newData: Partial< SiteSettings > ) => {
 		queryClient.setQueryData( siteSettingsQuery( siteId ).queryKey, ( oldData: SiteSettings ) => ( {

--- a/client/dashboard/app/queries/site-sftp.ts
+++ b/client/dashboard/app/queries/site-sftp.ts
@@ -2,7 +2,7 @@ import { fetchSftpUsers, createSftpUser, resetSftpPassword } from '../../data/si
 import { queryClient } from '../query-client';
 import type { SftpUser } from '../../data/site-hosting-sftp';
 
-export const siteSftpUsersQuery = ( siteId: string ) => ( {
+export const siteSftpUsersQuery = ( siteId: number ) => ( {
 	queryKey: [ 'site', siteId, 'sftp-users' ],
 	queryFn: () => fetchSftpUsers( siteId ),
 	meta: {
@@ -21,7 +21,7 @@ const updateCurrentSftpUsers = ( currentSftpUsers: SftpUser[], sftpUser: SftpUse
 	return [ ...currentSftpUsers, sftpUser ];
 };
 
-export const siteSftpUsersCreateMutation = ( siteId: string ) => ( {
+export const siteSftpUsersCreateMutation = ( siteId: number ) => ( {
 	mutationFn: () => createSftpUser( siteId ),
 	onSuccess: ( createdSftpUser: SftpUser ) => {
 		queryClient.setQueryData(
@@ -32,7 +32,7 @@ export const siteSftpUsersCreateMutation = ( siteId: string ) => ( {
 	},
 } );
 
-export const siteSftpUsersResetPasswordMutation = ( siteId: string ) => ( {
+export const siteSftpUsersResetPasswordMutation = ( siteId: number ) => ( {
 	mutationFn: ( sshUsername: string ) => resetSftpPassword( siteId, sshUsername ),
 	onSuccess: ( updatedSftpUser: SftpUser ) => {
 		queryClient.setQueryData(

--- a/client/dashboard/app/queries/site-ssh.ts
+++ b/client/dashboard/app/queries/site-ssh.ts
@@ -9,28 +9,28 @@ import {
 import { queryClient } from '../query-client';
 import type { SshAccessStatus, SiteSshKey } from '../../data/site-hosting-ssh';
 
-export const siteSshAccessStatusQuery = ( siteId: string ) => ( {
+export const siteSshAccessStatusQuery = ( siteId: number ) => ( {
 	queryKey: [ 'site', siteId, 'ssh-access' ],
 	queryFn: () => {
 		return fetchSshAccessStatus( siteId );
 	},
 } );
 
-export const siteSshAccessEnableMutation = ( siteId: string ) => ( {
+export const siteSshAccessEnableMutation = ( siteId: number ) => ( {
 	mutationFn: () => enableSshAccess( siteId ),
 	onSuccess: ( data: SshAccessStatus ) => {
 		queryClient.setQueryData( siteSshAccessStatusQuery( siteId ).queryKey, data );
 	},
 } );
 
-export const siteSshAccessDisableMutation = ( siteId: string ) => ( {
+export const siteSshAccessDisableMutation = ( siteId: number ) => ( {
 	mutationFn: () => disableSshAccess( siteId ),
 	onSuccess: ( data: SshAccessStatus ) => {
 		queryClient.setQueryData( siteSshAccessStatusQuery( siteId ).queryKey, data );
 	},
 } );
 
-export function siteSshKeysQuery( siteId: string ) {
+export function siteSshKeysQuery( siteId: number ) {
 	return {
 		queryKey: [ 'site', siteId, 'ssh-keys' ],
 		queryFn: () => {
@@ -39,7 +39,7 @@ export function siteSshKeysQuery( siteId: string ) {
 	};
 }
 
-export function siteSshKeysAttachMutation( siteId: string ) {
+export function siteSshKeysAttachMutation( siteId: number ) {
 	return {
 		mutationFn: ( name: string ) => attachSiteSshKey( siteId, name ),
 		onSuccess: () => {
@@ -48,7 +48,7 @@ export function siteSshKeysAttachMutation( siteId: string ) {
 	};
 }
 
-export function siteSshKeysDetachMutation( siteId: string ) {
+export function siteSshKeysDetachMutation( siteId: number ) {
 	return {
 		mutationFn: ( siteSshKey: SiteSshKey ) =>
 			detachSiteSshKey( siteId, siteSshKey.user_login, siteSshKey.name ),

--- a/client/dashboard/app/queries/site-static-file-404.ts
+++ b/client/dashboard/app/queries/site-static-file-404.ts
@@ -1,12 +1,12 @@
 import { fetchStaticFile404Setting, updateStaticFile404Setting } from '../../data/site-hosting';
 import { queryClient } from '../query-client';
 
-export const siteStaticFile404SettingQuery = ( siteId: string ) => ( {
+export const siteStaticFile404SettingQuery = ( siteId: number ) => ( {
 	queryKey: [ 'site', siteId, 'static-file-404' ],
 	queryFn: () => fetchStaticFile404Setting( siteId ),
 } );
 
-export const siteStaticFile404SettingMutation = ( siteId: string ) => ( {
+export const siteStaticFile404SettingMutation = ( siteId: number ) => ( {
 	mutationFn: ( setting: string ) => updateStaticFile404Setting( siteId, setting ),
 	onSuccess: () => {
 		queryClient.invalidateQueries( siteStaticFile404SettingQuery( siteId ) );

--- a/client/dashboard/app/queries/site-stats.ts
+++ b/client/dashboard/app/queries/site-stats.ts
@@ -1,6 +1,6 @@
 import { fetchSiteEngagementStats } from '../../data/site-stats';
 
-export const siteEngagementStatsQuery = ( siteId: string ) => ( {
+export const siteEngagementStatsQuery = ( siteId: number ) => ( {
 	queryKey: [ 'site', siteId, 'engagement-stats' ],
 	queryFn: () => fetchSiteEngagementStats( siteId ),
 } );

--- a/client/dashboard/app/queries/site-uptime.ts
+++ b/client/dashboard/app/queries/site-uptime.ts
@@ -1,6 +1,6 @@
 import { fetchSiteUptime } from '../../data/site-jetpack-monitor-uptime';
 
-export const siteUptimeQuery = ( siteId: string ) => ( {
+export const siteUptimeQuery = ( siteId: number ) => ( {
 	queryKey: [ 'site', siteId, 'uptime' ],
 	queryFn: () => fetchSiteUptime( siteId ),
 } );

--- a/client/dashboard/app/queries/site-users.ts
+++ b/client/dashboard/app/queries/site-users.ts
@@ -1,11 +1,11 @@
 import { fetchCurrentSiteUser, deleteSiteUser } from '../../data/site-users';
 
-export const siteCurrentUserQuery = ( siteId: string ) => ( {
+export const siteCurrentUserQuery = ( siteId: number ) => ( {
 	queryKey: [ 'site', siteId, 'users', 'current' ],
 	queryFn: () => fetchCurrentSiteUser( siteId ),
 } );
 
-export function siteUserDeleteMutation( siteId: string ) {
+export function siteUserDeleteMutation( siteId: number ) {
 	return {
 		mutationFn: ( userId: number ) => deleteSiteUser( siteId, userId ),
 	};

--- a/client/dashboard/app/queries/site-wordpress-version.ts
+++ b/client/dashboard/app/queries/site-wordpress-version.ts
@@ -1,12 +1,12 @@
 import { fetchWordPressVersion, updateWordPressVersion } from '../../data/site-hosting';
 import { queryClient } from '../query-client';
 
-export const siteWordPressVersionQuery = ( siteId: string ) => ( {
+export const siteWordPressVersionQuery = ( siteId: number ) => ( {
 	queryKey: [ 'site', siteId, 'wp-version' ],
 	queryFn: () => fetchWordPressVersion( siteId ),
 } );
 
-export const siteWordPressVersionMutation = ( siteId: string ) => ( {
+export const siteWordPressVersionMutation = ( siteId: number ) => ( {
 	mutationFn: ( version: string ) => updateWordPressVersion( siteId, version ),
 	onSuccess: () => {
 		queryClient.invalidateQueries( siteWordPressVersionQuery( siteId ) );

--- a/client/dashboard/app/queries/site.ts
+++ b/client/dashboard/app/queries/site.ts
@@ -8,20 +8,20 @@ export const siteBySlugQuery = ( siteSlug: string ) => ( {
 	queryFn: () => fetchSite( siteSlug ),
 } );
 
-export const siteByIdQuery = ( siteId: string ) => ( {
+export const siteByIdQuery = ( siteId: number ) => ( {
 	predicate: ( { queryKey, state }: Query ) => {
 		return queryKey[ 0 ] === 'site-by-slug' && ( state.data as Site )?.ID === siteId;
 	},
 } );
 
-export const siteDeleteMutation = ( siteId: string ) => ( {
+export const siteDeleteMutation = ( siteId: number ) => ( {
 	mutationFn: () => deleteSite( siteId ),
 	onSuccess: () => {
 		queryClient.invalidateQueries( siteByIdQuery( siteId ) );
 	},
 } );
 
-export const siteLaunchMutation = ( siteId: string ) => ( {
+export const siteLaunchMutation = ( siteId: number ) => ( {
 	mutationFn: () => launchSite( siteId ),
 	onSuccess: () => {
 		queryClient.invalidateQueries( siteByIdQuery( siteId ) );

--- a/client/dashboard/data/agency.ts
+++ b/client/dashboard/data/agency.ts
@@ -10,7 +10,7 @@ export interface AgencyBlog {
 	};
 }
 
-export async function fetchAgencyBlog( siteId: string ): Promise< AgencyBlog > {
+export async function fetchAgencyBlog( siteId: number ): Promise< AgencyBlog > {
 	return wpcom.req.get( {
 		path: `/agency/blog/${ siteId }`,
 		apiNamespace: 'wpcom/v2',

--- a/client/dashboard/data/p2.ts
+++ b/client/dashboard/data/p2.ts
@@ -1,7 +1,7 @@
 import wpcom from 'calypso/lib/wp';
 
 export async function fetchP2HubP2s(
-	siteId: string,
+	siteId: number,
 	options: { limit?: number } = {}
 ): Promise< { totalItems: number } > {
 	return wpcom.req.get(

--- a/client/dashboard/data/site-hosting-edge-cache.ts
+++ b/client/dashboard/data/site-hosting-edge-cache.ts
@@ -11,14 +11,14 @@ export interface DefensiveModeSettingsUpdate {
 	ttl?: number;
 }
 
-export async function fetchEdgeCacheStatus( siteId: string ): Promise< boolean > {
+export async function fetchEdgeCacheStatus( siteId: number ): Promise< boolean > {
 	return wpcom.req.get( {
 		path: `/sites/${ siteId }/hosting/edge-cache/active`,
 		apiNamespace: 'wpcom/v2',
 	} );
 }
 
-export async function updateEdgeCacheStatus( siteId: string, active: boolean ): Promise< boolean > {
+export async function updateEdgeCacheStatus( siteId: number, active: boolean ): Promise< boolean > {
 	return wpcom.req.post(
 		{
 			path: `/sites/${ siteId }/hosting/edge-cache/active`,
@@ -28,7 +28,7 @@ export async function updateEdgeCacheStatus( siteId: string, active: boolean ): 
 	);
 }
 
-export async function clearEdgeCache( siteId: string ) {
+export async function clearEdgeCache( siteId: number ) {
 	return wpcom.req.post( {
 		path: `/sites/${ siteId }/hosting/edge-cache/purge`,
 		apiNamespace: 'wpcom/v2',
@@ -36,7 +36,7 @@ export async function clearEdgeCache( siteId: string ) {
 }
 
 export async function fetchEdgeCacheDefensiveModeSettings(
-	siteId: string
+	siteId: number
 ): Promise< DefensiveModeSettings > {
 	return wpcom.req.get( {
 		path: `/sites/${ siteId }/hosting/edge-cache/defensive-mode`,
@@ -45,7 +45,7 @@ export async function fetchEdgeCacheDefensiveModeSettings(
 }
 
 export async function updateEdgeCacheDefensiveModeSettings(
-	siteId: string,
+	siteId: number,
 	data: DefensiveModeSettingsUpdate
 ): Promise< DefensiveModeSettings > {
 	return wpcom.req.post(

--- a/client/dashboard/data/site-hosting-sftp.ts
+++ b/client/dashboard/data/site-hosting-sftp.ts
@@ -5,7 +5,7 @@ export interface SftpUser {
 	password: string;
 }
 
-export async function fetchSftpUsers( siteId: string ): Promise< SftpUser[] > {
+export async function fetchSftpUsers( siteId: number ): Promise< SftpUser[] > {
 	const { users } = await wpcom.req.get( {
 		path: `/sites/${ siteId }/hosting/ssh-users`,
 		apiNamespace: 'wpcom/v2',
@@ -16,7 +16,7 @@ export async function fetchSftpUsers( siteId: string ): Promise< SftpUser[] > {
 	} ) );
 }
 
-export async function createSftpUser( siteId: string ): Promise< SftpUser > {
+export async function createSftpUser( siteId: number ): Promise< SftpUser > {
 	return wpcom.req.post( {
 		path: `/sites/${ siteId }/hosting/ssh-user`,
 		apiNamespace: 'wpcom/v2',
@@ -24,7 +24,7 @@ export async function createSftpUser( siteId: string ): Promise< SftpUser > {
 }
 
 export async function resetSftpPassword(
-	siteId: string,
+	siteId: number,
 	sshUsername: string
 ): Promise< SftpUser > {
 	return wpcom.req.post( {

--- a/client/dashboard/data/site-hosting-ssh.ts
+++ b/client/dashboard/data/site-hosting-ssh.ts
@@ -11,14 +11,14 @@ export interface SiteSshKey {
 	attached_at: string;
 }
 
-export async function fetchSshAccessStatus( siteId: string ): Promise< SshAccessStatus > {
+export async function fetchSshAccessStatus( siteId: number ): Promise< SshAccessStatus > {
 	return wpcom.req.get( {
 		path: `/sites/${ siteId }/hosting/ssh-access`,
 		apiNamespace: 'wpcom/v2',
 	} );
 }
 
-export async function enableSshAccess( siteId: string ) {
+export async function enableSshAccess( siteId: number ) {
 	return wpcom.req.post(
 		{
 			path: `/sites/${ siteId }/hosting/ssh-access`,
@@ -28,7 +28,7 @@ export async function enableSshAccess( siteId: string ) {
 	);
 }
 
-export async function disableSshAccess( siteId: string ) {
+export async function disableSshAccess( siteId: number ) {
 	return wpcom.req.post(
 		{
 			path: `/sites/${ siteId }/hosting/ssh-access`,
@@ -38,7 +38,7 @@ export async function disableSshAccess( siteId: string ) {
 	);
 }
 
-export async function fetchSiteSshKeys( siteId: string ): Promise< SiteSshKey[] > {
+export async function fetchSiteSshKeys( siteId: number ): Promise< SiteSshKey[] > {
 	const { ssh_keys } = await wpcom.req.get( {
 		path: `/sites/${ siteId }/hosting/ssh-keys`,
 		apiNamespace: 'wpcom/v2',
@@ -47,7 +47,7 @@ export async function fetchSiteSshKeys( siteId: string ): Promise< SiteSshKey[] 
 	return ssh_keys;
 }
 
-export async function attachSiteSshKey( siteId: string, name: string ) {
+export async function attachSiteSshKey( siteId: number, name: string ) {
 	return wpcom.req.post(
 		{
 			path: `/sites/${ siteId }/hosting/ssh-keys`,
@@ -57,7 +57,7 @@ export async function attachSiteSshKey( siteId: string, name: string ) {
 	);
 }
 
-export async function detachSiteSshKey( siteId: string, userLogin: string, name: string ) {
+export async function detachSiteSshKey( siteId: number, userLogin: string, name: string ) {
 	return wpcom.req.post( {
 		path: `/sites/${ siteId }/hosting/ssh-keys/${ userLogin }/${ name }`,
 		apiNamespace: 'wpcom/v2',

--- a/client/dashboard/data/site-hosting.ts
+++ b/client/dashboard/data/site-hosting.ts
@@ -1,14 +1,14 @@
 import wpcom from 'calypso/lib/wp';
 import type { DataCenterOption } from 'calypso/data/data-center/types';
 
-export async function fetchWordPressVersion( siteId: string ): Promise< string > {
+export async function fetchWordPressVersion( siteId: number ): Promise< string > {
 	return wpcom.req.get( {
 		path: `/sites/${ siteId }/hosting/wp-version`,
 		apiNamespace: 'wpcom/v2',
 	} );
 }
 
-export async function updateWordPressVersion( siteId: string, version: string ) {
+export async function updateWordPressVersion( siteId: number, version: string ) {
 	return wpcom.req.post(
 		{
 			path: `/sites/${ siteId }/hosting/wp-version`,
@@ -18,14 +18,14 @@ export async function updateWordPressVersion( siteId: string, version: string ) 
 	);
 }
 
-export async function fetchPHPVersion( siteId: string ): Promise< string > {
+export async function fetchPHPVersion( siteId: number ): Promise< string > {
 	return wpcom.req.get( {
 		path: `/sites/${ siteId }/hosting/php-version`,
 		apiNamespace: 'wpcom/v2',
 	} );
 }
 
-export async function updatePHPVersion( siteId: string, version: string ) {
+export async function updatePHPVersion( siteId: number, version: string ) {
 	return wpcom.req.post(
 		{
 			path: `/sites/${ siteId }/hosting/php-version`,
@@ -35,7 +35,7 @@ export async function updatePHPVersion( siteId: string, version: string ) {
 	);
 }
 
-export async function fetchPhpMyAdminToken( siteId: string ): Promise< string > {
+export async function fetchPhpMyAdminToken( siteId: number ): Promise< string > {
 	const { token } = await wpcom.req.post( {
 		path: `/sites/${ siteId }/hosting/pma/token`,
 		apiNamespace: 'wpcom/v2',
@@ -43,21 +43,21 @@ export async function fetchPhpMyAdminToken( siteId: string ): Promise< string > 
 	return token;
 }
 
-export async function fetchPrimaryDataCenter( siteId: string ): Promise< DataCenterOption | null > {
+export async function fetchPrimaryDataCenter( siteId: number ): Promise< DataCenterOption | null > {
 	return wpcom.req.get( {
 		path: `/sites/${ siteId }/hosting/geo-affinity`,
 		apiNamespace: 'wpcom/v2',
 	} );
 }
 
-export async function fetchStaticFile404Setting( siteId: string ): Promise< string > {
+export async function fetchStaticFile404Setting( siteId: number ): Promise< string > {
 	return wpcom.req.get( {
 		path: `/sites/${ siteId }/hosting/static-file-404`,
 		apiNamespace: 'wpcom/v2',
 	} );
 }
 
-export async function updateStaticFile404Setting( siteId: string, setting: string ) {
+export async function updateStaticFile404Setting( siteId: number, setting: string ) {
 	return wpcom.req.post(
 		{
 			path: `/sites/${ siteId }/hosting/static-file-404`,
@@ -67,7 +67,7 @@ export async function updateStaticFile404Setting( siteId: string, setting: strin
 	);
 }
 
-export async function clearObjectCache( siteId: string, reason: string ) {
+export async function clearObjectCache( siteId: number, reason: string ) {
 	return wpcom.req.post(
 		{
 			path: `/sites/${ siteId }/hosting/clear-cache`,
@@ -77,14 +77,14 @@ export async function clearObjectCache( siteId: string, reason: string ) {
 	);
 }
 
-export async function restoreDatabasePassword( siteId: string ) {
+export async function restoreDatabasePassword( siteId: number ) {
 	return wpcom.req.post( {
 		path: `/sites/${ siteId }/hosting/restore-database-password`,
 		apiNamespace: 'wpcom/v2',
 	} );
 }
 
-export async function restoreSitePlanSoftware( siteId: string ) {
+export async function restoreSitePlanSoftware( siteId: number ) {
 	return wpcom.req.post( {
 		path: `/sites/${ siteId }/hosting/restore-plan-software`,
 		apiNamespace: 'wpcom/v2',

--- a/client/dashboard/data/site-jetpack-monitor-uptime.ts
+++ b/client/dashboard/data/site-jetpack-monitor-uptime.ts
@@ -4,7 +4,7 @@ export interface SiteUptime {
 	[ key: string ]: { status: string; downtime_in_minutes?: number };
 }
 
-export async function fetchSiteUptime( siteId: string ): Promise< SiteUptime | undefined > {
+export async function fetchSiteUptime( siteId: number ): Promise< SiteUptime | undefined > {
 	return wpcom.req.get(
 		{
 			path: `/sites/${ siteId }/jetpack-monitor-uptime`,

--- a/client/dashboard/data/site-media-storage.ts
+++ b/client/dashboard/data/site-media-storage.ts
@@ -6,8 +6,8 @@ export interface SiteMediaStorage {
 	storageUsedBytes: number;
 }
 
-export async function fetchSiteMediaStorage( siteIdOrSlug: string ): Promise< SiteMediaStorage > {
-	const mediaStorage = await wpcom.req.get( `/sites/${ siteIdOrSlug }/media-storage` );
+export async function fetchSiteMediaStorage( siteId: number ): Promise< SiteMediaStorage > {
+	const mediaStorage = await wpcom.req.get( `/sites/${ siteId }/media-storage` );
 	return {
 		maxStorageBytesFromAddOns: Number( mediaStorage.max_storage_bytes_from_add_ons ),
 		maxStorageBytes: Number( mediaStorage.max_storage_bytes ),

--- a/client/dashboard/data/site-owner-transfer.ts
+++ b/client/dashboard/data/site-owner-transfer.ts
@@ -6,7 +6,7 @@ export interface SiteOwnerTransferConfirmation {
 	new_owner_email: string;
 }
 
-export async function startSiteOwnerTransfer( siteId: string, data: { new_site_owner: string } ) {
+export async function startSiteOwnerTransfer( siteId: number, data: { new_site_owner: string } ) {
 	return wpcom.req.post(
 		{
 			path: `/sites/${ siteId }/site-owner-transfer`,
@@ -23,7 +23,7 @@ export async function startSiteOwnerTransfer( siteId: string, data: { new_site_o
 }
 
 export async function checkSiteOwnerTransferEligibility(
-	siteId: string,
+	siteId: number,
 	data: { new_site_owner: string }
 ) {
 	return wpcom.req.post(
@@ -36,7 +36,7 @@ export async function checkSiteOwnerTransferEligibility(
 }
 
 export async function confirmSiteOwnerTransfer(
-	siteId: string,
+	siteId: number,
 	data: { hash: string }
 ): Promise< SiteOwnerTransferConfirmation > {
 	return wpcom.req.post(

--- a/client/dashboard/data/site-plans.ts
+++ b/client/dashboard/data/site-plans.ts
@@ -8,7 +8,7 @@ export interface Plan {
 	user_facing_expiry?: string;
 }
 
-export async function fetchCurrentSitePlan( siteId: string ): Promise< Plan > {
+export async function fetchCurrentSitePlan( siteId: number ): Promise< Plan > {
 	const plans: Record< string, Plan > = await wpcom.req.get( {
 		path: `/sites/${ siteId }/plans`,
 		apiVersion: '1.3',

--- a/client/dashboard/data/site-preview-links.ts
+++ b/client/dashboard/data/site-preview-links.ts
@@ -6,21 +6,21 @@ export interface SitePreviewLink {
 	expires_at?: string;
 }
 
-export async function fetchSitePreviewLinks( siteId: string ): Promise< SitePreviewLink[] > {
+export async function fetchSitePreviewLinks( siteId: number ): Promise< SitePreviewLink[] > {
 	return wpcom.req.get( {
 		path: `/sites/${ siteId }/preview-links`,
 		apiNamespace: 'wpcom/v2',
 	} );
 }
 
-export async function createSitePreviewLink( siteId: string ): Promise< SitePreviewLink > {
+export async function createSitePreviewLink( siteId: number ): Promise< SitePreviewLink > {
 	return wpcom.req.post( {
 		path: `/sites/${ siteId }/preview-links`,
 		apiNamespace: 'wpcom/v2',
 	} );
 }
 
-export async function deleteSitePreviewLink( siteId: string, code: string ) {
+export async function deleteSitePreviewLink( siteId: number, code: string ) {
 	return wpcom.req.post( {
 		method: 'DELETE',
 		path: `/sites/${ siteId }/preview-links/${ code }`,

--- a/client/dashboard/data/site-purchases.ts
+++ b/client/dashboard/data/site-purchases.ts
@@ -8,7 +8,7 @@ export interface Purchase {
 	user_id: number | string;
 }
 
-export async function fetchSitePurchases( siteId: string ): Promise< Purchase[] > {
+export async function fetchSitePurchases( siteId: number ): Promise< Purchase[] > {
 	return wpcom.req.get( {
 		path: `/sites/${ siteId }/purchases`,
 	} );

--- a/client/dashboard/data/site-reset.ts
+++ b/client/dashboard/data/site-reset.ts
@@ -13,7 +13,7 @@ export type SiteResetStatus = {
 };
 
 export async function fetchSiteResetContentSummary(
-	siteId: string
+	siteId: number
 ): Promise< SiteResetContentSummary > {
 	return wpcom.req.get( {
 		path: `/sites/${ siteId }/reset-site/content-summary`,
@@ -21,14 +21,14 @@ export async function fetchSiteResetContentSummary(
 	} );
 }
 
-export async function resetSite( siteId: string ) {
+export async function resetSite( siteId: number ) {
 	return wpcom.req.post( {
 		path: `/sites/${ siteId }/reset-site`,
 		apiNamespace: 'wpcom/v2',
 	} );
 }
 
-export async function fetchSiteResetStatus( siteId: string ): Promise< SiteResetStatus > {
+export async function fetchSiteResetStatus( siteId: number ): Promise< SiteResetStatus > {
 	return wpcom.req.get( {
 		path: `/sites/${ siteId }/reset-site/status`,
 		apiNamespace: 'wpcom/v2',

--- a/client/dashboard/data/site-settings.ts
+++ b/client/dashboard/data/site-settings.ts
@@ -11,7 +11,7 @@ export interface SiteSettings {
 	wpcom_locked_mode?: boolean;
 }
 
-export async function fetchSiteSettings( siteId: string ): Promise< SiteSettings > {
+export async function fetchSiteSettings( siteId: number ): Promise< SiteSettings > {
 	const { settings } = await wpcom.req.get( {
 		path: `/sites/${ siteId }/settings`,
 		apiVersion: '1.4',
@@ -19,7 +19,7 @@ export async function fetchSiteSettings( siteId: string ): Promise< SiteSettings
 	return fromRawSiteSettings( settings );
 }
 
-export async function updateSiteSettings( siteId: string, data: Partial< SiteSettings > ) {
+export async function updateSiteSettings( siteId: number, data: Partial< SiteSettings > ) {
 	const { updated } = await wpcom.req.post(
 		{
 			path: `/sites/${ siteId }/settings`,

--- a/client/dashboard/data/site-stats.ts
+++ b/client/dashboard/data/site-stats.ts
@@ -11,8 +11,8 @@ export interface EngagementStats {
 	previousData: EngagementStatsDataPoint;
 }
 
-export async function fetchSiteEngagementStats( siteIdOrSlug: string ) {
-	const response = await wpcom.req.get( `/sites/${ siteIdOrSlug }/stats/visits`, {
+export async function fetchSiteEngagementStats( siteId: number ) {
+	const response = await wpcom.req.get( `/sites/${ siteId }/stats/visits`, {
 		unit: 'day',
 		quantity: 14,
 		stat_fields: [ 'visitors', 'views', 'likes', 'comments' ].join( ',' ),

--- a/client/dashboard/data/site-users.ts
+++ b/client/dashboard/data/site-users.ts
@@ -4,14 +4,14 @@ export interface SiteUser {
 	id: number;
 }
 
-export async function fetchCurrentSiteUser( siteId: string ): Promise< SiteUser > {
+export async function fetchCurrentSiteUser( siteId: number ): Promise< SiteUser > {
 	return wpcom.req.get( {
 		path: `/sites/${ siteId }/users/me`,
 		apiNamespace: 'wp/v2',
 	} );
 }
 
-export async function deleteSiteUser( siteId: string, userId: number ) {
+export async function deleteSiteUser( siteId: number, userId: number ) {
 	return wpcom.req.post( {
 		path: `/sites/${ siteId }/users/${ userId }/delete`,
 	} );

--- a/client/dashboard/data/site.ts
+++ b/client/dashboard/data/site.ts
@@ -78,7 +78,7 @@ export interface SiteOptions {
 }
 
 export interface Site {
-	ID: string;
+	ID: number;
 	slug: string;
 	name: string;
 	URL: string;
@@ -109,20 +109,20 @@ export interface Site {
 	jetpack_modules: string[] | null;
 }
 
-export async function fetchSite( siteIdOrSlug: string ): Promise< Site > {
+export async function fetchSite( siteIdOrSlug: number | string ): Promise< Site > {
 	return await wpcom.req.get(
 		{ path: `/sites/${ siteIdOrSlug }` },
 		{ fields: JOINED_SITE_FIELDS, options: JOINED_SITE_OPTIONS }
 	);
 }
 
-export async function deleteSite( siteIdOrSlug: string ) {
+export async function deleteSite( siteId: number ) {
 	return wpcom.req.post( {
-		path: `/sites/${ siteIdOrSlug }/delete`,
+		path: `/sites/${ siteId }/delete`,
 	} );
 }
 
-export async function launchSite( siteId: string ) {
+export async function launchSite( siteId: number ) {
 	return wpcom.req.post( {
 		path: `/sites/${ siteId }/launch`,
 		apiNamespace: 'wpcom/v2',

--- a/client/dashboard/sites/hooks/use-performance-data.ts
+++ b/client/dashboard/sites/hooks/use-performance-data.ts
@@ -12,7 +12,7 @@ interface PerformanceData {
 	isLoading: boolean;
 }
 
-export function usePerformanceData( siteId: string, url: string ): PerformanceData {
+export function usePerformanceData( siteId: number, url: string ): PerformanceData {
 	const { data: siteSettings, isLoading: isLoadingSiteSettings } = useQuery( {
 		...siteSettingsQuery( siteId ),
 		refetchOnWindowFocus: false,

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -248,7 +248,7 @@ export default function Sites() {
 			>
 				<DataViewsCard>
 					<DataViews< Site >
-						getItemId={ ( item ) => item.ID }
+						getItemId={ ( item ) => item.ID.toString() }
 						data={ filteredData }
 						fields={ fields }
 						actions={ actions }

--- a/client/dashboard/sites/overview/site-card.tsx
+++ b/client/dashboard/sites/overview/site-card.tsx
@@ -18,7 +18,7 @@ import { getFormattedWordPressVersion } from '../../utils/wp-version';
 import SitePreview from '../site-preview';
 import type { Site } from '../../data/types';
 
-function PHPVersion( { siteId }: { siteId: string } ) {
+function PHPVersion( { siteId }: { siteId: number } ) {
 	return useQuery( sitePHPVersionQuery( siteId ) ).data ?? <TextBlur>X.Y</TextBlur>;
 }
 
@@ -106,7 +106,7 @@ function FieldTitle( { children }: { children: React.ReactNode } ) {
 }
 
 function PlanDetails( { site }: { site: Site } ) {
-	const { data: currentPlan } = useQuery( siteCurrentPlanQuery( site.slug ) );
+	const { data: currentPlan } = useQuery( siteCurrentPlanQuery( site.ID ) );
 
 	if ( ! site.plan ) {
 		return null;

--- a/client/dashboard/sites/overview/uptime-card.tsx
+++ b/client/dashboard/sites/overview/uptime-card.tsx
@@ -9,7 +9,7 @@ import type { Site } from '../../data/types';
 
 import './style.scss';
 
-function UptimeCardEnabled( { siteId }: { siteId: string } ) {
+function UptimeCardEnabled( { siteId }: { siteId: number } ) {
 	const { data: siteUptime } = useQuery( siteUptimeQuery( siteId ) );
 
 	let uptimePercentage;

--- a/client/dashboard/sites/settings-database/reset-password-modal.tsx
+++ b/client/dashboard/sites/settings-database/reset-password-modal.tsx
@@ -10,7 +10,7 @@ import { useState } from 'react';
 import { restoreDatabasePassword } from '../../data/site-hosting';
 
 interface ResetPasswordModalProps {
-	siteId: string;
+	siteId: number;
 	onClose: () => void;
 	onSuccess: () => void;
 	onError: () => void;

--- a/client/dashboard/sites/settings-sftp-ssh/enable-sftp-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/enable-sftp-card.tsx
@@ -24,7 +24,7 @@ export default function EnableSftpCard( {
 	siteId,
 	canUseSsh,
 }: {
-	siteId: string;
+	siteId: number;
 	canUseSsh: boolean;
 } ) {
 	const mutation = useMutation( siteSftpUsersCreateMutation( siteId ) );

--- a/client/dashboard/sites/settings-sftp-ssh/sftp-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/sftp-card.tsx
@@ -38,7 +38,7 @@ export default function SftpCard( {
 	siteId,
 	sftpUsers = [],
 }: {
-	siteId: string;
+	siteId: number;
 	sftpUsers: SftpUser[];
 } ) {
 	const { username = '', password = '' } = sftpUsers[ 0 ] ?? {};

--- a/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
@@ -88,7 +88,7 @@ export default function SshCard( {
 	sftpUsers,
 	sshEnabled,
 }: {
-	siteId: string;
+	siteId: number;
 	sftpUsers: SftpUser[];
 	sshEnabled: boolean;
 } ) {

--- a/client/dashboard/sites/settings-site-visibility/test/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/test/index.tsx
@@ -26,7 +26,7 @@ interface TestSiteOptions {
 	wpcom_data_sharing_opt_out: boolean;
 }
 
-const siteId = '123';
+const siteId = 123;
 const siteSlug = 'test-site';
 
 // Only mocks site and settings fields that are necessary for the tests.


### PR DESCRIPTION
## Proposed Changes

`site.ID` is actually number, not strings.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fixing a TypeScript logical error.

## Testing Instructions

N/A; no real changes to production code.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
