### PR TITLE
Newsletter settings: Exclude newsletter_has_active_plan from Jetpack settings update

### DIFF
--- a/client/state/jetpack/settings/utils.js
+++ b/client/state/jetpack/settings/utils.js
@@ -59,10 +59,12 @@ export const sanitizeSettings = ( settings ) => {
 			case 'jetpack_testimonial_posts_per_page':
 			case 'jetpack_portfolio_posts_per_page':
 			case 'post_by_email_address':
-			case 'newsletter_has_active_plan':
 				if ( settings[ key ] === 'regenerate' ) {
 					memo[ key ] = settings[ key ];
 				}
+				break;
+			// WordPress.com specific settings that should not be sent to Jetpack
+			case 'newsletter_has_active_plan':
 				break;
 			case 'infinite_scroll':
 				if ( settings[ key ] === 'default' ) {

--- a/client/state/jetpack/settings/utils.js
+++ b/client/state/jetpack/settings/utils.js
@@ -59,6 +59,7 @@ export const sanitizeSettings = ( settings ) => {
 			case 'jetpack_testimonial_posts_per_page':
 			case 'jetpack_portfolio_posts_per_page':
 			case 'post_by_email_address':
+			case 'newsletter_has_active_plan':
 				if ( settings[ key ] === 'regenerate' ) {
 					memo[ key ] = settings[ key ];
 				}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CML-581/newsletter-settings-fix-unexpected-error-when-saving-changes

## Proposed Changes

* Exclude `newsletter_has_active_plan` from the Jetpack settings update. It was added in https://github.com/Automattic/wp-calypso/pull/103824 but this is a read-only option, not an updateable option. It's how we determine whether to show "Add plans" or "Manage plans" under Paid Newsletter.


https://github.com/user-attachments/assets/579ffede-80bd-4b8d-b541-bb4bb748a0c8



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix a bug where the settings appear not to save correctly.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a WoA site, go to Settings > Newsletter (https://wordpress.com/settings/newsletter/SITE)
* Make a change to any of the available settings – toggling a setting on or off, updating the "welcome message" text, etc.
* Click "Save changes."
* You should not see this error: An unexpected error occurred. Please try again later. 
* Refresh the page. Check that the change you made actually was saved.
* Repeat on a Simple site.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
