### PR TITLE
Stats: Fix monthly views inconsistency

### DIFF
--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -199,7 +199,7 @@ export function getSiteStatsQueryDate( state, siteId, statType, query ) {
  * Returns a summary of site stats views organized by year and month
  * @param   {Object}  state    Global state tree
  * @param   {number}  siteId   Site ID
- * @returns {Object|null}      Stats View Summary or null if data is invalid
+ * @returns {Object}      Stats View Summary
  */
 export function getSiteStatsViewSummary( state, siteId ) {
 	const query = {

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -248,30 +248,26 @@ export function getSiteStatsViewSummary( state, siteId ) {
 		}
 
 		if ( ! viewSummary[ year ][ month ] ) {
-			const daysInMonth = new Date( year, month + 1, 0 ).getDate(); //When you set the day to 0, it gives you the last day of the previous month
+			const daysInMonth = new Date( year, month + 1, 0 ).getDate();
+			const isCurrentMonth = year === currentYear && month === currentMonth;
+			const daysToUse = isCurrentMonth ? currentDate.getDate() : daysInMonth;
 
 			viewSummary[ year ][ month ] = {
 				total: 0,
 				data: [],
 				average: 0,
-				daysInMonth,
+				daysInMonth: daysToUse,
 			};
 		}
 
 		// Add data to the summary
 		viewSummary[ year ][ month ].total += value;
 		viewSummary[ year ][ month ].data.push( item );
-	} );
 
-	// Calculate averages for all months
-	Object.entries( viewSummary ).forEach( ( [ year, months ] ) => {
-		Object.entries( months ).forEach( ( [ month, data ] ) => {
-			const isCurrentMonth = parseInt( year ) === currentYear && parseInt( month ) === currentMonth;
-			const daysToUse = isCurrentMonth ? currentDate.getDate() : data.daysInMonth;
-
-			// Calculate average with more precision
-			data.average = Math.round( ( data.total / daysToUse ) * 100 ) / 100;
-		} );
+		// Calculate average as integer
+		viewSummary[ year ][ month ].average = Math.round(
+			viewSummary[ year ][ month ].total / viewSummary[ year ][ month ].daysInMonth
+		);
 	} );
 
 	return viewSummary;

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -226,12 +226,7 @@ export function getSiteStatsViewSummary( state, siteId ) {
 
 		const [ dateStr, value ] = item;
 
-		// Validate date format (YYYY-MM-DD)
-		if ( ! /^\d{4}-\d{2}-\d{2}$/.test( dateStr ) ) {
-			return;
-		}
-
-		// Parse date components
+		// Parse date components - date format (YYYY-MM-DD)
 		const [ yearStr, monthStr ] = dateStr.split( '-' );
 		const year = parseInt( yearStr, 10 );
 		const month = parseInt( monthStr, 10 ) - 1; // Convert to 0-based month

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -232,15 +232,9 @@ export function getSiteStatsViewSummary( state, siteId ) {
 		}
 
 		// Parse date components
-		const [ yearStr, monthStr, dayStr ] = dateStr.split( '-' );
+		const [ yearStr, monthStr ] = dateStr.split( '-' );
 		const year = parseInt( yearStr, 10 );
 		const month = parseInt( monthStr, 10 ) - 1; // Convert to 0-based month
-		const day = parseInt( dayStr, 10 );
-
-		// Validate parsed values
-		if ( isNaN( year ) || isNaN( month ) || isNaN( day ) ) {
-			return;
-		}
 
 		// Initialize year and month objects if they don't exist
 		if ( ! viewSummary[ year ] ) {

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -1,6 +1,7 @@
 import { createSelector } from '@automattic/state-utils';
 import treeSelect from '@automattic/tree-select';
 import { get, map, flatten } from 'lodash';
+import { getMomentSiteZone } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSerializedStatsQuery, normalizers, buildExportArray } from './utils';
 
@@ -195,10 +196,10 @@ export function getSiteStatsQueryDate( state, siteId, statType, query ) {
 }
 
 /**
- * Returns the date of the last site stats query
+ * Returns a summary of site stats views organized by year and month
  * @param   {Object}  state    Global state tree
  * @param   {number}  siteId   Site ID
- * @returns {Object}           Stats View Summary
+ * @returns {Object|null}      Stats View Summary or null if data is invalid
  */
 export function getSiteStatsViewSummary( state, siteId ) {
 	const query = {
@@ -207,46 +208,71 @@ export function getSiteStatsViewSummary( state, siteId ) {
 	};
 	const viewData = getSiteStatsForQuery( state, siteId, 'statsVisits', query );
 
-	if ( ! viewData || ! viewData.data ) {
+	// Validate input data
+	if ( ! viewData?.data || ! Array.isArray( viewData.data ) ) {
 		return null;
 	}
 
 	const viewSummary = {};
+	const currentDate = getMomentSiteZone( state, siteId ).toDate();
+	const currentYear = currentDate.getFullYear();
+	const currentMonth = currentDate.getMonth();
 
 	viewData.data.forEach( ( item ) => {
-		const [ date, value ] = item;
-		const newDate = new Date( date );
-		const years = newDate.getFullYear();
-		const months = newDate.getMonth();
-
-		if ( ! viewSummary[ years ] ) {
-			viewSummary[ years ] = {};
+		// Validate item structure
+		if ( ! Array.isArray( item ) || item.length !== 2 ) {
+			return;
 		}
 
-		if ( ! viewSummary[ years ][ months ] ) {
-			viewSummary[ years ][ months ] = {
+		const [ dateStr, value ] = item;
+
+		// Validate date format (YYYY-MM-DD)
+		if ( ! /^\d{4}-\d{2}-\d{2}$/.test( dateStr ) ) {
+			return;
+		}
+
+		// Parse date components
+		const [ yearStr, monthStr, dayStr ] = dateStr.split( '-' );
+		const year = parseInt( yearStr, 10 );
+		const month = parseInt( monthStr, 10 ) - 1; // Convert to 0-based month
+		const day = parseInt( dayStr, 10 );
+
+		// Validate parsed values
+		if ( isNaN( year ) || isNaN( month ) || isNaN( day ) ) {
+			return;
+		}
+
+		// Initialize year and month objects if they don't exist
+		if ( ! viewSummary[ year ] ) {
+			viewSummary[ year ] = {};
+		}
+
+		if ( ! viewSummary[ year ][ month ] ) {
+			const daysInMonth = new Date( year, month + 1, 0 ).getDate(); //When you set the day to 0, it gives you the last day of the previous month
+
+			viewSummary[ year ][ month ] = {
 				total: 0,
 				data: [],
 				average: 0,
-				daysInMonth: new Date( years, months + 1, 0 ).getDate(),
+				daysInMonth,
 			};
 		}
-		viewSummary[ years ][ months ].total += value;
-		viewSummary[ years ][ months ].data.push( item );
-		const average =
-			viewSummary[ years ][ months ].total / viewSummary[ years ][ months ].daysInMonth;
-		viewSummary[ years ][ months ].average = Math.round( average );
+
+		// Add data to the summary
+		viewSummary[ year ][ month ].total += value;
+		viewSummary[ year ][ month ].data.push( item );
 	} );
 
-	// With the current month, calculate the average based on the days passed so far in the month
-	const date = new Date();
-	const thisMonth =
-		viewSummary[ date.getFullYear() ] && viewSummary[ date.getFullYear() ][ date.getMonth() ];
+	// Calculate averages for all months
+	Object.entries( viewSummary ).forEach( ( [ year, months ] ) => {
+		Object.entries( months ).forEach( ( [ month, data ] ) => {
+			const isCurrentMonth = parseInt( year ) === currentYear && parseInt( month ) === currentMonth;
+			const daysToUse = isCurrentMonth ? currentDate.getDate() : data.daysInMonth;
 
-	if ( thisMonth ) {
-		thisMonth.daysInMonth = date.getDate();
-		thisMonth.average = Math.round( thisMonth.total / thisMonth.daysInMonth );
-	}
+			// Calculate average with more precision
+			data.average = Math.round( ( data.total / daysToUse ) * 100 ) / 100;
+		} );
+	} );
 
 	return viewSummary;
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes STATS-75

## Proposed Changes

* Use site today so that the numbers are stable
* Use string processing rather than parsing with JS Date to make the numbers stable

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live
* Open devTools to simulate a location (with timezone): https://developer.chrome.com/docs/devtools/settings/locations
* Open `/stats/insights/xxx.com` and scroll to All-time insights
* Change timezones and ensure the numbers stay stable across timezones

<img width="407" alt="image" src="https://github.com/user-attachments/assets/ae407ce8-7706-4faa-865b-1d418c85ce5c" />


![image](https://github.com/user-attachments/assets/484d445c-417a-4547-87b4-5d89deb1a365)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
