### PR TITLE
Help Center: Prevent feedback 👍🏼 / 👎🏼 buttons from being "tabable" after the feedback was sent

### DIFF
--- a/packages/odie-client/src/components/message/was-this-helpful-buttons.tsx
+++ b/packages/odie-client/src/components/message/was-this-helpful-buttons.tsx
@@ -77,7 +77,7 @@ const WasThisHelpfulButtons = ( {
 	} );
 
 	return (
-		<div className={ containerClasses } aria-hidden={ rated }>
+		<div className={ containerClasses }>
 			<div className="odie-feedback-message">
 				<span className={ questionClasses } aria-hidden={ rated }>
 					{ __( 'Was this helpful?', __i18n_text_domain__ ) }

--- a/packages/odie-client/src/components/message/was-this-helpful-buttons.tsx
+++ b/packages/odie-client/src/components/message/was-this-helpful-buttons.tsx
@@ -77,12 +77,12 @@ const WasThisHelpfulButtons = ( {
 	} );
 
 	return (
-		<div className={ containerClasses }>
+		<div className={ containerClasses } aria-hidden={ rated }>
 			<div className="odie-feedback-message">
-				<span className={ questionClasses }>
+				<span className={ questionClasses } aria-hidden={ rated }>
 					{ __( 'Was this helpful?', __i18n_text_domain__ ) }
 				</span>
-				<span className={ thanksClasses }>
+				<span className={ thanksClasses } aria-hidden={ ! rated }>
 					{ __( 'We appreciate your feedback.', __i18n_text_domain__ ) }
 				</span>
 			</div>
@@ -91,6 +91,8 @@ const WasThisHelpfulButtons = ( {
 					className={ buttonLikedClasses }
 					onClick={ () => handleIsHelpful( true ) }
 					disabled={ notLiked }
+					tabIndex={ rated ? -1 : undefined }
+					aria-hidden={ rated }
 					aria-label={ __( 'Yes, this was helpful', __i18n_text_domain__ ) }
 				>
 					<ThumbsUpIcon className={ thumbsUpClasses } />
@@ -99,6 +101,8 @@ const WasThisHelpfulButtons = ( {
 					className={ buttonDislikedClasses }
 					onClick={ () => handleIsHelpful( false ) }
 					disabled={ liked }
+					tabIndex={ rated ? -1 : undefined }
+					aria-hidden={ rated }
 					aria-label={ __( 'No, this was not helpful', __i18n_text_domain__ ) }
 				>
 					<ThumbsDownIcon className={ thumbsDownClasses } />


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DOTCOM-13429

## Proposed Changes

* prevent feedback 👍🏼 / 👎🏼 buttons from being "tabable" after the feedback was sent
* hide "Was this helpful?" text from VoiceOver after the feedback was sent, leaving only the "We appreciate your feedback." text there.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

After the chat response is rated, the 👍 and 👎 buttons are still "tab-able". That shouldn't be the case.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start` (or use the Calypso Live link).
2. Open the Help Center and start a chat by clicking the `Still need help?` button.
3. Enable VoiceOver.
4. Ask a question.
5. Wait until response is displayed, together with the feedback section below it.
6. Tab through the 👍🏼 and 👎🏼 button and rate the response.
7. If you try to use the <kbd>Tab</kbd> button, it shouldn't be possible to select any of those two buttons.

Please note that the buttons are still selectable using <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>arrows</kbd>. Changing the behavior would require further changes where it would be the best to remove the buttons from the DOM after the feedback is submitted. The effort there is bit higher due to how the section is currently hidden just with `height: 0` animation. I did not want to invest too much time in that.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?