### PR TITLE
DS Site: Reflect move to `@automattic/ui`

### DIFF
--- a/apps/design-system-docs/docs/components/packages/a8c-ui.mdx
+++ b/apps/design-system-docs/docs/components/packages/a8c-ui.mdx
@@ -1,3 +1,12 @@
-# `@automattic/ui`
+# @automattic/ui
 
-Coming soon.
+[![NPM Version](https://img.shields.io/npm/v/%40automattic%2Fui)](https://www.npmjs.com/package/@automattic/ui)
+
+Used on top of the [WordPress Design System](./wp-components/) layer.
+
+This package of Automattic UI components is designed to be safe for bundling anywhere.
+
+- No dependency on `@wordpress/components`.
+- No CSS collisions when multiple versions of the package are loaded in the same page.
+- No need for a separate RTL stylesheet.
+- SSR-friendly.

--- a/apps/design-system-docs/docs/components/packages/index.mdx
+++ b/apps/design-system-docs/docs/components/packages/index.mdx
@@ -3,5 +3,3 @@ sidebar_position: 2
 ---
 
 # Package Reference
-
-Add content here.

--- a/apps/design-system-docs/docs/components/packages/wp-components/data.ts
+++ b/apps/design-system-docs/docs/components/packages/wp-components/data.ts
@@ -72,6 +72,16 @@ export const data: ComponentData[] = [
 		notes: 'Planned for deprecation.',
 	},
 	{
+		id: 'badge',
+		name: 'Badge',
+		whereUsed: 'global',
+		status: 'stable',
+		figma:
+			'https://www.figma.com/design/804HN2REV2iap2ytjRQ055/WordPress-Design-System?node-id=19297-39220&t=YhMXMUEdznvUwLv9-4',
+		docs: 'https://wordpress.github.io/gutenberg/?path=/docs/components-badge--docs',
+		notes: 'Still a private API. If possible, use `Badge` from `@automattic/ui` instead.',
+	},
+	{
 		id: 'base-control',
 		name: 'BaseControl',
 		whereUsed: 'global',
@@ -225,7 +235,7 @@ export const data: ComponentData[] = [
 		whereUsed: 'global',
 		status: 'use-with-caution',
 		docs: 'https://wordpress.github.io/gutenberg/?path=/docs/components-datepicker--docs',
-		notes: 'If possible, use `DateCalendar` from `@automattic/components` instead.',
+		notes: 'If possible, use `DateCalendar` from `@automattic/ui` instead.',
 	},
 	{
 		id: 'date-time-picker',
@@ -234,7 +244,7 @@ export const data: ComponentData[] = [
 		status: 'use-with-caution',
 		docs: 'https://wordpress.github.io/gutenberg/?path=/docs/components-datetimepicker--docs',
 		notes:
-			'If possible, use `DateCalendar` from `@automattic/components` instead. For the input fields, consider using an `TextControl` with `type="date"` or `type="datetime-local"`.',
+			'If possible, use `DateCalendar` from `@automattic/ui` instead. For the input fields, consider using an `TextControl` with `type="date"` or `type="datetime-local"`.',
 	},
 	{
 		id: 'disabled',

--- a/apps/design-system-docs/docs/components/packages/wp-components/index.mdx
+++ b/apps/design-system-docs/docs/components/packages/wp-components/index.mdx
@@ -6,4 +6,8 @@ import { WPComponentsTable } from './wp-components-table';
 
 # @wordpress/components
 
+[![NPM Version](https://img.shields.io/npm/v/%40wordpress%2Fcomponents)](https://www.npmjs.com/package/@wordpress/components)
+
+Used as the base layer for the Automattic Design System.
+
 <WPComponentsTable />


### PR DESCRIPTION
## Proposed Changes

Updates the DS site to reflect our move from `@automattic/components` to `@automattic/ui`.

<img width="949" alt="automattic/ui package home" src="https://github.com/user-attachments/assets/ef389c7c-d3e1-487b-ba16-a98039832d3a" />

## Testing Instructions

From the live link, go to the the Components ▸ Package Reference section.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
