### PR TITLE
STATS-109: Skip archives in topPosts API by default (skip_archives=1).

### DIFF
--- a/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
+++ b/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
@@ -62,10 +62,9 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 		? 'stats-top-posts-and-pages-analyze-content-performance-jetpack'
 		: 'stats-top-posts-and-pages-analyze-content-performance';
 
-	const query = {
-		...queryFromProps,
-		skip_archives: isArchiveBreakdownEnabled ? '1' : '0',
-	};
+	const query = isArchiveBreakdownEnabled
+		? queryFromProps
+		: { ...queryFromProps, skip_archives: '0' };
 
 	const mainStatType = MAIN_STAT_TYPE;
 	const subStatType = SUB_STAT_TYPE;

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -178,9 +178,8 @@ class StatsSummary extends Component {
 		}
 
 		const moduleQuery = merge( {}, statsQueryOptions, query );
-		// TODO: Refactor the query params for posts module.
-		if ( 'posts' === this.props.context.params.module ) {
-			moduleQuery.skip_archives = isArchiveBreakdownEnabled ? '1' : '0';
+		if ( 'posts' === this.props.context.params.module && ! isArchiveBreakdownEnabled ) {
+			moduleQuery.skip_archives = '0';
 		}
 
 		const urlParams = new URLSearchParams( this.props.context.querystring );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #STATS-109

## Proposed Changes

* Skip archives in topPosts API by default (skip_archives=1).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Everything should work same as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
