### PR TITLE
Bug: Wrap track event in dispatch to make it work

### DIFF
--- a/client/login/magic-login/verify-login-code.jsx
+++ b/client/login/magic-login/verify-login-code.jsx
@@ -8,6 +8,7 @@ import FormButton from 'calypso/components/forms/form-button';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import LoggedOutForm from 'calypso/components/logged-out-form';
 import { navigate } from 'calypso/lib/navigate';
+import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { rebootAfterLogin } from 'calypso/state/login/actions';
 import { fetchMagicLoginAuthenticate } from 'calypso/state/login/magic-login/actions';
@@ -35,6 +36,7 @@ const VerifyLoginCode = ( {
 	const [ codeCharacters, setCodeCharacters ] = useState( Array( CODE_LENGTH ).fill( '' ) );
 	const [ isRedirecting, setIsRedirecting ] = useState( false );
 	const [ showError, setShowError ] = useState( false );
+	const dispatch = useDispatch();
 
 	// Create refs for each input field to manage focus
 	const inputRefs = useRef( Array.from( { length: CODE_LENGTH }, () => createRef() ) );
@@ -152,9 +154,11 @@ const VerifyLoginCode = ( {
 		}
 
 		// Track magic code verification attempt
-		recordTracksEvent( 'calypso_login_magic_code_submit', {
-			code_length: verificationCode.length,
-		} );
+		dispatch(
+			recordTracksEvent( 'calypso_login_magic_code_submit', {
+				code_length: verificationCode.length,
+			} )
+		);
 
 		// Format: publicToken:code
 		const loginToken = `${ publicToken }:${ btoa( verificationCode ) }`;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Wrap the track function in dispatch to make it work

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The tracking is not working without that

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sanity check
* Log in using the magic code, then go to Track live and look at `calypso_login_magic_code_submit` to check the event after a couple minutes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
