### PR TITLE
Help Center: Improve events for articles seen

### DIFF
--- a/packages/help-center/src/components/help-center-article.tsx
+++ b/packages/help-center/src/components/help-center-article.tsx
@@ -53,14 +53,10 @@ export const HelpCenterArticle = () => {
 				result_url: post.URL,
 				post_id: post.ID,
 				blog_id: post.site_ID,
+				search_query: query,
 			};
 
-			query
-				? recordTracksEvent( 'calypso_helpcenter_search_result_article_viewed', {
-						...tracksData,
-						search_query: query,
-				  } )
-				: recordTracksEvent( 'calypso_helpcenter_article_viewed', tracksData );
+			recordTracksEvent( 'calypso_helpcenter_article_viewed', tracksData );
 		}
 	}, [ post, query, sectionName ] );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-13600/help-center-articles-improve-tracking

## Proposed Changes

* Delete `calypso_helpcenter_search_result_article_viewed`.
* Only have `calypso_helpcenter_article_viewed` with a prop that tells us if the event has been fired from a search result.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

It looks like `calypso_helpcenter_article_viewed` fires when you click a recommended resource or an in-product link, but not when you click on a guide in the search results. For that, there's a separate event, `calypso_helpcenter_search_result_article_viewed`.
It doesn't look like there's an event that captures all article views regardless of where they come from in the Help Center.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Help Center
* Use Tracks Vigilante or any method you prefer for checking events
* Click on an article and check that `calypso_helpcenter_article_viewed` is fired with no search_query.
* Search for something and click on an articles. We should still have `calypso_helpcenter_article_viewed` but with a search_query prop.
