### PR TITLE
A4A-837 A4A/Jeptack Cloud: Adjust billing explanation verbiage

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/billing/billing-details/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/billing/billing-details/index.tsx
@@ -142,8 +142,8 @@ export default function BillingDetails() {
 
 					<span className="billing-details__total-label billing-details__cost-label">
 						{ billing.isSuccess &&
-							translate( 'Cost for {{bold}}%(date)s{{/bold}}', {
-								components: { bold: <strong /> },
+							translate( 'Projected cost for {{bold}}%(date)s{{/bold}}', {
+								components: { bold: <strong style={ { whiteSpace: 'nowrap' } } /> },
 								args: { date: moment( billing.data.date ).format( 'MMMM, YYYY' ) },
 							} ) }
 
@@ -161,8 +161,9 @@ export default function BillingDetails() {
 			{ billing.isSuccess && useDailyPrices && billing.data.products.length > 0 && (
 				<Card compact className="billing-details__footer">
 					<small>
+						*&nbsp;
 						{ translate(
-							'* Estimate of the combined number of full days each license will be active for by the end of the current month, accounting for licenses that were newly issued or revoked.'
+							'The projected billing cost is calculated for each product based on the number of licenses you own for that product multiplied by the number of days each license will have been active for during the current month. This estimate accounts for licenses that were owned for only part of the month because they were issued or revoked within the current month.'
 						) }
 					</small>
 				</Card>

--- a/client/a8c-for-agencies/sections/purchases/billing/billing-summary/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/billing/billing-summary/index.tsx
@@ -42,7 +42,7 @@ function CostTooltip() {
 				<div>
 					<p>
 						{ translate(
-							'The total cost is being calculated based on the current date as well as the number of licenses in total.'
+							'The projected cost is calculated based on the total licenses owned multiplied by the days they will have been active for during the current month.'
 						) }
 					</p>
 
@@ -101,7 +101,7 @@ export default function BillingSummary() {
 					{ billing.isSuccess && <CostTooltip /> }
 					{ billing.isSuccess &&
 						/* translators: fullMonth (e.g. "January") and fullYear (e.g. "2024") */
-						translate( 'Cost for %(fullMonth)s, %(fullYear)s', {
+						translate( 'Projected cost for %(fullMonth)s, %(fullYear)s', {
 							args: {
 								fullMonth: moment( billing.data.date ).format( 'MMMM' ),
 								fullYear: moment( billing.data.date ).format( 'YYYY' ),

--- a/client/a8c-for-agencies/sections/purchases/billing/billing-summary/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/billing/billing-summary/style.scss
@@ -106,13 +106,15 @@
 }
 
 .billing-summary__open-cost-tooltip {
+	margin-top: 4px;
 	margin-inline-end: 8px;
 
 	&.button {
 		padding: 0;
 
 		.gridicon {
-			inset-block-start: 4px;
+			top: 0;
+			margin-top: 0;
 		}
 	}
 }

--- a/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
@@ -141,8 +141,8 @@ export default function BillingDetails() {
 
 					<span className="billing-details__total-label billing-details__cost-label">
 						{ billing.isSuccess &&
-							translate( 'Cost for {{bold}}%(date)s{{/bold}}', {
-								components: { bold: <strong /> },
+							translate( 'Projected cost for {{bold}}%(date)s{{/bold}}', {
+								components: { bold: <strong style={ { whiteSpace: 'nowrap' } } /> },
 								args: { date: moment( billing.data.date ).format( 'MMMM, YYYY' ) },
 							} ) }
 
@@ -160,8 +160,10 @@ export default function BillingDetails() {
 			{ billing.isSuccess && useDailyPrices && billing.data.products.length > 0 && (
 				<Card compact className="billing-details__footer">
 					<small>
-						* Estimate of the combined number of full days each license will be active for by the
-						end of the current month, accounting for licenses that were newly issued or revoked.
+						*&nbsp;
+						{ translate(
+							'The projected billing cost is calculated for each product based on the number of licenses you own for that product multiplied by the number of days each license will have been active for during the current month. This estimate accounts for licenses that were owned for only part of the month because they were issued or revoked within the current month.'
+						) }
 					</small>
 				</Card>
 			) }

--- a/client/jetpack-cloud/sections/partner-portal/billing-summary/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-summary/index.tsx
@@ -41,7 +41,7 @@ function CostTooltip() {
 				<div>
 					<p>
 						{ translate(
-							'The total cost is being calculated based on the current date as well as the number of licenses in total.'
+							'The projected cost is calculated based on the total licenses owned multiplied by the days they will have been active for during the current month.'
 						) }
 					</p>
 
@@ -100,7 +100,7 @@ export default function BillingSummary() {
 				<span className="billing-summary__label">
 					{ billing.isSuccess && <CostTooltip /> }
 					{ billing.isSuccess &&
-						translate( 'Cost for %(date)s', {
+						translate( 'Projected cost for %(date)s', {
 							args: { date: moment( billing.data.date ).format( 'MMMM, YYYY' ) },
 						} ) }
 


### PR DESCRIPTION
A4A-837

## Proposed Changes

* A4A-837 A4A/Jeptack Cloud: Adjust billing explanation verbiage.

This patch also fixes the tooltip icon being clipped at the bottom.

![Screenshot 2025-06-12 at 17 12 19](https://github.com/user-attachments/assets/5777b334-2b2e-4603-88e3-9141165d40cc)
![Screenshot 2025-06-12 at 17 12 26](https://github.com/user-attachments/assets/30ca9c6c-94a8-4669-aaa6-9f71e29c5191)

![Screenshot 2025-06-12 at 17 09 04](https://github.com/user-attachments/assets/59c35bf2-e836-49c1-a0d7-5d8be74cb630)
![Screenshot 2025-06-12 at 17 08 58](https://github.com/user-attachments/assets/21953cc2-d1bd-4aea-b55b-206b907e1666)

## Testing Instructions

* Apply this patch and run A4A and Jetpack Cloud checking the Billing page for the new verbiage.