### PR TITLE
Purchases: Add fallback text for "Product Description"

### DIFF
--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -401,12 +401,13 @@ export function getMembershipsFieldDefinitions( {
 		},
 		{
 			id: 'description',
-			label: fixMe( {
-				text: 'Product Description',
-				newCopy: translate( 'Product Description' ),
-				oldCopy: translate( 'Description' ),
-				translationOptions: { textOnly: true },
-			} ),
+			label: String(
+				fixMe( {
+					text: 'Product Description',
+					newCopy: translate( 'Product Description', { textOnly: true } ),
+					oldCopy: translate( 'Description', { textOnly: true } ),
+				} )
+			),
 			type: 'text',
 			enableGlobalSearch: true,
 			enableSorting: true,

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { Purchases, SiteDetails } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
 import { Fields } from '@wordpress/dataviews';
-import { LocalizeProps } from 'i18n-calypso';
+import { fixMe, LocalizeProps } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
 import { getDisplayName, isExpired, isRenewing, purchaseType } from 'calypso/lib/purchases';
@@ -401,7 +401,12 @@ export function getMembershipsFieldDefinitions( {
 		},
 		{
 			id: 'description',
-			label: translate( 'Product Description' ),
+			label: fixMe( {
+				text: 'Product Description',
+				newCopy: translate( 'Product Description' ),
+				oldCopy: translate( 'Description' ),
+				translationOptions: { textOnly: true },
+			} ),
 			type: 'text',
 			enableGlobalSearch: true,
 			enableSorting: true,


### PR DESCRIPTION
## Proposed Changes

In the interest of launching sooner rather than later, this PR adds fallback text to a new untranslated string added by https://github.com/Automattic/wp-calypso/pull/104124

Part of  https://linear.app/a8c/project/replace-calypsos-active-upgrades-subscriptions-with-dataviews-a7b39dea5417/overview

## Testing Instructions

- Visit /me/purchases and verify that everything looks ok.