### PR TITLE
Accessibility: Ensure that lists are structured correctly on checkout page

### DIFF
--- a/client/my-sites/checkout/src/components/CheckoutMoneyBackGuarantee.tsx
+++ b/client/my-sites/checkout/src/components/CheckoutMoneyBackGuarantee.tsx
@@ -9,8 +9,7 @@ const CheckoutMoneyBackGuaranteeWrapper = styled.div`
 	align-items: center;
 	margin: 1.5em 0 0;
 
-	& li {
-		list-style: none;
+	& p {
 		font-size: 14px;
 		margin: 0 0 0 0.5rem;
 		padding: 0;

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -394,6 +394,11 @@ function CheckoutSummaryGiftFeaturesList( { siteSlug }: { siteSlug: string } ) {
 	);
 }
 
+const CheckoutSummaryRefundWindowsContainer = styled.p`
+	margin: 0;
+	padding: 0;
+`;
+
 export function CheckoutSummaryRefundWindows( {
 	cart,
 	highlight = false,
@@ -495,10 +500,10 @@ export function CheckoutSummaryRefundWindows( {
 	return (
 		<>
 			{ includeRefundIcon && <StyledIcon icon={ reusableBlock } size={ 24 } /> }
-			<CheckoutSummaryFeaturesListItem>
+			<CheckoutSummaryRefundWindowsContainer>
 				{ ! includeRefundIcon && <WPCheckoutCheckIcon /> }
 				{ highlight ? <strong>{ text }</strong> : text }
-			</CheckoutSummaryFeaturesListItem>
+			</CheckoutSummaryRefundWindowsContainer>
 		</>
 	);
 }
@@ -608,7 +613,9 @@ export function CheckoutSummaryFeaturesList( props: {
 				/>
 			) }
 
-			<CheckoutSummaryRefundWindows cart={ responseCart } />
+			<CheckoutSummaryFeaturesListItem>
+				<CheckoutSummaryRefundWindows cart={ responseCart } />
+			</CheckoutSummaryFeaturesListItem>
 		</CheckoutSummaryFeaturesListWrapper>
 	);
 }

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -243,12 +243,14 @@ export function WPOrderReviewLineItems( {
 				</WPOrderReviewListItem>
 			) }
 			{ creditsLineItem && responseCart.sub_total_integer > 0 && (
-				<NonProductLineItem
-					subtotal
-					lineItem={ creditsLineItem }
-					isSummary={ isSummary }
-					isPwpoUser={ isPwpoUser }
-				/>
+				<WPOrderReviewListItem>
+					<NonProductLineItem
+						subtotal
+						lineItem={ creditsLineItem }
+						isSummary={ isSummary }
+						isPwpoUser={ isPwpoUser }
+					/>
+				</WPOrderReviewListItem>
 			) }
 		</WPOrderReviewList>
 	);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13533

## Proposed Changes

* Wrap NonProductLineItem used by Credits with WPOrderReviewListItem item to render `li` element instead of rendering contents directly. 
* Added new CheckoutSummaryRefundWindowsContainer component to replace `li` with `p` to render components semantically. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* There are errors related to accessibility on the checkout page. For example, the Credit product line was rendered under`ul` without being a parent `li` element. Similarly, the refund windows period message was rendering `li` without the corresponding parent `ul`. This PR fixes both of them.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual. 
-->

* Navigate to https://wordpress.com/start
* Select a domain, and create a new site
* Go to the checkout page
* Make sure your account has some store credits. If not, add from the store admin. 
* Look for the Credits product line. Look for HTML content within the dev console. It should have a parent `li` element. 
![CleanShot 2025-06-12 at 13 36 15@2x](https://github.com/user-attachments/assets/679744f7-356c-4ddb-841c-88b42a64b033)
* Scroll below a bit to look for the refund window message below the checkout button. Look at the HTML content of it. It should be rendered as a `p` tag. On production, it's li element without `ul` tag. 
![CleanShot 2025-06-12 at 13 37 54@2x](https://github.com/user-attachments/assets/bd62787c-bebe-47e0-b73f-c935b368d630)
* Run Axe Devtools on this page; it should report any issues related to the structure of the page. 



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
