### PR TITLE
Themes: Add focus when tabbing

### DIFF
--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -203,6 +203,11 @@ $x-nav-height: $x-nav-padding-top + $x-nav-item-height + $x-nav-item-padding-x-w
 		margin: 11px 18px 0 9px;
 		padding: 8px 9px !important;
 		text-decoration: none !important;
+
+		&:focus {
+			box-shadow: inset 0 0 0 1px var(--studio-white), 0 0 0 2px var(--studio-blue-50);
+			outline: 2px solid transparent;
+		}
 	}
 }
 
@@ -263,9 +268,10 @@ button.x-nav-link.x-link {
 		opacity: 0.35;
 	}
 
-	&:not(:active):focus::before {
+	&:not(:active):focus:not(.cta-btn-nav)::before {
 		content: "";
 		opacity: 1;
+		border: 2px solid rgba($studio-blue-50, 0.8);
 	}
 }
 
@@ -298,6 +304,11 @@ button.x-nav-link.x-link {
 		content: "";
 		right: $x-nav-padding-x-narrow;
 		left: $x-nav-item-padding-x-narrow;
+	}
+
+	&:focus {
+		box-shadow: inset 0 0 0 1px var(--studio-white), 0 0 0 2px var(--studio-blue-50);
+		outline: 2px solid transparent;
 	}
 }
 

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -305,11 +305,6 @@ button.x-nav-link.x-link {
 		right: $x-nav-padding-x-narrow;
 		left: $x-nav-item-padding-x-narrow;
 	}
-
-	&:focus {
-		box-shadow: inset 0 0 0 1px var(--studio-white), 0 0 0 2px var(--studio-blue-50);
-		outline: 2px solid transparent;
-	}
 }
 
 .x-nav-link__menu {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to: DOTCOM-13571

## Proposed Changes

This PR adds outline to the buttons on the top menu when you tab through them on `/themes` page while logged out. 

<img width="882" alt="Screenshot 2025-06-19 at 4 10 02 PM" src="https://github.com/user-attachments/assets/1f24e9ee-e08c-4108-a2a3-997785834233" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch or use the Calypso Live Link
* Navigate to `http://calypso.localhost:3000/themes` in an incognito window where you are logged out
* Try tabbing through the topbar menu such as Products, Features etc.
* Confirm that the buttons on the top such as `Log in`, `Get started`, `Resources` etc get outline when you tab through them

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
