### PR TITLE
Purchases: Load full billing history using pages and offsets

### DIFF
--- a/client/my-sites/purchases/billing-history/index.tsx
+++ b/client/my-sites/purchases/billing-history/index.tsx
@@ -53,7 +53,7 @@ export function BillingHistory( { siteSlug }: { siteSlug: string } ) {
 			{ isJetpackCloud() && <SidebarNavigation /> }
 			<DocumentHead title={ titles.billingHistory } />
 			<PageViewTracker path="/purchases/billing-history" title="Billing History" />
-			<QueryBillingTransactions />
+			<QueryBillingTransactions transactionType="past" />
 			{ ! isJetpackCloud() && (
 				<NavigationHeader
 					title={ titles.sectionTitle }

--- a/client/state/billing-transactions/actions.ts
+++ b/client/state/billing-transactions/actions.ts
@@ -13,61 +13,59 @@ import type { CalypsoDispatch } from '../types';
 import 'calypso/state/billing-transactions/init';
 
 export const requestBillingTransactions = ( transactionType?: BillingTransactionsType ) => {
-	return ( dispatch: CalypsoDispatch ) => {
+	return async ( dispatch: CalypsoDispatch ) => {
 		dispatch( {
 			type: BILLING_TRANSACTIONS_REQUEST,
 		} );
 
 		const limit = 200;
-		const url = '/me/billing-history' + ( transactionType ? `/${ transactionType }` : '' );
-		return wp.req
-			.get( url, {
-				apiVersion: '1.3',
-				limit,
-			} )
-			.then(
-				( {
-					billing_history,
-					upcoming_charges,
-				}: {
-					billing_history: BillingTransaction[];
-					upcoming_charges: UpcomingCharge[];
-				} ) => {
-					const fullBillingHistory = billing_history;
-					if ( billing_history.length === limit ) {
-						// If we have exactly the limit number of transactions, it means there are more transactions to fetch.
-						let nextData = [];
-						do {
-							// Fetch the next page of transactions.
-							return wp.req
-								.get( url, {
-									apiVersion: '1.3',
-									offset: billing_history.length,
-									limit,
-								} )
-								.then( ( { billing_history }: { billing_history: BillingTransaction[] } ) => {
-									fullBillingHistory.push( ...billing_history );
-									nextData = billing_history;
-								} );
-						} while ( nextData.length === limit );
-					}
+		let url = '/me/billing-history' + ( transactionType ? `/${ transactionType }` : '' );
+		if ( transactionType !== 'upcoming' ) {
+			url = url + '?limit=' + limit;
+		}
 
-					dispatch( {
-						type: BILLING_TRANSACTIONS_RECEIVE,
-						past: fullBillingHistory,
-						upcoming: upcoming_charges,
-					} );
-					dispatch( {
-						type: BILLING_TRANSACTIONS_REQUEST_SUCCESS,
-					} );
-				}
-			)
-			.catch( ( error: Error ) => {
-				dispatch( {
-					type: BILLING_TRANSACTIONS_REQUEST_FAILURE,
-					error,
-				} );
+		try {
+			const {
+				billing_history,
+				upcoming_charges,
+			}: {
+				billing_history: BillingTransaction[];
+				upcoming_charges: UpcomingCharge[];
+			} = await wp.req.get( url, {
+				apiVersion: '1.3',
 			} );
+
+			const fullBillingHistory = billing_history;
+			if ( billing_history.length === limit ) {
+				// If we have exactly the limit number of transactions, it means there are more transactions to fetch.
+				let nextData = [];
+				do {
+					// Fetch the next page of transactions.
+					const offset_url = url + '&offset=' + billing_history.length;
+
+					const res = await wp.req.get( offset_url, {
+						apiVersion: '1.3',
+					} );
+
+					fullBillingHistory.push( ...res.billing_history );
+					nextData = res.billing_history;
+				} while ( nextData.length === limit );
+			}
+
+			dispatch( {
+				type: BILLING_TRANSACTIONS_RECEIVE,
+				past: fullBillingHistory,
+				upcoming: upcoming_charges,
+			} );
+			dispatch( {
+				type: BILLING_TRANSACTIONS_REQUEST_SUCCESS,
+			} );
+		} catch ( error: any ) {
+			dispatch( {
+				type: BILLING_TRANSACTIONS_REQUEST_FAILURE,
+				error,
+			} );
+		}
 	};
 };
 

--- a/client/state/billing-transactions/actions.ts
+++ b/client/state/billing-transactions/actions.ts
@@ -18,9 +18,12 @@ export const requestBillingTransactions = ( transactionType?: BillingTransaction
 			type: BILLING_TRANSACTIONS_REQUEST,
 		} );
 
+		const limit = 200;
+		const url = '/me/billing-history' + ( transactionType ? `/${ transactionType }` : '' );
 		return wp.req
-			.get( '/me/billing-history' + ( transactionType ? `/${ transactionType }` : '' ), {
+			.get( url, {
 				apiVersion: '1.3',
+				limit,
 			} )
 			.then(
 				( {
@@ -30,9 +33,28 @@ export const requestBillingTransactions = ( transactionType?: BillingTransaction
 					billing_history: BillingTransaction[];
 					upcoming_charges: UpcomingCharge[];
 				} ) => {
+					const fullBillingHistory = billing_history;
+					if ( billing_history.length === limit ) {
+						// If we have exactly the limit number of transactions, it means there are more transactions to fetch.
+						let nextData = [];
+						do {
+							// Fetch the next page of transactions.
+							return wp.req
+								.get( url, {
+									apiVersion: '1.3',
+									offset: billing_history.length,
+									limit,
+								} )
+								.then( ( { billing_history }: { billing_history: BillingTransaction[] } ) => {
+									fullBillingHistory.push( ...billing_history );
+									nextData = billing_history;
+								} );
+						} while ( nextData.length === limit );
+					}
+
 					dispatch( {
 						type: BILLING_TRANSACTIONS_RECEIVE,
-						past: billing_history,
+						past: fullBillingHistory,
 						upcoming: upcoming_charges,
 					} );
 					dispatch( {

--- a/client/state/billing-transactions/test/actions.js
+++ b/client/state/billing-transactions/test/actions.js
@@ -1,3 +1,4 @@
+import nock from 'nock';
 import {
 	BILLING_TRANSACTIONS_RECEIVE,
 	BILLING_TRANSACTIONS_REQUEST,
@@ -5,7 +6,6 @@ import {
 	BILLING_TRANSACTIONS_REQUEST_FAILURE,
 } from 'calypso/state/action-types';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
-import useNock from 'calypso/test-helpers/use-nock';
 import { requestBillingTransactions, sendBillingReceiptEmail } from '../actions';
 
 describe( 'actions', () => {
@@ -40,12 +40,9 @@ describe( 'actions', () => {
 				],
 			};
 
-			useNock( ( nock ) => {
-				nock( 'https://public-api.wordpress.com:443' )
-					.persist()
-					.get( '/rest/v1.3/me/billing-history?limit=' + EndpointLimit )
-					.reply( 200, successResponse );
-			} );
+			nock( 'https://public-api.wordpress.com:443' )
+				.get( '/rest/v1.3/me/billing-history?limit=' + EndpointLimit )
+				.reply( 200, successResponse );
 
 			test( 'should dispatch fetch action when thunk triggered', async () => {
 				await requestBillingTransactions()( spy );
@@ -53,20 +50,15 @@ describe( 'actions', () => {
 				expect( spy ).toHaveBeenCalledWith( {
 					type: BILLING_TRANSACTIONS_REQUEST,
 				} );
-			} );
 
-			test( 'should dispatch receive action when request completes', async () => {
-				await requestBillingTransactions()( spy ).then( () => {
-					expect( spy ).toHaveBeenCalledWith( {
-						type: BILLING_TRANSACTIONS_RECEIVE,
-						past: successResponse.billing_history,
-						upcoming: successResponse.upcoming_charges,
-					} );
+				// should dispatch receive action when request completes'
+				expect( spy ).toHaveBeenCalledWith( {
+					type: BILLING_TRANSACTIONS_RECEIVE,
+					past: successResponse.billing_history,
+					upcoming: successResponse.upcoming_charges,
 				} );
-			} );
 
-			test( 'should dispatch request success action when request completes', async () => {
-				await requestBillingTransactions()( spy );
+				// should dispatch request success action when request completes'
 				expect( spy ).toHaveBeenCalledWith( {
 					type: BILLING_TRANSACTIONS_REQUEST_SUCCESS,
 				} );
@@ -109,19 +101,13 @@ describe( 'actions', () => {
 				upcoming_charges: [],
 			};
 
-			useNock( ( nock ) => {
-				nock( 'https://public-api.wordpress.com:443' )
-					.persist()
-					.get( '/rest/v1.3/me/billing-history?limit=' + EndpointLimit )
-					.reply( 200, successResponse1 );
+			nock( 'https://public-api.wordpress.com:443' )
+				.get( '/rest/v1.3/me/billing-history?limit=' + EndpointLimit )
+				.reply( 200, successResponse1 );
 
-				nock( 'https://public-api.wordpress.com:443' )
-					.persist()
-					.get(
-						'/rest/v1.3/me/billing-history?limit=' + EndpointLimit + '&offset=' + EndpointLimit
-					)
-					.reply( 200, successResponse2 );
-			} );
+			nock( 'https://public-api.wordpress.com:443' )
+				.get( '/rest/v1.3/me/billing-history?limit=' + EndpointLimit + '&offset=' + EndpointLimit )
+				.reply( 200, successResponse2 );
 
 			test( 'should dispatch fetch action when thunk triggered', async () => {
 				await requestBillingTransactions()( spy );
@@ -129,20 +115,15 @@ describe( 'actions', () => {
 				expect( spy ).toHaveBeenCalledWith( {
 					type: BILLING_TRANSACTIONS_REQUEST,
 				} );
-			} );
 
-			test( 'should dispatch receive action when request completes', async () => {
-				await requestBillingTransactions()( spy );
-
+				// should dispatch receive action when request completes'
 				expect( spy ).toHaveBeenCalledWith( {
 					type: BILLING_TRANSACTIONS_RECEIVE,
 					past: successResponse.billing_history,
 					upcoming: successResponse.upcoming_charges,
 				} );
-			} );
 
-			test( 'should dispatch request success action when request completes', async () => {
-				await requestBillingTransactions()( spy );
+				// should dispatch request success action when request completes'
 				expect( spy ).toHaveBeenCalledWith( {
 					type: BILLING_TRANSACTIONS_REQUEST_SUCCESS,
 				} );
@@ -153,24 +134,20 @@ describe( 'actions', () => {
 			const message =
 				'An active access token must be used to query information about the current user.';
 
-			useNock( ( nock ) => {
-				nock( 'https://public-api.wordpress.com:443' )
-					.persist()
-					.get( '/rest/v1.3/me/billing-history?limit=' + EndpointLimit )
-					.reply( 403, {
-						error: 'authorization_required',
-						message,
-					} );
-			} );
+			nock( 'https://public-api.wordpress.com:443' )
+				.get( '/rest/v1.3/me/billing-history?limit=' + EndpointLimit )
+				.reply( 403, {
+					error: 'authorization_required',
+					message,
+				} );
 
-			test( 'should dispatch request failure action when request fails', () => {
-				return requestBillingTransactions()( spy ).then( () => {
-					expect( spy ).toHaveBeenCalledWith( {
-						type: BILLING_TRANSACTIONS_REQUEST_FAILURE,
-						error: expect.objectContaining( {
-							message,
-						} ),
-					} );
+			test( 'should dispatch request failure action when request fails', async () => {
+				await requestBillingTransactions()( spy );
+				expect( spy ).toHaveBeenCalledWith( {
+					type: BILLING_TRANSACTIONS_REQUEST_FAILURE,
+					error: expect.objectContaining( {
+						message,
+					} ),
 				} );
 			} );
 		} );
@@ -180,23 +157,19 @@ describe( 'actions', () => {
 		const receiptId = 12345678;
 
 		describe( 'success', () => {
-			useNock( ( nock ) => {
-				nock( 'https://public-api.wordpress.com:443' )
-					.persist()
-					.get( '/rest/v1.1/me/billing-history/receipt/' + receiptId + '/email' )
-					.reply( 200, { success: true } );
-			} );
+			nock( 'https://public-api.wordpress.com:443' )
+				.get( '/rest/v1.1/me/billing-history/receipt/' + receiptId + '/email' )
+				.reply( 200, { success: true } );
 
-			test( 'should dispatch send success action when request completes', () => {
+			test( 'should dispatch send success action when request completes', async () => {
 				const { notice, type } = successNotice( 'Your receipt was sent by email successfully.' );
-				return sendBillingReceiptEmail( receiptId )( spy ).then( () => {
-					expect( spy ).toHaveBeenCalledWith( {
-						notice: {
-							...notice,
-							noticeId: expect.any( String ),
-						},
-						type,
-					} );
+				await sendBillingReceiptEmail( receiptId )( spy );
+				expect( spy ).toHaveBeenCalledWith( {
+					notice: {
+						...notice,
+						noticeId: expect.any( String ),
+					},
+					type,
 				} );
 			} );
 		} );
@@ -205,28 +178,24 @@ describe( 'actions', () => {
 			const message =
 				'An active access token must be used to query information about the current user.';
 
-			useNock( ( nock ) => {
-				nock( 'https://public-api.wordpress.com:443' )
-					.persist()
-					.get( '/rest/v1.1/me/billing-history/receipt/' + receiptId + '/email' )
-					.reply( 403, {
-						error: 'authorization_required',
-						message,
-					} );
-			} );
+			nock( 'https://public-api.wordpress.com:443' )
+				.get( '/rest/v1.1/me/billing-history/receipt/' + receiptId + '/email' )
+				.reply( 403, {
+					error: 'authorization_required',
+					message,
+				} );
 
-			test( 'should dispatch send failure action when request fails', () => {
+			test( 'should dispatch send failure action when request fails', async () => {
 				const { notice, type } = errorNotice(
 					'There was a problem sending your receipt. Please try again later or contact support.'
 				);
-				return sendBillingReceiptEmail( receiptId )( spy ).then( () => {
-					expect( spy ).toHaveBeenCalledWith( {
-						notice: {
-							...notice,
-							noticeId: expect.any( String ),
-						},
-						type,
-					} );
+				await sendBillingReceiptEmail( receiptId )( spy );
+				expect( spy ).toHaveBeenCalledWith( {
+					notice: {
+						...notice,
+						noticeId: expect.any( String ),
+					},
+					type,
 				} );
 			} );
 		} );

--- a/client/state/billing-transactions/test/actions.js
+++ b/client/state/billing-transactions/test/actions.js
@@ -41,7 +41,7 @@ describe( 'actions', () => {
 			};
 
 			nock( 'https://public-api.wordpress.com:443' )
-				.get( '/rest/v1.3/me/billing-history?limit=' + EndpointLimit )
+				.get( '/rest/v1.3/me/billing-history?limit=' + endpointLimit )
 				.reply( 200, successResponse );
 
 			test( 'should dispatch fetch action when thunk triggered', async () => {
@@ -66,9 +66,9 @@ describe( 'actions', () => {
 		} );
 
 		describe( 'success with multiple calls', () => {
-			// Let's generate more than "EndpointLimit" past transactions
+			// Let's generate more than "endpointLimit" past transactions
 			const billing_history = [];
-			for ( let i = 0; i < 2 * EndpointLimit - 1; i++ ) {
+			for ( let i = 0; i < 2 * endpointLimit - 1; i++ ) {
 				billing_history.push( {
 					id: Math.floor( Math.random() * 10000 ),
 					amount: '$1.23',
@@ -92,21 +92,21 @@ describe( 'actions', () => {
 			};
 
 			const successResponse1 = {
-				billing_history: billing_history.slice( 0, EndpointLimit ),
+				billing_history: billing_history.slice( 0, endpointLimit ),
 				upcoming_charges: successResponse.upcoming_charges,
 			};
 
 			const successResponse2 = {
-				billing_history: billing_history.slice( EndpointLimit ),
+				billing_history: billing_history.slice( endpointLimit ),
 				upcoming_charges: [],
 			};
 
 			nock( 'https://public-api.wordpress.com:443' )
-				.get( '/rest/v1.3/me/billing-history?limit=' + EndpointLimit )
+				.get( '/rest/v1.3/me/billing-history?limit=' + endpointLimit )
 				.reply( 200, successResponse1 );
 
 			nock( 'https://public-api.wordpress.com:443' )
-				.get( '/rest/v1.3/me/billing-history?limit=' + EndpointLimit + '&offset=' + EndpointLimit )
+				.get( '/rest/v1.3/me/billing-history?limit=' + endpointLimit + '&offset=' + endpointLimit )
 				.reply( 200, successResponse2 );
 
 			test( 'should dispatch fetch action when thunk triggered', async () => {
@@ -135,7 +135,7 @@ describe( 'actions', () => {
 				'An active access token must be used to query information about the current user.';
 
 			nock( 'https://public-api.wordpress.com:443' )
-				.get( '/rest/v1.3/me/billing-history?limit=' + EndpointLimit )
+				.get( '/rest/v1.3/me/billing-history?limit=' + endpointLimit )
 				.reply( 403, {
 					error: 'authorization_required',
 					message,

--- a/client/state/billing-transactions/test/actions.js
+++ b/client/state/billing-transactions/test/actions.js
@@ -15,6 +15,8 @@ describe( 'actions', () => {
 		spy = jest.fn();
 	} );
 
+	const EndpointLimit = 200;
+
 	describe( '#requestBillingTransactions()', () => {
 		describe( 'success', () => {
 			const successResponse = {
@@ -41,20 +43,20 @@ describe( 'actions', () => {
 			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
-					.get( '/rest/v1.3/me/billing-history' )
+					.get( '/rest/v1.3/me/billing-history?limit=' + EndpointLimit )
 					.reply( 200, successResponse );
 			} );
 
-			test( 'should dispatch fetch action when thunk triggered', () => {
-				requestBillingTransactions()( spy );
+			test( 'should dispatch fetch action when thunk triggered', async () => {
+				await requestBillingTransactions()( spy );
 
 				expect( spy ).toHaveBeenCalledWith( {
 					type: BILLING_TRANSACTIONS_REQUEST,
 				} );
 			} );
 
-			test( 'should dispatch receive action when request completes', () => {
-				return requestBillingTransactions()( spy ).then( () => {
+			test( 'should dispatch receive action when request completes', async () => {
+				await requestBillingTransactions()( spy ).then( () => {
 					expect( spy ).toHaveBeenCalledWith( {
 						type: BILLING_TRANSACTIONS_RECEIVE,
 						past: successResponse.billing_history,
@@ -63,11 +65,86 @@ describe( 'actions', () => {
 				} );
 			} );
 
-			test( 'should dispatch request success action when request completes', () => {
-				return requestBillingTransactions()( spy ).then( () => {
-					expect( spy ).toHaveBeenCalledWith( {
-						type: BILLING_TRANSACTIONS_REQUEST_SUCCESS,
-					} );
+			test( 'should dispatch request success action when request completes', async () => {
+				await requestBillingTransactions()( spy );
+				expect( spy ).toHaveBeenCalledWith( {
+					type: BILLING_TRANSACTIONS_REQUEST_SUCCESS,
+				} );
+			} );
+		} );
+
+		describe( 'success with multiple calls', () => {
+			// Let's generate more than "EndpointLimit" past transactions
+			const billing_history = [];
+			for ( let i = 0; i < 2 * EndpointLimit - 1; i++ ) {
+				billing_history.push( {
+					id: Math.floor( Math.random() * 10000 ),
+					amount: '$1.23',
+					date: '2016-12-12T11:22:33+0000',
+					tax: '$0.20',
+					subtotal: '$1.03',
+				} );
+			}
+
+			const successResponse = {
+				billing_history,
+				upcoming_charges: [
+					{
+						id: '87654321',
+						amount: '$4.56',
+						tax: '$0.55',
+						subtotal: '$4.01',
+						date: '2016-12-12T11:22:33+0000',
+					},
+				],
+			};
+
+			const successResponse1 = {
+				billing_history: billing_history.slice( 0, EndpointLimit ),
+				upcoming_charges: successResponse.upcoming_charges,
+			};
+
+			const successResponse2 = {
+				billing_history: billing_history.slice( EndpointLimit ),
+				upcoming_charges: [],
+			};
+
+			useNock( ( nock ) => {
+				nock( 'https://public-api.wordpress.com:443' )
+					.persist()
+					.get( '/rest/v1.3/me/billing-history?limit=' + EndpointLimit )
+					.reply( 200, successResponse1 );
+
+				nock( 'https://public-api.wordpress.com:443' )
+					.persist()
+					.get(
+						'/rest/v1.3/me/billing-history?limit=' + EndpointLimit + '&offset=' + EndpointLimit
+					)
+					.reply( 200, successResponse2 );
+			} );
+
+			test( 'should dispatch fetch action when thunk triggered', async () => {
+				await requestBillingTransactions()( spy );
+
+				expect( spy ).toHaveBeenCalledWith( {
+					type: BILLING_TRANSACTIONS_REQUEST,
+				} );
+			} );
+
+			test( 'should dispatch receive action when request completes', async () => {
+				await requestBillingTransactions()( spy );
+
+				expect( spy ).toHaveBeenCalledWith( {
+					type: BILLING_TRANSACTIONS_RECEIVE,
+					past: successResponse.billing_history,
+					upcoming: successResponse.upcoming_charges,
+				} );
+			} );
+
+			test( 'should dispatch request success action when request completes', async () => {
+				await requestBillingTransactions()( spy );
+				expect( spy ).toHaveBeenCalledWith( {
+					type: BILLING_TRANSACTIONS_REQUEST_SUCCESS,
 				} );
 			} );
 		} );
@@ -79,7 +156,7 @@ describe( 'actions', () => {
 			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
-					.get( '/rest/v1.3/me/billing-history' )
+					.get( '/rest/v1.3/me/billing-history?limit=' + EndpointLimit )
 					.reply( 403, {
 						error: 'authorization_required',
 						message,

--- a/client/state/billing-transactions/test/actions.js
+++ b/client/state/billing-transactions/test/actions.js
@@ -15,7 +15,7 @@ describe( 'actions', () => {
 		spy = jest.fn();
 	} );
 
-	const EndpointLimit = 200;
+	const endpointLimit = 200;
 
 	describe( '#requestBillingTransactions()', () => {
 		describe( 'success', () => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-831/load-the-whole-history-on-front-end

## Proposed Changes

* Change the billing history page to fetch the billing history using pages and offsets so it will not be limited to 200 results.
* Switch to an async/await approach for `requestBillingTransactions`

## Why are these changes being made?

Currently the billing history endpoint that powers the billing history page limits its results to 200 to prevent performance issues. However, this means that older receipts are not visible in the payment management interface. We can use pagination to solve this problem.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* In `client/state/billing-transactions/actions.ts`, change the `limit` to 2 or 3 (depending on the nb of history you have) - make sure it will call a couple of times the endpoint
* Checkout this branch locally and run `yarn && yarn start`, or use [the live branch](https://github.com/Automattic/wp-calypso/pull/104182#issuecomment-2967817069). 
* Go to `http://calypso.localhost:3000/me/purchases/billing`
* It should load (it takes a while due to the few endpoints)
* You can add a log if needed
* Your full billing history should be loaded, although it is way over the 2 or 3 limit you set
