### PR TITLE
A4A > Reports: Implement Build Report API integration

### DIFF
--- a/client/a8c-for-agencies/components/a4a-select-site/modal.tsx
+++ b/client/a8c-for-agencies/components/a4a-select-site/modal.tsx
@@ -26,6 +26,7 @@ const SelectSiteModal = ( {
 			onSiteSelect( {
 				blogId: selectedSite.rawSite.blog_id,
 				domain: selectedSite.site,
+				managedSiteId: selectedSite.id,
 			} );
 			onClose();
 		}

--- a/client/a8c-for-agencies/components/a4a-select-site/types.ts
+++ b/client/a8c-for-agencies/components/a4a-select-site/types.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 export type A4ASelectSiteItem = {
 	blogId: number;
 	domain: string;
+	managedSiteId: number;
 };
 
 export interface A4ASelectSiteProps {

--- a/client/a8c-for-agencies/sections/reports/hooks/use-build-report-form-validation.tsx
+++ b/client/a8c-for-agencies/sections/reports/hooks/use-build-report-form-validation.tsx
@@ -11,7 +11,7 @@ type ValidationError = {
 // Email validation utility
 const isValidEmailList = ( emailString: string ): boolean => {
 	const emails = emailString.split( ',' ).map( ( email ) => email.trim() );
-	const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+	const emailRegex = /^[^\s@]+@[^\s@]+\.[a-zA-Z]{2,}$/;
 	return emails.every( ( email ) => emailRegex.test( email ) );
 };
 
@@ -40,7 +40,7 @@ const VALIDATION_RULES = {
 		}
 
 		// Teammate emails validation when checkbox is checked
-		if ( data.sendMeACopy ) {
+		if ( data.sendCopyToTeam ) {
 			if ( ! data.teammateEmails.trim() ) {
 				errors.push( {
 					field: 'teammateEmails',

--- a/client/a8c-for-agencies/sections/reports/hooks/use-fetch-report-by-id.tsx
+++ b/client/a8c-for-agencies/sections/reports/hooks/use-fetch-report-by-id.tsx
@@ -2,46 +2,18 @@ import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
-import type { ReportFormData } from '../types';
-
-const mockData: ReportFormData = {
-	blog_id: 123456789,
-	timeframe: '30_days',
-	client_email: [ 'client@example.com', 'client2@example.com' ],
-	start_date: '2024-01-01',
-	end_date: '2024-01-31',
-	send_copy_to_team: true,
-	teammate_emails: [ 'teammate1@agency.com', 'teammate2@agency.com' ],
-	custom_intro_text: 'Here is your monthly report with key insights and performance metrics.',
-	stats_items: {
-		total_traffic: true,
-		top_pages: true,
-		top_devices: false,
-		top_locations: true,
-		device_breakdown: true,
-		total_traffic_all_time: false,
-		most_popular_time_of_day: true,
-		most_popular_day_of_week: true,
-	},
-};
+import type { Report } from '../types';
 
 export default function useFetchReportById( reportId: number | null ) {
 	const agencyId = useSelector( getActiveAgencyId );
 
-	return useQuery( {
+	return useQuery< Report, Error >( {
 		queryKey: [ 'a4a-report', agencyId, reportId ],
 		queryFn: async () => {
 			return wpcom.req.get( {
 				apiNamespace: 'wpcom/v2',
 				path: `/agency/${ agencyId }/reports/${ reportId }`,
 			} );
-		},
-		// TODO: Remove this once the API is ready
-		select: ( data ) => {
-			return {
-				...data,
-				form_data: mockData,
-			};
 		},
 		enabled: !! agencyId && !! reportId,
 		refetchOnWindowFocus: false,

--- a/client/a8c-for-agencies/sections/reports/hooks/use-send-report-mutation.tsx
+++ b/client/a8c-for-agencies/sections/reports/hooks/use-send-report-mutation.tsx
@@ -1,0 +1,68 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import type { BuildReportFormData, ReportFormData } from '../types';
+
+export interface APIError {
+	status: number;
+	code: string;
+	message: string;
+}
+
+export interface SendReportResponse {
+	id: string;
+	status: 'sent' | 'error' | 'pending';
+	message: string;
+}
+
+const parseEmailList = ( emailString: string ): string[] => {
+	return emailString
+		.split( ',' )
+		.map( ( email ) => email.trim() )
+		.filter( ( email ) => email.length > 0 );
+};
+
+const convertFormDataToApiFormat = ( formData: BuildReportFormData ): ReportFormData => {
+	return {
+		managed_site_id: formData.selectedSite?.managedSiteId || 0,
+		timeframe: formData.selectedTimeframe,
+		...( formData.selectedTimeframe === 'custom' && {
+			start_date: formData.startDate,
+			end_date: formData.endDate,
+		} ),
+		client_emails: parseEmailList( formData.clientEmail ),
+		send_copy_to_team: formData.sendCopyToTeam,
+		teammate_emails: parseEmailList( formData.teammateEmails ),
+		custom_intro_text: formData.customIntroText,
+		stats_items: formData.statsCheckedItems,
+	};
+};
+
+function sendReportMutation(
+	formData: BuildReportFormData,
+	agencyId?: number
+): Promise< SendReportResponse > {
+	if ( ! agencyId ) {
+		throw new Error( 'Agency ID is required to send a report' );
+	}
+
+	const apiData = convertFormDataToApiFormat( formData );
+
+	return wpcom.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: `/agency/${ agencyId }/reports`,
+		body: apiData,
+	} );
+}
+
+export default function useSendReportMutation< TContext = unknown >(
+	options?: UseMutationOptions< SendReportResponse, APIError, BuildReportFormData, TContext >
+): UseMutationResult< SendReportResponse, APIError, BuildReportFormData, TContext > {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useMutation< SendReportResponse, APIError, BuildReportFormData, TContext >( {
+		...options,
+		mutationFn: ( formData ) => sendReportMutation( formData, agencyId ),
+	} );
+}

--- a/client/a8c-for-agencies/sections/reports/lib/get-site-reports.ts
+++ b/client/a8c-for-agencies/sections/reports/lib/get-site-reports.ts
@@ -1,3 +1,4 @@
+import { urlToSlug } from 'calypso/lib/url/http-utils';
 import type { SiteReports, Report } from '../types';
 
 export const getSiteReports = ( reports: Report[] ): SiteReports[] => {
@@ -7,10 +8,11 @@ export const getSiteReports = ( reports: Report[] ): SiteReports[] => {
 
 	const grouped = reports.reduce(
 		( acc, report ) => {
-			if ( ! acc[ report.site ] ) {
-				acc[ report.site ] = [];
+			const url = urlToSlug( report.data.managed_site_url );
+			if ( ! acc[ url ] ) {
+				acc[ url ] = [];
 			}
-			acc[ report.site ].push( report );
+			acc[ url ].push( report );
 			return acc;
 		},
 		{} as Record< string, Report[] >

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/index.tsx
@@ -317,7 +317,7 @@ const BuildReport = () => {
 									label={ translate( 'Teammate email(s)' ) }
 									value={ teammateEmails }
 									onChange={ setTeammateEmails }
-									type="email"
+									type="text"
 									help={
 										! hasFieldError( 'teammateEmails' )
 											? translate( 'Use commas to separate addresses.' )

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/index.tsx
@@ -317,7 +317,7 @@ const BuildReport = () => {
 									label={ translate( 'Teammate email(s)' ) }
 									value={ teammateEmails }
 									onChange={ setTeammateEmails }
-									type="text"
+									type="email"
 									help={
 										! hasFieldError( 'teammateEmails' )
 											? translate( 'Use commas to separate addresses.' )

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
@@ -36,10 +36,11 @@ export const ReportStatusColumn = ( { status }: { status: 'sent' | 'pending' | '
 	return <StatusBadge statusProps={ { children: config.text, type: config.type as BadgeType } } />;
 };
 
-export const ReportDateColumn = ( { date }: { date: string | null } ) => {
+export const ReportDateColumn = ( { date }: { date: number | null } ) => {
 	if ( ! date ) {
 		return <Gridicon icon="minus" />;
 	}
 
-	return <FormattedDate date={ date } format="DD MMM YYYY" />;
+	const dateObj = new Date( date * 1000 );
+	return <FormattedDate date={ dateObj } format="DD MMM YYYY HH:mm" />;
 };

--- a/client/a8c-for-agencies/sections/reports/types.ts
+++ b/client/a8c-for-agencies/sections/reports/types.ts
@@ -1,9 +1,9 @@
 import type { A4ASelectSiteItem } from 'calypso/a8c-for-agencies/components/a4a-select-site/types';
 
 export interface ReportFormData {
-	blog_id: number;
+	managed_site_id: number;
 	timeframe: string;
-	client_email: string[];
+	client_emails: string[];
 	start_date?: string;
 	end_date?: string;
 	send_copy_to_team: boolean;
@@ -11,12 +11,16 @@ export interface ReportFormData {
 	custom_intro_text: string;
 	stats_items: BuildReportCheckedItemsState;
 }
+
+export interface ReportFormAPIResponse extends ReportFormData {
+	managed_site_url: string;
+	blog_id: number;
+}
 export interface Report {
 	id: string;
-	site: string;
 	status: 'sent' | 'error' | 'pending';
-	created_at: string;
-	form_data: ReportFormData;
+	created_at: number;
+	data: ReportFormAPIResponse;
 }
 
 export interface SiteReports {
@@ -39,7 +43,7 @@ export type BuildReportFormData = {
 	clientEmail: string;
 	startDate?: string;
 	endDate?: string;
-	sendMeACopy: boolean;
+	sendCopyToTeam: boolean;
 	teammateEmails: string;
 	customIntroText: string;
 	statsCheckedItems: BuildReportCheckedItemsState;


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1123/report-builder-api-integration-to-create-a-new-report

This PR is built on top of https://github.com/Automattic/wp-calypso/pull/104169. So, please review this first. 

## Proposed Changes

This PR implements API integration to create a new report. It also refactors the code to make the duplicate report work well. 

## Why are these changes being made?

* To allow users to create a new report.

## Testing Instructions

* Open the A4A live link
* Go to Reports: Dashboard > Click the `Build a new report` button > Fill out all the form fields > Click the `Send to client now` button and verify the report gets created, a success message is shown, and you are redirected to the Reports Dashboard page > Also, verify the report is loaded on the dashboard > Open the details view > Verify the data displayed is correct > Click the `...` on the table > Click the `Duplicate report` button > Verify data is prefilled. Continue and create a report. Verify a new report is displayed. 

<img width="1728" alt="Screenshot 2025-06-13 at 12 44 13 PM" src="https://github.com/user-attachments/assets/ff8d6800-79b1-4a79-8364-9a5e8516d648" />

<img width="890" alt="Screenshot 2025-06-13 at 12 44 17 PM" src="https://github.com/user-attachments/assets/007a178e-d670-429e-a82e-51134d7205a0" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?