### PR TITLE
i18n: Localize Studio URL for all supported locales

### DIFF
--- a/packages/i18n-utils/src/locales.ts
+++ b/packages/i18n-utils/src/locales.ts
@@ -8,7 +8,18 @@ export type Locale = string;
 export const i18nDefaultLocaleSlug: Locale = 'en';
 export const localesWithBlog: Locale[] = [ 'en', 'ja', 'es', 'pt', 'fr', 'pt-br' ];
 export const localesWithGoBlog: Locale[] = [ 'en', 'pt-br', 'de', 'es', 'fr', 'it' ];
-export const localesWithWpcomDeveloperSite: Locale[] = [ 'en', 'es' ];
+export const localesWithWpcomDeveloperSiteFullySupported: Locale[] = [ 'en', 'es' ];
+export const localesWithWpcomDeveloperSite: Locale[] = [
+	'en',
+	'de',
+	'es',
+	'fr',
+	'id',
+	'it',
+	'ja',
+	'nl',
+	'pt-br',
+];
 export const localesWithPrivacyPolicy: Locale[] = [ 'en', 'fr', 'de', 'es' ];
 export const localesWithCookiePolicy: Locale[] = [ 'en', 'fr', 'de', 'es' ];
 export const localesWithLearn: Locale[] = [ 'en', 'es' ];


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to pxLjZ-9QB-p2

## Proposed Changes

* Update the URL localization for developer.wordpress.com to localized the /studio link for all supported locales.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We are adding support for more locales for developer.wordpress.com, but the documentation isn't translated yet, so the only URL that should be localized is the /studio one.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to a supported locale for developer.wordpress.com, except for Spanish (German, French, Japanese, Brazilian Portuguese, Italian, Indonesian, Dutch).
* On calypso.live or calypso.localhost navigate to /me/developer and confirm that only the /studio URL is localized for developer.wordpress.com links.
* Go to /me/privacy and confirm that the links are still correctly localized.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
