### PR TITLE
[NOX In-Context] Remove the Opening doors screen when connecting Jetpack from the WooPayments flows

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -94,7 +94,7 @@ import { authQueryPropTypes, getRoleFromScope } from './utils';
 import wooDnaConfig from './woo-dna-config';
 import WooInstallExtSuccessNotice from './woo-install-ext-success-notice';
 import { WooLoader } from './woo-loader';
-import { ConnectingYourAccountStage } from './woo-loader-stages';
+import { ConnectingYourAccountStage, PlaceholderStage } from './woo-loader-stages';
 
 /**
  * Constants
@@ -1270,7 +1270,7 @@ export class JetpackAuthorize extends Component {
 					shouldCloseOnEsc={ false }
 					isDismissible={ false }
 				>
-					<WooLoader stages={ [ ConnectingYourAccountStage ] } />
+					<WooLoader stages={ [ ConnectingYourAccountStage, PlaceholderStage ] } />
 				</Modal>
 			);
 		}

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -94,7 +94,7 @@ import { authQueryPropTypes, getRoleFromScope } from './utils';
 import wooDnaConfig from './woo-dna-config';
 import WooInstallExtSuccessNotice from './woo-install-ext-success-notice';
 import { WooLoader } from './woo-loader';
-import { ConnectingYourAccountStage, OpeningTheDoorsStage } from './woo-loader-stages';
+import { ConnectingYourAccountStage } from './woo-loader-stages';
 
 /**
  * Constants
@@ -1270,7 +1270,7 @@ export class JetpackAuthorize extends Component {
 					shouldCloseOnEsc={ false }
 					isDismissible={ false }
 				>
-					<WooLoader stages={ [ ConnectingYourAccountStage, OpeningTheDoorsStage ] } />
+					<WooLoader stages={ [ ConnectingYourAccountStage ] } />
 				</Modal>
 			);
 		}

--- a/client/jetpack-connect/woo-loader-stages.tsx
+++ b/client/jetpack-connect/woo-loader-stages.tsx
@@ -1,6 +1,4 @@
 import { __ } from '@wordpress/i18n';
-import WooPurpleHeart from 'calypso/assets/images/onboarding/woo-purple-heart.png';
-import OpeningImage from './woo-loader-stage-images/OpeningImage';
 import SetupImage from './woo-loader-stage-images/SetupImage';
 
 export const ConnectingYourAccountStage = {
@@ -23,14 +21,4 @@ export const CreatingYourAccountStage = {
 	),
 	duration: 10000,
 	progress: 70,
-};
-
-export const OpeningTheDoorsStage = {
-	title: __( 'Opening the doors' ),
-	image: OpeningImage,
-	label: __( '#FunWooFact:' ),
-	text: __( 'Our favorite color is purple' ),
-	element: <img src={ WooPurpleHeart } alt="loader-hearticon" className="loader-hearticon" />,
-	duration: 30000,
-	progress: 100,
 };

--- a/client/jetpack-connect/woo-loader-stages.tsx
+++ b/client/jetpack-connect/woo-loader-stages.tsx
@@ -25,7 +25,7 @@ export const CreatingYourAccountStage = {
 
 // This is a placeholder stage that is used so the progress bar can reach 100%
 export const PlaceholderStage = {
-	title: __( 'Creating your account' ),
+	title: __( 'Connecting your account' ),
 	image: SetupImage,
 	label: __( '#FunWooFact:' ),
 	text: __(

--- a/client/jetpack-connect/woo-loader-stages.tsx
+++ b/client/jetpack-connect/woo-loader-stages.tsx
@@ -22,3 +22,15 @@ export const CreatingYourAccountStage = {
 	duration: 10000,
 	progress: 70,
 };
+
+// This is a placeholder stage that is used so the progress bar can reach 100%
+export const PlaceholderStage = {
+	title: __( 'Creating your account' ),
+	image: SetupImage,
+	label: __( '#FunWooFact:' ),
+	text: __(
+		'There are more than 150 WooCommerce meetups held all over the world! A great way to meet fellow store owners.'
+	),
+	duration: 30000,
+	progress: 100,
+};

--- a/client/jetpack-connect/woo-loader-stages.tsx
+++ b/client/jetpack-connect/woo-loader-stages.tsx
@@ -8,7 +8,7 @@ export const ConnectingYourAccountStage = {
 	text: __(
 		'There are more than 150 WooCommerce meetups held all over the world! A great way to meet fellow store owners.'
 	),
-	duration: 8000,
+	duration: 10000,
 	progress: 70,
 };
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes WOOPLUG-4679

## Proposed Changes

* This removes the Opening doors screen when connecting Jetpack from the WooPayments flows.
* Technically, this step is for connecting Jetpack only and doesn't "open doors" as the onboarding still has some other steps.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* In response to a design review of the current flow

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Get Calypso locally, configure it as described in the README, and run it using `yarn start`
* Create a new JN site with WooCommerce
* Go to Settings > Payments, and install WooPayments (make sure the country is US or UK, or any supported country)
* Once installed, select a few PMs and click continue
* Then click on the connect WP.com

![CleanShot 2025-06-19 at 08 52 46@2x](https://github.com/user-attachments/assets/f49f181a-c423-4a4c-a524-4e44688a384e)

* When you get redirected, change the URL by deleting `https://wordpress.com` and replacing it with `http://calypso.localhost:3000`. You should now be using the local Calypso installation.
* Continue the Jetpack connection steps and make sure you don't see the "Opening doors" screen

https://github.com/user-attachments/assets/6d60ded1-1497-49f6-aa50-d34a446cfbf2

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
