### PR TITLE
A4A: Fix bug with Onboarding modal refreshing when navigating.

### DIFF
--- a/client/a8c-for-agencies/components/onboarding-tour-modal/index.tsx
+++ b/client/a8c-for-agencies/components/onboarding-tour-modal/index.tsx
@@ -115,7 +115,11 @@ function OnboardingTourModal( { onClose, children }: OnboardingTourModalProps ) 
 							key={ menuItem.id }
 							onClick={ () => {
 								setCurrentSectionId( menuItem.id );
-								window.location.hash = `${ ONBOARDING_TOUR_HASH }-${ menuItem.id }`;
+								window.history.replaceState(
+									window.history.state,
+									'',
+									`${ ONBOARDING_TOUR_HASH }-${ menuItem.id }`
+								);
 								dispatch(
 									recordTracksEvent( 'calypso_onboarding_tour_modal_section_menu_item_click', {
 										section: menuItem.id,
@@ -169,7 +173,11 @@ function OnboardingTourModal( { onClose, children }: OnboardingTourModalProps ) 
 								currentSectionId={ currentSectionId }
 								setCurrentSectionId={ ( sectionId ) => {
 									setCurrentSectionId( sectionId );
-									window.location.hash = `${ ONBOARDING_TOUR_HASH }-${ sectionId }`;
+									window.history.replaceState(
+										window.history.state,
+										'',
+										`${ ONBOARDING_TOUR_HASH }-${ sectionId }`
+									);
 									dispatch(
 										recordTracksEvent( 'calypso_onboarding_tour_modal_section_menu_item_swipe', {
 											section: sectionId,


### PR DESCRIPTION
When navigating the onboarding modal through the navigation, it seems to open a new modal on each click:


https://github.com/user-attachments/assets/75706ad3-9c10-4a7f-b0fe-2d9a9847cd0e




Context: pfunGA-5WN-p2#comment-10319

## Proposed Changes

* Use `window.history.replaceState` instead of `window.location.hash` to set the hash value and prevent React from detecting URL changes.

## Why are these changes being made?


* This ensures our Onboarding tour component is of top-tier quality.

## Testing Instructions

* Use the A4A live link and navigate to `/overview` page.
* Relaunch the Welcome tour by clicking the relaunch button.
* Navigate using the sidebar menu.
* Confirm the animation works correctly.


https://github.com/user-attachments/assets/b115f529-0f2c-4de7-89f7-30a52ab0d70a



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?