### PR TITLE
Backported Settings: Fix the confirmation link

### DIFF
--- a/client/dashboard/app/queries/site-owner-transfer.ts
+++ b/client/dashboard/app/queries/site-owner-transfer.ts
@@ -5,10 +5,13 @@ import {
 } from '../../data/site-owner-transfer';
 import { queryClient } from '../query-client';
 import { siteByIdQuery } from './site';
-import type { SiteOwnerTransferConfirmation } from '../../data/site-owner-transfer';
+import type {
+	SiteOwnerTransferConfirmation,
+	SiteOwnerTransferContext,
+} from '../../data/site-owner-transfer';
 
 export const siteOwnerTransferMutation = ( siteId: number ) => ( {
-	mutationFn: ( data: { new_site_owner: string; context?: 'dashboard_v2' } ) =>
+	mutationFn: ( data: { new_site_owner: string; context?: SiteOwnerTransferContext } ) =>
 		startSiteOwnerTransfer( siteId, data ),
 } );
 

--- a/client/dashboard/app/queries/site-owner-transfer.ts
+++ b/client/dashboard/app/queries/site-owner-transfer.ts
@@ -8,7 +8,8 @@ import { siteByIdQuery } from './site';
 import type { SiteOwnerTransferConfirmation } from '../../data/site-owner-transfer';
 
 export const siteOwnerTransferMutation = ( siteId: number ) => ( {
-	mutationFn: ( data: { new_site_owner: string } ) => startSiteOwnerTransfer( siteId, data ),
+	mutationFn: ( data: { new_site_owner: string; context?: 'dashboard_v2' } ) =>
+		startSiteOwnerTransfer( siteId, data ),
 } );
 
 export const siteOwnerTransferEligibilityCheckMutation = ( siteId: number ) => ( {

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -356,7 +356,9 @@ const siteSettingsTransferSiteRoute = createRoute( {
 } ).lazy( () =>
 	import( '../sites/settings-transfer-site' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-transfer-site' )( {
-			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
+			component: () => (
+				<d.default siteSlug={ siteRoute.useParams().siteSlug } context="dashboard_v2" />
+			),
 		} )
 	)
 );

--- a/client/dashboard/data/site-owner-transfer.ts
+++ b/client/dashboard/data/site-owner-transfer.ts
@@ -1,5 +1,7 @@
 import wpcom from 'calypso/lib/wp';
 
