### PR TITLE
Add WP Admin util to open support links in Help Center

### DIFF
--- a/apps/help-center/help-center-wp-admin.js
+++ b/apps/help-center/help-center-wp-admin.js
@@ -10,13 +10,14 @@ const queryClient = new QueryClient();
 import './help-center.scss';
 
 function AdminHelpCenterContent() {
-	const { setShowHelpCenter } = useDataStoreDispatch( 'automattic/help-center' );
+	const { setShowHelpCenter, setShowSupportDoc } = useDataStoreDispatch( 'automattic/help-center' );
 	const { show, unreadCount } = useSelect( ( select ) => ( {
 		show: select( 'automattic/help-center' ).isHelpCenterShown(),
 		unreadCount: select( 'automattic/help-center' ).getUnreadCount(),
 	} ) );
 	const button = document.getElementById( 'wp-admin-bar-help-center' );
 	const masterbarNotificationsButton = document.getElementById( 'wp-admin-bar-notes' );
+	const supportLinks = document.querySelectorAll( '[data-wpcom-support-link="true"]' );
 
 	const closeHelpCenterWhenNotificationsPanelIsOpened = useCallback( () => {
 		const helpCenterContainerIsVisible = document.querySelector( '.help-center__container' );
@@ -73,6 +74,29 @@ function AdminHelpCenterContent() {
 	};
 
 	button.onclick = handleToggleHelpCenter;
+
+	const openSupportLinkInHelpCenter = useCallback(
+		( event ) => {
+			if ( ! setShowSupportDoc ) {
+				return;
+			}
+			event.preventDefault();
+			setShowSupportDoc( event.target.href );
+		},
+		[ setShowSupportDoc ]
+	);
+
+	useEffect( () => {
+		supportLinks.forEach( ( link ) => {
+			link.addEventListener( 'click', openSupportLinkInHelpCenter );
+		} );
+
+		return () => {
+			supportLinks.forEach( ( link ) => {
+				link.removeEventListener( 'click', openSupportLinkInHelpCenter );
+			} );
+		};
+	}, [] );
 
 	return (
 		<QueryClientProvider client={ queryClient }>

--- a/apps/help-center/help-center-wp-admin.js
+++ b/apps/help-center/help-center-wp-admin.js
@@ -17,7 +17,7 @@ function AdminHelpCenterContent() {
 	} ) );
 	const button = document.getElementById( 'wp-admin-bar-help-center' );
 	const masterbarNotificationsButton = document.getElementById( 'wp-admin-bar-notes' );
-	const supportLinks = document.querySelectorAll( '[data-wpcom-support-link="true"]' );
+	const supportLinks = document.querySelectorAll( '[data-target="wpcom-help-center"]' );
 
 	const closeHelpCenterWhenNotificationsPanelIsOpened = useCallback( () => {
 		const helpCenterContainerIsVisible = document.querySelector( '.help-center__container' );


### PR DESCRIPTION
Part of [DOTSUP-66](https://linear.app/a8c/issue/DOTSUP-66/open-settings-support-links-in-help-center)
Required by 185363-ghe-Automattic/wpcom and https://github.com/Automattic/jetpack/pull/43930

## Proposed Changes

Updates the Help Center app for WP Admin so any support link with a `data-target="wpcom-help-center"` attribute is opened in the Help Center directly rather than in a new tab.


https://github.com/user-attachments/assets/ede60109-d118-4de5-b03d-bb2a72fbcb4c



This is useful for cases where React is not available and therefore we cannot use the `WpcomSupportLink` component introduced in https://github.com/Automattic/jetpack/pull/43883.

## Why are these changes being made?

Because it provides a more consistent and quality user experience and it trains users to use the Help Center.

## Testing Instructions

- Apply these changes to your sandbox, along with 185363-ghe-Automattic/wpcom and https://github.com/Automattic/jetpack/pull/43930:

```
git checkout origin/dotsup-66-open-settings-support-links-in-help-center
install-plugin.sh help-center dotsup-66-open-settings-support-links-in-help-center
bin/jetpack-downloader test jetpack dotsup-66-open-settings-support-links-in-help-center
bin/jetpack-downloader test jetpack-mu-wpcom-plugin dotsup-66-open-settings-support-links-in-help-center
```
 
- Sandbox `widgets.wp.com` and a Simple site
- Go to the following screens, and make sure that the supports links are opened in the Help Center:
  - `/wp-admin/options-general.php`:
    - Action Bar visibility > [Learn more about the Action Bar](https://wordpress.com/support/action-bar/).
  - `/wp-admin/options-writing.php`:
    - Markdown > [Learn more about Markdown.](https://en.support.wordpress.com/markdown-quick-reference/)
    - Post by Email > You can publish posts using emails with the [Post by Email](https://wordpress.com/support/post-by-email/) feature.
    - Post by Voice > You can publish posts using voice with the [Post by Voice](https://wordpress.com/support/post-by-voice/) feature.
    - Portfolio Projects > [Learn More](https://en.support.wordpress.com/portfolios/)
    - Testimonials > [Learn More](https://en.support.wordpress.com/testimonials/)
  - `/wp-admin/options-reading.php`:
    - Site visibility > Control who can view your site. [Learn more](https://wordpress.com/support/privacy-settings/)
    - Site visibility > ...including those that train AI models. [Learn more](https://wordpress.com/support/privacy-settings/make-your-website-public/#prevent-third-party-sharing)
  - `/wp-admin/options-discussion.php`:
    - Markdown > [Learn more about Markdown.](https://en.support.wordpress.com/markdown-quick-reference/)




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?