### PR TITLE
Add incorrect workflow config notice to deployment logs

### DIFF
--- a/client/sites/deployments/deployment-run-logs/deployment-run-logs.tsx
+++ b/client/sites/deployments/deployment-run-logs/deployment-run-logs.tsx
@@ -1,11 +1,8 @@
 import { useI18n } from '@wordpress/react-i18n';
-import { translate } from 'i18n-calypso';
 import { useMemo, useState, ReactNode } from 'react';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { errorNotice } from 'calypso/state/notices/actions';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import { manageDeploymentPage } from '../routes';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { LogEntry, useCodeDeploymentsRunLogDetailQuery } from './use-code-deployment-run-log-query';
 import { DeploymentRun } from './use-code-deployment-run-query';
 
@@ -126,38 +123,6 @@ const DeploymentRunLog = ( { entry, run }: { entry: LogEntry; run: DeploymentRun
 };
 
 export const DeploymentRunLogs = ( { logEntries, run }: DeploymentRunLogsProps ) => {
-	const dispatch = useDispatch();
-	const siteSlug = useSelector( getSelectedSiteSlug );
-
-	const hasWorkflowValidationError = logEntries.some(
-		( entry ) => entry.level === 'error' && entry.message === 'Workflow validation failed'
-	);
-
-	if ( hasWorkflowValidationError ) {
-		dispatch(
-			errorNotice(
-				translate( 'The workflow file is invalid. {{a}}Take action{{/a}}', {
-					components: {
-						a: (
-							<a
-								href={ manageDeploymentPage( siteSlug as string, run.code_deployment_id ) }
-								onClick={ () => {
-									dispatch(
-										recordTracksEvent( 'calypso_hosting_github_workflow_validation_failure_click' )
-									);
-								} }
-							/>
-						),
-					},
-				} ),
-				{
-					id: 'github-invalid-workflow-file',
-					isPersistent: true,
-				}
-			)
-		);
-	}
-
 	return (
 		<div css={ { padding: '16px', background: 'var(--color-neutral-0)' } }>
 			<div

--- a/client/sites/deployments/deployment-run-logs/deployment-run-logs.tsx
+++ b/client/sites/deployments/deployment-run-logs/deployment-run-logs.tsx
@@ -1,8 +1,11 @@
 import { useI18n } from '@wordpress/react-i18n';
+import { translate } from 'i18n-calypso';
 import { useMemo, useState, ReactNode } from 'react';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { errorNotice } from 'calypso/state/notices/actions';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { manageDeploymentPage } from '../routes';
 import { LogEntry, useCodeDeploymentsRunLogDetailQuery } from './use-code-deployment-run-log-query';
 import { DeploymentRun } from './use-code-deployment-run-query';
 
@@ -123,6 +126,38 @@ const DeploymentRunLog = ( { entry, run }: { entry: LogEntry; run: DeploymentRun
 };
 
 export const DeploymentRunLogs = ( { logEntries, run }: DeploymentRunLogsProps ) => {
+	const dispatch = useDispatch();
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	const hasWorkflowValidationError = logEntries.some(
+		( entry ) => entry.level === 'error' && entry.message === 'Workflow validation failed'
+	);
+
+	if ( hasWorkflowValidationError ) {
+		dispatch(
+			errorNotice(
+				translate( 'The workflow file is invalid. {{a}}Take action{{/a}}', {
+					components: {
+						a: (
+							<a
+								href={ manageDeploymentPage( siteSlug as string, run.code_deployment_id ) }
+								onClick={ () => {
+									dispatch(
+										recordTracksEvent( 'calypso_hosting_github_workflow_validation_failure_click' )
+									);
+								} }
+							/>
+						),
+					},
+				} ),
+				{
+					id: 'github-invalid-workflow-file',
+					isPersistent: true,
+				}
+			)
+		);
+	}
+
 	return (
 		<div css={ { padding: '16px', background: 'var(--color-neutral-0)' } }>
 			<div

--- a/client/sites/deployments/deployments/deployments-list-item.tsx
+++ b/client/sites/deployments/deployments/deployments-list-item.tsx
@@ -8,6 +8,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { translate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
+import { CalypsoDispatch } from 'calypso/state/types';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { useDispatch, useSelector } from '../../../state';
 import { manageDeploymentPage, viewDeploymentLogs } from '../routes';
@@ -28,6 +29,36 @@ const noticeOptions = {
 interface DeploymentsListItemProps {
 	deployment: CodeDeploymentData;
 }
+
+const showWorkflowValidationError = (
+	dispatch: CalypsoDispatch,
+	siteSlug: string,
+	deploymentId: number
+) => {
+	dispatch(
+		errorNotice(
+			translate( 'The workflow file is invalid. {{a}}Take action{{/a}}', {
+				components: {
+					a: (
+						<a
+							href={ manageDeploymentPage( siteSlug, deploymentId ) }
+							onClick={ () => {
+								dispatch( removeNotice( 'github-invalid-workflow-file' ) );
+								dispatch(
+									recordTracksEvent( 'calypso_hosting_github_workflow_validation_failure_click' )
+								);
+							} }
+						/>
+					),
+				},
+			} ),
+			{
+				id: 'github-invalid-workflow-file',
+				isPersistent: true,
+			}
+		)
+	);
+};
 
 export const DeploymentsListItem = ( { deployment }: DeploymentsListItemProps ) => {
 	const siteSlug = useSelector( getSelectedSiteSlug );
@@ -51,26 +82,7 @@ export const DeploymentsListItem = ( { deployment }: DeploymentsListItemProps ) 
 				);
 
 				if ( error.code === 'invalid_workflow_file' ) {
-					dispatch(
-						errorNotice(
-							translate( 'The workflow file is invalid. {{a}}Take action{{/a}}', {
-								components: {
-									a: (
-										<a
-											href={ manageDeploymentPage( siteSlug as string, deployment.id ) }
-											onClick={ () => {
-												dispatch( removeNotice( 'github-invalid-workflow-file' ) );
-											} }
-										/>
-									),
-								},
-							} ),
-							{
-								id: 'github-invalid-workflow-file',
-								isPersistent: true,
-							}
-						)
-					);
+					showWorkflowValidationError( dispatch, siteSlug as string, deployment.id );
 				} else {
 					dispatch(
 						errorNotice(
@@ -93,31 +105,7 @@ export const DeploymentsListItem = ( { deployment }: DeploymentsListItemProps ) 
 
 	useEffect( () => {
 		if ( run?.failure_code === 'workflow_run_failure' ) {
-			dispatch(
-				errorNotice(
-					translate( 'The workflow file is invalid. {{a}}Take action{{/a}}', {
-						components: {
-							a: (
-								<a
-									href={ manageDeploymentPage( siteSlug as string, deployment.id ) }
-									onClick={ () => {
-										dispatch( removeNotice( 'github-invalid-workflow-file' ) );
-										dispatch(
-											recordTracksEvent(
-												'calypso_hosting_github_workflow_validation_failure_click'
-											)
-										);
-									} }
-								/>
-							),
-						},
-					} ),
-					{
-						id: 'github-invalid-workflow-file',
-						isPersistent: true,
-					}
-				)
-			);
+			showWorkflowValidationError( dispatch, siteSlug as string, deployment.id );
 		}
 	}, [ run?.failure_code, run?.id, dispatch, siteSlug, deployment.id ] );
 

--- a/client/sites/deployments/deployments/deployments-list-item.tsx
+++ b/client/sites/deployments/deployments/deployments-list-item.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { useLocale } from '@automattic/i18n-utils';
 import { Spinner } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { translate } from 'i18n-calypso';
@@ -88,11 +88,38 @@ export const DeploymentsListItem = ( { deployment }: DeploymentsListItemProps ) 
 		}
 	);
 
-	const [ isDisconnectRepositoryDialogVisible, setDisconnectRepositoryDialogVisibility ] =
-		useState( false );
-
 	const run = deployment.current_deployment_run;
 	const [ installation, repo ] = deployment.repository_name.split( '/' );
+
+	useEffect( () => {
+		if ( run?.failure_code === 'workflow_run_failure' ) {
+			dispatch(
+				errorNotice(
+					translate( 'The workflow file is invalid. {{a}}Take action{{/a}}', {
+						components: {
+							a: (
+								<a
+									href={ manageDeploymentPage( siteSlug as string, deployment.id ) }
+									onClick={ () => {
+										dispatch( removeNotice( 'github-invalid-workflow-file' ) );
+										dispatch(
+											recordTracksEvent(
+												'calypso_hosting_github_workflow_validation_failure_click'
+											)
+										);
+									} }
+								/>
+							),
+						},
+					} ),
+					{
+						id: 'github-invalid-workflow-file',
+						isPersistent: true,
+					}
+				)
+			);
+		}
+	}, [ run?.failure_code, dispatch, siteSlug, deployment.id ] );
 
 	const columns = run ? (
 		<>
@@ -113,6 +140,9 @@ export const DeploymentsListItem = ( { deployment }: DeploymentsListItemProps ) 
 	) : (
 		<DeploymentStarterMessage deployment={ deployment } />
 	);
+
+	const [ isDisconnectRepositoryDialogVisible, setDisconnectRepositoryDialogVisibility ] =
+		useState( false );
 
 	return (
 		<>

--- a/client/sites/deployments/deployments/deployments-list-item.tsx
+++ b/client/sites/deployments/deployments/deployments-list-item.tsx
@@ -119,7 +119,7 @@ export const DeploymentsListItem = ( { deployment }: DeploymentsListItemProps ) 
 				)
 			);
 		}
-	}, [ run?.failure_code, dispatch, siteSlug, deployment.id ] );
+	}, [ run?.failure_code, run?.id, dispatch, siteSlug, deployment.id ] );
 
 	const columns = run ? (
 		<>

--- a/client/sites/deployments/deployments/deployments-list-item.tsx
+++ b/client/sites/deployments/deployments/deployments-list-item.tsx
@@ -5,10 +5,8 @@ import { Spinner } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import { translate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
-import { CalypsoDispatch } from 'calypso/state/types';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { useDispatch, useSelector } from '../../../state';
 import { manageDeploymentPage, viewDeploymentLogs } from '../routes';
@@ -21,6 +19,7 @@ import { DeploymentStatus, DeploymentStatusValue } from './deployment-status';
 import { DeploymentsListItemActions } from './deployments-list-item-actions';
 import { CodeDeploymentData } from './use-code-deployments-query';
 import { useCreateCodeDeploymentRun } from './use-create-code-deployment-run';
+import { useWorkflowValidationError } from './use-workflow-validation-error';
 
 const noticeOptions = {
 	duration: 3000,
@@ -30,41 +29,13 @@ interface DeploymentsListItemProps {
 	deployment: CodeDeploymentData;
 }
 
-const showWorkflowValidationError = (
-	dispatch: CalypsoDispatch,
-	siteSlug: string,
-	deploymentId: number
-) => {
-	dispatch(
-		errorNotice(
-			translate( 'The workflow file is invalid. {{a}}Take action{{/a}}', {
-				components: {
-					a: (
-						<a
-							href={ manageDeploymentPage( siteSlug, deploymentId ) }
-							onClick={ () => {
-								dispatch( removeNotice( 'github-invalid-workflow-file' ) );
-								dispatch(
-									recordTracksEvent( 'calypso_hosting_github_workflow_validation_failure_click' )
-								);
-							} }
-						/>
-					),
-				},
-			} ),
-			{
-				id: 'github-invalid-workflow-file',
-				isPersistent: true,
-			}
-		)
-	);
-};
-
 export const DeploymentsListItem = ( { deployment }: DeploymentsListItemProps ) => {
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const dispatch = useDispatch();
 	const locale = useLocale();
 	const { __ } = useI18n();
+	const { showWorkflowValidationError, shouldShowWorkflowError } =
+		useWorkflowValidationError( dispatch );
 
 	const { triggerManualDeployment, isPending: isTriggeringDeployment } = useCreateCodeDeploymentRun(
 		deployment.blog_id,
@@ -82,7 +53,7 @@ export const DeploymentsListItem = ( { deployment }: DeploymentsListItemProps ) 
 				);
 
 				if ( error.code === 'invalid_workflow_file' ) {
-					showWorkflowValidationError( dispatch, siteSlug as string, deployment.id );
+					showWorkflowValidationError( siteSlug as string, deployment.id );
 				} else {
 					dispatch(
 						errorNotice(
@@ -104,10 +75,22 @@ export const DeploymentsListItem = ( { deployment }: DeploymentsListItemProps ) 
 	const [ installation, repo ] = deployment.repository_name.split( '/' );
 
 	useEffect( () => {
-		if ( run?.failure_code === 'workflow_run_failure' ) {
-			showWorkflowValidationError( dispatch, siteSlug as string, deployment.id );
+		if (
+			run?.failure_code === 'workflow_run_failure' &&
+			run?.id &&
+			shouldShowWorkflowError( run.id )
+		) {
+			showWorkflowValidationError( siteSlug as string, deployment.id, run.id );
 		}
-	}, [ run?.failure_code, run?.id, dispatch, siteSlug, deployment.id ] );
+	}, [
+		run?.failure_code,
+		run?.id,
+		dispatch,
+		siteSlug,
+		deployment.id,
+		showWorkflowValidationError,
+		shouldShowWorkflowError,
+	] );
 
 	const columns = run ? (
 		<>

--- a/client/sites/deployments/deployments/use-workflow-validation-error.tsx
+++ b/client/sites/deployments/deployments/use-workflow-validation-error.tsx
@@ -1,0 +1,64 @@
+import { translate } from 'i18n-calypso';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
+import { CalypsoDispatch } from 'calypso/state/types';
+import { manageDeploymentPage } from '../routes';
+
+const SHOWN_WORKFLOW_ERRORS_KEY = 'github-workflow-validation-errors-shown';
+
+const hasShownWorkflowError = ( runId: number ) => {
+	const shownErrors = JSON.parse( localStorage?.getItem( SHOWN_WORKFLOW_ERRORS_KEY ) || '[]' );
+	return shownErrors.includes( runId );
+};
+
+const markWorkflowErrorAsShown = ( runId: number ) => {
+	const shownErrors = JSON.parse( localStorage?.getItem( SHOWN_WORKFLOW_ERRORS_KEY ) || '[]' );
+	if ( ! shownErrors.includes( runId ) ) {
+		localStorage?.setItem( SHOWN_WORKFLOW_ERRORS_KEY, JSON.stringify( [ ...shownErrors, runId ] ) );
+	}
+};
+
+export const useWorkflowValidationError = ( dispatch: CalypsoDispatch ) => {
+	const showWorkflowValidationError = (
+		siteSlug: string,
+		deploymentId: number,
+		runId?: number
+	) => {
+		dispatch(
+			errorNotice(
+				translate( 'The workflow file is invalid. {{a}}Take action{{/a}}', {
+					components: {
+						a: (
+							<a
+								href={ manageDeploymentPage( siteSlug, deploymentId ) }
+								onClick={ () => {
+									dispatch( removeNotice( 'github-invalid-workflow-file' ) );
+									dispatch(
+										recordTracksEvent( 'calypso_hosting_github_workflow_validation_failure_click' )
+									);
+								} }
+							/>
+						),
+					},
+				} ),
+				{
+					id: 'github-invalid-workflow-file',
+					isPersistent: true,
+				}
+			)
+		);
+
+		if ( runId ) {
+			markWorkflowErrorAsShown( runId );
+		}
+	};
+
+	const shouldShowWorkflowError = ( runId: number ) => {
+		return ! hasShownWorkflowError( runId );
+	};
+
+	return {
+		showWorkflowValidationError,
+		shouldShowWorkflowError,
+	};
+};


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes [DOTDEV-166 Add incorrect workflow config notice to deployment logs](https://linear.app/a8c/issue/DOTDEV-166/add-incorrect-workflow-config-notice-to-deployment-logs)

## Proposed Changes

This PR adds a notice when a deployment run fails due to an invalid workflow configuration. The notice appears when the logs contain a "Workflow validation failed" error message and provides a direct link to the deployment management page where users can fix the workflow file.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

For manually triggered deployments, this notice is already being shown when the validation fails. We added the same validation to automatic deployments in 184674-ghe-Automattic/wpcom, so I propose adding the same notice to this error for a consistent UX.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Pre-requisite: failing workflow

- Create a repository and connect it to one of your sites in an advanced configuration
- Push a change to your repository that breaks the workflow configuration, eg. update the name of the artifact to something else than wpcom

### Testing the changes

- Checkout this branch or use the live link
- Go to https://wordpress.com/github-deployments/:siteId and open the logs for the failed run
- Check that there's an error message about the failed validation
- Check that the notice is shown on the top right
- Check that the link redirects to the workflow configuration page

![CleanShot 2025-06-16 at 12 16 38@2x](https://github.com/user-attachments/assets/6f56d530-a69e-4b3a-93a6-8a90af8fc7ac)
