### PR TITLE
STATS-111: Restore Archive Searches item label

### DIFF
--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -925,20 +925,15 @@ describe( 'utils', () => {
 					},
 					{
 						label: 'Searches',
-						value: 4,
+						value: 3,
 						children: [
 							{
-								label: 'http://jetpack.com/?s=I+can',
+								label: 'I can',
 								value: 2,
 								link: 'http://jetpack.com/?s=I+can',
 							},
 							{
-								label: 'http://jetpack.com/?s=',
-								value: 1,
-								link: 'http://jetpack.com/?s=',
-							},
-							{
-								label: 'http://jetpack.com/?s=plugin',
+								label: 'plugin',
 								value: 1,
 								link: 'http://jetpack.com/?s=plugin',
 							},
@@ -1129,37 +1124,6 @@ describe( 'utils', () => {
 						],
 					},
 					{
-						label: 'Searches',
-						value: 9,
-						children: [
-							{
-								label: 'http://jetpack.com/?s=',
-								value: 4,
-								link: 'http://jetpack.com/?s=',
-							},
-							{
-								label: 'http://jetpack.com/?s=I+can',
-								value: 2,
-								link: 'http://jetpack.com/?s=I+can',
-							},
-							{
-								label: 'http://jetpack.com/?s=my+website+is+not+active',
-								value: 1,
-								link: 'http://jetpack.com/?s=my+website+is+not+active',
-							},
-							{
-								label: 'http://jetpack.com/?s=Ani',
-								value: 1,
-								link: 'http://jetpack.com/?s=Ani',
-							},
-							{
-								label: 'http://jetpack.com/?s=plugin',
-								value: 1,
-								link: 'http://jetpack.com/?s=plugin',
-							},
-						],
-					},
-					{
 						label: 'Dates',
 						value: 7,
 						children: [
@@ -1172,6 +1136,32 @@ describe( 'utils', () => {
 								label: '2023/06',
 								value: 3,
 								link: 'http://jetpack.com/2023/06',
+							},
+						],
+					},
+					{
+						label: 'Searches',
+						value: 5,
+						children: [
+							{
+								label: 'I can',
+								value: 2,
+								link: 'http://jetpack.com/?s=I+can',
+							},
+							{
+								label: 'my website is not active',
+								value: 1,
+								link: 'http://jetpack.com/?s=my+website+is+not+active',
+							},
+							{
+								label: 'Ani',
+								value: 1,
+								link: 'http://jetpack.com/?s=Ani',
+							},
+							{
+								label: 'plugin',
+								value: 1,
+								link: 'http://jetpack.com/?s=plugin',
 							},
 						],
 					},

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -482,7 +482,7 @@ export const normalizers = {
 						totalViews += item.views;
 
 						return {
-							label: [ 'search' ].includes( archiveKey ) ? item.href : item.value,
+							label: item.value,
 							value: item.views,
 							link: item.href,
 						};

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -478,15 +478,17 @@ export const normalizers = {
 				if ( 'home' !== archiveKey && hasItems ) {
 					let totalViews = 0;
 
-					const children = archiveItems.map( ( item ) => {
-						totalViews += item.views;
+					const children = archiveItems
+						.filter( ( i ) => !! i.value )
+						.map( ( item ) => {
+							totalViews += item.views;
 
-						return {
-							label: item.value,
-							value: item.views,
-							link: item.href,
-						};
-					} );
+							return {
+								label: item.value,
+								value: item.views,
+								link: item.href,
+							};
+						} );
 
 					accumulatedArchives.push( {
 						label: getArchiveKeyLabel( archiveKey ),


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of STATS-111.

## Proposed Changes

* Use item value as the label instead of item href for Searches.
* Filter Archive items with an empty value.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso branch.
* Navigate to Stats > Traffic page with the feature flag: `?flags=stats/archive-breakdown`.
* Ensure the Archive pages show the `Searches` items with the value as label, and the empty value item is filtered.

|Before|After|
|-|-|
|<img width="642" alt="截圖 2025-06-19 下午2 40 46" src="https://github.com/user-attachments/assets/8e87d5f9-8021-47af-9310-84c1785b62f5" />|<img width="633" alt="截圖 2025-06-19 下午2 39 49" src="https://github.com/user-attachments/assets/46dc1aff-9e01-4519-b618-7c16bcd3e6be" />|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
