### PR TITLE
Ensure page header is inert when full page callout is rendered

### DIFF
--- a/client/dashboard/components/callout-overlay/index.tsx
+++ b/client/dashboard/components/callout-overlay/index.tsx
@@ -18,8 +18,12 @@ export function CalloutOverlay( { showCallout, callout, main }: CalloutOverlayPr
 			<VStack className="dashboard-callout-overlay" alignment="center">
 				{ callout }
 			</VStack>
-			{ /* The inert attribute is too new for our version of React to understand */ }
-			<div ref={ ( el ) => el?.setAttribute( 'inert', '' ) }>{ main }</div>
+			<div
+				// @ts-expect-error The inert attribute is too new for our version of React to understand.
+				inert="true"
+			>
+				{ main }
+			</div>
 		</>
 	);
 }

--- a/client/dashboard/components/page-layout/index.tsx
+++ b/client/dashboard/components/page-layout/index.tsx
@@ -1,4 +1,5 @@
 import { __experimentalVStack as VStack } from '@wordpress/components';
+import { CalloutOverlay } from '../callout-overlay';
 import './style.scss';
 
 const sizes = {
@@ -7,11 +8,13 @@ const sizes = {
 };
 
 function PageLayout( {
+	callout,
 	children,
 	header,
 	notices,
 	size = 'large',
 }: {
+	callout?: React.ReactNode;
 	children?: React.ReactNode;
 	header?: React.ReactNode;
 	notices?: React.ReactNode;
@@ -23,11 +26,19 @@ function PageLayout( {
 			className={ `dashboard-page-layout is-${ size }` }
 			style={ sizes[ size ] }
 		>
-			{ header }
-			{ notices }
-			<VStack spacing={ 6 } className="dashboard-page-layout__content">
-				{ children }
-			</VStack>
+			<CalloutOverlay
+				showCallout={ !! callout }
+				callout={ callout }
+				main={
+					<>
+						{ header }
+						{ notices }
+						<VStack spacing={ 6 } className="dashboard-page-layout__content">
+							{ children }
+						</VStack>
+					</>
+				}
+			/>
 		</VStack>
 	);
 }

--- a/client/dashboard/sites/deployments/index.tsx
+++ b/client/dashboard/sites/deployments/index.tsx
@@ -4,7 +4,6 @@ import { __ } from '@wordpress/i18n';
 import { siteBySlugQuery } from '../../app/queries/site';
 import { siteRoute } from '../../app/router';
 import { Callout } from '../../components/callout';
-import { CalloutOverlay } from '../../components/callout-overlay';
 import DataViewsCard from '../../components/dataviews-card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -23,40 +22,39 @@ function SiteDeployments() {
 
 	const showIneligiblePlanCallout = ! site.plan || ! hasDeploymentsFeature( site.plan );
 
+	const callout = (
+		<Callout
+			icon={ <img src={ ghIconUrl } alt={ __( 'GitHub logo' ) } /> }
+			title={ __( 'Deploy from GitHub' ) }
+			image={ illustrationUrl }
+			description={
+				<>
+					<Text as="p" variant="muted">
+						{ __(
+							'Connect your GitHub repo directly to your WordPress.com site—with seamless integration, straightforward version control, and automated workflows.'
+						) }
+					</Text>
+					<Text as="p" variant="muted">
+						{ __( 'Available on the WordPress.com Business and Commerce plans.' ) }
+					</Text>
+				</>
+			}
+			actions={
+				<RouterLinkButton __next40pxDefaultSize variant="primary" to="#">
+					{ __( 'Upgrade plan' ) }
+				</RouterLinkButton>
+			}
+		/>
+	);
+
 	return (
-		<PageLayout header={ <PageHeader title={ __( 'Deployments' ) } /> }>
-			<CalloutOverlay
-				showCallout={ showIneligiblePlanCallout }
-				callout={
-					<Callout
-						icon={ <img src={ ghIconUrl } alt={ __( 'GitHub logo' ) } /> }
-						title={ __( 'Deploy from GitHub' ) }
-						image={ illustrationUrl }
-						description={
-							<>
-								<Text as="p" variant="muted">
-									{ __(
-										'Connect your GitHub repo directly to your WordPress.com site—with seamless integration, straightforward version control, and automated workflows.'
-									) }
-								</Text>
-								<Text as="p" variant="muted">
-									{ __( 'Available on the WordPress.com Business and Commerce plans.' ) }
-								</Text>
-							</>
-						}
-						actions={
-							<RouterLinkButton __next40pxDefaultSize variant="primary" to="#">
-								{ __( 'Upgrade plan' ) }
-							</RouterLinkButton>
-						}
-					/>
-				}
-				main={
-					<DataViewsCard>
-						<></>
-					</DataViewsCard>
-				}
-			/>
+		<PageLayout
+			header={ <PageHeader title={ __( 'Deployments' ) } /> }
+			callout={ showIneligiblePlanCallout && callout }
+		>
+			<DataViewsCard>
+				<></>
+			</DataViewsCard>
 		</PageLayout>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to https://github.com/Automattic/wp-calypso/pull/104199

## Proposed Changes

* Move the `<CalloutOverlay>` up into the `<PageLayout>`
* Use a simpler method of setting `inert="true"` on the content obscured by the callout.
  * (Copied from `<SitePreview>`)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The `<CalloutOverlay>` used to obscure all of the content within the `<PageLayout>`. That's because `<PageHeader>` used to be a child of the layout component. Now the header is now a prop, which means all of a sudden it wasn't with the `<CalloutOverlay>`’s `main` area.

This meant the page header, which is supposed to be obscured by `inert="true"` and made inaccessible was accessible to screen readers.

The `<CalloutOverlay>` needs to be high up enough in the React tree so that it can wrap all the obscured content.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
