### PR TITLE
Checkout: Update support link

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact.tsx
@@ -1,7 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { Button } from '@wordpress/components';
-import { useTranslate } from 'i18n-calypso';
 import { useCheckoutHelpCenter } from 'calypso/my-sites/checkout/src/hooks/use-checkout-help-center';
 
 const ContactContainer = styled.div`
@@ -48,15 +47,14 @@ const ContactContainer = styled.div`
 `;
 
 export function DefaultMasterbarContact() {
-	const translate = useTranslate();
 	const { helpCenterButtonCopy, helpCenterButtonLink, toggleHelpCenter } = useCheckoutHelpCenter();
 
 	return (
 		<ContactContainer>
-			<label>{ helpCenterButtonCopy ?? translate( 'Need extra help?' ) }</label>
+			{ helpCenterButtonCopy && <label>{ helpCenterButtonCopy }</label> }
 			<Button className="thank-you-help-center" variant="link" onClick={ toggleHelpCenter }>
 				<Gridicon icon="help-outline" />
-				<span>{ helpCenterButtonLink ?? translate( 'Visit Help Center' ) }</span>
+				<span>{ helpCenterButtonLink }</span>
 			</Button>
 		</ContactContainer>
 	);

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -905,9 +905,9 @@ export default function CheckoutMainContent( {
 							leftElement={ <Step.BackButton onClick={ leaveModalProps.clickClose } /> }
 							rightElement={
 								<span className="checkout-skip-button">
-									<label>{ helpCenterButtonCopy ?? translate( 'Need extra help?' ) } </label>
+									{ helpCenterButtonCopy && <label>{ helpCenterButtonCopy }</label> }
 									<Step.LinkButton onClick={ toggleHelpCenter }>
-										{ helpCenterButtonLink ?? translate( 'Visit Help Center' ) }
+										{ helpCenterButtonLink }
 									</Step.LinkButton>
 								</span>
 							}

--- a/client/my-sites/checkout/src/hooks/use-checkout-help-center.ts
+++ b/client/my-sites/checkout/src/hooks/use-checkout-help-center.ts
@@ -17,7 +17,11 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 
 const HELP_CENTER_STORE = HelpCenter.register();
 
-export const useCheckoutHelpCenter = () => {
+export const useCheckoutHelpCenter = (): {
+	toggleHelpCenter: () => void;
+	helpCenterButtonCopy?: string;
+	helpCenterButtonLink: string;
+} => {
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 

--- a/client/my-sites/checkout/src/hooks/use-checkout-help-center.ts
+++ b/client/my-sites/checkout/src/hooks/use-checkout-help-center.ts
@@ -45,8 +45,8 @@ export const useCheckoutHelpCenter = () => {
 			location: 'thank-you-help-center',
 		} );
 
+		setShowHelpCenter( ! isShowingHelpCenter, hasPremiumSupport, helpCenterOptions );
 		if ( hasPremiumSupport ) {
-			setShowHelpCenter( ! isShowingHelpCenter, hasPremiumSupport, helpCenterOptions );
 			const urlWithQueryArgs = addQueryArgs( '/odie?provider=zendesk', {
 				userFieldMessage,
 				userFieldFlowName,
@@ -55,7 +55,7 @@ export const useCheckoutHelpCenter = () => {
 			} );
 			setNavigateToRoute( urlWithQueryArgs );
 		} else {
-			setShowHelpCenter( ! isShowingHelpCenter, hasPremiumSupport );
+			setNavigateToRoute( '/odie' );
 		}
 	};
 

--- a/client/my-sites/checkout/src/test/checkout-vat-form.tsx
+++ b/client/my-sites/checkout/src/test/checkout-vat-form.tsx
@@ -7,6 +7,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { dispatch } from '@wordpress/data';
 import nock from 'nock';
+import { useCheckoutHelpCenter } from 'calypso/my-sites/checkout/src/hooks/use-checkout-help-center';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
 import { getDomainsBySiteId, hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
@@ -37,6 +38,7 @@ jest.mock( 'calypso/state/sites/selectors' );
 jest.mock( 'calypso/state/sites/domains/selectors' );
 jest.mock( 'calypso/state/selectors/is-site-automated-transfer' );
 jest.mock( 'calypso/state/sites/plans/selectors/get-plans-by-site' );
+jest.mock( 'calypso/my-sites/checkout/src/hooks/use-checkout-help-center' );
 jest.mock( 'calypso/my-sites/checkout/use-cart-key' );
 jest.mock( 'calypso/lib/analytics/utils/refresh-country-code-cookie-gdpr' );
 jest.mock( 'calypso/state/products-list/selectors/is-marketplace-product' );
@@ -63,6 +65,11 @@ describe( 'Checkout contact step VAT form', () => {
 	getDomainsBySiteId.mockImplementation( () => [] );
 	isMarketplaceProduct.mockImplementation( () => false );
 	isJetpackSite.mockImplementation( () => false );
+	useCheckoutHelpCenter.mockImplementation( () => ( {
+		hasPremiumSupport: false,
+		userFieldMessage: null,
+		helpCenterButtonLink: 'Need help?',
+	} ) );
 	mockMatchMediaOnWindow();
 
 	const mockSetCartEndpoint = mockSetCartEndpointWith( {

--- a/packages/help-center/src/hooks/use-products-with-premium-support.ts
+++ b/packages/help-center/src/hooks/use-products-with-premium-support.ts
@@ -21,6 +21,8 @@ export function useProductsWithPremiumSupport( products: ResponseCartProduct[], 
 	const { data: supportStatus } = useSupportStatus();
 	const { data: geoData } = useGeoLocationQuery();
 
+	const defaultButtonLink = __( 'Need help?', __i18n_text_domain__ );
+
 	for ( const product of products ) {
 		if ( isDIFMProduct( product ) ) {
 			const hasPremiumSupport =
@@ -30,10 +32,12 @@ export function useProductsWithPremiumSupport( products: ResponseCartProduct[], 
 				userFieldFlowName:
 					FLOWS_ZENDESK_FLOWNAME[ DIFM_FLOW as keyof typeof FLOWS_ZENDESK_FLOWNAME ],
 				hasPremiumSupport,
-				helpCenterButtonCopy: hasPremiumSupport ? __( 'Questions?', __i18n_text_domain__ ) : null,
+				helpCenterButtonCopy: hasPremiumSupport
+					? __( 'Questions?', __i18n_text_domain__ )
+					: defaultButtonLink,
 				helpCenterButtonLink: hasPremiumSupport
 					? __( 'Contact our site-building team', __i18n_text_domain__ )
-					: null,
+					: defaultButtonLink,
 			};
 		}
 		if ( product?.product_slug === PLAN_100_YEARS ) {
@@ -42,6 +46,7 @@ export function useProductsWithPremiumSupport( products: ResponseCartProduct[], 
 				userFieldFlowName:
 					FLOWS_ZENDESK_FLOWNAME[ HUNDRED_YEAR_PLAN_FLOW as keyof typeof FLOWS_ZENDESK_FLOWNAME ],
 				hasPremiumSupport: true,
+				helpCenterButtonLink: defaultButtonLink,
 			};
 		}
 		if ( product?.extra?.is_hundred_year_domain ) {
@@ -50,6 +55,7 @@ export function useProductsWithPremiumSupport( products: ResponseCartProduct[], 
 				userFieldFlowName:
 					FLOWS_ZENDESK_FLOWNAME[ HUNDRED_YEAR_DOMAIN_FLOW as keyof typeof FLOWS_ZENDESK_FLOWNAME ],
 				hasPremiumSupport: true,
+				helpCenterButtonLink: defaultButtonLink,
 			};
 		}
 	}
@@ -57,5 +63,6 @@ export function useProductsWithPremiumSupport( products: ResponseCartProduct[], 
 	return {
 		hasPremiumSupport: false,
 		userFieldMessage: null,
+		helpCenterButtonLink: defaultButtonLink,
 	};
 }

--- a/packages/help-center/src/hooks/use-products-with-premium-support.ts
+++ b/packages/help-center/src/hooks/use-products-with-premium-support.ts
@@ -17,7 +17,16 @@ const getUserFieldMessage = ( flowName: string, url?: string ) => {
 	}. URL: ${ url }`;
 };
 
