### PR TITLE
Fix selected sort order on promote-post

### DIFF
--- a/client/my-sites/promote-post-i2/components/search-bar/index.tsx
+++ b/client/my-sites/promote-post-i2/components/search-bar/index.tsx
@@ -256,7 +256,26 @@ export default function SearchBar( props: Props ) {
 		} );
 	};
 
-	const getSortLabel = () => {
+	const getPostSortLabel = () => {
+		let selectedSortOption = sortOption.orderBy;
+		if ( selectedSortOption === 'clicks_total' || selectedSortOption === 'impressions_total' ) {
+			selectedSortOption = `${ selectedSortOption }|${ sortOption.order }`;
+		}
+
+		const selectedOption = sortOptions.find( ( item ) => item.value === selectedSortOption )?.label;
+
+		if ( selectedOption ) {
+			return isDesktop
+				? translate( 'Sort: %(sortOption)s', {
+						args: { sortOption: selectedOption },
+				  } )
+				: selectedOption;
+		}
+
+		return isDesktop ? translate( 'Sort: Last published' ) : translate( 'Recently published' );
+	};
+
+	const getCampaignSortLabel = () => {
 		let selectedSortOption = campaignSortOption.orderBy;
 		if (
 			campaignSortOption.orderBy === 'clicks_total' ||
@@ -356,7 +375,7 @@ export default function SearchBar( props: Props ) {
 							onSelect={ onChangeOrderOption }
 							options={ sortOptions }
 							initialSelected={ sortOption.orderBy }
-							selectedText={ getSortLabel() }
+							selectedText={ getPostSortLabel() }
 						/>
 					</>
 				) }
@@ -386,7 +405,7 @@ export default function SearchBar( props: Props ) {
 							onSelect={ onCampaignChangeOrderOption }
 							options={ campaignSortOptions }
 							initialSelected={ campaignSortOption.orderBy }
-							selectedText={ getSortLabel() }
+							selectedText={ getCampaignSortLabel() }
 						/>
 					</>
 				) }


### PR DESCRIPTION
https://linear.app/a8c/issue/ADS-107/blaze-ui-sort-order-doesnt-show

## Proposed Changes

* Fixing selected sort label on Blaze post list, making the selected option "stick".
![image](https://github.com/user-attachments/assets/60eb053a-0535-4a73-9750-a4e682d2295d)
* The issue was that there was only one `getSortLabel()` function used in both Campaigns tab and Posts list tab, so the sort label was grabbing the selected sort option from the `Campaigns` tab instead of from the post list tab.

This PR splits `getSortLabel()` into `getPostSortLabel()` and `getCampaignSortLabel()` for each tabs so they don't contaminate each other.

## Why are these changes being made?
* Going to Tools > Advertising and sorting the posts by something changes the order but doesn't change the selection in the dropdown. It always shows "Sort: Recently published"

## Testing Instructions

* Go to **Tools** > **Advertising** 
* Select Tab **Ready to promote**
* Change the sort option as above and see that the selected option sticks

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
