### PR TITLE
Migrate subscribers modal - update styles and inline support.

### DIFF
--- a/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
@@ -104,6 +104,7 @@ const MigrateSubscribersModal = ( {
 									supportLink={ localizeUrl( migrateSubscribersUrl ) }
 									showIcon={ ! supportPostId }
 									supportPostId={ supportPostId }
+									onClick={ supportPostId && onClose }
 								/>
 							),
 						}

--- a/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
@@ -71,6 +71,7 @@ const MigrateSubscribersModal = ( {
 		? 'https://jetpack.com/support/newsletter/import-subscribers/#migrate-subscribers-from-a-word-press-com-site'
 		: 'https://wordpress.com/support/migrate-subscribers-from-another-site/';
 
+	// Keep the link external on jetpack cloud.
 	const supportPostId = ! isWPCOMSite ? null : 312690;
 
 	const selectionRender = (

--- a/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
@@ -102,7 +102,7 @@ const MigrateSubscribersModal = ( {
 							Button: (
 								<InlineSupportLink
 									supportLink={ localizeUrl( migrateSubscribersUrl ) }
-									showIcon={ false }
+									showIcon={ ! supportPostId }
 									supportPostId={ supportPostId }
 								/>
 							),

--- a/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
@@ -1,9 +1,10 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { ActionButtons, BackButton, NextButton } from '@automattic/onboarding';
-import { Modal, Button, ButtonGroup } from '@wordpress/components';
+import { Modal, ButtonGroup } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import SitesDropdown from 'calypso/components/sites-dropdown';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
@@ -70,6 +71,8 @@ const MigrateSubscribersModal = ( {
 		? 'https://jetpack.com/support/newsletter/import-subscribers/#migrate-subscribers-from-a-word-press-com-site'
 		: 'https://wordpress.com/support/migrate-subscribers-from-another-site/';
 
+	const supportPostId = ! isWPCOMSite ? null : 312690;
+
 	const selectionRender = (
 		<div className="migrate-subscribers-modal__content">
 			<div className="migrate-subscribers-modal__form--container">
@@ -97,10 +100,10 @@ const MigrateSubscribersModal = ( {
 						translate( 'For more details, take a look at our <Button>support document</Button>.' ),
 						{
 							Button: (
-								<Button
-									variant="link"
-									target="_blank"
-									href={ localizeUrl( migrateSubscribersUrl ) }
+								<InlineSupportLink
+									supportLink={ localizeUrl( migrateSubscribersUrl ) }
+									showIcon={ false }
+									supportPostId={ supportPostId }
 								/>
 							),
 						}

--- a/client/my-sites/subscribers/components/migrate-subscribers-modal/style.scss
+++ b/client/my-sites/subscribers/components/migrate-subscribers-modal/style.scss
@@ -43,6 +43,10 @@
 
 	.migrate-subscribers-modal__form--container {
 		width: 100%;
+
+		.is-group-jetpack-cloud & p {
+			font-size: 1rem;
+		}
 	}
 
 	.migrate-subscriber__form-cancel-btn {

--- a/client/my-sites/subscribers/components/migrate-subscribers-modal/style.scss
+++ b/client/my-sites/subscribers/components/migrate-subscribers-modal/style.scss
@@ -49,30 +49,8 @@
 		box-shadow: unset;
 	}
 
-
-	.migrate-subscribers-modal__form--disclaimer {
-		font-size: $font-body-small;
-		line-height: 1.25;
-		color: var(--studio-gray-50);
-		margin-top: 16px;
-		strong {
-			white-space: nowrap;
-		}
-
-		a,
-		button {
-			font-size: $font-body-small;
-			color: var(--color-text);
-			text-decoration: underline;
-			height: unset;
-
-			&:hover {
-				color: var(--color-text-subtle);
-			}
-		}
-
-		.components-button {
-			padding: 0;
-		}
+	.sites-dropdown {
+		margin-top: 4px;
+		margin-bottom: 8px;
 	}
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/CML-568/update-migrate-subscribers-modal / https://github.com/Automattic/wp-calypso/issues/102123

## Proposed Changes

* Various style updates to the modal as suggested in the issue. Mostly removal of styles, and adding some margin to the site selector in this modal.
* Replaces the button link with `InlineSupportLink`, so we can open the link in the help center when possible. This also closes the modal when we open the support link in the help center (as suggested on the issue).
    * Note that Jetpack sites will still link externally to their jetpack support documentation for various reasons, both in calypso and jetpack cloud.

BEFORE
![Screenshot 2025-06-13 at 9 59 05 AM](https://github.com/user-attachments/assets/78e0d0d3-8d13-4cd4-ba19-cde1ef6c5077)
![inline-support-before](https://github.com/user-attachments/assets/d0c6c0ac-2a77-47ea-bdd6-80e361154d48)


AFTER
![Screenshot 2025-06-13 at 9 58 18 AM](https://github.com/user-attachments/assets/b0ce880d-686f-4c38-9fbb-e309d138f3c1)
![inline-support-after](https://github.com/user-attachments/assets/7699d32a-1345-404d-ba09-1e21a5244618)



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Styles are a bit wonky and mismatching their environments. 
* We should open support links inline with the help center when possible.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Go to subscribers in calypso with a dotcom site.
* Open the migration tool in the ellipsis menu in the top right.
* In the modal, verify the new styles.
* Verify clicking the support link closes the modal and opens the help center.
<br/>

* Go to subscribers in jetpack cloud with a jetpack site.
* Open the modal and verify the new styles look good.
* Repeat the above, verify the jetpack support link opens externally as it did before.
<br/>

* You can also test a jetpack site in calypso's version of subscribers. It is not common to get there but there seem to be some odd flows where it may be exposed. Just append your jetpack site url in the url for the calypso subscribers page and test.
* In this circumstance, the jetpack support link should still open externally.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
