### PR TITLE
Purchases: Make site-level purchases link to site-level purchase

### DIFF
--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -162,7 +162,7 @@ export function list( context, next ) {
 				{ useDataViewPurchasesList ? (
 					<PurchasesListDataView
 						noticeType={ context.params.noticeType }
-						getManagePurchaseUrlFor={ managePurchase }
+						getManagePurchaseUrlFor={ managePurchaseUrl }
 					/>
 				) : (
 					<PurchasesList noticeType={ context.params.noticeType } />

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -160,7 +160,10 @@ export function list( context, next ) {
 		return (
 			<PurchasesWrapper>
 				{ useDataViewPurchasesList ? (
-					<PurchasesListDataView noticeType={ context.params.noticeType } />
+					<PurchasesListDataView
+						noticeType={ context.params.noticeType }
+						getManagePurchaseUrlFor={ managePurchase }
+					/>
 				) : (
 					<PurchasesList noticeType={ context.params.noticeType } />
 				) }

--- a/client/me/purchases/purchases-list-in-dataviews/hooks/use-field-definitions.ts
+++ b/client/me/purchases/purchases-list-in-dataviews/hooks/use-field-definitions.ts
@@ -2,13 +2,20 @@ import { SiteDetails } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { GetManagePurchaseUrlFor } from 'calypso/lib/purchases/types';
 import { useStoredPaymentMethods } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
 import {
 	getPurchasesFieldDefinitions,
 	getMembershipsFieldDefinitions,
 } from '../purchases-data-field';
 
-export function usePurchasesFieldDefinitions( { sites }: { sites: SiteDetails[] } ) {
+export function usePurchasesFieldDefinitions( {
+	sites,
+	getManagePurchaseUrlFor,
+}: {
+	sites: SiteDetails[];
+	getManagePurchaseUrlFor: GetManagePurchaseUrlFor;
+} ) {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 	const paymentMethods = useStoredPaymentMethods().paymentMethods;
@@ -18,10 +25,11 @@ export function usePurchasesFieldDefinitions( { sites }: { sites: SiteDetails[] 
 			translate,
 			moment,
 			paymentMethods,
+			getManagePurchaseUrlFor,
 			sites,
 		} );
 		return fieldDefinitions;
-	}, [ translate, moment, paymentMethods, sites ] );
+	}, [ translate, moment, paymentMethods, sites, getManagePurchaseUrlFor ] );
 }
 
 export function useMembershipsFieldDefinitions() {

--- a/client/me/purchases/purchases-list-in-dataviews/index.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/index.tsx
@@ -15,7 +15,11 @@ import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
-import { MembershipSubscription, Purchase } from 'calypso/lib/purchases/types';
+import {
+	GetManagePurchaseUrlFor,
+	MembershipSubscription,
+	Purchase,
+} from 'calypso/lib/purchases/types';
 import { PurchaseListConciergeBanner } from 'calypso/me/purchases/purchases-list/purchase-list-concierge-banner';
 import PurchasesNavigation from 'calypso/me/purchases/purchases-navigation';
 import titles from 'calypso/me/purchases/titles';
@@ -43,6 +47,7 @@ import { PurchasesDataViews, MembershipsDataViews } from './purchases-data-view'
 
 export interface PurchasesListProps {
 	noticeType?: string | undefined;
+	getManagePurchaseUrlFor: GetManagePurchaseUrlFor;
 }
 
 export interface PurchasesListConnectedProps {
@@ -118,7 +123,13 @@ function PurchasesListDataView(
 	}
 
 	if ( purchases && purchases.length ) {
-		content = <PurchasesDataViews purchases={ purchases } sites={ sites } />;
+		content = (
+			<PurchasesDataViews
+				purchases={ purchases }
+				sites={ sites }
+				getManagePurchaseUrlFor={ props.getManagePurchaseUrlFor }
+			/>
+		);
 	}
 
 	if ( purchases && ! purchases.length && ! subscriptions.length ) {

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -6,7 +6,7 @@ import { fixMe, LocalizeProps } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
 import { getDisplayName, isExpired, isRenewing, purchaseType } from 'calypso/lib/purchases';
-import { MembershipSubscription } from 'calypso/lib/purchases/types';
+import { GetManagePurchaseUrlFor, MembershipSubscription } from 'calypso/lib/purchases/types';
 import { useSelector } from 'calypso/state';
 import { getSite } from 'calypso/state/sites/selectors';
 import { Icon, MembershipType, MembershipTerms } from '../membership-item';
@@ -65,12 +65,14 @@ export function getPurchasesFieldDefinitions( {
 	moment,
 	paymentMethods,
 	sites,
+	getManagePurchaseUrlFor,
 	fieldIds,
 }: {
 	translate: LocalizeProps[ 'translate' ];
 	moment: ReturnType< typeof useLocalizedMoment >;
 	paymentMethods: Array< StoredPaymentMethod >;
 	sites: SiteDetails[];
+	getManagePurchaseUrlFor: GetManagePurchaseUrlFor;
 	fieldIds?: string[];
 } ): Fields< Purchases.Purchase > {
 	const backupPaymentMethods = paymentMethods.filter(
@@ -90,7 +92,7 @@ export function getPurchasesFieldDefinitions( {
 			console.error( 'Cannot display manage purchase page for subscription without ID' );
 			return;
 		}
-		page( `/me/purchases/${ siteUrl }/${ subscriptionId }` );
+		page( getManagePurchaseUrlFor( siteUrl, subscriptionId ) );
 	};
 
 	const fields: Fields< Purchases.Purchase > = [

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -237,6 +237,7 @@ export function PurchasesDataViews( {
 
 	const purchasesDataFields = usePurchasesFieldDefinitions( {
 		sites: sitesWithPurchases,
+		getManagePurchaseUrlFor,
 	} );
 	const { data: adjustedPurchases, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( purchases, currentView, purchasesDataFields );

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -19,6 +19,7 @@ import {
 	usePurchasesFieldDefinitions,
 	useMembershipsFieldDefinitions,
 } from './hooks/use-field-definitions';
+import type { GetManagePurchaseUrlFor } from 'calypso/lib/purchases/types';
 
 import './style.scss';
 
@@ -207,9 +208,11 @@ function useHidePurchasesFieldsAtCertainWidths( {
 export function PurchasesDataViews( {
 	purchases,
 	sites,
+	getManagePurchaseUrlFor,
 }: {
 	purchases: Purchases.Purchase[];
 	sites: SiteDetails[];
+	getManagePurchaseUrlFor: GetManagePurchaseUrlFor;
 } ) {
 	const translate = useTranslate();
 	const [ currentView, setView ] = useState( purchasesDataView );
@@ -258,11 +261,11 @@ export function PurchasesDataViews( {
 						console.error( 'Cannot display manage purchase page for subscription without ID' );
 						return;
 					}
-					page( `/me/purchases/${ siteUrl }/${ subscriptionId }` );
+					page( getManagePurchaseUrlFor( siteUrl, subscriptionId ) );
 				},
 			},
 		],
-		[ translate ]
+		[ translate, getManagePurchaseUrlFor ]
 	);
 
 	const getItemId = ( item: Purchases.Purchase ) => {

--- a/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
+++ b/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
@@ -3,6 +3,7 @@ import config from '@automattic/calypso-config';
 import { CompactCard } from '@automattic/components';
 import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
 import EmptyContent from 'calypso/components/empty-content';
 import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import JetpackRnaActionCard from 'calypso/components/jetpack/card/jetpack-rna-action-card';
@@ -96,6 +97,10 @@ export default function SubscriptionsContentWrapper() {
 	const selectedSite = useSelector( getSelectedSite );
 	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSiteId ) );
 	const sites = useSelector( getSites ).filter( isValueTruthy );
+	const getManagePurchaseUrlFor: GetManagePurchaseUrlFor = useCallback(
+		( siteSlug, purchaseId ) => `/purchases/subscriptions/${ siteSlug }/${ purchaseId }`,
+		[]
+	);
 
 	if ( config.isEnabled( 'purchases/purchase-list-dataview' ) ) {
 		if ( ! selectedSiteId ) {
@@ -119,7 +124,13 @@ export default function SubscriptionsContentWrapper() {
 		if ( purchases.length < 1 ) {
 			return <NoPurchasesMessage />;
 		}
-		return <PurchasesDataViews purchases={ purchases } sites={ sites } />;
+		return (
+			<PurchasesDataViews
+				purchases={ purchases }
+				sites={ sites }
+				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
+			/>
+		);
 	}
 
 	return (


### PR DESCRIPTION
## Proposed Changes

This fixes a regression caused by the switch to using DataViews for the site-level purchases list (see https://github.com/Automattic/wp-calypso/pull/103966 and https://github.com/Automattic/wp-calypso/pull/104212) where the site-level purchases list no longer linked to a view of the purchase in the site-level context.

Tracked by https://linear.app/a8c/issue/CHE-203/clicking-through-to-view-a-purchase-takes-you-out-of-the-site-context

## Testing Instructions

- Visit a site-level purchases page like http://calypso.localhost:3000/purchases/subscriptions/example.com (use an actual site you own with purchases)
- Click on the title of a purchase to visit that purchase.
- Verify that you see the purchase, and that the sidebar and header are still the site-level view.
- Visit the account-level purchases page at http://calypso.localhost:3000/me/purchases
- Click on the title of a purchase to visit that purchase.
- Verify that you see the purchase, and that the sidebar and header are still the account-level view.