### PR TITLE
Subscribers - header popover to focus for keyboard nav

### DIFF
--- a/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
+++ b/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
@@ -12,6 +12,7 @@ import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import useSubscriberCountQuery from '../../queries/use-subscriber-count-query';
 import { useRecordExport } from '../../tracks';
+
 import '../shared/popover-style.scss';
 
 type SubscribersHeaderPopoverProps = {
@@ -71,7 +72,6 @@ const SubscribersHeaderPopover = ( {
 				isVisible={ isVisible }
 				context={ buttonRef.current }
 				className="subscriber-popover"
-				focusOnShow={ false }
 			>
 				{ hasSubscribers ? (
 					<PopoverMenuItem href={ downloadCsvLink } onClick={ onDownloadCsvClick }>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # noted in https://github.com/Automattic/wp-calypso/pull/104208#discussion_r2149636481 / https://linear.app/a8c/issue/CML-584/improve-a11y-of-subscribers-download-and-migration-dropdown 

## Proposed Changes

* Remove this prop preventing focus on opening the popover.

BEFORE (cannot access items with keyboard)
![no-key-11y](https://github.com/user-attachments/assets/a8d3eef4-f02a-430c-9ff4-fd939a875f8c)


AFTER (navigates items with keybaord)
![key-11y](https://github.com/user-attachments/assets/0855044f-c066-4a02-bb30-2e17e8e5f292)



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This should be accessible via keyboard navigation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /subscribers for a site.
* tab or click into the header.
* tab over to the ellipsis in the top right and open with enter
* verify up/down arrowkeys now navigate the popover
* 'esc' should close the popover and put focus back on the last focused element (ellipsis button).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
