### PR TITLE
Revert the removal of view transitions

### DIFF
--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -5,6 +5,8 @@
 // I'm tempted to even just replace all this with a display:none on the logo
 @import './loading-screen';
 
+@import './view-transitions';
+
 // Hacks that shouldn't be necessary.
 .environment-badge {
 	display: none;

--- a/client/dashboard/app/view-transitions.scss
+++ b/client/dashboard/app/view-transitions.scss
@@ -31,23 +31,11 @@ main div.dashboard-header-bar {
 }
 
 // Large and small must be separate so they don't cross-animate.
-.dashboard-page-layout.is-large .dashboard-page-header .dashboard-section-header__prefix {
-	view-transition-name: page-layout-header-prefix-large;
+.dashboard-page-layout.is-large .dashboard-page-header {
+	view-transition-name: page-layout-header-large;
 }
-.dashboard-page-layout.is-small .dashboard-page-header .dashboard-section-header__prefix {
-	view-transition-name: page-layout-header-prefix-small;
-}
-.dashboard-page-layout.is-large .dashboard-page-header .dashboard-section-header__heading-row {
-	view-transition-name: page-layout-header-heading-row-large;
-}
-.dashboard-page-layout.is-small .dashboard-page-header .dashboard-section-header__heading-row {
-	view-transition-name: page-layout-header-heading-row-small;
-}
-.dashboard-page-layout.is-large .dashboard-page-header .dashboard-section-header__description {
-	view-transition-name: page-layout-header-description-large;
-}
-.dashboard-page-layout.is-small .dashboard-page-header .dashboard-section-header__description {
-	view-transition-name: page-layout-header-description-small;
+.dashboard-page-layout.is-small .dashboard-page-header {
+	view-transition-name: page-layout-header-small;
 }
 
 .dashboard-page-layout.is-large .dashboard-page-header .components-button.is-primary {

--- a/client/dashboard/app/view-transitions.scss
+++ b/client/dashboard/app/view-transitions.scss
@@ -1,0 +1,94 @@
+::view-transition-old(root),
+::view-transition-new(root) {
+	animation-duration: 250ms;
+}
+
+// The main and sub headers must be separate view transitions, othervise the sub
+// header won't slide in!
+header.dashboard-header-bar {
+	view-transition-name: main-header;
+}
+main div.dashboard-header-bar {
+	view-transition-name: sub-header;
+}
+
+// Headers should show on top of the rest of the page (important for sticky).
+::view-transition-group(main-header),
+::view-transition-group(sub-header) {
+	z-index: 1;
+}
+
+// Do not let the browser transform (slide in) the main hear. This is important
+// for sticy positioning (when the page is scrolled down) and gently switching
+// between the main and sub headers.
+::view-transition-group(main-header) {
+	transform: none !important;
+}
+
+::view-transition-image-pair(main-header),
+::view-transition-image-pair(sub-header) {
+	height: auto;
+}
+
+// Large and small must be separate so they don't cross-animate.
+.dashboard-page-layout.is-large .dashboard-page-header .dashboard-section-header__prefix {
+	view-transition-name: page-layout-header-prefix-large;
+}
+.dashboard-page-layout.is-small .dashboard-page-header .dashboard-section-header__prefix {
+	view-transition-name: page-layout-header-prefix-small;
+}
+.dashboard-page-layout.is-large .dashboard-page-header .dashboard-section-header__heading-row {
+	view-transition-name: page-layout-header-heading-row-large;
+}
+.dashboard-page-layout.is-small .dashboard-page-header .dashboard-section-header__heading-row {
+	view-transition-name: page-layout-header-heading-row-small;
+}
+.dashboard-page-layout.is-large .dashboard-page-header .dashboard-section-header__description {
+	view-transition-name: page-layout-header-description-large;
+}
+.dashboard-page-layout.is-small .dashboard-page-header .dashboard-section-header__description {
+	view-transition-name: page-layout-header-description-small;
+}
+
+.dashboard-page-layout.is-large .dashboard-page-header .components-button.is-primary {
+	view-transition-name: page-layout-header-large--button;
+}
+
+::view-transition-old(page-layout-header-large--button),
+::view-transition-new(page-layout-header-large--button) {
+	height: 100%;
+}
+
+// Large and small must be separate so they don't cross-animate.
+.dashboard-page-layout.is-large .dashboard-page-layout__content {
+	view-transition-name: page-layout-content-large;
+}
+
+.dashboard-page-layout.is-small .dashboard-page-layout__content {
+	view-transition-name: page-layout-content-small;
+}
+
+::view-transition-old(page-layout-content-large),
+::view-transition-new(page-layout-content-large),
+::view-transition-old(page-layout-content-small),
+::view-transition-new(page-layout-content-small) {
+	// Never expand the main content horizontally, but allow it to shrink.
+	width: auto;
+	// Also disable shrinking. Leaving it commented out to test.
+	// max-width: 100%;
+	height: auto;
+}
+
+::view-transition-image-pair(page-layout-content) {
+	display: flex;
+	justify-content: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	::view-transition-group(*),
+	::view-transition-old(*),
+	::view-transition-new(*) {
+		animation: none;
+		transition: none;
+	}
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->
* See DOTCOM-13605
* Reverts https://github.com/Automattic/wp-calypso/pull/104190
* Additionally reverts https://github.com/Automattic/wp-calypso/pull/103718, making the settings view transitions go back to just cross-fading.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Click around and trigger view transitions, should work as before. Check that settings just cross-fades

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