-export function useProductsWithPremiumSupport( products: ResponseCartProduct[], url?: string ) {
+export function useProductsWithPremiumSupport(
+	products: ResponseCartProduct[],
+	url?: string
+): {
+	userFieldMessage: string | null;
+	userFieldFlowName?: string;
+	hasPremiumSupport: boolean;
+	helpCenterButtonCopy?: string;
+	helpCenterButtonLink: string;
+} {
 	const { data: supportStatus } = useSupportStatus();
 	const { data: geoData } = useGeoLocationQuery();
 
@@ -31,7 +40,7 @@ export function useProductsWithPremiumSupport( products: ResponseCartProduct[], 
 				userFieldMessage: getUserFieldMessage( DIFM_FLOW, url ),
 				userFieldFlowName:
 					FLOWS_ZENDESK_FLOWNAME[ DIFM_FLOW as keyof typeof FLOWS_ZENDESK_FLOWNAME ],
-				hasPremiumSupport,
+				hasPremiumSupport: hasPremiumSupport || false,
 				helpCenterButtonCopy: hasPremiumSupport
 					? __( 'Questions?', __i18n_text_domain__ )
 					: defaultButtonLink,


### PR DESCRIPTION
Fixes DOTCOM-788

## Proposed Changes

Updates the support link during checkout to simply say "Need help?" and always open a new chat.

Flow | Before | After
--- | --- | ---
Signup | <img width="1280" alt="Screenshot 2025-06-16 at 16 48 53" src="https://github.com/user-attachments/assets/e0c562a3-3736-4490-8f62-2da98396fac6" /> | <img width="1271" alt="Screenshot 2025-06-16 at 16 05 38" src="https://github.com/user-attachments/assets/060691f6-42c3-41da-b576-704164a26ab0" />
Post-signup | <img width="1270" alt="Screenshot 2025-06-16 at 16 03 36" src="https://github.com/user-attachments/assets/c5545cae-8c6e-43ea-b890-7983bf04b218" /> | <img width="1271" alt="Screenshot 2025-06-16 at 16 08 31" src="https://github.com/user-attachments/assets/e62650ca-b7cc-42ac-8c1b-a41246063f43" />





## Why are these changes being made?

Because it currently opens the Help Center under some circumstances, which is  pretty open ended and doesn't feel helpful.

## Testing Instructions

- Use the Calypso live link below
- Go to `/start` to create a new site
- Pick a paid plan
- During checkout, make sure that the support link in the top-right corner reads as "Need help?"
- Click on it
- Make sure it opens a new chat
- Close the Help Center and proceed with the signup
- Once the site has been created, go to Upgrades > Plans or Upgrades > Add-Ons
- Pick either a paid plan or add-on.
- During checkout, make sure that the support link in the top-right corner reads as "Need help?"
- Click on it
- Make sure it opens a new chat

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
