### PR TITLE
Help Center: Add navigation to handle if HC is already opened

### DIFF
--- a/client/my-sites/theme/theme-support-tab/index.jsx
+++ b/client/my-sites/theme/theme-support-tab/index.jsx
@@ -15,7 +15,8 @@ export default function ThemeSupportTab( { themeId } ) {
 	const dispatch = useDispatch();
 
 	const isLoggedIn = useSelector( isUserLoggedIn );
-	const { setNavigateToOdie, setShowHelpCenter } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const { setNavigateToOdie, setShowHelpCenter, setNavigateToRoute } =
+		useDataStoreDispatch( HELP_CENTER_STORE );
 
 	return (
 		<>
@@ -62,6 +63,7 @@ export default function ThemeSupportTab( { themeId } ) {
 							__next40pxDefaultSize
 							onClick={ () => {
 								setShowHelpCenter( true );
+								setNavigateToRoute( '/' );
 								dispatch(
 									recordTracksEvent( 'calypso_theme_sheet_button_click', {
 										theme_name: themeId,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTTHEM-26/theme-showcase-the-visit-guides-support-button-should-navigate-to-the

## Proposed Changes

![image](https://github.com/user-attachments/assets/97b01bab-a637-4937-a554-93adb4d44641)

When clicking "Visit guides" at the bottom of https://wordpress.com/theme/bysshe/, nothing happens if the Help center is already opened.

With this PR the Help center shows Home ( `/` ) when clicking on that link.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open a theme page ([example](https://wordpress.com/theme/bysshe/))
- Open the Help center and then start an AI chat
- Click "Visit guides", it should return you to the Help Center home

