### PR TITLE
Revert "Prevent merging PRs that sync from upstream (#103296)"

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -473,15 +473,6 @@ object RunAllUnitTests : BuildType({
 						exit 1
 					fi
 				fi
-
-				# If there are changes on the CHANGELOG.md prevent the PR from merging.
-				# In this case, we want to merge via specific instructions on the CLI.
-				if grep -q ^packages/dataviews/CHANGELOG.md <<< "${'$'}CHANGES"; then
-					echo "ERROR: changes to 'packages/dataviews/CHANGELOG.md detected'."
-					echo "PRs that sync changes from upstream cannot be merged via GitHub UI."
-					echo "Please, check packages/dataviews/SYNC.md to merge via the CLI commands."
-					exit 1
-				fi
 			""".trimIndent()
 		}
 		bashNodeScript {


### PR DESCRIPTION
This reverts commit 94af4e52adc3706d102db66dca732e93d1c34d17.

## Proposed Changes

https://github.com/Automattic/wp-calypso/pull/103296 introduced a check that failed when changes were detected in `packages/dataview/changelog.md`. The rationale is that PRs that touched those files shouldn't be merged via the GitHub UI, but rather the CLI.

## Why are these changes being made?

The same check prevented CLI merging. We need to find alternate ways to notify the PR authors.

## Testing Instructions
