### PR TITLE
Dashboard V2: Update the heading levels.

### DIFF
--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -33,7 +33,7 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 	return (
 		<PageLayout size="small" header={ <PageHeader title={ __( 'Settings' ) } /> }>
 			<VStack spacing={ 3 }>
-				<SectionHeader title={ __( 'General' ) } level={ 3 } />
+				<SectionHeader title={ __( 'General' ) } />
 				<SummaryButtonList>
 					<SiteVisibilitySettingsSummary site={ site } />
 					<SubscriptionGiftingSettingsSummary site={ site } settings={ settings } />
@@ -42,7 +42,7 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 				</SummaryButtonList>
 			</VStack>
 			<VStack spacing={ 3 }>
-				<SectionHeader title={ __( 'Server' ) } level={ 3 } />
+				<SectionHeader title={ __( 'Server' ) } />
 				<SummaryButtonList>
 					<WordPressSettingsSummary site={ site } />
 					<PHPSettingsSummary site={ site } />


### PR DESCRIPTION
## Proposed Changes

Update `General` and `Server` headings to use level 2 for accessibility. 

## Why are these changes being made?

Currently, this is our heading order:

- Level 1: Settings
    -  Level 3: General
    -  Level 3: Server
-  Level 2: Actions
-  Level 2: Danger zone

## Issues

This doesn't solve the sizing issue. According to the designs, these headings should be `15px`, but currently, our section headings are using `heading-x-large()` which is `20px`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
