### PR TITLE
Sites List v2: Implement Views, Visitors, Likes fields

### DIFF
--- a/client/dashboard/app/queries/site-stats.ts
+++ b/client/dashboard/app/queries/site-stats.ts
@@ -1,6 +1,30 @@
-import { fetchSiteEngagementStats } from '../../data/site-stats';
+import { EngagementStatsDataPoint, fetchSiteEngagementStats } from '../../data/site-stats';
 
 export const siteEngagementStatsQuery = ( siteId: number ) => ( {
 	queryKey: [ 'site', siteId, 'engagement-stats' ],
 	queryFn: () => fetchSiteEngagementStats( siteId ),
+	select: ( { data: stats }: { data: Array< [ string, number, number, number, number ] > } ) => {
+		// We need to normalize the returned data. We ask for 14 days of data (quantity:14)
+		// and we get a response with an array of data like: `[ '2025-04-13', 1, 3, 0, 0 ]`.
+		// Each number in the response is referring to the order of the field provided in `stat_fields`.
+		// The returned array is sorted with ascending date order, so we need to use the last 7 entries
+		// for our current data and the first 7 entries for the previous data.
+		// Noting that we can't use `unit:'week'` because the API has a specific behavior for start/end of weeks.
+		const calculateStats = ( data: Array< [ string, number, number, number, number ] > ) =>
+			data.reduce(
+				( accumulator: EngagementStatsDataPoint, [ , visitors, views, likes, comments ] ) => {
+					accumulator.visitors += Number( visitors );
+					accumulator.views += Number( views );
+					accumulator.likes += Number( likes );
+					accumulator.comments += Number( comments );
+					return accumulator;
+				},
+				{ visitors: 0, views: 0, likes: 0, comments: 0 }
+			);
+
+		const dataLength = stats.length;
+		const currentData = calculateStats( stats.slice( Math.max( 0, dataLength - 7 ) ) );
+		const previousData = calculateStats( stats.slice( 0, Math.max( 0, dataLength - 7 ) ) );
+		return { previousData, currentData };
+	},
 } );

--- a/client/dashboard/data/constants.ts
+++ b/client/dashboard/data/constants.ts
@@ -24,3 +24,8 @@ export enum DotcomPlans {
 	PREMIUM_2_YEARS = 'value_bundle-2y',
 	PREMIUM_3_YEARS = 'value_bundle-3y',
 }
+
+export enum JetpackModules {
+	STATS = 'stats',
+	MONITOR = 'monitor',
+}

