### PR TITLE
Hosting dashboard: Coming Soon status label links to /home, i.e. the launch checklist

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -1,7 +1,7 @@
 import { DataViews, filterSortAndPaginate } from '@automattic/dataviews';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate, Link } from '@tanstack/react-router';
-import { Button, Modal } from '@wordpress/components';
+import { Button, Modal, ExternalLink } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
@@ -298,8 +298,7 @@ function ComingSoonStatusButton( { href, children }: { href: string; children: R
 	return (
 		<>
 			<ComponentViewTracker eventName="calypso_dashboard_site_launch_nag_impression" />
-			<Button
-				variant="link"
+			<ExternalLink
 				href={ href }
 				onClick={ () => {
 					recordTracksEvent( 'calypso_dashboard_site_launch_nag_click' );
@@ -307,7 +306,7 @@ function ComingSoonStatusButton( { href, children }: { href: string; children: R
 				style={ { position: 'absolute' } }
 			>
 				{ children }
-			</Button>
+			</ExternalLink>
 		</>
 	);
 }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -6,6 +6,8 @@ import { useResizeObserver } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
 import { useMemo, useState } from 'react';
+import { useInView } from 'react-intersection-observer';
+import { useAnalytics } from '../app/analytics';
 import { sitesQuery } from '../app/queries/sites';
 import { sitesRoute } from '../app/router';
 import DataViewsCard from '../components/dataviews-card';
@@ -98,9 +100,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 			}
 
 			return (
-				<Button variant="link" href={ `/home/${ item.slug }` } style={ { position: 'absolute' } }>
-					{ label }
-				</Button>
+				<ComingSoonStatusButton href={ `/home/${ item.slug }` }>{ label }</ComingSoonStatusButton>
 			);
 		},
 	},
@@ -289,5 +289,31 @@ export default function Sites() {
 				</DataViewsCard>
 			</PageLayout>
 		</>
+	);
+}
+
+function ComingSoonStatusButton( { href, children }: { href: string; children: React.ReactNode } ) {
+	const { recordTracksEvent } = useAnalytics();
+	const { ref } = useInView( {
+		triggerOnce: true,
+		onChange: ( inView ) => {
+			if ( inView ) {
+				recordTracksEvent( 'calypso_dashboard_site_launch_nag_inview' );
+			}
+		},
+	} );
+
+	return (
+		<Button
+			ref={ ref }
+			variant="link"
+			href={ href }
+			onClick={ () => {
+				recordTracksEvent( 'calypso_dashboard_site_launch_nag_click' );
+			} }
+			style={ { position: 'absolute' } }
+		>
+			{ children }
+		</Button>
 	);
 }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -6,10 +6,10 @@ import { useResizeObserver } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
 import { useMemo, useState } from 'react';
-import { useInView } from 'react-intersection-observer';
 import { useAnalytics } from '../app/analytics';
 import { sitesQuery } from '../app/queries/sites';
 import { sitesRoute } from '../app/router';
+import ComponentViewTracker from '../components/component-view-tracker';
 import DataViewsCard from '../components/dataviews-card';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
@@ -294,26 +294,20 @@ export default function Sites() {
 
 function ComingSoonStatusButton( { href, children }: { href: string; children: React.ReactNode } ) {
 	const { recordTracksEvent } = useAnalytics();
-	const { ref } = useInView( {
-		triggerOnce: true,
-		onChange: ( inView ) => {
-			if ( inView ) {
-				recordTracksEvent( 'calypso_dashboard_site_launch_nag_inview' );
-			}
-		},
-	} );
 
 	return (
-		<Button
-			ref={ ref }
-			variant="link"
-			href={ href }
-			onClick={ () => {
-				recordTracksEvent( 'calypso_dashboard_site_launch_nag_click' );
-			} }
-			style={ { position: 'absolute' } }
-		>
-			{ children }
-		</Button>
+		<>
+			<ComponentViewTracker eventName="calypso_dashboard_site_launch_nag_impression" />
+			<Button
+				variant="link"
+				href={ href }
+				onClick={ () => {
+					recordTracksEvent( 'calypso_dashboard_site_launch_nag_click' );
+				} }
+				style={ { position: 'absolute' } }
+			>
+				{ children }
+			</Button>
+		</>
 	);
 }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -91,7 +91,18 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		filterBy: {
 			operators: [ 'is' ],
 		},
-		render: ( { item }: { item: Site } ) => getSiteStatusLabel( item ),
+		render: ( { item }: { item: Site } ) => {
+			const label = getSiteStatusLabel( item );
+			if ( item.launch_status !== 'unlaunched' ) {
+				return label;
+			}
+
+			return (
+				<Button variant="link" href={ `/home/${ item.slug }` } style={ { position: 'absolute' } }>
+					{ label }
+				</Button>
+			);
+		},
 	},
 	{
 		id: 'is_a8c',

--- a/client/dashboard/utils/site-status.ts
+++ b/client/dashboard/utils/site-status.ts
@@ -4,11 +4,11 @@ import type { Site } from '../data/types';
 export const STATUS_LABELS = {
 	public: __( 'Public' ),
 	private: __( 'Private' ),
-	coming_soon: __( 'Coming Soon' ),
+	coming_soon: __( 'Coming soon' ),
 	deleted: __( 'Deleted' ),
 	redirect: __( 'Redirect' ),
-	migration_pending: __( 'Migration Pending' ),
-	migration_started: __( 'Migration Started' ),
+	migration_pending: __( 'Migration pending' ),
+	migration_started: __( 'Migration started' ),
 };
 
 export function getSiteStatus( item: Site ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTDASH-66

## Proposed Changes

* Add links to the "Coming soon" status field
* Change the status labels to use sentence case, like the mockups
* Copy the existing analytics
  * `calypso_dashboard_site_launch_nag_inview` when the link has been seen by the user
  * `calypso_dashboard_site_launch_nag_click` when the link is clicked

![CleanShot 2025-06-17 at 17 52 00@2x](https://github.com/user-attachments/assets/06ae15e2-9aa3-417f-bf56-f7ecb313d826)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The purpose of this link is to nudge the user towards launching their site

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use a site that has never been launched
	* The status field should link to the site's `/home` page (where there should be a checklist of some kind)
	* Confirm the links focus ring looks correct
	* Check the tracks events are sent as expected
* Use a site that has already been launched
	* Make the site "Coming soon" again
	* Check status label is not a link
* Confirm the behaviour is the same for table and grid mode

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
