### PR TITLE
UI package: add types field, remove wildcard src export

### DIFF
--- a/packages/ui/.stylelintrc.js
+++ b/packages/ui/.stylelintrc.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
 	extends: [ '../../.stylelintrc' ],
 	plugins: [ 'stylelint-plugin-logical-css' ],
 	rules: {

--- a/packages/ui/jest.config.js
+++ b/packages/ui/jest.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
 	preset: '../../test/packages/jest-preset.js',
 	testEnvironment: 'jsdom',
 };

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -12,7 +12,10 @@
 	"exports": {
 		".": {
 			"calypso:src": "./src/index.ts",
-			"types": "./dist/index.d.ts",
+			"types": {
+				"import": "./dist/index.d.ts",
+				"require": "./dist/index.d.cts"
+			},
 			"import": "./dist/index.js",
 			"require": "./dist/index.cjs"
 		},

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -11,15 +11,13 @@
 	"exports": {
 		".": {
 			"calypso:src": "./src/index.ts",
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.js"
 		},
 		"./style.css": {
 			"import": "./dist/index.css",
 			"require": "./dist/index.css"
-		},
-		"./src/*": {
-			"calypso:src": "./src/*"
 		}
 	},
 	"sideEffects": [

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,6 +5,7 @@
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic Inc.",
+	"type": "module",
 	"main": "dist/index.js",
 	"module": "dist/index.mjs",
 	"calypso:src": "src/index.ts",
@@ -12,13 +13,10 @@
 		".": {
 			"calypso:src": "./src/index.ts",
 			"types": "./dist/index.d.ts",
-			"import": "./dist/index.mjs",
-			"require": "./dist/index.js"
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
 		},
-		"./style.css": {
-			"import": "./dist/index.css",
-			"require": "./dist/index.css"
-		}
+		"./style.css": "./dist/index.css"
 	},
 	"sideEffects": [
 		"*.css",


### PR DESCRIPTION
Little followup to #104187 and #104191:
- add a `types` subfield to `exports`. It's useful for TypeScript compilations that only want to see the types, not the actual code. We already have a legacy `types` field. There are two identical files that the `types` field can point to: `dist/index.d.ts` and `dist/index.d.mts`. They are both ESM with `import` and `export` statements, none of them is CJS. I don't understand why `tsup` generates the type declaration file and why their docs even consider the distinction important.
- remove the wildcard `./src/*` export. These should be added only for legacy purposes, a new package shouldn't have it. Everything the package wants to export is already on `.` and `./style.css`.

I'd also consider adding a `"type": "module"` field to `package.json`. That would change the file extensions: ESM modules (the default) have `.js`, the legacy CJS ones would be `.cjs`. That's a better default for new packages.