--- a/client/dashboard/data/site-stats.ts
+++ b/client/dashboard/data/site-stats.ts
@@ -12,30 +12,9 @@ export interface EngagementStats {
 }
 
 export async function fetchSiteEngagementStats( siteId: number ) {
-	const response = await wpcom.req.get( `/sites/${ siteId }/stats/visits`, {
+	return wpcom.req.get( `/sites/${ siteId }/stats/visits`, {
 		unit: 'day',
 		quantity: 14,
 		stat_fields: [ 'visitors', 'views', 'likes', 'comments' ].join( ',' ),
 	} );
-	// We need to normalize the returned data. We ask for 14 days of data (quantity:14)
-	// and we get a response with an array of data like: `[ '2025-04-13', 1, 3, 0, 0 ]`.
-	// Each number in the response is referring to the order of the field provided in `stat_fields`.
-	// The returend array is sorted with ascending date order, so we need to use the last 7 entries
-	// for our current data and the first 7 entries for the previous data.
-	// Noting that we can't use `unit:'week'` because the API has a specific behavior for start/end of weeks.
-	const calculateStats = ( data: Array< [ string, number, number, number, number ] > ) =>
-		data.reduce(
-			( accumulator: EngagementStatsDataPoint, [ , visitors, views, likes, comments ] ) => {
-				accumulator.visitors += Number( visitors );
-				accumulator.views += Number( views );
-				accumulator.likes += Number( likes );
-				accumulator.comments += Number( comments );
-				return accumulator;
-			},
-			{ visitors: 0, views: 0, likes: 0, comments: 0 }
-		);
-	const dataLength = response.data.length;
-	const currentData = calculateStats( response.data.slice( Math.max( 0, dataLength - 7 ) ) );
-	const previousData = calculateStats( response.data.slice( 0, Math.max( 0, dataLength - 7 ) ) );
-	return { previousData, currentData };
 }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -17,7 +17,7 @@ import TimeSince from '../components/time-since';
 import { STATUS_LABELS, getSiteStatus, getSiteStatusLabel } from '../utils/site-status';
 import { getFormattedWordPressVersion } from '../utils/wp-version';
 import AddNewSite from './add-new-site';
-import { Uptime } from './site-fields';
+import { EngagementStat, Uptime } from './site-fields';
 import SiteIcon from './site-icon';
 import SitePreview from './site-preview';
 import type { FetchSitesOptions, Site } from '../data/types';
@@ -178,6 +178,24 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		id: 'uptime',
 		label: __( 'Uptime' ),
 		render: ( { item } ) => <Uptime site={ item } />,
+		enableSorting: false,
+	},
+	{
+		id: 'visitors',
+		label: __( 'Visitors' ),
+		render: ( { item } ) => <EngagementStat site={ item } type="visitors" />,
+		enableSorting: false,
+	},
+	{
+		id: 'views',
+		label: __( 'Views' ),
+		render: ( { item } ) => <EngagementStat site={ item } type="views" />,
+		enableSorting: false,
+	},
+	{
+		id: 'likes',
+		label: __( 'Likes' ),
+		render: ( { item } ) => <EngagementStat site={ item } type="likes" />,
 		enableSorting: false,
 	},
 ];

--- a/client/dashboard/sites/site-fields.tsx
+++ b/client/dashboard/sites/site-fields.tsx
@@ -1,8 +1,40 @@
 import { useQuery } from '@tanstack/react-query';
 import { useInView } from 'react-intersection-observer';
+import { siteEngagementStatsQuery } from '../app/queries/site-stats';
 import { siteUptimeQuery } from '../app/queries/site-uptime';
 import { TextBlur } from '../components/text-blur';
 import type { Site } from '../data/types';
