### PR TITLE
A4A: Pluralize Partner Directory and Agency tier sidebar menu labels.

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
@@ -171,7 +171,7 @@ const useMainMenuItems = ( path: string ) => {
 							link: A4A_PARTNER_DIRECTORY_DASHBOARD_LINK,
 							title: translate( 'Partner Directories' ),
 							trackEventProps: {
-								menu_item: 'Automattic for Agencies / Partner Directories',
+								menu_item: 'Automattic for Agencies / Partner Directory',
 							},
 							withChevron: true,
 						},
@@ -211,7 +211,7 @@ const useMainMenuItems = ( path: string ) => {
 							link: A4A_AGENCY_TIER_LINK,
 							title: translate( 'Agency Tiers' ),
 							trackEventProps: {
-								menu_item: 'Automattic for Agencies / Agency Tiers',
+								menu_item: 'Automattic for Agencies / Agency Tier',
 							},
 						},
 				  ]

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
@@ -169,10 +169,11 @@ const useMainMenuItems = ( path: string ) => {
 							icon: commentAuthorAvatar,
 							path: '/dashboard',
 							link: A4A_PARTNER_DIRECTORY_DASHBOARD_LINK,
-							title: translate( 'Partner Directory' ),
+							title: translate( 'Partner Directories' ),
 							trackEventProps: {
-								menu_item: 'Automattic for Agencies / Partner Directory',
+								menu_item: 'Automattic for Agencies / Partner Directories',
 							},
+							withChevron: true,
 						},
 				  ]
 				: [] ),
@@ -208,9 +209,9 @@ const useMainMenuItems = ( path: string ) => {
 							icon: starEmpty,
 							path: '/',
 							link: A4A_AGENCY_TIER_LINK,
-							title: translate( 'Agency Tier' ),
+							title: translate( 'Agency Tiers' ),
 							trackEventProps: {
-								menu_item: 'Automattic for Agencies / Agency Tier',
+								menu_item: 'Automattic for Agencies / Agency Tiers',
 							},
 						},
 				  ]

--- a/client/a8c-for-agencies/components/sidebar-menu/partner-directory.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/partner-directory.tsx
@@ -12,15 +12,15 @@ type Props = {
 	path: string;
 };
 
-export default function ( { path }: Props ) {
+export default function PartnerDirectory( { path }: Props ) {
 	const translate = useTranslate();
 	const menuItems = usePartnerDirectoryMenuItems( path );
 
 	return (
 		<Sidebar
 			path={ A4A_PARTNER_DIRECTORY_LINK }
-			title={ translate( 'Partner Directory' ) }
-			description={ translate( 'Boost your agency’s visibility across Automattic platforms.' ) }
+			title={ translate( 'Partner Directories' ) }
+			description={ translate( "Boost your agency's visibility across Automattic platforms." ) }
 			backButtonProps={ {
 				label: translate( 'Back to overview' ),
 				icon: chevronLeft,

--- a/client/a8c-for-agencies/sections/agency-tier/lib/get-tier-permission-data.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/lib/get-tier-permission-data.tsx
@@ -17,7 +17,7 @@ const getTierPermissionData = (
 		}
 	> = {
 		'a8c-for-agencies-partner-directory': {
-			title: translate( 'Partner Directory' ),
+			title: translate( 'Partner Directories' ),
 			content: {
 				heading: preventWidows(
 					translate( 'Access this benefit when you become an Agency Partner.' )

--- a/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
@@ -26,7 +26,7 @@ export default function AgencyTierOverview() {
 
 	const agency = useSelector( getActiveAgency );
 
-	const title = translate( 'Agency Tier and benefits' );
+	const title = translate( 'Agency Tiers and benefits' );
 	const benefits = getTierBenefits( translate );
 
 	const currentAgencyTier = agency?.tier?.id;

--- a/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
@@ -26,7 +26,7 @@ export default function AgencyTierOverview() {
 
 	const agency = useSelector( getActiveAgency );
 
-	const title = translate( 'Agency Tiers and benefits' );
+	const title = translate( 'Agency tiers and benefits' );
 	const benefits = getTierBenefits( translate );
 
 	const currentAgencyTier = agency?.tier?.id;

--- a/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
@@ -49,7 +49,7 @@ interface Section {
 
 export default function PartnerDirectory( { selectedSection }: Props ) {
 	const translate = useTranslate();
-	const title = translate( 'Partner Directory' );
+	const title = translate( 'Partner Directories' );
 
 	const agency = useSelector( getActiveAgency );
 	const hasAgency = useSelector( hasFetchedAgency );
@@ -66,7 +66,7 @@ export default function PartnerDirectory( { selectedSection }: Props ) {
 			content: <Dashboard />,
 			breadcrumbItems: [
 				{
-					label: translate( 'Partner Directory' ),
+					label: translate( 'Partner Directories' ),
 					href: A4A_PARTNER_DIRECTORY_LINK,
 				},
 			],


### PR DESCRIPTION
Context:  p1749812687270229/1749745262.071259-slack-C047ACYM8UQ

<img width="1102" alt="Screenshot 2025-06-13 at 7 15 37 PM" src="https://github.com/user-attachments/assets/00138588-8074-4d91-aa57-5400e5458096" />
<img width="997" alt="Screenshot 2025-06-13 at 7 34 13 PM" src="https://github.com/user-attachments/assets/59ba4457-b615-48a5-bf06-699a50715b94" />


## Proposed Changes

* Pluralize 'Partner Directory' sidebar menu label to 'Partner Directories'.
* Pluralize 'Agency Tier' sidebar menu label to 'Agency tiers'.
* Update related page titles to reflect sidebar label changes.

## Why are these changes being made?

* This ensures our language accurately represents our products and features.

## Testing Instructions

* Use A4A live link and navigate to the `/overview` page.
* Verify that the sidebar menu and related pages have been correctly updated. See screenshot above for reference.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?