### PR TITLE
Reader hovercards - simplify logic for showing/hiding hovercards.

### DIFF
--- a/client/components/gravatar-with-hovercards/index.jsx
+++ b/client/components/gravatar-with-hovercards/index.jsx
@@ -4,80 +4,25 @@ import { useEffect, useRef } from 'react';
 import Gravatar from '../gravatar';
 import '@gravatar-com/hovercards/dist/style.css';
 
-// Create a single style element to control hovercard visibility. We do this because hovercards do
-// not clean up their child popovers when the component unmounts. While the useEffect unmount
-// cleanup works for removing existing hovercard popovers on unmount, there are cirumstances where
-// hovercards will not appear until after this runs causing them to appear on the next page. An
-// example of this is mousing over and clicking a Gravatar quickly, triggering navigation before the
-// hovercard has initially appeared. In this circumstance the hovercard then appears after
-// navigation and the cleanup attempt. Other methods, such as checking a container ref
-// onHovercardShown to see if we need to remove the outdated popover, do remove the popovers but
-// have a jarring flickering effect as the hovercard is still initially visible before removal.
-// Controlling visiblity this way prevents the flickering in cleanup: we ensure hovercards have no
-// visibility until verifying that their container ref is in the dom.
-// This issue is being tracked in https://github.com/Automattic/gravatar/issues/210
-// More details and gifs of these issues shown in https://github.com/Automattic/wp-calypso/pull/104136
-const createStyleElement = () => {
-	let styleElement = document.getElementById( 'gravatar-hovercard-style' );
-	if ( ! styleElement ) {
-		styleElement = document.createElement( 'style' );
-		styleElement.id = 'gravatar-hovercard-style';
-		styleElement.textContent = '.gravatar-hovercard { display: none !important; }';
-		document.head.appendChild( styleElement );
-	}
-	return styleElement;
-};
-
-const hideHovercards = ( styleElement ) => {
-	if ( ! document.head.contains( styleElement ) ) {
-		document.head.appendChild( styleElement );
-	}
-};
-
-const showHovercards = ( styleElement ) => {
-	styleElement.remove();
-};
-
 function GravatarWithHovercards( props ) {
 	const containerRef = useRef( null );
-	const styleElementRef = useRef( null );
 
 	useEffect( () => {
-		// Initialize style element only when component mounts
-		styleElementRef.current = createStyleElement();
 		return () => {
 			// Remove any lingering hovercards on unmount
 			const hovercards = document.querySelectorAll( '.gravatar-hovercard' );
 			hovercards.forEach( ( card ) => card.remove() );
-			// Ensure hovercards will remain hidden until container ref is verified for next hovercard
-			if ( styleElementRef.current ) {
-				hideHovercards( styleElementRef.current );
-			}
 		};
 	}, [] );
 
-	const handleHovercardShown = ( hash, hovercardElement ) => {
-		// Timeout to bump this check to the end of the callstack to avoid a race condition where
-		// this is evaluated after dismount but before dom update. This was happening about 5-10% of
-		// the time and makes it so hovering a gravatar does not trigger the hovercard until another
-		// unhover/rehover.
-		setTimeout( () => {
-			// Only show the hovercard if our container is in the dom
-			if ( containerRef.current && document.body.contains( containerRef.current ) ) {
-				showHovercards( styleElementRef.current );
-			} else {
-				hovercardElement?.remove();
-				hideHovercards( styleElementRef.current );
-			}
-		}, 0 );
+	const shouldShowHovercard = () => {
+		// Only show the hovercard if the container is in the dom.
+		return containerRef.current && document.body.contains( containerRef.current );
 	};
 
 	return (
 		<div ref={ containerRef }>
-			<Hovercards
-				onHovercardShown={ handleHovercardShown }
-				onHovercardHidden={ () => hideHovercards( styleElementRef.current ) }
-			>
+			<Hovercards onCanShowHovercard={ shouldShowHovercard }>
 				<Gravatar { ...props } />
 			</Hovercards>
 		</div>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Follow up on https://github.com/Automattic/wp-calypso/pull/104136 / https://linear.app/a8c/issue/CML-560/reader-add-gravatar-hovercards 

## Proposed Changes

Greatly simplify the logic for controlling hovercard visilibity.
* In the first go around I overlooked the existence of the `onCanShowHovercard` callback, and did our checks for showing the card in `onShowHovercard` instead. Doing the later means the hovercard appears before being removed, causing a flicker of the card before it is removed which is what prompted the extra style logic. Now that we are using the former, we can get rid of that hackiness.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Better code: more stable, less hacky, more readable.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the reader and test hovercards by hovering gravatars.
* (regression test) Hover over a gravatar in a stream, once the hovercard appears click it. Verify the hovercard is not present on the next page.
* (related test) Hover over a gravatar in a stream and click it before the hovercard appears. Verify the hovercard does not appear on the next page and does not cause a flicker in the top left (thats what our styles were preventing).
* Compared to horizon, you should not really notice any changes in behavior.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
