### PR TITLE
A4A > Reports: Implement Delete Report

### DIFF
--- a/client/a8c-for-agencies/sections/reports/delete-report-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/delete-report-confirmation-dialog/index.tsx
@@ -3,6 +3,8 @@ import { A4AConfirmationDialog } from 'calypso/a8c-for-agencies/components/a4a-c
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import type { Report } from '../types';
 
+import './style.scss';
+
 type Props = {
 	report: Report;
 	onClose: () => void;
@@ -28,17 +30,21 @@ export default function DeleteReportConfirmationDialog( {
 			isDestructive
 			isLoading={ isLoading }
 		>
-			{ translate(
-				"The report for {{strong}}%(siteName)s{{/strong}} will be deleted permanently. This can't be undone. {{br/}}{{br/}}If it's already scheduled to be sent, it may still go out.",
-				{
-					args: { siteName: urlToSlug( report.data.managed_site_url ) },
-					components: {
-						strong: <strong />,
-						br: <br />,
-					},
-					comment: '%(siteName)s is the site name for the report being deleted',
-				}
-			) }
+			<div className="delete-report-confirmation-dialog__content">
+				<div>
+					{ translate(
+						"The report for {{strong}}%(siteName)s{{/strong}} will be deleted permanently. This can't be undone.",
+						{
+							args: { siteName: urlToSlug( report.data.managed_site_url ) },
+							components: {
+								strong: <strong />,
+							},
+							comment: '%(siteName)s is the site name for the report being deleted',
+						}
+					) }
+				</div>
+				<div>{ translate( "If it's already scheduled to be sent, it may still go out." ) }</div>
+			</div>
 		</A4AConfirmationDialog>
 	);
 }

--- a/client/a8c-for-agencies/sections/reports/delete-report-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/delete-report-confirmation-dialog/index.tsx
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import { A4AConfirmationDialog } from 'calypso/a8c-for-agencies/components/a4a-confirmation-dialog';
+import { urlToSlug } from 'calypso/lib/url/http-utils';
 import type { Report } from '../types';
 
 type Props = {
@@ -19,18 +20,18 @@ export default function DeleteReportConfirmationDialog( {
 
 	return (
 		<A4AConfirmationDialog
-			title={ translate( 'Are you sure you want to delete this report?' ) }
+			title={ translate( 'Delete this report?' ) }
 			onClose={ onClose }
 			onConfirm={ onConfirm }
-			closeLabel={ translate( 'Keep report' ) }
+			closeLabel={ translate( 'Cancel' ) }
 			ctaLabel={ translate( 'Delete report' ) }
 			isDestructive
 			isLoading={ isLoading }
 		>
 			{ translate(
-				'This report for {{strong}}%(siteName)s{{/strong}} will be permanently deleted. This action cannot be undone. {{br/}}{{br/}}Note: If the report is already queued for sending, it may still be delivered.',
+				"The report for {{strong}}%(siteName)s{{/strong}} will be deleted permanently. This can't be undone. {{br/}}{{br/}}If it's already scheduled to be sent, it may still go out.",
 				{
-					args: { siteName: report.site },
+					args: { siteName: urlToSlug( report.data.managed_site_url ) },
 					components: {
 						strong: <strong />,
 						br: <br />,

--- a/client/a8c-for-agencies/sections/reports/delete-report-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/delete-report-confirmation-dialog/index.tsx
@@ -1,0 +1,43 @@
+import { useTranslate } from 'i18n-calypso';
+import { A4AConfirmationDialog } from 'calypso/a8c-for-agencies/components/a4a-confirmation-dialog';
+import type { Report } from '../types';
+
+type Props = {
+	report: Report;
+	onClose: () => void;
+	onConfirm: () => void;
+	isLoading?: boolean;
+};
+
+export default function DeleteReportConfirmationDialog( {
+	report,
+	onClose,
+	onConfirm,
+	isLoading,
+}: Props ) {
+	const translate = useTranslate();
+
+	return (
+		<A4AConfirmationDialog
+			title={ translate( 'Are you sure you want to delete this report?' ) }
+			onClose={ onClose }
+			onConfirm={ onConfirm }
+			closeLabel={ translate( 'Keep report' ) }
+			ctaLabel={ translate( 'Delete report' ) }
+			isDestructive
+			isLoading={ isLoading }
+		>
+			{ translate(
+				'This report for {{strong}}%(siteName)s{{/strong}} will be permanently deleted. This action cannot be undone. {{br/}}{{br/}}Note: If the report is already queued for sending, it may still be delivered.',
+				{
+					args: { siteName: report.site },
+					components: {
+						strong: <strong />,
+						br: <br />,
+					},
+					comment: '%(siteName)s is the site name for the report being deleted',
+				}
+			) }
+		</A4AConfirmationDialog>
+	);
+}

--- a/client/a8c-for-agencies/sections/reports/delete-report-confirmation-dialog/style.scss
+++ b/client/a8c-for-agencies/sections/reports/delete-report-confirmation-dialog/style.scss
@@ -1,0 +1,5 @@
+.delete-report-confirmation-dialog__content {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}

--- a/client/a8c-for-agencies/sections/reports/hooks/use-delete-report-mutation.ts
+++ b/client/a8c-for-agencies/sections/reports/hooks/use-delete-report-mutation.ts
@@ -1,0 +1,45 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+export interface DeleteReportResponse {
+	success: boolean;
+	message: string;
+}
+
+export interface DeleteReportVariables {
+	id: number;
+}
+
+export interface APIError {
+	status: number;
+	code: string;
+	message: string;
+}
+
+function deleteReportMutation(
+	{ id }: DeleteReportVariables,
+	agencyId?: number
+): Promise< DeleteReportResponse > {
+	if ( ! agencyId ) {
+		throw new Error( 'Agency ID is required to delete a report' );
+	}
+
+	return wpcom.req.post( {
+		method: 'DELETE',
+		apiNamespace: 'wpcom/v2',
+		path: `/agency/${ agencyId }/reports/${ id }`,
+	} );
+}
+
+export default function useDeleteReportMutation< TContext = unknown >(
+	options?: UseMutationOptions< DeleteReportResponse, APIError, DeleteReportVariables, TContext >
+): UseMutationResult< DeleteReportResponse, APIError, DeleteReportVariables, TContext > {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useMutation< DeleteReportResponse, APIError, DeleteReportVariables, TContext >( {
+		...options,
+		mutationFn: ( variables ) => deleteReportMutation( variables, agencyId ),
+	} );
+}

--- a/client/a8c-for-agencies/sections/reports/hooks/use-fetch-reports.ts
+++ b/client/a8c-for-agencies/sections/reports/hooks/use-fetch-reports.ts
@@ -2,12 +2,13 @@ import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { getReportsQueryKey } from '../lib/get-reports-query-key';
 
 export default function useFetchReports() {
 	const agencyId = useSelector( getActiveAgencyId );
 
 	return useQuery( {
-		queryKey: [ 'a4a-reports', agencyId ],
+		queryKey: getReportsQueryKey( agencyId ),
 		queryFn: () =>
 			wpcom.req.get( {
 				apiNamespace: 'wpcom/v2',

--- a/client/a8c-for-agencies/sections/reports/hooks/use-handle-report-delete.ts
+++ b/client/a8c-for-agencies/sections/reports/hooks/use-handle-report-delete.ts
@@ -1,0 +1,89 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { getReportsQueryKey } from '../lib/get-reports-query-key';
+import useDeleteReportMutation from './use-delete-report-mutation';
+import type { Report } from '../types';
+
+export default function useHandleReportDelete() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const queryClient = useQueryClient();
+
+	// Reports query key so we optimistically update the reports list
+	const agencyId = useSelector( getActiveAgencyId );
+	const reportsQueryKey = getReportsQueryKey( agencyId );
+
+	const { mutate: deleteReport, isPending } = useDeleteReportMutation( {
+		// Optimistically update the reports list
+		onMutate: async ( { id }: { id: number } ) => {
+			// Cancel any current refetches, so they don't overwrite our optimistic update
+			await queryClient.cancelQueries( {
+				queryKey: reportsQueryKey,
+			} );
+			// Snapshot the previous value
+			const previousReports = queryClient.getQueryData( reportsQueryKey );
+			// Optimistically remove the report from the list
+			queryClient.setQueryData( reportsQueryKey, ( oldReports: Report[] | undefined ) => {
+				if ( ! oldReports ) {
+					return [];
+				}
+				return oldReports.filter( ( report: Report ) => report.id !== id );
+			} );
+			// Store previous reports in case of failure
+			return { previousReports };
+		},
+		onError: ( error, variables, context ) => {
+			// Rollback on error
+			if ( context?.previousReports ) {
+				queryClient.setQueryData( reportsQueryKey, context.previousReports );
+			}
+		},
+		onSettled: () => {
+			queryClient.invalidateQueries( {
+				queryKey: reportsQueryKey,
+			} );
+		},
+	} );
+
+	const handleDeleteReport = useCallback(
+		( report: Report, callback?: ( isSuccess: boolean ) => void ) => {
+			deleteReport(
+				{ id: report.id },
+				{
+					onSuccess: () => {
+						dispatch(
+							successNotice( translate( 'The report has been deleted.' ), {
+								id: 'delete-report-success',
+								duration: 5000,
+							} )
+						);
+						callback?.( true );
+					},
+
+					onError: ( error ) => {
+						dispatch(
+							errorNotice(
+								error.message || translate( 'Failed to delete report. Please try again.' ),
+								{
+									id: 'delete-report-error',
+									duration: 5000,
+								}
+							)
+						);
+						callback?.( false );
+					},
+				}
+			);
+		},
+		[ deleteReport, dispatch, translate ]
+	);
+
+	return {
+		handleDeleteReport,
+		isPending,
+	};
+}

--- a/client/a8c-for-agencies/sections/reports/lib/get-reports-query-key.ts
+++ b/client/a8c-for-agencies/sections/reports/lib/get-reports-query-key.ts
@@ -1,0 +1,1 @@
+export const getReportsQueryKey = ( agencyId?: number ) => [ 'a4a-reports', agencyId ];

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/index.tsx
@@ -341,7 +341,7 @@ const BuildReport = () => {
 									label={ translate( 'Teammate email(s)' ) }
 									value={ teammateEmails }
 									onChange={ setTeammateEmails }
-									type="email"
+									type="text"
 									help={
 										! hasFieldError( 'teammateEmails' )
 											? translate( 'Use commas to separate addresses.' )

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/index.tsx
@@ -341,7 +341,7 @@ const BuildReport = () => {
 									label={ translate( 'Teammate email(s)' ) }
 									value={ teammateEmails }
 									onChange={ setTeammateEmails }
-									type="text"
+									type="email"
 									help={
 										! hasFieldError( 'teammateEmails' )
 											? translate( 'Use commas to separate addresses.' )

--- a/client/a8c-for-agencies/sections/reports/reports-details/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/reports-details/index.tsx
@@ -28,7 +28,7 @@ export default function ReportsDetails( { siteReports, closeSitePreviewPane }: P
 	const dispatch = useDispatch();
 
 	const [ selectedReportTab, setSelectedReportTab ] = useState( REPORTS_ID );
-	const [ reportForDelete, setReportForDelete ] = useState< Report | null >( null );
+	const [ reportToDelete, setReportToDelete ] = useState< Report | null >( null );
 
 	const { handleDeleteReport, isPending: isDeletingReport } = useHandleReportDelete();
 
@@ -64,7 +64,7 @@ export default function ReportsDetails( { siteReports, closeSitePreviewPane }: P
 				callback( items: Report[] ) {
 					const report = items[ 0 ];
 					dispatch( recordTracksEvent( 'calypso_a4a_reports_delete_report_button_click' ) );
-					setReportForDelete( report );
+					setReportToDelete( report );
 				},
 			},
 		],
@@ -98,14 +98,14 @@ export default function ReportsDetails( { siteReports, closeSitePreviewPane }: P
 				features={ features }
 				hideNavIfSingleTab
 			/>
-			{ reportForDelete && (
+			{ reportToDelete && (
 				<DeleteReportConfirmationDialog
-					report={ reportForDelete }
-					onClose={ () => setReportForDelete( null ) }
+					report={ reportToDelete }
+					onClose={ () => setReportToDelete( null ) }
 					onConfirm={ () => {
 						dispatch( recordTracksEvent( 'calypso_a4a_reports_delete_report_confirm_click' ) );
-						handleDeleteReport( reportForDelete, () => {
-							setReportForDelete( null );
+						handleDeleteReport( reportToDelete, () => {
+							setReportToDelete( null );
 						} );
 					} }
 					isLoading={ isDeletingReport }

--- a/client/a8c-for-agencies/sections/reports/reports-details/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/reports-details/index.tsx
@@ -103,6 +103,7 @@ export default function ReportsDetails( { siteReports, closeSitePreviewPane }: P
 					report={ reportForDelete }
 					onClose={ () => setReportForDelete( null ) }
 					onConfirm={ () => {
+						dispatch( recordTracksEvent( 'calypso_a4a_reports_delete_report_confirm_click' ) );
 						handleDeleteReport( reportForDelete, () => {
 							setReportForDelete( null );
 						} );

--- a/client/a8c-for-agencies/sections/reports/reports-details/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/reports-details/index.tsx
@@ -7,6 +7,8 @@ import ItemView, { createFeaturePreview } from 'calypso/layout/hosting-dashboard
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { A4A_REPORTS_BUILD_LINK } from '../constants';
+import DeleteReportConfirmationDialog from '../delete-report-confirmation-dialog';
+import useHandleReportDelete from '../hooks/use-handle-report-delete';
 import ReportsMobileView from './mobile-view';
 import Reports from './reports';
 import type { SiteReports, Report } from '../types';
@@ -26,6 +28,9 @@ export default function ReportsDetails( { siteReports, closeSitePreviewPane }: P
 	const dispatch = useDispatch();
 
 	const [ selectedReportTab, setSelectedReportTab ] = useState( REPORTS_ID );
+	const [ reportForDelete, setReportForDelete ] = useState< Report | null >( null );
+
+	const { handleDeleteReport, isPending: isDeletingReport } = useHandleReportDelete();
 
 	const itemData: ItemData = {
 		title: siteReports.site,
@@ -53,6 +58,15 @@ export default function ReportsDetails( { siteReports, closeSitePreviewPane }: P
 					return report.status !== 'error';
 				},
 			},
+			{
+				id: 'delete-report',
+				label: translate( 'Delete report' ),
+				callback( items: Report[] ) {
+					const report = items[ 0 ];
+					dispatch( recordTracksEvent( 'calypso_a4a_reports_delete_report_button_click' ) );
+					setReportForDelete( report );
+				},
+			},
 		],
 		[ dispatch, translate ]
 	);
@@ -76,12 +90,26 @@ export default function ReportsDetails( { siteReports, closeSitePreviewPane }: P
 	);
 
 	return (
-		<ItemView
-			className="reports-details-items"
-			itemData={ itemData }
-			closeItemView={ closeSitePreviewPane }
-			features={ features }
-			hideNavIfSingleTab
-		/>
+		<>
+			<ItemView
+				className="reports-details-items"
+				itemData={ itemData }
+				closeItemView={ closeSitePreviewPane }
+				features={ features }
+				hideNavIfSingleTab
+			/>
+			{ reportForDelete && (
+				<DeleteReportConfirmationDialog
+					report={ reportForDelete }
+					onClose={ () => setReportForDelete( null ) }
+					onConfirm={ () => {
+						handleDeleteReport( reportForDelete, () => {
+							setReportForDelete( null );
+						} );
+					} }
+					isLoading={ isDeletingReport }
+				/>
+			) }
+		</>
 	);
 }

--- a/client/a8c-for-agencies/sections/reports/reports-details/reports.tsx
+++ b/client/a8c-for-agencies/sections/reports/reports-details/reports.tsx
@@ -65,7 +65,7 @@ export default function Reports( { reports, actions }: { reports: Report[]; acti
 			<ItemsDataViews
 				data={ {
 					items: data,
-					getItemId: ( item: Report ) => item.id,
+					getItemId: ( item: Report ) => `${ item.id }`,
 					pagination: paginationInfo,
 					enableSearch: false,
 					fields,

--- a/client/a8c-for-agencies/sections/reports/types.ts
+++ b/client/a8c-for-agencies/sections/reports/types.ts
@@ -24,7 +24,7 @@ export interface ReportFormAPIResponse extends ReportFormData {
 	blog_id: number;
 }
 export interface Report {
-	id: string;
+	id: number;
 	status: 'sent' | 'error' | 'pending';
 	created_at: number;
 	data: ReportFormAPIResponse;


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1121/delete-report

## Proposed Changes

This PR implements the delete report feature.

Note: We are doing an optimistic update for deletion. Meaning that the report is soft-deleted from the copy on the UI while the delete request is made in the background. We revert if there is a failure. 

## Why are these changes being made?

* To be able to delete the report

## Testing Instructions

* Open the A4A live link
* Ensure you are not sandboxing the public API or have the latest trunk
* Go to Reports: Dashboard > Open any report details > Click the `...` icon

<img width="1728" alt="Screenshot 2025-06-13 at 1 58 07 PM" src="https://github.com/user-attachments/assets/19c8c3d7-2e33-4925-8210-823d30dabe9a" />

*  Click the `Delete report` button > Verify the below-shown confirmation modal is shown > Verify both the buttons work as expected. Click the `Delete report` button on the modal > Verify the report is deleted

<img width="674" alt="Screenshot 2025-06-24 at 3 47 19 PM" src="https://github.com/user-attachments/assets/89ee16a3-7313-4e01-a058-2ab44f4be15d" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?