### PR TITLE
Backported Settings: Allow user to go back to the root of Settings by clicking the Settings tab

### DIFF
--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -144,7 +144,7 @@ const DotcomPreviewPane = ( {
 					visible: enabled && visible !== false,
 					selected,
 					onTabClick: () => {
-						if ( enabled && ! selected ) {
+						if ( enabled ) {
 							showSitesPage( defaultRoute );
 						}
 					},

--- a/client/sites/settings/controller.tsx
+++ b/client/sites/settings/controller.tsx
@@ -220,7 +220,12 @@ export function dashboardBackportSiteSettings( context: PageJSContext, next: () 
 
 	// Route doesn't require a <PageViewTracker /> because the dashboard
 	// fires its own page view events.
-	context.primary = <DashboardBackportSiteSettingsRenderer siteSlug={ site?.slug } />;
+	context.primary = (
+		<DashboardBackportSiteSettingsRenderer
+			siteSlug={ site?.slug }
+			feature={ context.params.feature }
+		/>
+	);
 
 	next();
 }

--- a/client/sites/settings/index.tsx
+++ b/client/sites/settings/index.tsx
@@ -137,7 +137,7 @@ export default function () {
 	 */
 	page( '/sites/settings/v2', siteSelection, sites, makeLayout, clientRender );
 	page(
-		'/sites/settings/v2/*',
+		'/sites/settings/v2/:site/:feature?',
 		siteSelection,
 		navigation,
 		dashboardBackportSiteSettings,

--- a/client/sites/settings/v2/index.tsx
+++ b/client/sites/settings/v2/index.tsx
@@ -8,8 +8,10 @@ import type { AnalyticsClient } from 'calypso/dashboard/app/analytics';
 
 export default function DashboardBackportSiteSettingsRenderer( {
 	siteSlug,
+	feature,
 }: {
 	siteSlug?: string;
+	feature?: string;
 } ) {
 	const rootInstanceRef = useRef< ReturnType< typeof createRoot > | null >( null );
 	const containerRef = useRef< HTMLDivElement >( null );
@@ -54,7 +56,7 @@ export default function DashboardBackportSiteSettingsRenderer( {
 		persistPromise.then( () => {
 			rootInstanceRef.current?.render( <Layout analyticsClient={ analyticsClient } /> );
 		} );
-	}, [ analyticsClient, siteSlug ] );
+	}, [ analyticsClient, siteSlug, feature ] );
 
 	return <div className="dashboard-backport-site-settings-root" ref={ containerRef } />;
 }

--- a/client/sites/settings/v2/router.tsx
+++ b/client/sites/settings/v2/router.tsx
@@ -1,3 +1,4 @@
+import pagejs from '@automattic/calypso-router';
 import {
 	Outlet,
 	Router,
@@ -317,7 +318,7 @@ const isCompatibilityRoute = ( router: AnyRouter, url: string ) => {
 const syncMemoryRouterToBrowserHistory = ( router: AnyRouter ) => {
 	let lastPath = '';
 
-	// Sync TanStack Router's history to the browser history.
+	// Sync TanStack Router's history to the browser history (pagejs).
 	router.history.subscribe( () => {
 		const { pathname, search } = router.history.location;
 		const newUrl = `${ pathname }${ search }`;
@@ -328,7 +329,7 @@ const syncMemoryRouterToBrowserHistory = ( router: AnyRouter ) => {
 		}
 
 		if ( window.location.pathname + window.location.search !== newUrl ) {
-			window.history.pushState( null, '', newUrl );
+			pagejs.show( newUrl );
 			lastPath = newUrl;
 		}
 	} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-33

## Proposed Changes

* Currently, the user cannot go back to the root setting page when clicking the "Settings" tab if they're on the any sub -age. This PR proposed a change to resolved it by
  * Sync TanStack Router's history to pagejs (not just browser history)
  * Page.js supports extracting the feature parameter from the URL, so we can use it to force the Backported Settings component to re-render.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve user experience

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites/settings/v2/:site`
* Navigate to any sub page
* Click the "Settings" tab
* Ensure you can go back to the root settings page
* Ensure the browser back & forward button works as before

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
