### PR TITLE
DataViews: use the default operators defined by the field type definition

### DIFF
--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- Update the field type definitions to declare the default and valid operators they support. Fields with no `type` property can use all operators and, if none is provided in the field's config, they'll display `is` and `isNot`.
+- Update the field type definitions to declare the default and valid operators they support. Fields with no `type` property can use all operators and, if none is provided in the field's config, they'll use `is` and `isNot` by default.
 - Add a story for each FieldTypeDefinition.
 - Add new filter operators: `before`, `after`, `beforeInc`, and `afterInc` for date fields.
 - Adjust the spacing of the `DataForm` based on the type.

--- a/packages/dataviews/src/normalize-fields.ts
+++ b/packages/dataviews/src/normalize-fields.ts
@@ -51,7 +51,9 @@ function getFilterBy< Item >(
 
 		// Assign default values if no operator was provided.
 		if ( ! operators || ! Array.isArray( operators ) ) {
-			operators = [ OPERATOR_IS_ANY, OPERATOR_IS_NONE ];
+			operators = !! fieldTypeDefinition.filterBy
+				? fieldTypeDefinition.filterBy.defaultOperators
+				: [];
 		}
 
 		// Make sure only valid operators are included.

--- a/packages/dataviews/src/test/normalize-fields.ts
+++ b/packages/dataviews/src/test/normalize-fields.ts
@@ -53,6 +53,22 @@ describe( 'normalizeFields: default getValue', () => {
 			const result = normalizedFields[ 0 ].filterBy;
 			expect( result ).toStrictEqual( { operators: [ 'is', 'isNot' ] } );
 		} );
+		it( 'returns the default field type definition if undefined for untyped field (for primary filters)', () => {
+			const fields: Field< {} >[] = [
+				{
+					id: 'user',
+					filterBy: {
+						isPrimary: true,
+					},
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			const result = normalizedFields[ 0 ].filterBy;
+			expect( result ).toStrictEqual( {
+				isPrimary: true,
+				operators: [ 'is', 'isNot' ],
+			} );
+		} );
 
 		it( 'returns the field type definition for typed fields', () => {
 			const fields: Field< {} >[] = [
@@ -64,6 +80,31 @@ describe( 'normalizeFields: default getValue', () => {
 			const normalizedFields = normalizeFields( fields );
 			const result = normalizedFields[ 0 ].filterBy;
 			expect( result ).toStrictEqual( {
+				operators: [
+					'is',
+					'isNot',
+					'lessThan',
+					'greaterThan',
+					'lessThanOrEqual',
+					'greaterThanOrEqual',
+				],
+			} );
+		} );
+
+		it( 'returns the field type definition for typed fields (for primary filters)', () => {
+			const fields: Field< {} >[] = [
+				{
+					id: 'user',
+					type: 'integer',
+					filterBy: {
+						isPrimary: true,
+					},
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			const result = normalizedFields[ 0 ].filterBy;
+			expect( result ).toStrictEqual( {
+				isPrimary: true,
 				operators: [
 					'is',
 					'isNot',


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/104040

## What

If the field declares a primary filter but doesn't declare which operators it supports, use the default operators defined in the field type definition.

## Why

It's a bug, it follows-up changes introduced at https://github.com/Automattic/wp-calypso/pull/104040 We were hard-coding `isAny`/`isNone` when we have the default operators available through the field type.

## Testing Instructions

Make sure tests pass. For example, `yarn run test-packages packages/dataviews/src/test/normalize-fields.ts` that includes the cases that would fail in trunk.