+
+export function EngagementStat( {
+	site,
+	type,
+}: {
+	site: Site;
+	type: 'visitors' | 'views' | 'likes';
+} ) {
+	const { ref, inView } = useInView( { triggerOnce: true, fallbackInView: true } );
+	const isEligible =
+		! site.is_deleted && ( ! site.jetpack || site.jetpack_modules?.includes( 'stats' ) );
+
+	const { data: stats, isLoading } = useQuery( {
+		...siteEngagementStatsQuery( site.ID ),
+		enabled: isEligible && inView,
+	} );
+
+	if ( ! isEligible ) {
+		return '-';
+	}
+
+	const renderContent = () => {
+		if ( isLoading ) {
+			return <TextBlur>100</TextBlur>;
+		}
+
+		return stats?.currentData[ type ];
+	};
+
+	return <span ref={ ref }>{ renderContent() }</span>;
+}
 
 export function Uptime( { site }: { site: Site } ) {
 	const { ref, inView } = useInView( { triggerOnce: true, fallbackInView: true } );

--- a/client/dashboard/sites/site-fields.tsx
+++ b/client/dashboard/sites/site-fields.tsx
@@ -1,9 +1,20 @@
 import { useQuery } from '@tanstack/react-query';
+import { __experimentalText as Text } from '@wordpress/components';
 import { useInView } from 'react-intersection-observer';
 import { siteEngagementStatsQuery } from '../app/queries/site-stats';
 import { siteUptimeQuery } from '../app/queries/site-uptime';
 import { TextBlur } from '../components/text-blur';
+import { JetpackModules } from '../data/constants';
+import { hasJetpackModule } from '../utils/site-features';
 import type { Site } from '../data/types';
+
+function IneligibleIndicator() {
+	return <Text color="#CCCCCC">-</Text>;
+}
+
+function LoadingIndicator( { label }: { label: string } ) {
+	return <TextBlur>{ label }</TextBlur>;
+}
 
 export function EngagementStat( {
 	site,
@@ -14,7 +25,7 @@ export function EngagementStat( {
 } ) {
 	const { ref, inView } = useInView( { triggerOnce: true, fallbackInView: true } );
 	const isEligible =
-		! site.is_deleted && ( ! site.jetpack || site.jetpack_modules?.includes( 'stats' ) );
+		! site.is_deleted && ( ! site.jetpack || hasJetpackModule( site, JetpackModules.STATS ) );
 
 	const { data: stats, isLoading } = useQuery( {
 		...siteEngagementStatsQuery( site.ID ),
@@ -22,12 +33,12 @@ export function EngagementStat( {
 	} );
 
 	if ( ! isEligible ) {
-		return '-';
+		return <IneligibleIndicator />;
 	}
 
 	const renderContent = () => {
 		if ( isLoading ) {
-			return <TextBlur>100</TextBlur>;
+			return <LoadingIndicator label="100" />;
 		}
 
 		return stats?.currentData[ type ];
@@ -38,7 +49,7 @@ export function EngagementStat( {
 
 export function Uptime( { site }: { site: Site } ) {
 	const { ref, inView } = useInView( { triggerOnce: true, fallbackInView: true } );
-	const isEligible = !! site.jetpack_modules?.includes( 'monitor' );
+	const isEligible = hasJetpackModule( site, JetpackModules.MONITOR );
 
 	const { data: uptime, isLoading } = useQuery( {
 		...siteUptimeQuery( site.ID, 'week' ),
@@ -46,15 +57,15 @@ export function Uptime( { site }: { site: Site } ) {
 	} );
 
 	if ( ! isEligible ) {
-		return '-';
+		return <IneligibleIndicator />;
 	}
 
 	const renderContent = () => {
 		if ( isLoading ) {
-			return <TextBlur>100%</TextBlur>;
+			return <LoadingIndicator label="100%" />;
 		}
 
-		return uptime ? `${ uptime }%` : '-';
+		return uptime ? `${ uptime }%` : <IneligibleIndicator />;
 	};
 
 	return <span ref={ ref }>{ renderContent() }</span>;

--- a/client/dashboard/utils/site-features.ts
+++ b/client/dashboard/utils/site-features.ts
@@ -1,4 +1,4 @@
-import { DotcomFeatures } from '../data/constants';
+import { DotcomFeatures, JetpackModules } from '../data/constants';
 import type { Site } from '../data/types';
 
 export function hasPlanFeature( site: Site, feature: `${ DotcomFeatures }` ) {
@@ -11,4 +11,8 @@ export function hasPlanFeature( site: Site, feature: `${ DotcomFeatures }` ) {
 
 export function hasAtomicFeature( site: Site, feature: `${ DotcomFeatures }` ) {
 	return site.is_wpcom_atomic && ! site.plan?.expired && hasPlanFeature( site, feature );
+}
+
+export function hasJetpackModule( site: Site, module: `${ JetpackModules }` ) {
+	return site.jetpack && site.jetpack_modules?.includes( module );
 }


### PR DESCRIPTION
Ref DOTDASH-50
Ref DOTDASH-51
Ref DOTDASH-52

## Proposed Changes

This PR implements the Sites List fields Views, Visitors, and Likes.
![Screenshot 2025-06-20 at 3 04 47 PM](https://github.com/user-attachments/assets/846a2f00-75c9-4ddd-89ce-b9eca6803a90)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Sites List v2 implementation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Ensure that the fields Views, Visitors, and Likes are selectable and working as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
