### PR TITLE
Hosting dashboard e2e: Create a new "BrowserContext" for each site visibility test

### DIFF
--- a/test/e2e/specs/dashboard/settings__site-visibility.ts
+++ b/test/e2e/specs/dashboard/settings__site-visibility.ts
@@ -39,6 +39,7 @@ describe( 'Dashboard: Site Visibility Settings', function () {
 	const siteName = DataHelper.getBlogName();
 
 	beforeAll( async function () {
+		incognitoContext = await browser.newContext();
 		page = await browser.newPage();
 
 		// Using a newly created user avoid having too many sites.
@@ -67,6 +68,10 @@ describe( 'Dashboard: Site Visibility Settings', function () {
 	} );
 
 	afterAll( async function () {
+		if ( incognitoContext ) {
+			await incognitoContext.close();
+		}
+
 		if ( ! newUserDetails ) {
 			return;
 		}
@@ -81,14 +86,6 @@ describe( 'Dashboard: Site Visibility Settings', function () {
 			username: newUserDetails.body.username,
 			email: testUser.email,
 		} );
-	} );
-
-	beforeEach( async function () {
-		incognitoContext = await browser.newContext();
-	} );
-
-	afterEach( async function () {
-		await incognitoContext.close();
 	} );
 
 	it( 'Can change site visibility to Private', async function () {

--- a/test/e2e/specs/dashboard/settings__site-visibility.ts
+++ b/test/e2e/specs/dashboard/settings__site-visibility.ts
@@ -13,8 +13,8 @@ import {
 	UserSignupPage,
 	NewUserResponse,
 } from '@automattic/calypso-e2e';
-import { Page, Browser } from 'playwright';
 import { apiCloseAccount } from '../shared';
+import type { Page, Browser, BrowserContext } from 'playwright';
 
 declare const browser: Browser;
 
@@ -30,6 +30,7 @@ describe( 'Dashboard: Site Visibility Settings', function () {
 	let dashboardPage: DashboardPage;
 	let restAPIClient: RestAPIClient;
 	let site: NewSiteResponse;
+	let incognitoContext: BrowserContext;
 
 	const testUser = DataHelper.getNewTestUser( {
 		usernamePrefix: 'sitevisibility',
@@ -82,12 +83,20 @@ describe( 'Dashboard: Site Visibility Settings', function () {
 		} );
 	} );
 
+	beforeEach( async function () {
+		incognitoContext = await browser.newContext();
+	} );
+
+	afterEach( async function () {
+		await incognitoContext.close();
+	} );
+
 	it( 'Can change site visibility to Private', async function () {
 		await page.getByRole( 'radio', { name: 'Private' } ).click();
 		await saveChanges( page );
 
 		// Open the site in a new incognito browser context to verify it's private
-		const incognitoPage = await browser.newPage();
+		const incognitoPage = await incognitoContext.newPage();
 		await incognitoPage.goto( site.blog_details.url );
 		const pageContent = await incognitoPage.content();
 		expect( pageContent ).toContain( 'Private Site' );
@@ -99,7 +108,7 @@ describe( 'Dashboard: Site Visibility Settings', function () {
 		await saveChanges( page );
 
 		// Open the site in a new incognito browser context to verify it's coming soon
-		const incognitoPage = await browser.newPage();
+		const incognitoPage = await incognitoContext.newPage();
 		await incognitoPage.goto( site.blog_details.url );
 		const pageContent = await incognitoPage.content();
 		expect( pageContent ).toContain( 'coming soon' );
@@ -111,7 +120,7 @@ describe( 'Dashboard: Site Visibility Settings', function () {
 		await saveChanges( page );
 
 		// Open the site in a new incognito browser context to verify it's public
-		const incognitoPage = await browser.newPage();
+		const incognitoPage = await incognitoContext.newPage();
 		await incognitoPage.goto( site.blog_details.url );
 		const pageContent = await incognitoPage.content();
 		expect( pageContent ).not.toContain( 'Private Site' );


### PR DESCRIPTION
This should better emulate the idea of creating an incognito window.

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

Site visibility tests depend on opening the site frontend in an incognito tab. It looks like this is best achieved by using a fresh "BrowserContext" for the window.

See Playwright docs: https://playwright.dev/docs/api/class-browsercontext#browser-context-close

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The site visibility tests seems extra flaky to me. They fail like this:
- https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_desktop/15101243
- https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_desktop/15101615

It's checking whether the front end is showing the "Private Site" message. But looks like the site has instead redirected the user to the WordPress.com `/log-in` page. That's not what I get when manually testing. I wonder if the issue is something to do with the frontend not being opened in a a real incognito window.

Even if this isn't the real fix, it should be a harmless change.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `cd test/e2e`
* `yarn build`
* `export CALYPSO_BASE_URL=https://wpcalypso.wordpress.com`
* `yarn test -- specs/dashboard/settings__site-visibility.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
