### PR TITLE
A4A: Increase onboarding tour font size and fix agency tier resume button.

### DIFF
--- a/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour-sections.tsx
+++ b/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour-sections.tsx
@@ -309,7 +309,7 @@ export default function useOnboardingTourSections() {
 							label: translate( 'Check out Agency Tiers' ),
 							variant: 'secondary',
 							href: A4A_AGENCY_TIER_LINK,
-							onClick: () => onExplore( 'agency_tiers', onClose ),
+							onClick: () => onExplore( 'agency-tiers', onClose ),
 						},
 						{
 							label: translate( 'Next benefit' ),

--- a/client/a8c-for-agencies/components/onboarding-tour-modal/style.scss
+++ b/client/a8c-for-agencies/components/onboarding-tour-modal/style.scss
@@ -187,13 +187,13 @@ $mobile-footer-height: 150px;
 	margin-block-end: 8px;
 
 	p {
-		@include body-small;
+		@include body-medium;
 		margin: 0;
 	}
 }
 
 .onboarding-tour-modal__section-content-hint {
-	@include body-small;
+	@include body-medium;
 	padding: 12px;
 	background-color: $hint-container-bg-color;
 }


### PR DESCRIPTION
This addresses two pieces of feedback we gathered during the CFT for the unified onboarding tour project.


## Proposed Changes

| Description | Screenshot |
|--------|--------|
| Increase the size of the Onboarding tour text to `body-medium`. | <img width="773" alt="Screenshot 2025-06-12 at 5 58 09 PM" src="https://github.com/user-attachments/assets/2d89a55a-53a0-4cc6-bfd8-d1473f613987" /> |
| Fix Issue with the resume CTA not redirecting properly to the Agency tier section. | <img width="562" alt="Screenshot 2025-06-12 at 5 59 59 PM" src="https://github.com/user-attachments/assets/b35b51ae-6ce9-4a1a-a9e7-ea735dbb34ba" /> | 

## Why are these changes being made?

This is part of the Agency onboarding improvement part 2 project.

## Testing Instructions

### Test 1 (Font size)
* Use the A4A live link and navigate to `/overview#onboarding-tour`
* Verify that the main content text has a 13px font size.

### Test 2 (Agency tiers resume CTA)
* Open the onboarding tour modal and navigate to the Agency tiers section.
* Click the `Checkout Agency Tiers` button.
* Once redirected, click the 'Continue tour' button in the Tour snackbar.
* Confirm that the modal goes to the Agency tiers section. 

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
