### PR TITLE
Checkout: Separate step title and step button to improve accessibility

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,6 @@
+{
+	"permissions": {
+		"allow": [ "Bash(gh pr:*)" ],
+		"deny": []
+	}
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,6 +1,0 @@
-{
-	"permissions": {
-		"allow": [ "Bash(gh pr:*)" ],
-		"deny": []
-	}
-}

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -921,27 +921,28 @@ const StepTitle = styled.span< StepTitleProps & HTMLAttributes< HTMLSpanElement 
 			? props.theme.colors.textColorDark
 			: props.theme.colors.textColorDisabled };
 	font-weight: ${ ( props ) => props.theme.weights.bold };
-	margin-right: ${ ( props ) => ( props.fullWidth ? '0' : '8px' ) };
 	flex: 1;
-
-	.rtl & {
-		margin-right: 0;
-		margin-left: ${ ( props ) => ( props.fullWidth ? '0' : '8px' ) };
-	}
+	margin-right: 8px;
 `;
 
 interface StepTitleProps {
 	isComplete?: boolean;
 	isActive?: boolean;
-	fullWidth?: boolean;
 }
 
-const StepHeader = styled.h2< StepHeaderProps & HTMLAttributes< HTMLHeadingElement > >`
-	font-size: 20px;
+const StepHeaderWrapper = styled.div< StepHeaderProps & HTMLAttributes< HTMLDivElement > >`
 	display: flex;
 	width: 100%;
 	align-items: center;
 	margin: 0 0 ${ ( props ) => ( props.isComplete || props.isActive ? '8px' : '0' ) };
+`;
+
+const StepHeader = styled.h2< StepHeaderProps & HTMLAttributes< HTMLHeadingElement > >`
+	font-size: 20px;
+	display: flex;
+	align-items: center;
+	margin: 0;
+	flex: 1;
 `;
 
 interface StepHeaderProps {
@@ -982,21 +983,19 @@ function CheckoutStepHeader( {
 	const shouldShowEditButton = canEditStep && !! onEdit;
 
 	return (
-		<StepHeader
+		<StepHeaderWrapper
 			isComplete={ isComplete }
 			isActive={ isActive }
 			className={ joinClasses( [ className, 'checkout-step__header' ] ) }
 		>
-			<Stepper isComplete={ isComplete } isActive={ isActive } id={ id }>
-				{ stepNumber || null }
-			</Stepper>
-			<StepTitle
-				fullWidth={ ! shouldShowEditButton }
-				isComplete={ isComplete }
-				isActive={ isActive }
-			>
-				{ title }
-			</StepTitle>
+			<StepHeader isComplete={ isComplete } isActive={ isActive }>
+				<Stepper isComplete={ isComplete } isActive={ isActive } id={ id }>
+					{ stepNumber || null }
+				</Stepper>
+				<StepTitle isComplete={ isComplete } isActive={ isActive }>
+					{ title }
+				</StepTitle>
+			</StepHeader>
 			{ shouldShowEditButton && (
 				<HeaderEditButton
 					className="checkout-step__edit-button"
@@ -1007,7 +1006,7 @@ function CheckoutStepHeader( {
 					{ editButtonText || __( 'Edit' ) }
 				</HeaderEditButton>
 			) }
-		</StepHeader>
+		</StepHeaderWrapper>
 	);
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13285/fix-voiceover-navigation-on-the-cart-step

## Proposed Changes

* In checkout, separate the step title from the step action to improve accessibility navigation

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve accessibility in accessing the `Edit` link

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this changes and run `yarn start` or use the Calypso live link below
* Purchase anything and go to the Checkout screen
* Activate VoiceOver and navigate through the sections using `cmd+opt+<right arrow>`
* When navigating to the `Billing information` step, make sure you can navigate and press the `Edit` button by focusing on the `Edit` link and pressing `cmd+opt+<space>`
* Make sure you don't see any visual differences between this version and production in any screen sizes.
* Optionally, you can install an extension or change the language to a `RTL` language (I have tested with [this one](https://chromewebstore.google.com/detail/ltr-rtl/dihficgdollilpfaliclpihepalmdgbb)) and check that when displaying the checkout for a `RTL` language, there are no regressions compared with production.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
