### PR TITLE
E2E: Remove card view option from PurchasesPage clickOnPurchase

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/me/purchases-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/purchases-page.ts
@@ -38,7 +38,7 @@ export class PurchasesPage {
 			.locator( '#purchases-list .dataviews-view-table__row' )
 			.filter( { hasText: name } )
 			.filter( { hasText: siteSlug } )
-			.locator( '.dataviews-view-table__actions-column button' )
+			.locator( '.purchase-item__title button' )
 			.click();
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/me/purchases-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/purchases-page.ts
@@ -34,24 +34,11 @@ export class PurchasesPage {
 	 * @param {string} siteSlug Site slug.
 	 */
 	async clickOnPurchase( name: string, siteSlug: string ) {
-		const purchasesListDataView = this.page.locator( '#purchases-list .dataviews-wrapper' );
-		const purchasesListCardView = this.page.locator( '.card.purchase-item' );
-		await purchasesListCardView.or( purchasesListDataView ).first().waitFor( { state: 'visible' } );
-
-		if ( await purchasesListDataView.isVisible() ) {
-			await this.page
-				.locator( '#purchases-list .dataviews-view-table__row' )
-				.filter( { hasText: name } )
-				.filter( { hasText: siteSlug } )
-				.locator( '.dataviews-view-table__actions-column button' )
-				.click();
-			return;
-		}
-
 		await this.page
-			.locator( '.card.purchase-item' )
+			.locator( '#purchases-list .dataviews-view-table__row' )
 			.filter( { hasText: name } )
 			.filter( { hasText: siteSlug } )
+			.locator( '.dataviews-view-table__actions-column button' )
 			.click();
 	}
 


### PR DESCRIPTION
## Proposed Changes

This PR is a follow-up to https://github.com/Automattic/wp-calypso/pull/103897 which updates the purchases list component of the e2e tests to work with the DataViews version of the purchases list as well as the card version still used in production. In https://github.com/Automattic/wp-calypso/pull/104212 we are enabling this feature everywhere so this PR removes the handling of the old version of the purchases page.

In addition, this fixes a regression because https://github.com/Automattic/wp-calypso/pull/104013 changed how you click on a purchase; you now have to click on the title and not the (removed) chevron.

Part of https://linear.app/a8c/project/replace-calypsos-active-upgrades-subscriptions-with-dataviews-a7b39dea5417/overview / https://github.com/Automattic/wp-calypso/issues/86616

## Why are these changes being made?

As we migrate the purchases list to use DataViews, we must make sure that the e2e tests continue to work.

Tracked by https://linear.app/a8c/issue/CHE-155/fix-e2e-tests-to-use-dataviews-subscription-list

## Testing Instructions

First, prepare the e2e tests [following these instructions](https://github.com/Automattic/wp-calypso/blob/e7e11899710f88a4ab1f059ca520b7e562bc037f/test/e2e/README.md) but don't actually run any yet. (NOTE: you will need access to the secret store.)

Third, start localhost calypso: `yarn && yarn start`

Fourth, make your environment use calypso.localhost: `export CALYPSO_BASE_URL=http://calypso.localhost:3000`

Finally, run the following test and verify it passes: `yarn workspace wp-e2e-tests test test/e2e/specs/onboarding/signup__with-theme-LOHP.ts`

