### PR TITLE
Clean up aria roles issue on checkout page

### DIFF
--- a/client/my-sites/checkout/src/test/checkout-main.tsx
+++ b/client/my-sites/checkout/src/test/checkout-main.tsx
@@ -269,12 +269,19 @@ describe( 'CheckoutMain', () => {
 		await user.click( removeProductButton );
 
 		const restoreButton = await screen.findByText( 'Restore' );
-		expect( screen.queryByLabelText( 'foo.cash' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'foo.cash' ) ).not.toBeInTheDocument();
 
 		await user.click( restoreButton );
 
-		const restoredItem = await screen.findByLabelText( 'foo.cash' );
-		expect( restoredItem ).toBeInTheDocument();
+		await waitFor( () => {
+			screen
+				.getAllByText( 'foo.cash' )
+				.map( ( element ) => element.closest( '.checkout-line-item' ) )
+				.filter( ( container ): container is Element => container !== null )
+				.forEach( ( container ) => {
+					expect( container ).toBeInTheDocument();
+				} );
+		} );
 	} );
 
 	it( 'does not redirect to the plans page if the cart is empty when it loads', async () => {

--- a/client/my-sites/checkout/src/test/checkout-main.tsx
+++ b/client/my-sites/checkout/src/test/checkout-main.tsx
@@ -185,10 +185,18 @@ describe( 'CheckoutMain', () => {
 			'Remove WordPress.com Personal from cart'
 		);
 		const user = userEvent.setup();
-		expect( screen.getAllByLabelText( 'WordPress.com Personal' ) ).toHaveLength( 1 );
+
+		screen
+			.getAllByText( 'WordPress.com Personal' )
+			.map( ( element ) => element.closest( '.checkout-line-item' ) )
+			.filter( ( container ): container is Element => container !== null )
+			.forEach( ( container ) => {
+				expect( container ).toBeInTheDocument();
+			} );
+
 		await user.click( removeProductButton );
 		await waitFor( async () => {
-			expect( screen.queryByLabelText( 'WordPress.com Personal' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'WordPress.com Personal' ) ).not.toBeInTheDocument();
 		} );
 	} );
 

--- a/client/my-sites/checkout/src/test/checkout-main.tsx
+++ b/client/my-sites/checkout/src/test/checkout-main.tsx
@@ -82,8 +82,12 @@ describe( 'CheckoutMain', () => {
 		render( <MockCheckout initialCart={ initialCart } setCart={ mockSetCartEndpoint } /> );
 		await waitFor( () => {
 			screen
-				.getAllByLabelText( 'WordPress.com Personal' )
-				.map( ( element ) => expect( element ).toHaveTextContent( 'R$144' ) );
+				.getAllByText( 'WordPress.com Personal' )
+				.map( ( element ) => element.closest( '.checkout-line-item' ) )
+				.filter( ( container ): container is Element => container !== null )
+				.forEach( ( container ) => {
+					expect( container ).toHaveTextContent( 'R$144' );
+				} );
 		} );
 	} );
 
@@ -103,8 +107,12 @@ describe( 'CheckoutMain', () => {
 		);
 		await waitFor( () => {
 			screen
-				.getAllByLabelText( 'WordPress.com Personal' )
-				.map( ( element ) => expect( element ).toHaveTextContent( 'R$144' ) );
+				.getAllByText( 'WordPress.com Personal' )
+				.map( ( element ) => element.closest( '.checkout-line-item' ) )
+				.filter( ( container ): container is Element => container !== null )
+				.forEach( ( container ) => {
+					expect( container ).toHaveTextContent( 'R$144' );
+				} );
 		} );
 	} );
 
@@ -112,8 +120,12 @@ describe( 'CheckoutMain', () => {
 		render( <MockCheckout initialCart={ initialCart } setCart={ mockSetCartEndpoint } /> );
 		await waitFor( () => {
 			screen
-				.getAllByLabelText( 'Tax' )
-				.map( ( element ) => expect( element ).toHaveTextContent( 'R$7' ) );
+				.getAllByText( 'Tax' )
+				.map( ( element ) => element.closest( '.checkout-line-item' ) )
+				.filter( ( container ): container is Element => container !== null )
+				.forEach( ( container ) => {
+					expect( container ).toHaveTextContent( 'R$7' );
+				} );
 		} );
 	} );
 
@@ -121,8 +133,12 @@ describe( 'CheckoutMain', () => {
 		render( <MockCheckout initialCart={ initialCart } setCart={ mockSetCartEndpoint } /> );
 		await waitFor( () => {
 			screen
-				.getAllByLabelText( 'Total' )
-				.map( ( element ) => expect( element ).toHaveTextContent( 'R$156' ) );
+				.getAllByText( 'Total' )
+				.map( ( element ) => element.closest( '.checkout-line-item' ) )
+				.filter( ( container ): container is Element => container !== null )
+				.forEach( ( container ) => {
+					expect( container ).toHaveTextContent( 'R$156' );
+				} );
 		} );
 	} );
 
