### PR TITLE
Dashboard v2: Use curly quotes

### DIFF
--- a/client/dashboard/sites/settings-agency/index.tsx
+++ b/client/dashboard/sites/settings-agency/index.tsx
@@ -80,7 +80,7 @@ export default function SettingsAgency( { siteSlug }: { siteSlug: string } ) {
 			return (
 				<Notice>
 					{ __(
-						"Clients can't access the WordPress.com Help Center or hosting features on development sites. You may configure access after the site is launched."
+						'Clients can’t access the WordPress.com Help Center or hosting features on development sites. You may configure access after the site is launched.'
 					) }
 				</Notice>
 			);

--- a/client/dashboard/sites/settings-sftp-ssh/enable-sftp-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/enable-sftp-card.tsx
@@ -59,10 +59,10 @@ export default function EnableSftpCard( {
 						description={
 							canUseSsh
 								? __(
-										"Access and edit your website's files directly by creating SFTP credentials and using an SFTP client. Optionally, enable SSH to perform advanced site operations using the command line."
+										'Access and edit your website’s files directly by creating SFTP credentials and using an SFTP client. Optionally, enable SSH to perform advanced site operations using the command line.'
 								  )
 								: __(
-										"Access and edit your website's files directly by creating SFTP credentials and using an SFTP client."
+										'Access and edit your website’s files directly by creating SFTP credentials and using an SFTP client.'
 								  )
 						}
 						level={ 3 }

--- a/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
@@ -295,7 +295,7 @@ export default function SshCard( {
 						title={ __( 'SSH' ) }
 						description={ createInterpolateElement(
 							__(
-								"SSH lets you access your site's backend via a terminal, so you can manage files and use <wpCliLink>WP-CLI</wpCliLink> for quick changes and troubleshooting. <learnMoreLink>Learn more</learnMoreLink>."
+								'SSH lets you access your site’s backend via a terminal, so you can manage files and use <wpCliLink>WP-CLI</wpCliLink> for quick changes and troubleshooting. <learnMoreLink>Learn more</learnMoreLink>.'
 							),
 							{
 								wpCliLink: <ExternalLink href="https://wp-cli.org/" children={ null } />,

--- a/client/dashboard/sites/settings-site-visibility/agency-development-site-launch-modal.tsx
+++ b/client/dashboard/sites/settings-site-visibility/agency-development-site-launch-modal.tsx
@@ -50,10 +50,10 @@ export default function AgencyDevelopmentSiteLaunchModal( {
 	};
 
 	return (
-		<Modal title={ __( "You're about to launch this website" ) } onRequestClose={ onClose }>
+		<Modal title={ __( 'You’re about to launch this website' ) } onRequestClose={ onClose }>
 			<VStack spacing={ 6 }>
 				<Text as="p">
-					{ __( "After launch, we'll bill your agency in the next billing cycle." ) }
+					{ __( 'After launch, we’ll bill your agency in the next billing cycle.' ) }
 				</Text>
 				<HStack justify="flex-end" spacing={ 2 }>
 					<Button disabled={ isLaunching } onClick={ onClose }>

--- a/client/dashboard/sites/settings-site-visibility/launch-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/launch-form.tsx
@@ -23,7 +23,7 @@ function getAgencyBillingMessage( agency: AgencyBlog | undefined, isAgencyQueryE
 		Number.isFinite( agency.prices?.actual_price ) && typeof agency.prices?.currency === 'string';
 
 	if ( isAgencyQueryError || ! priceInfoIsDefined ) {
-		return __( "After launch, we'll bill your agency in the next billing cycle." );
+		return __( 'After launch, we’ll bill your agency in the next billing cycle.' );
 	}
 
 	const { existing_wpcom_license_count: existingWPCOMLicenseCount = 0, name, prices } = agency;
@@ -33,8 +33,8 @@ function getAgencyBillingMessage( agency: AgencyBlog | undefined, isAgencyQueryE
 		sprintf(
 			/* translators: agencyName is the name of the agency that will be billed for the site; licenseCount is the number of licenses the agency will be billed for; price is the price per license */
 			_n(
-				"After launch, we'll bill %(agencyName)s in the next billing cycle. With %(licenseCount)d production hosting license, you will be charged %(price)s / license / month. <learnMoreLink>Learn more</learnMoreLink>",
-				"After launch, we'll bill %(agencyName)s in the next billing cycle. With %(licenseCount)d production hosting licenses, you will be charged %(price)s / license / month. <learnMoreLink>Learn more</learnMoreLink>",
+				'After launch, we’ll bill %(agencyName)s in the next billing cycle. With %(licenseCount)d production hosting license, you will be charged %(price)s / license / month. <learnMoreLink>Learn more</learnMoreLink>',
+				'After launch, we’ll bill %(agencyName)s in the next billing cycle. With %(licenseCount)d production hosting licenses, you will be charged %(price)s / license / month. <learnMoreLink>Learn more</learnMoreLink>',
 				existingWPCOMLicenseCount + 1
 			),
 			{
@@ -70,7 +70,7 @@ export function LaunchAgencyDevelopmentSiteForm( {
 
 	return (
 		<Notice
-			title={ __( "Your site hasn't been launched yet" ) }
+			title={ __( 'Your site hasn’t been launched yet' ) }
 			actions={
 				<>
 					<Button size="compact" variant="primary" onClick={ () => onLaunchClick() }>

--- a/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
@@ -88,7 +88,7 @@ export function ConfirmNewOwnerForm( {
 					<Text lineHeight="20px">
 						{ createInterpolateElement(
 							__(
-								"Ready to transfer <siteSlug /> and its associated purchases? Simply enter the new owner's email below, or choose an existing user to start the transfer process."
+								'Ready to transfer <siteSlug /> and its associated purchases? Simply enter the new owner’s email below, or choose an existing user to start the transfer process.'
 							),
 							{
 								siteSlug: <strong>{ site.slug }</strong>,

--- a/client/dashboard/sites/settings/danger-zone.tsx
+++ b/client/dashboard/sites/settings/danger-zone.tsx
@@ -76,7 +76,7 @@ const SiteDeleteAction = ( { site }: { site: Site } ) => {
 			<ActionList.ActionItem
 				title={ __( 'Delete site' ) }
 				description={ __(
-					"Delete all your posts, pages, media, and data, and give up your site's address."
+					'Delete all your posts, pages, media, and data, and give up your site’s address.'
 				) }
 				actions={
 					<Button

--- a/client/dashboard/sites/site-delete-modal/index.tsx
+++ b/client/dashboard/sites/site-delete-modal/index.tsx
@@ -50,7 +50,7 @@ function SiteDeleteWarningContent( { site, onClose }: { site: Site; onClose: () 
 	const renderWarningContent = () => {
 		if ( isAtomicRemovalInProgress ) {
 			return __(
-				"We are still in the process of removing your previous plan. Please check back in a few minutes and you'll be able to delete your site."
+				'We are still in the process of removing your previous plan. Please check back in a few minutes and you’ll be able to delete your site.'
 			);
 		}
 

--- a/client/dashboard/sites/site-reset-modal/index.tsx
+++ b/client/dashboard/sites/site-reset-modal/index.tsx
@@ -48,7 +48,7 @@ function InProgressContent( { progress }: { progress: number | undefined } ) {
 	return (
 		<VStack spacing={ 4 }>
 			<ProgressBar className="reset-site-modal-progress-bar" value={ progressValue } />
-			<Text>{ __( "We're resetting your site. We'll email you once it's ready." ) }</Text>
+			<Text>{ __( 'We’re resetting your site. We’ll email you once it’s ready.' ) }</Text>
 		</VStack>
 	);
 }
@@ -107,7 +107,7 @@ function SiteResetContent( {
 				{ createInterpolateElement(
 					/* translators: <siteDomain />: site domain */
 					__(
-						"Resetting <siteDomain /> will remove all of its content but keep the site and its URL up and running. You'll also lose any modifications you've made to your current theme. This cannot be undone."
+						'Resetting <siteDomain /> will remove all of its content but keep the site and its URL up and running. You’ll also lose any modifications you’ve made to your current theme. This cannot be undone.'
 					),
 					{
 						siteDomain: <strong>{ siteDomain }</strong>,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-31, pgz0xU-1S-p2

## Proposed Changes

* Replace straight quotes with curly quotes

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Make the usage of quotes consistent

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure the changes make sense

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?