### PR TITLE
Backported Settings: Preload router on controller

### DIFF
--- a/client/blocks/site-favicon/index.tsx
+++ b/client/blocks/site-favicon/index.tsx
@@ -17,6 +17,7 @@ interface SiteFaviconProps {
 	size?: number;
 	className?: string;
 	fallback?: SiteFaviconFallback;
+	lazy?: boolean;
 }
 
 const SiteFavicon = ( {
@@ -25,6 +26,7 @@ const SiteFavicon = ( {
 	size = 40,
 	className = '',
 	fallback = 'color',
+	lazy = false,
 }: SiteFaviconProps ) => {
 	const { __ } = useI18n();
 	const siteColor = color ?? 'linear-gradient(45deg, #ff0056, #ff8a78, #57b7ff, #9c00d4)';
@@ -59,7 +61,7 @@ const SiteFavicon = ( {
 
 	return (
 		<div className={ clsx( 'site-favicon', className, defaultFaviconClass ) }>
-			<SiteIcon siteId={ blogId } size={ size } defaultIcon={ defaultFavicon } />
+			<SiteIcon siteId={ blogId } size={ size } defaultIcon={ defaultFavicon } lazy={ lazy } />
 		</div>
 	);
 };

--- a/client/dashboard/app/query-client.ts
+++ b/client/dashboard/app/query-client.ts
@@ -5,7 +5,7 @@ import { persistQueryClient } from '@tanstack/react-query-persist-client';
 export const queryClient = new QueryClient( {
 	defaultOptions: {
 		queries: {
-			staleTime: 1000 * 60 * 1, // 1 minutes
+			staleTime: 1000 * 60 * 1, // 1 minute
 			refetchOnWindowFocus: true,
 			refetchOnMount: true,
 		},

--- a/client/dashboard/app/query-client.ts
+++ b/client/dashboard/app/query-client.ts
@@ -5,7 +5,7 @@ import { persistQueryClient } from '@tanstack/react-query-persist-client';
 export const queryClient = new QueryClient( {
 	defaultOptions: {
 		queries: {
-			staleTime: 0,
+			staleTime: 1000 * 60 * 1, // 1 minutes
 			refetchOnWindowFocus: true,
 			refetchOnMount: true,
 		},

--- a/client/dashboard/sites/settings-hundred-year-plan/summary.tsx
+++ b/client/dashboard/sites/settings-hundred-year-plan/summary.tsx
@@ -12,7 +12,7 @@ export default function HundredYearPlanSummary( {
 	density,
 }: {
 	site: Site;
-	settings: SiteSettings;
+	settings?: SiteSettings;
 	density?: Density;
 } ) {
 	if ( ! canViewHundredYearPlanSettings( site ) ) {
@@ -26,7 +26,9 @@ export default function HundredYearPlanSummary( {
 			density={ density }
 			decoration={ <Icon icon={ institution } /> }
 			badges={
-				settings.wpcom_locked_mode ? [ { text: __( 'Site locked' ), intent: 'info' as const } ] : []
+				settings?.wpcom_locked_mode
+					? [ { text: __( 'Site locked' ), intent: 'info' as const } ]
+					: []
 			}
 		/>
 	);

--- a/client/dashboard/sites/settings-subscription-gifting/summary.tsx
+++ b/client/dashboard/sites/settings-subscription-gifting/summary.tsx
@@ -12,11 +12,18 @@ export default function SubscriptionGiftingSettingsSummary( {
 	density,
 }: {
 	site: Site;
-	settings: SiteSettings;
+	settings?: SiteSettings;
 	density?: Density;
 } ) {
 	if ( ! canViewSubscriptionGiftingSettings( site ) ) {
 		return null;
+	}
+
+	let badges;
+	if ( settings ) {
+		badges = settings.wpcom_gifting_subscription
+			? [ { text: __( 'Enabled' ), intent: 'success' as const } ]
+			: [ { text: __( 'Disabled' ) } ];
 	}
 	return (
 		<RouterLinkSummaryButton
@@ -24,11 +31,7 @@ export default function SubscriptionGiftingSettingsSummary( {
 			title={ __( 'Accept a gift subscription' ) }
 			density={ density }
 			decoration={ <Icon icon={ heading } /> }
-			badges={
-				settings.wpcom_gifting_subscription
-					? [ { text: __( 'Enabled' ), intent: 'success' as const } ]
-					: [ { text: __( 'Disabled' ) } ]
-			}
+			badges={ badges }
 		/>
 	);
 }

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -26,10 +26,6 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: settings } = useQuery( siteSettingsQuery( site.ID ) );
 
-	if ( ! settings ) {
-		return null;
-	}
-
 	return (
 		<PageLayout size="small" header={ <PageHeader title={ __( 'Settings' ) } /> }>
 			<VStack spacing={ 3 }>

--- a/client/sites/components/sites-dataviews/site-icon.tsx
+++ b/client/sites/components/sites-dataviews/site-icon.tsx
@@ -67,6 +67,7 @@ export default function SiteIcon( {
 				blogId={ site.ID }
 				fallback={ isMigrationPending ? 'migration' : 'first-grapheme' }
 				size={ size }
+				lazy
 			/>
 		</ThumbnailLink>
 	);

--- a/client/sites/settings/controller.tsx
+++ b/client/sites/settings/controller.tsx
@@ -2,7 +2,6 @@ import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { __ } from '@wordpress/i18n';
 import { useSelector } from 'react-redux';
-import { persistPromise } from 'calypso/dashboard/app/query-client';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { fetchSiteFeatures } from 'calypso/state/sites/features/actions';
 import { isSimpleSite } from 'calypso/state/sites/selectors';
@@ -26,9 +25,7 @@ import SftpSshSettings from './sftp-ssh';
 import useSftpSshSettingTitle from './sftp-ssh/hooks/use-sftp-ssh-setting-title';
 import SiteSettings from './site';
 import DashboardBackportSiteSettingsRenderer from './v2';
-import { router } from './v2/layout';
 import type { Context as PageJSContext } from '@automattic/calypso-router';
-import type { RouteByPath } from '@tanstack/react-router';
 
 export function SettingsSidebar() {
 	const slug = useSelector( getSelectedSiteSlug );
@@ -229,14 +226,6 @@ export async function dashboardBackportSiteSettings( context: PageJSContext, nex
 			feature={ feature }
 		/>
 	);
-
-	await Promise.all( [
-		persistPromise,
-		router.preloadRoute( {
-			to: router.routesByPath[ '/$siteSlug/' ] as RouteByPath,
-			params: { siteSlug: siteSlug },
-		} ),
-	] );
 
 	next();
 }

--- a/client/sites/settings/controller.tsx
+++ b/client/sites/settings/controller.tsx
@@ -214,11 +214,10 @@ export function performanceSettings( context: PageJSContext, next: () => void ) 
  * Backport Hosting Dashboard Site Settings page to the current one.
  */
 export async function dashboardBackportSiteSettings( context: PageJSContext, next: () => void ) {
-	const state = context.store.getState();
-	const site = getSelectedSite( state );
+	const { site: siteSlug, feature } = context.params;
 
 	if ( ! isEnabled( 'dashboard/v2/backport/site-settings' ) ) {
-		return page.redirect( `/sites/settings/site/${ site?.slug }` );
+		return page.redirect( `/sites/settings/site/${ siteSlug }` );
 	}
 
 	// Route doesn't require a <PageViewTracker /> because the dashboard
@@ -226,8 +225,8 @@ export async function dashboardBackportSiteSettings( context: PageJSContext, nex
 	context.primary = (
 		<DashboardBackportSiteSettingsRenderer
 			store={ context.store }
-			siteSlug={ site?.slug }
-			feature={ context.params.feature }
+			siteSlug={ siteSlug }
+			feature={ feature }
 		/>
 	);
 
@@ -235,7 +234,7 @@ export async function dashboardBackportSiteSettings( context: PageJSContext, nex
 		persistPromise,
 		router.preloadRoute( {
 			to: router.routesByPath[ '/$siteSlug/' ] as RouteByPath,
-			params: { siteSlug: site?.slug },
+			params: { siteSlug: siteSlug },
 		} ),
 	] );
 

--- a/client/sites/settings/controller.tsx
+++ b/client/sites/settings/controller.tsx
@@ -26,8 +26,9 @@ import SftpSshSettings from './sftp-ssh';
 import useSftpSshSettingTitle from './sftp-ssh/hooks/use-sftp-ssh-setting-title';
 import SiteSettings from './site';
 import DashboardBackportSiteSettingsRenderer from './v2';
-import { createRouter } from './v2/layout';
+import { router } from './v2/layout';
 import type { Context as PageJSContext } from '@automattic/calypso-router';
+import type { RouteByPath } from '@tanstack/react-router';
 
 export function SettingsSidebar() {
 	const slug = useSelector( getSelectedSiteSlug );
@@ -230,7 +231,13 @@ export async function dashboardBackportSiteSettings( context: PageJSContext, nex
 		/>
 	);
 
-	await Promise.all( [ persistPromise, createRouter().load() ] );
+	await Promise.all( [
+		persistPromise,
+		router.preloadRoute( {
+			to: router.routesByPath[ '/$siteSlug/' ] as RouteByPath,
+			params: { siteSlug: site?.slug },
+		} ),
+	] );
 
 	next();
 }

--- a/client/sites/settings/controller.tsx
+++ b/client/sites/settings/controller.tsx
@@ -2,6 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { __ } from '@wordpress/i18n';
 import { useSelector } from 'react-redux';
+import { persistPromise } from 'calypso/dashboard/app/query-client';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { fetchSiteFeatures } from 'calypso/state/sites/features/actions';
 import { isSimpleSite } from 'calypso/state/sites/selectors';
@@ -25,6 +26,7 @@ import SftpSshSettings from './sftp-ssh';
 import useSftpSshSettingTitle from './sftp-ssh/hooks/use-sftp-ssh-setting-title';
 import SiteSettings from './site';
 import DashboardBackportSiteSettingsRenderer from './v2';
+import { createRouter } from './v2/layout';
 import type { Context as PageJSContext } from '@automattic/calypso-router';
 
 export function SettingsSidebar() {
@@ -210,7 +212,7 @@ export function performanceSettings( context: PageJSContext, next: () => void ) 
 /**
  * Backport Hosting Dashboard Site Settings page to the current one.
  */
-export function dashboardBackportSiteSettings( context: PageJSContext, next: () => void ) {
+export async function dashboardBackportSiteSettings( context: PageJSContext, next: () => void ) {
 	const state = context.store.getState();
 	const site = getSelectedSite( state );
 
@@ -227,6 +229,8 @@ export function dashboardBackportSiteSettings( context: PageJSContext, next: () 
 			feature={ context.params.feature }
 		/>
 	);
+
+	await Promise.all( [ persistPromise, createRouter().load() ] );
 
 	next();
 }

--- a/client/sites/settings/v2/index.tsx
+++ b/client/sites/settings/v2/index.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useRef, useMemo } from 'react';
 import { createRoot } from 'react-dom/client';
-import { useDispatch } from 'calypso/state';
+import { AUTH_QUERY_KEY } from 'calypso/dashboard/app/auth';
+import { siteBySlugQuery } from 'calypso/dashboard/app/queries/site';
+import { siteSettingsQuery } from 'calypso/dashboard/app/queries/site-settings';
+import { queryClient } from 'calypso/dashboard/app/query-client';
+import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent, recordPageView } from 'calypso/state/analytics/actions';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getSiteSettings } from 'calypso/state/site-settings/selectors';
+import { getSite } from 'calypso/state/sites/selectors';
 import Layout from './layout';
 import type { AnalyticsClient } from 'calypso/dashboard/app/analytics';
 import type { Store } from 'redux';
@@ -17,6 +24,9 @@ export default function DashboardBackportSiteSettingsRenderer( {
 } ) {
 	const rootInstanceRef = useRef< ReturnType< typeof createRoot > | null >( null );
 	const containerRef = useRef< HTMLDivElement >( null );
+	const user = useSelector( ( state ) => getCurrentUser( state ) );
+	const site = useSelector( ( state ) => getSite( state, siteSlug ) );
+	const siteSettings = useSelector( ( state ) => site?.ID && getSiteSettings( state, site.ID ) );
 	const dispatch = useDispatch();
 
 	const analyticsClient: AnalyticsClient = useMemo(
@@ -64,6 +74,21 @@ export default function DashboardBackportSiteSettingsRenderer( {
 			/>
 		);
 	}, [ store, analyticsClient, siteSlug, feature ] );
+
+	// Use data already available in Redux to seed the React Query cache and avoid redundant data fetching.
+	useEffect( () => {
+		if ( user ) {
+			queryClient.setQueryData( AUTH_QUERY_KEY, user );
+		}
+
+		if ( site ) {
+			queryClient.setQueryData( siteBySlugQuery( site.slug ).queryKey, site );
+		}
+
+		if ( site && siteSettings ) {
+			queryClient.setQueryData( siteSettingsQuery( site.ID ).queryKey, siteSettings );
+		}
+	}, [ user, site, siteSettings ] );
 
 	return <div className="dashboard-backport-site-settings-root" ref={ containerRef } />;
 }

--- a/client/sites/settings/v2/index.tsx
+++ b/client/sites/settings/v2/index.tsx
@@ -3,13 +3,13 @@ import { createRoot } from 'react-dom/client';
 import { AUTH_QUERY_KEY } from 'calypso/dashboard/app/auth';
 import { siteBySlugQuery } from 'calypso/dashboard/app/queries/site';
 import { siteSettingsQuery } from 'calypso/dashboard/app/queries/site-settings';
-import { queryClient } from 'calypso/dashboard/app/query-client';
+import { queryClient, persistPromise } from 'calypso/dashboard/app/query-client';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent, recordPageView } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getSiteSettings } from 'calypso/state/site-settings/selectors';
 import { getSite } from 'calypso/state/sites/selectors';
-import Layout from './layout';
+import Layout, { router } from './layout';
 import type { AnalyticsClient } from 'calypso/dashboard/app/analytics';
 import type { Store } from 'redux';
 
@@ -65,15 +65,22 @@ export default function DashboardBackportSiteSettingsRenderer( {
 			return;
 		}
 
-		rootInstanceRef.current?.render(
-			<Layout
-				store={ store }
-				analyticsClient={ analyticsClient }
-				siteSlug={ siteSlug }
-				feature={ feature }
-			/>
-		);
-	}, [ store, analyticsClient, siteSlug, feature ] );
+		Promise.all( [
+			persistPromise,
+			router.preloadRoute( {
+				to: `/${ siteSlug }`,
+			} ),
+		] ).then( () => {
+			rootInstanceRef.current?.render(
+				<Layout
+					store={ store }
+					analyticsClient={ analyticsClient }
+					siteSlug={ siteSlug }
+					feature={ feature }
+				/>
+			);
+		} );
+	}, [ store, analyticsClient, user, siteSlug, feature ] );
 
 	// Use data already available in Redux to seed the React Query cache and avoid redundant data fetching.
 	useEffect( () => {

--- a/client/sites/settings/v2/index.tsx
+++ b/client/sites/settings/v2/index.tsx
@@ -56,9 +56,14 @@ export default function DashboardBackportSiteSettingsRenderer( {
 		}
 
 		rootInstanceRef.current?.render(
-			<Layout store={ store } analyticsClient={ analyticsClient } />
+			<Layout
+				store={ store }
+				analyticsClient={ analyticsClient }
+				siteSlug={ siteSlug }
+				feature={ feature }
+			/>
 		);
-	}, [ analyticsClient, store, siteSlug, feature ] );
+	}, [ store, analyticsClient, siteSlug, feature ] );
 
 	return <div className="dashboard-backport-site-settings-root" ref={ containerRef } />;
 }

--- a/client/sites/settings/v2/index.tsx
+++ b/client/sites/settings/v2/index.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useMemo } from 'react';
 import { createRoot } from 'react-dom/client';
-import { persistPromise } from 'calypso/dashboard/app/query-client';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent, recordPageView } from 'calypso/state/analytics/actions';
 import Layout from './layout';
@@ -56,11 +55,9 @@ export default function DashboardBackportSiteSettingsRenderer( {
 			return;
 		}
 
-		persistPromise.then( () => {
-			rootInstanceRef.current?.render(
-				<Layout store={ store } analyticsClient={ analyticsClient } />
-			);
-		} );
+		rootInstanceRef.current?.render(
+			<Layout store={ store } analyticsClient={ analyticsClient } />
+		);
 	}, [ analyticsClient, store, siteSlug, feature ] );
 
 	return <div className="dashboard-backport-site-settings-root" ref={ containerRef } />;

--- a/client/sites/settings/v2/layout.tsx
+++ b/client/sites/settings/v2/layout.tsx
@@ -12,9 +12,13 @@ const config = {
 	basePath: '/sites/settings/v2',
 };
 
+export function createRouter() {
+	return getRouter( config );
+}
+
 function RouterProviderWithAuth() {
 	const auth = useAuth();
-	const router = getRouter( config );
+	const router = createRouter();
 	return <RouterProvider router={ router } context={ { auth, config } } />;
 }
 

--- a/client/sites/settings/v2/layout.tsx
+++ b/client/sites/settings/v2/layout.tsx
@@ -1,10 +1,11 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider } from '@tanstack/react-router';
+import { useEffect } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { AnalyticsProvider, type AnalyticsClient } from 'calypso/dashboard/app/analytics';
 import { AuthProvider, useAuth } from 'calypso/dashboard/app/auth';
 import { queryClient } from 'calypso/dashboard/app/query-client';
-import { getRouter } from './router';
+import { getRouter, syncBrowserHistoryToRouter, syncMemoryRouterToBrowserHistory } from './router';
 import type { Store } from 'redux';
 
 // Serves a similar purpose to AppConfig form v2 dashboard.
@@ -12,23 +13,49 @@ const config = {
 	basePath: '/sites/settings/v2',
 };
 
-export function createRouter() {
-	return getRouter( config );
-}
+export const router = getRouter( config );
 
-function RouterProviderWithAuth() {
+function RouterProviderWithAuth( { siteSlug, feature }: { siteSlug?: string; feature?: string } ) {
 	const auth = useAuth();
-	const router = createRouter();
+
+	useEffect( () => {
+		syncBrowserHistoryToRouter( router );
+	}, [ siteSlug, feature ] );
+
+	useEffect( () => {
+		const handlePopstate = () => {
+			syncBrowserHistoryToRouter( router );
+		};
+
+		const unsubscribe = syncMemoryRouterToBrowserHistory( router );
+		window.addEventListener( 'popstate', handlePopstate );
+
+		return () => {
+			unsubscribe();
+			window.removeEventListener( 'popstate', handlePopstate );
+		};
+	}, [] );
+
 	return <RouterProvider router={ router } context={ { auth, config } } />;
 }
 
-function Layout( { store, analyticsClient }: { store: Store; analyticsClient: AnalyticsClient } ) {
+function Layout( {
+	store,
+	analyticsClient,
+	siteSlug,
+	feature,
+}: {
+	store: Store;
+	analyticsClient: AnalyticsClient;
+	siteSlug?: string;
+	feature?: string;
+} ) {
 	return (
 		<QueryClientProvider client={ queryClient }>
 			<AuthProvider>
 				<AnalyticsProvider client={ analyticsClient }>
 					<ReduxProvider store={ store }>
-						<RouterProviderWithAuth />
+						<RouterProviderWithAuth siteSlug={ siteSlug } feature={ feature } />
 					</ReduxProvider>
 				</AnalyticsProvider>
 			</AuthProvider>

--- a/client/sites/settings/v2/root.tsx
+++ b/client/sites/settings/v2/root.tsx
@@ -1,11 +1,18 @@
-import { Outlet } from '@tanstack/react-router';
+import { useIsFetching } from '@tanstack/react-query';
+import { Outlet, useRouterState } from '@tanstack/react-router';
 import Snackbars from 'calypso/dashboard/app/snackbars';
+import { LoadingLine } from 'calypso/dashboard/components/loading-line';
 import { PageViewTracker } from 'calypso/dashboard/components/page-view-tracker';
 import './style.scss';
 
 export default function Root() {
+	const isFetching = useIsFetching();
+	const router = useRouterState();
+	const isNavigating = router.status === 'pending';
+
 	return (
 		<>
+			{ ( isFetching > 0 || isNavigating ) && <LoadingLine /> }
 			<Outlet />
 			<Snackbars />
 			<PageViewTracker />

--- a/client/sites/settings/v2/root.tsx
+++ b/client/sites/settings/v2/root.tsx
@@ -1,18 +1,11 @@
-import { useIsFetching } from '@tanstack/react-query';
-import { Outlet, useRouterState } from '@tanstack/react-router';
+import { Outlet } from '@tanstack/react-router';
 import Snackbars from 'calypso/dashboard/app/snackbars';
-import { LoadingLine } from 'calypso/dashboard/components/loading-line';
 import { PageViewTracker } from 'calypso/dashboard/components/page-view-tracker';
 import './style.scss';
 
 export default function Root() {
-	const isFetching = useIsFetching();
-	const router = useRouterState();
-	const isNavigating = router.status === 'pending';
-
 	return (
 		<>
-			{ ( isFetching > 0 || isNavigating ) && <LoadingLine /> }
 			<Outlet />
 			<Snackbars />
 			<PageViewTracker />

--- a/client/sites/settings/v2/router.tsx
+++ b/client/sites/settings/v2/router.tsx
@@ -57,7 +57,7 @@ const siteRoute = createRoute( {
 	path: '$siteSlug',
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		queryClient.ensureQueryData( siteSettingsQuery( site.ID ) );
+		await queryClient.ensureQueryData( siteSettingsQuery( site.ID ) );
 	},
 	component: () => <Outlet />,
 } );
@@ -315,11 +315,26 @@ const isCompatibilityRoute = ( router: AnyRouter, url: string ) => {
 	);
 };
 
-const syncMemoryRouterToBrowserHistory = ( router: AnyRouter ) => {
-	let lastPath = '';
+let lastPath = '';
 
+export const syncBrowserHistoryToRouter = ( router: AnyRouter ) => {
+	const currentPath = `${ window.location.pathname }${ window.location.search }`;
+	const basepath = router.options.basepath;
+
+	// Avoid handling routes outside of the basepath.
+	if ( basepath && ! currentPath.startsWith( basepath ) ) {
+		return;
+	}
+
+	if ( currentPath !== lastPath ) {
+		router.navigate( { to: currentPath, replace: true } );
+		lastPath = currentPath;
+	}
+};
+
+export const syncMemoryRouterToBrowserHistory = ( router: AnyRouter ) => {
 	// Sync TanStack Router's history to the browser history (pagejs).
-	router.history.subscribe( () => {
+	return router.history.subscribe( () => {
 		const { pathname, search } = router.history.location;
 		const newUrl = `${ pathname }${ search }`;
 
@@ -331,21 +346,6 @@ const syncMemoryRouterToBrowserHistory = ( router: AnyRouter ) => {
 		if ( window.location.pathname + window.location.search !== newUrl ) {
 			pagejs.show( newUrl );
 			lastPath = newUrl;
-		}
-	} );
-
-	window.addEventListener( 'popstate', () => {
-		const currentPath = `${ window.location.pathname }${ window.location.search }`;
-		const basepath = router.options.basepath;
-
-		// Avoid handling routes outside of the basepath.
-		if ( basepath && ! currentPath.startsWith( basepath ) ) {
-			return;
-		}
-
-		if ( currentPath !== lastPath ) {
-			router.navigate( { to: currentPath, replace: true } );
-			lastPath = currentPath;
 		}
 	} );
 };
@@ -365,6 +365,5 @@ export const getRouter = ( { basePath }: { basePath: string } ) => {
 		history: createMemoryHistory( { initialEntries: [ window.location.pathname ] } ),
 	} );
 
-	syncMemoryRouterToBrowserHistory( router );
 	return router;
 };

--- a/client/sites/settings/v2/router.tsx
+++ b/client/sites/settings/v2/router.tsx
@@ -57,7 +57,7 @@ const siteRoute = createRoute( {
 	path: '$siteSlug',
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		await queryClient.ensureQueryData( siteSettingsQuery( site.ID ) );
+		queryClient.ensureQueryData( siteSettingsQuery( site.ID ) );
 	},
 	component: () => <Outlet />,
 } );

--- a/client/sites/settings/v2/style.scss
+++ b/client/sites/settings/v2/style.scss
@@ -34,15 +34,6 @@
 }
 
 .is-global.is-section-site-settings {
-	// Stick the loading line to the top of the content.
-	.hosting-dashboard-item-view__content {
-		position: relative;
-
-		.loading-line-wrapper {
-			position: absolute;
-		}
-	}
-
 	// BaseControl currently has an override for the label to accommodate the use case where the label is shown next to the control.
 	// In site settings forms, the label is above the control for regular fields so we need to override this override for UI consistency.
 	.dataforms-layouts-regular__field .components-base-control__label {

--- a/client/sites/settings/v2/style.scss
+++ b/client/sites/settings/v2/style.scss
@@ -14,7 +14,7 @@
 		font-weight: 500 !important;
 		line-height: 1;
 	}
-	
+
 	.dashboard-section-header.is-level-2 .dashboard-section-header__heading {
 		font-size: 15px;
 		line-height: 20px;
@@ -34,6 +34,15 @@
 }
 
 .is-global.is-section-site-settings {
+	// Stick the loading line to the top of the content.
+	.hosting-dashboard-item-view__content {
+		position: relative;
+
+		.loading-line-wrapper {
+			position: absolute;
+		}
+	}
+
 	// BaseControl currently has an override for the label to accommodate the use case where the label is shown next to the control.
 	// In site settings forms, the label is above the control for regular fields so we need to override this override for UI consistency.
 	.dataforms-layouts-regular__field .components-base-control__label {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-32

## Proposed Changes

* Improving the loading speed on the backport as follows:
  * Use data already available in Redux to seed the React Query cache and avoid redundant data fetching
  * Preload the route
  * Avoid creating the new router on each render.
  * Avoid loading the `SiteIcon` component if it's not within the viewport. This is because `SiteIcon` depends on site data from the Redux store, but on the sites list screen, we use React Query to fetch that data instead. As a result, the required Redux data might not be available when `SiteIcon` renders. By deferring the loading of `SiteIcon` until it's actually visible, we can prevent unnecessary network requests and avoid blocking the loading of the settings screen.
* According to the Performance tool, the time from the tab appearing to the settings being displayed improved by 59.22%, decreasing from 1275 ms to 520 ms.

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/be1a1c68-5878-4dc4-8d87-16bd62766493) | ![image](https://github.com/user-attachments/assets/76a03f42-c233-494b-acaa-fee56c2ed2a7) |

## TODO

There’s an issue where the dashboard fetches site data using React Query, but the SiteIcon component relies on site data from the Redux store. As a result, if you land directly on the Settings page, it may trigger multiple individual site queries, which can delay the rendering of the settings.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the user experience

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites/settings/v2/:site?flags=dashboard/v2/backport/site-settings`
* Ensure that the Settings content loads faster than before

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
