### PR TITLE
Fix children with same key

### DIFF
--- a/packages/odie-client/src/data/use-odie-chat.ts
+++ b/packages/odie-client/src/data/use-odie-chat.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import { useOdieAssistantContext } from '../context';
+import { generateUUID } from '../utils';
 import type { OdieChat, ReturnedChat } from '../types';
 
 /**
@@ -34,7 +35,10 @@ export const useOdieChat = ( chatId: number | null ) => {
 			) as ReturnedChat;
 
 			return {
-				messages: data.messages || [],
+				messages: ( data.messages || [] ).map( ( message ) => ( {
+					...message,
+					internal_message_id: generateUUID(),
+				} ) ),
 				odieId: Number( data.chat_id ) || chatId,
 				wpcomUserId: data.wpcom_user_id,
 			};


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

Adding a new unique key for the messages being displayed in the chat. This is not a problem in production, but in development we have `warnings` in the browser console.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Even tho the errors are not surfacing in the browser console, we have a warning in development mode for React. When creating new messages we are assinging a random Uuid but when retreiving them from wpcom, we are not assigning a unique key, and hence the error in the console.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visual inspection is enough, but you can try to open an old conversation in the Help Center with the AI assistant and check for the `warnings` in the console. eg:
![image](https://github.com/user-attachments/assets/21daf5b4-b7c0-46ee-9d02-145f8734932f)
The screenshot used is "cooked" for displaying the error when I had applied the fix :)

To surface those `warnings` you might need to checkout and run locally the branch.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
