### PR TITLE
Open domain info links in Help Center

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -583,6 +583,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/pay-with-paypal/',
 		post_id: 168671,
 	},
+	'update-contact-information-email-or-name-changes': {
+		link: 'https://wordpress.com/support/domains/update-contact-information/#email-or-name-changes',
+		post_id: 3441,
+	},
 };
 
 export default contextLinks;

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -591,6 +591,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/domains/change-name-servers/#step-1-find-your-new-name-servers',
 		post_id: 41383,
 	},
+	'60-day-transfer-lock': {
+		link: 'https://wordpress.com/support/domains/update-contact-information/#60-day-transfer-lock',
+		post_id: 3441,
+	},
 };
 
 export default contextLinks;

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -587,6 +587,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/domains/update-contact-information/#email-or-name-changes',
 		post_id: 3441,
 	},
+	'change-name-servers-finding-out-new-ns': {
+		link: 'https://wordpress.com/support/domains/change-name-servers/#step-1-find-your-new-name-servers',
+		post_id: 41383,
+	},
 };
 
 export default contextLinks;

--- a/client/my-sites/domains/domain-management/components/designated-agent-notice/index.jsx
+++ b/client/my-sites/domains/domain-management/components/designated-agent-notice/index.jsx
@@ -1,7 +1,8 @@
 import { Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { DESIGNATED_AGENT, DOMAIN_REGISTRATION_AGREEMENTS } from '@automattic/urls';
+import { DOMAIN_REGISTRATION_AGREEMENTS } from '@automattic/urls';
 import { localize } from 'i18n-calypso';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 
 import './style.scss';
 
@@ -31,11 +32,7 @@ const DesignatedAgentNotice = ( props ) => (
 							/>
 						),
 						supportLink: (
-							<a
-								href={ localizeUrl( DESIGNATED_AGENT ) }
-								target="_blank"
-								rel="noopener noreferrer"
-							/>
+							<InlineSupportLink supportContext="domain-designated-agent" showIcon={ false } />
 						),
 					},
 				}

--- a/client/my-sites/domains/domain-management/components/transfer-lock-opt-out-form/index.jsx
+++ b/client/my-sites/domains/domain-management/components/transfer-lock-opt-out-form/index.jsx
@@ -18,12 +18,7 @@ const TransferLockOptOutForm = ( props ) => (
 			<span>
 				{ props.translate( "Opt-out of the 60-day transfer lock. {{link}}What's this?{{/link}}.", {
 					components: {
-						link: (
-							<InlineSupportLink
-								supportContext="update-contact-information-email-or-name-changes"
-								showIcon={ false }
-							/>
-						),
+						link: <InlineSupportLink supportContext="60-day-transfer-lock" showIcon={ false } />,
 					},
 				} ) }
 			</span>

--- a/client/my-sites/domains/domain-management/components/transfer-lock-opt-out-form/index.jsx
+++ b/client/my-sites/domains/domain-management/components/transfer-lock-opt-out-form/index.jsx
@@ -1,9 +1,8 @@
 import { Gridicon, FormLabel } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
-import { UPDATE_CONTACT_INFORMATION_EMAIL_OR_NAME_CHANGES } from '@automattic/urls';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 
 import './style.scss';
 
@@ -20,10 +19,9 @@ const TransferLockOptOutForm = ( props ) => (
 				{ props.translate( "Opt-out of the 60-day transfer lock. {{link}}What's this?{{/link}}.", {
 					components: {
 						link: (
-							<a
-								href={ localizeUrl( UPDATE_CONTACT_INFORMATION_EMAIL_OR_NAME_CHANGES ) }
-								target="_blank"
-								rel="noopener noreferrer"
+							<InlineSupportLink
+								supportContext="update-contact-information-email-or-name-changes"
+								showIcon={ false }
 							/>
 						),
 					},

--- a/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import FormButton from 'calypso/components/forms/form-button';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import {
 	composeAnalytics,
 	recordGoogleEvent,
@@ -146,10 +147,9 @@ class CustomNameserversForm extends PureComponent {
 		const subtitle = translate( '{{link}}Look up{{/link}} the name servers for popular hosts', {
 			components: {
 				link: (
-					<a
-						href={ localizeUrl( CHANGE_NAME_SERVERS_FINDING_OUT_NEW_NS ) }
-						target="_blank"
-						rel="noopener noreferrer"
+					<InlineSupportLink
+						supportContext="change-name-servers-finding-out-new-ns"
+						showIcon={ false }
 						onClick={ this.handleLookUpClick }
 					/>
 				),

--- a/packages/urls/src/index.ts
+++ b/packages/urls/src/index.ts
@@ -12,7 +12,6 @@ export const CALYPSO_CONTACT = '/help/contact';
 export const CALYPSO_HELP = '/help';
 export const CALYPSO_HELP_WITH_HELP_CENTER = CALYPSO_HELP + '?help-center=home';
 export const CUSTOM_DNS = `${ root }/domains/custom-dns/`;
-export const DESIGNATED_AGENT = `${ root }/update-contact-information/#designated-agent`;
 export const DOMAIN_REGISTRATION_AGREEMENTS = `${ root }/domain-registration-agreements/`;
 export const DOMAIN_WAITING = `${ root }/domains/register-domain/#waiting-for-domain-changes`;
 export const DOMAINS = `${ root }/domains/`;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTSUP-60/open-domains-support-links-in-help-center

## Proposed Changes

Open "What's this?" and "Designated Agent" in the Help Center, in `/domains/manage/all/contact-info/edit/`:

![image](https://github.com/user-attachments/assets/c72fefca-1c3e-41e9-bd66-329a1ee97f1b)

Open "Look up" in the Help Center:

![image](https://github.com/user-attachments/assets/5136dab2-606c-47d4-8b76-0354e4c8452a)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open /domains/manage/all/overview/[domain-name]
* Expand Contact Info and check the links as in "Proposed Changes" up here
* Expand Name Servers and do the same