### PR TITLE
Add retry logic when fetching the current user

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -43,7 +43,7 @@ const UserStepComponent: StepType = function UserStep( {
 			wpcom.loadToken( wpAccountCreateResponse.bearer_token );
 			reloadProxy();
 			requestAllBlogsAccess();
-			dispatch( fetchCurrentUser() as unknown as AnyAction );
+			dispatch( fetchCurrentUser( { retry: true } ) as unknown as AnyAction );
 		}
 		if ( ! isLoggedIn ) {
 			dispatch( fetchCurrentUser() as unknown as AnyAction );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -43,6 +43,9 @@ const UserStepComponent: StepType = function UserStep( {
 			wpcom.loadToken( wpAccountCreateResponse.bearer_token );
 			reloadProxy();
 			requestAllBlogsAccess();
+			// Allow retries of fetching new users after creation. New user sign-ups go to one DC
+			// but follow-up API calls go to the closest DC, which may be different and might not
+			// have replicated the user data yet.
 			dispatch( fetchCurrentUser( { retry: true } ) as unknown as AnyAction );
 		}
 		if ( ! isLoggedIn ) {

--- a/client/lib/user/shared-utils/raw-current-user-fetch.js
+++ b/client/lib/user/shared-utils/raw-current-user-fetch.js
@@ -1,5 +1,36 @@
 import wpcom from 'calypso/lib/wp';
 
-export function rawCurrentUserFetch() {
-	return wpcom.req.get( '/me', { meta: 'flags' } );
+const MAX_RETRIES = 3;
+const RETRY_DELAY = 1000; // 1 second
+
+const isErrorResponse = ( response ) => {
+	return response?.body?.error || response?.code >= 400;
+};
+
+export async function rawCurrentUserFetch() {
+	let retryCount = 0;
+	let lastError;
+
+	while ( retryCount <= MAX_RETRIES ) {
+		try {
+			const response = await wpcom.req.get( '/me', { meta: 'flags' } );
+
+			if ( isErrorResponse( response ) ) {
+				throw response;
+			}
+
+			return response;
+		} catch ( error ) {
+			lastError = error;
+			retryCount++;
+
+			if ( retryCount > MAX_RETRIES ) {
+				break;
+			}
+
+			await new Promise( ( resolve ) => setTimeout( resolve, RETRY_DELAY ) );
+		}
+	}
+
+	throw lastError;
 }

--- a/client/lib/user/shared-utils/raw-current-user-fetch.js
+++ b/client/lib/user/shared-utils/raw-current-user-fetch.js
@@ -1,17 +1,18 @@
 import wpcom from 'calypso/lib/wp';
 
-const MAX_RETRIES = 3;
+const MAX_TRIES = 3;
 const RETRY_DELAY = 1000; // 1 second
 
 const isErrorResponse = ( response ) => {
 	return response?.body?.error || response?.code >= 400;
 };
 
-export async function rawCurrentUserFetch() {
+export async function rawCurrentUserFetch( { retry = false } = {} ) {
 	let retryCount = 0;
 	let lastError;
+	const maxRetries = retry ? MAX_TRIES : 0;
 
-	while ( retryCount <= MAX_RETRIES ) {
+	while ( retryCount <= maxRetries ) {
 		try {
 			const response = await wpcom.req.get( '/me', { meta: 'flags' } );
 
@@ -24,7 +25,7 @@ export async function rawCurrentUserFetch() {
 			lastError = error;
 			retryCount++;
 
-			if ( retryCount > MAX_RETRIES ) {
+			if ( retryCount > maxRetries ) {
 				break;
 			}
 

--- a/client/state/current-user/actions.js
+++ b/client/state/current-user/actions.js
@@ -27,7 +27,7 @@ export function setCurrentUser( user ) {
 
 let fetchingUser = null;
 
-export function fetchCurrentUser() {
+export function fetchCurrentUser( { retry = false } = {} ) {
 	return ( dispatch ) => {
 		if ( fetchingUser ) {
 			return fetchingUser;
@@ -37,7 +37,7 @@ export function fetchCurrentUser() {
 			type: CURRENT_USER_FETCH,
 		} );
 
-		fetchingUser = rawCurrentUserFetch()
+		fetchingUser = rawCurrentUserFetch( { retry } )
 			.then( async ( user ) => {
 				const userData = filterUserObject( user );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTOBRD-162

## Proposed Changes

Retry the fetch of the user from /me on error, up to three times.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fetching the current user just after creation can fail due to replication lag. This change reduces the likelihood of the problem bubbling up by reattempting failed fetches, under these circumstances only.

It does not replace the need for places further up the callstack to smoothly handle fetch user failures.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. On your sandbox modify `oauth2_authentication` (fbhepr%2Skers%2Sjcpbz%2Schoyvp.ncv%2Serfg%2Spynff.jcpbz%2Qwfba%2Qncv.cuc%3Se%3Q47r4n92n%23511-og) to return an `invalid_token`
2. Sandbox public-api
3. While logged out go to https://wordpress.com/setup/ai-site-builder/user?prompt=coffee+shop&locale=en&source=landing-page
4. "Continue with email", enter an email and Continue.

You should see a request to /rest/v1.1/users/new which succeeds, shortly followed by a request to rest/v1.1/me?http_envelope=1&meta=flags which fails with an invalid_token. This will be retried several times. 

If you want to test the behaviour of this diff slightly more accurately you can make `oauth2_authentication` only sometimes return an `invalid_token`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?