### PR TITLE
Help Center: Fix "View Conversation" notice 

### DIFF
--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -47,7 +47,6 @@ export const useGetCombinedChat = (
 
 	useEffect( () => {
 		const interactionHasChanged = previousUuidRef.current !== currentSupportInteraction?.uuid;
-		previousUuidRef.current = currentSupportInteraction?.uuid;
 		if (
 			! currentSupportInteraction?.uuid ||
 			isOdieChatLoading ||
@@ -56,6 +55,8 @@ export const useGetCombinedChat = (
 		) {
 			return;
 		}
+
+		previousUuidRef.current = currentSupportInteraction?.uuid;
 
 		// We don't have a conversation id, so our chat is simply the odie chat
 		if ( ! conversationId ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTSUP-217/help-center-experience-fix-broken-view-conversation-link

## Proposed Changes

We had a bug in the `use-get-combined-chat` function, where the chat was not refreshed when clicking on the "View conversation":
- interactionHasChanged was set to true, correctly
- We set up previousUuidRef with the new interaction
- The first if returns, as `isOdieChatLoading` still is true
- When isOdieChatLoading gets to false, interactionHasChanged is false this time, since we already updated previousUuidRef

Now I moved the previousUuidRef assigned after the first if (where we check that we should proceed in recalculating the chat).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Clicking the "View conversation" link in the “You have another open conversation already started.” notice doesn't result in any action.

![image](https://github.com/user-attachments/assets/e3e60e69-c5ed-48b7-8067-b17fd45dafcc)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You should have an account with a single open Zendesk conversation.
* Click the 3-dots menu on top and click on New Chat
* A new AI chat should open, with the notice at the bottom. Click on "View conversation"
* You should get to the open Zendesk conversation.
* Test a new chat with AI and escalating it to Zendesk.
* Create another chat with AI and you should see "view conversation**s**". Click on that and you should land in the History page.

