### PR TITLE
Hosting dashboard: Fix incorrectly enabled save button in site visibility interface

### DIFF
--- a/client/dashboard/data/site-settings.ts
+++ b/client/dashboard/data/site-settings.ts
@@ -6,9 +6,9 @@ export interface SiteSettings {
 	/**
 	 * @deprecated Use `wpcom_public_coming_soon` instead.
 	 */
-	wpcom_coming_soon?: number;
-	wpcom_public_coming_soon?: number;
-	wpcom_data_sharing_opt_out?: boolean;
+	wpcom_coming_soon?: number | string;
+	wpcom_public_coming_soon?: number | string;
+	wpcom_data_sharing_opt_out?: boolean | string;
 	wpcom_prevent_third_party_sharing?: boolean;
 	wpcom_gifting_subscription?: boolean;
 	wpcom_performance_report_url?: string;

--- a/client/dashboard/data/site-settings.ts
+++ b/client/dashboard/data/site-settings.ts
@@ -1,9 +1,14 @@
 import wpcom from 'calypso/lib/wp';
 
 export interface SiteSettings {
+	blog_public?: number;
 	is_fully_managed_agency_site?: boolean;
-	wpcom_site_visibility?: 'coming-soon' | 'public' | 'private';
-	wpcom_discourage_search_engines?: boolean;
+	/**
+	 * @deprecated Use `wpcom_public_coming_soon` instead.
+	 */
+	wpcom_coming_soon?: number;
+	wpcom_public_coming_soon?: number;
+	wpcom_data_sharing_opt_out?: boolean;
 	wpcom_prevent_third_party_sharing?: boolean;
 	wpcom_gifting_subscription?: boolean;
 	wpcom_performance_report_url?: string;
@@ -16,7 +21,7 @@ export async function fetchSiteSettings( siteId: number ): Promise< SiteSettings
 		path: `/sites/${ siteId }/settings`,
 		apiVersion: '1.4',
 	} );
-	return fromRawSiteSettings( settings );
+	return settings;
 }
 
 export async function updateSiteSettings( siteId: number, data: Partial< SiteSettings > ) {
@@ -25,72 +30,7 @@ export async function updateSiteSettings( siteId: number, data: Partial< SiteSet
 			path: `/sites/${ siteId }/settings`,
 			apiVersion: '1.4',
 		},
-		toRawSiteSettings( data )
+		data
 	);
