### PR TITLE
Fix form input regressions

### DIFF
--- a/client/assets/stylesheets/shared/_extends-forms.scss
+++ b/client/assets/stylesheets/shared/_extends-forms.scss
@@ -87,6 +87,11 @@
 	}
 }
 
+// Mixin for consistent focus box-shadow, matches the default focus style in input-control.
+@mixin form-field-core-styles-focus {
+	box-shadow: 0 0 0 0.5px var(--wp-admin-theme-color);
+}
+
 %form-field-core-styles {
 	@include input-control;
 
@@ -101,12 +106,35 @@
 		font-size: $font-body-small;
 	}
 
+	&:hover:not(:focus, .is-valid, .is-error) {
+		border-color: var(--color-neutral-10);
+	}
+
+	// The base focus style is included in input-control, but these states are overriden by the default styles above.
+	&:focus {
+		&:hover,
+		&.is-valid,
+		&.is-error {
+			@include form-field-core-styles-focus;
+		}
+
+		// Sass won't output these unless separated.
+		&.is-valid:hover,
+		&.is-error:hover {
+			@include form-field-core-styles-focus;
+		}
+	}
+
 	&:disabled {
 		background-color: var(--wp-components-color-gray-100, #f0f0f0);
+		border-color: var(--color-neutral-10);
+		color: var(--color-neutral-60);
 	}
 
 	&.is-error {
-		border-color: var(--color-error);
+		&:hover {
+			border-color: var(--color-error);
+		}
 
 		&:focus {
 			--wp-admin-theme-color: var(--color-error);
@@ -114,7 +142,9 @@
 	}
 
 	&.is-valid {
-		border-color: var(--color-success);
+		&:hover {
+			border-color: var(--color-success);
+		}
 
 		&:focus {
 			--wp-admin-theme-color: var(--color-success);

--- a/client/components/forms/form-text-input/stories/index.stories.tsx
+++ b/client/components/forms/form-text-input/stories/index.stories.tsx
@@ -1,0 +1,30 @@
+import FormTextInput from '../index';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react';
+
+export type FormTextInputStory = StoryObj< typeof FormTextInput >;
+
+const meta: Meta = {
+	title: 'client/components/Forms/Form Text Input',
+	component: FormTextInput,
+	decorators: [
+		( Story: StoryFn ) => (
+			<div style={ { maxWidth: '360px', padding: '30px' } }>
+				<Story />
+			</div>
+		),
+	],
+};
+
+export default meta;
+
+export const Default: FormTextInputStory = {};
+
+export const CoreStyles: FormTextInputStory = { args: { hasCoreStyles: true } };
+
+export const CoreStylesValid: FormTextInputStory = {
+	args: { hasCoreStyles: true, className: 'is-valid' },
+};
+
+export const CoreStylesError: FormTextInputStory = {
+	args: { hasCoreStyles: true, className: 'is-error' },
+};

--- a/client/components/forms/form-text-input/style.scss
+++ b/client/components/forms/form-text-input/style.scss
@@ -1,7 +1,7 @@
 @import "@automattic/typography/styles/variables";
 @import "../../../assets/stylesheets/shared/extends-forms";
 
-.form-text-input:not(.form-text-input-core-styles) {
+.form-text-input {
 	@at-root {
 		input[type='text']#{&},
 		input[type='url']#{&},


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DSGCOM-95: Update text fields on login](https://linear.app/a8c/issue/DSGCOM-95/update-text-fields-on-login)

## Proposed Changes

* Revert the specificity change of the selector for the existing form input styles
* The original purpose of using the `:not(...)` selector was to avoid having to override all the existing hover and focus, and valid/error rules, but without it these need to be added.
* Add stories 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The increased specificity of the selector introduced in https://github.com/Automattic/wp-calypso/pull/103616 led to regressions where inputs are being customised, eg. search fields in the [help center](https://github.com/Automattic/wp-calypso/pull/103616#issuecomment-2967197755) and [A4A](https://github.com/Automattic/wp-calypso/pull/103616#issuecomment-2965710845)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/log-in
* Using keyboard and mouse interact with the form field, checking hover and focus states. They should match the behaviour on https://wordpress.com/log-in/ 
* Submit the form with and without a username or email, to check the valid and disabled states

### Screenshots

| Default | Focused | Error | Disabled |
|-|-|-|-|
| ![calypso localhost_3000_log-in_redirect_to=%2Fsites(2 1366x768)](https://github.com/user-attachments/assets/f0e79dbc-5dca-4992-bd25-089efe4eb2ee) | ![calypso localhost_3000_log-in_redirect_to=%2Fsites(2 1366x768) (1)](https://github.com/user-attachments/assets/c0bf0b3e-4675-42c1-a26b-0c5fcb0e77b5) | ![calypso localhost_3000_log-in_redirect_to=%2Fsites(2 1366x768) (2)](https://github.com/user-attachments/assets/fb064da2-da00-43e8-9268-f01f6cfdfb16) | ![calypso localhost_3000_log-in_redirect_to=%2Fsites(2 1366x768) (3)](https://github.com/user-attachments/assets/cfe982f5-a733-456f-acd7-764cc3312295) |

* Log in and on the sites page activate the Help Center by clicking the question mark icon in the top right of the admin bar
* Check that the search bar does not have an inner border
    
| Before | After |
|-|-|
| ![Screenshot 2025-06-13 at 2 08 13 PM](https://github.com/user-attachments/assets/7584dc20-48ae-4db2-a94f-d3e02c9c5f69) | ![Screenshot 2025-06-13 at 2 11 56 PM](https://github.com/user-attachments/assets/b2ae5a70-eff3-4754-a53f-a84cf197b189) |

* Run `yarn storybook:start` and go to http://localhost:6006/?path=/story/client-components-forms-form-text-input--default to view the component stories

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
