### PR TITLE
[Help Center] Refactor messages

### DIFF
--- a/packages/odie-client/src/constants.ts
+++ b/packages/odie-client/src/constants.ts
@@ -12,10 +12,16 @@ export const ODIE_ERROR_MESSAGE_NON_ELIGIBLE = __(
 	__i18n_text_domain__
 );
 
-export const ODIE_RATE_LIMIT_MESSAGE = __(
+export const ODIE_RATE_LIMIT_MESSAGE_CONTENT = __(
 	"Hi there! You've hit your AI usage limit. Upgrade your plan for unlimited Wapuu support! You can still get user support using the buttons below.",
 	__i18n_text_domain__
 );
+
+export const ODIE_RATE_LIMIT_MESSAGE: Message = {
+	content: ODIE_RATE_LIMIT_MESSAGE_CONTENT,
+	role: 'bot',
+	type: 'message',
+};
 
 export const ODIE_FORWARD_TO_FORUMS_MESSAGE = __(
 	'It sounds like you want to talk to a human. Human support is only available for our [paid plans](https://wordpress.com/pricing/). For community support, visit our forums:',

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -227,14 +227,8 @@ export const useSendOdieMessage = () => {
 
 			if ( isRateLimitError ) {
 				// Handle rate limit error with standard rate limit message
-				const errorMessage: Message = {
-					content: ODIE_RATE_LIMIT_MESSAGE,
-					internal_message_id,
-					role: 'bot',
-					type: 'message',
-					context: undefined,
-				};
-				addMessage( { message: errorMessage, props: {}, isFromError: true } );
+				const message: Message = { ...ODIE_RATE_LIMIT_MESSAGE, internal_message_id };
+				addMessage( { message, props: {}, isFromError: true } );
 			} else if ( isUserEligibleForPaidSupport && canConnectToZendesk ) {
 				// User is eligible for premium support - transfer to Zendesk
 				newConversation( {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://github.com/Automattic/wp-calypso/pull/104241#discussion_r2154423816

## Proposed Changes

* Refactor `ODIE_RATE_LIMIT_MESSAGE` to separate `content` from the full `Message` object for clarity and reuse.
* Replace inline `Message` object creation in `use-send-odie-message.tsx` with reference to shared constant.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This improves consistency, centralizes message definitions, and makes future updates (e.g. translations, variants) easier to maintain.
* Reduces code duplication when generating bot messages.

## Testing Instructions

* Visual inspection is enough. Confirm that the rate limit message appears correctly when triggered and nothing breaks.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
