### PR TITLE
Sites List v2: Implement Last Published column

### DIFF
--- a/client/dashboard/components/time-since/index.tsx
+++ b/client/dashboard/components/time-since/index.tsx
@@ -1,0 +1,109 @@
+import { sprintf, __ } from '@wordpress/i18n';
+import { useEffect, useMemo, useState } from 'react';
+import { useAuth } from '../../app/auth';
+
+function useRelativeTime( date: string, dateFormat = 'll', locale: string ) {
+	const [ now, setNow ] = useState( () => new Date() );
+
+	useEffect( () => {
+		const intervalId = setInterval( () => setNow( new Date() ), 10000 );
+		return () => clearInterval( intervalId );
+	}, [] );
+
+	return useMemo( () => {
+		const dateObj = new Date( date );
+		const millisAgo = now.getTime() - dateObj.getTime();
+
+		// Handle invalid or future dates
+		if ( isNaN( dateObj.getTime() ) || millisAgo < 0 ) {
+			return formatDate( dateObj, dateFormat, locale );
+		}
+
+		const secondsAgo = Math.floor( millisAgo / 1000 );
+		const minutesAgo = Math.floor( secondsAgo / 60 );
+		const hoursAgo = Math.floor( minutesAgo / 60 );
+		const daysAgo = Math.floor( hoursAgo / 24 );
+
+		// Just now
+		if ( secondsAgo < 60 ) {
+			return __( 'just now' );
+		}
+
+		// Minutes ago (less than 60 minutes)
+		if ( minutesAgo < 60 ) {
+			return sprintf(
+				/* translators: %s is the number of minutes. Example for a resulting string: 2m ago */
+				__( '%(minutes)dm ago' ),
+				{
+					minutes: minutesAgo,
+				}
+			);
+		}
+
+		// Hours ago (less than 24 hours)
+		if ( hoursAgo < 24 ) {
+			return sprintf(
+				/* translators: %s is the number of hours. Example for a resulting string: 5h ago */
+				__( '%(hours)dh ago' ),
+				{
+					hours: hoursAgo,
+				}
+			);
+		}
+
+		// Days ago (less than 7 days)
+		if ( daysAgo < 7 ) {
+			return sprintf(
+				/* translators: %s is the number of days. Example for a resulting string: 4d ago */
+				__( '%(days)dd ago' ),
+				{
+					days: daysAgo,
+				}
+			);
+		}
+
+		// For older dates, use the date format
+		return formatDate( dateObj, dateFormat, locale );
+	}, [ now, date, dateFormat, locale ] );
+}
+
+function formatDate( date: Date, format: string, locale: string ) {
+	if ( ! date || isNaN( date.getTime() ) ) {
+		return '';
+	}
+
+	const formatOptions: Intl.DateTimeFormatOptions = {
+		dateStyle: 'medium',
+		timeStyle: 'short',
+	};
+
+	if ( format === 'll' ) {
+		formatOptions.dateStyle = 'medium';
+		delete formatOptions.timeStyle;
+	} else if ( format === 'lll' ) {
+		formatOptions.dateStyle = undefined;
+		formatOptions.timeStyle = undefined;
+		formatOptions.day = 'numeric';
+		formatOptions.month = 'short';
+		formatOptions.year = 'numeric';
+	} else if ( format === 'llll' ) {
+		formatOptions.dateStyle = 'full';
+		formatOptions.timeStyle = 'medium';
+	}
+
+	return new Intl.DateTimeFormat( locale, formatOptions ).format( date );
+}
+
+export default function TimeSince( { date, format = 'll' }: { date: string; format?: string } ) {
+	const { user } = useAuth();
+	const locale = user.locale_variant || user.language || 'en';
+
+	const fullDate = formatDate( new Date( date ), 'llll', locale );
+	const relativeDate = useRelativeTime( date, format, locale );
+
+	return (
+		<time dateTime={ date } title={ fullDate }>
+			{ relativeDate }
+		</time>
+	);
+}

