### PR TITLE
Checkout: Set max wait time for auto-completing contact step

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-prefill-checkout-contact-form.ts
+++ b/client/my-sites/checkout/src/hooks/use-prefill-checkout-contact-form.ts
@@ -81,6 +81,7 @@ function useCachedContactDetailsForCheckoutForm(
 			} )
 			.then( ( didSkip: boolean ) => {
 				if ( ! isMounted.current ) {
+					didFillForm.current = false;
 					return false;
 				}
 				if ( didSkip ) {
@@ -91,7 +92,11 @@ function useCachedContactDetailsForCheckoutForm(
 			} )
 			.catch( ( error: Error ) => {
 				setShouldShowContactDetailsValidationErrors?.( true );
-				isMounted.current && setComplete( true );
+				if ( isMounted.current ) {
+					setComplete( true );
+				} else {
+					didFillForm.current = false;
+				}
 				// eslint-disable-next-line no-console
 				console.error( 'Error while autocompleting contact details:', error );
 				logToLogstash( {

--- a/client/my-sites/checkout/src/hooks/use-prefill-checkout-contact-form.ts
+++ b/client/my-sites/checkout/src/hooks/use-prefill-checkout-contact-form.ts
@@ -46,6 +46,16 @@ function useCachedContactDetailsForCheckoutForm(
 		};
 	}, [] );
 
+	// Set a max loading time. If for some reason fetching the contact details
+	// gets stuck, we don't want to block the user from entering info into the
+	// form. Auto-complete should be an enhancement, not a required feature.
+	const maxWaitTimeoutMs = 800;
+	useEffect( () => {
+		setTimeout( () => {
+			setComplete( true );
+		}, maxWaitTimeoutMs );
+	}, [] );
+
 	// When we have fetched or loaded contact details, send them to the
 	// `wpcom-checkout` data store for use by the checkout contact form.
 	useEffect( () => {


### PR DESCRIPTION
## Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/99149 a modification was made to the code that attempts to autocomplete the checkout contact details step so that it would not even attempt to render the contact form until the autocomplete attempt had succeeded or failed. However, we've noticed since then that the checkout contact unit tests often fail apparently randomly ([for example](https://github.com/Automattic/wp-calypso/pull/104176#issuecomment-2970363689)).

In this PR, I'm adding code to make sure that the autocomplete code will allow the contact form to render even if the autocomplete attempt has not finished after a certain timeout has been reached (currently 800 milliseconds). This should provide a fallback in case something gets stuck and allow the user to fill out their contact form manually.

Tracked by https://linear.app/a8c/issue/CHE-199/checkout-set-max-wait-time-for-auto-completing-contact-step

## Testing Instructions

Automated tests.