### PR TITLE
Fallback to secondary contact method when LLMs are down

### DIFF
--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -172,7 +172,7 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 					aria-relevant="additions"
 				>
 					{ chat.messages.map( ( message ) => (
-						<div key={ message.created_at }>
+						<div key={ `${ message.created_at }-${ message.internal_message_id }` }>
 							{ [ 'bot', 'business' ].includes( message.role ) && message.content }
 						</div>
 					) ) }

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -172,7 +172,7 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 					aria-relevant="additions"
 				>
 					{ chat.messages.map( ( message ) => (
-						<div key={ `${ message.created_at }-${ message.internal_message_id }` }>
+						<div key={ `${ message.internal_message_id }` }>
 							{ [ 'bot', 'business' ].includes( message.role ) && message.content }
 						</div>
 					) ) }
@@ -196,7 +196,8 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 							const displayChatWithSupportLabel =
 								! nextMessage?.context?.flags?.show_contact_support_msg &&
 								message.context?.flags?.show_contact_support_msg &&
-								! chatHasEnded;
+								! chatHasEnded &&
+								! message.context?.flags?.is_error_message;
 
 							const displayChatWithSupportEndedLabel = ! nextMessage && chatHasEnded;
 

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -11,6 +11,8 @@ import {
 	ODIE_FORWARD_TO_ZENDESK_MESSAGE,
 	ODIE_THIRD_PARTY_MESSAGE_CONTENT,
 	ODIE_EMAIL_FALLBACK_MESSAGE_CONTENT,
+	ODIE_ERROR_MESSAGE,
+	ODIE_ERROR_MESSAGE_NON_ELIGIBLE,
 } from '../../constants';
 import { useOdieAssistantContext } from '../../context';
 import {
@@ -32,11 +34,13 @@ const getDisplayMessage = (
 	isRequestingHumanSupport: boolean,
 	messageContent: string,
 	hasCannedResponse?: boolean,
-	forceEmailSupport?: boolean
+	forceEmailSupport?: boolean,
+	isErrorMessage?: boolean
 ) => {
 	if ( isUserEligibleForPaidSupport && ! canConnectToZendesk && isRequestingHumanSupport ) {
 		return ODIE_THIRD_PARTY_MESSAGE_CONTENT;
 	}
+
 	if ( isUserEligibleForPaidSupport && hasCannedResponse ) {
 		return messageContent;
 	}
@@ -45,11 +49,15 @@ const getDisplayMessage = (
 		return ODIE_EMAIL_FALLBACK_MESSAGE_CONTENT;
 	}
 
+	if ( isErrorMessage && ! isUserEligibleForPaidSupport ) {
+		return ODIE_ERROR_MESSAGE_NON_ELIGIBLE;
+	}
+
 	const forwardMessage = isUserEligibleForPaidSupport
 		? ODIE_FORWARD_TO_ZENDESK_MESSAGE
 		: ODIE_FORWARD_TO_FORUMS_MESSAGE;
 
-	return forwardMessage;
+	return isErrorMessage ? ODIE_ERROR_MESSAGE : forwardMessage;
 };
 
 export const UserMessage = ( {
@@ -88,9 +96,9 @@ export const UserMessage = ( {
 		isRequestingHumanSupport,
 		message.content,
 		hasCannedResponse,
-		forceEmailSupport
+		forceEmailSupport,
+		message?.context?.flags?.is_error_message
 	);
-
 	const displayingThirdPartyMessage =
 		isUserEligibleForPaidSupport && ! canConnectToZendesk && isRequestingHumanSupport;
 

--- a/packages/odie-client/src/constants.ts
+++ b/packages/odie-client/src/constants.ts
@@ -8,7 +8,7 @@ export const ODIE_ERROR_MESSAGE = __(
 );
 
 export const ODIE_ERROR_MESSAGE_NON_ELIGIBLE = __(
-	'Sorry, I am offline right now. Come back later or ask for help in our forums.',
+	'Sorry, I am offline right now. Come back later or ask for help in our forums:',
 	__i18n_text_domain__
 );
 

--- a/packages/odie-client/src/constants.ts
+++ b/packages/odie-client/src/constants.ts
@@ -7,6 +7,11 @@ export const ODIE_ERROR_MESSAGE = __(
 	__i18n_text_domain__
 );
 
+export const ODIE_ERROR_MESSAGE_NON_ELIGIBLE = __(
+	'Sorry, I am offline right now. Come back later or ask for help in our forums.',
+	__i18n_text_domain__
+);
+
 export const ODIE_RATE_LIMIT_MESSAGE = __(
 	"Hi there! You've hit your AI usage limit. Upgrade your plan for unlimited Wapuu support! You can still get user support using the buttons below.",
 	__i18n_text_domain__
@@ -32,6 +37,22 @@ export const ODIE_TRANSFER_MESSAGE: Message[] = [
 				hide_disclaimer_content: true,
 				show_contact_support_msg: false,
 				show_ai_avatar: false,
+			},
+			site_id: null,
+		},
+	},
+];
+
+export const ODIE_ON_ERROR_TRANSFER_MESSAGE: Message[] = [
+	{
+		content: ODIE_ERROR_MESSAGE,
+		role: 'bot',
+		type: 'message',
+		context: {
+			flags: {
+				hide_disclaimer_content: true,
+				show_contact_support_msg: false,
+				show_ai_avatar: true,
 			},
 			site_id: null,
 		},

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -15,6 +15,29 @@ import { generateUUID, getOdieIdFromInteraction, getIsRequestingHumanSupport } f
 import { useManageSupportInteraction, broadcastOdieMessage } from '.';
 import type { Chat, Message, ReturnedChat } from '../types';
 
+const getErrorMessageForSiteIdAndInternalMessageId = (
+	selectedSiteId: number | null | undefined,
+	internal_message_id: string
+): Message => {
+	return {
+		content: ODIE_ERROR_MESSAGE_NON_ELIGIBLE,
+		internal_message_id,
+		role: 'bot',
+		type: 'message',
+		context: {
+			site_id: selectedSiteId ?? null,
+			flags: {
+				forward_to_human_support: true,
+				canned_response: false,
+				hide_disclaimer_content: false,
+				show_contact_support_msg: true,
+				show_ai_avatar: true,
+				is_error_message: true,
+			},
+		},
+	};
+};
+
 /**
  * Sends a new message to ODIE.
  * If the chat_id is not set, it will create a new chat and send a message to the chat.
@@ -56,11 +79,15 @@ export const useSendOdieMessage = () => {
 		If the message is a request for human support, it will escalate the chat to human support, if eligible.
 		If email support is forced, it will add an email fallback message.
 	*/
-	const addMessage = (
-		message: Message | Message[],
-		props?: Partial< Chat >,
-		fromError: boolean = false
-	) => {
+	const addMessage = ( {
+		message,
+		props = {},
+		isFromError = false,
+	}: {
+		message: Message | Message[];
+		props?: Partial< Chat >;
+		isFromError: boolean;
+	} ) => {
 		if ( ! Array.isArray( message ) ) {
 			if ( getIsRequestingHumanSupport( message ) ) {
 				if ( forceEmailSupport ) {
@@ -70,12 +97,14 @@ export const useSendOdieMessage = () => {
 						messages: [ ...prevChat.messages, ...[ ODIE_EMAIL_FALLBACK_MESSAGE ] ],
 						status: 'loaded',
 					} ) );
+					broadcastOdieMessage( message, odieBroadcastClientId );
 					return;
 				} else if ( ! chat.conversationId && canConnectToZendesk && isUserEligibleForPaidSupport ) {
 					newConversation( {
 						createdFrom: 'automatic_escalation',
-						fromError,
+						isFromError,
 					} );
+					broadcastOdieMessage( message, odieBroadcastClientId );
 					return;
 				}
 			}
@@ -128,30 +157,16 @@ export const useSendOdieMessage = () => {
 					// Note: newConversation will add the ODIE_ON_ERROR_TRANSFER_MESSAGE automatically
 					newConversation( {
 						createdFrom: 'empty_response_error',
-						fromError: true,
+						isFromError: true,
 					} );
 				} else {
 					// User is not eligible for premium support - show error message with support buttons
-					const errorMessage: Message = {
-						content: ODIE_ERROR_MESSAGE_NON_ELIGIBLE,
-						internal_message_id,
-						role: 'bot',
-						type: 'message',
-						context: {
-							site_id: selectedSiteId ?? null,
-							flags: {
-								forward_to_human_support: true,
-								canned_response: false,
-								hide_disclaimer_content: false,
-								show_contact_support_msg: true,
-								show_ai_avatar: true,
-								is_error_message: true,
-							},
-						},
-					};
+					const errorMessage = getErrorMessageForSiteIdAndInternalMessageId(
+						selectedSiteId,
+						internal_message_id
+					);
 
-					addMessage( errorMessage, {}, true );
-					broadcastOdieMessage( errorMessage, odieBroadcastClientId );
+					addMessage( { message: errorMessage, props: {}, isFromError: true } );
 				}
 				return;
 			}
@@ -176,8 +191,11 @@ export const useSendOdieMessage = () => {
 				context: returnedChat.messages[ 0 ].context,
 			};
 			setExperimentVariationName( returnedChat.experiment_name );
-			addMessage( botMessage, { odieId: returnedChat.chat_id } );
-			broadcastOdieMessage( botMessage, odieBroadcastClientId );
+			addMessage( {
+				message: botMessage,
+				props: { odieId: returnedChat.chat_id },
+				isFromError: false,
+			} );
 		},
 		onSettled: () => {
 			queryClient.invalidateQueries( { queryKey: [ 'odie-chat', botNameSlug, odieId ] } );
@@ -194,37 +212,21 @@ export const useSendOdieMessage = () => {
 					type: 'message',
 					context: undefined,
 				};
-				addMessage( errorMessage, {}, true );
-				broadcastOdieMessage( errorMessage, odieBroadcastClientId );
+				addMessage( { message: errorMessage, props: {}, isFromError: true } );
 			} else if ( isUserEligibleForPaidSupport && canConnectToZendesk ) {
 				// User is eligible for premium support - transfer to Zendesk
-				// Note: newConversation will add the ODIE_ON_ERROR_TRANSFER_MESSAGE automatically
 				newConversation( {
 					createdFrom: 'api_error',
-					fromError: true,
+					isFromError: true,
 				} );
 			} else {
 				// User is not eligible for premium support - show error message with support buttons
-				const errorMessage: Message = {
-					content: ODIE_ERROR_MESSAGE_NON_ELIGIBLE,
-					internal_message_id,
-					role: 'bot',
-					type: 'message',
-					context: {
-						site_id: selectedSiteId ?? null,
-						flags: {
-							forward_to_human_support: true,
-							canned_response: false,
-							hide_disclaimer_content: false,
-							show_contact_support_msg: true,
-							show_ai_avatar: true,
-							is_error_message: true,
-						},
-					},
-				};
+				const errorMessage: Message = getErrorMessageForSiteIdAndInternalMessageId(
+					selectedSiteId,
+					internal_message_id
+				);
 
-				addMessage( errorMessage, {}, true );
-				broadcastOdieMessage( errorMessage, odieBroadcastClientId );
+				addMessage( { message: errorMessage, props: {}, isFromError: true } );
 			}
 		},
 	} );

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -5,9 +5,9 @@ import apiFetch from '@wordpress/api-fetch';
 import { useSelect } from '@wordpress/data';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import {
-	ODIE_ERROR_MESSAGE,
 	ODIE_RATE_LIMIT_MESSAGE,
 	ODIE_EMAIL_FALLBACK_MESSAGE,
+	ODIE_ERROR_MESSAGE_NON_ELIGIBLE,
 } from '../constants';
 import { useOdieAssistantContext } from '../context';
 import { useCreateZendeskConversation } from '../hooks';
