### PR TITLE
Display the purchase plan notification after translations have been loaded

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-purchase-plan-notification/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-purchase-plan-notification/index.ts
@@ -1,6 +1,6 @@
 import { PLAN_FREE, getPlan } from '@automattic/calypso-products';
 import { useEffect } from '@wordpress/element';
-import { sprintf } from '@wordpress/i18n';
+import { sprintf, getLocaleData } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useDispatch } from 'calypso/state';
 import { successNotice } from 'calypso/state/notices/actions';
@@ -35,6 +35,11 @@ export const usePurchasePlanNotification = (
 		}
 
 		const plan = getPlan( sitePlanSlug );
+		// Only display the notification after translation data has been loaded
+		const localeSlug = getLocaleData()[ '' ].localeSlug;
+		if ( ! localeSlug ) {
+			return;
+		}
 
 		dispatch(
 			successNotice(


### PR DESCRIPTION

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to p1750336897659039-slack-C02AED43D

## Proposed Changes

* Add a check that the translations were loaded before displaying the purchase plan notification, to avoid showing it in English to our non-English users.

**Before:**
<img width="596" alt="Screenshot 2025-06-19 at 16 47 21" src="https://github.com/user-attachments/assets/e98eba3b-6cce-40c2-a07e-cf74a04b1391" />

**After**
<img width="596" alt="Screenshot 2025-06-19 at 16 46 41" src="https://github.com/user-attachments/assets/fcea84ea-7134-4982-905a-eec2d5260684" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Showing translated messages results in better UX for our international users.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Change your Calypso locale to one of Mag-16 locales.
* Go to the wordpress.com/home URL of a test site with a Business plan.
* In Chrome go to Dev tools -> Application -> Local Storage and add a new entry with key `show-purchase-plan-notification-{your test site id}` and value of `true`.
* Reload the page and see that the message appears in English.
* Repeat on calypso.live or locale instance and check that the message is translated now.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
