### PR TITLE
Hosting dashboard: Fallback for <SiteIcon> shows unique color from Gravatar

### DIFF
--- a/client/dashboard/sites/site-icon/index.tsx
+++ b/client/dashboard/sites/site-icon/index.tsx
@@ -4,7 +4,11 @@ import type { Site } from '../../data/types';
 import './style.scss';
 
 export default function SiteIcon( { site, size = 48 }: { site: Site; size?: number } ) {
-	const dims = { width: size, height: size };
+	const dims = {
+		width: size,
+		height: size,
+		style: { width: size, height: size },
+	};
 	const ico = site.icon?.ico;
 	const src = useMemo( () => {
 		if ( ! ico ) {
@@ -19,21 +23,18 @@ export default function SiteIcon( { site, size = 48 }: { site: Site; size?: numb
 	}, [ ico ] );
 
 	if ( ico ) {
-		return (
-			<img
-				className="site-icon"
-				src={ src }
-				alt={ site.name }
-				{ ...dims }
-				loading="lazy"
-				style={ { width: size, height: size } }
-			/>
-		);
+		return <img className="site-icon" src={ src } alt={ site.name } { ...dims } loading="lazy" />;
 	}
 
+	const hash = site.ID.toString( 8 ).repeat( 32 ).substring( 0, 32 );
+
 	return (
-		<div className="site-letter" style={ { ...dims, fontSize: size * 0.5 } }>
-			<span>{ site.name.charAt( 0 ) }</span>
-		</div>
+		<img
+			className="site-icon"
+			src={ `https://www.gravatar.com/avatar/${ hash }?s=96&f=y&d=color` }
+			alt={ site.name }
+			{ ...dims }
+			loading="lazy"
+		/>
 	);
 }

--- a/client/dashboard/sites/site-icon/style.scss
+++ b/client/dashboard/sites/site-icon/style.scss
@@ -2,4 +2,5 @@
 
 .site-icon {
 	border-radius: $radius-small;
+	filter: saturate(0.6) brightness(1.2);
 }

--- a/client/dashboard/sites/site-icon/style.scss
+++ b/client/dashboard/sites/site-icon/style.scss
@@ -1,20 +1,5 @@
-.site-icon,
-.site-letter {
-	border-radius: 2px;
-}
+@import '@wordpress/base-styles/variables';
 
-.site-letter {
-	align-items: center;
-	background-color: #f5f7f7;
-	border: 1px solid #eee;
-	color: var(--wp-admin-theme-color);
-	cursor: default;
-	display: flex;
-	flex-shrink: 0;
-	font-size: 24px;
-	height: 48px;
-	justify-content: center;
-	overflow: hidden;
-	width: 48px;
-	box-sizing: border-box;
+.site-icon {
+	border-radius: $radius-small;
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

WIP

![CleanShot 2025-06-18 at 16 01 53@2x](https://github.com/user-attachments/assets/940128c9-49dd-4342-a535-13f681e3fcd9)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