@@ -56,7 +56,11 @@ export const useSendOdieMessage = () => {
 		If the message is a request for human support, it will escalate the chat to human support, if eligible.
 		If email support is forced, it will add an email fallback message.
 	*/
-	const addMessage = ( message: Message | Message[], props?: Partial< Chat > ) => {
+	const addMessage = (
+		message: Message | Message[],
+		props?: Partial< Chat >,
+		fromError: boolean = false
+	) => {
 		if ( ! Array.isArray( message ) ) {
 			if ( getIsRequestingHumanSupport( message ) ) {
 				if ( forceEmailSupport ) {
@@ -68,7 +72,10 @@ export const useSendOdieMessage = () => {
 					} ) );
 					return;
 				} else if ( ! chat.conversationId && canConnectToZendesk && isUserEligibleForPaidSupport ) {
-					newConversation( { createdFrom: 'automatic_escalation' } );
+					newConversation( {
+						createdFrom: 'automatic_escalation',
+						fromError,
+					} );
 					return;
 				}
 			}
@@ -115,16 +122,37 @@ export const useSendOdieMessage = () => {
 				returnedChat.messages.length === 0 ||
 				! returnedChat.messages[ 0 ].content
 			) {
-				const errorMessage: Message = {
-					content: ODIE_ERROR_MESSAGE,
-					internal_message_id,
-					role: 'bot',
-					type: 'error',
-				};
+				// Handle empty/error response based on user eligibility
+				if ( isUserEligibleForPaidSupport && canConnectToZendesk ) {
+					// User is eligible for premium support - transfer to Zendesk
+					// Note: newConversation will add the ODIE_ON_ERROR_TRANSFER_MESSAGE automatically
+					newConversation( {
+						createdFrom: 'empty_response_error',
+						fromError: true,
+					} );
+				} else {
+					// User is not eligible for premium support - show error message with support buttons
+					const errorMessage: Message = {
+						content: ODIE_ERROR_MESSAGE_NON_ELIGIBLE,
+						internal_message_id,
+						role: 'bot',
+						type: 'message',
+						context: {
+							site_id: selectedSiteId ?? null,
+							flags: {
+								forward_to_human_support: true,
+								canned_response: false,
+								hide_disclaimer_content: false,
+								show_contact_support_msg: true,
+								show_ai_avatar: true,
+								is_error_message: true,
+							},
+						},
+					};
 
-				addMessage( errorMessage );
-
-				broadcastOdieMessage( errorMessage, odieBroadcastClientId );
+					addMessage( errorMessage, {}, true );
+					broadcastOdieMessage( errorMessage, odieBroadcastClientId );
+				}
 				return;
 			}
 
@@ -156,14 +184,48 @@ export const useSendOdieMessage = () => {
 		},
 		onError: ( error ) => {
 			const isRateLimitError = error.message.includes( '429' );
-			const errorMessage: Message = {
-				content: isRateLimitError ? ODIE_RATE_LIMIT_MESSAGE : ODIE_ERROR_MESSAGE,
-				internal_message_id,
-				role: 'bot',
-				type: 'error',
-			};
-			addMessage( errorMessage );
-			broadcastOdieMessage( errorMessage, odieBroadcastClientId );
+
+			if ( isRateLimitError ) {
+				// Handle rate limit error with standard rate limit message
+				const errorMessage: Message = {
+					content: ODIE_RATE_LIMIT_MESSAGE,
+					internal_message_id,
+					role: 'bot',
+					type: 'message',
+					context: undefined,
+				};
+				addMessage( errorMessage, {}, true );
+				broadcastOdieMessage( errorMessage, odieBroadcastClientId );
+			} else if ( isUserEligibleForPaidSupport && canConnectToZendesk ) {
+				// User is eligible for premium support - transfer to Zendesk
+				// Note: newConversation will add the ODIE_ON_ERROR_TRANSFER_MESSAGE automatically
+				newConversation( {
+					createdFrom: 'api_error',
+					fromError: true,
+				} );
+			} else {
+				// User is not eligible for premium support - show error message with support buttons
+				const errorMessage: Message = {
+					content: ODIE_ERROR_MESSAGE_NON_ELIGIBLE,
+					internal_message_id,
+					role: 'bot',
+					type: 'message',
+					context: {
+						site_id: selectedSiteId ?? null,
+						flags: {
+							forward_to_human_support: true,
+							canned_response: false,
+							hide_disclaimer_content: false,
+							show_contact_support_msg: true,
+							show_ai_avatar: true,
+							is_error_message: true,
+						},
+					},
+				};
+
+				addMessage( errorMessage, {}, true );
+				broadcastOdieMessage( errorMessage, odieBroadcastClientId );
+			}
 		},
 	} );
 };

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -3,7 +3,7 @@ import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { useUpdateZendeskUserFields } from '@automattic/zendesk-client';
 import { useSelect } from '@wordpress/data';
 import Smooch from 'smooch';
