### PR TITLE
SEO: Update the title/description for logged-out themes showcase and patterns

### DIFF
--- a/client/my-sites/patterns/components/header/index.tsx
+++ b/client/my-sites/patterns/components/header/index.tsx
@@ -29,11 +29,11 @@ export const PatternsHeader = () => {
 
 	const CONTENT: Record< Category[ 'name' ], ContentEntry > = {
 		default: {
-			title: translate( 'WordPress Patterns', {
+			title: translate( 'WordPress Block Patterns: Build Your Web Pages 10X Faster', {
 				comment: 'HTML title of the Pattern Library home page',
 			} ),
 			metaDescription: translate(
-				'Dive into hundreds of expertly designed, fully responsive layouts, and bring any kind of site to life, faster.',
+				'WordPress block patterns: pre-designed sections for headers, testimonials, galleries, and more. Copy, paste, customize. Build pages 10x faster.',
 				{ comment: 'Intro text on the Pattern Library home page' }
 			),
 			patternsHeading: translate( 'Build Faster with Patterns', {
@@ -377,6 +377,7 @@ export const PatternsHeader = () => {
 
 	const categoryConfig = CONTENT[ category ];
 	const { title } = categoryConfig || CONTENT.default;
+	const skipTitleFormatting = categoryConfig ? false : true;
 
 	let heading: Substitution = CONTENT.default.patternsHeading;
 	let description: Substitution = CONTENT.default.patternsDescription;
@@ -404,7 +405,7 @@ export const PatternsHeader = () => {
 
 	return (
 		<>
-			<DocumentHead title={ title } meta={ metas } />
+			<DocumentHead title={ title } meta={ metas } skipTitleFormatting={ skipTitleFormatting } />
 
 			<header className="patterns-header">
 				<div className="patterns-header__inner">

--- a/client/my-sites/themes/theme-showcase-header.jsx
+++ b/client/my-sites/themes/theme-showcase-header.jsx
@@ -11,6 +11,10 @@ import useThemeShowcaseDescription from './use-theme-showcase-description';
 import useThemeShowcaseLoggedOutSeoContent from './use-theme-showcase-logged-out-seo-content';
 import useThemeShowcaseTitle from './use-theme-showcase-title';
 
+const shouldSkipTitleFormatting = ( { filter, tier } ) => {
+	return filter === 'recommended' && tier === 'all';
+};
+
 export default function ThemeShowcaseHeader( {
 	canonicalUrl,
 	filter,
@@ -27,6 +31,7 @@ export default function ThemeShowcaseHeader( {
 
 	const description = useThemeShowcaseDescription( { filter, tier, vertical } );
 	const title = useThemeShowcaseTitle( { filter, tier, vertical } );
+	const skipTitleFormatting = shouldSkipTitleFormatting( { filter, tier } );
 	const loggedOutSeoContent = useThemeShowcaseLoggedOutSeoContent( filter, tier );
 	const {
 		title: documentHeadTitle,
@@ -72,12 +77,22 @@ export default function ThemeShowcaseHeader( {
 	}
 
 	if ( isCollectionView ) {
-		return <DocumentHead title={ documentHeadTitle } meta={ metas } />;
+		return (
+			<DocumentHead
+				title={ documentHeadTitle }
+				meta={ metas }
+				skipTitleFormatting={ skipTitleFormatting }
+			/>
+		);
 	}
 
 	return (
 		<>
-			<DocumentHead title={ documentHeadTitle } meta={ metas } />
+			<DocumentHead
+				title={ documentHeadTitle }
+				meta={ metas }
+				skipTitleFormatting={ skipTitleFormatting }
+			/>
 			{ isLoggedIn ? (
 				<div className="themes__header-navigation-container">
 					<NavigationHeader

--- a/client/my-sites/themes/theme-showcase-header.jsx
+++ b/client/my-sites/themes/theme-showcase-header.jsx
@@ -12,7 +12,7 @@ import useThemeShowcaseLoggedOutSeoContent from './use-theme-showcase-logged-out
 import useThemeShowcaseTitle from './use-theme-showcase-title';
 
 const shouldSkipTitleFormatting = ( { filter, tier } ) => {
-	return filter === 'recommended' && tier === 'all';
+	return ( ! filter || filter === 'recommended' ) && ( ! tier || tier === 'all' );
 };
 
 export default function ThemeShowcaseHeader( {

--- a/client/my-sites/themes/use-theme-showcase-logged-out-seo-content.js
+++ b/client/my-sites/themes/use-theme-showcase-logged-out-seo-content.js
@@ -27,10 +27,10 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 		() => ( {
 			recommended: {
 				all: {
-					title: translate( 'WordPress Themes' ),
+					title: translate( 'WordPress Themes | 1000s of Options for All WordPress Sites' ),
 					header: translate( 'Find the perfect theme for your website' ),
 					description: translate(
-						"Beautiful and responsive WordPress themes. Choose from free and premium options for all types of websites. Then, activate the one that's best for you."
+						'Professional WordPress themes for business, blogs, and ecommerce. 1000+ mobile-responsive designs with easy customization. Browse free and premium.'
 					),
 				},
 				free: {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to M4R73CH-886

## Proposed Changes

* Update the meta title/description of the logged-out /themes and /patterns pages.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is part of a request to adjust the SEO metadata on these pages.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.
* Using calypso.live or `export DEBUG="calypso:server-render" && yarn start` on local instance navigate to /themes and /patterns pages.
* Confirm that the main page titles/descriptions match the ones in the PR and the titles don't have `- WordPress.com` appended, but the titles/descriptions for any other categories remain unchanged. For descriptions server-side rendering is required, which can be tested on a local instance using the command provided above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
