### PR TITLE
Accessibility: Fix a11y issues on VIP login page

### DIFF
--- a/client/layout/masterbar/item.tsx
+++ b/client/layout/masterbar/item.tsx
@@ -33,6 +33,7 @@ interface MasterbarItemProps {
 	hasGlobalBorderStyle?: boolean;
 	as?: React.ComponentType;
 	variant?: string;
+	ariaLabel?: string;
 }
 
 class MasterbarItem extends Component< MasterbarItemProps > {
@@ -51,6 +52,7 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 		hasGlobalBorderStyle: PropTypes.bool,
 		as: PropTypes.elementType,
 		variant: PropTypes.string,
+		ariaLabel: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -228,6 +230,7 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 			onTouchStart: this.preload,
 			onMouseEnter: this.preload,
 			disabled: this.props.disabled,
+			'aria-label': this.props.ariaLabel,
 		};
 
 		return (
@@ -252,6 +255,7 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 	}
 }
 
+// eslint-disable-next-line react/display-name
 export default forwardRef< HTMLButtonElement | HTMLAnchorElement, MasterbarItemProps >(
 	( props, ref ) => <MasterbarItem innerRef={ ref } { ...props } />
 );

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -194,7 +194,7 @@ class MasterbarLoggedOut extends Component {
 	}
 
 	renderWordPressItem() {
-		const { locale } = this.props;
+		const { locale, translate } = this.props;
 
 		let homeUrl = '/';
 		if ( ! isDefaultLocale( locale ) ) {
@@ -202,7 +202,11 @@ class MasterbarLoggedOut extends Component {
 		}
 
 		return (
-			<Item url={ homeUrl } className="masterbar__item-logo masterbar__item--always-show-content">
+			<Item
+				url={ homeUrl }
+				className="masterbar__item-logo masterbar__item--always-show-content"
+				ariaLabel={ translate( 'WordPress.com logo' ) }
+			>
 				<WordPressLogo className="masterbar__wpcom-logo" />
 				<WordPressWordmark className="masterbar__wpcom-wordmark" />
 			</Item>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13188

## Proposed Changes

* Add an aria-label attribute to the MasterbarItem component to resolve a11y issues on the VIP login page.
 
## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The axe Devtools has reported some issues with the page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Goto https://dashboard.wpvip.com/
* Select login with WordPress.com
* Make sure you are on the WordPress.com OAuth login screen.
* Replace domain with either local or Calypso live URL.
* Notice WordPress.com logo has an appropriate aria label in dev console. 

![CleanShot 2025-06-13 at 12 30 13@2x](https://github.com/user-attachments/assets/5757fafa-2269-4c3e-b8a7-10e66f2b7b15)

* Run axe DevTools on the page make sure it doesn't report any issues.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
