### PR TITLE
A4A > Marketplace: Update the filter to include the newly added Woo extensions. 

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/lib/product-slugs.ts
+++ b/client/a8c-for-agencies/sections/marketplace/lib/product-slugs.ts
@@ -25,7 +25,6 @@ export const PAYMENTS_PRODUCT_SLUGS = [
 	'woocommerce-stripe',
 	'woocommerce-klarna',
 	'woocommerce-paypal',
-	'woocommerce-klaviyo',
 ];
 
 export const SHIPPING_DELIVERY_FULFILLMENT_PRODUCT_SLUGS = [
@@ -49,6 +48,7 @@ export const CONVERSION_PRODUCT_SLUGS = [
 	'woocommerce-points-and-rewards',
 	'woocommerce-product-add-ons',
 	'woocommerce-product-bundles',
+	'woocommerce-klaviyo',
 ];
 
 export const CUSTOMER_SERVICE_PRODUCT_SLUGS = [

--- a/client/a8c-for-agencies/sections/marketplace/lib/product-slugs.ts
+++ b/client/a8c-for-agencies/sections/marketplace/lib/product-slugs.ts
@@ -16,7 +16,17 @@ export const SOCIAL_PRODUCT_SLUGS = [ 'jetpack-social' ];
 
 export const GROWTH_PRODUCT_SLUGS = [ 'jetpack-creator', 'jetpack-ai', 'jetpack-stats' ];
 
-export const PAYMENTS_PRODUCT_SLUGS = [ 'woocommerce-woopayments' ];
+export const PAYMENTS_PRODUCT_SLUGS = [
+	'woocommerce-woopayments',
+	'woocommerce-afterpay',
+	'woocommerce-square',
+	'woocommerce-affirm',
+	'woocommerce-mollie',
+	'woocommerce-stripe',
+	'woocommerce-klarna',
+	'woocommerce-paypal',
+	'woocommerce-klaviyo',
+];
 
 export const SHIPPING_DELIVERY_FULFILLMENT_PRODUCT_SLUGS = [
 	'woocommerce-advanced-notifications',


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/A4A-1134/marketplace-update-the-payments-filter-to-include-the-newly-added-woo

## Proposed Changes

This PR updates the filter on the Marketplace to include the newly added Woo extensions. 

## Why are these changes being made?

To show all the newly added extensions when the filter is applied.

## Testing Instructions

* Open the A4A live link
* Go to Marketplace > Apply the "Payments" filter > Verify 8 Woo payment extensions are shown.

<img width="1390" alt="Screenshot 2025-06-16 at 4 29 41 PM" src="https://github.com/user-attachments/assets/08cf624d-47cf-4e67-bd26-1670051baf7b" />

* Apply the "Conversion" filter and verify "Klaviyo" is displayed here

<img width="1390" alt="Screenshot 2025-06-16 at 4 29 41 PM" src="https://github.com/user-attachments/assets/7d8782b0-7356-466f-984e-d73c84c3a698" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
