### PR TITLE
UI: Use content hash for CSS modules

### DIFF
--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -1,13 +1,5 @@
-/* eslint-disable import/no-nodejs-modules */
-import { execSync } from 'node:child_process';
-import { createHash } from 'node:crypto';
 import { sassPlugin, postcssModules } from 'esbuild-sass-plugin';
 import { defineConfig } from 'tsup';
-
-let gitHeadSha;
-try {
-	gitHeadSha = execSync( 'git rev-parse HEAD' ).toString();
-} catch {}
 
 export default defineConfig( {
 	entry: [ 'src/index.ts' ],
@@ -22,13 +14,7 @@ export default defineConfig( {
 			filter: /\.module\.(css|scss)$/,
 			embedded: true,
 			transform: postcssModules( {
-				generateScopedName: ( name, filename ) => {
-					const hash = createHash( 'md5' )
-						.update( name + filename + gitHeadSha )
-						.digest( 'hex' )
-						.slice( 0, 6 );
-					return `a8cui-${ hash }`;
-				},
+				generateScopedName: 'a8cui-[contenthash:base64:6]',
 			} ),
 		} ),
 	],


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/104187#discussion_r2146031305

## Proposed Changes

Use a content hash (instead of a git commit hash) for generating CSS module class names in `@automattic/ui`.

## Why are these changes being made?

See discussion in https://github.com/Automattic/wp-calypso/pull/104187#discussion_r2146031305

tl;dr — It's simpler and keeps the builds deterministic from source code.

## Testing Instructions

 `yarn workspace @automattic/ui build` and inspect the output in dist.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
