### PR TITLE
Theme Showcase: Update Theme Support Cards

### DIFF
--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -744,44 +744,6 @@ $button-border: 4px;
 	}
 }
 
-.theme__sheet-card-support {
-	display: flex;
-	align-items: center;
-
-	&:not(:last-child) {
-		margin-bottom: 0;
-	}
-
-	@include breakpoint-deprecated( "<960px" ) {
-		flex-wrap: wrap;
-	}
-
-	.gridicon {
-		color: var(--color-neutral-10);
-		flex: 0 0 auto;
-	}
-
-	.button {
-		flex: 0 0 auto;
-
-		@include breakpoint-deprecated( "<960px" ) {
-			flex: 1 1 100%;
-			margin-top: 20px;
-			text-align: center;
-		}
-	}
-}
-
-.theme__sheet-card-support-details {
-	flex: 1 1 20px;
-	padding: 0 20px;
-
-	small {
-		display: block;
-		color: var(--color-grey-10);
-	}
-}
-
 .theme__sheet-footer-line {
 	color: var(--color-neutral-10);
 	border-top: 1px solid var(--color-neutral-10);

--- a/client/my-sites/theme/theme-support-tab/index.jsx
+++ b/client/my-sites/theme/theme-support-tab/index.jsx
@@ -1,0 +1,102 @@
+import { Card, Gridicon } from '@automattic/components';
+import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { Button } from '@wordpress/components';
+import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
+import { useTranslate } from 'i18n-calypso';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+import './style.scss';
+
+export default function ThemeSupportTab( { themeId } ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const { setNavigateToOdie, setShowHelpCenter } = useDataStoreDispatch( HELP_CENTER_STORE );
+
+	return (
+		<>
+			<Card className="theme__sheet-card-support">
+				<Gridicon icon="play" size={ 48 } />
+				<div className="theme__sheet-card-support-details">
+					{ translate( 'Learn WordPress' ) }
+					<small>
+						{ translate(
+							'Follow along with beginner-friendly courses and build your first website or blog'
+						) }
+					</small>
+				</div>
+				<Button
+					__next40pxDefaultSize
+					href={ localizeUrl( 'https://wordpress.com/support/courses' ) }
+					onClick={ () =>
+						dispatch(
+							recordTracksEvent( 'calypso_theme_sheet_button_click', {
+								theme_name: themeId,
+								button_context: 'courses',
+							} )
+						)
+					}
+					rel="noreferrer"
+					target="_blank"
+					variant="primary"
+				>
+					{ translate( 'Watch a course' ) }
+				</Button>
+			</Card>
+
+			<Card className="theme__sheet-card-support">
+				<Gridicon icon="help-outline" size={ 48 } />
+				<div className="theme__sheet-card-support-details">
+					{ translate( 'Discover comprehensive guides' ) }
+					<small>
+						{ translate( 'Explore deep-dive tutorials for every WordPress.com feature' ) }
+					</small>
+				</div>
+				<Button
+					__next40pxDefaultSize
+					onClick={ () => {
+						setShowHelpCenter( true );
+						dispatch(
+							recordTracksEvent( 'calypso_theme_sheet_button_click', {
+								theme_name: themeId,
+								button_context: 'help-center',
+							} )
+						);
+					} }
+					variant="secondary"
+				>
+					{ translate( 'Visit guides' ) }
+				</Button>
+			</Card>
+
+			<Card className="theme__sheet-card-support">
+				<Gridicon icon="comment" size={ 48 } />
+				<div className="theme__sheet-card-support-details">
+					{ translate( 'Contact support' ) }
+					<small>
+						{ translate(
+							'Get answers from our AI assistant, with access to 24/7 expert human support on paid plans'
+						) }
+					</small>
+				</div>
+				<Button
+					__next40pxDefaultSize
+					onClick={ () => {
+						setNavigateToOdie();
+						dispatch(
+							recordTracksEvent( 'calypso_theme_sheet_button_click', {
+								theme_name: themeId,
+								button_context: 'help-center-ai',
+							} )
+						);
+					} }
+					variant="secondary"
+				>
+					{ translate( 'Get in touch' ) }
+				</Button>
+			</Card>
+		</>
+	);
+}

--- a/client/my-sites/theme/theme-support-tab/index.jsx
+++ b/client/my-sites/theme/theme-support-tab/index.jsx
@@ -4,8 +4,9 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 import './style.scss';
 
@@ -13,6 +14,7 @@ export default function ThemeSupportTab( { themeId } ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
+	const isLoggedIn = useSelector( isUserLoggedIn );
 	const { setNavigateToOdie, setShowHelpCenter } = useDataStoreDispatch( HELP_CENTER_STORE );
 
 	return (
@@ -46,57 +48,61 @@ export default function ThemeSupportTab( { themeId } ) {
 				</Button>
 			</Card>
 
-			<Card className="theme__sheet-card-support">
-				<Gridicon icon="help-outline" size={ 48 } />
-				<div className="theme__sheet-card-support-details">
-					{ translate( 'Discover comprehensive guides' ) }
-					<small>
-						{ translate( 'Explore deep-dive tutorials for every WordPress.com feature' ) }
-					</small>
-				</div>
-				<Button
-					__next40pxDefaultSize
-					onClick={ () => {
-						setShowHelpCenter( true );
-						dispatch(
-							recordTracksEvent( 'calypso_theme_sheet_button_click', {
-								theme_name: themeId,
-								button_context: 'help-center',
-							} )
-						);
-					} }
-					variant="secondary"
-				>
-					{ translate( 'Visit guides' ) }
-				</Button>
-			</Card>
+			{ isLoggedIn && (
+				<>
+					<Card className="theme__sheet-card-support">
+						<Gridicon icon="help-outline" size={ 48 } />
+						<div className="theme__sheet-card-support-details">
+							{ translate( 'Discover comprehensive guides' ) }
+							<small>
+								{ translate( 'Explore deep-dive tutorials for every WordPress.com feature' ) }
+							</small>
+						</div>
+						<Button
+							__next40pxDefaultSize
+							onClick={ () => {
+								setShowHelpCenter( true );
+								dispatch(
+									recordTracksEvent( 'calypso_theme_sheet_button_click', {
+										theme_name: themeId,
+										button_context: 'help-center',
+									} )
+								);
+							} }
+							variant="secondary"
+						>
+							{ translate( 'Visit guides' ) }
+						</Button>
+					</Card>
 
-			<Card className="theme__sheet-card-support">
-				<Gridicon icon="comment" size={ 48 } />
-				<div className="theme__sheet-card-support-details">
-					{ translate( 'Contact support' ) }
-					<small>
-						{ translate(
-							'Get answers from our AI assistant, with access to 24/7 expert human support on paid plans'
-						) }
-					</small>
-				</div>
-				<Button
-					__next40pxDefaultSize
-					onClick={ () => {
-						setNavigateToOdie();
-						dispatch(
-							recordTracksEvent( 'calypso_theme_sheet_button_click', {
-								theme_name: themeId,
-								button_context: 'help-center-ai',
-							} )
-						);
-					} }
-					variant="secondary"
-				>
-					{ translate( 'Get in touch' ) }
-				</Button>
-			</Card>
+					<Card className="theme__sheet-card-support">
+						<Gridicon icon="comment" size={ 48 } />
+						<div className="theme__sheet-card-support-details">
+							{ translate( 'Contact support' ) }
+							<small>
+								{ translate(
+									'Get answers from our AI assistant, with access to 24/7 expert human support on paid plans'
+								) }
+							</small>
+						</div>
+						<Button
+							__next40pxDefaultSize
+							onClick={ () => {
+								setNavigateToOdie();
+								dispatch(
+									recordTracksEvent( 'calypso_theme_sheet_button_click', {
+										theme_name: themeId,
+										button_context: 'help-center-ai',
+									} )
+								);
+							} }
+							variant="secondary"
+						>
+							{ translate( 'Get in touch' ) }
+						</Button>
+					</Card>
+				</>
+			) }
 		</>
 	);
 }

--- a/client/my-sites/theme/theme-support-tab/index.jsx
+++ b/client/my-sites/theme/theme-support-tab/index.jsx
@@ -25,7 +25,7 @@ export default function ThemeSupportTab( { themeId } ) {
 					{ translate( 'Learn WordPress' ) }
 					<small>
 						{ translate(
-							'Follow along with beginner-friendly courses and build your first website or blog'
+							'Follow along with beginner-friendly courses and build your first website or blog.'
 						) }
 					</small>
 				</div>
@@ -42,7 +42,7 @@ export default function ThemeSupportTab( { themeId } ) {
 					}
 					rel="noreferrer"
 					target="_blank"
-					variant="primary"
+					variant="secondary"
 				>
 					{ translate( 'Watch a course' ) }
 				</Button>
@@ -55,7 +55,7 @@ export default function ThemeSupportTab( { themeId } ) {
 						<div className="theme__sheet-card-support-details">
 							{ translate( 'Discover comprehensive guides' ) }
 							<small>
-								{ translate( 'Explore deep-dive tutorials for every WordPress.com feature' ) }
+								{ translate( 'Explore deep-dive tutorials for every WordPress.com feature.' ) }
 							</small>
 						</div>
 						<Button
@@ -81,7 +81,7 @@ export default function ThemeSupportTab( { themeId } ) {
 							{ translate( 'Contact support' ) }
 							<small>
 								{ translate(
-									'Get answers from our AI assistant, with access to 24/7 expert human support on paid plans'
+									'Get answers from our AI assistant, with access to 24/7 expert human support on paid plans.'
 								) }
 							</small>
 						</div>

--- a/client/my-sites/theme/theme-support-tab/style.scss
+++ b/client/my-sites/theme/theme-support-tab/style.scss
@@ -2,39 +2,36 @@
 @import "@wordpress/base-styles/variables";
 
 .theme__sheet-card-support {
-	display: flex;
 	align-items: center;
-
-	&:not(:last-child) {
-		margin-bottom: 0;
-	}
-
-	@include breakpoint-deprecated( "<960px" ) {
-		flex-wrap: wrap;
-	}
+	display: grid;
+	gap: 0 20px;
+	grid-template-columns: 48px 1fr;
 
 	.gridicon {
 		color: var(--color-neutral-10);
-		flex: 0 0 auto;
-	}
+ 	}
 
-	.button {
-		flex: 0 0 auto;
+	.theme__sheet-card-support-details {
+		text-wrap: pretty;
 
-		@include breakpoint-deprecated( "<960px" ) {
-			flex: 1 1 100%;
-			margin-top: 20px;
-			text-align: center;
+		small {
+			display: block;
 		}
 	}
-}
 
-.theme__sheet-card-support-details {
-	flex: 1 1 20px;
-	padding: 0 20px;
+	.components-button {
+		grid-column: 2;
+		justify-self: start;
+		margin-top: 20px;
+	}
 
-	small {
-		display: block;
-		color: var(--color-grey-10);
+	@media (min-width: #{ ($break-small) }) and (max-width: #{ ($break-medium) }), (min-width: #{ ($break-wide) }) {
+		grid-template-columns: 48px 1fr auto;
+
+		.components-button {
+			grid-column: 3;
+			justify-self: end;
+			margin-top: 0;
+		}
 	}
 }

--- a/client/my-sites/theme/theme-support-tab/style.scss
+++ b/client/my-sites/theme/theme-support-tab/style.scss
@@ -9,7 +9,7 @@
 
 	.gridicon {
 		color: var(--color-neutral-10);
- 	}
+	}
 
 	.theme__sheet-card-support-details {
 		text-wrap: pretty;

--- a/client/my-sites/theme/theme-support-tab/style.scss
+++ b/client/my-sites/theme/theme-support-tab/style.scss
@@ -1,0 +1,40 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
+.theme__sheet-card-support {
+	display: flex;
+	align-items: center;
+
+	&:not(:last-child) {
+		margin-bottom: 0;
+	}
+
+	@include breakpoint-deprecated( "<960px" ) {
+		flex-wrap: wrap;
+	}
+
+	.gridicon {
+		color: var(--color-neutral-10);
+		flex: 0 0 auto;
+	}
+
+	.button {
+		flex: 0 0 auto;
+
+		@include breakpoint-deprecated( "<960px" ) {
+			flex: 1 1 100%;
+			margin-top: 20px;
+			text-align: center;
+		}
+	}
+}
+
+.theme__sheet-card-support-details {
+	flex: 1 1 20px;
+	padding: 0 20px;
+
+	small {
+		display: block;
+		color: var(--color-grey-10);
+	}
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTTHEM-17

## Proposed Changes

* Update the Calypso Theme Showcase support cards.
* Display the same support content to any site type, for any kind of theme.

| Before | After |
|--------|--------|
| ![Screenshot 2025-06-13 at 17 33 23](https://github.com/user-attachments/assets/27750ed8-ac0b-4e3e-81d6-9daf216a9509) | ![Screenshot 2025-06-14 at 11 02 02](https://github.com/user-attachments/assets/80760118-843c-4670-b7d4-ae770f1738d1) | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Discontinuing generic theme support, as it tends to become outdated.
* Providing a clear path to self-serve help content.
* Focusing the theme page on exploring the theme itself.
* Driving support questions to the Help Center instead of forums.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the Theme Showcase (`/themes`).
* Click on a theme (any theme).
* Scroll to the bottom, and locate the support cards.
* Try all three buttons.
  * "Watch a course" should open [Courses](https://wordpress.com/support/courses/) in a separate tab.
  * "Visit guides" should open the Help Center, focused on theme related content. (Note: content displayed depends on a separate PR: 185499-ghe-Automattic/wpcom).
  * "Get in touch" should open the AI assistant in the Help Center.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?