### PR TITLE
Stats: Apply `skip_archives` parameter to the `top-posts` query

### DIFF
--- a/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
+++ b/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
@@ -34,7 +34,7 @@ type StatTypeOptionType = {
 
 const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 	period,
-	query,
+	query: queryFromProps,
 	moduleStrings,
 	className,
 	summaryUrl,
@@ -59,6 +59,11 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 			mainItemLabel: item.mainItemLabel,
 		};
 	} );
+
+	const query = {
+		...queryFromProps,
+		skip_archives: isArchiveBreakdownEnabled ? '1' : '0',
+	};
 
 	const mainStatType = MAIN_STAT_TYPE;
 	const subStatType = SUB_STAT_TYPE;

--- a/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
+++ b/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
@@ -105,11 +105,12 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 
 	// Query both statTypes for the Traffic page module card to avoid loading when switching between controls.
 	// Only query one statType at a time to avoid loading plenty of data for the summary mode.
-	const shouldQuerySubStatType = ! summary || query.viewdType === subStatType;
+	const shouldQueryMainStatType = ! summary || statType === mainStatType;
+	const shouldQuerySubStatType = ! summary || statType === subStatType;
 
 	return (
 		<>
-			{ ! shouldGateStatsModule && siteId && (
+			{ ! shouldGateStatsModule && siteId && shouldQueryMainStatType && (
 				<QuerySiteStats statType={ mainStatType } siteId={ siteId } query={ query } />
 			) }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of STATS-99.

## Proposed Changes

* Add `skip_archives` to query parameters for the `/stats/top-posts` endpoint to ignore pages that should be displayed in the Archive pages list.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The previous Homepage and Archive pages' views count from the `postviews` table should be ignored. In the future, we should rely on the `archives` table records to display the Archive pages list.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with local Calypso.
* Navigate to Stats > Traffic page.
* Ensure the `Posts & pages` list now excludes `Home page / Archives` and `Homepage` records.
* Click on the `View all` link of the module.
* Ensure the `Post & pages` list of the `Most viewed` summary page also ignores `Home page / Archives` and `Homepage` records.

|Before|After|
|-|-|
|<img width="631" alt="截圖 2025-06-12 晚上9 58 09" src="https://github.com/user-attachments/assets/91ed340f-06bb-47a7-9fb8-7e6333d3bfa4" />|<img width="638" alt="截圖 2025-06-12 晚上9 57 54" src="https://github.com/user-attachments/assets/59f4eadb-d4a1-49a9-8bc0-3997dd340748" />|

|Before|After|
|-|-|
|<img width="1300" alt="截圖 2025-06-12 晚上9 57 24" src="https://github.com/user-attachments/assets/8de72eb6-e3ca-4a85-a971-4f52b8e52b6c" />|<img width="1281" alt="截圖 2025-06-12 晚上9 57 35" src="https://github.com/user-attachments/assets/2f1dffa9-ad17-44c3-afcd-6459f2cad2f9" />|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
