### PR TITLE
Dashboard v2: Implement storage

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -6,9 +6,7 @@ import { useResizeObserver } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
 import { useMemo, useState } from 'react';
-import { useInView } from 'react-intersection-observer';
 import { useAnalytics } from '../app/analytics';
-import { siteMediaStorageQuery } from '../app/queries/site-media-storage';
 import { sitesQuery } from '../app/queries/sites';
 import { sitesRoute } from '../app/router';
 import ComponentViewTracker from '../components/component-view-tracker';
@@ -19,7 +17,7 @@ import TimeSince from '../components/time-since';
 import { STATUS_LABELS, getSiteStatus, getSiteStatusLabel } from '../utils/site-status';
 import { getFormattedWordPressVersion } from '../utils/wp-version';
 import AddNewSite from './add-new-site';
-import { EngagementStat, Uptime, PHPVersion } from './site-fields';
+import { EngagementStat, Uptime, PHPVersion, MediaStorage } from './site-fields';
 import SiteIcon from './site-icon';
 import SitePreview from './site-preview';
 import type { FetchSitesOptions, Site } from '../data/types';
@@ -206,25 +204,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 	{
 		id: 'storage',
 		label: __( 'Storage' ),
-		render: function Storage( { item }: { item: Site } ) {
-			const { ref, inView } = useInView( {
-				triggerOnce: true,
-				fallbackInView: true,
-			} );
-
-			const { data: mediaStorage } = useQuery( {
-				...siteMediaStorageQuery( item.ID ),
-				enabled: inView,
-			} );
-
-			const value = mediaStorage
-				? `${ Math.round(
-						( mediaStorage.storageUsedBytes / mediaStorage.maxStorageBytes ) * 100
-				  ) }%`
-				: null;
-
-			return <span ref={ ref }>{ value }</span>;
-		},
+		render: ( { item } ) => <MediaStorage site={ item } />,
 		enableSorting: false,
 	},
 ];

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -6,7 +6,9 @@ import { useResizeObserver } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
 import { useMemo, useState } from 'react';
+import { useInView } from 'react-intersection-observer';
 import { useAnalytics } from '../app/analytics';
+import { siteMediaStorageQuery } from '../app/queries/site-media-storage';
 import { sitesQuery } from '../app/queries/sites';
 import { sitesRoute } from '../app/router';
 import ComponentViewTracker from '../components/component-view-tracker';
@@ -200,6 +202,29 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		id: 'php_version',
 		label: __( 'PHP version' ),
 		render: ( { item }: { item: Site } ) => <PHPVersion site={ item } />,
+	},
+	{
+		id: 'storage',
+		label: __( 'Storage' ),
+		render: function Storage( { item }: { item: Site } ) {
+			const { ref, inView } = useInView( {
+				triggerOnce: true,
+				fallbackInView: true,
+			} );
+
+			const { data: mediaStorage } = useQuery( {
+				...siteMediaStorageQuery( item.ID ),
+				enabled: inView,
+			} );
+
+			const value = mediaStorage
+				? `${ Math.round(
+						( mediaStorage.storageUsedBytes / mediaStorage.maxStorageBytes ) * 100
+				  ) }%`
+				: null;
+
+			return <span ref={ ref }>{ value }</span>;
+		},
 		enableSorting: false,
 	},
 ];

--- a/client/dashboard/sites/site-fields.tsx
+++ b/client/dashboard/sites/site-fields.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalText as Text } from '@wordpress/components';
 import { useInView } from 'react-intersection-observer';
+import { siteMediaStorageQuery } from '../app/queries/site-media-storage';
 import { sitePHPVersionQuery } from '../app/queries/site-php-version';
 import { siteEngagementStatsQuery } from '../app/queries/site-stats';
 import { siteUptimeQuery } from '../app/queries/site-uptime';
@@ -90,4 +91,26 @@ export function PHPVersion( { site }: { site: Site } ) {
 	}
 
 	return <span ref={ ref }>{ ! isLoading ? data : <LoadingIndicator label="X.Y" /> }</span>;
+}
+
+export function MediaStorage( { site }: { site: Site } ) {
+	const { ref, inView } = useInView( {
+		triggerOnce: true,
+		fallbackInView: true,
+	} );
+
+	const { data: mediaStorage, isLoading } = useQuery( {
+		...siteMediaStorageQuery( site.ID ),
+		enabled: inView,
+	} );
+
+	const value = mediaStorage ? (
+		`${
+			Math.round( ( mediaStorage.storageUsedBytes / mediaStorage.maxStorageBytes ) * 1000 ) / 10
+		}%`
+	) : (
+		<IneligibleIndicator />
+	);
+
+	return <span ref={ ref }>{ ! isLoading ? value : <LoadingIndicator label="100%" /> }</span>;
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTDASH-56

## Proposed Changes

* This PR adds the storage column to the v2 site list. It's hidden by default.

![image](https://github.com/user-attachments/assets/cbcf3ace-a2dd-4e93-8b9b-368ea6edff24)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2/sites.
* Verify you cannot see the storage by default
* Open the view option to show storage
* Verify you can see the storage now

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
