### PR TITLE
Hosting dashboard: Truncate super long site names and URLs in sites list

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -58,6 +58,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		render: ( { item }: { item: Site } ) => (
 			<span style={ { overflowWrap: 'anywhere' } }>{ new URL( item.URL ).hostname }</span>
 		),
+		getValue: ( { item } ) => new URL( item.URL ).hostname,
 	},
 	{
 		id: 'icon.ico',

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -303,7 +303,7 @@ export default function Sites() {
 								},
 							} );
 						} }
-						renderItemLink={ ( { item, ...props }: { item: Site } ) => (
+						renderItemLink={ ( { item, ...props } ) => (
 							<Link to={ `/sites/${ item.slug }` } { ...props } />
 						) }
 						defaultLayouts={ DEFAULT_LAYOUTS }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -50,15 +50,22 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		label: __( 'Site' ),
 		enableGlobalSearch: true,
 		getValue: ( { item } ) => item.name || new URL( item.URL ).hostname,
+		render: ( { field, item } ) => (
+			<span style={ { overflowX: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }>
+				{ field.getValue( { item } ) }
+			</span>
+		),
 	},
 	{
 		id: 'URL',
 		label: __( 'URL' ),
 		enableGlobalSearch: true,
-		render: ( { item }: { item: Site } ) => (
-			<span style={ { overflowWrap: 'anywhere' } }>{ new URL( item.URL ).hostname }</span>
-		),
 		getValue: ( { item } ) => new URL( item.URL ).hostname,
+		render: ( { field, item } ) => (
+			<span style={ { overflowX: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }>
+				{ field.getValue( { item } ) }
+			</span>
+		),
 	},
 	{
 		id: 'icon.ico',

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -118,7 +118,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 	{
 		id: 'wp_version',
 		label: __( 'WP version' ),
-		getValue: ( { item }: { item: Site } ) => getFormattedWordPressVersion( item ),
+		getValue: ( { item } ) => getFormattedWordPressVersion( item ),
 	},
 	{
 		id: 'is_a8c',

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -62,7 +62,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 	{
 		id: 'icon.ico',
 		label: __( 'Media' ),
-		render: ( { item }: { item: Site } ) => <SiteIcon site={ item } />,
+		render: ( { item } ) => <SiteIcon site={ item } />,
 		enableSorting: false,
 	},
 	{
@@ -73,12 +73,12 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		id: 'backups',
 		type: 'boolean',
 		label: __( 'Backups' ),
-		getValue: ( { item }: { item: Site } ) => !! item.plan?.features?.active?.includes( 'backups' ),
+		getValue: ( { item } ) => !! item.plan?.features?.active?.includes( 'backups' ),
 		elements: [
 			{ value: true, label: __( 'Enabled' ) },
 			{ value: false, label: __( 'Disabled' ) },
 		],
-		render: ( { item }: { item: Site } ) =>
+		render: ( { item } ) =>
 			item.plan?.features?.active?.includes( 'backups' ) ? (
 				<Icon icon={ check } />
 			) : (
@@ -91,12 +91,12 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 	{
 		id: 'status',
 		label: __( 'Status' ),
-		getValue: ( { item }: { item: Site } ) => getSiteStatus( item ),
+		getValue: ( { item } ) => getSiteStatus( item ),
 		elements: Object.entries( STATUS_LABELS ).map( ( [ value, label ] ) => ( { value, label } ) ),
 		filterBy: {
 			operators: [ 'is' ],
 		},
-		render: ( { item }: { item: Site } ) => {
+		render: ( { item } ) => {
 			const label = getSiteStatusLabel( item );
 			if ( item.launch_status !== 'unlaunched' ) {
 				return label;
@@ -123,12 +123,12 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		filterBy: {
 			operators: [ 'is' as Operator ],
 		},
-		render: ( { item }: { item: Site } ) => ( item.is_a8c ? __( 'Yes' ) : __( 'No' ) ),
+		render: ( { item } ) => ( item.is_a8c ? __( 'Yes' ) : __( 'No' ) ),
 	},
 	{
 		id: 'preview',
 		label: __( 'Preview' ),
-		render: function PreviewRender( { item }: { item: Site } ) {
+		render: function PreviewRender( { item } ) {
 			const [ resizeListener, { width } ] = useResizeObserver();
 			const { is_deleted, is_private, URL: url } = item;
 			// If the site is a private A8C site, X-Frame-Options is set to same


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTDASH-70

## Proposed Changes

* Truncate long site names and URLs using ellipsis
* Fix a bug in the search box
  * Because the URL field wasn't using the `getValue` callback, the search took the entire URL into account. But we don't want it to search the URL scheme
* Remove unnecessary type definitions
  * Callback function parameters don't need explicit types because they're already defined by the explicit `Field<Site>[]` type given to `DEFAULT_FIELDS`.

(ignore the html in the site name, this is just the test site I use for checking XSS bugs)

![CleanShot 2025-06-18 at 16 45 08@2x](https://github.com/user-attachments/assets/2538cac3-30e6-4704-aa2c-e827b85056fa)

The `white-space: nowrap` rule is also needed otherwise the URL might wrap on hyphens before getting truncated, like this:

![CleanShot 2025-06-18 at 16 46 24@2x](https://github.com/user-attachments/assets/b1d8905d-d2d1-439b-b292-953e88b8e5d3)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a test site with a long name and a long URL
* Test the site list grid mode, the text shouldn't wrap
* Test the table mode
	* The text won't be truncated because it has plenty of room and it will scroll if too long
	* On mobile confirm that the table's horizontal scrollbar appears rather than the text being truncated
* Test the search bug fix:
  * In `wpcalypso` type "://" into the search box, notice that all the sites are returned
  * With this PR type "://" into the search box, notice that (probably) none of the sites are returned

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
