### PR TITLE
Sites List v2: Add navigational actions

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -323,14 +323,8 @@ export default function Sites() {
 	}, [ hasA8CSites, view.type ] );
 
 	const actions = useMemo( () => {
-		return getDefaultActions( router ).filter( ( action ) => {
-			if ( action.id === 'admin' && view.type === 'grid' ) {
-				return false;
-			}
-
-			return true;
-		} );
-	}, [ view.type.router ] );
+		return getDefaultActions( router );
+	}, [ router ] );
 
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -1,9 +1,10 @@
 import { DataViews, filterSortAndPaginate } from '@automattic/dataviews';
 import { useQuery } from '@tanstack/react-query';
-import { useNavigate, Link } from '@tanstack/react-router';
-import { Button, Modal, ExternalLink } from '@wordpress/components';
+import { useNavigate, useRouter, Link } from '@tanstack/react-router';
+import { Button, Modal, ExternalLink, Icon } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
+import { wordpress } from '@wordpress/icons';
 import { useMemo, useState } from 'react';
 import { useAnalytics } from '../app/analytics';
 import { sitesQuery } from '../app/queries/sites';
@@ -28,21 +29,7 @@ import type {
 	ViewGrid,
 	Filter,
 } from '@automattic/dataviews';
-
-const actions = [
-	{
-		id: 'admin',
-		isPrimary: true,
-		label: __( 'WP Admin' ),
-		callback: ( sites: Site[] ) => {
-			const site = sites[ 0 ];
-			if ( site.options?.admin_url ) {
-				window.location.href = site.options.admin_url;
-			}
-		},
-		isEligible: ( item: Site ) => ( item.is_deleted || ! item.options?.admin_url ? false : true ),
-	},
-];
+import type { AnyRouter } from '@tanstack/react-router';
 
 const DEFAULT_FIELDS: Field< Site >[] = [
 	{
@@ -221,6 +208,53 @@ const DEFAULT_VIEW = {
 	search: '',
 };
 
+const getDefaultActions = ( router: AnyRouter ) => {
+	return [
+		{
+			id: 'admin',
+			isPrimary: true,
+			icon: <Icon icon={ wordpress } />,
+			label: __( 'WP admin ↗' ),
+			callback: ( sites: Site[] ) => {
+				const site = sites[ 0 ];
+				if ( site.options?.admin_url ) {
+					window.open( site.options.admin_url, '_blank' );
+				}
+			},
+			isEligible: ( item: Site ) => ( item.is_deleted || ! item.options?.admin_url ? false : true ),
+		},
+		{
+			id: 'site',
+			label: __( 'Visit site ↗' ),
+			callback: ( sites: Site[] ) => {
+				const site = sites[ 0 ];
+				if ( site.URL ) {
+					window.open( site.URL, '_blank' );
+				}
+			},
+			isEligible: ( item: Site ) => ( item.is_deleted || ! item.URL ? false : true ),
+		},
+		{
+			id: 'domains',
+			label: __( 'Domains ↗' ),
+			callback: ( sites: Site[] ) => {
+				const site = sites[ 0 ];
+				window.open( `/domains/manage/${ site.slug }` );
+			},
+			isEligible: ( item: Site ) => ! item.is_deleted,
+		},
+		{
+			id: 'settings',
+			label: __( 'Settings' ),
+			callback: ( sites: Site[] ) => {
+				const site = sites[ 0 ];
+				router.navigate( { to: '/sites/$siteSlug/settings', params: { siteSlug: site.slug } } );
+			},
+			isEligible: ( item: Site ) => ! item.is_deleted,
+		},
+	];
+};
+
 const getFetchSitesOptions = (
 	viewOptions: Partial< ViewTable | ViewGrid > | undefined = {}
 ): FetchSitesOptions => {
@@ -237,6 +271,7 @@ const getFetchSitesOptions = (
 
 export default function Sites() {
 	const navigate = useNavigate( { from: sitesRoute.fullPath } );
+	const router = useRouter();
 	const viewOptions: Partial< ViewTable | ViewGrid > | undefined = sitesRoute.useSearch().view;
 	const { data: sites, isLoading: isLoadingSites } = useQuery(
 		sitesQuery( getFetchSitesOptions( viewOptions ) )
@@ -286,6 +321,16 @@ export default function Sites() {
 			return true;
 		} );
 	}, [ hasA8CSites, view.type ] );
+
+	const actions = useMemo( () => {
+		return getDefaultActions( router ).filter( ( action ) => {
+			if ( action.id === 'admin' && view.type === 'grid' ) {
+				return false;
+			}
+
+			return true;
+		} );
+	}, [ view.type.router ] );
 
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 


### PR DESCRIPTION
Ref DOTDASH-42

## Proposed Changes

This PR implements the following navigational actions:

* WP admin only shows in the Grid view.
* Visit site shows in both views.
* Domains takes users to the Calypso admin since neither dashboards supports site domains yet.
* Settings takes users to the Site Settings screens in the Hosting Dashboard. 
* None of the actions above are available for deleted sites.

![Screenshot 2025-06-23 at 3 00 32 PM](https://github.com/user-attachments/assets/a8b0d202-ce3b-4b85-9dbe-2700b307899f)

> [!NOTE]
> Currently DataViews actions do not support separators. I've created DOTDASH-81 to track this.

> [!NOTE]
> Confirming with @matt-west in QOBjujZah0UlGDDdLKZhzi-fi-4204_220132#1309173373 whether we want to hide the "WP Admin" action in the table view.

> [!NOTE]
> The Settings action does not yet take into account the v1 backport. We'll need to see how the backport is implemented first to see if we can use TanStack route to navigate to Site Settings, or use window.location.href if not.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Sites List v2 development.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2.
* Ensure that the site actions are as described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?