### PR TITLE
Refactor CSV download path logic in StatsSummary.

### DIFF
--- a/client/my-sites/stats/features/modules/stats-top-posts/use-option-labels.ts
+++ b/client/my-sites/stats/features/modules/stats-top-posts/use-option-labels.ts
@@ -16,7 +16,7 @@ export function validQueryViewType( statType: StatType = MAIN_STAT_TYPE ) {
 		return MAIN_STAT_TYPE;
 	}
 
-	return ! [ MAIN_STAT_TYPE, SUB_STAT_TYPE ].includes( statType ) ? MAIN_STAT_TYPE : statType;
+	return [ MAIN_STAT_TYPE, SUB_STAT_TYPE ].includes( statType ) ? statType : MAIN_STAT_TYPE;
 }
 
 export default function useOptionLabels() {

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -28,7 +28,10 @@ import StatsModuleLocations from '../features/modules/stats-locations';
 import LocationsNavTabs from '../features/modules/stats-locations/locations-nav-tabs';
 import { GEO_MODES } from '../features/modules/stats-locations/types';
 import PostsNavTabs from '../features/modules/stats-top-posts/nav-tabs';
-import { validQueryViewType as getValidTopPostStatType } from '../features/modules/stats-top-posts/use-option-labels';
+import {
+	validQueryViewType as getValidTopPostStatType,
+	SUB_STAT_TYPE as TOP_POSTS_SUB_STAT_TYPE,
+} from '../features/modules/stats-top-posts/use-option-labels';
 import StatsModuleUTM from '../features/modules/stats-utm';
 import { shouldGateStats } from '../hooks/use-should-gate-stats';
 import { StatsGlobalValuesContext } from '../pages/providers/global-provider';
@@ -91,6 +94,28 @@ class StatsSummary extends Component {
 				context={ this.props.context }
 			/>
 		);
+	}
+
+	getPath( statType ) {
+		if ( statType === 'statsCountryViews' ) {
+			const geoMode = this.props.context.query.geoMode;
+			const geoModeLabel =
+				geoMode && Object.prototype.hasOwnProperty.call( GEO_MODES, geoMode )
+					? GEO_MODES[ geoMode ]
+					: 'country';
+
+			return `locations-${ geoModeLabel }`;
+		}
+
+		switch ( statType ) {
+			case TOP_POSTS_SUB_STAT_TYPE:
+				return 'archives';
+
+			case 'statsTopPosts':
+				return 'posts';
+			default:
+				return '';
+		}
 	}
 
 	render() {
@@ -225,11 +250,10 @@ class StatsSummary extends Component {
 
 			case 'posts':
 				title = StatsStrings.posts.title;
-				path = 'posts';
 				statType = getValidTopPostStatType( moduleQuery?.viewType );
 				summaryView = (
 					<Fragment key="posts-summary">
-						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
+						{ this.renderSummaryHeader( this.getPath( statType ), statType, false, moduleQuery ) }
 						<StatsModuleTopPosts
 							moduleStrings={ StatsStrings.posts }
 							period={ this.props.period }
@@ -387,12 +411,6 @@ class StatsSummary extends Component {
 
 		const { module } = this.props.context.params;
 
-		const geoMode = this.props.context.query.geoMode;
-		const geoModeLabel =
-			geoMode && Object.prototype.hasOwnProperty.call( GEO_MODES, geoMode )
-				? GEO_MODES[ geoMode ]
-				: 'country';
-
 		return (
 			<Main fullWidthLayout>
 				<PageViewTracker
@@ -415,7 +433,7 @@ class StatsSummary extends Component {
 									<DownloadCsv
 										statType={ statType }
 										query={ moduleQuery }
-										path={ statType === 'statsCountryViews' ? `${ path }-${ geoModeLabel }` : path }
+										path={ this.getPath( statType ) || path }
 										period={ this.props.period }
 										skipQuery
 										hideIfNoData

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -113,6 +113,24 @@ class StatsSummary extends Component {
 
 			case 'statsTopPosts':
 				return 'posts';
+			case 'statsReferrers':
+				return 'referrers';
+			case 'statsClicks':
+				return 'clicks';
+			case 'statsCountryViews':
+				return 'countryviews';
+			case 'statsTopAuthors':
+				return 'authors';
+			case 'statsVideoPlays':
+				return 'videoplays';
+			case 'statsFileDownloads':
+				return 'filedownloads';
+			case 'statsSearchTerms':
+				return 'searchterms';
+			case 'statsUTM':
+				return 'utm';
+			case 'statsDevices':
+				return 'devices';
 			default:
 				return '';
 		}
@@ -132,7 +150,6 @@ class StatsSummary extends Component {
 		let summaryView;
 		let chartTitle;
 		let barChart;
-		let path;
 		let statType;
 
 		const { period, endOf } = this.props.period;
@@ -165,11 +182,10 @@ class StatsSummary extends Component {
 		switch ( this.props.context.params.module ) {
 			case 'referrers':
 				title = translate( 'Referrers' );
-				path = 'referrers';
 				statType = 'statsReferrers';
 				summaryView = (
 					<Fragment key="referrers-summary">
-						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
+						{ this.renderSummaryHeader( this.getPath( statType ), statType, false, moduleQuery ) }
 						<StatsModuleReferrers
 							moduleStrings={ StatsStrings.referrers }
 							period={ this.props.period }
@@ -183,11 +199,10 @@ class StatsSummary extends Component {
 
 			case 'clicks':
 				title = translate( 'Clicks' );
-				path = 'clicks';
 				statType = 'statsClicks';
 				summaryView = (
 					<Fragment key="clicks-summary">
-						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
+						{ this.renderSummaryHeader( this.getPath( statType ), statType, false, moduleQuery ) }
 						<StatsModuleClicks
 							moduleStrings={ StatsStrings.clicks }
 							period={ this.props.period }
@@ -201,11 +216,10 @@ class StatsSummary extends Component {
 
 			case 'countryviews':
 				title = translate( 'Countries' );
-				path = 'countryviews';
 				statType = 'statsCountryViews';
 				summaryView = (
 					<Fragment key="countries-summary">
-						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
+						{ this.renderSummaryHeader( this.getPath( statType ), statType, false, moduleQuery ) }
 						{ isEnabled( 'stats/locations' ) ? (
 							<StatsModuleLocations
 								moduleStrings={ StatsStrings.countries }
@@ -230,11 +244,10 @@ class StatsSummary extends Component {
 
 			case 'locations':
 				title = translate( 'Locations' );
-				path = 'locations';
 				statType = 'statsCountryViews';
 				summaryView = (
 					<Fragment key="countries-summary">
-						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
+						{ this.renderSummaryHeader( this.getPath( statType ), statType, false, moduleQuery ) }
 						<StatsModuleLocations
 							moduleStrings={ StatsStrings.countries }
 							period={ this.props.period }
@@ -267,13 +280,12 @@ class StatsSummary extends Component {
 
 			case 'authors':
 				title = translate( 'Authors' );
-				path = 'authors';
 				statType = 'statsTopAuthors';
 				// TODO: should be refactored so that className doesn't have to be passed in
 				/* eslint-disable wpcalypso/jsx-classname-namespace */
 				summaryView = (
 					<Fragment key="authors-summary">
-						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
+						{ this.renderSummaryHeader( this.getPath( statType ), statType, false, moduleQuery ) }
 						<StatsModuleAuthors
 							moduleStrings={ StatsStrings.authors }
 							period={ this.props.period }
@@ -289,7 +301,6 @@ class StatsSummary extends Component {
 
 			case 'videoplays':
 				title = translate( 'Videos' );
-				path = 'videoplays';
 				statType = 'statsVideoPlays';
 				moduleQuery.complete_stats = 1;
 				summaryView = (
@@ -297,7 +308,7 @@ class StatsSummary extends Component {
 						{ /* For CSV button to work, video page needs to pass custom data to the button.
 								It can't use the shared header as long as the CSV download button stays there. */ }
 						<VideoPressStatsModule
-							path={ path }
+							path={ this.getPath( statType ) }
 							moduleStrings={ StatsStrings.videoplays }
 							period={ this.props.period }
 							query={ query }
@@ -311,11 +322,10 @@ class StatsSummary extends Component {
 
 			case 'filedownloads':
 				title = translate( 'File Downloads' );
-				path = 'filedownloads';
 				statType = 'statsFileDownloads';
 				summaryView = (
 					<Fragment key="filedownloads-summary">
-						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
+						{ this.renderSummaryHeader( this.getPath( statType ), statType, false, moduleQuery ) }
 						<StatsModuleDownloads
 							moduleStrings={ StatsStrings.filedownloads }
 							period={ this.props.period }
@@ -370,11 +380,10 @@ class StatsSummary extends Component {
 
 			case 'searchterms':
 				title = translate( 'Search Terms' );
-				path = 'searchterms';
 				statType = 'statsSearchTerms';
 				summaryView = (
 					<Fragment key="search-terms-summary">
-						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
+						{ this.renderSummaryHeader( this.getPath( statType ), statType, false, moduleQuery ) }
 						<StatsModuleSearch
 							moduleStrings={ StatsStrings.search }
 							period={ this.props.period }
@@ -391,7 +400,6 @@ class StatsSummary extends Component {
 				break;
 			case 'utm': {
 				title = translate( 'UTM insights' );
-				path = 'utm';
 				statType = 'statsUTM';
 				summaryView = <></>; // done inline to use context values
 				break;
@@ -399,7 +407,6 @@ class StatsSummary extends Component {
 			case 'devices': {
 				// TODO: finish after the Traffic page.
 				title = translate( 'Devices' );
-				path = 'devices';
 				statType = 'statsDevices';
 
 				summaryView = <></>;
@@ -433,7 +440,7 @@ class StatsSummary extends Component {
 									<DownloadCsv
 										statType={ statType }
 										query={ moduleQuery }
-										path={ this.getPath( statType ) || path }
+										path={ this.getPath( statType ) }
 										period={ this.props.period }
 										skipQuery
 										hideIfNoData
@@ -468,7 +475,12 @@ class StatsSummary extends Component {
 									<>
 										{ supportsUTMStats || isInternal ? (
 											<>
-												{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
+												{ this.renderSummaryHeader(
+													this.getPath( statType ),
+													statType,
+													false,
+													moduleQuery
+												) }
 												<StatsModuleUTM
 													siteId={ siteId }
 													period={ this.props.period }

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -28,6 +28,7 @@ import StatsModuleLocations from '../features/modules/stats-locations';
 import LocationsNavTabs from '../features/modules/stats-locations/locations-nav-tabs';
 import { GEO_MODES } from '../features/modules/stats-locations/types';
 import PostsNavTabs from '../features/modules/stats-top-posts/nav-tabs';
+import { validQueryViewType as getValidTopPostStatType } from '../features/modules/stats-top-posts/use-option-labels';
 import StatsModuleUTM from '../features/modules/stats-utm';
 import { shouldGateStats } from '../hooks/use-should-gate-stats';
 import { StatsGlobalValuesContext } from '../pages/providers/global-provider';
@@ -225,7 +226,7 @@ class StatsSummary extends Component {
 			case 'posts':
 				title = StatsStrings.posts.title;
 				path = 'posts';
-				statType = 'statsTopPosts';
+				statType = getValidTopPostStatType( moduleQuery?.viewType );
 				summaryView = (
 					<Fragment key="posts-summary">
 						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Depends on https://github.com/Automattic/wp-calypso/pull/104245/

## Proposed Changes

* The change shouldn't have any effect.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* All the CSV download action in Stats summary pages should work as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
