### PR TITLE
Update Speed Test Tool links to local ones

### DIFF
--- a/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
@@ -1,5 +1,7 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import {
 	Metrics,
 	PerformanceMetricsHistory,
@@ -141,23 +143,11 @@ export const CoreWebVitalsDetails: React.FC< CoreWebVitalsDetailsProps > = ( {
 				<p>
 					{ getMetricValuations( translate )[ activeTab ].explanation }
 					&nbsp;
-					{ isPerformanceScoreSelected ? (
-						<a
-							href="https://developer.chrome.com/docs/lighthouse/performance/performance-scoring"
-							target="_blank"
-							rel="noreferrer"
-						>
-							{ translate( 'See calculator ↗' ) }
-						</a>
-					) : (
-						<a
-							href={ `https://web.dev/articles/${ encodeURIComponent( activeTab ) }` }
-							target="_blank"
-							rel="noreferrer"
-						>
-							{ translate( 'Learn more ↗' ) }
-						</a>
-					) }
+					<InlineSupportLink
+						supportLink={ localizeUrl( getMetricValuations( translate )[ activeTab ].docsUrl ) }
+					>
+						{ translate( 'Learn more ↗' ) }
+					</InlineSupportLink>
 				</p>
 				<div className="core-web-vitals-display__ranges">
 					<div className="range">

--- a/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
@@ -1,7 +1,6 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
-import InlineSupportLink from 'calypso/components/inline-support-link';
 import {
 	Metrics,
 	PerformanceMetricsHistory,
@@ -143,11 +142,13 @@ export const CoreWebVitalsDetails: React.FC< CoreWebVitalsDetailsProps > = ( {
 				<p>
 					{ getMetricValuations( translate )[ activeTab ].explanation }
 					&nbsp;
-					<InlineSupportLink
-						supportLink={ localizeUrl( getMetricValuations( translate )[ activeTab ].docsUrl ) }
+					<a
+						href={ localizeUrl( getMetricValuations( translate )[ activeTab ].docsUrl ) }
+						target="_blank"
+						rel="noreferrer"
 					>
 						{ translate( 'Learn more ↗' ) }
-					</InlineSupportLink>
+					</a>
 				</p>
 				<div className="core-web-vitals-display__ranges">
 					<div className="range">

--- a/client/performance-profiler/components/disclaimer-section/index.tsx
+++ b/client/performance-profiler/components/disclaimer-section/index.tsx
@@ -15,7 +15,11 @@ export const Disclaimer = () => {
 					) }
 				</div>
 				<div className="link">
-					<a href="https://developer.chrome.com/docs/crux" target="_blank" rel="noreferrer">
+					<a
+						href="https://developer.wordpress.com/docs/site-performance/speed-test/#accessing-the-speed-test-tool"
+						target="_blank"
+						rel="noreferrer"
+					>
 						{ translate( 'Learn more about the Chrome UX Report ↗' ) }
 					</a>
 				</div>

--- a/client/performance-profiler/components/performance-score/index.tsx
+++ b/client/performance-profiler/components/performance-score/index.tsx
@@ -98,12 +98,12 @@ export const PerformanceScore = ( props: PerformanceScoreProps ) => {
 			</div>
 			<div className="disclaimer">
 				{ translate(
-					'The performance score is a combined representation of your site‘s individual speed metrics. {{link}}See calculator ↗{{/link}}',
+					'The performance score is a combined representation of your site‘s individual speed metrics. {{link}}Learn more ↗{{/link}}',
 					{
 						components: {
 							link: (
 								<a
-									href="https://developer.chrome.com/docs/lighthouse/performance/performance-scoring"
+									href="https://developer.wordpress.com/docs/site-performance/speed-test/#1-performance-score"
 									target="_blank"
 									rel="noreferrer"
 								/>

--- a/client/performance-profiler/components/performance-score/index.tsx
+++ b/client/performance-profiler/components/performance-score/index.tsx
@@ -103,7 +103,7 @@ export const PerformanceScore = ( props: PerformanceScoreProps ) => {
 						components: {
 							link: (
 								<a
-									href="https://developer.wordpress.com/docs/site-performance/speed-test/#1-performance-score"
+									href="https://developer.wordpress.com/docs/site-performance/speed-test/#performance-score"
 									target="_blank"
 									rel="noreferrer"
 								/>

--- a/client/performance-profiler/utils/metrics.ts
+++ b/client/performance-profiler/utils/metrics.ts
@@ -21,6 +21,8 @@ export const getMetricValuations = ( translate: ( text: string ) => string ) => 
 		explanation: translate(
 			'First Contentful Paint reflects the time it takes to display the first text or image to visitors. The best sites load in under 1.8 seconds.'
 		),
+		docsUrl:
+			'https://developer.wordpress.com/docs/site-performance/speed-test/#2-first-contentful-paint-fcp-',
 	},
 	lcp: {
 		good: translate( 'Your site‘s Largest Contentful Paint is excellent' ),
@@ -31,6 +33,8 @@ export const getMetricValuations = ( translate: ( text: string ) => string ) => 
 		explanation: translate(
 			'Largest Contentful Paint measures the time it takes for the largest visible element (like an image or text block) on a page to load. The best sites load in under 2.5 seconds.'
 		),
+		docsUrl:
+			'https://developer.wordpress.com/docs/site-performance/speed-test/#3-largest-contentful-paint-lcp-',
 	},
 	cls: {
 		good: translate( 'Your site‘s Cumulative Layout Shift is excellent' ),
@@ -41,6 +45,8 @@ export const getMetricValuations = ( translate: ( text: string ) => string ) => 
 		explanation: translate(
 			'Cumulative Layout Shift is assessed by measuring how often content moves unexpectedly during loading. The best sites have a score of 0.1 or lower.'
 		),
+		docsUrl:
+			'https://developer.wordpress.com/docs/site-performance/speed-test/#4-cumulative-layout-shift-cls-',
 	},
 	inp: {
 		good: translate( 'Your site‘s Interaction to Next Paint is excellent' ),
@@ -51,6 +57,8 @@ export const getMetricValuations = ( translate: ( text: string ) => string ) => 
 		explanation: translate(
 			'Interaction to Next Paint measures the overall responsiveness of a webpage by evaluating how quickly it reacts to user interactions. A good score is 200 milliseconds or less, indicating that the page responds swiftly to user inputs.'
 		),
+		docsUrl:
+			'https://developer.wordpress.com/docs/site-performance/speed-test/#7-interaction-to-next-paint-inp-',
 	},
 	ttfb: {
 		good: translate( 'Your site‘s Time to First Byte is excellent' ),
@@ -61,6 +69,8 @@ export const getMetricValuations = ( translate: ( text: string ) => string ) => 
 		explanation: translate(
 			'Time to First Byte reflects the time taken for a user‘s browser to receive the first byte of data from the server after making a request. The best sites load around 800 milliseconds or less.'
 		),
+		docsUrl:
+			'https://developer.wordpress.com/docs/site-performance/speed-test/#5-time-to-first-byte-ttfb-',
 	},
 	tbt: {
 		good: translate( 'Your site‘s Total Blocking Time is excellent' ),
@@ -71,6 +81,8 @@ export const getMetricValuations = ( translate: ( text: string ) => string ) => 
 		explanation: translate(
 			'Total Blocking Time measures the total amount of time that a page is blocked from responding to user input, such as mouse clicks, screen taps, or keyboard presses. The best sites have a wait time of less than 200 milliseconds.'
 		),
+		docsUrl:
+			'https://developer.wordpress.com/docs/site-performance/speed-test/#6-total-blocking-time-tbt-',
 	},
 	overall: {
 		good: translate( 'Your site‘s Performance Score is excellent' ),
@@ -81,6 +93,8 @@ export const getMetricValuations = ( translate: ( text: string ) => string ) => 
 		explanation: translate(
 			'The performance score is a combined representation of your site‘s individual speed metrics.'
 		),
+		docsUrl:
+			'https://developer.wordpress.com/docs/site-performance/speed-test/#1-performance-score',
 	},
 } );
 

--- a/client/performance-profiler/utils/metrics.ts
+++ b/client/performance-profiler/utils/metrics.ts
@@ -22,7 +22,7 @@ export const getMetricValuations = ( translate: ( text: string ) => string ) => 
 			'First Contentful Paint reflects the time it takes to display the first text or image to visitors. The best sites load in under 1.8 seconds.'
 		),
 		docsUrl:
-			'https://developer.wordpress.com/docs/site-performance/speed-test/#2-first-contentful-paint-fcp-',
+			'https://developer.wordpress.com/docs/site-performance/speed-test/#first-contentful-paint-fcp-',
 	},
 	lcp: {
 		good: translate( 'Your site‘s Largest Contentful Paint is excellent' ),
@@ -34,7 +34,7 @@ export const getMetricValuations = ( translate: ( text: string ) => string ) => 
 			'Largest Contentful Paint measures the time it takes for the largest visible element (like an image or text block) on a page to load. The best sites load in under 2.5 seconds.'
 		),
 		docsUrl:
-			'https://developer.wordpress.com/docs/site-performance/speed-test/#3-largest-contentful-paint-lcp-',
+			'https://developer.wordpress.com/docs/site-performance/speed-test/#largest-contentful-paint-lcp-',
 	},
 	cls: {
 		good: translate( 'Your site‘s Cumulative Layout Shift is excellent' ),
@@ -46,7 +46,7 @@ export const getMetricValuations = ( translate: ( text: string ) => string ) => 
 			'Cumulative Layout Shift is assessed by measuring how often content moves unexpectedly during loading. The best sites have a score of 0.1 or lower.'
 		),
 		docsUrl:
-			'https://developer.wordpress.com/docs/site-performance/speed-test/#4-cumulative-layout-shift-cls-',
+			'https://developer.wordpress.com/docs/site-performance/speed-test/#cumulative-layout-shift-cls-',
 	},
 	inp: {
 		good: translate( 'Your site‘s Interaction to Next Paint is excellent' ),
@@ -58,7 +58,7 @@ export const getMetricValuations = ( translate: ( text: string ) => string ) => 
 			'Interaction to Next Paint measures the overall responsiveness of a webpage by evaluating how quickly it reacts to user interactions. A good score is 200 milliseconds or less, indicating that the page responds swiftly to user inputs.'
 		),
 		docsUrl:
-			'https://developer.wordpress.com/docs/site-performance/speed-test/#7-interaction-to-next-paint-inp-',
+			'https://developer.wordpress.com/docs/site-performance/speed-test/#interaction-to-next-paint-inp-',
 	},
 	ttfb: {
 		good: translate( 'Your site‘s Time to First Byte is excellent' ),
@@ -70,7 +70,7 @@ export const getMetricValuations = ( translate: ( text: string ) => string ) => 
 			'Time to First Byte reflects the time taken for a user‘s browser to receive the first byte of data from the server after making a request. The best sites load around 800 milliseconds or less.'
 		),
 		docsUrl:
-			'https://developer.wordpress.com/docs/site-performance/speed-test/#5-time-to-first-byte-ttfb-',
+			'https://developer.wordpress.com/docs/site-performance/speed-test/#time-to-first-byte-ttfb-',
 	},
 	tbt: {
 		good: translate( 'Your site‘s Total Blocking Time is excellent' ),
@@ -82,7 +82,7 @@ export const getMetricValuations = ( translate: ( text: string ) => string ) => 
 			'Total Blocking Time measures the total amount of time that a page is blocked from responding to user input, such as mouse clicks, screen taps, or keyboard presses. The best sites have a wait time of less than 200 milliseconds.'
 		),
 		docsUrl:
-			'https://developer.wordpress.com/docs/site-performance/speed-test/#6-total-blocking-time-tbt-',
+			'https://developer.wordpress.com/docs/site-performance/speed-test/#total-blocking-time-tbt-',
 	},
 	overall: {
 		good: translate( 'Your site‘s Performance Score is excellent' ),
@@ -93,8 +93,7 @@ export const getMetricValuations = ( translate: ( text: string ) => string ) => 
 		explanation: translate(
 			'The performance score is a combined representation of your site‘s individual speed metrics.'
 		),
-		docsUrl:
-			'https://developer.wordpress.com/docs/site-performance/speed-test/#1-performance-score',
+		docsUrl: 'https://developer.wordpress.com/docs/site-performance/speed-test/#performance-score',
 	},
 } );
 

--- a/client/site-profiler/components/footnote/index.tsx
+++ b/client/site-profiler/components/footnote/index.tsx
@@ -50,7 +50,10 @@ const onLearnMoreClick = () => {
 	recordTracksEvent( 'calypso_site_profiler_cta', {
 		cta_name: 'crux_learn_more',
 	} );
-	window.open( 'https://developer.chrome.com/docs/crux', '_blank' );
+	window.open(
+		'https://developer.wordpress.com/docs/site-performance/speed-test/#accessing-the-speed-test-tool',
+		'_blank'
+	);
 };
 
 export const FootNote = () => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDEV-51

## Proposed Changes

I propose updating the Speed Test Tool links to point to internal URLs in the WordPress.com support documents.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To keep users on WordPress.com sites, allowing them to learn more via internal resources.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run Calypso on local or launch using Live Link
2. Navigate to `/sites/performance/DOMAIN`
3. Trigger the performance test
4. Confirm links point to internal resources
5. Navigate to `/speed-test-tool`
6. Trigger the performance test
7. Confirm links point to internal resources

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