-import { ODIE_TRANSFER_MESSAGE } from '../constants';
+import { ODIE_ON_ERROR_TRANSFER_MESSAGE, ODIE_TRANSFER_MESSAGE } from '../constants';
 import { useOdieAssistantContext } from '../context';
 import { useManageSupportInteraction } from '../data';
 import { setHelpCenterZendeskConversationStarted } from '../utils';
@@ -13,11 +13,13 @@ export const useCreateZendeskConversation = (): ( ( {
 	interactionId,
 	section,
 	createdFrom,
+	fromError,
 }: {
 	avoidTransfer?: boolean;
 	interactionId?: string;
 	section?: string | null;
 	createdFrom?: string;
+	fromError?: boolean;
 } ) => Promise< void > ) => {
 	const {
 		selectedSiteId,
@@ -45,11 +47,13 @@ export const useCreateZendeskConversation = (): ( ( {
 		interactionId = '',
 		section = '',
 		createdFrom = '',
+		fromError = false,
 	}: {
 		avoidTransfer?: boolean;
 		interactionId?: string;
 		section?: string | null;
 		createdFrom?: string;
+		fromError?: boolean;
 	} ) => {
 		const currentInteractionID = interactionId || currentSupportInteraction!.uuid;
 		if (
@@ -65,7 +69,10 @@ export const useCreateZendeskConversation = (): ( ( {
 			...prevChat,
 			messages: avoidTransfer
 				? prevChat.messages
-				: [ ...prevChat.messages, ...ODIE_TRANSFER_MESSAGE ],
+				: [
+						...prevChat.messages,
+						...( fromError ? ODIE_ON_ERROR_TRANSFER_MESSAGE : ODIE_TRANSFER_MESSAGE ),
+				  ],
 			status: 'transfer',
 		} ) );
 

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -13,13 +13,13 @@ export const useCreateZendeskConversation = (): ( ( {
 	interactionId,
 	section,
 	createdFrom,
-	fromError,
+	isFromError,
 }: {
 	avoidTransfer?: boolean;
 	interactionId?: string;
 	section?: string | null;
 	createdFrom?: string;
-	fromError?: boolean;
+	isFromError?: boolean;
 } ) => Promise< void > ) => {
 	const {
 		selectedSiteId,
@@ -47,13 +47,13 @@ export const useCreateZendeskConversation = (): ( ( {
 		interactionId = '',
 		section = '',
 		createdFrom = '',
-		fromError = false,
+		isFromError = false,
 	}: {
 		avoidTransfer?: boolean;
 		interactionId?: string;
 		section?: string | null;
 		createdFrom?: string;
-		fromError?: boolean;
+		isFromError?: boolean;
 	} ) => {
 		const currentInteractionID = interactionId || currentSupportInteraction!.uuid;
 		if (
@@ -71,7 +71,7 @@ export const useCreateZendeskConversation = (): ( ( {
 				? prevChat.messages
 				: [
 						...prevChat.messages,
-						...( fromError ? ODIE_ON_ERROR_TRANSFER_MESSAGE : ODIE_TRANSFER_MESSAGE ),
+						...( isFromError ? ODIE_ON_ERROR_TRANSFER_MESSAGE : ODIE_TRANSFER_MESSAGE ),
 				  ],
 			status: 'transfer',
 		} ) );

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -133,6 +133,7 @@ export type Context = {
 		hide_disclaimer_content?: boolean;
 		show_contact_support_msg?: boolean;
 		show_ai_avatar?: boolean;
+		is_error_message?: boolean;
 	};
 };
 


### PR DESCRIPTION
Part of # peZLxy-1kF-p2#comment-2532 p1749758704613009-slack-C069S5S3GP2 

## Proposed Changes

* Adds a better `key` to message container elements to fix React warning in console about missing unique keys (existing issue - quick-win)
* Enhances `getDisplayMessage` logic to support error fallback messages, distinguishing between paid and non-paid users.
* Updates `useSendOdieMessage` to:
  - Handle empty or malformed LLM responses.
  - Gracefully escalate users to Zendesk or show a contextual error message with support actions (forum).
  - Include an optional `fromError` param when triggering escalation from error scenarios.
  - Improve message fallback for server-side errors depending on user eligibility.

## Why are these changes being made?

These changes improve the resilience of the support flow when relying on external LLMs. If a model fails to return a usable response (e.g. empty message or API failure), we ensure users are properly guided to the correct support channel (Zendesk for eligible users, fallback error message with helpful actions for others). This prevents dead ends and improves user trust and satisfaction during edge-case errors or outages.

## Testing Instructions

**Pre-requisite**: Have two different users one with a **paid** site and a nother with a **free** site.

### Zendesk Escalation Scenario

For all tests below, sandbox the **public API**.

One Bin file: 3820f-pb/

1. **Simulate API error with eligible (paid) user:**
   - In `send_chat_message()` (`file indicated in One Bin file`), add this at the top of the method:
     ```php
     $request->set_param( 'test', true );
     ```
   - At line 781, force an error:
     ```php
     return new WP_Error( 'error', 'Error', [ 'status' => 500 ] );
     ```
   - Go to Help Center, ask a question.
   - Expected: You are escalated to Zendesk automatically.

2. **Simulate empty LLM response with eligible (paid) user:**
   - Instead of the above, at line 841, inject:
     ```php
     $chat_response['messages'][0]->content = '';
     ```
   - Ask anything again.
   - Expected: You are escalated to Zendesk.

### Forum Escalation Scenarios

3. **Repeat both steps above with a non-eligible (free) user.**
   - Expected: Instead of escalation, a fallback error message is shown with contact options (forum).

### Normal Path Testing (without modifying API, regression testing)

4. With both users (paid and free):
   - Go to Help Center and ask for escalation manually.
   - Expected: Paid user is redirected to Zendesk, free user receives appropriate fallback message (forums button).

### Reference screenshots
![image](https://github.com/user-attachments/assets/7b84738c-92af-4b6a-b1bb-c5ec1f0b692a) ![image](https://github.com/user-attachments/assets/2c5b69e9-b503-4156-9a63-b03f303f6587)



## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?