### PR TITLE
Data forms: let vertical spacing do the vertical spacing rather than cell padding

### DIFF
--- a/packages/dataviews/src/dataforms-layouts/panel/style.scss
+++ b/packages/dataviews/src/dataforms-layouts/panel/style.scss
@@ -11,9 +11,9 @@
 	min-height: $grid-unit-40;
 	display: flex;
 	align-items: center;
-	padding: 6px 0; // Matches button to ensure alignment
 	line-height: $grid-unit-05 * 5;
 	hyphens: auto;
+	align-self: center;
 }
 
 .dataforms-layouts-panel__field-control {

--- a/packages/dataviews/src/dataforms-layouts/regular/style.scss
+++ b/packages/dataviews/src/dataforms-layouts/regular/style.scss
@@ -17,9 +17,9 @@
 	min-height: $grid-unit-40;
 	display: flex;
 	align-items: center;
-	padding: 6px 0; // Matches button to ensure alignment
 	line-height: $grid-unit-05 * 5;
 	hyphens: auto;
+	align-self: center;
 }
 
 .dataforms-layouts-regular__field-control {


### PR DESCRIPTION
	
## Proposed Changes

CSS changes only.

This PR removes padding around data forms labels
	
See https://github.com/WordPress/gutenberg/pull/70435

> [!NOTE]
>  Unlike the [Gutenberg PR](https://github.com/WordPress/gutenberg/pull/70435), this PR doesn't update the spacing for the Dataform VStack since the `@automattic/dataviews` package already has [changes on that line](https://github.com/Automattic/wp-calypso/blob/trunk/packages/dataviews/src/dataforms-layouts/data-form-layout.tsx#L51) that haven't been synced with Core. Things look fine.

## Why are these changes being made?

There is a misalignment between label and control.

The label padding is allegedly there to ensure alignment with a neighbouring button. However for read only fields, there might be no button.

Furthermore, it's better to adjust padding using the container gap spacing rather than tweaking the padding on a single column for alignment.

| Before | After |
|--------|--------|
| <img width="728" alt="Screenshot 2025-06-16 at 6 14 49 pm" src="https://github.com/user-attachments/assets/9e02cc46-f40e-4f55-b5c4-198db9310f1b" /> | <img width="634" alt="Screenshot 2025-06-16 at 6 08 17 pm" src="https://github.com/user-attachments/assets/4d72ce89-175e-4119-bfb8-3c99aea860f1" /> |





## Testing Instructions

Load this branch and fire up storybook:

```
yarn workspace @automattic/dataviews storybook:start
```

Go to http://localhost:57863/?path=/story/dataviews-dataviews--default

And head to the Dataforms component: [http://localhost:50240?path=/story/dataviews-dataform--combined-fields](http://localhost:50240/?path=/story/dataviews-dataform--combined-fields)

Play around with the variables, especially side views. Ensure that the label and controls align in the centre.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
