### PR TITLE
Stats: Fix free subscribers count.

### DIFF
--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -164,9 +164,9 @@ function useSubscribersTotalsQueries( siteId: number | null, filterAdmin?: boole
 				total: results[ 1 ]?.data?.total_subscribers,
 				paid_subscribers: results[ 1 ]?.data?.paid_subscribers,
 				free_subscribers:
-					results[ 1 ]?.data?.email_subscribers !== undefined &&
+					results[ 1 ]?.data?.total_subscribers !== undefined &&
 					results[ 1 ]?.data?.paid_subscribers !== undefined
-						? results[ 1 ].data.email_subscribers - results[ 1 ].data.paid_subscribers
+						? results[ 1 ].data.total_subscribers - results[ 1 ].data.paid_subscribers
 						: null,
 				social_followers: results[ 1 ]?.data?.social_followers,
 				is_owner_subscribed: results[ 0 ]?.data?.is_owner_subscribed,
@@ -185,9 +185,9 @@ function useSubscribersTotalsQueries( siteId: number | null, filterAdmin?: boole
 			total: results[ 1 ]?.data?.total_subscribers,
 			paid_subscribers: results[ 1 ]?.data?.paid_subscribers,
 			free_subscribers:
-				results[ 1 ]?.data?.email_subscribers !== undefined &&
+				results[ 1 ]?.data?.total_subscribers !== undefined &&
 				results[ 1 ]?.data?.paid_subscribers !== undefined
-					? results[ 1 ].data.email_subscribers - results[ 1 ].data.paid_subscribers
+					? results[ 1 ].data.total_subscribers - results[ 1 ].data.paid_subscribers
 					: null,
 			social_followers: results[ 1 ]?.data?.social_followers,
 			is_owner_subscribed: results[ 2 ]?.data?.is_owner_subscribed,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/CML-573/subscribers-slightly-higher-free-subscribers-count-than-total

## Proposed Changes

* Subtract paid subscribers from total subscribers to get free subscribers, instead of subtracting paid subscribers from email subscribers. This way the free subscribers count includes email subscribers, as the hover text says: "Email subscribers and free WordPress.com subscribers." 

Before | After
---- | ----
<img width="1342" alt="Screenshot 2025-06-20 at 3 03 12 PM" src="https://github.com/user-attachments/assets/1eb36a2f-ffd7-4609-afa3-514181016571" /> | <img width="1327" alt="Screenshot 2025-06-20 at 2 55 06 PM" src="https://github.com/user-attachments/assets/a61804f8-3c6b-45d5-988c-0519a6762604" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* So that the numbers line up and don't confuse users.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Stats > Subscribers for a site with a paid newsletter plan.
* Check that free subscribers = total subscribers - paid subscribers.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
