### PR TITLE
A4A: Add the link to the program incentive. Overview and FAQ pages

### DIFF
--- a/client/a8c-for-agencies/sections/overview/sidebar/contact-support/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/contact-support/index.tsx
@@ -17,7 +17,7 @@ export default function OverviewSidebarContactSupport() {
 
 	return (
 		<Button
-			className="overview__contact-support-button"
+			className="overview__sidebar-button"
 			onClick={ toggleContactForm }
 			href={ CONTACT_URL_HASH_FRAGMENT }
 		>

--- a/client/a8c-for-agencies/sections/overview/sidebar/contact-support/style.scss
+++ b/client/a8c-for-agencies/sections/overview/sidebar/contact-support/style.scss
@@ -1,13 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.overview__contact-support-button {
-	width: 100%;
-	border: 1px solid var(--color-accent);
-	font-weight: 500;
-	color: var(--color-accent);
-}
-
 // Zendesk Chat Button
 iframe#launcher {
 	right: 24px !important;

--- a/client/a8c-for-agencies/sections/overview/sidebar/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/index.tsx
@@ -1,8 +1,8 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
-import { useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import OverviewSidebarAgencyTier from './agency-tier';
 import OverviewSidebarContactSupport from './contact-support';
@@ -19,7 +19,7 @@ const OverviewSidebar = () => {
 	const dispatch = useDispatch();
 
 	const onProgramIncentiveClick = useCallback( () => {
-		dispatch( recordTracksEvent( 'a4a_overview_program_incentive_click' ) );
+		dispatch( recordTracksEvent( 'calypso_a4a_overview_program_incentive_click' ) );
 	}, [ dispatch ] );
 
 	return (

--- a/client/a8c-for-agencies/sections/overview/sidebar/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/index.tsx
@@ -1,4 +1,9 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { Button } from '@automattic/components';
+import { useDispatch } from '@wordpress/data';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import OverviewSidebarAgencyTier from './agency-tier';
 import OverviewSidebarContactSupport from './contact-support';
 import OverviewSidebarFeaturedWooPayments from './featured-woopayments';
@@ -6,8 +11,17 @@ import OverviewSidebarGrowthAccelerator from './growth-accelerator';
 import OverviewSidebarQuickLinks from './quick-links';
 import OverviewSidebarRelaunchWelcomeTour from './relaunch-welcome-tour';
 
+import './style.scss';
+
 const OverviewSidebar = () => {
 	const isNewArrangement = isEnabled( 'a4a-unified-onboarding-tour' );
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const onProgramIncentiveClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'a4a_overview_program_incentive_click' ) );
+	}, [ dispatch ] );
+
 	return (
 		<div className="overview-sidebar">
 			{ isNewArrangement && (
@@ -21,6 +35,15 @@ const OverviewSidebar = () => {
 			<OverviewSidebarFeaturedWooPayments />
 			{ ! isNewArrangement && <OverviewSidebarGrowthAccelerator /> }
 			<OverviewSidebarContactSupport />
+			<Button
+				className="overview__sidebar-button"
+				onClick={ onProgramIncentiveClick }
+				href="https://automattic.com/for-agencies/program-incentives/"
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				{ translate( 'Program incentive details' ) }
+			</Button>
 		</div>
 	);
 };

--- a/client/a8c-for-agencies/sections/overview/sidebar/style.scss
+++ b/client/a8c-for-agencies/sections/overview/sidebar/style.scss
@@ -1,0 +1,7 @@
+a.overview__sidebar-button {
+	width: 100%;
+	border: 1px solid var(--color-accent);
+	font-weight: 500;
+	color: var(--color-accent);
+    margin-block-end: 16px;
+}

--- a/client/a8c-for-agencies/sections/overview/sidebar/style.scss
+++ b/client/a8c-for-agencies/sections/overview/sidebar/style.scss
@@ -3,5 +3,5 @@ a.overview__sidebar-button {
 	border: 1px solid var(--color-accent);
 	font-weight: 500;
 	color: var(--color-accent);
-    margin-block-end: 16px;
+	margin-block-end: 16px;
 }

--- a/client/a8c-for-agencies/sections/referrals/primary/footer/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/footer/index.tsx
@@ -5,8 +5,7 @@ import './style.scss';
 export default function ReferralsFooter() {
 	const translate = useTranslate();
 
-	const link =
-		'https://agencieshelp.automattic.com/knowledge-base/about-automattic-for-agencies/#payout-calculation-and-schedule';
+	const link = 'https://automattic.com/for-agencies/program-incentives/';
 
 	return (
 		<div className="referrals-footer">


### PR DESCRIPTION
Resolve: https://github.com/Automattic/automattic-for-agencies-dev/issues/2401

A4A-1117/referrals-faq-page-links-to-wrong-help-page

## Proposed Changes

This PR add the https://automattic.com/for-agencies/program-incentives/ link to the Overview page and updates the link on the Referral FAQ page.

![image](https://github.com/user-attachments/assets/f976aafe-2a1c-4a8e-a98d-631c2e44379c)

## Why are these changes being made?

- A4A-1117/referrals-faq-page-links-to-wrong-help-page

## Testing Instructions

- Check the code
- Use the A4A live link and:
- Check the Overview page, at the right sidebar there is a new button `Program incentive details`. If you click, it takes yo to the https://automattic.com/for-agencies/program-incentives page.
- Go to the `referrals/faq` and check the link below: `See the payout schedule...`. It should take you to the program incentives page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
