### PR TITLE
Billing History: Prevent unecessary call when the limit is the same as the total

### DIFF
--- a/client/state/billing-transactions/actions.ts
+++ b/client/state/billing-transactions/actions.ts
@@ -36,10 +36,11 @@ export const requestBillingTransactions = ( transactionType?: BillingTransaction
 			} = await wp.req.get( url, {
 				apiVersion: '1.3',
 			} );
+			let billingHistoryTotal = billing_history_total ?? 0;
 			const fullBillingHistory = billing_history ?? [];
-			if ( fullBillingHistory.length === limit && ( billing_history_total ?? 0 ) !== limit ) {
+			if ( fullBillingHistory.length === limit && billingHistoryTotal !== limit ) {
 				// If we have exactly the limit number of transactions (and this is not the full total), it means there are more transactions to fetch.
-				do {
+				while ( fullBillingHistory.length < billingHistoryTotal ) {
 					// Fetch the next page of transactions.
 					const offset_url = url + '&offset=' + fullBillingHistory.length;
 
@@ -47,8 +48,9 @@ export const requestBillingTransactions = ( transactionType?: BillingTransaction
 						apiVersion: '1.3',
 					} );
 
+					billingHistoryTotal = res.billing_history_total ?? 0;
 					fullBillingHistory.push( ...res.billing_history );
-				} while ( fullBillingHistory.length < ( billing_history_total ?? 0 ) );
+				}
 			}
 
 			dispatch( {

--- a/client/state/billing-transactions/actions.ts
+++ b/client/state/billing-transactions/actions.ts
@@ -48,8 +48,15 @@ export const requestBillingTransactions = ( transactionType?: BillingTransaction
 						apiVersion: '1.3',
 					} );
 
+					const newBillingHistoryChunk = res.billing_history ?? [];
+					if ( newBillingHistoryChunk.length === 0 ) {
+						// Prevent potential infinite loop if no more transactions are returned.
+						break;
+					}
+					fullBillingHistory.push( ...newBillingHistoryChunk );
+
+					// Value is updated in case the value changes in the back-end
 					billingHistoryTotal = res.billing_history_total ?? 0;
-					fullBillingHistory.push( ...res.billing_history );
 				}
 			}
 

--- a/client/state/billing-transactions/actions.ts
+++ b/client/state/billing-transactions/actions.ts
@@ -30,28 +30,25 @@ export const requestBillingTransactions = ( transactionType?: BillingTransaction
 				upcoming_charges,
 				billing_history_total,
 			}: {
-				billing_history: BillingTransaction[];
-				upcoming_charges: UpcomingCharge[];
-				billing_history_total: number;
+				billing_history?: BillingTransaction[];
+				upcoming_charges?: UpcomingCharge[];
+				billing_history_total?: number;
 			} = await wp.req.get( url, {
 				apiVersion: '1.3',
 			} );
-
-			const fullBillingHistory = billing_history;
-			if ( billing_history.length === limit && billing_history_total !== limit ) {
+			const fullBillingHistory = billing_history ?? [];
+			if ( fullBillingHistory.length === limit && ( billing_history_total ?? 0 ) !== limit ) {
 				// If we have exactly the limit number of transactions (and this is not the full total), it means there are more transactions to fetch.
-				let nextData = [];
 				do {
 					// Fetch the next page of transactions.
-					const offset_url = url + '&offset=' + billing_history.length;
+					const offset_url = url + '&offset=' + fullBillingHistory.length;
 
 					const res = await wp.req.get( offset_url, {
 						apiVersion: '1.3',
 					} );
 
 					fullBillingHistory.push( ...res.billing_history );
-					nextData = res.billing_history;
-				} while ( nextData.length === limit );
+				} while ( fullBillingHistory.length < ( billing_history_total ?? 0 ) );
 			}
 
 			dispatch( {

--- a/client/state/billing-transactions/actions.ts
+++ b/client/state/billing-transactions/actions.ts
@@ -28,16 +28,18 @@ export const requestBillingTransactions = ( transactionType?: BillingTransaction
 			const {
 				billing_history,
 				upcoming_charges,
+				billing_history_total,
 			}: {
 				billing_history: BillingTransaction[];
 				upcoming_charges: UpcomingCharge[];
+				billing_history_total: number;
 			} = await wp.req.get( url, {
 				apiVersion: '1.3',
 			} );
 
 			const fullBillingHistory = billing_history;
-			if ( billing_history.length === limit ) {
-				// If we have exactly the limit number of transactions, it means there are more transactions to fetch.
+			if ( billing_history.length === limit && billing_history_total !== limit ) {
+				// If we have exactly the limit number of transactions (and this is not the full total), it means there are more transactions to fetch.
 				let nextData = [];
 				do {
 					// Fetch the next page of transactions.

--- a/client/state/billing-transactions/test/actions.js
+++ b/client/state/billing-transactions/test/actions.js
@@ -29,6 +29,7 @@ describe( 'actions', () => {
 						subtotal: '$1.03',
 					},
 				],
+				billing_history_total: 1,
 				upcoming_charges: [
 					{
 						id: '87654321',
@@ -78,8 +79,9 @@ describe( 'actions', () => {
 				} );
 			}
 
-			const successResponse = {
+			const totalSuccessResponse = {
 				billing_history,
+				billing_history_total: billing_history.length,
 				upcoming_charges: [
 					{
 						id: '87654321',
@@ -93,11 +95,13 @@ describe( 'actions', () => {
 
 			const successResponse1 = {
 				billing_history: billing_history.slice( 0, endpointLimit ),
-				upcoming_charges: successResponse.upcoming_charges,
+				billing_history_total: totalSuccessResponse.billing_history_total,
+				upcoming_charges: totalSuccessResponse.upcoming_charges,
 			};
 
 			const successResponse2 = {
 				billing_history: billing_history.slice( endpointLimit ),
+				billing_history_total: totalSuccessResponse.billing_history_total,
 				upcoming_charges: [],
 			};
 
@@ -119,8 +123,8 @@ describe( 'actions', () => {
 				// should dispatch receive action when request completes'
 				expect( spy ).toHaveBeenCalledWith( {
 					type: BILLING_TRANSACTIONS_RECEIVE,
-					past: successResponse.billing_history,
-					upcoming: successResponse.upcoming_charges,
+					past: totalSuccessResponse.billing_history,
+					upcoming: totalSuccessResponse.upcoming_charges,
 				} );
 
 				// should dispatch request success action when request completes'


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Blocked by https://linear.app/a8c/issue/SHILL-836/return-the-total-number-of-receipts-in-the-endpoint-result
Fixes https://linear.app/a8c/issue/SHILL-840/prevent-potential-useless-call-to-billing-history

## Proposed Changes

* Prevent unecessary call

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This is pretty straight forward.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
