### PR TITLE
Connect Refresh: Update the fonts for Blaze-Pro Login

### DIFF
--- a/client/layout/masterbar/blaze-pro.scss
+++ b/client/layout/masterbar/blaze-pro.scss
@@ -12,8 +12,8 @@
 		url(https://s0.wp.com/i/fonts/inter/Inter-roman.var.woff2?t=woff2&v=3.19) format("woff2");
 }
 
-$inter: Inter, $sans;
-$sfProText: "SF Pro Text", $sans;
+$inter: Inter, $sans; // for general
+$sfProText: "SF Pro Text", $sans; // for sub title
 $colorBlack: #1f1f1f;
 
 body.is-section-signup {
@@ -363,6 +363,7 @@ body.is-section-signup {
 				width: 360px;
 
 				.formatted-header__title {
+					font-family: $inter;
 					font-size: 2rem;
 					font-weight: 700;
 					line-height: 40px;
@@ -565,7 +566,6 @@ body.is-section-signup {
 
 	.wp-login__container {
 		.wp-login__main-footer {
-			margin-top: 48px;
 			text-align: center;
 		}
 

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -60,11 +60,6 @@ $image-height: 47px;
 			font-weight: 500;
 			line-height: 25px;
 		}
-
-		// .login__form-terms,
-		// .login__social-tos {
-		// 	font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif !important;
-		// }
 	}
 }
 

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -40,6 +40,32 @@ $image-height: 47px;
 	.step-container-v2__heading {
 		text-align: center;
 	}
+
+	// Add Blaze Pro font styles for OAuth clients
+	&.is-blaze-pro {
+		* {
+			font-family: Inter, -apple-system, system-ui, blinkmacsystemfont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+		}
+
+		.wp-login__heading-text {
+			font-family: Inter, -apple-system, system-ui, blinkmacsystemfont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+			font-size: 2rem;
+			font-weight: 700;
+			line-height: 40px;
+		}
+
+		.wp-login__heading-subtext {
+			font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+			font-size: rem(18px);
+			font-weight: 500;
+			line-height: 25px;
+		}
+
+		// .login__form-terms,
+		// .login__social-tos {
+		// 	font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif !important;
+		// }
+	}
 }
 
 .wp-login__heading-logo {
@@ -586,6 +612,8 @@ $image-height: 47px;
 		}
 	}
 }
+
+
 
 /* stylelint-disable scales/font-weights, scales/radii */
 .layout.is-section-login.is-grav-powered-client {

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -41,7 +41,7 @@ $image-height: 47px;
 		text-align: center;
 	}
 
-	// Add Blaze Pro font styles for OAuth clients
+	/* Start: Blaze Pro OAuth client font styles for login page */
 	&.is-blaze-pro {
 		* {
 			font-family: Inter, -apple-system, system-ui, blinkmacsystemfont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
@@ -61,6 +61,7 @@ $image-height: 47px;
 			line-height: 25px;
 		}
 	}
+	/* End: Blaze Pro OAuth client font styles for login page */
 }
 
 .wp-login__heading-logo {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of addressing https://linear.app/a8c/issue/DOTCOM-13542/login-ensure-custom-typesetsfonts-are-picked-up-for-the-client-screens

## Proposed Changes

This PR:
- updates the font used for Blaze Pro Login screen to match the one used in signup and other login screens
- also adjusts the font size & weight to match

### Media

| Before | After |
|--------|--------|
| <img width="1102" alt="Screenshot 2025-06-16 at 6 34 02 PM" src="https://github.com/user-attachments/assets/85238dae-29a5-404f-8c04-6ef04de90a8f" /> | <img width="1052" alt="Screenshot 2025-06-16 at 6 27 54 PM" src="https://github.com/user-attachments/assets/d0e57925-e6a2-4448-89da-bd8647f0d86c" /> | 

Below are the lost-password and create-account (signup) screens (not yet refactored to unified design):

| lost-password | create-account (signup) |
|--------|--------|
| <img width="1048" alt="Screenshot 2025-06-16 at 6 28 07 PM" src="https://github.com/user-attachments/assets/3b50e9b3-6854-4f2b-9b92-94e284d37b37" /> | <img width="1048" alt="Screenshot 2025-06-16 at 6 28 15 PM" src="https://github.com/user-attachments/assets/dd131547-5729-479e-92ec-aeab948be8ad" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [Blaze Pro](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D99370%26state%3D0f0d1f16975b65cf8e9e924461b7c892f78eabeeb190dc03654cef0465786da0%26redirect_uri%3Dhttps%253A%252F%252Fblazepro.tumblr.com%252Fauth%252Fconnected%26blog_id%3D0%26wpcom_connect%3D1%26calypso_env%3Dproduction%26scope%3Dglobal%26from-calypso%3D1&client_id=99370&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D99370%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%253Fresponse_type%253Dcode%2526client_id%253D99370%2526state%253D0f0d1f16975b65cf8e9e924461b7c892f78eabeeb190dc03654cef0465786da0%2526redirect_uri%253Dhttps%25253A%25252F%25252Fblazepro.tumblr.com%25252Fauth%25252Fconnected%2526blog_id%253D0%2526wpcom_connect%253D1%2526calypso_env%253Dproduction%2526scope%253Dglobal%2526from-calypso%253D1) and confirm
* Go to [WordPress.com](http://calypso.localhost:3000/log-in) and confirm no changes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
