### PR TITLE
Sites List v2: Add site badge

### DIFF
--- a/client/dashboard/sites/fields.tsx
+++ b/client/dashboard/sites/fields.tsx
@@ -1,11 +1,14 @@
+import { Badge } from '@automattic/ui';
 import { Link } from '@tanstack/react-router';
-import { __experimentalText as Text } from '@wordpress/components';
+import { __experimentalHStack as HStack, __experimentalText as Text } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import TimeSince from '../components/time-since';
 import { STATUS_LABELS, getSiteStatus } from '../utils/site-status';
+import { isP2 } from '../utils/site-types';
 import { getFormattedWordPressVersion } from '../utils/wp-version';
 import { canManageSite } from './features';
+import { isSitePlanTrial } from './plans';
 import {
 	EngagementStat,
 	LastBackup,
@@ -27,6 +30,22 @@ function getSiteManagementUrl( site: Site ) {
 	return site.options?.admin_url;
 }
 
+function SiteBadge( { site }: { site: Site } ) {
+	if ( site.is_wpcom_staging_site ) {
+		return <Badge>{ __( 'Staging' ) }</Badge>;
+	}
+
+	if ( isSitePlanTrial( site ) ) {
+		return <Badge>{ __( 'Trial' ) }</Badge>;
+	}
+
+	if ( isP2( site ) ) {
+		return <Badge>{ __( 'P2' ) }</Badge>;
+	}
+
+	return null;
+}
+
 const DEFAULT_FIELDS: Field< Site >[] = [
 	{
 		id: 'name',
@@ -34,7 +53,19 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		enableGlobalSearch: true,
 		getValue: ( { item } ) => item.name || new URL( item.URL ).hostname,
 		render: ( { field, item } ) => (
-			<Link to={ getSiteManagementUrl( item ) }>{ field.getValue( { item } ) }</Link>
+			<Link to={ getSiteManagementUrl( item ) }>
+				<HStack alignment="center" spacing={ 1 }>
+					<Text
+						as="span"
+						style={ { overflowX: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }
+					>
+						{ field.getValue( { item } ) }
+					</Text>
+					<Text as="span" style={ { flexShrink: 0 } }>
+						{ SiteBadge( { site: item } ) }
+					</Text>
+				</HStack>
+			</Link>
 		),
 	},
 	{

--- a/client/dashboard/sites/fields.tsx
+++ b/client/dashboard/sites/fields.tsx
@@ -62,7 +62,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 						{ field.getValue( { item } ) }
 					</Text>
 					<Text as="span" style={ { flexShrink: 0 } }>
-						{ SiteBadge( { site: item } ) }
+						<SiteBadge site={ item } />
 					</Text>
 				</HStack>
 			</Link>

--- a/client/dashboard/sites/plans.ts
+++ b/client/dashboard/sites/plans.ts
@@ -1,14 +1,6 @@
 import { DotcomPlans } from '../data/constants';
 import type { Site } from '../data/types';
 
-export const isSitePlanOneOf = ( site: Site, plans: DotcomPlans[] ) => {
-	if ( ! site.plan ) {
-		return false;
-	}
-
-	return plans.includes( site.plan.product_slug as DotcomPlans );
-};
-
 export const isSitePlanNotOneOf = ( site: Site, plans: DotcomPlans[] ) => {
 	if ( ! site.plan ) {
 		return false;

--- a/client/dashboard/sites/plans.ts
+++ b/client/dashboard/sites/plans.ts
@@ -1,6 +1,14 @@
 import { DotcomPlans } from '../data/constants';
 import type { Site } from '../data/types';
 
+export const isSitePlanOneOf = ( site: Site, plans: DotcomPlans[] ) => {
+	if ( ! site.plan ) {
+		return false;
+	}
+
+	return plans.includes( site.plan.product_slug as DotcomPlans );
+};
+
 export const isSitePlanNotOneOf = ( site: Site, plans: DotcomPlans[] ) => {
 	if ( ! site.plan ) {
 		return false;


### PR DESCRIPTION
Ref DOTDASH-19

## Proposed Changes

This PR implements site badges. 

Table view
![SCR-20250626-mhld](https://github.com/user-attachments/assets/6f10c535-7281-4132-8875-83e9cd670d46)

List view
![SCR-20250626-mhmx](https://github.com/user-attachments/assets/a46d39d4-b5b6-4601-8478-238fb4dad694)

> [!NOTE]
> For this PR, the badges will not have colors since there's currently no way to achieve that via the Badge DS component. See QOBjujZah0UlGDDdLKZhzi-fi-4204_220132#1313202223 for more context.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Sites List v2 development.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Ensure that the site badges P2 site, staging site, and trial site render as intended.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?