### PR TITLE
Universal Header Navigation Bar: Fix tab and accessibility navigation

### DIFF
--- a/packages/wpcom-template-parts/src/types.ts
+++ b/packages/wpcom-template-parts/src/types.ts
@@ -37,6 +37,7 @@ export interface ClickableItemProps extends MenuItemProps {
 	type: string;
 	typeClassName?: string;
 	target?: string;
+	tabIndex?: number;
 }
 
 export type LanguageOptions = Record< string, string >;

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -23,6 +23,8 @@ const UniversalNavbarHeader = ( {
 	const { __ } = useI18n();
 	const [ isMobileMenuOpen, setMobileMenuOpen ] = useState( false );
 	const isEnglishLocale = useIsEnglishLocale();
+	// Allow tabbing in mobile version only when the menu is open
+	const mobileMenuTabIndex = isMobileMenuOpen ? undefined : -1;
 
 	if ( ! startUrl ) {
 		startUrl = addQueryArgs(
@@ -399,6 +401,7 @@ const UniversalNavbarHeader = ( {
 											}
 											urlValue={ startUrl }
 											type="menu"
+											tabIndex={ mobileMenuTabIndex }
 										/>
 										<ClickableItem
 											titleValue=""
@@ -410,6 +413,7 @@ const UniversalNavbarHeader = ( {
 											}
 											urlValue={ localizeUrl( '//wordpress.com/log-in', locale, isLoggedIn, true ) }
 											type="menu"
+											tabIndex={ mobileMenuTabIndex }
 										/>
 									</ul>
 								) }
@@ -424,6 +428,7 @@ const UniversalNavbarHeader = ( {
 												content={ __( 'Plans & Pricing', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/pricing/' ) }
 												type="menu"
+												tabIndex={ mobileMenuTabIndex }
 											/>
 										</ul>
 									</div>
@@ -437,30 +442,35 @@ const UniversalNavbarHeader = ( {
 												content={ __( 'WordPress Hosting', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/hosting/' ) }
 												type="menu"
+												tabIndex={ mobileMenuTabIndex }
 											/>
 											<ClickableItem
 												titleValue=""
 												content={ __( 'Domain Names', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/domains/' ) }
 												type="menu"
+												tabIndex={ mobileMenuTabIndex }
 											/>
 											<ClickableItem
 												titleValue=""
 												content={ __( 'AI Website Builder', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/ai-website-builder/?ref=topnav' ) }
 												type="menu"
+												tabIndex={ mobileMenuTabIndex }
 											/>
 											<ClickableItem
 												titleValue=""
 												content={ __( 'Website Builder', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/website-builder/' ) }
 												type="menu"
+												tabIndex={ mobileMenuTabIndex }
 											/>
 											<ClickableItem
 												titleValue=""
 												content={ __( 'Create a Blog', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/create-blog/' ) }
 												type="menu"
+												tabIndex={ mobileMenuTabIndex }
 											/>
 											<ClickableItem
 												titleValue=""
@@ -472,12 +482,14 @@ const UniversalNavbarHeader = ( {
 													true
 												) }
 												type="menu"
+												tabIndex={ mobileMenuTabIndex }
 											/>
 											<ClickableItem
 												titleValue=""
 												content={ __( 'Professional Email', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/professional-email/' ) }
 												type="menu"
+												tabIndex={ mobileMenuTabIndex }
 											/>
 											{ isEnglishLocale && (
 												<ClickableItem
@@ -486,6 +498,7 @@ const UniversalNavbarHeader = ( {
 													urlValue={ localizeUrl( '//wordpress.com/website-design-service/' ) }
 													type="menu"
 													target="_self"
+													tabIndex={ mobileMenuTabIndex }
 												/>
 											) }
 											<ClickableItem
@@ -493,12 +506,14 @@ const UniversalNavbarHeader = ( {
 												content={ __( 'Commerce', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/ecommerce/' ) }
 												type="menu"
+												tabIndex={ mobileMenuTabIndex }
 											/>
 											<ClickableItem
 												titleValue=""
 												content={ __( 'Enterprise', __i18n_text_domain__ ) }
 												urlValue="https://wpvip.com/?utm_source=WordPresscom&utm_medium=automattic_referral&utm_campaign=top_nav"
 												type="menu"
+												tabIndex={ mobileMenuTabIndex }
 											/>
 										</ul>
 									</div>
@@ -512,6 +527,7 @@ const UniversalNavbarHeader = ( {
 												content={ __( 'Overview', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/features/' ) }
 												type="menu"
+												tabIndex={ mobileMenuTabIndex }
 											/>
 											<ClickableItem
 												titleValue=""
@@ -523,6 +539,7 @@ const UniversalNavbarHeader = ( {
 													true
 												) }
 												type="menu"
+												tabIndex={ mobileMenuTabIndex }
 											/>
 											<ClickableItem
 												titleValue=""
@@ -534,6 +551,7 @@ const UniversalNavbarHeader = ( {
 													true
 												) }
 												type="menu"
+												tabIndex={ mobileMenuTabIndex }
 											/>
 											<ClickableItem
 												titleValue=""
@@ -545,12 +563,14 @@ const UniversalNavbarHeader = ( {
 													true
 												) }
 												type="menu"
+												tabIndex={ mobileMenuTabIndex }
 											/>
 											<ClickableItem
 												titleValue=""
 												content={ __( 'Google Apps', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/google/' ) }
 												type="menu"
+												tabIndex={ mobileMenuTabIndex }
 											/>
 										</ul>
 									</div>
@@ -564,48 +584,56 @@ const UniversalNavbarHeader = ( {
 												content={ __( 'WordPress.com Support', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/support/' ) }
 												type="menu"
+												tabIndex={ mobileMenuTabIndex }
 											/>
 											<ClickableItem
 												titleValue=""
 												content={ __( 'News', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/blog/' ) }
 												type="menu"
+												tabIndex={ mobileMenuTabIndex }
 											/>
 											<ClickableItem
 												titleValue=""
 												content={ __( 'Website Building Tips', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/go/' ) }
 												type="menu"
+												tabIndex={ mobileMenuTabIndex }
 											/>
 											<ClickableItem
 												titleValue=""
 												content={ __( 'Business Name Generator', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/business-name-generator/' ) }
 												type="menu"
+												tabIndex={ mobileMenuTabIndex }
 											/>
 											<ClickableItem
 												titleValue=""
 												content={ __( 'Logo Maker', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/logo-maker/' ) }
 												type="menu"
+												tabIndex={ mobileMenuTabIndex }
 											/>
 											<ClickableItem
 												titleValue=""
 												content={ __( 'Discover New Posts', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/discover/' ) }
 												type="menu"
+												tabIndex={ mobileMenuTabIndex }
 											/>
 											<ClickableItem
 												titleValue=""
 												content={ __( 'Popular Tags', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/tags/' ) }
 												type="menu"
+												tabIndex={ mobileMenuTabIndex }
 											/>
 											<ClickableItem
 												titleValue=""
 												content={ __( 'Blog Search', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/reader/search/' ) }
 												type="menu"
+												tabIndex={ mobileMenuTabIndex }
 											/>
 										</ul>
 									</div>

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -374,11 +374,7 @@ const UniversalNavbarHeader = ( {
 							onClick={ () => setMobileMenuOpen( false ) }
 						/>
 						<div className="x-menu-content">
-							<button
-								className="x-menu-button x-link"
-								onClick={ () => setMobileMenuOpen( false ) }
-								tabIndex={ -1 }
-							>
+							<button className="x-menu-button x-link" onClick={ () => setMobileMenuOpen( false ) }>
 								<span className="x-hidden">
 									{ __( 'Close the navigation menu', __i18n_text_domain__ ) }
 								</span>

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -343,7 +343,7 @@ const UniversalNavbarHeader = ( {
 											role="menuitem"
 											className="x-nav-link x-nav-link__menu x-link"
 											aria-haspopup="true"
-											aria-expanded="false"
+											aria-expanded={ isMobileMenuOpen }
 											onClick={ () => setMobileMenuOpen( true ) }
 										>
 											<span className="x-hidden">{ __( 'Menu', __i18n_text_domain__ ) }</span>
@@ -365,7 +365,7 @@ const UniversalNavbarHeader = ( {
 						className={ isMobileMenuOpen ? 'x-menu x-menu__active x-menu__open' : 'x-menu' }
 						role="menu"
 						aria-label={ __( 'WordPress.com Navigation Menu', __i18n_text_domain__ ) }
-						aria-hidden="true"
+						aria-hidden={ ! isMobileMenuOpen }
 					>
 						{ /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */ }
 						<div
@@ -383,7 +383,7 @@ const UniversalNavbarHeader = ( {
 									<span></span>
 								</span>
 							</button>
-							<div className="x-menu-list">
+							<div className="x-menu-list" aria-hidden={ ! isMobileMenuOpen }>
 								<div className="x-menu-list-title">
 									{ __( 'Get Started', __i18n_text_domain__ ) }
 								</div>
@@ -416,7 +416,7 @@ const UniversalNavbarHeader = ( {
 							</div>
 							{ variant !== 'minimal' ? (
 								<>
-									<div className="x-menu-list">
+									<div className="x-menu-list" aria-hidden={ ! isMobileMenuOpen }>
 										<div className="x-hidden">{ __( 'About', __i18n_text_domain__ ) }</div>
 										<ul className="x-menu-grid">
 											<ClickableItem
@@ -427,7 +427,7 @@ const UniversalNavbarHeader = ( {
 											/>
 										</ul>
 									</div>
-									<div className="x-menu-list">
+									<div className="x-menu-list" aria-hidden={ ! isMobileMenuOpen }>
 										<div className="x-menu-list-title">
 											{ __( 'Products', __i18n_text_domain__ ) }
 										</div>
@@ -502,7 +502,7 @@ const UniversalNavbarHeader = ( {
 											/>
 										</ul>
 									</div>
-									<div className="x-menu-list">
+									<div className="x-menu-list" aria-hidden={ ! isMobileMenuOpen }>
 										<div className="x-menu-list-title">
 											{ __( 'Features', __i18n_text_domain__ ) }
 										</div>
@@ -554,7 +554,7 @@ const UniversalNavbarHeader = ( {
 											/>
 										</ul>
 									</div>
-									<div className="x-menu-list">
+									<div className="x-menu-list" aria-hidden={ ! isMobileMenuOpen }>
 										<div className="x-menu-list-title">
 											{ __( 'Resources', __i18n_text_domain__ ) }
 										</div>

--- a/packages/wpcom-template-parts/src/universal-header-navigation/menu-items.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/menu-items.tsx
@@ -59,6 +59,7 @@ export const ClickableItem = ( {
 	type,
 	typeClassName,
 	target,
+	tabIndex,
 }: ClickableItemProps ) => {
 	let liClassName = '';
 	if ( type === 'menu' ) {
@@ -81,6 +82,7 @@ export const ClickableItem = ( {
 				title={ titleValue }
 				target={ target }
 				onClick={ onClick }
+				tabIndex={ tabIndex }
 			>
 				{ content }
 			</a>

--- a/packages/wpcom-template-parts/src/universal-header-navigation/menu-items.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/menu-items.tsx
@@ -79,7 +79,7 @@ export const ClickableItem = ( {
 				className={ typeClassName ? typeClassName : `x-${ type }-link x-link` }
 				href={ urlValue }
 				title={ titleValue }
-				tabIndex={ -1 }
+				// tabIndex={ -1 }
 				target={ target }
 				onClick={ onClick }
 			>

--- a/packages/wpcom-template-parts/src/universal-header-navigation/menu-items.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/menu-items.tsx
@@ -79,7 +79,6 @@ export const ClickableItem = ( {
 				className={ typeClassName ? typeClassName : `x-${ type }-link x-link` }
 				href={ urlValue }
 				title={ titleValue }
-				// tabIndex={ -1 }
 				target={ target }
 				onClick={ onClick }
 			>

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -210,11 +210,13 @@ $x-nav-height: $x-nav-padding-top + $x-nav-item-height + $x-nav-item-padding-x-w
 	display: none;
 	position: relative;
 
-	&:hover > .x-dropdown-content {
-		opacity: 1;
-		pointer-events: all;
-		transform: translateY(0) scale(1);
-		transition: all 450ms cubic-bezier(0.5, 1, 0.89, 1);
+	&:hover,&:focus-within {
+		> .x-dropdown-content {
+			opacity: 1;
+			pointer-events: all;
+			transform: translateY(0) scale(1);
+			transition: all 450ms cubic-bezier(0.5, 1, 0.89, 1);
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-13599
Related to DOTCOM-13571

## Proposed Changes

* Displays the menu dropdowns when focusing the menu items
* Removes `tabIndex: -1` to allow tabbing into the menu items

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve the accessibility and to allow navigation using Tab

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* When logged-out, navigate to the `/themes` or `/plugins` pages
* Navigate into the top bar menu using the Tab key
* Activate VoiceOver
* Make sure you can navigate through the menu items
* Reduce the screen size to small screen, and make sure the menu is collapsed
* Expand the menu and using VoiceOver, navigate through the menu items using `ctrl-opt-<righ/left arrows>`
* Check you can navigate and select them using `ctrl-opt-<space>`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
