### PR TITLE
Help Center: Improve screen reader accessibility by making hash-linked elements focusable

### DIFF
--- a/packages/help-center/src/hooks/use-content-filter.ts
+++ b/packages/help-center/src/hooks/use-content-filter.ts
@@ -70,7 +70,10 @@ export const useContentFilter = ( node: HTMLDivElement | null ) => {
 						event.preventDefault();
 						// We need to use CSS.escape since we can have non latin chars in the hash
 						const target = node?.querySelector( `#${ CSS.escape( hash.slice( 1 ) ) }` );
-						if ( target ) {
+						if ( target instanceof HTMLElement ) {
+							target.setAttribute( 'tabindex', '-1' );
+							target.focus();
+
 							target.scrollIntoView();
 						}
 					};
@@ -135,7 +138,7 @@ export const useContentFilter = ( node: HTMLDivElement | null ) => {
 				},
 			},
 		],
-		[ navigate, link, node ]
+		[ navigate, link, node, site?.domain ]
 	);
 
 	useEffect( () => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-13424 

## Proposed Changes

* improve screen reader accessibility by making hash-linked elements focusable
* add missing `site?.domain` dependency (not related to the fix)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

At the moment it is not possible to use TOC links in articles loaded in the Help Center.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start` (or use Calypso Live).
2. Open one of the documentation articles in the Help Center in Calypso that has table of contents at the top.
3. Enable VoiceOver.
4. Tab through the items and then select one using <kbd>control</kbd> + <kbd>option</kbd> + <kbd>space</kbd>.
5. Observe how the focus jumps to the related h2 heading and this heading is also announced. Please note that while VoiceOver is enabled, the page scroll works differently: It won't make the heading scrolled at the top of the Help Center. Instead, the focused heading will be in the middle of the Help Center. This is expected.
6. If you then use <kbd>tab</kbd> or <kbd>control</kbd> + <kbd>option</kbd> + arrows, you should be moving from that focused h2 tag.
7. Disable VoiceOver and try to navigate the Help Center as usual. The scrolling and links should work as expected. There should be no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?