### PR TITLE
Accessibility: Ensure li elements are used semantically on thank you page

### DIFF
--- a/client/components/thank-you-v2/index.tsx
+++ b/client/components/thank-you-v2/index.tsx
@@ -44,7 +44,7 @@ export default function ThankYouV2( props: ThankYouV2Props ) {
 
 			<ThankYouHeader title={ title } subtitle={ subtitle } buttons={ headerButtons } />
 
-			{ products && <div className="thank-you__products">{ products }</div> }
+			{ products && <ul className="thank-you__products">{ products }</ul> }
 
 			{ footerDetails && ! isGravatarDomain && <ThankYouFooter details={ footerDetails } /> }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13532

## Proposed Changes

* Replace the product container type from `div` to `ul` since all product items are rendered with the `li` element. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Axe Devtools has reported an issue with this page about having an `li` tag without a corresponding parent `ul` tag. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch or use the Calypso live link
* Visit the following URL. Replace `SITE_URL` & `RECEIPT_URL` with appropriate values. Use `no-site` when viewing a purchase without a site. .ie domain purchase. 
```
checkout/thank-you/[SITE_URL]/[RECEIPT_ID]
```
* Run axe DevTools on this page; it should not report any issues related to incorrect use of `li`

* To get the receipt ID, go to the store admin of your account, locate the Ownership ID section.

![CleanShot 2025-06-12 at 14 46 33@2x](https://github.com/user-attachments/assets/cb60bfd1-ac58-42e8-86bd-5302d8d689c9)
* It will take you to the payments admin page for that subscription.
* The receipt ID will be listed there.

![CleanShot 2025-06-12 at 14 48 03@2x](https://github.com/user-attachments/assets/d02f93bb-3b32-4d34-8c64-ff1ca629dcf3)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
