### PR TITLE
E2E Tests: Fix Cancel plan renewal test to add one more step

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
@@ -29,6 +29,12 @@ export async function cancelPurchaseFlow(
 
 	await page.getByRole( 'button', { name: 'Submit' } ).click();
 
+	await page
+		.getByRole( 'combobox', { name: 'Where is your next adventure taking you?' } )
+		.selectOption( feedback.customReasonText );
+
+	await page.getByRole( 'textbox', { name: 'Can you please specify?' } ).fill( feedback.reason );
+
 	await Promise.all( [
 		page.waitForNavigation( { timeout: 30 * 1000 } ),
 		page.getByRole( 'button', { name: /Submit and (remove|cancel) plan/ } ).click(),


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

> [!CAUTION]
> Do not merge yet as the updated method is used by other tests. I still need to check those 

## Proposed Changes

* Fix the E2E test `Cancel plan renewal` executed as part of `specs/onboarding/signup__with-theme-LOHP.ts` test

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix the test

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The tests should pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
