### PR TITLE
Site settings: Post-save snackbar copy update

### DIFF
--- a/client/dashboard/sites/settings-agency/index.tsx
+++ b/client/dashboard/sites/settings-agency/index.tsx
@@ -95,10 +95,10 @@ export default function SettingsAgency( { siteSlug }: { siteSlug: string } ) {
 				{ ...formData },
 				{
 					onSuccess: () => {
-						createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
+						createSuccessNotice( __( 'Agency settings saved.' ), { type: 'snackbar' } );
 					},
 					onError: () => {
-						createErrorNotice( __( 'Failed to save settings.' ), { type: 'snackbar' } );
+						createErrorNotice( __( 'Failed to save agency settings.' ), { type: 'snackbar' } );
 					},
 				}
 			);

--- a/client/dashboard/sites/settings-caching/index.tsx
+++ b/client/dashboard/sites/settings-caching/index.tsx
@@ -78,13 +78,13 @@ export default function CachingSettings( { siteSlug }: { siteSlug: string } ) {
 			onSuccess: () => {
 				createSuccessNotice(
 					formData.active
-						? __( 'Global edge caching enabled.' )
-						: __( 'Global edge caching disabled.' ),
+						? __( 'Global edge cache enabled.' )
+						: __( 'Global edge cache disabled.' ),
 					{ type: 'snackbar' }
 				);
 			},
 			onError: () => {
-				createErrorNotice( __( 'Failed to save global edge caching settings.' ), {
+				createErrorNotice( __( 'Failed to save global edge cache settings.' ), {
 					type: 'snackbar',
 				} );
 			},

--- a/client/dashboard/sites/settings-caching/index.tsx
+++ b/client/dashboard/sites/settings-caching/index.tsx
@@ -76,10 +76,17 @@ export default function CachingSettings( { siteSlug }: { siteSlug: string } ) {
 		e.preventDefault();
 		edgeCacheStatusMutation.mutate( formData.active, {
 			onSuccess: () => {
-				createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
+				createSuccessNotice(
+					formData.active
+						? __( 'Global edge caching enabled.' )
+						: __( 'Global edge caching disabled.' ),
+					{ type: 'snackbar' }
+				);
 			},
 			onError: () => {
-				createErrorNotice( __( 'Failed to save settings.' ), { type: 'snackbar' } );
+				createErrorNotice( __( 'Failed to save global edge caching settings.' ), {
+					type: 'snackbar',
+				} );
 			},
 		} );
 	};

--- a/client/dashboard/sites/settings-defensive-mode/index.tsx
+++ b/client/dashboard/sites/settings-defensive-mode/index.tsx
@@ -94,10 +94,13 @@ export default function DefensiveModeSettings( { siteSlug }: { siteSlug: string 
 	const handleSubmit = ( data: DefensiveModeSettingsUpdate ) => {
 		mutation.mutate( data, {
 			onSuccess: () => {
-				createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
+				createSuccessNotice(
+					data.active ? __( 'Defensive mode enabled.' ) : __( 'Defensive mode disabled.' ),
+					{ type: 'snackbar' }
+				);
 			},
 			onError: () => {
-				createErrorNotice( __( 'Failed to save settings.' ), {
+				createErrorNotice( __( 'Failed to save defensive mode settings.' ), {
 					type: 'snackbar',
 				} );
 			},

--- a/client/dashboard/sites/settings-hundred-year-plan/index.tsx
+++ b/client/dashboard/sites/settings-hundred-year-plan/index.tsx
@@ -78,10 +78,14 @@ export default function HundredYearPlanSettings( { siteSlug }: { siteSlug: strin
 			{ ...formData },
 			{
 				onSuccess: () => {
-					createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
+					createSuccessNotice( __( 'Settings saved.' ), {
+						type: 'snackbar',
+					} );
 				},
 				onError: () => {
-					createErrorNotice( __( 'Failed to save settings.' ), { type: 'snackbar' } );
+					createErrorNotice( __( 'Failed to save settings.' ), {
+						type: 'snackbar',
+					} );
 				},
 			}
 		);

--- a/client/dashboard/sites/settings-php/index.tsx
+++ b/client/dashboard/sites/settings-php/index.tsx
@@ -85,10 +85,10 @@ export default function PHPVersionSettings( { siteSlug }: { siteSlug: string } )
 		e.preventDefault();
 		mutation.mutate( formData.version, {
 			onSuccess: () => {
-				createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
+				createSuccessNotice( __( 'PHP version saved.' ), { type: 'snackbar' } );
 			},
 			onError: () => {
-				createErrorNotice( __( 'Failed to save settings.' ), {
+				createErrorNotice( __( 'Failed to save PHP version.' ), {
 					type: 'snackbar',
 				} );
 			},

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -150,10 +150,12 @@ export function PrivacyForm( {
 		e.preventDefault();
 		mutation.mutate( toSiteSettings( formData ), {
 			onSuccess: () => {
-				createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
+				createSuccessNotice( __( 'Site visibility settings saved.' ), { type: 'snackbar' } );
 			},
 			onError: () => {
-				createErrorNotice( __( 'Failed to save settings.' ), { type: 'snackbar' } );
+				createErrorNotice( __( 'Failed to save site visibility settings.' ), {
+					type: 'snackbar',
+				} );
 			},
 		} );
 	};

--- a/client/dashboard/sites/settings-subscription-gifting/index.tsx
+++ b/client/dashboard/sites/settings-subscription-gifting/index.tsx
@@ -78,13 +78,13 @@ export default function SubscriptionGiftingSettings( { siteSlug }: { siteSlug: s
 				onSuccess: () => {
 					createSuccessNotice(
 						formData.wpcom_gifting_subscription
-							? __( 'Subscription gifting enabled.' )
-							: __( 'Subscription gifting disabled.' ),
+							? __( 'Gift subscription enabled.' )
+							: __( 'Gift subscription disabled.' ),
 						{ type: 'snackbar' }
 					);
 				},
 				onError: () => {
-					createErrorNotice( __( 'Failed to save subscription gifting settings.' ), {
+					createErrorNotice( __( 'Failed to save gift subscription settings.' ), {
 						type: 'snackbar',
 					} );
 				},

--- a/client/dashboard/sites/settings-subscription-gifting/index.tsx
+++ b/client/dashboard/sites/settings-subscription-gifting/index.tsx
@@ -76,10 +76,17 @@ export default function SubscriptionGiftingSettings( { siteSlug }: { siteSlug: s
 			{ ...formData },
 			{
 				onSuccess: () => {
-					createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
+					createSuccessNotice(
+						formData.wpcom_gifting_subscription
+							? __( 'Subscription gifting enabled.' )
+							: __( 'Subscription gifting disabled.' ),
+						{ type: 'snackbar' }
+					);
 				},
 				onError: () => {
-					createErrorNotice( __( 'Failed to save settings.' ), { type: 'snackbar' } );
+					createErrorNotice( __( 'Failed to save subscription gifting settings.' ), {
+						type: 'snackbar',
+					} );
 				},
 			}
 		);

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -65,10 +65,10 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 		e.preventDefault();
 		mutation.mutate( formData.version, {
 			onSuccess: () => {
-				createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
+				createSuccessNotice( __( 'WordPress version saved.' ), { type: 'snackbar' } );
 			},
 			onError: () => {
-				createErrorNotice( __( 'Failed to save settings.' ), {
+				createErrorNotice( __( 'Failed to save WordPress version.' ), {
 					type: 'snackbar',
 				} );
 			},


### PR DESCRIPTION
Ref DOTDASH-40

## Proposed Changes

On save success
| Setting | Before | After |
| --- | --- | --- |
| Site visibility | Settings saved | Site visibility settings saved |
| Accept a gift subscription | Settings saved | Subscription gifting enabled/disabled |
| Control your legacy | Settings saved | Settings saved | 
| PHP | Settings saved | PHP version saved |
| WordPress | Settings saved | WordPress version saved |
| Agency settings | Settings saved | Agency settings saved |
| Handling requests for nonexistent assets | Settings saved | Settings saved | 
| Caching | Settings saved | Global edge caching enabled/disabled |
| Defensive mode | Settings saved | Defensive mode enabled/disabled |

On save failure
| Setting | Before | After |
| --- | --- | --- |
| Site visibility | Failed to save settings | Failed to save site visibility settings |
| Accept a gift subscription |  Failed to save settings | Failed to save subscription gifting settings |
| Control your legacy | Failed to save settings | Failed to save settings |
| PHP | Failed to save settings | Failed to save PHP version |
| WordPress | Failed to save settings | Failed to save WordPress version |
| Agency settings | Failed to save settings | Failed to save agency settings |
| Handling requests for nonexistent assets | Settings saved | Settings saved | 
| Caching | Failed to save settings | Failed to save global edge caching settings |
| Defensive mode | Failed to save settings | Failed to save defensive mode settings |

Two settings were kept the same:

* "Control your legacy". "Legacy settings saved " feels odd, same as "Control your legacy settings saved".
* "Handling requests for nonexistent assets". "Handling requests for nonexistent assets" feels too verbose, same as "Nonexistent assets request handling settings saved". I don't think either are easily understood.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

UX polish.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /sites/settings/v2/:siteSlug
* Ensure that the copy is updated as described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
