### PR TITLE
Hosting dashboard: Fallback to using URL in place of site name when site title is empty

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -48,6 +48,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		id: 'name',
 		label: __( 'Site' ),
 		enableGlobalSearch: true,
+		getValue: ( { item } ) => item.name || new URL( item.URL ).hostname,
 	},
 	{
 		id: 'URL',

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -38,7 +38,7 @@ function SiteOverview() {
 		<PageLayout
 			header={
 				<PageHeader
-					title={ site.name }
+					title={ site.name || new URL( site.URL ).hostname }
 					actions={
 						site.options?.admin_url && (
 							<Button

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -30,7 +30,8 @@ function Site() {
 									onClick={ () => onToggle() }
 								>
 									<div style={ { display: 'flex', gap: '8px', alignItems: 'center' } }>
-										<SiteIcon site={ site } size={ 16 } /> { site.name }
+										<SiteIcon site={ site } size={ 16 } />{ ' ' }
+										{ site.name || new URL( site.URL ).hostname }
 									</div>
 								</Button>
 							) }

--- a/client/dashboard/sites/site/switcher.tsx
+++ b/client/dashboard/sites/site/switcher.tsx
@@ -8,11 +8,18 @@ import { sitesQuery } from '../../app/queries/sites';
 import RouterLinkMenuItem from '../../components/router-link-menu-item';
 import AddNewSite from '../add-new-site';
 import SiteIcon from '../site-icon';
+import type { Site } from '../../data/types';
 import type { View } from '@automattic/dataviews';
 
 import './switcher.scss';
 
-const fields = [ { id: 'name', enableGlobalSearch: true } ];
+const fields = [
+	{
+		id: 'name',
+		getValue: ( { item }: { item: Site } ) => item.name || new URL( item.URL ).hostname,
+		enableGlobalSearch: true,
+	},
+];
 
 const DEFAULT_VIEW: View = {
 	type: 'list',
@@ -51,7 +58,7 @@ export default function Switcher( { onClose }: { onClose: () => void } ) {
 							<span
 								style={ { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }
 							>
-								{ site.name }
+								{ fields[ 0 ].getValue( { item: site } ) }
 							</span>
 						</div>
 					</RouterLinkMenuItem>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTDASH-69

## Proposed Changes

Site names are not mandatory. When the site name is missing we should fall back to the site's URL.

Adds fallback to:
- Site list
- Site switcher
- Title of site overview page

![CleanShot 2025-06-18 at 17 21 41@2x](https://github.com/user-attachments/assets/90d0e978-3d28-4d59-b652-12aa353057a2)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Falling back to the URL is what Calypso does. But I suppose we're not constrained to do it this way. Another option would be to use `Unnamed site`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set your test site's name to empty
* Load v2 and test the site list and site overview pages

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
