### PR TITLE
STATS-118: Change info label.

### DIFF
--- a/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
+++ b/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
@@ -140,7 +140,7 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 					titleNodes={
 						<StatsInfoArea>
 							{ translate(
-								'{{link}}Posts and pages{{/link}} sorted by most visited. Learn about what content resonates the most.',
+								'Most viewed {{link}}posts, pages and archive{{/link}}. Learn about what content resonates the most.',
 								{
 									comment: '{{link}} links to support documentation.',
 									components: {

--- a/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
+++ b/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
@@ -139,19 +139,33 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 					path="posts"
 					titleNodes={
 						<StatsInfoArea>
-							{ translate(
-								'Most viewed {{link}}posts, pages and archive{{/link}}. Learn about what content resonates the most.',
-								{
-									comment: '{{link}} links to support documentation.',
-									components: {
-										link: (
-											<InlineSupportLink supportContext={ supportContext } showIcon={ false } />
-										),
-									},
-									context:
-										'Stats: Link in a popover for the Posts & Pages when the module has data',
-								}
-							) }
+							{ isArchiveBreakdownEnabled
+								? translate(
+										'Most viewed {{link}}posts, pages and archive{{/link}}. Learn about what content resonates the most.',
+										{
+											comment: '{{link}} links to support documentation.',
+											components: {
+												link: (
+													<InlineSupportLink supportContext={ supportContext } showIcon={ false } />
+												),
+											},
+											context:
+												'Stats: Link in a popover for the Posts & Pages when the module has data',
+										}
+								  )
+								: translate(
+										'{{link}}Posts and pages{{/link}} sorted by most visited. Learn about what content resonates the most.',
+										{
+											comment: '{{link}} links to support documentation.',
+											components: {
+												link: (
+													<InlineSupportLink supportContext={ supportContext } showIcon={ false } />
+												),
+											},
+											context:
+												'Stats: Link in a popover for the Posts & Pages when the module has data',
+										}
+								  ) }
 						</StatsInfoArea>
 					}
 					moduleStrings={ moduleStrings }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #STATS-118

## Proposed Changes

* Change the info tooltip label

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso branch.
* Navigate to Stats > Traffic page with the feature flag: ?flags=stats/archive-breakdown.
* Check the tooltip of most viewed in the module and the summary page.

| Before | After |
|--------|--------|
| <img width="326" alt="image" src="https://github.com/user-attachments/assets/81cf29bc-55d0-4b96-a079-98588770f788" /> | <img width="404" alt="image" src="https://github.com/user-attachments/assets/e3e3c944-3049-49e4-b952-f887912e88a8" /> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
