### PR TITLE
Staging Sites: Add icons to site preview pane environment switcher

### DIFF
--- a/client/sites/components/site-preview-pane/site-environment-icon.tsx
+++ b/client/sites/components/site-preview-pane/site-environment-icon.tsx
@@ -4,10 +4,10 @@
  * Renders an environment icon (Production or Staging) based on the type prop
  */
 
-type EnvironmentType = 'production' | 'staging';
+type SiteEnvironmentType = 'production' | 'staging';
 
 interface SiteEnvironmentIconProps {
-	type?: EnvironmentType;
+	type?: SiteEnvironmentType;
 }
 
 export default function SiteEnvironmentIcon( { type = 'production' }: SiteEnvironmentIconProps ) {

--- a/client/sites/components/site-preview-pane/site-environment-icon.tsx
+++ b/client/sites/components/site-preview-pane/site-environment-icon.tsx
@@ -1,10 +1,16 @@
 /**
- * Environment Icon component
+ * SiteEnvironmentIcon component
  *
  * Renders an environment icon (Production or Staging) based on the type prop
  */
 
-export default function EnvironmentIcon( { type = 'production' } ) {
+type EnvironmentType = 'production' | 'staging';
+
+interface SiteEnvironmentIconProps {
+	type?: EnvironmentType;
+}
+
+export default function SiteEnvironmentIcon( { type = 'production' }: SiteEnvironmentIconProps ) {
 	const colors = {
 		production: {
 			primary: '#4AB866',
@@ -14,19 +20,18 @@ export default function EnvironmentIcon( { type = 'production' } ) {
 			primary: '#F0B849',
 			secondary: '#F0B849',
 		},
-	};
+	} as const;
 
-	const { primary, secondary } = colors[ type ] || colors.production;
+	const { primary, secondary } = colors[ type ];
 
 	return (
 		<svg
-			className="environment-icon"
+			className="site-environment-icon"
 			width="24"
 			height="24"
 			viewBox="0 0 24 24"
 			fill="none"
 			xmlns="http://www.w3.org/2000/svg"
-			style={ { '--fill-color': primary } }
 		>
 			<rect x="4" y="4" width="16" height="16" rx="8" fill={ primary } />
 			<rect

--- a/client/sites/components/site-preview-pane/site-environment-icon.tsx
+++ b/client/sites/components/site-preview-pane/site-environment-icon.tsx
@@ -1,7 +1,7 @@
 /**
  * SiteEnvironmentIcon component
  *
- * Renders an environment icon (Production or Staging) based on the type prop
+ * Renders site environment icon (Production or Staging) based on the type prop
  */
 
 type SiteEnvironmentType = 'production' | 'staging';

--- a/client/sites/components/site-preview-pane/site-environment-icons/environment-icon.jsx
+++ b/client/sites/components/site-preview-pane/site-environment-icons/environment-icon.jsx
@@ -1,0 +1,45 @@
+/**
+ * Environment Icon component
+ *
+ * Renders an environment icon (Production or Staging) based on the type prop
+ */
+
+export default function EnvironmentIcon( { type = 'production' } ) {
+	const colors = {
+		production: {
+			primary: '#4AB866',
+			secondary: '#069E08',
+		},
+		staging: {
+			primary: '#F0B849',
+			secondary: '#F0B849',
+		},
+	};
+
+	const { primary, secondary } = colors[ type ] || colors.production;
+
+	return (
+		<svg
+			className="environment-icon"
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			style={ { '--fill-color': primary } }
+		>
+			<rect x="4" y="4" width="16" height="16" rx="8" fill={ primary } />
+			<rect
+				x="5.25"
+				y="5.25"
+				width="13.5"
+				height="13.5"
+				rx="6.75"
+				stroke="white"
+				strokeOpacity="0.6"
+				strokeWidth="2.5"
+			/>
+			<rect x="6" y="6" width="12" height="12" rx="6" fill={ secondary } />
+		</svg>
+	);
+}

--- a/client/sites/components/site-preview-pane/site-environment-switcher.scss
+++ b/client/sites/components/site-preview-pane/site-environment-switcher.scss
@@ -1,20 +1,39 @@
 .site-preview-pane__site-switcher-dropdown-menu {
 	.components-popover__content {
-		width: 189px;
-		padding: calc(4px * 1);
+		width: 180px;
+		padding: calc( 4px * 1 );
 	}
 
 	.components-dropdown-menu__menu-item.is-active {
-		background-color: var(--color-primary);
-		color: var(--color-light-backdrop);
+		background-color: var( --color-primary );
+		color: var( --color-light-backdrop );
 	}
 
 	.components-dropdown-menu__menu-item:focus {
 		box-shadow: initial;
 	}
 
-	.components-dropdown-menu__menu-item:hover:not(.is-active) {
-		color: var(--color-primary);
+	.components-dropdown-menu__menu-item:hover:not( .is-active ) {
+		color: var( --color-primary );
+	}
+
+	.components-dropdown-menu__menu
+		.components-dropdown-menu__menu-item.is-active
+		svg.environment-icon,
+	.components-dropdown-menu__menu .components-menu-item.is-active svg.environment-icon {
+		background: none;
+		box-shadow: none;
+	}
+
+	svg.environment-icon {
+		fill: none;
+		background: none;
+		box-shadow: none;
+		border-radius: 0;
+
+		rect {
+			fill: var( --fill-color, inherit );
+		}
 	}
 }
 
@@ -27,4 +46,3 @@
 .site-preview-pane__site-environment-switcher.components-button.has-icon.has-text {
 	gap: 0;
 }
-

--- a/client/sites/components/site-preview-pane/site-environment-switcher.scss
+++ b/client/sites/components/site-preview-pane/site-environment-switcher.scss
@@ -19,21 +19,14 @@
 
 	.components-dropdown-menu__menu
 		.components-dropdown-menu__menu-item.is-active
-		svg.environment-icon,
-	.components-dropdown-menu__menu .components-menu-item.is-active svg.environment-icon {
+		.site-environment-icon,
+	.components-dropdown-menu__menu .components-menu-item.is-active .site-environment-icon {
 		background: none;
 		box-shadow: none;
 	}
 
-	svg.environment-icon {
+	.site-environment-icon {
 		fill: none;
-		background: none;
-		box-shadow: none;
-		border-radius: 0;
-
-		rect {
-			fill: var( --fill-color, inherit );
-		}
 	}
 }
 

--- a/client/sites/components/site-preview-pane/site-environment-switcher.tsx
+++ b/client/sites/components/site-preview-pane/site-environment-switcher.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { SiteExcerptData } from '@automattic/sites';
 import { DropdownMenu, Button } from '@wordpress/components';
 import { chevronDownSmall } from '@wordpress/icons';
@@ -5,6 +6,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import SitesProductionBadge from 'calypso/sites-dashboard/components/sites-production-badge';
 import SitesStagingBadge from 'calypso/sites-dashboard/components/sites-staging-badge';
+import EnvironmentIcon from './site-environment-icons/environment-icon';
 
 import './site-environment-switcher.scss';
 
@@ -46,6 +48,8 @@ export default function SiteEnvironmentSwitcher( {
 		onChange( siteIdToChange as number );
 	};
 
+	const stagingSitesRedesign = config.isEnabled( 'hosting/staging-sites-redesign' );
+
 	return (
 		<DropdownMenu
 			icon={ chevronDownSmall }
@@ -56,7 +60,7 @@ export default function SiteEnvironmentSwitcher( {
 				),
 			} }
 			popoverProps={ {
-				position: 'bottom',
+				placement: stagingSitesRedesign ? 'bottom-start' : 'bottom',
 				className: 'site-preview-pane__site-switcher-dropdown-menu',
 			} }
 			controls={ [
@@ -64,11 +68,17 @@ export default function SiteEnvironmentSwitcher( {
 					title: __( 'Production' ),
 					onClick: () => setEnvironment( productionSiteId ),
 					isActive: ! site.is_wpcom_staging_site,
+					...( stagingSitesRedesign && {
+						icon: () => <EnvironmentIcon type="production" />,
+					} ),
 				},
 				{
 					title: __( 'Staging' ),
 					onClick: () => setEnvironment( stagingSiteId ),
 					isActive: site.is_wpcom_staging_site,
+					...( stagingSitesRedesign && {
+						icon: () => <EnvironmentIcon type="staging" />,
+					} ),
 				},
 			] }
 		/>

--- a/client/sites/components/site-preview-pane/site-environment-switcher.tsx
+++ b/client/sites/components/site-preview-pane/site-environment-switcher.tsx
@@ -4,9 +4,9 @@ import { DropdownMenu, Button } from '@wordpress/components';
 import { chevronDownSmall } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
+import SiteEnvironmentIcon from 'calypso/sites/components/site-preview-pane/site-environment-icon';
 import SitesProductionBadge from 'calypso/sites-dashboard/components/sites-production-badge';
 import SitesStagingBadge from 'calypso/sites-dashboard/components/sites-staging-badge';
-import EnvironmentIcon from './site-environment-icons/environment-icon';
 
 import './site-environment-switcher.scss';
 
@@ -69,7 +69,7 @@ export default function SiteEnvironmentSwitcher( {
 					onClick: () => setEnvironment( productionSiteId ),
 					isActive: ! site.is_wpcom_staging_site,
 					...( stagingSitesRedesign && {
-						icon: () => <EnvironmentIcon type="production" />,
+						icon: () => <SiteEnvironmentIcon type="production" />,
 					} ),
 				},
 				{
@@ -77,7 +77,7 @@ export default function SiteEnvironmentSwitcher( {
 					onClick: () => setEnvironment( stagingSiteId ),
 					isActive: site.is_wpcom_staging_site,
 					...( stagingSitesRedesign && {
-						icon: () => <EnvironmentIcon type="staging" />,
+						icon: () => <SiteEnvironmentIcon type="staging" />,
 					} ),
 				},
 			] }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DOTDEV-173

## Proposed Changes

* introduce new `EnvironmentIcon` component that handles both: staging and production site environment icons
* use it for the site environment switcher dropdown menu.

![Markup on 2025-06-19 at 14:43:17](https://github.com/user-attachments/assets/64dddd24-710d-402b-92bf-1d64a62b831e)

The PR does not handle the change of the environment badge design as that is still in the discussion: DOTDEV-173-linear-issue#comment-d1dd772e. I will handle it in a separate PR.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* DOTDEV-173

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start` (or use Calypso Live).
2. Navigate to the Sites dashboard and select one of the Atomic sites that has staging site created. 
3. If the `hosting/staging-sites-redesign` feature flag is enabled, the new design should be used (`?flags=hosting%2Fstaging-sites-redesign`).
4. If the feature flag is disabled (`?flags=-hosting%2Fstaging-sites-redesign`), the old design should be used.
5. The dropdown should be operational without any issues.

The design is available at ASqz3fW9Go9m5bHL2XiuUR-fi-1_49530.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?