### PR TITLE
Themes: Ensure the esc key closes the dropdown menu

### DIFF
--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -30,9 +30,14 @@ const UniversalNavbarHeader = ( {
 	useEffect( () => {
 		const handleKeyDown = ( event: KeyboardEvent ) => {
 			if ( event.key === 'Escape' ) {
-				// Remove focus from the currently focused element to close any open dropdown
-				if ( document.activeElement instanceof HTMLElement ) {
-					document.activeElement.blur();
+				const activeElement = document.activeElement;
+				if (
+					activeElement &&
+					activeElement.closest( '[role="menu"], .x-dropdown-content, .x-menu' )
+				) {
+					if ( activeElement instanceof HTMLElement ) {
+						activeElement.blur();
+					}
 				}
 			}
 		};

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -3,7 +3,7 @@ import { WordPressWordmark } from '@automattic/components';
 import { useLocalizeUrl, useIsEnglishLocale, useLocale } from '@automattic/i18n-utils';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { HeaderProps } from '../types';
 import { NonClickableItem, ClickableItem } from './menu-items';
 import './style.scss';
@@ -25,6 +25,23 @@ const UniversalNavbarHeader = ( {
 	const isEnglishLocale = useIsEnglishLocale();
 	// Allow tabbing in mobile version only when the menu is open
 	const mobileMenuTabIndex = isMobileMenuOpen ? undefined : -1;
+
+	// Handle Escape key to close dropdowns
+	useEffect( () => {
+		const handleKeyDown = ( event: KeyboardEvent ) => {
+			if ( event.key === 'Escape' ) {
+				// Remove focus from the currently focused element to close any open dropdown
+				if ( document.activeElement instanceof HTMLElement ) {
+					document.activeElement.blur();
+				}
+			}
+		};
+
+		document.addEventListener( 'keydown', handleKeyDown );
+		return () => {
+			document.removeEventListener( 'keydown', handleKeyDown );
+		};
+	}, [] );
 
 	if ( ! startUrl ) {
 		startUrl = addQueryArgs(

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -31,10 +31,7 @@ const UniversalNavbarHeader = ( {
 		const handleKeyDown = ( event: KeyboardEvent ) => {
 			if ( event.key === 'Escape' ) {
 				const activeElement = document.activeElement;
-				if (
-					activeElement &&
-					activeElement.closest( '[role="menu"], .x-dropdown-content, .x-menu' )
-				) {
+				if ( activeElement && activeElement.closest( '[role="menu"], .x-dropdown-content' ) ) {
 					if ( activeElement instanceof HTMLElement ) {
 						activeElement.blur();
 					}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to: DOTCOM-13571

This PR ensures that the `esc` key closes the dropdowns that are opened by tabbing through the menu. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Pull the changes from this branch or use the Calypso Live Link
* Navigate to `http://calypso.localhost:3000/themes` in an incognito window where you are logged out
* Try tabbing through the topbar menu such as Products, Features etc.
* When the dropdown opens, press `Esc` key and confirm that it closes dropdown
* Please note that this currently works only for dropdowns that are open with tab and not on hover 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
