### PR TITLE
Dashboard v2: Enable scroll restoration

### DIFF
--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -1,6 +1,6 @@
 import {
-	Router,
 	createRoute,
+	createRouter,
 	createRootRoute,
 	redirect,
 	createLazyRoute,
@@ -566,7 +566,7 @@ const createRouteTree = ( config: AppConfig ) => {
 
 export const getRouter = ( config: AppConfig ) => {
 	const routeTree = createRouteTree( config );
-	return new Router( {
+	return createRouter( {
 		routeTree,
 		basepath: config.basePath,
 		defaultErrorComponent: UnknownError,
@@ -578,6 +578,8 @@ export const getRouter = ( config: AppConfig ) => {
 		// "default", we can still customize it in CSS and add more transition
 		// areas.
 		defaultViewTransition: true,
+		scrollRestoration: true,
+		getScrollRestorationKey: ( location ) => location.pathname,
 	} );
 };
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Enable scroll restoration on dashboard v2. Restoring the scroll position when a user navigates back to the previous page would provide a smoother and more seamless user experience. Does it make sense?
* We might want to avoid restoring the scroll position when the user clicks a link in the top menu, as this likely represents a new navigation rather than a "back" action 🤔

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the scroll experience

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Scroll down to the bottom, select a sites, and navigate back by clicking either "WordPress.com" or "Sites" on the top
* Ensure the scroll position restores to the bottom on sites screen
* Navigate to settings, scroll down to the bottom, select Defensive mode, and navigate back by clicking breadcrumbs
* Ensure the scroll position restores to the bottom on settings screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
