### PR TITLE
STATS-107: Preserve tab while navigating from the "Most viewed" section of Traffic page to the summary page.

### DIFF
--- a/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
+++ b/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
@@ -154,6 +154,7 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 					query={ query }
 					statType={ statType }
 					showSummaryLink={ !! summary }
+					summaryLinkModifier={ ( link: string ) => `${ link }&viewType=${ statType }` }
 					className={ className }
 					summary={ summary }
 					listItemClassName={ listItemClassName }

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -36,6 +36,7 @@ class StatsModule extends Component {
 		query: PropTypes.object,
 		statType: PropTypes.string,
 		showSummaryLink: PropTypes.bool,
+		summaryLinkModifier: PropTypes.func,
 		translate: PropTypes.func,
 		metricLabel: PropTypes.string,
 		mainItemLabel: PropTypes.string,
@@ -58,6 +59,7 @@ class StatsModule extends Component {
 		valueField: 'value',
 		minutesLimit: 30,
 		isRealTime: false,
+		summaryLinkModifier: ( link ) => link,
 	};
 
 	state = {
@@ -181,7 +183,7 @@ class StatsModule extends Component {
 	}
 
 	getSummaryLink() {
-		const { summary, period, path, siteSlug, query } = this.props;
+		const { summary, period, path, siteSlug, query, summaryLinkModifier } = this.props;
 		if ( summary ) {
 			return;
 		}
@@ -199,7 +201,7 @@ class StatsModule extends Component {
 			url += `?startDate=${ period.endOf.format( 'YYYY-MM-DD' ) }`;
 		}
 
-		return url;
+		return summaryLinkModifier( url );
 	}
 
 	isAllTimeList() {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #107

## Proposed Changes

* Preserve tab while navigating from the "Most viewed" section of Traffic page to the summary page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso branch.
* Navigate to Stats > Traffic page with the feature flag: ?flags=stats/archive-breakdown.
* The tab selection is preserved while navigating from the "Most viewed" section to the summary page, by clicking on the view all / view details button.
* When navigating backward (e.g., by clicking the back button), the "Posts & Pages" tab will always be selected.

[[Screencast](https://linear.app/a8c/issue/STATS-107/add-query-parameter-viewtype-in-the-view-all-link#comment-351a0004)]

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
