### PR TITLE
A4A: Anchor Onboarding tour in the layout.

### DIFF
--- a/client/a8c-for-agencies/components/hoc/with-onboarding-tour/style.scss
+++ b/client/a8c-for-agencies/components/hoc/with-onboarding-tour/style.scss
@@ -13,8 +13,16 @@
 
 .a4a-onboarding-tour-snackbar {
 	position: fixed;
-	bottom: 64px;
-	right: 64px;
+	z-index: 1000;
+	top: 0;
+	left: 0;
+
+	@include break-mobile {
+		bottom: 64px;
+		right: 64px;
+		top: auto;
+		left: auto;
+	}
 
 	.components-snackbar__icon {
 		fill: var(--color-text-inverted);

--- a/client/a8c-for-agencies/components/layout/layout-with-guided-tour.tsx
+++ b/client/a8c-for-agencies/components/layout/layout-with-guided-tour.tsx
@@ -5,9 +5,12 @@ import {
 	A4A_ONBOARDING_TOURS_EVENT_NAMES,
 } from 'calypso/a8c-for-agencies/sections/onboarding-tours/constants';
 import { GuidedTourContextProvider } from 'calypso/components/guided-tour/data/guided-tour-context';
-import Layout from 'calypso/layout/hosting-dashboard';
+import BaseLayout from 'calypso/layout/hosting-dashboard';
+import { withOnboardingTour } from '../hoc/with-onboarding-tour';
 
 import './style.scss';
+
+const Layout = withOnboardingTour( BaseLayout );
 
 export function LayoutWithGuidedTour( { ...props }: ComponentProps< typeof Layout > ) {
 	const guidedTours = useGuidedTours();

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import { useContext, useEffect, useCallback, useState, useRef } from 'react';
 import A4AAgencyApprovalNotice from 'calypso/a8c-for-agencies/components/a4a-agency-approval-notice';
+import { withOnboardingTour } from 'calypso/a8c-for-agencies/components/hoc/with-onboarding-tour';
 import {
 	DATAVIEWS_LIST,
 	DATAVIEWS_TABLE,
@@ -45,7 +46,8 @@ import { updateSitesDashboardUrl } from './update-sites-dashboard-url';
 
 import './style.scss';
 import './sites-dataviews-style.scss';
-export default function SitesDashboard() {
+
+export function SitesDashboard() {
 	const jetpackSiteDisconnected = useSelector( checkIfJetpackSiteGotDisconnected );
 	const dispatch = useDispatch();
 
@@ -310,3 +312,5 @@ export default function SitesDashboard() {
 		</Layout>
 	);
 }
+
+export default withOnboardingTour( SitesDashboard );


### PR DESCRIPTION
This PR ensures that the 'Continue' snackbar for the onboarding tour is visible in mobile view.

<img width="404" alt="Screenshot 2025-06-16 at 6 37 43 AM" src="https://github.com/user-attachments/assets/e9bfbada-5ffa-47b3-80a8-dcd772f50bf2" /> <img width="402" alt="Screenshot 2025-06-16 at 6 37 49 AM" src="https://github.com/user-attachments/assets/4e200b00-3f1e-45d9-b3cc-83635f0beaea" />

Context: pgjTho-LC-p2#comment-725

## Proposed Changes

* Anchor the Onboarding Tour components in the Layout and not on the sidebar. This ensures that during mobile view, the snackbar is always visible.

## Why are these changes being made?

This is part of the Agency onboarding improvement part 2 project.

## Testing Instructions

* Use the A4A live link and navigate to `/overview` page.
* Set your screen to mobile view.
* Launch the Onboarding tour and click any explore flow.
* Confirm that the snack is always visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
