### PR TITLE
STATS-120: Add track events for module tab toggling

### DIFF
--- a/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
+++ b/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
@@ -7,6 +7,7 @@ import { useSelector } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import StatsInfoArea from 'calypso/my-sites/stats/features/modules/shared/stats-info-area';
+import { trackStatsAnalyticsEvent } from 'calypso/my-sites/stats/utils';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import {
 	isRequestingSiteStatsForQuery,
@@ -31,6 +32,7 @@ type StatTypeOptionType = {
 	value: StatType;
 	label: string;
 	mainItemLabel: string;
+	analyticsId: string;
 };
 
 const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
@@ -61,6 +63,7 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 			value: key as StatType,
 			label: item.tabLabel,
 			mainItemLabel: item.mainItemLabel,
+			analyticsId: item.analyticsId,
 		};
 	} );
 
@@ -83,7 +86,13 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 		: isRequestingTopPostsData;
 
 	const [ localStatType, setLocalStatType ] = useState< StatType | null >( null );
-	const onStatTypeChange = ( option: StatTypeOptionType ) => setLocalStatType( option.value );
+	const onStatTypeChange = ( option: StatTypeOptionType ) => {
+		trackStatsAnalyticsEvent( 'stats_posts_module_menu_clicked', {
+			stat_type: option.analyticsId,
+		} );
+
+		setLocalStatType( option.value );
+	};
 
 	const statType = localStatType || validQueryViewType( query.viewType ) || mainStatType;
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of STATS-120.

## Proposed Changes

* Add track events for `Most viewed` module card tab toggling.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page.
* Toggle the tab of the `Most viewed` module card.
* Inspect the browser Network tab.
* Ensure the track event `stats_posts_module_menu_clicked` is triggered to send analytics.

<img width="995" alt="截圖 2025-06-21 凌晨12 06 22" src="https://github.com/user-attachments/assets/3661dd0c-acb7-4ab1-a506-2f8f51923e24" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
