### PR TITLE
Connect Refresh: Remove "Not on WordPress.com?" nudge form unified Login form

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -575,7 +575,6 @@ class Login extends Component {
 				userEmail={ userEmail }
 				handleUsernameChange={ handleUsernameChange }
 				signupUrl={ signupUrl }
-				hideSignupLink={ isGravPoweredClient || isBlazePro }
 				sendMagicLoginLink={ this.sendMagicLoginLink }
 				isFromAkismet={ this.props.isFromAkismet }
 				isSendingEmail={ this.props.isSendingEmail }

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -96,7 +96,6 @@ export class LoginForm extends Component {
 		locale: PropTypes.string,
 		showSocialLoginFormOnly: PropTypes.bool,
 		currentQuery: PropTypes.object,
-		hideSignupLink: PropTypes.bool,
 		sendMagicLoginLink: PropTypes.func,
 		isSendingEmail: PropTypes.bool,
 		cancelSocialAccountConnectLinking: PropTypes.func,
@@ -748,19 +747,16 @@ export class LoginForm extends Component {
 		let loginUrl;
 
 		const {
-			oauth2Client,
 			requestError,
 			socialAccountIsLinking: linkingSocialUser,
 			isWoo,
 			isBlazePro,
-			hideSignupLink,
 			isSendingEmail,
 			isSocialFirst,
 			isJetpack,
 		} = this.props;
 
 		const isPasswordHidden = this.isUsernameOrEmailView();
-		const isOauthLogin = !! oauth2Client;
 		const signupUrl = this.getSignupUrl();
 		const shouldRenderForgotPasswordLink = ! isPasswordHidden && isWoo;
 
@@ -993,19 +989,6 @@ export class LoginForm extends Component {
 								buttonText={ this.getLoginButtonText() }
 							/>
 						</div>
-
-						{ ! hideSignupLink && isOauthLogin && (
-							<p className={ clsx( 'login__form-signup-link' ) }>
-								{ this.props.translate(
-									'Not on WordPress.com? {{signupLink}}Create an Account{{/signupLink}}.',
-									{
-										components: {
-											signupLink: <a href={ signupUrl } />,
-										},
-									}
-								) }
-							</p>
-						) }
 					</>
 				) }
 			</Card>

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -254,28 +254,12 @@ $breakpoint-mobile: 782px; //Mobile size.
 	}
 }
 
-.login__form-terms,
-.login__form-signup-link {
+.login__form-terms {
 	font-size: $font-body-extra-small;
 	text-align: center;
 
 	a {
 		white-space: pre;
-	}
-}
-
-.login__form-signup-link {
-	clear: both;
-	font-size: $font-body-small;
-	padding-top: 20px;
-	margin-bottom: unset;
-
-	&.disabled {
-		a,
-		a:hover {
-			pointer-events: none;
-			color: var(--color-text-subtle);
-		}
 	}
 }
 

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -228,10 +228,6 @@
 			}
 		}
 
-		.login__form-signup-link {
-			display: none;
-		}
-
 		.auth-form__separator {
 			padding: 10px 0;
 			&::before,
@@ -473,11 +469,6 @@
 	.login__form-terms {
 		font-size: $font-body-extra-small;
 		margin-bottom: 1em;
-	}
-
-	.login__form-signup-link {
-		font-size: $font-body;
-		line-height: 24px;
 	}
 
 	.masterbar__oauth-client {

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -630,10 +630,6 @@ $breakpoint-mobile: 660px;
 		margin-bottom: 8px;
 	}
 
-	.login__form-signup-link {
-		display: none;
-	}
-
 	.login__form-password {
 		margin-top: 8px;
 	}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DS-245/login-remove-the-additional-not-on-wordpress-nudge-from-cta-section

## Proposed Changes

Removes the additional nudge from the Login form that renders for some OAuth clients (not all). There is a "Create an account" CTA already on the page for the unified clients that should suffice, as per the discussion in the issue.

| Before | After |
|--------|--------|
| <img width="1090" alt="Screenshot 2025-06-19 at 2 52 55 PM" src="https://github.com/user-attachments/assets/faee1943-473f-4767-b421-42b161c06e86" /> | <img width="1077" alt="Screenshot 2025-06-19 at 2 52 33 PM" src="https://github.com/user-attachments/assets/40c66e27-7b88-43f0-93ce-7001b1ec77cd" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DS-245/login-remove-the-additional-not-on-wordpress-nudge-from-cta-section


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to any of the client Login screens from https://linear.app/a8c/issue/DOTCOM-13220/login-make-the-two-columnwhite-layout-the-default-across-all-contexts and confirm
* Example: [Studio](http://calypso.localhost:3000/log-in?client_id=95109&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dtoken%26client_id%3D95109%26redirect_uri%3Dwpcom-local-dev%253A%252F%252Fauth%26scope%3Dglobal%26client_source%26jetpack-code%26jetpack-user-id%3D0%26action%3Doauth2-login%26from-calypso%3D1)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
