### PR TITLE
Hosting dashboard: Add css utility class for truncating with ellipsis

### DIFF
--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -41,3 +41,11 @@ a {
 #wpcom {
 	font-size: $font-size-medium;
 }
+
+// Utility classes
+
+.truncate {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -50,22 +50,14 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		label: __( 'Site' ),
 		enableGlobalSearch: true,
 		getValue: ( { item } ) => item.name || new URL( item.URL ).hostname,
-		render: ( { field, item } ) => (
-			<span style={ { overflowX: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }>
-				{ field.getValue( { item } ) }
-			</span>
-		),
+		render: ( { field, item } ) => <span className="truncate">{ field.getValue( { item } ) }</span>,
 	},
 	{
 		id: 'URL',
 		label: __( 'URL' ),
 		enableGlobalSearch: true,
 		getValue: ( { item } ) => new URL( item.URL ).hostname,
-		render: ( { field, item } ) => (
-			<span style={ { overflowX: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }>
-				{ field.getValue( { item } ) }
-			</span>
-		),
+		render: ( { field, item } ) => <span className="truncate">{ field.getValue( { item } ) }</span>,
 	},
 	{
 		id: 'icon.ico',

--- a/client/dashboard/sites/site/switcher.tsx
+++ b/client/dashboard/sites/site/switcher.tsx
@@ -55,11 +55,7 @@ export default function Switcher( { onClose }: { onClose: () => void } ) {
 					<RouterLinkMenuItem key={ site.ID } to={ `/sites/${ site.slug }` } onClick={ onClose }>
 						<div style={ { display: 'flex', gap: '8px', alignItems: 'center', width: '100%' } }>
 							<SiteIcon site={ site } size={ 24 } />
-							<span
-								style={ { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }
-							>
-								{ fields[ 0 ].getValue( { item: site } ) }
-							</span>
+							<span className="truncate">{ fields[ 0 ].getValue( { item: site } ) }</span>
 						</div>
 					</RouterLinkMenuItem>
 				) ) }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Copied the class name from [tailwindcss](https://tailwindcss.com/docs/text-overflow)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Inspired by conversation here https://github.com/Automattic/wp-calypso/pull/104288#discussion_r2153777926

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