-	return fromRawSiteSettings( updated );
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function fromRawSiteSettings( rawSettings: any ): SiteSettings {
-	// Pluck out raw settings which don't map directly to a field in SiteSettings.
-	const {
-		blog_public: blogPublicRaw,
-		wpcom_coming_soon: wpcomComingSoonRaw,
-		wpcom_public_coming_soon: wpcomPublicComingSoonRaw,
-		wpcom_data_sharing_opt_out: wpcomDataSharingOptOutRaw,
-		...settings
-	} = rawSettings;
-
-	const blog_public = Number( blogPublicRaw );
-	const wpcom_coming_soon = Number( wpcomComingSoonRaw );
-	const wpcom_public_coming_soon = Number( wpcomPublicComingSoonRaw );
-	const wpcom_data_sharing_opt_out = Boolean( wpcomDataSharingOptOutRaw );
-
-	if ( wpcom_coming_soon === 1 || wpcom_public_coming_soon === 1 ) {
-		settings.wpcom_site_visibility = 'coming-soon';
-		settings.wpcom_discourage_search_engines = false;
-	} else if ( blog_public === -1 ) {
-		settings.wpcom_site_visibility = 'private';
-		settings.wpcom_discourage_search_engines = false;
-	} else {
-		settings.wpcom_site_visibility = 'public';
-		settings.wpcom_discourage_search_engines = blog_public === 0;
-	}
-
-	settings.wpcom_prevent_third_party_sharing = wpcom_data_sharing_opt_out;
-
-	return settings;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function toRawSiteSettings( settings: Partial< SiteSettings > ): any {
-	// Pluck out settings which don't map directly to a field in the raw settings.
-	const {
-		wpcom_site_visibility,
-		wpcom_discourage_search_engines,
-		wpcom_prevent_third_party_sharing,
-		...rest
-	} = settings;
-	const rawSettings = rest as any; // eslint-disable-line @typescript-eslint/no-explicit-any
-
-	if ( wpcom_site_visibility !== undefined ) {
-		if ( wpcom_site_visibility === 'coming-soon' ) {
-			rawSettings.blog_public = 0;
-			rawSettings.wpcom_public_coming_soon = 1;
-			rawSettings.wpcom_data_sharing_opt_out = false;
-		} else if ( wpcom_site_visibility === 'private' ) {
-			rawSettings.blog_public = -1;
-			rawSettings.wpcom_public_coming_soon = 0;
-			rawSettings.wpcom_data_sharing_opt_out = false;
-		} else {
-			rawSettings.blog_public = wpcom_discourage_search_engines ? 0 : 1;
-			rawSettings.wpcom_public_coming_soon = 0;
-			rawSettings.wpcom_data_sharing_opt_out = wpcom_prevent_third_party_sharing;
-		}
-
-		// Take opportunity, while the user is switching visibility settings, to disable the legacy coming soon setting.
-		rawSettings.wpcom_coming_soon = 0;
-	}
-
-	return rawSettings;
+	return updated;
 }

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -134,7 +134,7 @@ export function PrivacyForm( {
 
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
-	const initialData = settingsToFormData( settings );
+	const initialData = fromSiteSettings( settings );
 	const [ formData, setFormData ] = useState( () => ( {
 		...initialData,
 		preventThirdPartySharing:
@@ -148,7 +148,7 @@ export function PrivacyForm( {
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
-		mutation.mutate( formDataToSettings( formData ), {
+		mutation.mutate( toSiteSettings( formData ), {
 			onSuccess: () => {
 				createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
 			},
@@ -162,7 +162,7 @@ export function PrivacyForm( {
 		setFormData( ( data ) => {
 			const newFormData = { ...data, ...edits };
 
-			if ( edits.visibility !== undefined ) {
+			if ( edits.visibility === 'public' ) {
 				// Forget any previous edits to the discoverability controls when the visibility changes.
 				newFormData.discourageSearchEngines = initialData.discourageSearchEngines;
 				newFormData.preventThirdPartySharing =
@@ -173,7 +173,8 @@ export function PrivacyForm( {
 				newFormData.preventThirdPartySharing = true;
 			}
 
-			return newFormData;
+			// Ensure switching to 'coming-soon' or 'private' sets the correct values for the hidden checkbox settings.
+			return fromSiteSettings( toSiteSettings( newFormData ) );
 		} );
 	};
 
@@ -254,9 +255,11 @@ export function PrivacyForm( {
 	);
 }
 
-function settingsToFormData( settings: SiteSettings ): PrivacyFormData {
-	const { blog_public, wpcom_coming_soon, wpcom_public_coming_soon, wpcom_data_sharing_opt_out } =
-		settings;
+function fromSiteSettings( settings: SiteSettings ): PrivacyFormData {
+	const blog_public = Number( settings.blog_public );
+	const wpcom_coming_soon = Number( settings.wpcom_coming_soon );
+	const wpcom_public_coming_soon = Number( settings.wpcom_public_coming_soon );
+	const wpcom_data_sharing_opt_out = Boolean( settings.wpcom_data_sharing_opt_out );
 
 	let visibility: PrivacyFormData[ 'visibility' ];
 	let discourageSearchEngines;
@@ -279,7 +282,7 @@ function settingsToFormData( settings: SiteSettings ): PrivacyFormData {
 	};
 }
 
-function formDataToSettings( settings: PrivacyFormData ): Partial< SiteSettings > {
+function toSiteSettings( settings: PrivacyFormData ): Partial< SiteSettings > {
 	const { visibility, discourageSearchEngines, preventThirdPartySharing } = settings;
 
 	let blog_public;

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -22,9 +22,17 @@ import type { Site, SiteSettings } from '../../data/types';
 import type { Field, Form } from '@automattic/dataviews';
 import type { UseMutationResult } from '@tanstack/react-query';
 
-const visibilityFields: Field< SiteSettings >[] = [
+// The raw SiteSettings don't map nicely to the controls in the form. Mapping from SiteSettings to
+// PrivacyFormData allows us to create a more user-friendly form.
+interface PrivacyFormData {
+	visibility: 'coming-soon' | 'public' | 'private';
+	discourageSearchEngines: boolean;
+	preventThirdPartySharing: boolean;
+}
+
+const visibilityFields: Field< PrivacyFormData >[] = [
 	{
-		id: 'wpcom_site_visibility',
+		id: 'visibility',
 		Edit: 'toggleGroup',
 		elements: [
 			{
@@ -52,19 +60,19 @@ const visibilityFields: Field< SiteSettings >[] = [
 
 const visibilityForm = {
 	type: 'regular',
-	fields: [ { id: 'wpcom_site_visibility', labelPosition: 'none' } ],
+	fields: [ { id: 'visibility', labelPosition: 'none' } ],
 } satisfies Form;
 
 // This form also has access to `isPrimaryDomainStaging` which isn't a persisted setting, but is data
 // needed to determine whether the checkboxes should be disabled.
-const robotFields: Field< SiteSettings & { isPrimaryDomainStaging: boolean } >[] = [
+const robotFields: Field< PrivacyFormData & { isPrimaryDomainStaging: boolean } >[] = [
 	{
-		id: 'wpcom_discourage_search_engines',
+		id: 'discourageSearchEngines',
 		label: __( 'Discourage search engines from indexing this site' ),
 		description: __(
 			'This does not block access to your site — it is up to search engines to honor your request.'
 		),
-		isVisible: ( { wpcom_site_visibility }: SiteSettings ) => wpcom_site_visibility === 'public',
+		isVisible: ( { visibility } ) => visibility === 'public',
 		Edit: ( { field, onChange, data, hideLabelFromVision } ) => (
 			<CheckboxControl
 				__nextHasNoMarginBottom
@@ -79,13 +87,13 @@ const robotFields: Field< SiteSettings & { isPrimaryDomainStaging: boolean } >[]
 		),
 	},
 	{
-		id: 'wpcom_prevent_third_party_sharing',
+		id: 'preventThirdPartySharing',
 		Edit: ( { field, onChange, data, hideLabelFromVision } ) => (
 			<CheckboxControl
 				__nextHasNoMarginBottom
 				label={ hideLabelFromVision ? '' : field.label }
 				checked={ data.isPrimaryDomainStaging || field.getValue( { item: data } ) }
-				disabled={ data.isPrimaryDomainStaging || data.wpcom_discourage_search_engines }
+				disabled={ data.isPrimaryDomainStaging || data.discourageSearchEngines }
 				onChange={ () => {
 					onChange( { [ field.id ]: ! field.getValue( { item: data } ) } );
 				} }
@@ -100,13 +108,13 @@ const robotFields: Field< SiteSettings & { isPrimaryDomainStaging: boolean } >[]
 			/>
 		),
 		label: __( 'Prevent third-party sharing for this site' ),
-		isVisible: ( { wpcom_site_visibility }: SiteSettings ) => wpcom_site_visibility === 'public',
+		isVisible: ( { visibility } ) => visibility === 'public',
 	},
 ];
 
 const robotForm = {
 	type: 'regular',
-	fields: [ 'wpcom_discourage_search_engines', 'wpcom_prevent_third_party_sharing' ],
+	fields: [ 'discourageSearchEngines', 'preventThirdPartySharing' ],
 } satisfies Form;
 
 export function PrivacyForm( {
@@ -125,46 +133,44 @@ export function PrivacyForm( {
 	const hasNonWpcomDomain = domains.some( ( domain ) => ! domain.wpcom_domain );
 
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const [ formData, setFormData ] = useState( {
-		wpcom_site_visibility: settings.wpcom_site_visibility,
-		wpcom_discourage_search_engines: settings.wpcom_discourage_search_engines,
-		wpcom_prevent_third_party_sharing:
-			settings.wpcom_discourage_search_engines || settings.wpcom_prevent_third_party_sharing,
-	} );
 
-	const isDirty = Object.entries( formData ).some(
-		( [ key, value ] ) => settings[ key as keyof SiteSettings ] !== value
+	const initialData = settingsToFormData( settings );
+	const [ formData, setFormData ] = useState( () => ( {
+		...initialData,
+		preventThirdPartySharing:
+			initialData.discourageSearchEngines || initialData.preventThirdPartySharing,
+	} ) );
+
+	const isDirty = Object.entries( initialData ).some(
+		( [ key, value ] ) => formData[ key as keyof PrivacyFormData ] !== value
 	);
 	const { isPending } = mutation;
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
-		mutation.mutate(
-			{ ...formData },
-			{
-				onSuccess: () => {
-					createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
-				},
-				onError: () => {
-					createErrorNotice( __( 'Failed to save settings.' ), { type: 'snackbar' } );
-				},
-			}
-		);
+		mutation.mutate( formDataToSettings( formData ), {
+			onSuccess: () => {
+				createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
+			},
+			onError: () => {
+				createErrorNotice( __( 'Failed to save settings.' ), { type: 'snackbar' } );
+			},
+		} );
 	};
 
-	const handleChange = ( edits: Partial< SiteSettings > ) => {
+	const handleChange = ( edits: Partial< PrivacyFormData > ) => {
 		setFormData( ( data ) => {
 			const newFormData = { ...data, ...edits };
 
-			if ( edits.wpcom_site_visibility !== undefined ) {
+			if ( edits.visibility !== undefined ) {
 				// Forget any previous edits to the discoverability controls when the visibility changes.
-				newFormData.wpcom_discourage_search_engines = settings.wpcom_discourage_search_engines;
-				newFormData.wpcom_prevent_third_party_sharing =
-					settings.wpcom_discourage_search_engines || settings.wpcom_prevent_third_party_sharing;
+				newFormData.discourageSearchEngines = initialData.discourageSearchEngines;
+				newFormData.preventThirdPartySharing =
+					initialData.discourageSearchEngines || initialData.preventThirdPartySharing;
 			}
-			if ( edits.wpcom_discourage_search_engines === true ) {
+			if ( edits.discourageSearchEngines === true ) {
 				// Checking the search engine box forces the third party checkbox too.
-				newFormData.wpcom_prevent_third_party_sharing = true;
+				newFormData.preventThirdPartySharing = true;
 			}
 
 			return newFormData;
@@ -177,13 +183,13 @@ export function PrivacyForm( {
 				<CardBody>
 					<form onSubmit={ handleSubmit } className="dashboard-site-settings-privacy-form">
 						<VStack spacing={ 4 }>
-							<DataForm< SiteSettings >
+							<DataForm< PrivacyFormData >
 								data={ formData }
 								fields={ visibilityFields }
 								form={ visibilityForm }
 								onChange={ handleChange }
 							/>
-							{ formData.wpcom_site_visibility === 'public' && isPrimaryDomainStaging && (
+							{ formData.visibility === 'public' && isPrimaryDomainStaging && (
 								<Notice
 									variant="warning"
 									density="medium"
@@ -219,7 +225,7 @@ export function PrivacyForm( {
 									) }
 								</Notice>
 							) }
-							<DataForm< SiteSettings & { isPrimaryDomainStaging: boolean } >
+							<DataForm< PrivacyFormData & { isPrimaryDomainStaging: boolean } >
 								data={ { ...formData, isPrimaryDomainStaging } }
 								fields={ robotFields }
 								form={ robotForm }
@@ -241,8 +247,65 @@ export function PrivacyForm( {
 				</CardBody>
 			</Card>
 
-			{ settings.wpcom_site_visibility === 'coming-soon' &&
-				formData.wpcom_site_visibility === 'coming-soon' && <ShareSiteForm site={ site } /> }
+			{ site.is_coming_soon && formData.visibility === 'coming-soon' && (
+				<ShareSiteForm site={ site } />
+			) }
 		</>
 	);
+}
+
+function settingsToFormData( settings: SiteSettings ): PrivacyFormData {
+	const { blog_public, wpcom_coming_soon, wpcom_public_coming_soon, wpcom_data_sharing_opt_out } =
+		settings;
+
+	let visibility: PrivacyFormData[ 'visibility' ];
+	let discourageSearchEngines;
+
+	if ( wpcom_coming_soon === 1 || wpcom_public_coming_soon === 1 ) {
+		visibility = 'coming-soon';
+		discourageSearchEngines = false;
+	} else if ( blog_public === -1 ) {
+		visibility = 'private';
+		discourageSearchEngines = false;
+	} else {
+		visibility = 'public';
+		discourageSearchEngines = blog_public === 0;
+	}
+
+	return {
+		visibility,
+		discourageSearchEngines,
+		preventThirdPartySharing: Boolean( wpcom_data_sharing_opt_out ),
+	};
+}
+
+function formDataToSettings( settings: PrivacyFormData ): Partial< SiteSettings > {
+	const { visibility, discourageSearchEngines, preventThirdPartySharing } = settings;
+
+	let blog_public;
+	let wpcom_public_coming_soon;
+	let wpcom_data_sharing_opt_out;
+
+	if ( visibility === 'coming-soon' ) {
+		blog_public = 0;
+		wpcom_public_coming_soon = 1;
+		wpcom_data_sharing_opt_out = false;
+	} else if ( visibility === 'private' ) {
+		blog_public = -1;
+		wpcom_public_coming_soon = 0;
+		wpcom_data_sharing_opt_out = false;
+	} else {
+		blog_public = discourageSearchEngines ? 0 : 1;
+		wpcom_public_coming_soon = 0;
+		wpcom_data_sharing_opt_out = preventThirdPartySharing;
+	}
+
+	return {
+		blog_public,
+		wpcom_public_coming_soon,
+		wpcom_data_sharing_opt_out,
+
+		// Take opportunity, while the user is switching visibility settings, to disable the legacy coming soon setting.
+		wpcom_coming_soon: 0,
+	};
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-13370

## Proposed Changes

* Moves the `toRawSiteSettings` and `fromRawSiteSettings` mappings out of the data layer and into the component
* Run the mapping when the user changes the form, not when they click save
  * This ensures that the form's state always matches what would eventually get saved, which is what makes the `isDirty` logic more robust

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The mapping was moved out of the component and into the data layer because of this conversation: https://github.com/Automattic/wp-calypso/pull/103426#discussion_r2091093907

But having the conversion happen in the data layer makes it difficult to make the `isDirty` logic work correctly.

One of the ideas behind having the mapping happen in the data layer, means that the logic for deciding whether whether a site was public, private, or “coming soon” wouldn't need to be spread throughout the dashboard code. However there’s already a way for the client to easily access what state the site is in: the `Site` object contains flags for the site’s status. The backend has calculated it so the front end doesn't have to. It should really only need to be the site visibility settings UI that needs to deal with the low level `blog_public` and `wpcom_public_coming_soon` settings.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check unit tests pass
  * Glad we have good coverage here so the code can be refactored with confidence 😊
* Test manually at `/v2/sites/{{ site slug }}/settings/site-visibility`
  * The “Save” button should be enabled as soon as the user makes an edit, and
  * Should be disabled as soon as the save process is complete, and
  * Should go back to disabled if the user reverts the settings back to what they were before they hit save

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
