### PR TITLE
UI package: Enforce logical properties in CSS

### DIFF
--- a/packages/ui/.stylelintrc.js
+++ b/packages/ui/.stylelintrc.js
@@ -1,0 +1,17 @@
+module.exports = {
+	extends: [ '../../.stylelintrc' ],
+	plugins: [ 'stylelint-plugin-logical-css' ],
+	rules: {
+		'declaration-property-max-values': {
+			// Prevents shorthand left/right values (unclear for RTL)
+			margin: 3,
+			padding: 3,
+		},
+		'plugin/use-logical-properties-and-values': [
+			true,
+			{
+				ignore: [ 'width', 'min-width', 'max-width', 'height', 'min-height', 'max-height' ],
+			},
+		],
+	},
+};

--- a/packages/ui/.stylelintrc.js
+++ b/packages/ui/.stylelintrc.js
@@ -10,7 +10,21 @@ module.exports = {
 		'plugin/use-logical-properties-and-values': [
 			true,
 			{
-				ignore: [ 'width', 'min-width', 'max-width', 'height', 'min-height', 'max-height' ],
+				ignore: [
+					// Doesn't affect RTL styles
+					'width',
+					'min-width',
+					'max-width',
+					'height',
+					'min-height',
+					'max-height',
+					'margin-top',
+					'margin-bottom',
+					'padding-top',
+					'padding-bottom',
+					'top',
+					'bottom',
+				],
 			},
 		],
 	},

--- a/packages/ui/.stylelintrc.js
+++ b/packages/ui/.stylelintrc.js
@@ -6,6 +6,11 @@ module.exports = {
 			// Prevents shorthand left/right values (unclear for RTL)
 			margin: 3,
 			padding: 3,
+			'border-width': 3,
+			'border-color': 3,
+			'border-style': 3,
+			'border-radius': 3,
+			inset: 3,
 		},
 		'plugin/use-logical-properties-and-values': [
 			true,

--- a/packages/ui/.stylelintrc.js
+++ b/packages/ui/.stylelintrc.js
@@ -3,7 +3,7 @@ module.exports = {
 	plugins: [ 'stylelint-plugin-logical-css' ],
 	rules: {
 		'declaration-property-max-values': {
-			// Prevents shorthand left/right values (unclear for RTL)
+			// Prevents left/right values with shorthand property names (unclear for RTL)
 			margin: 3,
 			padding: 3,
 			'border-width': 3,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -67,6 +67,8 @@
 		"postcss-modules": "^6.0.1",
 		"sass-embedded": "^1.89.0",
 		"storybook": "^8.6.14",
+		"stylelint": "^16.15.0",
+		"stylelint-plugin-logical-css": "^1.2.3",
 		"tsup": "^8.5.0",
 		"typescript": "^5.8.3"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -2184,6 +2184,8 @@ __metadata:
     postcss-modules: "npm:^6.0.1"
     sass-embedded: "npm:^1.89.0"
     storybook: "npm:^8.6.14"
+    stylelint: "npm:^16.15.0"
+    stylelint-plugin-logical-css: "npm:^1.2.3"
     tsup: "npm:^8.5.0"
     typescript: "npm:^5.8.3"
   peerDependencies:
@@ -35061,6 +35063,15 @@ __metadata:
   peerDependencies:
     stylelint: ^16.1.0
   checksum: a0a0ecd91f4d193bbe2cc3408228f8a2d8fcb2b2578d77233f86780c9247c796a04e16aad7a91d97cb918e2de34b6a8062bab66ee017c3835d855081d94f4828
+  languageName: node
+  linkType: hard
+
+"stylelint-plugin-logical-css@npm:^1.2.3":
+  version: 1.2.3
+  resolution: "stylelint-plugin-logical-css@npm:1.2.3"
+  peerDependencies:
+    stylelint: ^14.0.0 || ^15.0.0 || ^16.0.0
+  checksum: d0ffd76edf56cc948fcee378a01dced8057a4093a5dc70f850cc76da03063bcafd6f044d3973bae97df02264e2f4cb024e52493e97039647b4ef7a826c8dbdba
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes ARC-182

## Proposed Changes

Enforce CSS logical properties in the `@automattic/ui` package.

## Why are these changes being made?

This should allow us to ship a single stylesheet that works in both LTR and RTL, no conversation necessary.

## Testing Instructions

Try adding some violating rules in the `Badge` stylesheet, e.g. `margin: 0 2px 0 0` or `left: 0`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
