### PR TITLE
Newsletter importer: Add unsupported files notice

### DIFF
--- a/client/my-sites/importer/newsletter/content-upload/author-mapping-pane.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/author-mapping-pane.jsx
@@ -147,8 +147,8 @@ class AuthorMappingPane extends PureComponent {
 		}
 
 		const formattedTypes = fileTypes.map( ( [ type, count ] ) => {
-			/* translators: %(count)d is the number of files, %(type)s is the file extension (e.g. "avif", "svg") */
-			return translate( '%(count)d .%(type)s image', {
+			/* translators: %(count)s is the number of files, %(type)s is the file extension (e.g. "avif", "svg") */
+			return translate( '%(count)s .%(type)s image', {
 				args: {
 					count: formatNumber( count ),
 					type,

--- a/client/my-sites/importer/newsletter/content-upload/author-mapping-pane.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/author-mapping-pane.jsx
@@ -1,10 +1,12 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { Notice } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { verse, page, file } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import useUsersQuery from 'calypso/data/users/use-users-query';
 import AuthorMapping from 'calypso/my-sites/importer/author-mapping-item';
 import ImporterActionButton from 'calypso/my-sites/importer/importer-action-buttons/action-button';
@@ -26,6 +28,12 @@ class AuthorMappingPane extends PureComponent {
 			importerState: PropTypes.string.isRequired,
 			percentComplete: PropTypes.number,
 			statusMessage: PropTypes.string,
+			customData: PropTypes.shape( {
+				unsupportedFileTypes: PropTypes.object,
+				postsNumber: PropTypes.number,
+				pagesNumber: PropTypes.number,
+				attachmentsNumber: PropTypes.number,
+			} ),
 		} ),
 		onMap: PropTypes.func,
 		onStartImport: PropTypes.func,
@@ -124,6 +132,61 @@ class AuthorMappingPane extends PureComponent {
 		}
 	};
 
+	getUnsupportedFilesMessage() {
+		const { translate } = this.props;
+		const unsupportedFiles = this.props.importerStatus?.customData?.unsupportedFileTypes;
+
+		if ( ! unsupportedFiles ) {
+			return null;
+		}
+
+		const fileTypes = Object.entries( unsupportedFiles );
+		if ( fileTypes.length === 0 ) {
+			return null;
+		}
+
+		const formattedTypes = fileTypes.map( ( [ type, count ] ) => {
+			return translate( '%(count)d .%(type)s image', {
+				args: { count, type },
+				count,
+			} );
+		} );
+
+		const learnMoreLink = (
+			<InlineSupportLink
+				showIcon={ false }
+				supportLink={ localizeUrl( 'https://wordpress.com/support/accepted-filetypes/#images' ) }
+				supportPostId={ 2037 }
+			/>
+		);
+
+		if ( formattedTypes.length === 1 ) {
+			return translate(
+				'We were unable to import %(files)s. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
+				{
+					args: { files: formattedTypes[ 0 ] },
+					components: {
+						learnMoreLink,
+					},
+				}
+			);
+		}
+
+		const lastType = formattedTypes.pop();
+		return translate(
+			'We were unable to import %(files)s and %(lastFile)s. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
+			{
+				args: {
+					files: formattedTypes.join( ', ' ),
+					lastFile: lastType,
+				},
+				components: {
+					learnMoreLink,
+				},
+			}
+		);
+	}
+
 	componentDidMount() {
 		recordTracksEvent( 'calypso_site_importer_map_authors_single' );
 	}
@@ -152,9 +215,15 @@ class AuthorMappingPane extends PureComponent {
 		const posts = importerStatus?.customData?.postsNumber || 0;
 		const pages = importerStatus?.customData?.pagesNumber || 0;
 		const attachments = importerStatus?.customData?.attachmentsNumber || 0;
+		const unsupportedFilesMessage = this.getUnsupportedFilesMessage();
 
 		return (
 			<div className="importer__mapping-pane">
+				{ unsupportedFilesMessage && (
+					<Notice status="warning" className="importer__notice" isDismissible={ false }>
+						{ unsupportedFilesMessage }
+					</Notice>
+				) }
 				<Notice status="success" className="importer__notice" isDismissible={ false }>
 					<p>{ this.props.translate( 'All set! We’ve found:' ) }</p>
 					<div className="importer__notice-stats">
@@ -210,8 +279,8 @@ class AuthorMappingPane extends PureComponent {
 	}
 }
 
-const withTotalUsers = createHigherOrderComponent(
-	( Component ) => ( props ) => {
+const withTotalUsers = createHigherOrderComponent( ( Component ) => {
+	const WithTotalUsers = ( props ) => {
 		const { siteId } = props;
 		const { data } = useUsersQuery( siteId, {
 			authors_only: 1,
@@ -220,8 +289,11 @@ const withTotalUsers = createHigherOrderComponent(
 		const totalUsers = data?.total ?? 0;
 
 		return <Component totalUsers={ totalUsers } { ...props } />;
-	},
-	'withTotalUsers'
-);
+	};
+	WithTotalUsers.displayName = `WithTotalUsers(${
+		Component.displayName || Component.name || 'Component'
+	})`;
+	return WithTotalUsers;
+}, 'withTotalUsers' );
 
 export default localize( withTotalUsers( AuthorMappingPane ) );

--- a/client/my-sites/importer/newsletter/content-upload/author-mapping-pane.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/author-mapping-pane.jsx
@@ -1,5 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { formatNumber } from '@automattic/number-formatters';
 import { Notice } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { verse, page, file } from '@wordpress/icons';
@@ -146,8 +147,12 @@ class AuthorMappingPane extends PureComponent {
 		}
 
 		const formattedTypes = fileTypes.map( ( [ type, count ] ) => {
+			/* translators: %(count)d is the number of files, %(type)s is the file extension (e.g. "avif", "svg") */
 			return translate( '%(count)d .%(type)s image', {
-				args: { count, type },
+				args: {
+					count: formatNumber( count ),
+					type,
+				},
 				count,
 			} );
 		} );
@@ -161,6 +166,7 @@ class AuthorMappingPane extends PureComponent {
 		);
 
 		if ( formattedTypes.length === 1 ) {
+			/* translators: %(files)s is a formatted string like "3 .avif images". {{learnMoreLink}} is a link to the documentation */
 			return translate(
 				'We were unable to import %(files)s. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
 				{
@@ -173,6 +179,8 @@ class AuthorMappingPane extends PureComponent {
 		}
 
 		const lastType = formattedTypes.pop();
+		/* translators: %(files)s is a comma-separated list of file types (e.g. "3 .avif images, 1 .svg image"),
+		   %(lastFile)s is the last file type in the list. {{learnMoreLink}} is a link to the documentation */
 		return translate(
 			'We were unable to import %(files)s and %(lastFile)s. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
 			{

--- a/client/my-sites/importer/newsletter/content-upload/author-mapping-pane.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/author-mapping-pane.jsx
@@ -141,7 +141,9 @@ class AuthorMappingPane extends PureComponent {
 			return null;
 		}
 
-		const fileTypes = Object.entries( unsupportedFiles );
+		const fileTypes = Object.entries( unsupportedFiles ).filter( function ( entry ) {
+			return entry[ 1 ] > 0;
+		} );
 		if ( fileTypes.length === 0 ) {
 			return null;
 		}

--- a/client/my-sites/importer/newsletter/content-upload/author-mapping-pane.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/author-mapping-pane.jsx
@@ -30,7 +30,7 @@ class AuthorMappingPane extends PureComponent {
 			percentComplete: PropTypes.number,
 			statusMessage: PropTypes.string,
 			customData: PropTypes.shape( {
-				unsupportedFileTypes: PropTypes.object,
+				unsupportedFileTypes: PropTypes.objectOf( PropTypes.number ),
 				postsNumber: PropTypes.number,
 				pagesNumber: PropTypes.number,
 				attachmentsNumber: PropTypes.number,
@@ -148,7 +148,7 @@ class AuthorMappingPane extends PureComponent {
 
 		const formattedTypes = fileTypes.map( ( [ type, count ] ) => {
 			/* translators: %(count)s is the number of files, %(type)s is the file extension (e.g. "avif", "svg") */
-			return translate( '%(count)s .%(type)s image', {
+			return translate( '%(count)s .%(type)s image', '%(count)s .%(type)s images', {
 				args: {
 					count: formatNumber( count ),
 					type,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/CML-536/substack-importer-let-users-know-about-accepted-file-types

## Proposed Changes

* Add unsupported files notice. I'm using [the core Notice component](https://wordpress.github.io/gutenberg/?path=/docs/components-notice--docs) that's already used on this screen. It has an actions option, but I wanted to use `InlineSupportLink` to open the help center. I'm open to changing that. Also let me know if the punctuation / color / copy can be improved.
* Fix missing display name linter error.

<img width="1277" alt="Screenshot 2025-06-13 at 3 57 36 PM" src="https://github.com/user-attachments/assets/5810d33e-7546-4409-9911-faee9830120a" />

Possible message formats:
- "We were unable to import 1 .svg image. Learn more"
- "We were unable to import 3 .avif images. Learn more"
- "We were unable to import 2 .avif images and 1 .svg image. Learn more"
- "We were unable to import 3 .avif images, 2 .bin images and 1 .svg image. Learn more"

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To clearly communicate to the user why certain images won't upload.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply 185414-ghe-Automattic/wpcom to your sandbox.
* Follow these setup instructions: PCYsg-163J-p2
* Import a content zip with one or more invalid image types. Note that it's difficult to test types other than .avif because Substack doesn't allow them (and yet we've seen them in imports).
* Check that you see the correct notice.
* Check that the import succeeds.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?