### PR TITLE
Prepare `@automattic/ui` for 1.0.0 release

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.0.0
+
 ### Enhancements
 
 - `Badge`: Add component (forked from `@wordpress/components`) ([#104187](https://github.com/Automattic/wp-calypso/pull/104187)).

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -77,8 +77,7 @@
 	},
 	"scripts": {
 		"clean": "rm -rf dist",
-		"build": "yarn clean && yarn bundle",
-		"bundle": "tsup",
+		"build": "yarn clean && tsup",
 		"prepack": "yarn build",
 		"storybook:start": "storybook dev -p 56851"
 	}


### PR DESCRIPTION
Closes ARC-199

## Proposed Changes

Prepares the `@automattic/ui` package for initial release.

## Testing Instructions

Changelog version is bumped, and `npm pack` in the `packages/ui` directory works.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
