### PR TITLE
Dashboard v2: implement hosting feature activation flow pt 2

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -7,6 +7,10 @@ module.exports = {
 					{
 						group: [
 							'calypso/*',
+							// Allowed: calypso/components/async-load
+							'!calypso/components',
+							'calypso/components/*',
+							'!calypso/components/async-load',
 							// Allowed: calypso/data/php-versions
 							'!calypso/data',
 							'calypso/data/*',

--- a/client/dashboard/sites/hosting-feature/activation.tsx
+++ b/client/dashboard/sites/hosting-feature/activation.tsx
@@ -1,46 +1,125 @@
-import { __experimentalText as Text, Button } from '@wordpress/components';
+import { __experimentalText as Text, Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import { useEffect, useState } from 'react';
+import AsyncLoad from 'calypso/components/async-load';
+import { useAnalytics } from '../../app/analytics';
 import { Callout } from '../../components/callout';
+import { HostingFeatures } from '../features';
 import illustrationUrl from './activation-illustration.svg';
+import type { Site } from '../../data/types';
 
-export default function HostingFeatureActivation() {
+interface HostingFeatureActivationProps {
+	site: Site;
+	feature: HostingFeatures;
+	tracksFeatureId: string;
+}
+
+export default function HostingFeatureActivation( {
+	site,
+	feature,
+	tracksFeatureId,
+}: HostingFeatureActivationProps ) {
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const { recordTracksEvent } = useAnalytics();
+
+	useEffect( () => {
+		recordTracksEvent( 'calypso_dashboard_hosting_feature_activation_impression', {
+			feature_id: tracksFeatureId,
+		} );
+	}, [ recordTracksEvent, tracksFeatureId ] );
+
+	const handleClick = () => {
+		if ( window.location.pathname.startsWith( '/v2/' ) ) {
+			// The current behavior is as follows:
+			// - In v2, we're redirecting to the v1 activation flow.
+			// - In backported v1, we're async-loading the "calypso/blocks/eligibility-warnings" component.
+			//
+			// TODO: consolidate the above by porting the component in v2.
+			// See: DOTDASH-72
+
+			window.location.href = addQueryArgs( `/hosting-features/${ site.slug }`, {
+				activate: true,
+			} );
+			return;
+		}
+
+		recordTracksEvent( 'calypso_dashboard_hosting_feature_activation_click', {
+			feature_id: tracksFeatureId,
+		} );
+
+		setIsModalOpen( true );
+	};
+
+	const handleConfirm = ( options: { geo_affinity?: string } ) => {
+		recordTracksEvent( 'calypso_dashboard_hosting_feature_activation_confirm', {
+			feature_id: tracksFeatureId,
+		} );
+
+		window.location.href = addQueryArgs( '/setup/transferring-hosted-site', {
+			siteId: String( site.ID ),
+			feature,
+			initiate_transfer_context: 'hosting',
+			initiate_transfer_geo_affinity: options.geo_affinity || '',
+			redirect_to: window.location.href.replace( window.location.origin, '' ),
+		} );
+	};
+
 	return (
-		<Callout
-			image={ illustrationUrl }
-			title={ __( 'Activate hosting features' ) }
-			description={
-				<>
-					<Text variant="muted">
-						{ __(
-							'Your plan includes a range of powerful hosting features. Activate them to get started.'
-						) }
-					</Text>
+		<>
+			<Callout
+				image={ illustrationUrl }
+				title={ __( 'Activate hosting features' ) }
+				description={
+					<>
+						<Text variant="muted">
+							{ __(
+								'Your plan includes a range of powerful hosting features. Activate them to get started.'
+							) }
+						</Text>
 
-					<ul style={ { paddingInlineStart: '15px', margin: 0 } }>
-						<Text as="li" variant="muted">
-							{ __( 'Git-based deployments' ) }
-						</Text>
-						<Text as="li" variant="muted">
-							{ __( 'Server monitoring' ) }
-						</Text>
-						<Text as="li" variant="muted">
-							{ __( 'Access and error logs' ) }
-						</Text>
-						<Text as="li" variant="muted">
-							{ __( 'Secure access via SFTP/SSH' ) }
-						</Text>
-						<Text as="li" variant="muted">
-							{ __( 'Advanced server settings' ) }
-						</Text>
-					</ul>
-				</>
-			}
-			actions={
-				// TODO: enable button and implement activation flow
-				<Button variant="primary" size="compact" disabled>
-					{ __( 'Activate' ) }
-				</Button>
-			}
-		/>
+						<ul style={ { paddingInlineStart: '15px', margin: 0 } }>
+							<Text as="li" variant="muted">
+								{ __( 'Git-based deployments' ) }
+							</Text>
+							<Text as="li" variant="muted">
+								{ __( 'Server monitoring' ) }
+							</Text>
+							<Text as="li" variant="muted">
+								{ __( 'Access and error logs' ) }
+							</Text>
+							<Text as="li" variant="muted">
+								{ __( 'Secure access via SFTP/SSH' ) }
+							</Text>
+							<Text as="li" variant="muted">
+								{ __( 'Advanced server settings' ) }
+							</Text>
+						</ul>
+					</>
+				}
+				actions={
+					<Button variant="primary" size="compact" onClick={ handleClick }>
+						{ __( 'Activate' ) }
+					</Button>
+				}
+			/>
+			{ isModalOpen && (
+				<Modal
+					title={ __( 'Before you continue' ) }
+					onRequestClose={ () => setIsModalOpen( false ) }
+					size="medium"
+				>
+					<AsyncLoad
+						require="calypso/blocks/eligibility-warnings"
+						placeholder={ null }
+						onDismiss={ () => setIsModalOpen( false ) }
+						onProceed={ handleConfirm }
+						showDataCenterPicker
+						standaloneProceed
+						currentContext="hosting-features"
+					/>
+				</Modal>
+			) }
+		</>
 	);
 }

--- a/client/dashboard/sites/hosting-feature/index.tsx
+++ b/client/dashboard/sites/hosting-feature/index.tsx
@@ -25,7 +25,13 @@ export default function HostingFeature( props: HostingFeatureProps ) {
 	}
 
 	if ( hasPlanFeature( site, feature ) ) {
-		return <HostingFeatureActivation />;
+		return (
+			<HostingFeatureActivation
+				site={ site }
+				feature={ feature }
+				tracksFeatureId={ tracksFeatureId }
+			/>
+		);
 	}
 
 	return (

--- a/client/sites/settings/controller.tsx
+++ b/client/sites/settings/controller.tsx
@@ -222,6 +222,7 @@ export function dashboardBackportSiteSettings( context: PageJSContext, next: () 
 	// fires its own page view events.
 	context.primary = (
 		<DashboardBackportSiteSettingsRenderer
+			store={ context.store }
 			siteSlug={ site?.slug }
 			feature={ context.params.feature }
 		/>

--- a/client/sites/settings/v2/index.tsx
+++ b/client/sites/settings/v2/index.tsx
@@ -5,11 +5,14 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent, recordPageView } from 'calypso/state/analytics/actions';
 import Layout from './layout';
 import type { AnalyticsClient } from 'calypso/dashboard/app/analytics';
+import type { Store } from 'redux';
 
 export default function DashboardBackportSiteSettingsRenderer( {
+	store,
 	siteSlug,
 	feature,
 }: {
+	store: Store;
 	siteSlug?: string;
 	feature?: string;
 } ) {
@@ -54,9 +57,11 @@ export default function DashboardBackportSiteSettingsRenderer( {
 		}
 
 		persistPromise.then( () => {
-			rootInstanceRef.current?.render( <Layout analyticsClient={ analyticsClient } /> );
+			rootInstanceRef.current?.render(
+				<Layout store={ store } analyticsClient={ analyticsClient } />
+			);
 		} );
-	}, [ analyticsClient, siteSlug, feature ] );
+	}, [ analyticsClient, store, siteSlug, feature ] );
 
 	return <div className="dashboard-backport-site-settings-root" ref={ containerRef } />;
 }

--- a/client/sites/settings/v2/layout.tsx
+++ b/client/sites/settings/v2/layout.tsx
@@ -1,9 +1,11 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider } from '@tanstack/react-router';
+import { Provider as ReduxProvider } from 'react-redux';
 import { AnalyticsProvider, type AnalyticsClient } from 'calypso/dashboard/app/analytics';
 import { AuthProvider, useAuth } from 'calypso/dashboard/app/auth';
 import { queryClient } from 'calypso/dashboard/app/query-client';
 import { getRouter } from './router';
+import type { Store } from 'redux';
 
 // Serves a similar purpose to AppConfig form v2 dashboard.
 const config = {
@@ -16,12 +18,14 @@ function RouterProviderWithAuth() {
 	return <RouterProvider router={ router } context={ { auth, config } } />;
 }
 
-function Layout( { analyticsClient }: { analyticsClient: AnalyticsClient } ) {
+function Layout( { store, analyticsClient }: { store: Store; analyticsClient: AnalyticsClient } ) {
 	return (
 		<QueryClientProvider client={ queryClient }>
 			<AuthProvider>
 				<AnalyticsProvider client={ analyticsClient }>
-					<RouterProviderWithAuth />
+					<ReduxProvider store={ store }>
+						<RouterProviderWithAuth />
+					</ReduxProvider>
 				</AnalyticsProvider>
 			</AuthProvider>
 		</QueryClientProvider>


### PR DESCRIPTION
Fixes DOTCOM-13376

## Proposed Changes

This PR implements the hosting feature activation flow as follows:

- In backported v1, we're async-loading the "calypso/blocks/eligibility-warnings" component, and proceed as v1 to the `/setup/transferring-hosted-site` flow.
- In v2, we're redirecting to the v1 activation flow. This is a temporary solution, as the above component depends on many things in the v1 Redux store.

We should actually implement it for v2, which is tracked here: DOTDASH-72

|Backported v1|v2|
|-|-|
|<img width="805" alt="image" src="https://github.com/user-attachments/assets/d94984dc-bf85-413f-a0a1-f00e6123d4bd" />|<img width="805" alt="image" src="https://github.com/user-attachments/assets/9e9b16c8-8bcf-4d6f-be47-630c602a2415" />|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Prepare a Simple site with a Business plan.
1. Go to `/sites/settings/v2/:slug?flags=dashboard/v2/backport/site-settings`.
2. Click any hosting feature
3. Verify you see the activation callout
4. Click Activate
5. Verify you can see the modal
6. Verify you can complete the activation flow and get redirected to the original settings page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
