### PR TITLE
Help Center: "Sell online paypal" now opens in HC

### DIFF
--- a/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
+++ b/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
@@ -4,11 +4,6 @@ import paymentsImage from 'calypso/assets/images/illustrations/payments.svg';
 import PurchaseDetail from 'calypso/components/purchase-detail';
 
 export default localize( ( { isJetpack, translate } ) => {
-	const supportDocLink = localizeUrl(
-		isJetpack
-			? 'https://jetpack.com/support/pay-with-paypal/'
-			: 'https://wordpress.com/support/pay-with-paypal/'
-	);
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
@@ -16,9 +11,13 @@ export default localize( ( { isJetpack, translate } ) => {
 				description={ translate(
 					'Add a button to any post or page to collect PayPal payments for physical products, services, or donations.'
 				) }
-				href={ supportDocLink }
+				{ ...( isJetpack
+					? {
+							href: localizeUrl( 'https://jetpack.com/support/pay-with-paypal/' ),
+							target: '_blank',
+					  }
+					: { supportContext: 'sell-online-paypal' } ) }
 				icon={ <img alt="" src={ paymentsImage } /> }
-				target="_blank"
 				title={ translate( 'Sell online with PayPal' ) }
 			/>
 		</div>

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -480,6 +480,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/manage-purchases/upgrade-your-plan/#upgrade-credit',
 		post_id: 267100,
 	},
+	'sell-online-paypal': {
+		link: 'https://wordpress.com/support/pay-with-paypal/',
+		post_id: 168671,
+	},
 };
 
 export default contextLinks;

--- a/client/components/purchase-detail/index.jsx
+++ b/client/components/purchase-detail/index.jsx
@@ -2,6 +2,7 @@ import { Gridicon } from '@automattic/components';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import PurchaseButton from './purchase-button';
 import TipInfo from './tip-info';
 
@@ -18,6 +19,7 @@ export default class PurchaseDetail extends PureComponent {
 		isPlaceholder: PropTypes.bool,
 		isRequired: PropTypes.bool,
 		isSubmitting: PropTypes.bool,
+		supportContext: PropTypes.string,
 		onClick: PropTypes.func,
 		primaryButton: PropTypes.bool,
 		requiredText: PropTypes.string,
@@ -32,13 +34,29 @@ export default class PurchaseDetail extends PureComponent {
 	};
 
 	renderPurchaseButton() {
-		const { buttonText, isPlaceholder, isSubmitting, href, onClick, primaryButton, target, rel } =
-			this.props;
+		const {
+			buttonText,
+			isPlaceholder,
+			isSubmitting,
+			href,
+			onClick,
+			primaryButton,
+			target,
+			rel,
+			supportContext,
+		} = this.props;
 
 		if ( ! buttonText && ! isPlaceholder ) {
 			return null;
 		}
 
+		if ( supportContext ) {
+			return (
+				<InlineSupportLink className="button" showIcon={ false } supportContext={ supportContext }>
+					{ buttonText }
+				</InlineSupportLink>
+			);
+		}
 		return (
 			<PurchaseButton
 				disabled={ isSubmitting }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTSUP-59/open-plans-support-links-in-help-center

## Proposed Changes

![image](https://github.com/user-attachments/assets/6e1ff21f-4431-4bf0-9650-e8d4ad19431f)

Open the link `/plans/my-plan/`  inside the Help Center.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is to help with help link consistency across the whole experience


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use calypso.live link
*  Go to http://calypso.localhost:3000/plans/my-plan/[Website at least Premium]
* Press "Sell online with PayPal", it should open in the Help Center rather than in a new tab.
* Try with a Jetpack website. It should still send you to `https://jetpack.com/support/pay-with-paypal/`