@@ -140,8 +156,12 @@ describe( 'CheckoutMain', () => {
 		render( <MockCheckout initialCart={ cart } setCart={ mockSetCartEndpoint } /> );
 		await waitFor( () => {
 			screen
-				.getAllByLabelText( 'Total' )
-				.map( ( element ) => expect( element ).toHaveTextContent( 'R$156' ) );
+				.getAllByText( 'Total' )
+				.map( ( element ) => element.closest( '.checkout-line-item' ) )
+				.filter( ( container ): container is Element => container !== null )
+				.forEach( ( container ) => {
+					expect( container ).toHaveTextContent( 'R$156' );
+				} );
 		} );
 	} );
 
@@ -300,8 +320,12 @@ describe( 'CheckoutMain', () => {
 		);
 		await waitFor( async () => {
 			screen
-				.getAllByLabelText( 'WordPress.com Personal' )
-				.map( ( element ) => expect( element ).toHaveTextContent( 'R$144' ) );
+				.getAllByText( 'WordPress.com Personal' )
+				.map( ( element ) => element.closest( '.checkout-line-item' ) )
+				.filter( ( container ): container is Element => container !== null )
+				.forEach( ( container ) => {
+					expect( container ).toHaveTextContent( 'R$144' );
+				} );
 		} );
 	} );
 
@@ -321,8 +345,12 @@ describe( 'CheckoutMain', () => {
 		);
 		await waitFor( async () => {
 			screen
-				.getAllByLabelText( 'Jetpack Scan Daily' )
-				.map( ( element ) => expect( element ).toHaveTextContent( 'R$41' ) );
+				.getAllByText( 'Jetpack Scan Daily' )
+				.map( ( element ) => element.closest( '.checkout-line-item' ) )
+				.filter( ( container ): container is Element => container !== null )
+				.forEach( ( container ) => {
+					expect( container ).toHaveTextContent( 'R$41' );
+				} );
 		} );
 	} );
 
@@ -342,11 +370,19 @@ describe( 'CheckoutMain', () => {
 		);
 		await waitFor( async () => {
 			screen
-				.getAllByLabelText( 'Jetpack Scan Daily' )
-				.map( ( element ) => expect( element ).toHaveTextContent( 'R$41' ) );
+				.getAllByText( 'Jetpack Scan Daily' )
+				.map( ( element ) => element.closest( '.checkout-line-item' ) )
+				.filter( ( container ): container is Element => container !== null )
+				.forEach( ( container ) => {
+					expect( container ).toHaveTextContent( 'R$41' );
+				} );
 			screen
-				.getAllByLabelText( 'Jetpack Backup (Daily)' )
-				.map( ( element ) => expect( element ).toHaveTextContent( 'R$42' ) );
+				.getAllByText( 'Jetpack Backup (Daily)' )
+				.map( ( element ) => element.closest( '.checkout-line-item' ) )
+				.filter( ( container ): container is Element => container !== null )
+				.forEach( ( container ) => {
+					expect( container ).toHaveTextContent( 'R$42' );
+				} );
 		} );
 	} );
 
@@ -369,8 +405,12 @@ describe( 'CheckoutMain', () => {
 
 		await waitFor( async () => {
 			screen
-				.getAllByLabelText( 'Akismet Plus (10K requests/month)' )
-				.map( ( element ) => expect( element ).toHaveTextContent( '$100' ) );
+				.getAllByText( 'Akismet Plus (10K requests/month)' )
+				.map( ( element ) => element.closest( '.checkout-line-item' ) )
+				.filter( ( container ): container is Element => container !== null )
+				.forEach( ( container ) => {
+					expect( container ).toHaveTextContent( '$100' );
+				} );
 		} );
 	} );
 
@@ -393,8 +433,12 @@ describe( 'CheckoutMain', () => {
 
 		await waitFor( async () => {
 			screen
-				.getAllByLabelText( 'Akismet Plus (20K requests/month)' )
-				.map( ( element ) => expect( element ).toHaveTextContent( '$200' ) );
+				.getAllByText( 'Akismet Plus (20K requests/month)' )
+				.map( ( element ) => element.closest( '.checkout-line-item' ) )
+				.filter( ( container ): container is Element => container !== null )
+				.forEach( ( container ) => {
+					expect( container ).toHaveTextContent( '$200' );
+				} );
 		} );
 	} );
 
