### PR TITLE
Add subscribers: Hide import limit notice on uploading modal.

### DIFF
--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -185,7 +185,7 @@ const AddSubscribersModal = ( {
 							</span>
 						</Notice>
 					) }
-					<SubscriberImportLimitNotice closeModal={ onClose } />
+					{ ! isUploading && <SubscriberImportLimitNotice closeModal={ onClose } /> }
 					{ ! isUploading && isImportInProgress && hasStaleImportJobs && (
 						<StaleImportJobsNotice isJetpack={ isJetpack } siteId={ site?.ID || null } />
 					) }
@@ -234,7 +234,7 @@ const AddSubscribersModal = ( {
 							</span>
 						</Notice>
 					) }
-					<SubscriberImportLimitNotice closeModal={ onClose } />
+					{ ! isUploading && <SubscriberImportLimitNotice closeModal={ onClose } /> }
 					{ ! isUploading && isImportInProgress && hasStaleImportJobs && (
 						<StaleImportJobsNotice isJetpack={ isJetpack } siteId={ site?.ID || null } />
 					) }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* We added a new import limit notice recently, and I realized it's showing up on the upload-in-progress version of the modal. This PR hides it when uploading.

Before | After
---- | ----
<img width="654" alt="Screenshot 2025-06-20 at 11 20 11 AM" src="https://github.com/user-attachments/assets/e8ec7161-12c5-4563-ab0d-39df37a4ec5f" /> | <img width="575" alt="Screenshot 2025-06-20 at 11 30 51 AM" src="https://github.com/user-attachments/assets/d500b9dd-7c51-46c5-ab79-cb6027691721" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix a small issue in the UI.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /subscribers/{site url}
* Add a subscriber manually. Check that the import limit notice is visible in the form, but not after you click "Add subscribers."
* Add subscribers via CSV. Check that the import limit notice is visible in the form, but not after you click "Add subscribers."

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
