### PR TITLE
Add subscribers modal: Update import from Substack copy

### DIFF
--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -12,7 +12,7 @@ import {
 import { Modal, __experimentalVStack as VStack } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { copy, upload, reusableBlock } from '@wordpress/icons';
-import { useTranslate } from 'i18n-calypso';
+import { fixMe, useTranslate } from 'i18n-calypso';
 import { LoadingBar } from 'calypso/components/loading-bar';
 import Notice from 'calypso/components/notice';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -144,9 +144,13 @@ const AddSubscribersModal = ( {
 								icon={ reusableBlock }
 								title={ translate( 'Import from Substack' ) }
 								text={
-									isJetpack
-										? translate( 'Quickly bring your free and paid subscribers.' )
-										: translate( 'Quickly bring your subscribers (and even your content!).' )
+									fixMe( {
+										text: 'Migrate your content along with your free and paid subscribers.',
+										newCopy: translate(
+											'Migrate your content along with your free and paid subscribers.'
+										),
+										oldCopy: translate( 'Quickly bring your free and paid subscribers.' ),
+									} ) as string
 								}
 								onClick={ importFromSubstack }
 							/>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CML-579/update-copy-on-import-modal-to-clarify-you-can-import-paid-subs-from

## Proposed Changes

* Updates copy from "Quickly bring your subscribers (and even your content!)." (or "Quickly bring your free and paid subscribers." for Jetpack sites) to "Migrate your content along with your free and paid subscribers." for all site types. 

Before | After
---- | ----
<img width="568" alt="Screenshot 2025-06-17 at 3 35 02 PM" src="https://github.com/user-attachments/assets/8fdec0ad-d1d3-45b0-8338-93bf11a20348" /> | <img width="573" alt="Screenshot 2025-06-17 at 3 27 44 PM" src="https://github.com/user-attachments/assets/3ba28976-ba4d-4174-9e96-6eadeb2437c6" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To clarify that you can import paid subscribers from Substack. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /subscribers/{site url}
* Click "Add subscribers."
* Check that the new copy is visible.
* Switch locales and check that you still see a translation.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
