### PR TITLE
Marketing Tools: Restores facebook placement

### DIFF
--- a/client/sites/marketing/tools/marketing-features-data.ts
+++ b/client/sites/marketing/tools/marketing-features-data.ts
@@ -1,21 +1,30 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
+import { PLAN_BUSINESS, getPlan, PLAN_ECOMMERCE } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { getLocaleSlug } from 'i18n-calypso';
 import fiverrLogo from 'calypso/assets/images/customer-home/fiverr-logo.svg';
 import rocket from 'calypso/assets/images/customer-home/illustration--rocket.svg';
 import earnIllustration from 'calypso/assets/images/customer-home/illustration--task-earn.svg';
 import wordPressLogo from 'calypso/assets/images/icons/wordpress-logo.svg';
+import facebookLogo from 'calypso/assets/images/illustrations/facebook-logo.png';
 import { marketingConnections } from 'calypso/my-sites/marketing/paths';
 import * as T from 'calypso/types';
 import { MarketingToolsFeatureData } from './types';
 
 export const getMarketingFeaturesData = (
 	selectedSiteSlug: T.SiteSlug | null,
-	translate: ( text: string ) => string,
+	translate: ( text: string, options?: any ) => string,
 	localizeUrl: ( url: string ) => string
 ): MarketingToolsFeatureData[] => {
 	const isEnglish = ( config( 'english_locales' ) as string[] ).includes( getLocaleSlug() ?? '' );
+	const currentDate = new Date();
+	const shouldShowFacebook =
+		( currentDate.getFullYear() === 2025 &&
+			currentDate.getMonth() >= 6 &&
+			currentDate.getMonth() <= 9 ) ||
+		config.isEnabled( 'marketing-force-facebook-display' ); // July-October 2025 OR if the feature flag is enabled.
+
 	const result: MarketingToolsFeatureData[] = [
 		{
 			title: translate( 'Let our WordPress.com experts build your site!' ),
@@ -91,6 +100,33 @@ export const getMarketingFeaturesData = (
 			},
 		},
 	];
+
+	// Add Facebook feature conditionally as 3rd item
+	if ( shouldShowFacebook ) {
+		const facebookDescription = translate(
+			'Discover an easy way to advertise your brand across Facebook and Instagram. Capture website actions to help you target audiences and measure results. Available on %(businessPlanName)s and %(commercePlanName)s plans.',
+			{
+				args: {
+					businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+					commercePlanName: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+				},
+			}
+		);
+
+		result.splice( 2, 0, {
+			title: translate( 'Want to connect with your audience on Facebook and Instagram?' ),
+			description: facebookDescription,
+			categories: [ 'share', 'new' ],
+			imagePath: facebookLogo,
+			imageAlt: translate( 'Facebook Logo' ),
+			buttonText: translate( 'Add Facebook for WordPress.com' ),
+			onClick: () => {
+				recordTracksEvent( 'calypso_marketing_tools_facebook_button_click' );
+				page( `/plugins/official-facebook-pixel/${ selectedSiteSlug }` );
+			},
+		} );
+	}
+
 	if ( isEnglish ) {
 		result.push( {
 			title: translate( 'Increase traffic to your WordPress.com site' ),

--- a/client/sites/marketing/tools/marketing-features-data.ts
+++ b/client/sites/marketing/tools/marketing-features-data.ts
@@ -113,7 +113,7 @@ export const getMarketingFeaturesData = (
 			}
 		);
 
-		result.splice( 2, 0, {
+		result.splice( 3, 0, {
 			title: translate( 'Want to connect with your audience on Facebook and Instagram?' ),
 			description: facebookDescription,
 			categories: [ 'share', 'new' ],

--- a/config/development.json
+++ b/config/development.json
@@ -116,6 +116,7 @@
 		"logmein": true,
 		"mailchimp": true,
 		"manage/import/site-importer-endpoints": true,
+		"marketing-force-facebook-display": true,
 		"marketplace-fetch-all-dynamic-products": true,
 		"marketplace-personal-premium": false,
 		"marketplace-reviews-notification": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -86,6 +86,7 @@
 		"login/magic-login": true,
 		"login/use-magic-code": true,
 		"mailchimp": true,
+		"marketing-force-facebook-display": true,
 		"marketplace-fetch-all-dynamic-products": true,
 		"marketplace-personal-premium": false,
 		"marketplace-reviews-notification": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -93,6 +93,7 @@
 		"login/use-magic-code": true,
 		"logmein": true,
 		"mailchimp": true,
+		"marketing-force-facebook-display": true,
 		"marketplace-fetch-all-dynamic-products": true,
 		"marketplace-personal-premium": false,
 		"marketplace-reviews-notification": false,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of pfUMqg-5a-p2

## Proposed Changes

* Restores the Facebook marketing feature added in #94832.
* Links redirect to the facebook pixel plugin page.
* The placement will be shown from July to October 2025,

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We're restoring the Facebook feature placement.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Go to /marketing/tools/[domain]
* You should see the Facebook marketing feature added

| Before | After |
|--------|--------|
|<img width="1123" alt="Screenshot 2025-06-17 at 14 07 00" src="https://github.com/user-attachments/assets/9dc40e61-cf51-4bea-b90e-d61b18d93ead" />|<img width="1119" alt="Screenshot 2025-06-17 at 14 08 21" src="https://github.com/user-attachments/assets/941e23e1-ef6b-4299-81c2-74341eeaa9c2" />|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?