### PR TITLE
A4A: Swap 'Next steps' and 'Upcoming events' section in the Overview page.

### DIFF
--- a/client/a8c-for-agencies/sections/overview/body/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/index.tsx
@@ -9,8 +9,8 @@ const OverviewBody = () => {
 	return (
 		<div className="overview-body">
 			{ ! isEnabled( 'a4a-unified-onboarding-tour' ) && <OverviewBodyIntroCards /> }
-			<OverviewBodyEvents />
 			<OverviewBodyNextSteps />
+			<OverviewBodyEvents />
 			<OverviewBodyHosting />
 			<OverviewBodyProducts />
 		</div>


### PR DESCRIPTION
On the Overview page, the most important thing to show agencies after signup is the "Next Steps" section.

With the launch of the "Upcoming events" section, the "Next Steps" section moved to second in order. We need to swap these.

<img width="1249" alt="Screenshot 2025-06-16 at 8 06 54 PM" src="https://github.com/user-attachments/assets/9a19b6b4-fb66-45e6-bbc7-e513fc6b6c07" />


Closes https://linear.app/a8c/issue/A4A-1136/re-order-upcoming-events-and-next-steps-sections

## Proposed Changes

* Swap the position of the two sections.

## Why are these changes being made?

* It is important that we have a seamless post-signup flow.

## Testing Instructions

* Use the A4A live link and navigate to the `/overview` page.
* Confirm that the Upcoming events section is below the Next steps.
* **NOTE: If you can't see the next steps section, please clear the `a4a-onboarding-tour-dismissed` preference to reset.**

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