@@ -427,11 +471,19 @@ describe( 'CheckoutMain', () => {
 		);
 		await waitFor( async () => {
 			screen
-				.getAllByLabelText( 'WordPress.com Personal' )
-				.map( ( element ) => expect( element ).toHaveTextContent( 'R$144' ) );
+				.getAllByText( 'WordPress.com Personal' )
+				.map( ( element ) => element.closest( '.checkout-line-item' ) )
+				.filter( ( container ): container is Element => container !== null )
+				.forEach( ( container ) => {
+					expect( container ).toHaveTextContent( 'R$144' );
+				} );
 			screen
-				.getAllByLabelText( 'Support Session' )
-				.map( ( element ) => expect( element ).toHaveTextContent( 'R$49' ) );
+				.getAllByText( 'Support Session' )
+				.map( ( element ) => element.closest( '.checkout-line-item' ) )
+				.filter( ( container ): container is Element => container !== null )
+				.forEach( ( container ) => {
+					expect( container ).toHaveTextContent( 'R$49' );
+				} );
 		} );
 	} );
 
@@ -464,11 +516,19 @@ describe( 'CheckoutMain', () => {
 		);
 		await waitFor( async () => {
 			screen
-				.getAllByLabelText( 'WordPress.com Personal' )
-				.map( ( element ) => expect( element ).toHaveTextContent( 'R$144' ) );
+				.getAllByText( 'WordPress.com Personal' )
+				.map( ( element ) => element.closest( '.checkout-line-item' ) )
+				.filter( ( container ): container is Element => container !== null )
+				.forEach( ( container ) => {
+					expect( container ).toHaveTextContent( 'R$144' );
+				} );
 			screen
-				.getAllByLabelText( 'Premium Theme: Ovation' )
-				.map( ( element ) => expect( element ).toHaveTextContent( 'R$69' ) );
+				.getAllByText( 'Premium Theme: Ovation' )
+				.map( ( element ) => element.closest( '.checkout-line-item' ) )
+				.filter( ( container ): container is Element => container !== null )
+				.forEach( ( container ) => {
+					expect( container ).toHaveTextContent( 'R$69' );
+				} );
 		} );
 	} );
 
