### PR TITLE
Keep the original order of finished items of Launchpad

### DIFF
--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -106,12 +106,12 @@ export function sortLaunchpadTasksByCompletionStatus( response: LaunchpadRespons
 	return response;
 }
 
-const defaultSuccessCallback = ( response: LaunchpadResponse ) => {
+export function defaultSuccessCallback( response: LaunchpadResponse ) {
 	const tasks = response.checklist || [];
 	response.checklist = tasks.map( addOrderToTask );
 
 	return response;
-};
+}
 
 type SiteSlug = string | number | null;
 

--- a/packages/launchpad/src/launchpad.tsx
+++ b/packages/launchpad/src/launchpad.tsx
@@ -2,7 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import {
 	Site,
 	type SiteSelect,
-	sortLaunchpadTasksByCompletionStatus,
+	defaultSuccessCallback,
 	useSortedLaunchpadTasks,
 } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
@@ -71,7 +71,7 @@ const Launchpad = ( {
 	};
 
 	const launchpadOptions = {
-		onSuccess: sortLaunchpadTasksByCompletionStatus,
+		onSuccess: defaultSuccessCallback,
 	};
 
 	if ( ! launchpadContext ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13604/launchpad-dont-change-the-items-order-after-completion

## Proposed Changes

* Per PDC feedback: we don't want to change the order of the finished items upon completion

| Initial order | Item completed - prod | Item completed - PR |
|--------|--------|--------|
| ![image](https://github.com/user-attachments/assets/a7b9c594-de74-4474-8ada-1172605eeff8) | ![image](https://github.com/user-attachments/assets/7964a5b2-369d-4fe2-846f-bb99888eeea8) | ![image](https://github.com/user-attachments/assets/31d8717e-9ea0-4dcd-886f-ac932dbbc453) | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is part of an Onboarding review with PDC members

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply [these Jetpack changes](https://github.com/Automattic/jetpack/pull/43945#issuecomment-2968818387) to your sandbox
* Sandbox your public API
* Create a new site at [the /setup/onboarding setup](http://calypso.localhost:3000/setup/onboarding)
* Once you're at the home page, complete one item from the Launchpad that isn't at the beginning
* Make sure that item stays at the same order upon completion

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
