### PR TITLE
Update Studio download links on `/me/get-apps` to v1.5.4

### DIFF
--- a/client/blocks/get-apps/apps-config.tsx
+++ b/client/blocks/get-apps/apps-config.tsx
@@ -160,17 +160,17 @@ export const createWordPressStudioConfig = (
 			[ PlatformType.MacIntel ]: {
 				...platformConfigs[ PlatformType.MacIntel ],
 				onClick: () => recordTracksEvent( 'calypso_studio_download_mac_click' ),
-				link: 'https://cdn.a8c-ci.services/studio/studio-darwin-x64-v1.5.3.dmg',
+				link: 'https://cdn.a8c-ci.services/studio/studio-darwin-x64-v1.5.4.dmg',
 			},
 			[ PlatformType.MacSilicon ]: {
 				...platformConfigs[ PlatformType.MacSilicon ],
 				onClick: () => recordTracksEvent( 'calypso_studio_download_mac_silicon_click' ),
-				link: 'https://cdn.a8c-ci.services/studio/studio-darwin-arm64-v1.5.3.dmg',
+				link: 'https://cdn.a8c-ci.services/studio/studio-darwin-arm64-v1.5.4.dmg',
 			},
 			[ PlatformType.Windows ]: {
 				...platformConfigs[ PlatformType.Windows ],
 				onClick: () => recordTracksEvent( 'calypso_studio_download_windows_click' ),
-				link: 'https://cdn.a8c-ci.services/studio/studio-win32-v1.5.3.exe',
+				link: 'https://cdn.a8c-ci.services/studio/studio-win32-v1.5.4.exe',
 			},
 		},
 	};


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Update the download links for Studio on https://wordpress.com/me/get-apps to match with the latest Studio release version 1.5.4.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* pfHvTO-yN-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/me/get-apps`.
* Ensure that the download URLs for Studio are for v1.5.4 and work as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?