### PR TITLE
Mobile apps: Clear noise on OAuth2 login page

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -986,7 +986,7 @@ export class LoginForm extends Component {
 						{ ! isBlazePro &&
 							! isJetpack &&
 							! isAndroidOAuth2Client( oauth2Client ) &&
-							! isIosOAuth2Client( oauth2Client )(
+							! isIosOAuth2Client( oauth2Client ) && (
 								<p className="login__form-terms">{ renderTerms() }</p>
 							) }
 

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -29,7 +29,12 @@ import {
 	canDoMagicLogin,
 	getLoginLinkPageUrl,
 } from 'calypso/lib/login';
-import { isGravatarFlowOAuth2Client, isGravatarOAuth2Client } from 'calypso/lib/oauth2-clients';
+import {
+	isAndroidOAuth2Client,
+	isGravatarFlowOAuth2Client,
+	isGravatarOAuth2Client,
+	isIosOAuth2Client,
+} from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -978,9 +983,12 @@ export class LoginForm extends Component {
 							</div>
 						</div>
 
-						{ ! isBlazePro && ! isJetpack && (
-							<p className="login__form-terms">{ renderTerms() }</p>
-						) }
+						{ ! isBlazePro &&
+							! isJetpack &&
+							! isAndroidOAuth2Client( oauth2Client ) &&
+							! isIosOAuth2Client( oauth2Client )(
+								<p className="login__form-terms">{ renderTerms() }</p>
+							) }
 
 						{ shouldRenderForgotPasswordLink && this.renderLostPasswordLink() }
 

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -30,6 +30,8 @@ import {
 	isBlazeProOAuth2Client,
 	isPartnerPortalOAuth2Client,
 	isStudioAppOAuth2Client,
+	isAndroidOAuth2Client,
+	isIosOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { createAccountUrl } from 'calypso/lib/paths';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
@@ -334,7 +336,9 @@ export default withCurrentRoute(
 			const isGravatar = isGravatarOAuth2Client( oauth2Client );
 			const isWPJobManager = isWPJobManagerOAuth2Client( oauth2Client );
 			const isBlazePro = getIsBlazePro( state );
+			const isAndroid = isAndroidOAuth2Client( oauth2Client );
 			const isGravPoweredClient = isGravPoweredOAuth2Client( oauth2Client );
+			const isIos = isIosOAuth2Client( oauth2Client );
 			const isPartnerPortal = isPartnerPortalOAuth2Client( oauth2Client );
 			const isWooJPC = isWooJPCFlow( state );
 
@@ -357,7 +361,8 @@ export default withCurrentRoute(
 				isJetpackLogin ||
 				( isWhiteLogin && ! isBlazePro ) ||
 				isJetpackWooDnaFlow ||
-				isInvitationURL;
+				isInvitationURL ||
+				( currentRoute.startsWith( '/log-in' ) && ( isAndroid || isIos ) );
 			const isPopup = '1' === currentQuery?.is_popup;
 			const noMasterbarForSection =
 				! isWooOAuth2Client( oauth2Client ) &&

--- a/client/lib/oauth2-clients.js
+++ b/client/lib/oauth2-clients.js
@@ -17,6 +17,7 @@ export const isGravatarFlowOAuth2Client = ( oauth2Client ) => {
 export const isGravatarOAuth2Client = ( oauth2Client ) => {
 	return oauth2Client?.id === 1854 || isGravatarFlowOAuth2Client( oauth2Client );
 };
+
 export const isIosOAuth2Client = ( oauth2Client ) => {
 	return oauth2Client?.id === 11;
 };

--- a/client/lib/oauth2-clients.js
+++ b/client/lib/oauth2-clients.js
@@ -2,6 +2,10 @@ export const isAkismetOAuth2Client = ( oauth2Client ) => {
 	return oauth2Client?.id === 973;
 };
 
+export const isAndroidOAuth2Client = ( oauth2Client ) => {
+	return oauth2Client?.id === 2697;
+};
+
 export const isCrowdsignalOAuth2Client = ( oauth2Client ) => {
 	return oauth2Client?.id === 978;
 };
@@ -12,6 +16,9 @@ export const isGravatarFlowOAuth2Client = ( oauth2Client ) => {
 
 export const isGravatarOAuth2Client = ( oauth2Client ) => {
 	return oauth2Client?.id === 1854 || isGravatarFlowOAuth2Client( oauth2Client );
+};
+export const isIosOAuth2Client = ( oauth2Client ) => {
+	return oauth2Client?.id === 11;
 };
 
 export const isWPJobManagerOAuth2Client = ( oauth2Client ) => {

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -27,6 +27,8 @@ import {
 	isCrowdsignalOAuth2Client,
 	isGravatarFlowOAuth2Client,
 	isGravatarOAuth2Client,
+	isAndroidOAuth2Client,
+	isIosOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login, lostPassword } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -139,10 +141,15 @@ export class Login extends Component {
 	}
 
 	renderFooter() {
-		const { isJetpack, isWhiteLogin, translate } = this.props;
-		const isOauthLogin = !! this.props.oauth2Client;
+		const { isJetpack, isWhiteLogin, oauth2Client, translate } = this.props;
+		const isOauthLogin = !! oauth2Client;
 
-		if ( isJetpack || isWhiteLogin ) {
+		if (
+			isJetpack ||
+			isWhiteLogin ||
+			isAndroidOAuth2Client( oauth2Client ) ||
+			isIosOAuth2Client( oauth2Client )
+		) {
 			return null;
 		}
 

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -15,6 +15,8 @@ import {
 	isCrowdsignalOAuth2Client,
 	isJetpackCloudOAuth2Client,
 	isGravPoweredOAuth2Client,
+	isAndroidOAuth2Client,
+	isIosOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -109,15 +111,19 @@ export class LoginLinks extends Component {
 	};
 
 	renderBackLink() {
+		const { isWhiteLogin, oauth2Client, query, translate } = this.props;
+
 		if (
-			isCrowdsignalOAuth2Client( this.props.oauth2Client ) ||
-			isJetpackCloudOAuth2Client( this.props.oauth2Client ) ||
-			this.props.isWhiteLogin
+			isAndroidOAuth2Client( oauth2Client ) ||
+			isIosOAuth2Client( oauth2Client ) ||
+			isCrowdsignalOAuth2Client( oauth2Client ) ||
+			isJetpackCloudOAuth2Client( oauth2Client ) ||
+			isWhiteLogin
 		) {
 			return null;
 		}
 
-		const redirectTo = this.props.query?.redirect_to;
+		const redirectTo = query?.redirect_to;
 		if ( redirectTo ) {
 			const { pathname, searchParams: redirectToQuery } = getUrlParts( redirectTo );
 
@@ -138,8 +144,8 @@ export class LoginLinks extends Component {
 				const { hostname } = getUrlParts( redirectToQuery.get( 'site_url' ) );
 				const linkText = hostname
 					? // translators: hostname is a the hostname part of the URL. eg "google.com"
-					  this.props.translate( 'Back to %(hostname)s', { args: { hostname } } )
-					: this.props.translate( 'Back' );
+					  translate( 'Back to %(hostname)s', { args: { hostname } } )
+					: translate( 'Back' );
 
 				return (
 					<ExternalLink className="wp-login__site-return-link" href={ returnToSiteUrl }>
@@ -153,7 +159,7 @@ export class LoginLinks extends Component {
 		return (
 			<LoggedOutFormBackLink
 				classes={ { 'logged-out-form__link-item': false } }
-				oauth2Client={ this.props.oauth2Client }
+				oauth2Client={ oauth2Client }
 				recordClick={ this.recordBackToWpcomLinkClick }
 			/>
 		);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTOBRD-161

## Proposed Changes

* Remove the header and footer links, terms of service text, and the `Back` button on the mobile apps login page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As explained on issue, we want to remove potential distractions so the users focus on logging in.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to `/log-in?client_id=2697&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D2697%26redirect_uri%3Dwordpress%253A%252F%252Fwpcom-authorize%26response_type%3Dcode%26scope%3Dglobal%26from-calypso%3D1` (the link you would get if trying to log in on the wordpress mobile app for android)
* Check that the header and footer links, terms of service text, and the `Back` button have been removed.
* Repeat with `/log-in?client_id=11&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D11%26redirect_uri%3Dwordpress%253A%252F%252Fwpcom-authorize%26response_type%3Dcode%26scope%3Dglobal%26from-calypso%3D1` (the link you would get if trying to log in on the wordpress mobile app for iOs)

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/0321cef6-f227-416e-84ec-65ae491b60f2)|![image](https://github.com/user-attachments/assets/dec4e01c-9a62-41ba-a751-62373a9302b5)|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
