### PR TITLE
Remove missing variable from the Help Center to fix build

### DIFF
--- a/packages/help-center/src/components/notices.scss
+++ b/packages/help-center/src/components/notices.scss
@@ -1,4 +1,4 @@
-.help-center__notice{
+.help-center__notice {
 	background-color: var( --studio-yellow-0 );
 	border-left: 4px solid var( --studio-yellow-20 );
 	padding: 8px 16px;
@@ -12,6 +12,6 @@
 	}
 
 	button.help-center__notice-link {
-		font-size: $font-body-small;
+		font-size: 14px;
 	}
 }


### PR DESCRIPTION
## Proposed Changes

The HC had a missing SCSS variable. This hard-codes the value for simplicity. 

## Why are these changes being made?
To fix the build.

## Testing Instructions
1. cd into `apps/help-center`.
2. run `yarn build`.
3. Make the build passes.
