### PR TITLE
Add 'Add staging site' button to site header

### DIFF
--- a/client/layout/hosting-dashboard/item-view/item-view-header/index.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/index.tsx
@@ -1,7 +1,8 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useMediaQuery } from '@wordpress/compose';
-import { Icon, external } from '@wordpress/icons';
+import { Icon, external, plus } from '@wordpress/icons';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import { useEffect, useRef } from 'react';
@@ -9,6 +10,7 @@ import SiteFavicon from 'calypso/blocks/site-favicon';
 import QuerySitePhpVersion from 'calypso/components/data/query-site-php-version';
 import QuerySiteWpVersion from 'calypso/components/data/query-site-wp-version';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
+import { useStagingSite } from 'calypso/sites/staging-site/hooks/use-staging-site';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getAtomicHostingPhpVersion } from 'calypso/state/selectors/get-atomic-hosting-php-version';
@@ -65,6 +67,12 @@ export default function ItemViewHeader( {
 	const shouldDisplayVersionNumbers =
 		! itemData.hideEnvDataInHeader && isAtomic && ( wpVersion || phpVersion );
 
+	const { data: stagingSites = [], isLoading: isLoadingStagingSites } = useStagingSite( siteId, {
+		enabled: ! itemData.hideEnvDataInHeader && isAtomic,
+	} );
+
+	const showAddStagingButton = ! isLoadingStagingSites && stagingSites.length === 0 && isAtomic;
+
 	const handlePhpVersionClick = () => {
 		dispatch( recordTracksEvent( 'calypso_hosting_php_version_click' ) );
 	};
@@ -114,6 +122,18 @@ export default function ItemViewHeader( {
 											</Button>
 										) : (
 											itemData.subtitle
+										) }
+
+										{ showAddStagingButton && isEnabled( 'hosting/staging-sites-redesign' ) && (
+											<Button
+												variant="link"
+												href={ `/staging-site/${ selectedSite?.domain }` }
+												className="hosting-dashboard-item-view__header-add-staging"
+												icon={ plus }
+												iconPosition="right"
+											>
+												{ translate( 'Add staging site' ) }
+											</Button>
 										) }
 
 										{ extraProps && extraProps.subtitleExtra ? (

--- a/client/layout/hosting-dashboard/item-view/item-view-header/style.scss
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/style.scss
@@ -1,12 +1,11 @@
-@import "@wordpress/base-styles/breakpoints";
-@import "@automattic/components/src/styles/typography";
-@import "@wordpress/base-styles/mixins";
-@import "@wordpress/base-styles/variables";
+@import '@wordpress/base-styles/breakpoints';
+@import '@automattic/components/src/styles/typography';
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
 
 $blueberry-color: #3858e9;
 
 .hosting-dashboard-item-view__header {
-
 	.hosting-dashboard-item-view__header-content {
 		.hosting-dashboard-item-view__header-info {
 			display: flex;
@@ -28,7 +27,7 @@ $blueberry-color: #3858e9;
 				display: flex;
 				gap: 16px;
 				font-family: $font-sf-pro-text;
-				font-size: rem(14px);
+				font-size: rem( 14px );
 				color: #101517;
 				letter-spacing: -0.15px;
 
@@ -38,6 +37,14 @@ $blueberry-color: #3858e9;
 					padding: 0;
 					height: auto;
 					text-transform: capitalize;
+				}
+			}
+
+			.hosting-dashboard-item-view__header-add-staging {
+				text-decoration: none;
+
+				&:hover {
+					text-decoration: none;
 				}
 			}
 		}
@@ -62,7 +69,7 @@ $blueberry-color: #3858e9;
 		margin-inline-end: 12px;
 	}
 
-	@media (min-width: $break-large) {
+	@media ( min-width: $break-large ) {
 		.hosting-dashboard-item-view__header-favicon {
 			margin-inline-end: 24px;
 			position: relative;
@@ -80,23 +87,22 @@ $blueberry-color: #3858e9;
 
 				.hosting-dashboard-item-view__header-title {
 					@include heading-2x-large;
-					color: var(--color-text-black);
+					color: var( --color-text-black );
 					padding: 4px 0;
 				}
 
 				.hosting-dashboard-item-view__header-summary {
-
 					.hosting-dashboard-item-view__header-summary-link {
 						display: flex;
 						gap: 2px;
 						align-items: center;
 						@include body-large;
-						color: var(--color-accent-70);
+						color: var( --color-accent-70 );
 						width: fit-content;
 						text-decoration: none;
 
 						&:hover {
-							color: var(--color-link-dark);
+							color: var( --color-link-dark );
 							text-decoration: underline;
 						}
 
@@ -110,7 +116,7 @@ $blueberry-color: #3858e9;
 		}
 	}
 
-	@media (max-width: $break-large) {
+	@media ( max-width: $break-large ) {
 		display: flex;
 		padding: 24px 24px 8px;
 
@@ -125,17 +131,16 @@ $blueberry-color: #3858e9;
 
 				.hosting-dashboard-item-view__header-title {
 					@include heading-medium;
-					color: var(--color-text-black);
+					color: var( --color-text-black );
 					padding: 6px 0 4px 0;
 				}
 
 				.hosting-dashboard-item-view__header-summary {
-
 					.hosting-dashboard-item-view__header-summary-link {
 						display: flex;
 						align-items: center;
 						@include body-medium;
-						color: var(--color-accent-70);
+						color: var( --color-accent-70 );
 						width: fit-content;
 						text-decoration: none;
 
@@ -144,7 +149,6 @@ $blueberry-color: #3858e9;
 						}
 					}
 				}
-
 			}
 		}
 	}

--- a/client/my-sites/domains/domain-management/domain-overview-pane/test/index.test.tsx
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/test/index.test.tsx
@@ -2,8 +2,8 @@
  * @jest-environment jsdom
  */
 import page from '@automattic/calypso-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, fireEvent } from '@testing-library/react';
-import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { QueryParams } from '../../dataviews/query-params';
@@ -105,10 +105,19 @@ describe( 'DomainOverviewPane', () => {
 	const renderComponent = ( props = {} ) => {
 		const mockStore = configureStore();
 		const store = mockStore( createState() );
+		const queryClient = new QueryClient( {
+			defaultOptions: {
+				queries: {
+					retry: false,
+				},
+			},
+		} );
 		return render(
-			<Provider store={ store }>
-				<DomainOverviewPane { ...defaultProps } { ...props } queryParams={ queryParams } />
-			</Provider>
+			<QueryClientProvider client={ queryClient }>
+				<Provider store={ store }>
+					<DomainOverviewPane { ...defaultProps } { ...props } queryParams={ queryParams } />
+				</Provider>
+			</QueryClientProvider>
 		);
 	};
 

--- a/client/my-sites/domains/domain-management/test/controller.test.tsx
+++ b/client/my-sites/domains/domain-management/test/controller.test.tsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 // @ts-nocheck - TODO: Fix TypeScript issues
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
@@ -171,8 +172,17 @@ describe( 'domainManagementPaneView', () => {
 		const paneViewHandler = domainController.domainManagementPaneView( DOMAIN_OVERVIEW );
 		paneViewHandler( pageContext, mockNext );
 
+		const queryClient = new QueryClient( {
+			defaultOptions: {
+				queries: {
+					retry: false,
+				},
+			},
+		} );
 		const { container } = render(
-			<Provider store={ testStore }>{ pageContext.primary as React.ReactElement }</Provider>
+			<QueryClientProvider client={ queryClient }>
+				<Provider store={ testStore }>{ pageContext.primary as React.ReactElement }</Provider>
+			</QueryClientProvider>
 		);
 		expect( container ).toBeInTheDocument();
 		expect( mockNext ).toHaveBeenCalled();
@@ -215,8 +225,17 @@ describe( 'domainManagementPaneView', () => {
 		const paneViewHandler = domainController.domainManagementPaneView( DOMAIN_OVERVIEW );
 		paneViewHandler( pageContext, mockNext );
 
+		const queryClient = new QueryClient( {
+			defaultOptions: {
+				queries: {
+					retry: false,
+				},
+			},
+		} );
 		const { container } = render(
-			<Provider store={ testStore }>{ pageContext.primary as React.ReactElement }</Provider>
+			<QueryClientProvider client={ queryClient }>
+				<Provider store={ testStore }>{ pageContext.primary as React.ReactElement }</Provider>
+			</QueryClientProvider>
 		);
 		expect( container ).toBeInTheDocument();
 		expect( pageContext.primary.props ).toMatchObject( {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes [DOTDEV-172 Staging Sites Redesign: Move `Add staging site` button to top level](https://linear.app/a8c/issue/DOTDEV-172/staging-sites-redesign-move-add-staging-site-button-to-top-level)

## Proposed Changes

* Add a new 'Add a staging site' button to the site header 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

https://linear.app/a8c/issue/DOTDEV-172/staging-sites-redesign-move-add-staging-site-button-to-top-level

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start` (or use Calypso Live).
2. Navigate to the Sites dashboard and select one of the Atomic sites that has no staging site created. 
3. If the `hosting/staging-sites-redesign` feature flag is enabled, the new button should be rendered in the header (`?flags=hosting%2Fstaging-sites-redesign`).
4. If the feature flag is disabled (`?flags=-hosting%2Fstaging-sites-redesign`), the button should be hidden.
5. When a staging site is added, the environment dropdown should be rendered.

![CleanShot 2025-06-19 at 21 01 13@2x](https://github.com/user-attachments/assets/75f8521d-c0a5-4889-9043-4b5b5c304fcb)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
