### PR TITLE
Subscriber import limit notice - fix issues with opening inline help and jetpack links

### DIFF
--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -181,7 +181,7 @@ const AddSubscribersModal = ( {
 							</span>
 						</Notice>
 					) }
-					<SubscriberImportLimitNotice />
+					<SubscriberImportLimitNotice closeModal={ onClose } />
 					{ ! isUploading && isImportInProgress && hasStaleImportJobs && (
 						<StaleImportJobsNotice isJetpack={ isJetpack } siteId={ site?.ID || null } />
 					) }
@@ -230,7 +230,7 @@ const AddSubscribersModal = ( {
 							</span>
 						</Notice>
 					) }
-					<SubscriberImportLimitNotice />
+					<SubscriberImportLimitNotice closeModal={ onClose } />
 					{ ! isUploading && isImportInProgress && hasStaleImportJobs && (
 						<StaleImportJobsNotice isJetpack={ isJetpack } siteId={ site?.ID || null } />
 					) }

--- a/client/my-sites/subscribers/components/subscriber-import-limit-notice/index.tsx
+++ b/client/my-sites/subscribers/components/subscriber-import-limit-notice/index.tsx
@@ -4,18 +4,30 @@ import { Notice } from '@wordpress/components';
 import { useTranslate, fixMe } from 'i18n-calypso';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useSelector } from 'calypso/state';
+import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+
 import './style.scss';
 
-export default function SubscriberImportLimitNotice() {
+export default function SubscriberImportLimitNotice( {
+	closeModal = () => {},
+}: {
+	closeModal?: () => void;
+} ) {
 	const translate = useTranslate();
 	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
 	const currentPlan = selectedSite?.plan?.product_slug || '';
 	const isOnFreePlan = isFreePlan( currentPlan ) || isJetpackFreePlan( currentPlan );
+	const isWPCOMSite = useSelector( ( state ) => getIsSiteWPCOM( state, selectedSite?.ID ) );
 
 	if ( ! isOnFreePlan || ! selectedSite?.ID ) {
 		return null;
 	}
+
+	const supportLink = ! isWPCOMSite
+		? 'https://jetpack.com/support/newsletter/import-subscribers/#add-up-to-100-subscribers'
+		: 'https://wordpress.com/support/import-subscribers-to-a-newsletter/#import-limits';
+	const supportPostId = ! isWPCOMSite ? null : 220199;
 
 	return (
 		<Notice status="info" isDismissible={ false } className="subscribers-import-limit-notice">
@@ -28,11 +40,10 @@ export default function SubscriberImportLimitNotice() {
 							supportLink: (
 								<InlineSupportLink
 									noWrap={ false }
-									showIcon={ false }
-									supportLink={ localizeUrl(
-										'https://wordpress.com/support/import-subscribers-to-a-newsletter/#import-limits'
-									) }
-									supportPostId={ 220199 }
+									showIcon={ ! supportPostId }
+									supportLink={ localizeUrl( supportLink ) }
+									supportPostId={ supportPostId }
+									onClick={ supportPostId && closeModal }
 								/>
 							),
 							upgradeLink: <a href={ `/plans/${ selectedSite.slug }` } />,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

follow up on # https://github.com/Automattic/wp-calypso/pull/104101

## Proposed Changes

Some updates to this shared notice component we added earlier this week:
* Updates the notice to link to the Jetpack support docs for jetpack sites.
* Updates the notice to trigger parent modals to close if we are opening the support doc inline with the help center.

BEFORE
![wpcom-link-before](https://github.com/user-attachments/assets/6b76913d-cc2c-460c-85fa-0108c659478a)


AFTER
![wpcom-link-after](https://github.com/user-attachments/assets/82ac34f8-4469-4821-9b26-627eb8efbde9)
![jetpack-after](https://github.com/user-attachments/assets/c043df6c-82bd-467e-a68d-c8fa462bf781)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Jetpack sites we getting linked to wpcom support
* in calypso, clicking this link to open support in the help center did not close the modal, leaving the help center hidden behind the gray backdrop. Closing modals when opening inline support was advised in related issues such as https://github.com/Automattic/wp-calypso/pull/104208 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to subscribers in calypso.
* Open the import modal.
* after selecting either to import manually or upload csv, click the support link about the 100 subscribers limit.
* verify the modal now closes when the help center is opened.
<br/>

* Go to subscribers in jetpack cloud.
* Repeat the steps above.
* Verify that the modal now opens jetpack support in a new tab. This was previously opening the help center with an error, and also pointing to wpcom support docs.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
