### PR TITLE
Connect Refresh: Move locale-suggestions to bottom of Login page

### DIFF
--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -518,7 +518,7 @@ export class Login extends Component {
 					'is-jetpack': isJetpack,
 				} ) }
 			>
-				{ this.renderI18nSuggestions() }
+				{ ! isWhiteLogin && this.renderI18nSuggestions() }
 
 				<DocumentHead
 					title={ translate( 'Log In' ) }
@@ -534,6 +534,8 @@ export class Login extends Component {
 				/>
 
 				<div className="wp-login__container">{ this.renderContent( isSocialFirst ) }</div>
+
+				{ isWhiteLogin && this.renderI18nSuggestions() }
 			</Main>
 		);
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13354/calypso-rethink-locale-suggestions-popup-in-login

## Proposed Changes

- For the unified Login page, this adds the locale-suggestions to the bottom of the page, as decided in https://linear.app/a8c/issue/DOTCOM-13354/calypso-rethink-locale-suggestions-popup-in-login
- For non-unified client Login, this does nothing. Locale-suggestions still render at the top

| before | after | non-unified |
|--------|--------|--------|
| <img width="1463" alt="Screenshot 2025-06-18 at 12 39 15 PM" src="https://github.com/user-attachments/assets/b81c0be8-8a41-484d-a1e9-ff05f7c052b1" /> | <img width="1459" alt="Screenshot 2025-06-18 at 12 39 01 PM" src="https://github.com/user-attachments/assets/107e4765-0cd7-4606-a3e4-50150a9d301f" /> | <img width="1451" alt="Screenshot 2025-06-18 at 12 39 29 PM" src="https://github.com/user-attachments/assets/1af2dbc6-916d-4b0d-a38f-97e7b1510874" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13354/calypso-rethink-locale-suggestions-popup-in-login

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Switch browser locale to DE while keeping EN in user settings
  - Go to [WP Login](http://calypso.localhost:3000/log-in) and confirm
  - Go to a client like [Crowdsignal](http://calypso.localhost:3000/log-in?client_id=978&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3Df5da55616562ed1b1ef36c8e88328853efcc0167150831e59437c3330ec11509%26redirect_uri%3Dhttps%253A%252F%252Fapp.crowdsignal.com%252Fconnect%253Fsource%253Dlogin%2526action%253Drequest_access_token%26wpcom_connect%3D1%26from-calypso%3D1) and confirm
  - Go to a non-unified client Login like [Gravatar](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D4a5153e30a28e2ef24ca7e599abd80f3969340cd1f88327c1f5d2fbc88593fa1%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1&client_id=1854) and confirm still at the top

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
