### PR TITLE
A4A > Reports: Implement Duplicate Report

### DIFF
--- a/client/a8c-for-agencies/components/a4a-select-site/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-select-site/index.tsx
@@ -14,6 +14,7 @@ const A4ASelectSite = ( {
 	title,
 	subtitle,
 	selectedSiteId,
+	isDisabled,
 }: A4ASelectSiteProps ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -30,6 +31,7 @@ const A4ASelectSite = ( {
 	return (
 		<>
 			<Button
+				disabled={ isDisabled }
 				__next40pxDefaultSize
 				variant="secondary"
 				onClick={ handleOpenModal }

--- a/client/a8c-for-agencies/components/a4a-select-site/modal.tsx
+++ b/client/a8c-for-agencies/components/a4a-select-site/modal.tsx
@@ -3,10 +3,11 @@ import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import A4AModal from 'calypso/a8c-for-agencies/components/a4a-modal';
 import { A4A_SITES_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { type SiteItem } from 'calypso/a8c-for-agencies/sections/migrations/hooks/use-fetch-all-managed-sites';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import A4ASelectSiteTable from './site-table';
-import type { SelectSiteModalProps, A4ASelectSiteItem } from './types';
+import type { SelectSiteModalProps } from './types';
 
 const SelectSiteModal = ( {
 	onClose,
@@ -18,11 +19,14 @@ const SelectSiteModal = ( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const [ selectedSite, setSelectedSite ] = useState< A4ASelectSiteItem | null >( null );
+	const [ selectedSite, setSelectedSite ] = useState< SiteItem | null >( null );
 
 	const handleSelectSite = () => {
 		if ( selectedSite ) {
-			onSiteSelect( selectedSite );
+			onSiteSelect( {
+				blogId: selectedSite.rawSite.blog_id,
+				domain: selectedSite.site,
+			} );
 			onClose();
 		}
 	};

--- a/client/a8c-for-agencies/components/a4a-select-site/site-table.tsx
+++ b/client/a8c-for-agencies/components/a4a-select-site/site-table.tsx
@@ -5,11 +5,14 @@ import A4ATablePlaceholder from 'calypso/a8c-for-agencies/components/a4a-table-p
 import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
-import { useFetchAllManagedSites } from 'calypso/a8c-for-agencies/sections/migrations/hooks/use-fetch-all-managed-sites';
+import {
+	useFetchAllManagedSites,
+	type SiteItem,
+} from 'calypso/a8c-for-agencies/sections/migrations/hooks/use-fetch-all-managed-sites';
 import FormRadio from 'calypso/components/forms/form-radio';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import type { SelectSiteTableProps, A4ASelectSiteItem } from './types';
+import type { SelectSiteTableProps } from './types';
 
 const A4ASelectSiteTable = ( {
 	selectedSite,
@@ -27,31 +30,34 @@ const A4ASelectSiteTable = ( {
 	} );
 
 	const onSelectSite = useCallback(
-		( item: A4ASelectSiteItem ) => {
+		( item: SiteItem ) => {
 			setSelectedSite( item );
 			dispatch( recordTracksEvent( 'calypso_a4a_select_site_table_select_site_click' ) );
 		},
 		[ dispatch, setSelectedSite ]
 	);
 
-	const updatedSelectedSiteId = selectedSite?.id || selectedSiteId;
+	const updatedSelectedSiteId = selectedSite?.rawSite.blog_id || selectedSiteId;
 
 	const fields = useMemo( () => {
 		const siteColumn = {
 			id: 'site',
 			label: translate( 'Site' ),
-			getValue: ( { item }: { item: A4ASelectSiteItem } ) => item.site,
-			render: ( { item }: { item: A4ASelectSiteItem } ) => (
-				<div>
-					<FormRadio
-						htmlFor={ `site-${ item.id }` }
-						id={ `site-${ item.id }` }
-						checked={ updatedSelectedSiteId === item.id }
-						onChange={ () => onSelectSite( item ) }
-						label={ item.site }
-					/>
-				</div>
-			),
+			getValue: ( { item }: { item: SiteItem } ) => item.site,
+			render: ( { item }: { item: SiteItem } ) => {
+				const blogId = item.rawSite.blog_id;
+				return (
+					<div>
+						<FormRadio
+							htmlFor={ `site-${ blogId }` }
+							id={ `site-${ blogId }` }
+							checked={ updatedSelectedSiteId === blogId }
+							onChange={ () => onSelectSite( item ) }
+							label={ item.site }
+						/>
+					</div>
+				);
+			},
 			enableGlobalSearch: true,
 			enableHiding: false,
 			enableSorting: false,
@@ -61,7 +67,7 @@ const A4ASelectSiteTable = ( {
 	}, [ onSelectSite, updatedSelectedSiteId, translate ] );
 
 	const { data: allSites, paginationInfo } = useMemo( () => {
-		return filterSortAndPaginate( items as A4ASelectSiteItem[], dataViewsState, fields );
+		return filterSortAndPaginate( items as SiteItem[], dataViewsState, fields );
 	}, [ items, dataViewsState, fields ] );
 
 	return (
@@ -73,7 +79,7 @@ const A4ASelectSiteTable = ( {
 					data={ {
 						items: allSites,
 						fields,
-						getItemId: ( item ) => `${ item.id }`,
+						getItemId: ( item ) => `${ item.rawSite.blog_id }`,
 						pagination: paginationInfo,
 						enableSearch: true,
 						actions: [],

--- a/client/a8c-for-agencies/components/a4a-select-site/types.ts
+++ b/client/a8c-for-agencies/components/a4a-select-site/types.ts
@@ -1,11 +1,9 @@
-import type { Site } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+import { type SiteItem } from 'calypso/a8c-for-agencies/sections/migrations/hooks/use-fetch-all-managed-sites';
 import type { ReactNode } from 'react';
 
 export type A4ASelectSiteItem = {
-	id: number;
-	site: string;
-	date: string;
-	rawSite: Site;
+	blogId: number;
+	domain: string;
 };
 
 export interface A4ASelectSiteProps {
@@ -16,6 +14,7 @@ export interface A4ASelectSiteProps {
 	title?: string;
 	subtitle?: ReactNode;
 	selectedSiteId?: number;
+	isDisabled?: boolean;
 }
 
 export interface A4ASelectSiteButtonProps {
@@ -33,7 +32,7 @@ export interface SelectSiteModalProps {
 }
 
 export interface SelectSiteTableProps {
-	selectedSite: A4ASelectSiteItem | null;
-	setSelectedSite: ( site: A4ASelectSiteItem | null ) => void;
+	selectedSite: SiteItem | null;
+	setSelectedSite: ( site: SiteItem | null ) => void;
 	selectedSiteId?: number;
 }

--- a/client/a8c-for-agencies/sections/reports/hooks/use-build-report-form-validation.tsx
+++ b/client/a8c-for-agencies/sections/reports/hooks/use-build-report-form-validation.tsx
@@ -20,7 +20,7 @@ const VALIDATION_RULES = {
 	step1: ( data: BuildReportFormData, translate: ( key: string ) => string ): ValidationError[] => {
 		const errors: ValidationError[] = [];
 
-		if ( ! data.selectedSite.trim() ) {
+		if ( ! data.selectedSite?.domain.trim() ) {
 			errors.push( {
 				field: 'selectedSite',
 				message: translate( 'Please select a site to report on.' ),

--- a/client/a8c-for-agencies/sections/reports/hooks/use-duplicate-report-form-data.tsx
+++ b/client/a8c-for-agencies/sections/reports/hooks/use-duplicate-report-form-data.tsx
@@ -20,7 +20,7 @@ interface UseDuplicateReportFormDataReturn {
 	setStatsCheckedItems: ( value: BuildReportCheckedItemsState ) => void;
 	isLoading: boolean;
 	isDuplicating: boolean;
-	error: boolean;
+	error: Error | null;
 }
 
 export const useDuplicateReportFormData = (

--- a/client/a8c-for-agencies/sections/reports/hooks/use-duplicate-report-form-data.tsx
+++ b/client/a8c-for-agencies/sections/reports/hooks/use-duplicate-report-form-data.tsx
@@ -1,0 +1,124 @@
+import { getQueryArg } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import { useState, useEffect, useCallback } from 'react';
+import { useSelector } from 'calypso/state';
+import getSites from 'calypso/state/selectors/get-sites';
+import useFetchReportById from './use-fetch-report-by-id';
+import type { BuildReportFormData, BuildReportCheckedItemsState } from '../types';
+import type { A4ASelectSiteItem } from 'calypso/a8c-for-agencies/components/a4a-select-site/types';
+
+interface UseDuplicateReportFormDataReturn {
+	formData: BuildReportFormData;
+	setSelectedTimeframe: ( value: string ) => void;
+	setSelectedSite: ( site: A4ASelectSiteItem | null ) => void;
+	setClientEmail: ( value: string ) => void;
+	setCustomIntroText: ( value: string ) => void;
+	setSendMeACopy: ( value: boolean ) => void;
+	setTeammateEmails: ( value: string ) => void;
+	setStartDate: ( value: string | undefined ) => void;
+	setEndDate: ( value: string | undefined ) => void;
+	setStatsCheckedItems: ( value: BuildReportCheckedItemsState ) => void;
+	isLoading: boolean;
+	isDuplicating: boolean;
+	error: boolean;
+}
+
+export const useDuplicateReportFormData = (
+	availableTimeframes: { label: string; value: string }[],
+	statsOptions: { label: string; value: string }[]
+): UseDuplicateReportFormDataReturn => {
+	const translate = useTranslate();
+	const sites = useSelector( getSites );
+
+	// Get sourceId from URL parameters
+	const sourceId = getQueryArg( window.location.href, 'sourceId' ) as unknown as number;
+	const isDuplicating = Boolean( sourceId );
+
+	const { data, isLoading, error } = useFetchReportById( isDuplicating ? sourceId : null );
+
+	// Initialize default values
+	const today = new Date();
+	const yesterday = new Date( today );
+	yesterday.setDate( today.getDate() - 1 );
+
+	// Form state
+	const [ selectedTimeframe, setSelectedTimeframe ] = useState(
+		availableTimeframes[ 0 ]?.value || '30_days'
+	);
+	const [ selectedSite, setSelectedSite ] = useState< A4ASelectSiteItem | null >( null );
+	const [ clientEmail, setClientEmail ] = useState( '' );
+	const [ customIntroText, setCustomIntroText ] = useState( '' );
+	const [ sendMeACopy, setSendMeACopy ] = useState( false );
+	const [ teammateEmails, setTeammateEmails ] = useState( '' );
+	const [ startDate, setStartDate ] = useState< string | undefined >(
+		yesterday.toISOString().split( 'T' )[ 0 ]
+	);
+	const [ endDate, setEndDate ] = useState< string | undefined >(
+		today.toISOString().split( 'T' )[ 0 ]
+	);
+	const [ statsCheckedItems, setStatsCheckedItems ] = useState< BuildReportCheckedItemsState >(
+		statsOptions.reduce( ( acc, item ) => ( { ...acc, [ item.value ]: true } ), {} )
+	);
+
+	const findSiteById = useCallback(
+		( siteId: number ): A4ASelectSiteItem | null => {
+			const foundSite = sites.find( ( site ) => site?.ID === siteId );
+			if ( foundSite ) {
+				return {
+					blogId: foundSite.ID,
+					domain: foundSite.domain,
+				};
+			}
+			return null;
+		},
+		[ sites ]
+	);
+
+	const reportData = data?.form_data;
+
+	// Populate form data when report data is fetched
+	useEffect( () => {
+		if ( ! reportData || ! sites.length ) {
+			return;
+		}
+
+		const site = findSiteById( reportData.blog_id );
+		setSelectedSite( site );
+		setSelectedTimeframe( reportData.timeframe );
+		setClientEmail( reportData.client_email?.join( ', ' ) || '' );
+		setCustomIntroText( reportData.custom_intro_text );
+		setSendMeACopy( reportData.send_copy_to_team );
+		setTeammateEmails( reportData.teammate_emails?.join( ', ' ) || '' );
+		setStartDate( reportData.start_date );
+		setEndDate( reportData.end_date );
+		setStatsCheckedItems( reportData.stats_items );
+	}, [ reportData, sites, findSiteById, translate ] );
+
+	const formData: BuildReportFormData = {
+		selectedSite,
+		selectedTimeframe,
+		clientEmail,
+		startDate,
+		endDate,
+		sendMeACopy,
+		teammateEmails,
+		customIntroText,
+		statsCheckedItems,
+	};
+
+	return {
+		formData,
+		setSelectedTimeframe,
+		setSelectedSite,
+		setClientEmail,
+		setCustomIntroText,
+		setSendMeACopy,
+		setTeammateEmails,
+		setStartDate,
+		setEndDate,
+		setStatsCheckedItems,
+		isLoading,
+		isDuplicating,
+		error,
+	};
+};

--- a/client/a8c-for-agencies/sections/reports/hooks/use-fetch-report-by-id.tsx
+++ b/client/a8c-for-agencies/sections/reports/hooks/use-fetch-report-by-id.tsx
@@ -1,0 +1,52 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import type { ReportFormData } from '../types';
+
+const mockData: ReportFormData = {
+	blog_id: 123456789,
+	timeframe: '30_days',
+	client_email: [ 'client@example.com', 'client2@example.com' ],
+	start_date: '2024-01-01',
+	end_date: '2024-01-31',
+	send_copy_to_team: true,
+	teammate_emails: [ 'teammate1@agency.com', 'teammate2@agency.com' ],
+	custom_intro_text: 'Here is your monthly report with key insights and performance metrics.',
+	stats_items: {
+		total_traffic: true,
+		top_pages: true,
+		top_devices: false,
+		top_locations: true,
+		device_breakdown: true,
+		total_traffic_all_time: false,
+		most_popular_time_of_day: true,
+		most_popular_day_of_week: true,
+	},
+};
+
+export default function useFetchReportById( reportId: number | null ) {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useQuery( {
+		queryKey: [ 'a4a-report', agencyId, reportId ],
+		queryFn: async () => {
+			return wpcom.req.get( {
+				apiNamespace: 'wpcom/v2',
+				path: `/agency/${ agencyId }/reports/${ reportId }`,
+			} );
+		},
+		// TODO: Remove this once the API is ready
+		select: ( data ) => {
+			return {
+				...data,
+				form_data: mockData,
+			};
+		},
+		enabled: !! agencyId && !! reportId,
+		refetchOnWindowFocus: false,
+		retry: ( failureCount ) => {
+			return failureCount < 3;
+		},
+	} );
+}

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/index.tsx
@@ -7,6 +7,7 @@ import {
 	DatePicker,
 	Popover,
 } from '@wordpress/components';
+import { Icon, error } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useMemo, useCallback } from 'react';
 import A4ASelectSite from 'calypso/a8c-for-agencies/components/a4a-select-site';
@@ -20,15 +21,15 @@ import LayoutHeader, {
 } from 'calypso/layout/hosting-dashboard/header';
 import { A4A_REPORTS_LINK } from '../../constants';
 import { useFormValidation } from '../../hooks/use-build-report-form-validation';
+import { useDuplicateReportFormData } from '../../hooks/use-duplicate-report-form-data';
 import { formatDate } from '../../lib/format-date';
-import type { BuildReportFormData, BuildReportCheckedItemsState } from '../../types';
+import type { BuildReportCheckedItemsState } from '../../types';
 import type { A4ASelectSiteItem } from 'calypso/a8c-for-agencies/components/a4a-select-site/types';
 
 import './style.scss';
 
 const BuildReport = () => {
 	const translate = useTranslate();
-	const title = translate( 'Build Report' );
 
 	const availableTimeframes = useMemo(
 		() => [
@@ -58,44 +59,42 @@ const BuildReport = () => {
 		[ translate ]
 	);
 
-	const today = new Date();
-	const yesterday = new Date( today );
-	yesterday.setDate( today.getDate() - 1 );
+	// Use the custom hook for form data management
+	const {
+		formData,
+		setSelectedTimeframe,
+		setSelectedSite,
+		setClientEmail,
+		setCustomIntroText,
+		setSendMeACopy,
+		setTeammateEmails,
+		setStartDate,
+		setEndDate,
+		setStatsCheckedItems,
+		isLoading: isDuplicateLoading,
+		isDuplicating,
+		error: duplicateError,
+	} = useDuplicateReportFormData( availableTimeframes, statsOptions );
 
-	const [ selectedTimeframe, setSelectedTimeframe ] = useState( availableTimeframes[ 0 ].value );
-	const [ selectedSite, setSelectedSite ] = useState< A4ASelectSiteItem | null >( null );
-	const [ clientEmail, setClientEmail ] = useState( '' );
-	const [ customIntroText, setCustomIntroText ] = useState( '' );
-	const [ sendMeACopy, setSendMeACopy ] = useState( false );
-	const [ teammateEmails, setTeammateEmails ] = useState( '' );
-	const [ startDate, setStartDate ] = useState< string | undefined >(
-		yesterday.toISOString().split( 'T' )[ 0 ]
-	);
-	const [ endDate, setEndDate ] = useState< string | undefined >(
-		today.toISOString().split( 'T' )[ 0 ]
-	);
-	const [ isStartDatePickerOpen, setIsStartDatePickerOpen ] = useState( false );
-	const [ isEndDatePickerOpen, setIsEndDatePickerOpen ] = useState( false );
-	const [ showValidationErrors, setShowValidationErrors ] = useState( false );
-
-	const [ statsCheckedItems, setStatsCheckedItems ] = useState< BuildReportCheckedItemsState >(
-		statsOptions.reduce( ( acc, item ) => ( { ...acc, [ item.value ]: true } ), {} )
-	);
-
-	const [ currentStep, setCurrentStep ] = useState( 1 );
-
-	// Form data for validation
-	const formData: BuildReportFormData = {
-		selectedSite: selectedSite?.site || '',
+	const {
+		selectedSite,
 		selectedTimeframe,
-		clientEmail,
 		startDate,
 		endDate,
+		clientEmail,
 		sendMeACopy,
 		teammateEmails,
 		customIntroText,
 		statsCheckedItems,
-	};
+	} = formData;
+
+	const title = isDuplicating ? translate( 'Duplicate Report' ) : translate( 'Build Report' );
+
+	const [ isStartDatePickerOpen, setIsStartDatePickerOpen ] = useState( false );
+	const [ isEndDatePickerOpen, setIsEndDatePickerOpen ] = useState( false );
+	const [ showValidationErrors, setShowValidationErrors ] = useState( false );
+
+	const [ currentStep, setCurrentStep ] = useState( 1 );
 
 	// Get validation errors for current step
 	const validationErrors = useFormValidation( currentStep, formData );
@@ -144,18 +143,18 @@ const BuildReport = () => {
 		setCurrentStep( ( prev ) => prev - 1 );
 	}, [] );
 
-	const handleStep2CheckboxChange = ( groupKey: 'stats', itemName: string ) => {
-		const setterMap: Record<
-			string,
-			React.Dispatch< React.SetStateAction< BuildReportCheckedItemsState > >
-		> = {
-			stats: setStatsCheckedItems,
-		};
-		setterMap[ groupKey ]?.( ( prev: BuildReportCheckedItemsState ) => ( {
-			...prev,
-			[ itemName ]: ! prev[ itemName ],
-		} ) );
-	};
+	const handleStep2CheckboxChange = useCallback(
+		( groupKey: 'stats', itemName: string ) => {
+			const setterMap: Record< string, ( value: BuildReportCheckedItemsState ) => void > = {
+				stats: ( value: BuildReportCheckedItemsState ) => setStatsCheckedItems( value ),
+			};
+			setterMap[ groupKey ]?.( {
+				...statsCheckedItems,
+				[ itemName ]: ! statsCheckedItems[ itemName ],
+			} );
+		},
+		[ statsCheckedItems, setStatsCheckedItems ]
+	);
 
 	const stepContent = useMemo( () => {
 		switch ( currentStep ) {
@@ -168,9 +167,10 @@ const BuildReport = () => {
 
 						<div className="build-report__field">
 							<A4ASelectSite
-								selectedSiteId={ selectedSite?.id }
+								isDisabled={ isDuplicateLoading }
+								selectedSiteId={ selectedSite?.blogId }
 								onSiteSelect={ ( site: A4ASelectSiteItem ) => setSelectedSite( site ) }
-								buttonLabel={ selectedSite?.site || translate( 'Choose a site to report on' ) }
+								buttonLabel={ selectedSite?.domain || translate( 'Choose a site to report on' ) }
 								trackingEvent="calypso_a4a_reports_select_site_button_click"
 								data-field="selectedSite"
 							/>
@@ -188,6 +188,7 @@ const BuildReport = () => {
 							value={ selectedTimeframe }
 							options={ availableTimeframes }
 							onChange={ setSelectedTimeframe }
+							disabled={ isDuplicateLoading }
 						/>
 
 						{ selectedTimeframe === 'custom' && (
@@ -293,6 +294,7 @@ const BuildReport = () => {
 										: undefined
 								}
 								data-field="clientEmail"
+								disabled={ isDuplicateLoading }
 							/>
 							{ hasFieldError( 'clientEmail' ) && (
 								<div className="build-report__error-message">
@@ -305,6 +307,7 @@ const BuildReport = () => {
 							label={ translate( 'Also send to your team' ) }
 							checked={ sendMeACopy }
 							onChange={ setSendMeACopy }
+							disabled={ isDuplicateLoading }
 						/>
 						{ sendMeACopy && (
 							<div>
@@ -314,7 +317,7 @@ const BuildReport = () => {
 									label={ translate( 'Teammate email(s)' ) }
 									value={ teammateEmails }
 									onChange={ setTeammateEmails }
-									type="text"
+									type="email"
 									help={
 										! hasFieldError( 'teammateEmails' )
 											? translate( 'Use commas to separate addresses.' )
@@ -322,6 +325,7 @@ const BuildReport = () => {
 									}
 									placeholder={ translate( 'colleague1@example.com, colleague2@example.com' ) }
 									data-field="teammateEmails"
+									disabled={ isDuplicateLoading }
 								/>
 								{ hasFieldError( 'teammateEmails' ) && (
 									<div className="build-report__error-message">
@@ -395,22 +399,32 @@ const BuildReport = () => {
 	}, [
 		currentStep,
 		translate,
-		selectedSite?.id,
-		selectedSite?.site,
+		isDuplicateLoading,
+		selectedSite?.blogId,
+		selectedSite?.domain,
 		hasFieldError,
 		getFieldError,
 		selectedTimeframe,
 		availableTimeframes,
+		setSelectedTimeframe,
 		startDate,
 		isStartDatePickerOpen,
 		endDate,
 		isEndDatePickerOpen,
 		clientEmail,
+		setClientEmail,
 		sendMeACopy,
+		setSendMeACopy,
 		teammateEmails,
+		setTeammateEmails,
 		customIntroText,
+		setCustomIntroText,
 		statsOptions,
+		setSelectedSite,
+		setStartDate,
+		setEndDate,
 		statsCheckedItems,
+		handleStep2CheckboxChange,
 	] );
 
 	const actions = useMemo(
@@ -422,7 +436,7 @@ const BuildReport = () => {
 					</Button>
 				) }
 				{ currentStep < 3 && (
-					<Button variant="primary" onClick={ handleNextStep }>
+					<Button variant="primary" onClick={ handleNextStep } disabled={ isDuplicateLoading }>
 						{ translate( 'Next' ) }
 					</Button>
 				) }
@@ -433,7 +447,7 @@ const BuildReport = () => {
 				) }
 			</div>
 		),
-		[ currentStep, translate, handleNextStep, handlePrevStep ]
+		[ currentStep, handlePrevStep, translate, handleNextStep, isDuplicateLoading ]
 	);
 
 	return (
@@ -448,7 +462,7 @@ const BuildReport = () => {
 								href: A4A_REPORTS_LINK,
 							},
 							{
-								label: translate( 'Build Report' ),
+								label: title,
 							},
 						] }
 					/>
@@ -459,8 +473,28 @@ const BuildReport = () => {
 			</LayoutTop>
 			<LayoutBody>
 				<div className="build-report__content">
-					{ stepContent }
-					{ actions }
+					<div className="build-report__content-header">
+						<h1 className="build-report__content-title">{ title }</h1>
+						<p className="build-report__content-description">
+							{ isDuplicating
+								? translate(
+										'Start with your previous send. All fields are filled in. Just make updates for the new report and send.'
+								  )
+								: translate(
+										'Get started by choosing the details to include for your client below.'
+								  ) }
+						</p>
+						{ duplicateError && (
+							<div className="build-report__content-note">
+								<Icon icon={ error } />
+								{ translate( 'Note: Some data could not be duplicated.' ) }
+							</div>
+						) }
+					</div>
+					<div className="build-report__form">
+						{ stepContent }
+						{ actions }
+					</div>
 				</div>
 			</LayoutBody>
 		</Layout>

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/index.tsx
@@ -287,7 +287,7 @@ const BuildReport = () => {
 								label={ translate( 'Client email(s)' ) }
 								value={ clientEmail }
 								onChange={ setClientEmail }
-								type="email"
+								type="text"
 								help={
 									! hasFieldError( 'clientEmail' )
 										? translate( "We'll email the report here. Use commas to separate addresses." )
@@ -317,7 +317,7 @@ const BuildReport = () => {
 									label={ translate( 'Teammate email(s)' ) }
 									value={ teammateEmails }
 									onChange={ setTeammateEmails }
-									type="email"
+									type="text"
 									help={
 										! hasFieldError( 'teammateEmails' )
 											? translate( 'Use commas to separate addresses.' )

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/style.scss
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/style.scss
@@ -4,14 +4,17 @@
 .build-report {
 	.build-report__content {
 		max-width: 660px;
+		margin-inline: auto;
+		margin-block-start: 32px;
+	}
+
+	.build-report__form {
 		display: flex;
 		flex-direction: column;
 		gap: 16px;
-		padding: 16px 24px;
 		border: 1px solid var( --color-neutral-10 );
 		border-radius: 4px;
-		margin-inline: auto;
-		margin-block-start: 16px;
+		padding: 16px 24px;
 	}
 
 	.build-report__step-title {
@@ -77,6 +80,30 @@
 		margin-block-start: 4px;
 		margin-block-end: 0;
 	}
+}
+
+.build-report__content-header {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	margin-block-end: 24px;
+}
+
+.build-report__content-title {
+	@include heading-2x-large;
+}
+
+.build-report__content-description {
+	@include body-medium;
+	color: var( --color-neutral-50 );
+	margin-block-end: 0;
+}
+
+.build-report__content-note {
+	@include body-small;
+	display: flex;
+	align-items: center;
+	gap: 4px;
 }
 
 .build-report__date-popover {

--- a/client/a8c-for-agencies/sections/reports/types.ts
+++ b/client/a8c-for-agencies/sections/reports/types.ts
@@ -1,8 +1,22 @@
+import type { A4ASelectSiteItem } from 'calypso/a8c-for-agencies/components/a4a-select-site/types';
+
+export interface ReportFormData {
+	blog_id: number;
+	timeframe: string;
+	client_email: string[];
+	start_date?: string;
+	end_date?: string;
+	send_copy_to_team: boolean;
+	teammate_emails: string[];
+	custom_intro_text: string;
+	stats_items: BuildReportCheckedItemsState;
+}
 export interface Report {
 	id: string;
 	site: string;
-	status: 'sent' | 'error';
+	status: 'sent' | 'error' | 'pending';
 	created_at: string;
+	form_data: ReportFormData;
 }
 
 export interface SiteReports {
@@ -14,13 +28,13 @@ export interface SiteReports {
 
 export interface ReportsApiResponse {
 	data: Report;
-	status: 'sent' | 'error';
+	status: 'sent' | 'error' | 'pending';
 }
 
 export type BuildReportCheckedItemsState = Record< string, boolean >;
 
 export type BuildReportFormData = {
-	selectedSite: string;
+	selectedSite: A4ASelectSiteItem | null;
 	selectedTimeframe: string;
 	clientEmail: string;
 	startDate?: string;


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1120/duplicate-report

## Proposed Changes

This PR implements the `Duplicate report` functionality for reports.

Includes:

- Refactoring the whole form state into a new hook: useDuplicateReportFormData to handle it better. 
- Minor refactoring to `A4ASelectSite` to handle the required data correctly. 

## Why are these changes being made?

To allow users to duplicate reports.

## Testing Instructions

* Open the A4A live link
* Go to Reports > Click the `Build a new report` button > Verify you can see a heading and description added as shown below. Fill out the form and verify everything works as expected. The form submission has not yet been implemented. 

<img width="1912" alt="Screenshot 2025-06-12 at 6 24 20 PM" src="https://github.com/user-attachments/assets/7928a40c-e2c6-47d5-8dfb-ad5ddcf503f3" />

* Go to Dashboard > Open a report details > Verify you can see a button to duplicate the report. It should not be show for failed report.

<img width="1912" alt="Screenshot 2025-06-12 at 6 24 38 PM" src="https://github.com/user-attachments/assets/eb81c8ed-3771-4b3d-adbf-5955dace158d" />

* Click the button > Verify you are redirected to the same form as the build report with the heading and description updated. Not all the information will be updated as we are mocking the data. 

<img width="1912" alt="Screenshot 2025-06-12 at 6 23 55 PM" src="https://github.com/user-attachments/assets/8be034e9-8103-4b3d-8a36-8bc4b984a94e" />

In case of error:

<img width="1912" alt="Screenshot 2025-06-12 at 6 22 43 PM" src="https://github.com/user-attachments/assets/a8e6997f-afb7-4ced-90c9-1ce45c08bf59" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
