### PR TITLE
Rename Media column to Site icon

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -252,17 +252,17 @@ export default function Sites() {
 	);
 
 	const fields = useMemo( () => {
-		const excludedFields = new Set< string >();
+		return DEFAULT_FIELDS.filter( ( field ) => {
+			if ( field.id === 'is_a8c' && ! hasA8CSites ) {
+				return false;
+			}
 
-		if ( hasA8CSites ) {
-			excludedFields.add( 'is_a8c' );
-		}
+			if ( field.id === 'icon.ico' && view.type === 'grid' ) {
+				return false;
+			}
 
-		if ( view.type === 'grid' ) {
-			excludedFields.add( 'icon.ico' );
-		}
-
-		return DEFAULT_FIELDS.filter( ( field ) => ! excludedFields.has( field.id ) );
+			return true;
+		} );
 	}, [ hasA8CSites, view.type ] );
 
 	const [ isModalOpen, setIsModalOpen ] = useState( false );

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -69,7 +69,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 	},
 	{
 		id: 'icon.ico',
-		label: __( 'Media' ),
+		label: __( 'Site icon' ),
 		render: ( { item } ) => <SiteIcon site={ item } />,
 		enableSorting: false,
 	},
@@ -123,7 +123,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 	{
 		id: 'is_a8c',
 		type: 'boolean',
-		label: __( 'A8C Owned' ),
+		label: __( 'A8C owned' ),
 		elements: [
 			{ value: true, label: __( 'Yes' ) },
 			{ value: false, label: __( 'No' ) },
@@ -220,6 +220,7 @@ export default function Sites() {
 		sitesQuery( getFetchSitesOptions( viewOptions ) )
 	);
 	const hasA8CSites = sites?.some( ( site ) => site.is_a8c );
+
 	const defaultView = useMemo(
 		() =>
 			hasA8CSites
@@ -236,6 +237,7 @@ export default function Sites() {
 				: DEFAULT_VIEW,
 		[ hasA8CSites ]
 	);
+
 	const view = useMemo(
 		() => ( {
 			...defaultView,
@@ -248,11 +250,21 @@ export default function Sites() {
 		} ),
 		[ defaultView, viewOptions ]
 	);
-	const fields = useMemo(
-		() =>
-			hasA8CSites ? DEFAULT_FIELDS : DEFAULT_FIELDS.filter( ( field ) => field.id !== 'is_a8c' ),
-		[ hasA8CSites ]
-	);
+
+	const fields = useMemo( () => {
+		const excludedFields = new Set< string >();
+
+		if ( hasA8CSites ) {
+			excludedFields.add( 'is_a8c' );
+		}
+
+		if ( view.type === 'grid' ) {
+			excludedFields.add( 'icon.ico' );
+		}
+
+		return DEFAULT_FIELDS.filter( ( field ) => ! excludedFields.has( field.id ) );
+	}, [ hasA8CSites, view.type ] );
+
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( sites ?? [], view, fields );


### PR DESCRIPTION
Ref DOTDASH-18

## Proposed Changes

This PR renames the "Media" column to "Site Icon", and hides it in the grid view.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

UI improvements.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Ensure that the changes described above are applied

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
