### PR TITLE
Fix Help Center when notifications are not visible

### DIFF
--- a/apps/help-center/help-center-wp-admin.js
+++ b/apps/help-center/help-center-wp-admin.js
@@ -27,7 +27,7 @@ function AdminHelpCenterContent() {
 		) {
 			setShowHelpCenter( false );
 		}
-	}, [ masterbarNotificationsButton.classList, setShowHelpCenter ] );
+	}, [ masterbarNotificationsButton?.classList, setShowHelpCenter ] );
 
 	useEffect( () => {
 		if ( masterbarNotificationsButton ) {


### PR DESCRIPTION
Fixes DOTSUP-212 and DOTSUP-224

## Proposed Changes

For some reason, the notifications button is not visible in WP Admin on some Atomic sites. This causes the Help Center not to load because there is some part of the logic that relies on that button:

```
TypeError: Cannot read properties of null (reading 'classList')
    at l (help-center-wp-admin.min.js?ver=4288460481:54:80841)
```

To prevent that error, we're now ensuring that the notifications button exist before running the dependent logic.

## Why are these changes being made?

To fix an error that prevents the Help Center from loading in WP Admin on some Atomic sites

## Testing Instructions

- Apply these changes to your sandbox
- Sandbox `widgets.wp.com`
- Switch to the user of the site reported in DOTSUP-224
- Visit a WP Admin screen
- Make sure the Help Center is opened correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
