### PR TITLE
Dashboard v2: Update the logic of the canTransferSite function

### DIFF
--- a/client/dashboard/sites/features.ts
+++ b/client/dashboard/sites/features.ts
@@ -47,15 +47,8 @@ export const canRestorePlanSoftware = ( site: Site ) => site.is_wpcom_atomic;
 export const canDuplicateSite = ( site: Site ) => hasPlanFeature( site, DotcomFeatures.COPY_SITE );
 
 export const canTransferSite = ( site: Site, user: User ) => {
-	// The following types of the site are not allowed to transfer the ownership:
-	// * NonAtomicJetpackSite
-	// * P2 Hub
-	// * WP For Teams
-	// * VIP Site
-	// * Staging site
-	// We may need to handle this via endpoint somewhere. See canCurrentUserStartSiteOwnerTransfer.
 	const isAllowedSiteType = ! (
-		( site.jetpack && site.is_wpcom_atomic ) ||
+		( site.jetpack && ! site.is_wpcom_atomic ) ||
 		site.is_wpcom_staging_site ||
 		site.is_vip ||
 		!! site.options?.p2_hub_blog_id ||

--- a/client/dashboard/sites/features.ts
+++ b/client/dashboard/sites/features.ts
@@ -47,12 +47,21 @@ export const canRestorePlanSoftware = ( site: Site ) => site.is_wpcom_atomic;
 export const canDuplicateSite = ( site: Site ) => hasPlanFeature( site, DotcomFeatures.COPY_SITE );
 
 export const canTransferSite = ( site: Site, user: User ) => {
-	// TODO: The following types of the site are not allowed to transfer the ownership:
+	// The following types of the site are not allowed to transfer the ownership:
 	// * NonAtomicJetpackSite
 	// * P2 Hub
 	// * WP For Teams
 	// * VIP Site
 	// * Staging site
 	// We may need to handle this via endpoint somewhere. See canCurrentUserStartSiteOwnerTransfer.
-	return site.site_owner === user.ID;
+	const isAllowedSiteType = ! (
+		( site.jetpack && site.is_wpcom_atomic ) ||
+		site.is_wpcom_staging_site ||
+		site.is_vip ||
+		!! site.options?.p2_hub_blog_id ||
+		site.options?.is_wpforteams_site
+	);
+
+	const isSiteOwner = site.site_owner === user.ID;
+	return isAllowedSiteType && isSiteOwner;
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Update the logic of the `canTransferSite` function to disable "Transfer site" on the following site type:
   * NonAtomicJetpackSite
   * P2 Hub
   * WP For Teams
   * VIP Site
   * Staging site

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The "Transfer site" action is not allowed on specific sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Pick the following site
   * NonAtomicJetpackSite
   * P2 Hub
   * WP For Teams
   * VIP Site
   * Staging site
* Navigate to Settings
* Ensure you cannot see the "Transfer site" action

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
