### PR TITLE
Help Center: Include URL hash in the contextual section

### DIFF
--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -26,7 +26,7 @@ import '../styles.scss';
 const HelpCenter: React.FC< Container > = ( {
 	handleClose,
 	hidden,
-	currentRoute = window.location.pathname + window.location.search,
+	currentRoute = window.location.pathname + window.location.search + window.location.hash,
 } ) => {
 	const portalParent = useRef( document.createElement( 'div' ) ).current;
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
- DOTCOM-13614

## Proposed Changes

We include the URL hash in the section so that it's included when calling the contextual search API.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Some screens rely on hash navigation (Jetpack) and without including the hash in the section what can't determine the path we're trying to fetch contextual help for if multiple paths share a common URL + Params.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live link
* Navigate to: `https://{site}/wp-admin/admin.php?page=stats#!/stats/day/rortiz14052025.wordpress.com`
* Open your browser's network inspection tool
* Filter by XHR and `search`
* Click on the button that opens the help center
* You should see a network request to the search endpoint
* The hash part of the URL should be included in the payload, inside the section argument.


https://github.com/user-attachments/assets/d8b8cf5a-f7cf-4ab0-a449-c633350e3425



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