@@ -486,11 +546,15 @@ describe( 'CheckoutMain', () => {
 				additionalProps={ additionalProps }
 			/>
 		);
-		expect(
-			await screen.findByLabelText(
-				`Google Workspace for '${ domainName }' and quantity '${ quantity }'`
-			)
-		).toBeInTheDocument();
+		await waitFor( () => {
+			screen
+				.getAllByText( `Google Workspace for '${ domainName }' and quantity '${ quantity }'` )
+				.map( ( element ) => element.closest( '.checkout-line-item' ) )
+				.filter( ( container ): container is Element => container !== null )
+				.forEach( ( container ) => {
+					expect( container ).toBeInTheDocument();
+				} );
+		} );
 	} );
 
 	it( 'adds the product quantity to the cart when the url has a product with a quantity but no domain', async () => {
@@ -506,9 +570,15 @@ describe( 'CheckoutMain', () => {
 				additionalProps={ additionalProps }
 			/>
 		);
-		expect(
-			await screen.findByLabelText( `Google Workspace for '' and quantity '${ quantity }'` )
-		).toBeInTheDocument();
+		await waitFor( () => {
+			screen
+				.getAllByText( `Google Workspace for '' and quantity '${ quantity }'` )
+				.map( ( element ) => element.closest( '.checkout-line-item' ) )
+				.filter( ( container ): container is Element => container !== null )
+				.forEach( ( container ) => {
+					expect( container ).toBeInTheDocument();
+				} );
+		} );
 	} );
 
 	it( 'does not redirect if the cart is empty when it loads but the url has a domain map', async () => {
@@ -540,12 +610,20 @@ describe( 'CheckoutMain', () => {
 		);
 		await waitFor( async () => {
 			screen
-				.getAllByLabelText( 'WordPress.com Personal' )
-				.map( ( element ) => expect( element ).toHaveTextContent( 'R$144' ) );
+				.getAllByText( 'WordPress.com Personal' )
+				.map( ( element ) => element.closest( '.checkout-line-item' ) )
+				.filter( ( container ): container is Element => container !== null )
+				.forEach( ( container ) => {
+					expect( container ).toHaveTextContent( 'R$144' );
+				} );
 			expect( screen.getAllByText( 'Domain Mapping: billed annually' ) ).toHaveLength( 1 );
 			screen
-				.getAllByLabelText( 'bar.com' )
-				.map( ( element ) => expect( element ).toHaveTextContent( 'R$0' ) );
+				.getAllByText( 'bar.com' )
+				.map( ( element ) => element.closest( '.checkout-line-item' ) )
+				.filter( ( container ): container is Element => container !== null )
+				.forEach( ( container ) => {
+					expect( container ).toHaveTextContent( 'R$0' );
+				} );
 		} );
 	} );
 
@@ -562,8 +640,12 @@ describe( 'CheckoutMain', () => {
 		);
 		await waitFor( async () => {
 			screen
-				.getAllByLabelText( 'WordPress.com Personal' )
-				.map( ( element ) => expect( element ).toHaveTextContent( 'R$144' ) );
+				.getAllByText( 'WordPress.com Personal' )
+				.map( ( element ) => element.closest( '.checkout-line-item' ) )
+				.filter( ( container ): container is Element => container !== null )
+				.forEach( ( container ) => {
+					expect( container ).toHaveTextContent( 'R$144' );
+				} );
 		} );
 	} );
 
@@ -714,11 +796,19 @@ describe( 'CheckoutMain', () => {
 		);
 		await waitFor( () => {
 			screen
-				.getAllByLabelText( 'WordPress.com Personal' )
-				.map( ( element ) => expect( element ).toHaveTextContent( 'R$144' ) );
+				.getAllByText( 'WordPress.com Personal' )
+				.map( ( element ) => element.closest( '.checkout-line-item' ) )
+				.filter( ( container ): container is Element => container !== null )
+				.forEach( ( container ) => {
+					expect( container ).toHaveTextContent( 'R$144' );
+				} );
 			screen
-				.getAllByLabelText( 'Coupon: MYCOUPONCODE' )
-				.map( ( element ) => expect( element ).toHaveTextContent( 'R$10' ) );
+				.getAllByText( 'Coupon: MYCOUPONCODE' )
+				.map( ( element ) => element.closest( '.checkout-line-item' ) )
+				.filter( ( container ): container is Element => container !== null )
+				.forEach( ( container ) => {
+					expect( container ).toHaveTextContent( 'R$10' );
+				} );
 		} );
 	} );
 

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -239,8 +239,6 @@ function WPNonProductLineItem( {
 	createUserAndSiteBeforeTransaction?: boolean;
 	isPwpoUser?: boolean;
 } ) {
-	const id = lineItem.id;
-	const itemSpanId = `checkout-line-item-${ id }`;
 	const label = lineItem.label;
 	const actualAmountDisplay = lineItem.formattedAmount;
 	const { formStatus } = useFormStatus();
@@ -261,11 +259,9 @@ function WPNonProductLineItem( {
 			data-e2e-product-slug={ lineItem.id }
 			data-product-type={ lineItem.type }
 		>
-			<LineItemTitle id={ itemSpanId } isSummary={ isSummary }>
-				{ label }
-			</LineItemTitle>
+			<LineItemTitle isSummary={ isSummary }>{ label }</LineItemTitle>
 
-			<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">
+			<span className="checkout-line-item__price">
 				<LineItemPrice actualAmount={ actualAmountDisplay } />
 			</span>
 
@@ -1356,7 +1352,6 @@ function CheckoutLineItem( {
 	shouldShowComparison?: boolean;
 	compareToPrice?: number;
 } > ) {
-	const id = product.uuid;
 	const translate = useTranslate();
 	const hasBundledDomainsInCart = responseCart.products.some(
 		( product ) =>
@@ -1369,7 +1364,6 @@ function CheckoutLineItem( {
 			product.product_slug.startsWith( 'wp_mp_theme' )
 	);
 	const { formStatus } = useFormStatus();
-	const itemSpanId = `checkout-line-item-${ id }`;
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
 	const [ isPlaceholder, setIsPlaceholder ] = useState( false );
 	const hasRemoveFromCartModal = getHasRemoveFromCartModal( {
@@ -1496,7 +1490,7 @@ function CheckoutLineItem( {
 					<GiftBadgeWithText />
 				</MobileGiftWrapper>
 			) }
-			<LineItemTitle id={ itemSpanId } isSummary={ isSummary }>
+			<LineItemTitle isSummary={ isSummary }>
 				{ label }
 				{ responseCart.is_gift_purchase && (
 					<DesktopGiftWrapper>
@@ -1505,7 +1499,7 @@ function CheckoutLineItem( {
 				) }
 			</LineItemTitle>
 
-			<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">
+			<span className="checkout-line-item__price">
 				{ shouldShowComparison ? (
 					<>
 						<LineItemPrice


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13281

## Proposed Changes

I propose to clean up the aria roles issue on the checkout page.

The elements currently have `aria-labelledby` attribute, but they don't have any particular role. Removing those seems be a way to go as those texts are correctly read by VoiceOver without those ARIA attributes..

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To clean up axe Dev Tools findings and make cleaner HTML.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to checkout by adding the new site to the cart
2. Confirm there is no issue anymore:

```
aria-labelledby attribute is not well supported on a span with no valid role attribute.
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
