### PR TITLE
Purchases: Enable DataViews version everywhere

### DIFF
--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -73,6 +73,7 @@
 		"newsletter-categories": true,
 		"oauth": true,
 		"purchases/new-payment-methods": true,
+		"purchases/purchase-list-dataview": true,
 		"realtime-site-count": true,
 		"site-indicator": false,
 		"upgrades/redirect-payments": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -65,6 +65,7 @@
 		"newsletter-categories": true,
 		"oauth": false,
 		"purchases/new-payment-methods": true,
+		"purchases/purchase-list-dataview": true,
 		"realtime-site-count": true,
 		"site-indicator": false,
 		"upgrades/redirect-payments": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -70,6 +70,7 @@
 		"newsletter-categories": true,
 		"oauth": true,
 		"purchases/new-payment-methods": true,
+		"purchases/purchase-list-dataview": true,
 		"realtime-site-count": true,
 		"site-indicator": false,
 		"upgrades/redirect-payments": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -70,6 +70,7 @@
 		"newsletter-categories": true,
 		"oauth": true,
 		"purchases/new-payment-methods": true,
+		"purchases/purchase-list-dataview": true,
 		"realtime-site-count": true,
 		"site-indicator": false,
 		"upgrades/redirect-payments": true,

--- a/config/production.json
+++ b/config/production.json
@@ -115,7 +115,7 @@
 		"press-this": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
-		"purchases/purchase-list-dataview": false,
+		"purchases/purchase-list-dataview": true,
 		"push-notifications": true,
 		"reader": true,
 		"reader/full-errors": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -112,7 +112,7 @@
 		"press-this": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
-		"purchases/purchase-list-dataview": false,
+		"purchases/purchase-list-dataview": true,
 		"push-notifications": true,
 		"reader": true,
 		"reader/full-errors": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -120,7 +120,7 @@
 		"press-this": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
-		"purchases/purchase-list-dataview": false,
+		"purchases/purchase-list-dataview": true,
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/quick-post": true,


### PR DESCRIPTION
## Proposed Changes

This PR enables the DataViews version of the purchases list in all environments.

Completes the project https://linear.app/a8c/project/replace-calypsos-active-upgrades-subscriptions-with-dataviews-a7b39dea5417/overview

Tracked by https://linear.app/a8c/issue/CHE-198/purchases-enable-dataviews-version-everywhere

## Testing Instructions

- Visit `/me/purchases` and verify that everything looks ok.