### PR TITLE
Upgrade WoA to PHP 8.3: Remove PHP 8.1 from being selected

### DIFF
--- a/client/data/php-versions/index.jsx
+++ b/client/data/php-versions/index.jsx
@@ -1,10 +1,11 @@
 import { __, sprintf } from '@wordpress/i18n';
 
-export const getPHPVersions = () => {
+export const getPHPVersions = ( siteId ) => {
 	// PHP 8.3 is now the default recommended version
 	const recommendedValue = '8.3';
 	// translators: PHP Version for a version switcher
 	const recommendedLabel = sprintf( __( '%s (Recommended)' ), recommendedValue );
+	const PHP81BrokenSites = [ 64254301, 181414687 ];
 
 	const phpVersions = [
 		{
@@ -27,7 +28,7 @@ export const getPHPVersions = () => {
 			// translators: PHP Version for a version switcher
 			label: sprintf( __( '%s (Deprecated)' ), '8.1' ),
 			value: '8.1',
-			disabled: false, // EOL 31st December, 2025
+			disabled: ! PHP81BrokenSites.includes( siteId ?? 0 ), // EOL 31st December, 2025
 		},
 		{
 			label: '8.2',

--- a/client/sites/settings/server/server-configuration-form.tsx
+++ b/client/sites/settings/server/server-configuration-form.tsx
@@ -94,7 +94,7 @@ export default function ServerConfigurationForm( { disabled }: ServerConfigurati
 	const isPhpVersionChanged = selectedPhpVersion && selectedPhpVersion !== phpVersion;
 	const isStaticFile404Changed = selectedStaticFile404 && selectedStaticFile404 !== staticFile404;
 
-	const { recommendedValue, phpVersions } = getPHPVersions();
+	const { recommendedValue, phpVersions } = getPHPVersions( siteId );
 	const dataCenterOptions = getDataCenterOptions();
 
 	const wpVersionRef = useRef< HTMLLabelElement >( null );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of 
[DOTCOM-13652](https://linear.app/a8c/issue/DOTCOM-13652/remove-php-81-from-being-selected-in-calypso)

## Proposed Changes

* We're removing the option to select PHP 8.1 on Atomic sites. Sites that have not migrated to PHP 8.3 or PHP 8.2 will continue to have the option to switch to PHP 8.1 so that they can troubleshoot their sites while they work on them.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* PHP 8.1 EoL is on December 30th, and we're migrating sites to PHP 8.3

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* I haven't found a way to test this without releasing the code. The change is trivial enough that I think we can test it and revert it if needed. Switching to user and testing on the container requires login.
* We can test that sites that you own don't display the option to switch to PHP 8.1.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
