### PR TITLE
Hosting Dashboard: Add `titleAs` prop to `<Callout>`

### DIFF
--- a/client/dashboard/components/callout/index.tsx
+++ b/client/dashboard/components/callout/index.tsx
@@ -2,7 +2,7 @@ import {
 	Card,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
-	__experimentalHeading as Heading,
+	__experimentalText as Text,
 	Icon,
 } from '@wordpress/components';
 import { forwardRef } from 'react';
@@ -12,12 +12,12 @@ import './styles.scss';
 function UnforwardedCallout(
 	{
 		title,
+		titleAs: TitleComponent = Text,
 		icon,
 		image,
 		imageAlt,
 		description,
 		actions,
-		headingLevel = 6,
 		variant = 'default',
 	}: CalloutProps,
 	ref: React.ForwardedRef< HTMLElement >
@@ -33,9 +33,7 @@ function UnforwardedCallout(
 			>
 				<VStack justify="flex-start" alignment="flex-start" spacing="4">
 					{ icon && <Icon icon={ icon } /> }
-					<Heading level={ headingLevel } className="dashboard-callout__title">
-						{ title }
-					</Heading>
+					<TitleComponent className="dashboard-callout__title">{ title }</TitleComponent>
 					{ description }
 					{ actions }
 				</VStack>

--- a/client/dashboard/components/callout/styles.scss
+++ b/client/dashboard/components/callout/styles.scss
@@ -23,6 +23,7 @@
 .dashboard-callout__title {
 	@include heading-large;
 	color: $gray-900;
+	margin: 0;
 }
 
 .dashboard-callout__image {

--- a/client/dashboard/components/callout/test/index.tsx
+++ b/client/dashboard/components/callout/test/index.tsx
@@ -2,12 +2,11 @@
  * @jest-environment jsdom
  */
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import { Callout } from '../index';
 
 describe( 'Callout', () => {
 	test( 'renders title and description', () => {
-		render( <Callout title="Test Title" description={ <p>Helpful content</p> } /> );
+		render( <Callout title="Test Title" titleAs="h6" description={ <p>Helpful content</p> } /> );
 		expect(
 			screen.getByRole( 'heading', {
 				name: 'Test Title',

--- a/client/dashboard/components/callout/types.ts
+++ b/client/dashboard/components/callout/types.ts
@@ -1,4 +1,4 @@
-import type { Icon, __experimentalHeading as Heading } from '@wordpress/components';
+import type { Icon } from '@wordpress/components';
 import type { ComponentProps, ReactNode } from 'react';
 
 export interface CalloutProps {
@@ -7,10 +7,10 @@ export interface CalloutProps {
 	 */
 	title: string;
 	/**
-	 * The level of the heading to be used for the title.
-	 * @default 6
+	 * The type of element to use for the title. Allows for the title can a heading element.
+	 * @default <Text>
 	 */
-	headingLevel?: ComponentProps< typeof Heading >[ 'level' ];
+	titleAs?: React.ElementType | keyof JSX.IntrinsicElements;
 	/**
 	 * A short paragraph providing supporting context or details to reinforce the title.
 	 * Elements will be arranged in a VStack with consistent spacing.

--- a/client/dashboard/sites/deployments/index.tsx
+++ b/client/dashboard/sites/deployments/index.tsx
@@ -31,6 +31,7 @@ function SiteDeployments() {
 					<Callout
 						icon={ <img src={ ghIconUrl } alt={ __( 'GitHub logo' ) } /> }
 						title={ __( 'Deploy from GitHub' ) }
+						titleAs="h1"
 						image={ illustrationUrl }
 						description={
 							<>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-13434

## Proposed Changes

Allows the Callout consumer to decide the semantics of the title. By default it's regular text. But on some pages (e.g. Deployments) it acts as the page header.

## Why are we making these changes

The issue in DOTCOM-13434 relates to the settings callout titles using an `<h6>` element. But we can't just make force _all_ callout titles to use `<p>` or `<span>`. In some contexts the callout title really will be used a heading. For example:

![CleanShot 2025-06-16 at 11 04 09@2x](https://github.com/user-attachments/assets/2d69aafc-8ecd-46d8-a02c-47400974c568)

Here "Monitor server stats" really is the primary heading on the page.

That's why a user of the callout component needs the ability to set the heading level.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test with a simple site
* `/v2/sites/{{ site slug }}/settings/php`
  * The callout title should not be a heading
  * Use the a11y tree in the dev tools, you can see the "PHP" is the page heading and the callout title is regular static test
  * Compare with `wpcalypso`, the _visual_ style of the callout title should not have changed
* `/v2/sites/{{ site slug }}/deployments`
  * The callout title should be an h1
  * Use the a11y tree in the dev tools, you can see the callout title acts as the page’s main heading
    * There’s currently a bug that means “Deployments” also appears as a heading in the a11y tree. This a bug fixed by: https://github.com/Automattic/wp-calypso/pull/104203
  * Compare with `wpcalypso`, the _visual_ style of the callout title should not have changed

![CleanShot 2025-06-13 at 16 50 02@2x](https://github.com/user-attachments/assets/c3f0ef62-d541-4972-a9b5-e3ba7352651d)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
