### PR TITLE
Improve Help Center chat ellipsis menu voice over navigation

### DIFF
--- a/packages/help-center/src/components/help-center-header.scss
+++ b/packages/help-center/src/components/help-center-header.scss
@@ -136,6 +136,15 @@
 					fill: var( --studio-white );
 				}
 			}
+
+			&:not(:hover) {
+				background-color: unset;
+				color: var(--studio-gray-70);
+
+				svg {
+					fill: var(--studio-gray-70);
+				}
+			}
 		}
 	}
 

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -132,7 +132,12 @@ const ChatEllipsisMenu = () => {
 					) }
 				</div>
 			</button>
-			<button tabIndex={ 0 } onClick={ toggleSoundNotifications }>
+			<button
+				tabIndex={ 0 }
+				onClick={ toggleSoundNotifications }
+				aria-pressed={ !! areSoundNotificationsEnabled }
+				aria-label={ __( 'Notification sound', __i18n_text_domain__ ) }
+			>
 				<ToggleControl
 					className="conversation-menu__notification-toggle"
 					label={ __( 'Notification sound', __i18n_text_domain__ ) }

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -108,39 +108,41 @@ const ChatEllipsisMenu = () => {
 
 	return (
 		<EllipsisMenu
-			popoverClassName="help-center help-center__container-header-menu"
+			popoverClassName="help-center help-center__container-header-menu conversation-menu__wrapper"
 			position="bottom"
 			trackEventProps={ { source: 'help_center' } }
 			ariaLabel={ __( 'Chat options', __i18n_text_domain__ ) }
 		>
-			<div className="conversation-menu__wrapper">
-				<button onClick={ clearChat }>
-					<Icon icon={ comment } />
-					<div>{ __( 'New chat', __i18n_text_domain__ ) }</div>
-				</button>
-				<button onClick={ handleViewChats } disabled={ recentConversations.length < 2 }>
-					<Icon icon={ scheduled } />
-					<div>
-						{ _n(
-							'View recent chat',
-							'View recent chats',
-							recentConversations.length,
-							__i18n_text_domain__
-						) }
-					</div>
-				</button>
-				<button onClick={ toggleSoundNotifications }>
-					<ToggleControl
-						className="conversation-menu__notification-toggle"
-						label={ __( 'Notification sound', __i18n_text_domain__ ) }
-						checked={ areSoundNotificationsEnabled }
-						onChange={ ( newValue ) => {
-							setAreSoundNotificationsEnabled( newValue );
-						} }
-						__nextHasNoMarginBottom
-					/>
-				</button>
-			</div>
+			<button tabIndex={ 0 } onClick={ clearChat }>
+				<Icon icon={ comment } />
+				<div>{ __( 'New chat', __i18n_text_domain__ ) }</div>
+			</button>
+			<button
+				tabIndex={ 0 }
+				onClick={ handleViewChats }
+				disabled={ recentConversations.length < 2 }
+			>
+				<Icon icon={ scheduled } />
+				<div>
+					{ _n(
+						'View recent chat',
+						'View recent chats',
+						recentConversations.length,
+						__i18n_text_domain__
+					) }
+				</div>
+			</button>
+			<button tabIndex={ 0 } onClick={ toggleSoundNotifications }>
+				<ToggleControl
+					className="conversation-menu__notification-toggle"
+					label={ __( 'Notification sound', __i18n_text_domain__ ) }
+					checked={ areSoundNotificationsEnabled }
+					onChange={ ( newValue ) => {
+						setAreSoundNotificationsEnabled( newValue );
+					} }
+					__nextHasNoMarginBottom
+				/>
+			</button>
 		</EllipsisMenu>
 	);
 };

--- a/packages/odie-client/src/components/ellipsis-menu/index.tsx
+++ b/packages/odie-client/src/components/ellipsis-menu/index.tsx
@@ -59,6 +59,7 @@ export const EllipsisMenu: FunctionComponent< EllipsisMenuProps > = ( {
 					position={ position }
 					context={ popoverContext.current }
 					className={ popoverClasses }
+					focusOnShow
 				>
 					{ children }
 				</PopoverMenu>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13503

## Proposed Changes

* Added `focusOnShow` to ellipsis menu
* Remove wrapper, so the first child element can be focused

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Screen reader users cannot use the meatballs / kebab menu in the AI Assistant.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Help Center on WordPress.com.
* Click on theStill need help? button.
* Enable VoiceOver.
* Try tabbing through the UI with Control + Option + Arrows or Tab / Shift + Tab.
* Navigate to the meatballs / kebab menu in the header of the assistant.
* Open it using Control + Option + Space and try to navigate into its items.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
