### PR TITLE
Dataviews: ensure data form labels aren't horizontally centered in top position

### DIFF
--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -10,6 +10,7 @@
 - Update SYNC.md docs to include information on rebasing existing sync branches on top of Calypso trunk and other frequently asked questions.
 - Hide the label in input widgets to prevent duplicate labels in the filter UI.
 - Add new filter operator: `between`.
+- Add `label-position-side` classes to labels in the form field layouts. Ensure that labels in the panel view do not align center, and that all side labels are center aligned.
 
 ## 0.2.1
 

--- a/packages/dataviews/src/dataforms-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/index.tsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -192,6 +197,10 @@ export default function FormPanelField< Item >( {
 		return fieldDef.id === field.id;
 	} );
 	const labelPosition = field.labelPosition ?? 'side';
+	const labelClassName = clsx(
+		'dataforms-layouts-panel__field-label',
+		`dataforms-layouts-panel__field-label--label-position-${ labelPosition }`
+	);
 
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
@@ -211,7 +220,7 @@ export default function FormPanelField< Item >( {
 		return (
 			<VStack className="dataforms-layouts-panel__field" spacing={ 0 }>
 				<div
-					className="dataforms-layouts-panel__field-label"
+					className={ labelClassName }
 					style={ { paddingBottom: 0 } }
 				>
 					{ fieldLabel }
@@ -251,9 +260,7 @@ export default function FormPanelField< Item >( {
 			ref={ setPopoverAnchor }
 			className="dataforms-layouts-panel__field"
 		>
-			<div className="dataforms-layouts-panel__field-label">
-				{ fieldLabel }
-			</div>
+			<div className={ labelClassName }>{ fieldLabel }</div>
 			<div className="dataforms-layouts-panel__field-control">
 				<PanelDropdown
 					field={ field }

--- a/packages/dataviews/src/dataforms-layouts/panel/style.scss
+++ b/packages/dataviews/src/dataforms-layouts/panel/style.scss
@@ -13,7 +13,10 @@
 	align-items: center;
 	line-height: $grid-unit-05 * 5;
 	hyphens: auto;
-	align-self: center;
+
+	&--label-position-side {
+		align-self: center;
+	}
 }
 
 .dataforms-layouts-panel__field-control {

--- a/packages/dataviews/src/dataforms-layouts/regular/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/regular/index.tsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import { useContext, useMemo } from '@wordpress/element';
@@ -85,7 +90,12 @@ export default function FormRegularField< Item >( {
 	if ( labelPosition === 'side' ) {
 		return (
 			<HStack className="dataforms-layouts-regular__field">
-				<div className="dataforms-layouts-regular__field-label">
+				<div
+					className={ clsx(
+						'dataforms-layouts-regular__field-label',
+						`dataforms-layouts-regular__field-label--label-position-${ labelPosition }`
+					) }
+				>
 					{ fieldDefinition.label }
 				</div>
 				<div className="dataforms-layouts-regular__field-control">

--- a/packages/dataviews/src/dataforms-layouts/regular/style.scss
+++ b/packages/dataviews/src/dataforms-layouts/regular/style.scss
@@ -19,7 +19,10 @@
 	align-items: center;
 	line-height: $grid-unit-05 * 5;
 	hyphens: auto;
-	align-self: center;
+
+	&--label-position-side {
+		align-self: center;
+	}
 }
 
 .dataforms-layouts-regular__field-control {


### PR DESCRIPTION


## Proposed Changes

Add label position classes to form field layouts for improved alignment

- Introduced `label-position-side` classes to ensure consistent label alignment in panel and regular layouts.
- Updated styles to align side labels correctly and prevent center alignment issues.
- Refactored label class names to utilize `clsx` for dynamic class assignment.

## Why are these changes being made?

For the panel + top combination of the data form field, the label is center-aligned _horizontally_.

<img width="400" alt="Screenshot 2025-06-20 at 3 52 59 pm" src="https://github.com/user-attachments/assets/d73718b9-161d-4f95-902c-b266fbc4344c" />

However as @andrewserong [points out](https://github.com/Automattic/wp-calypso/pull/104291#issuecomment-2989845881) the centre alignment is required for vertical center alignment were labels are on the side.

This ensures that the label sits at the center even when its height is smaller than the control's height.


<img width="400" alt="Screenshot 2025-06-20 at 3 46 58 pm" src="https://github.com/user-attachments/assets/f0ae39ac-e30a-4a0f-9a5d-cebe3bf3d946" />



## Testing Instructions

Run `yarn workspace @automattic/dataviews storybook:start`

Ensure the labels are centered aligned for panel's top position:

http://localhost:57863/?path=/story/dataviews-dataform--combined-fields&args=labelPosition:top

<img width="400" alt="Screenshot 2025-06-20 at 3 47 03 pm" src="https://github.com/user-attachments/assets/a303c3f2-d804-4000-be4d-6d70b03b71c0" />

Check that side view labels are center aligned as well.

http://localhost:57863/?path=/story/dataviews-dataform--combined-fields&args=type:regular;labelPosition:side

<img width="400" alt="Screenshot 2025-06-20 at 3 46 29 pm" src="https://github.com/user-attachments/assets/c8cd352f-c83f-44b3-adeb-3f8196e27bdc" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