--- a/client/dashboard/data/site.ts
+++ b/client/dashboard/data/site.ts
@@ -31,6 +31,7 @@ export const SITE_OPTIONS = [
 	'admin_url',
 	'is_redirect',
 	'is_wpforteams_site',
+	'updated_at',
 	'p2_hub_blog_id',
 	'site_creation_flow',
 	'software_version',
@@ -62,6 +63,7 @@ export interface SiteOptions {
 	p2_hub_blog_id?: number;
 	site_creation_flow?: string;
 	software_version: string;
+	updated_at?: string;
 }
 
 export interface Site {

--- a/client/dashboard/data/site.ts
+++ b/client/dashboard/data/site.ts
@@ -31,10 +31,10 @@ export const SITE_OPTIONS = [
 	'admin_url',
 	'is_redirect',
 	'is_wpforteams_site',
-	'updated_at',
 	'p2_hub_blog_id',
 	'site_creation_flow',
 	'software_version',
+	'updated_at',
 ];
 
 export const JOINED_SITE_OPTIONS = SITE_OPTIONS.join( ',' );

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -141,11 +141,11 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		enableSorting: false,
 	},
 	{
-		id: 'last-published',
+		id: 'last_published',
 		label: __( 'Last published' ),
+		getValue: ( { item }: { item: Site } ) => item.options?.updated_at,
 		render: ( { item }: { item: Site } ) =>
 			item.options?.updated_at ? <TimeSince date={ item.options.updated_at } /> : '',
-		enableSorting: true,
 	},
 ];
 

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -11,6 +11,7 @@ import { sitesRoute } from '../app/router';
 import DataViewsCard from '../components/dataviews-card';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
+import TimeSince from '../components/time-since';
 import { STATUS_LABELS, getSiteStatus, getSiteStatusLabel } from '../utils/site-status';
 import AddNewSite from './add-new-site';
 import SiteIcon from './site-icon';
@@ -138,6 +139,13 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 			);
 		},
 		enableSorting: false,
+	},
+	{
+		id: 'last-published',
+		label: __( 'Last published' ),
+		render: ( { item }: { item: Site } ) =>
+			item.options?.updated_at ? <TimeSince date={ item.options.updated_at } /> : '',
+		enableSorting: true,
 	},
 ];
 

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -143,7 +143,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 	{
 		id: 'last_published',
 		label: __( 'Last published' ),
-		getValue: ( { item }: { item: Site } ) => item.options?.updated_at,
+		getValue: ( { item }: { item: Site } ) => item.options?.updated_at ?? '',
 		render: ( { item }: { item: Site } ) =>
 			item.options?.updated_at ? <TimeSince date={ item.options.updated_at } /> : '',
 	},

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -143,8 +143,8 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 	{
 		id: 'last_published',
 		label: __( 'Last published' ),
-		getValue: ( { item }: { item: Site } ) => item.options?.updated_at ?? '',
-		render: ( { item }: { item: Site } ) =>
+		getValue: ( { item } ) => item.options?.updated_at ?? '',
+		render: ( { item } ) =>
 			item.options?.updated_at ? <TimeSince date={ item.options.updated_at } /> : '',
 	},
 ];


### PR DESCRIPTION
Ref DOTDASH-47

## Proposed Changes

This PR implements the Last Published column.

| Table view | Grid view |
| --- | --- |
| ![Screenshot 2025-06-18 at 10 44 29 AM](https://github.com/user-attachments/assets/4e7fab50-cf33-4e99-985e-3a14afd7451e) | ![Screenshot 2025-06-18 at 10 44 16 AM](https://github.com/user-attachments/assets/40879a4a-0f95-43ce-a19d-6e5859074482) |

> [!NOTE]
> The TimeSince component is ported from https://github.com/Automattic/wp-calypso/blob/trunk/packages/components/src/time-since/index.tsx.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Sites List v2 implementation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Ensure that the property Last Published is selectable in the DataViews appearance dropdown
* Ensure that the Last Published column works as in v1

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
