### PR TITLE
Sites List v2: Fix the styles of the title field

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -1,7 +1,13 @@
 import { DataViews, filterSortAndPaginate } from '@automattic/dataviews';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate, useRouter, Link } from '@tanstack/react-router';
-import { Button, Modal, ExternalLink, Icon } from '@wordpress/components';
+import {
+	__experimentalText as Text,
+	Button,
+	Modal,
+	ExternalLink,
+	Icon,
+} from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
@@ -38,9 +44,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		enableGlobalSearch: true,
 		getValue: ( { item } ) => item.name || new URL( item.URL ).hostname,
 		render: ( { field, item } ) => (
-			<span style={ { overflowX: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }>
-				{ field.getValue( { item } ) }
-			</span>
+			<Link to={ `/sites/${ item.slug }` }>{ field.getValue( { item } ) }</Link>
 		),
 	},
 	{
@@ -49,9 +53,13 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		enableGlobalSearch: true,
 		getValue: ( { item } ) => new URL( item.URL ).hostname,
 		render: ( { field, item } ) => (
-			<span style={ { overflowX: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }>
+			<Text
+				as="span"
+				variant="muted"
+				style={ { overflowX: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }
+			>
 				{ field.getValue( { item } ) }
-			</span>
+			</Text>
 		),
 	},
 	{
@@ -117,7 +125,10 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 			// origin.
 			const iframeDisabled = is_deleted || ( item.is_a8c && is_private );
 			return (
-				<>
+				<Link
+					to={ `/sites/${ item.slug }` }
+					style={ { display: 'block', height: '100%', width: '100%' } }
+				>
 					{ resizeListener }
 					{ iframeDisabled && (
 						<div
@@ -135,7 +146,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 					{ width && ! iframeDisabled && (
 						<SitePreview url={ url } scale={ width / 1200 } height={ 1200 } />
 					) }
-				</>
+				</Link>
 			);
 		},
 		enableSorting: false,
@@ -396,9 +407,6 @@ export default function Sites() {
 								},
 							} );
 						} }
-						renderItemLink={ ( { item, ...props } ) => (
-							<Link to={ `/sites/${ item.slug }` } { ...props } />
-						) }
 						defaultLayouts={ DEFAULT_LAYOUTS }
 						paginationInfo={ paginationInfo }
 					/>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTDASH-67, DOTDASH-68

## Proposed Changes

* Follow-up of https://github.com/Automattic/wp-calypso/pull/104353. The current implementation of `renderItemLink` introduces layout inconsistencies with Core, particularly because the `className` is applied to the link component instead of the wrapper `<div>` (it's not rendered). I believe we can resolve this by wrapping the content with the Link component directly and reverting [#103328](https://github.com/Automattic/wp-calypso/pull/103328).
* The only concern is we might need the a11y from the clickable item that is injected by dataviews 🤔

| Before | After |
| - | - |
|![image](https://github.com/user-attachments/assets/838c9484-d707-4931-b992-8387f6ce6974)|![image](https://github.com/user-attachments/assets/07f07339-4120-4058-bd9d-dd4b067c45cd)|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Ensure the styles of the title looks good without underline

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
