### PR TITLE
Open plugins 'How to get help' in support center

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -99,6 +99,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/followers/',
 		post_id: 5444,
 	},
+	'general-support-options': {
+		link: 'https://wordpress.com/support/help-support-options/',
+		post_id: 149,
+	},
 	'getting-started-video': {
 		link: 'https://wordpress.com/support/getting-started-with-wordpress-com/#video-getting-started-with-word-press-com',
 		post_id: 158974,

--- a/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
@@ -5,6 +5,11 @@ import styled from '@emotion/styled';
 import { Fragment } from 'react';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 
+const PLUGIN_DETAILS_LINK_TYPES = {
+	NEW_TAB: 'NewTab',
+	HELP_CENTER: 'HelpCenter',
+};
+
 const Container = styled( FoldableCard )`
 	display: flex;
 	flex-direction: column;
@@ -114,10 +119,10 @@ const PluginDetailsSidebarUSP = ( {
 				links.map( ( link, idx ) => {
 					const { openIn, label, ...linkProps } = link;
 					let LinkComponent;
-					if ( openIn === 'NewTab' ) {
+					if ( openIn === PLUGIN_DETAILS_LINK_TYPES.NEW_TAB ) {
 						LinkComponent = ExternalLink;
 						linkProps.icon = true;
-					} else if ( openIn === 'HelpCenter' ) {
+					} else if ( openIn === PLUGIN_DETAILS_LINK_TYPES.HELP_CENTER ) {
 						LinkComponent = StyledInlineSupportLink;
 					} else {
 						LinkComponent = Link;
@@ -134,4 +139,5 @@ const PluginDetailsSidebarUSP = ( {
 	);
 };
 
+export { PLUGIN_DETAILS_LINK_TYPES };
 export default PluginDetailsSidebarUSP;

--- a/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
@@ -3,6 +3,7 @@ import { useBreakpoint } from '@automattic/viewport-react';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { Fragment } from 'react';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 
 const Container = styled( FoldableCard )`
 	display: flex;
@@ -72,6 +73,10 @@ const Link = styled.a`
 	${ linkStyles }
 `;
 
+const StyledInlineSupportLink = styled( InlineSupportLink )`
+	${ linkStyles }
+`;
+
 const PluginDetailsSidebarUSP = ( {
 	id,
 	title,
@@ -107,17 +112,20 @@ const PluginDetailsSidebarUSP = ( {
 			<Description showAsAccordion={ isNarrow }>{ description }</Description>
 			{ links &&
 				links.map( ( link, idx ) => {
+					const { openIn, label, ...linkProps } = link;
+					let LinkComponent;
+					if ( openIn === 'NewTab' ) {
+						LinkComponent = ExternalLink;
+						linkProps.icon = true;
+					} else if ( openIn === 'HelpCenter' ) {
+						LinkComponent = StyledInlineSupportLink;
+					} else {
+						LinkComponent = Link;
+					}
+
 					return (
 						<Fragment key={ idx }>
-							{ link.openInNewTab ? (
-								<ExternalLink icon href={ link.href } onClick={ link.onClick }>
-									{ link.label }
-								</ExternalLink>
-							) : (
-								<Link href={ link.href } onClick={ link.onClick }>
-									{ link.label }
-								</Link>
-							) }
+							<LinkComponent { ...linkProps }>{ label }</LinkComponent>
 							<br />
 						</Fragment>
 					);

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -11,7 +11,9 @@ import { useSelector } from 'react-redux';
 import './style.scss';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { PlanUSPS, USPS } from 'calypso/my-sites/plugins/plugin-details-CTA/usps';
-import PluginDetailsSidebarUSP from 'calypso/my-sites/plugins/plugin-details-sidebar-usp';
+import PluginDetailsSidebarUSP, {
+	PLUGIN_DETAILS_LINK_TYPES,
+} from 'calypso/my-sites/plugins/plugin-details-sidebar-usp';
 import usePluginsSupportText from 'calypso/my-sites/plugins/use-plugins-support-text';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -55,19 +57,19 @@ const PluginDetailsSidebar = ( {
 		{
 			supportContext: 'general-support-options',
 			label: translate( 'How to get help!' ),
-			openIn: 'HelpCenter',
+			openIn: PLUGIN_DETAILS_LINK_TYPES.HELP_CENTER,
 		},
 		{
 			href: localizeUrl( 'https://automattic.com/privacy/' ),
 			label: translate( 'See privacy policy' ),
-			openIn: 'NewTab',
+			openIn: PLUGIN_DETAILS_LINK_TYPES.NEW_TAB,
 		},
 	];
 	documentation_url &&
 		supportLinks.unshift( {
 			href: documentation_url,
 			label: translate( 'View documentation' ),
-			openIn: 'NewTab',
+			openIn: PLUGIN_DETAILS_LINK_TYPES.NEW_TAB,
 		} );
 
 	const isPremiumVersionAvailable = !! premium_slug;
@@ -139,7 +141,11 @@ const PluginDetailsSidebar = ( {
 						'Take a look at the posibilities of this plugin before your commit.'
 					) }
 					links={ [
-						{ href: { demo_url }, label: translate( 'View live demo' ), openIn: 'NewTab' },
+						{
+							href: { demo_url },
+							label: translate( 'View live demo' ),
+							openIn: PLUGIN_DETAILS_LINK_TYPES.NEW_TAB,
+						},
 					] }
 					first
 				/>

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -53,21 +53,21 @@ const PluginDetailsSidebar = ( {
 
 	const supportLinks = [
 		{
-			href: localizeUrl( 'https://wordpress.com/support/help-support-options' ),
+			supportContext: 'general-support-options',
 			label: translate( 'How to get help!' ),
-			openInNewTab: true,
+			openIn: 'HelpCenter',
 		},
 		{
 			href: localizeUrl( 'https://automattic.com/privacy/' ),
 			label: translate( 'See privacy policy' ),
-			openInNewTab: true,
+			openIn: 'NewTab',
 		},
 	];
 	documentation_url &&
 		supportLinks.unshift( {
 			href: documentation_url,
 			label: translate( 'View documentation' ),
-			openInNewTab: true,
+			openIn: 'NewTab',
 		} );
 
 	const isPremiumVersionAvailable = !! premium_slug;
@@ -139,7 +139,7 @@ const PluginDetailsSidebar = ( {
 						'Take a look at the posibilities of this plugin before your commit.'
 					) }
 					links={ [
-						{ href: { demo_url }, label: translate( 'View live demo' ), openInNewTab: true },
+						{ href: { demo_url }, label: translate( 'View live demo' ), openIn: 'NewTab' },
 					] }
 					first
 				/>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTSUP-61

## Proposed Changes

The plugins sidebar has a "How to get help' link that opens in a new tab. This change makes it open in the support center instead.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is to help with help link consistency across the whole experience

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use calypso.live link
2. Go to http://calypso.localhost:3000/plugins/wordpress-seo-premium
3. Look at the sidebar and compare it to the production one - other than a different icon for the "how to get help" link, it should look identical.
4. Press "how to get help", it should open in the help centre rather than in a new tab.
5. Try the other links in the sidebar, they should work as before.
6. Repeat with some other plugins.

Before | After
-------|------
https://github.com/user-attachments/assets/3c87eaf8-e414-49d9-920e-9143d9d4b9c4 | https://github.com/user-attachments/assets/f7c5c1a1-c9c7-4f68-8650-2a43114f8213


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
