### PR TITLE
Sites List v2: Implement field Backup

### DIFF
--- a/client/dashboard/app/queries/site-backups.ts
+++ b/client/dashboard/app/queries/site-backups.ts
@@ -1,0 +1,13 @@
+import { fetchSiteBackups, Backup } from '../../data/site-jetpack-rewind-backups';
+
+export const siteBackupLastEntryQuery = ( siteId: number ) => ( {
+	queryKey: [ 'site', siteId, 'backup-last-entry' ],
+	queryFn: () => fetchSiteBackups( siteId ),
+	select: ( backups: Backup[] ) => {
+		if ( ! Array.isArray( backups ) ) {
+			return null;
+		}
+
+		return backups.find( ( backup ) => backup.status === 'finished' );
+	},
+} );

--- a/client/dashboard/data/constants.ts
+++ b/client/dashboard/data/constants.ts
@@ -1,5 +1,6 @@
 export enum DotcomFeatures {
 	ATOMIC = 'atomic',
+	BACKUPS = 'backups',
 	SUBSCRIPTION_GIFTING = 'subscription-gifting',
 	COPY_SITE = 'copy-site',
 	LEGACY_CONTACT = 'legacy-contact',

--- a/client/dashboard/data/site-jetpack-rewind-backups.ts
+++ b/client/dashboard/data/site-jetpack-rewind-backups.ts
@@ -1,0 +1,13 @@
+import wpcom from 'calypso/lib/wp';
+
+export interface Backup {
+	last_updated: string;
+	status: 'started' | 'finished' | 'error';
+}
+
+export async function fetchSiteBackups( siteId: number ) {
+	return wpcom.req.get( {
+		path: `/sites/${ siteId }/rewind/backups`,
+		apiNamespace: 'wpcom/v2',
+	} );
+}

--- a/client/dashboard/sites/features.ts
+++ b/client/dashboard/sites/features.ts
@@ -3,6 +3,7 @@ import { hasAtomicFeature, hasPlanFeature } from '../utils/site-features';
 import type { Site, User } from '../data/types';
 
 export const HostingFeatures = {
+	BACKUPS: DotcomFeatures.BACKUPS,
 	PHP: DotcomFeatures.SFTP,
 	SFTP: DotcomFeatures.SFTP,
 	SSH: DotcomFeatures.SSH,

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -81,6 +81,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		id: 'backup',
 		label: __( 'Backup' ),
 		render: ( { item } ) => <LastBackup site={ item } />,
+		enableSorting: false,
 	},
 	{
 		id: 'status',

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -4,7 +4,6 @@ import { useNavigate, Link } from '@tanstack/react-router';
 import { Button, Modal, ExternalLink } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { Icon, check } from '@wordpress/icons';
 import { useMemo, useState } from 'react';
 import { useAnalytics } from '../app/analytics';
 import { sitesQuery } from '../app/queries/sites';
@@ -17,7 +16,7 @@ import TimeSince from '../components/time-since';
 import { STATUS_LABELS, getSiteStatus, getSiteStatusLabel } from '../utils/site-status';
 import { getFormattedWordPressVersion } from '../utils/wp-version';
 import AddNewSite from './add-new-site';
-import { EngagementStat, Uptime, PHPVersion, MediaStorage } from './site-fields';
+import { EngagementStat, LastBackup, Uptime, PHPVersion, MediaStorage } from './site-fields';
 import SiteIcon from './site-icon';
 import SitePreview from './site-preview';
 import type { FetchSitesOptions, Site } from '../data/types';
@@ -79,23 +78,9 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		label: __( 'Subscribers' ),
 	},
 	{
-		id: 'backups',
-		type: 'boolean',
-		label: __( 'Backups' ),
-		getValue: ( { item } ) => !! item.plan?.features?.active?.includes( 'backups' ),
-		elements: [
-			{ value: true, label: __( 'Enabled' ) },
-			{ value: false, label: __( 'Disabled' ) },
-		],
-		render: ( { item } ) =>
-			item.plan?.features?.active?.includes( 'backups' ) ? (
-				<Icon icon={ check } />
-			) : (
-				__( 'Disabled' )
-			),
-		filterBy: {
-			operators: [ 'is' as Operator ],
-		},
+		id: 'backup',
+		label: __( 'Backup' ),
+		render: ( { item } ) => <LastBackup site={ item } />,
 	},
 	{
 		id: 'status',
@@ -212,7 +197,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 const DEFAULT_LAYOUTS = {
 	table: {
 		mediaField: 'icon.ico',
-		fields: [ 'subscribers_count', 'status', 'backups', 'protect', 'wp_version' ],
+		fields: [ 'status', 'visitors', 'subscribers_count', 'wp_version' ],
 		titleField: 'name',
 		descriptionField: 'URL',
 	},


### PR DESCRIPTION
Ref DOTDASH-61

## Proposed Changes

This PR replaces the field Backups with Backup. The difference is that Backups shows whether backups are enabled on the site or not, whereas Backup shows the date of the last successful update.

Table view 
<img width="191" alt="Screenshot 2025-06-21 at 4 53 58 PM" src="https://github.com/user-attachments/assets/fcf36dfc-be73-49f5-9b64-b4a2fe0704db" />

Grid view
<img width="279" alt="SCR-20250621-owdi" src="https://github.com/user-attachments/assets/65b571c9-7797-4c15-b8aa-f352b32c0d33" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Sites List v2 development.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Ensure that the field Backup is working as described above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
