### PR TITLE
Keep the browser history when going to a page

### DIFF
--- a/client/me/purchases/billing-history/hooks/use-receipt-actions.ts
+++ b/client/me/purchases/billing-history/hooks/use-receipt-actions.ts
@@ -1,4 +1,4 @@
-import pageRedirect from '@automattic/calypso-router';
+import page from '@automattic/calypso-router';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { useDispatch } from 'react-redux';
@@ -30,7 +30,7 @@ function handleViewReceipt(
 	if ( ! items?.length || ! items[ 0 ]?.id ) {
 		return;
 	}
-	pageRedirect.redirect( getReceiptUrlFor( items[ 0 ].id ) );
+	page( getReceiptUrlFor( items[ 0 ].id ) );
 }
 
 function handleEmailReceipt( items: BillingTransaction[], dispatch: AppDispatch ): void {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CHE-144/broken-billing-history-back-button-behavior

## Proposed Changes

* Use page(url) instead of PageRedirect.redirect(url) when viewing a receipt 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See issue. This could mislead the user by sending them back to the `purchase` page instead of billing history when using the browser "back" button

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

On production 
* Visit [Me > Purchases](https://wordpress.com/me/purchases/)
* Click "Billing History" tab
* View an individual receipt
* Click browser's back button
* You're taken to Me > Purchases, instead of Me > Purchases > Billing History


On this branch:
* Start dev env `yarn && yarn start`
* Visit [ Dev Me > Purchases](http://calypso.localhost:3000/me/purchases/)
* View an individual receipt
* Click browser's back button
* You're taken to Me > Purchases > Billing History 🥳 
