### PR TITLE
Subscribers: use export CSV endpoint

### DIFF
--- a/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
+++ b/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
@@ -3,15 +3,12 @@ import { moreVertical } from '@wordpress/icons';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
-import { useDispatch } from 'react-redux';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
-import { addQueryArgs } from 'calypso/lib/url';
 import { useSelector } from 'calypso/state';
-import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
+import { useDownloadSubscribersCSV } from '../../hooks';
 import useSubscriberCountQuery from '../../queries/use-subscriber-count-query';
-import { useRecordExport } from '../../tracks';
 import '../shared/popover-style.scss';
 
 type SubscribersHeaderPopoverProps = {
@@ -24,27 +21,12 @@ const SubscribersHeaderPopover = ( {
 	openMigrateSubscribersModal,
 }: SubscribersHeaderPopoverProps ) => {
 	const [ isVisible, setIsVisible ] = useState( false );
-	const dispatch = useDispatch();
 	const onToggle = useCallback( () => setIsVisible( ( visible ) => ! visible ), [] );
 	const buttonRef = useRef< HTMLButtonElement >( null );
-	const downloadCsvLink = addQueryArgs(
-		{ page: 'subscribers', blog: siteId, blog_subscribers: 'csv', type: 'all' },
-		'https://dashboard.wordpress.com/wp-admin/index.php'
-	);
 	const { data: subscribersTotals } = useSubscriberCountQuery( siteId );
 	const hasSubscribers = !! subscribersTotals?.total_subscribers;
-	const recordExport = useRecordExport();
 	const currentUserSiteCount = useSelector( getCurrentUserSiteCount );
-
-	const onDownloadCsvClick = () => {
-		dispatch(
-			recordGoogleEvent(
-				'Subscribers',
-				'Clicked Download email subscribers as CSV menu item on Subscribers'
-			)
-		);
-		recordExport();
-	};
+	const { downloadCSV } = useDownloadSubscribersCSV( siteId );
 
 	const hasMultipleSites = currentUserSiteCount && currentUserSiteCount > 1;
 
@@ -74,7 +56,12 @@ const SubscribersHeaderPopover = ( {
 				focusOnShow={ false }
 			>
 				{ hasSubscribers ? (
-					<PopoverMenuItem href={ downloadCsvLink } onClick={ onDownloadCsvClick }>
+					<PopoverMenuItem
+						onClick={ ( event: React.MouseEvent ) => {
+							event.preventDefault();
+							downloadCSV();
+						} }
+					>
 						{ translate( 'Download subscribers as CSV' ) }
 					</PopoverMenuItem>
 				) : null }

--- a/client/my-sites/subscribers/hooks/index.ts
+++ b/client/my-sites/subscribers/hooks/index.ts
@@ -4,3 +4,4 @@ export { default as useSubscriptionPlans } from './use-subscription-plans';
 export { default as useUnsubscribeModal } from './use-unsubscribe-modal';
 export { useAddSubscribersCallback } from './use-add-subscribers-callback';
 export { useMigrateSubscribersCallback } from './use-migrate-subscribers-callback';
+export { useDownloadSubscribersCSV } from './use-download-subscribers-csv';

--- a/client/my-sites/subscribers/hooks/use-download-subscribers-csv.ts
+++ b/client/my-sites/subscribers/hooks/use-download-subscribers-csv.ts
@@ -1,0 +1,58 @@
+import { saveAs } from 'browser-filesaver';
+import { translate } from 'i18n-calypso';
+import { useCallback, useState } from 'react';
+import wpcom from 'calypso/lib/wp';
+import { useDispatch } from 'calypso/state';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
+import { useRecordExport } from '../tracks';
+
+export const useDownloadSubscribersCSV = ( siteId: number | null ) => {
+	const [ isDownloading, setIsDownloading ] = useState( false );
+	const dispatch = useDispatch();
+	const recordExport = useRecordExport();
+
+	const downloadCSV = useCallback( async () => {
+		if ( ! siteId ) {
+			return;
+		}
+
+		setIsDownloading( true );
+
+		try {
+			const response: string = await wpcom.req.get( {
+				path: `/sites/${ siteId }/subscribers/export`,
+				apiNamespace: 'wpcom/v2',
+			} );
+
+			// Download the CSV.
+			const blob = new Blob( [ response ], { type: 'text/csv;charset=utf-8;' } );
+			saveAs( blob, `subscribers-export-${ siteId }.csv` );
+
+			// Record that it happened.
+			dispatch(
+				recordGoogleEvent(
+					'Subscribers',
+					'Clicked Download email subscribers as CSV menu item on Subscribers'
+				)
+			);
+			recordExport();
+		} catch ( error ) {
+			dispatch(
+				errorNotice(
+					translate( 'An unknown error has occurred. Please contact support for help.' ),
+					{
+						duration: 5000,
+					}
+				)
+			);
+		} finally {
+			setIsDownloading( false );
+		}
+	}, [ siteId, dispatch, recordExport ] );
+
+	return {
+		downloadCSV,
+		isDownloading,
+	};
+};


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/CML-389/subscriber-export-run-in-async-job
Needs 185309-ghe-Automattic/wpcom

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?