### PR TITLE
Connect Refresh: Clean up some of the Jetpack magic-login screen customisations

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -110,11 +110,13 @@ const LayoutLoggedOut = ( {
 	const hasGravPoweredClientClass =
 		isGravPoweredClient && ! currentRoute.startsWith( '/log-in/link/use' );
 
-	const isMagicLogin = currentRoute && currentRoute.startsWith( '/log-in/link' );
+	const isMagicLogin =
+		currentRoute &&
+		( currentRoute.startsWith( '/log-in/link' ) ||
+			currentRoute.startsWith( '/log-in/jetpack/link' ) );
 
 	const isWpcomMagicLogin =
 		isMagicLogin &&
-		! isJetpackLogin &&
 		! hasGravPoweredClientClass &&
 		! isJetpackCloudOAuth2Client( oauth2Client ) &&
 		! isWooOAuth2Client( oauth2Client );

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -1359,10 +1359,7 @@ class MagicLogin extends Component {
 			);
 		}
 
-		const isWhiteLogin =
-			! this.props.isWCCOM &&
-			! this.props.isFromAutomatticForAgenciesPlugin &&
-			! this.props.isJetpackLogin;
+		const isWhiteLogin = ! this.props.isWCCOM && ! this.props.isFromAutomatticForAgenciesPlugin;
 
 		// If this is part of the Jetpack login flow, some steps will display a different UI
 		const requestLoginEmailFormProps = {

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -93,6 +93,8 @@
 	line-height: 20px;
 	word-wrap: break-word;
 
+	text-align: center;
+
 	margin-top: 45px;
 	margin-bottom: 45px;
 
@@ -134,12 +136,11 @@
 		}
 	}
 
-	.logged-out-form {
-		padding: 0 24px 0 24px;
-		.magic-login__form-sub-header {
-			text-align: center;
-		}
+	.magic-login__form-sub-header {
+		text-align: center;
+	}
 
+	.logged-out-form {
 		.form-label {
 			font-weight: 400;
 		}
@@ -218,7 +219,6 @@
 		box-shadow: 0 0 0 1px var(--color-border-subtle);
 		margin: 0 auto;
 		max-width: 400px;
-		padding: 0 24px;
 
 		p {
 			margin-bottom: 20px;
@@ -263,7 +263,6 @@
 		display: block;
 		font-size: $font-body-small;
 		font-weight: 600;
-		padding: 0 24px;
 		text-align: center;
 		text-decoration: underline;
 

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -22,8 +22,6 @@
 }
 
 .layout.is-jetpack-login:not(.woo) {
-	background-color: #fff;
-
 	&, .empty-content__title {
 		font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	}
@@ -37,27 +35,11 @@
 	}
 
 	.magic-login {
-		max-width: calc(450px + 48px);
-		margin-top: calc(96px - 48px);
 
-		@include break-small {
-			margin-top: calc(160px - 48px);
+		.magic-login__form-form {
+			box-shadow: none;
 		}
-
-		&.is-section-login {
-			min-height: 100%;
-			padding-bottom: 0;
-		}
-
 		.magic-login__form {
-			.magic-login__form-header {
-				padding: 0 24px 0 24px;
-			}
-
-			.magic-login__form-form {
-				box-shadow: none;
-			}
-
 			.magic-login__form-action {
 				.button.is-primary {
 					background-color: var(--studio-jetpack-green-50);
@@ -76,22 +58,7 @@
 		}
 
 		.magic-login__form-header {
-			margin-top: 0;
-			margin-bottom: 16px;
-
 			font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-			font-size: 32px;
-			font-weight: 500;
-
-			text-align: initial;
-		}
-
-		.logged-out-form {
-			max-width: calc(450px + 48px);
-
-			> form {
-				margin: 0;
-			}
 		}
 
 		.magic-login__successfully-jetpack {

--- a/client/login/magic-login/verify-login-code.jsx
+++ b/client/login/magic-login/verify-login-code.jsx
@@ -172,7 +172,7 @@ const VerifyLoginCode = ( {
 	return (
 		<div className="magic-login__successfully-jetpack">
 			<h1 className="magic-login__form-header">{ translate( 'Check your email for a code' ) }</h1>
-			<p>
+			<p className="magic-login__form-sub-header">
 				{ translate( 'Enter the code sent to your email {{strong}}%(email)s{{/strong}}', {
 					args: {
 						email: usernameOrEmail,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13602/update-jetpack-magic-login-screen-to-match-default-wp

## Proposed Changes

- Follows up from https://github.com/Automattic/wp-calypso/pull/104146 and does some cleanup to the magic login screen for the Jetpack Login page (`/log-in/jetpack/link`)
- Removes some customisations and matches a little closer the default magic-login screen. Colors and fonts maintained.

| Before | After | Default WP |
|--------|--------|--------|
| <img width="778" alt="Screenshot 2025-06-12 at 7 46 39 PM" src="https://github.com/user-attachments/assets/df9e6456-2bb8-4536-88b7-50d4b087aa73" /> | <img width="772" alt="Screenshot 2025-06-12 at 7 45 54 PM" src="https://github.com/user-attachments/assets/061c1fd3-7171-4e36-986c-0ec8d12bfeef" /> | <img width="716" alt="Screenshot 2025-06-12 at 7 49 00 PM" src="https://github.com/user-attachments/assets/8d17fa22-b37f-461b-b06e-54a8ad7f2dd2" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13602/update-jetpack-magic-login-screen-to-match-default-wp


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/log-in/jetpack/link` and confirm
* Go to `/log-in/link` and confirm no changes
* Go to magic-login page from the [Gravatar Login](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D4a5153e30a28e2ef24ca7e599abd80f3969340cd1f88327c1f5d2fbc88593fa1%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1&client_id=1854) and cofirm no changes (these are also customised pages)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
