### PR TITLE
Stats: Fix `Most viewed` summary page list labels

### DIFF
--- a/client/my-sites/stats/features/modules/stats-locations/style.scss
+++ b/client/my-sites/stats/features/modules/stats-locations/style.scss
@@ -108,17 +108,17 @@ $locations-horizontal-bar-width: 380px;
 				display: inherit;
 			}
 		}
+
+		.stats__summary--narrow-mobile {
+			.stats-card--column-header {
+				padding: 0;
+			}
+		}
 	}
 
 	.stats-card-skeleton.locations-skeleton {
 		&.stats-card-skeleton--with-hero .stats-card__content {
 			flex-direction: column;
-		}
-	}
-
-	.stats__summary--narrow-mobile {
-		.stats-card--column-header {
-			padding: 0;
 		}
 	}
 }

--- a/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
+++ b/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
@@ -160,19 +160,20 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 					listItemClassName={ listItemClassName }
 					skipQuery
 					isRealTime={ isRealTime }
-					{ ...( isArchiveBreakdownEnabled && ! summary
-						? {
-								toggleControl: (
-									<SimplifiedSegmentedControl
-										options={ options }
-										initialSelected={ statType }
-										onSelect={ onStatTypeChange }
-									/>
-								),
-								mainItemLabel: options.find( ( option ) => option.value === statType )
-									?.mainItemLabel,
-						  }
-						: null ) }
+					toggleControl={
+						isArchiveBreakdownEnabled &&
+						! summary && (
+							<SimplifiedSegmentedControl
+								options={ options }
+								initialSelected={ statType }
+								onSelect={ onStatTypeChange }
+							/>
+						)
+					}
+					mainItemLabel={
+						isArchiveBreakdownEnabled &&
+						options.find( ( option ) => option.value === statType )?.mainItemLabel
+					}
 				/>
 			) }
 			{ presentEmptyUI && (

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { includes, isEqual } from 'lodash';
@@ -207,7 +208,6 @@ class StatsModule extends Component {
 	isAllTimeList() {
 		const { summary, statType } = this.props;
 		const summarizedTypes = [
-			'statsTopPosts',
 			'statsSearchTerms',
 			'statsClicks',
 			'statsReferrers',
@@ -218,6 +218,12 @@ class StatsModule extends Component {
 			'statsEmailsOpen',
 			'statsEmailsClick',
 		];
+
+		// TODO: Remove this once the archive breakdown is enabled by default.
+		if ( ! config.isEnabled( 'stats/archive-breakdown' ) ) {
+			summarizedTypes.push( 'statsTopPosts' );
+		}
+
 		return summary && includes( summarizedTypes, statType );
 	}
 
@@ -333,7 +339,7 @@ class StatsModule extends Component {
 						)
 					}
 					additionalColumns={ additionalColumns }
-					splitHeader={ !! toggleControl || !! additionalColumns }
+					splitHeader={ !! toggleControl || !! additionalColumns || !! mainItemLabel }
 					toggleControl={ toggleControl }
 					multiHeader={ isAllTime }
 					mainItemLabel={ mainItemLabel }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Fix the `Most viewed` module summary page's list labels.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page with the feature flag: `stats/archive-breakdown`.
* Go to the `Most viewed` module summary page.
* Ensure the `Posts & pages` and `Archive pages` labels align with the design.

#### Posts & pages
|Before|After|
|-|-|
|<img width="1303" alt="截圖 2025-06-20 凌晨1 09 39" src="https://github.com/user-attachments/assets/62606cf1-912c-4b68-a370-978009741aa9" />|<img width="1278" alt="截圖 2025-06-20 凌晨1 01 12" src="https://github.com/user-attachments/assets/251925ce-5817-428a-8725-7448c1e3a778" />|

#### Archive pages
|Before|After|
|-|-|
|<img width="1295" alt="截圖 2025-06-20 凌晨1 09 45" src="https://github.com/user-attachments/assets/d20f4042-876f-4222-9a79-0c8b5d237cab" />|<img width="1283" alt="截圖 2025-06-20 凌晨1 01 18" src="https://github.com/user-attachments/assets/de4bb372-18b0-4059-a269-2653293a94c9" />|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
