### PR TITLE
STATS-108: Add archive download button.

### DIFF
--- a/client/my-sites/stats/features/modules/stats-top-posts/use-option-labels.ts
+++ b/client/my-sites/stats/features/modules/stats-top-posts/use-option-labels.ts
@@ -16,7 +16,7 @@ export function validQueryViewType( statType: StatType = MAIN_STAT_TYPE ) {
 		return MAIN_STAT_TYPE;
 	}
 
-	return ! [ MAIN_STAT_TYPE, SUB_STAT_TYPE ].includes( statType ) ? MAIN_STAT_TYPE : statType;
+	return [ MAIN_STAT_TYPE, SUB_STAT_TYPE ].includes( statType ) ? statType : MAIN_STAT_TYPE;
 }
 
 export default function useOptionLabels() {

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -28,7 +28,11 @@ import StatsModuleLocations from '../features/modules/stats-locations';
 import LocationsNavTabs from '../features/modules/stats-locations/locations-nav-tabs';
 import { GEO_MODES } from '../features/modules/stats-locations/types';
 import PostsNavTabs from '../features/modules/stats-top-posts/nav-tabs';
-import { validQueryViewType as getValidTopPostStatType } from '../features/modules/stats-top-posts/use-option-labels';
+import {
+	validQueryViewType as getValidTopPostStatType,
+	SUB_STAT_TYPE as TOP_POSTS_SUB_STAT_TYPE,
+	MAIN_STAT_TYPE as TOP_POSTS_MAIN_STAT_TYPE,
+} from '../features/modules/stats-top-posts/use-option-labels';
 import StatsModuleUTM from '../features/modules/stats-utm';
 import { shouldGateStats } from '../hooks/use-should-gate-stats';
 import { StatsGlobalValuesContext } from '../pages/providers/global-provider';
@@ -72,12 +76,40 @@ class StatsSummary extends Component {
 		}
 	}
 
+	getPath( statType, path ) {
+		if ( statType === 'statsCountryViews' ) {
+			const geoMode = this.props.context.query.geoMode;
+			const geoModeLabel =
+				geoMode && Object.prototype.hasOwnProperty.call( GEO_MODES, geoMode )
+					? GEO_MODES[ geoMode ]
+					: 'country';
+
+			return `${ path }-${ geoModeLabel }`;
+		}
+
+		switch ( statType ) {
+			case TOP_POSTS_MAIN_STAT_TYPE:
+				return 'posts';
+
+			case TOP_POSTS_SUB_STAT_TYPE:
+				return 'archives';
+
+			default:
+				return path;
+		}
+	}
+
 	renderSummaryHeader( path, statType, hideNavigation, query ) {
 		const period = this.props.period;
 
 		const headerCSVButton = (
 			<div className="stats-module__header-nav-button">
-				<DownloadCsv statType={ statType } query={ query } path={ path } period={ period } />
+				<DownloadCsv
+					statType={ statType }
+					query={ query }
+					path={ this.getPath( statType, path ) }
+					period={ period }
+				/>
 			</div>
 		);
 
@@ -387,12 +419,6 @@ class StatsSummary extends Component {
 
 		const { module } = this.props.context.params;
 
-		const geoMode = this.props.context.query.geoMode;
-		const geoModeLabel =
-			geoMode && Object.prototype.hasOwnProperty.call( GEO_MODES, geoMode )
-				? GEO_MODES[ geoMode ]
-				: 'country';
-
 		return (
 			<Main fullWidthLayout>
 				<PageViewTracker
@@ -415,7 +441,7 @@ class StatsSummary extends Component {
 									<DownloadCsv
 										statType={ statType }
 										query={ moduleQuery }
-										path={ statType === 'statsCountryViews' ? `${ path }-${ geoModeLabel }` : path }
+										path={ this.getPath( statType, path ) }
 										period={ this.props.period }
 										skipQuery
 										hideIfNoData

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -28,6 +28,7 @@ import StatsModuleLocations from '../features/modules/stats-locations';
 import LocationsNavTabs from '../features/modules/stats-locations/locations-nav-tabs';
 import { GEO_MODES } from '../features/modules/stats-locations/types';
 import PostsNavTabs from '../features/modules/stats-top-posts/nav-tabs';
+import { validQueryViewType as getValidTopPostStatType } from '../features/modules/stats-top-posts/use-option-labels';
 import StatsModuleUTM from '../features/modules/stats-utm';
 import { shouldGateStats } from '../hooks/use-should-gate-stats';
 import { StatsGlobalValuesContext } from '../pages/providers/global-provider';
@@ -225,7 +226,7 @@ class StatsSummary extends Component {
 			case 'posts':
 				title = StatsStrings.posts.title;
 				path = 'posts';
-				statType = 'statsTopPosts';
+				statType = getValidTopPostStatType( moduleQuery?.viewType );
 				summaryView = (
 					<Fragment key="posts-summary">
 						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #STATS-108

## Proposed Changes

* Add download CSV button for archives too.

Contains a followup refactor [PR](https://github.com/Automattic/wp-calypso/pull/104323).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* N/A

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Most viewed summary page and choose the Archive tab
* If there is data, the Download CSV button will be present.
* Click on the button and verify it matches the content with the UI.

<img width="984" alt="image" src="https://github.com/user-attachments/assets/0385327d-cb1f-4a46-a311-6b6fd61a3f9c" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