+export type SiteOwnerTransferContext = 'dashboard_v2';
+
 export interface SiteOwnerTransferConfirmation {
 	transfer: boolean;
 	email_sent: boolean;
@@ -8,7 +10,7 @@ export interface SiteOwnerTransferConfirmation {
 
 export async function startSiteOwnerTransfer(
 	siteId: number,
-	data: { new_site_owner: string; context?: 'dashboard_v2' }
+	data: { new_site_owner: string; context?: SiteOwnerTransferContext }
 ) {
 	return wpcom.req.post(
 		{

--- a/client/dashboard/data/site-owner-transfer.ts
+++ b/client/dashboard/data/site-owner-transfer.ts
@@ -6,7 +6,10 @@ export interface SiteOwnerTransferConfirmation {
 	new_owner_email: string;
 }
 
-export async function startSiteOwnerTransfer( siteId: number, data: { new_site_owner: string } ) {
+export async function startSiteOwnerTransfer(
+	siteId: number,
+	data: { new_site_owner: string; context?: 'dashboard_v2' }
+) {
 	return wpcom.req.post(
 		{
 			path: `/sites/${ siteId }/site-owner-transfer`,
@@ -15,11 +18,7 @@ export async function startSiteOwnerTransfer( siteId: number, data: { new_site_o
 		{
 			calypso_origin: window.location.origin,
 		},
-		{
-			// We need to update the check when modifying the base path for v2
-			context: window.location.pathname.startsWith( '/v2' ) ? 'dashboard_v2' : undefined,
-			...data,
-		}
+		data
 	);
 }
 

--- a/client/dashboard/data/site-owner-transfer.ts
+++ b/client/dashboard/data/site-owner-transfer.ts
@@ -16,7 +16,8 @@ export async function startSiteOwnerTransfer( siteId: number, data: { new_site_o
 			calypso_origin: window.location.origin,
 		},
 		{
-			context: 'dashboard_v2',
+			// We need to update the check when modifying the base path for v2
+			context: window.location.pathname.startsWith( '/v2' ) ? 'dashboard_v2' : undefined,
 			...data,
 		}
 	);

--- a/client/dashboard/sites/settings-transfer-site/index.tsx
+++ b/client/dashboard/sites/settings-transfer-site/index.tsx
@@ -15,6 +15,7 @@ import { ConfirmNewOwnerForm, ConfirmNewOwnerFormData } from './confirm-new-owne
 import { EmailConfirmation } from './email-confirmation';
 import { InvitationEmailSent } from './invitation-email-sent';
 import { StartSiteTransferForm } from './start-site-transfer-form';
+import type { SiteOwnerTransferContext } from '../../data/types';
 
 const MIN_STEP = 0;
 
@@ -49,7 +50,7 @@ export default function SettingsTransferSite( {
 	context,
 }: {
 	siteSlug: string;
-	context?: string;
+	context?: SiteOwnerTransferContext;
 } ) {
 	const { user } = useAuth();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );

--- a/client/dashboard/sites/settings-transfer-site/index.tsx
+++ b/client/dashboard/sites/settings-transfer-site/index.tsx
@@ -44,7 +44,13 @@ const SettingsTransferSitePageLayout = ( { children }: { children: React.ReactNo
 };
 
 // TODO: Use Stepper component when the design is ready.
-export default function SettingsTransferSite( { siteSlug }: { siteSlug: string } ) {
+export default function SettingsTransferSite( {
+	siteSlug,
+	context,
+}: {
+	siteSlug: string;
+	context?: string;
+} ) {
 	const { user } = useAuth();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const [ newOwnerEmail, setNewOwnerEmail ] = useState( '' );
@@ -91,6 +97,7 @@ export default function SettingsTransferSite( { siteSlug }: { siteSlug: string }
 						<StartSiteTransferForm
 							newOwnerEmail={ newOwnerEmail }
 							site={ site }
+							context={ context }
 							onSubmit={ handleStartSiteTransfer }
 							onBack={ handleBack }
 						/>

--- a/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
@@ -63,11 +63,13 @@ const List = ( { title, children }: { title: string; children: React.ReactNode }
 export function StartSiteTransferForm( {
 	site,
 	newOwnerEmail,
+	context,
 	onSubmit,
 	onBack,
 }: {
 	site: Site;
 	newOwnerEmail: string;
+	context?: string;
 	onSubmit: () => void;
 	onBack: () => void;
 } ) {
@@ -91,7 +93,7 @@ export function StartSiteTransferForm( {
 		event.preventDefault();
 
 		mutation.mutate(
-			{ new_site_owner: newOwnerEmail },
+			{ new_site_owner: newOwnerEmail, context },
 			{
 				onSuccess: () => {
 					onSubmit();

--- a/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
@@ -14,7 +14,7 @@ import React, { useState } from 'react';
 import { siteOwnerTransferMutation } from '../../app/queries/site-owner-transfer';
 import Notice from '../../components/notice';
 import { SectionHeader } from '../../components/section-header';
-import type { Site } from '../../data/types';
+import type { Site, SiteOwnerTransferContext } from '../../data/types';
 import type { Field } from '@automattic/dataviews';
 
 export type StartSiteTransferFormData = {
@@ -69,7 +69,7 @@ export function StartSiteTransferForm( {
 }: {
 	site: Site;
 	newOwnerEmail: string;
-	context?: string;
+	context?: SiteOwnerTransferContext;
 	onSubmit: () => void;
 	onBack: () => void;
 } ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-25

## Proposed Changes

* Limit context to v2 to ensure the confirmation link works correctly

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Go to `/sites/settings/v2/:site`
* Transfer your site
* Ensure the confirmation link in the email you received points to v1 URL

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
