### PR TITLE
Fix unit test: add missing default operator

### DIFF
--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- Update the field type definitions to declare the default and valid operators they support. Fields with no `type` property can use all operators and, if none is provided in the field's config, they'll use `is` and `isNot` by default.
+- Update the field type definitions to declare the default and valid operators they support. Fields with no `type` property can use all operators; if none is provided in the field's config, they'll use `is` and `isNot` by default.
 - Add a story for each FieldTypeDefinition.
 - Add new filter operators: `before`, `after`, `beforeInc`, and `afterInc` for date fields.
 - Adjust the spacing of the `DataForm` based on the type.

--- a/packages/dataviews/src/test/normalize-fields.ts
+++ b/packages/dataviews/src/test/normalize-fields.ts
@@ -113,6 +113,7 @@ describe( 'normalizeFields: default getValue', () => {
 					'greaterThan',
 					'lessThanOrEqual',
 					'greaterThanOrEqual',
+					'between',
 				],
 			} );
 		} );


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/104296 

## Proposed Changes

Adds a missing default operator for a unit test.

## Why are these changes being made?

The PR checks were green for 10496, but just a bit before [another PR](https://github.com/Automattic/wp-calypso/pull/103577) landed in trunk that affected a unit test upon merging.

## Testing Instructions

Make sure unit tests pass.