### PR TITLE
Add label for Woo logo on Woo login page

### DIFF
--- a/client/layout/masterbar/woo.jsx
+++ b/client/layout/masterbar/woo.jsx
@@ -51,7 +51,11 @@ const WooOauthMasterbar = () => {
 				<nav className="masterbar__woo-nav-wrapper">
 					<ul className="masterbar__woo-nav">
 						<li className="masterbar__woo-nav-item">
-							<a href="https://woocommerce.com" className="masterbar__woo-link">
+							<a
+								href="https://woocommerce.com"
+								className="masterbar__woo-link"
+								aria-label="WooCommerce"
+							>
 								<SVGIcon
 									name="woocommerce-logo"
 									icon={ WooLogo }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13186

## Proposed Changes

* I propose to add label for Woo logo on Woo login page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To meet accessibility standards.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to https://woocommerce.com/
2. Click Log in
3. Replace wordpress.com domain with Calypso Live or local link
4. Confirm that axe Dev Tools doesn't show issue with logo without alt text

<img width="1387" alt="Screenshot 2025-06-13 at 16 34 19" src="https://github.com/user-attachments/assets/45204ef7-5ea1-4094-b2a2-bc03cfa8a1fb" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
