### PR TITLE
Fix more contrast issues on Jetpack login page

### DIFF
--- a/client/assets/stylesheets/_wp-base-styles-overrides.scss
+++ b/client/assets/stylesheets/_wp-base-styles-overrides.scss
@@ -41,7 +41,7 @@
 
 	/* Jetpack Cloud */
 	.jetpack-cloud &:not(.is-error, .is-valid) {
-		--wp-admin-theme-color: var(--studio-jetpack-green-40);
+		--wp-admin-theme-color: var(--studio-jetpack-green-50);
 	}
 
 	/* Jetpack login */

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -55,9 +55,9 @@
 
 .jetpack-cloud {
 	.components-button:not(.is-destructive) {
-		--wp-components-color-accent: var(--studio-jetpack-green-40);
-		--wp-components-color-accent-darker-10: var(--studio-jetpack-green-30);
-		--wp-components-color-accent-darker-20: var(--studio-jetpack-green-30);
+		--wp-components-color-accent: var(--studio-jetpack-green-50);
+		--wp-components-color-accent-darker-10: var(--studio-jetpack-green-60);
+		--wp-components-color-accent-darker-20: var(--studio-jetpack-green-60);
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13185

## Proposed Changes

* I propose to fix contrast on Jetpack Cloud login page for input and button.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To meet accessibility standards.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start Calypso (`yarn && yarn start`) or use live link
3. As logged out user, access https://cloud.jetpack.com/dashboard
4. When redirected to Login page, change domain to http://calypso.localhost:3000/
5. Run axe Dev Tools scan and confirm there are not issues with elements contrast

![Screenshot 2025-06-12 at 12 42 14](https://github.com/user-attachments/assets/fe1d6cae-6e4e-40fc-9524-5447eeb2de48)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
