### PR TITLE
Staging Sites: Add `hosting/staging-sites-redesign` feature flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -70,6 +70,7 @@
 		"home/layout-dev": true,
 		"hosting-server-settings-enhancements": true,
 		"hosting/datacenter-picker": true,
+		"hosting/staging-sites-redesign": true,
 		"i18n/community-translator": false,
 		"i18n/empathy-mode": true,
 		"i18n/translation-scanner": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -36,6 +36,7 @@
 		"help": true,
 		"home/layout-dev": true,
 		"hosting-server-settings-enhancements": true,
+		"hosting/staging-sites-redesign": true,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,
 		"importer/site-backups": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -36,7 +36,7 @@
 		"help": true,
 		"home/layout-dev": true,
 		"hosting-server-settings-enhancements": true,
-		"hosting/staging-sites-redesign": true,
+		"hosting/staging-sites-redesign": false,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,
 		"importer/site-backups": true,

--- a/config/production.json
+++ b/config/production.json
@@ -44,6 +44,7 @@
 		"help": true,
 		"help/gpt-response": true,
 		"hosting-server-settings-enhancements": true,
+		"hosting/staging-sites-redesign": false,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,
 		"importer/site-backups": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -44,6 +44,7 @@
 		"help": true,
 		"help/gpt-response": true,
 		"hosting-server-settings-enhancements": true,
+		"hosting/staging-sites-redesign": false,
 		"i18n/empathy-mode": true,
 		"importer/site-backups": true,
 		"importer/unified": true,

--- a/config/test.json
+++ b/config/test.json
@@ -43,6 +43,7 @@
 		"google-my-business": false,
 		"help": true,
 		"hosting-server-settings-enhancements": true,
+		"hosting/staging-sites-redesign": false,
 		"importers/newsletter": true,
 		"importers/substack": true,
 		"individual-subscriber-stats": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -53,7 +53,7 @@
 		"help/gpt-response": true,
 		"home/layout-dev": true,
 		"hosting/datacenter-picker": true,
-		"hosting/staging-sites-redesign": true,
+		"hosting/staging-sites-redesign": false,
 		"hosting-server-settings-enhancements": true,
 		"i18n/translation-scanner": true,
 		"importer/site-backups": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -53,6 +53,7 @@
 		"help/gpt-response": true,
 		"home/layout-dev": true,
 		"hosting/datacenter-picker": true,
+		"hosting/staging-sites-redesign": true,
 		"hosting-server-settings-enhancements": true,
 		"i18n/translation-scanner": true,
 		"importer/site-backups": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTDEV-168

## Proposed Changes

* introduce `hosting/staging-sites-redesign` feature flag to all environments; enabled by default for the development only

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

32f09b309deb-linear-project

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Simple code review should be enough.

If you would like to test the new feature flag, you can follow these steps:
1. Check out the PR branch and apply this diff:

```diff
diff --git a/client/sites/components/sites-dataviews/index.tsx b/client/sites/components/sites-dataviews/index.tsx
index 5438404e026..3a3f28ac47b 100644
--- a/client/sites/components/sites-dataviews/index.tsx
+++ b/client/sites/components/sites-dataviews/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { TimeSince } from '@automattic/components';
 import { DataViews, Field } from '@automattic/dataviews';
 import { SiteExcerptData } from '@automattic/sites';
@@ -98,6 +99,10 @@ const DotcomSitesDataViews = ( {
 	useQueryReaderTeams();
 	const isAutomattician = useSelector( isA8cTeamMember );
 
+	if ( config.isEnabled( 'hosting/staging-sites-redesign' ) ) {
+		console.log( 'staging-sites-redesign feature flag enabled' );
+	}
+
 	// Generate DataViews table field-columns
 	const fields = useMemo( () => {
 		const dataViewFields: Field< SiteExcerptData >[] = [

```

2. Build the app with `yarn start` and navigate to http://calypso.localhost:3000/sites with browser console opened.
3. There should be the related `console.log` recorded.
4. Open the same page, but now with feature flag disabled: http://calypso.localhost:3000/sites?flags=-hosting/staging-sites-redesign.
5. There should be no `console.log` recorded this time.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?