### PR TITLE
Site list v2: add WP version column

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -14,6 +14,7 @@ import DataViewsCard from '../components/dataviews-card';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
 import { STATUS_LABELS, getSiteStatus, getSiteStatusLabel } from '../utils/site-status';
+import { getFormattedWordPressVersion } from '../utils/wp-version';
 import AddNewSite from './add-new-site';
 import SiteIcon from './site-icon';
 import SitePreview from './site-preview';
@@ -105,6 +106,11 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		},
 	},
 	{
+		id: 'wp_version',
+		label: __( 'WP version' ),
+		getValue: ( { item }: { item: Site } ) => getFormattedWordPressVersion( item ),
+	},
+	{
 		id: 'is_a8c',
 		type: 'boolean',
 		label: __( 'A8C Owned' ),
@@ -155,7 +161,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 const DEFAULT_LAYOUTS = {
 	table: {
 		mediaField: 'icon.ico',
-		fields: [ 'subscribers_count', 'status', 'backups', 'protect' ],
+		fields: [ 'subscribers_count', 'status', 'backups', 'protect', 'wp_version' ],
 		titleField: 'name',
 		descriptionField: 'URL',
 	},


### PR DESCRIPTION
Fixes DOTDASH-62

## Proposed Changes

This PR adds the WP version column to the v2 site list:


<img width="1014" alt="image" src="https://github.com/user-attachments/assets/adaf3a9c-136f-412a-8b79-0fa8d75c9f50" />

As per design, this column is added to the initial default columns.

## Testing Instructions

1. Go to /v2/sites.
2. Verify you can see the new WP version column.
3. Verify you can play around with it, e.g. sorting etc.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
