### PR TITLE
Sites List v2: Implement Host field

### DIFF
--- a/client/dashboard/data/site.ts
+++ b/client/dashboard/data/site.ts
@@ -16,6 +16,7 @@ export const SITE_FIELDS = [
 	'is_private',
 	'is_wpcom_atomic',
 	'is_wpcom_staging_site',
+	'hosting_provider_guess',
 	'lang',
 	'launch_status',
 	'site_migration',
@@ -97,6 +98,7 @@ export interface Site {
 	site_owner: number;
 	jetpack: boolean;
 	jetpack_modules: string[] | null;
+	hosting_provider_guess?: string;
 }
 
 export async function fetchSite( siteIdOrSlug: number | string ): Promise< Site > {

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -204,12 +204,14 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 				return 'WordPress.com';
 			}
 
-			// Normalize the provider name to title case.
-			return provider
-				.replace( /[-_]/g, ' ' )
-				.split( ' ' )
-				.map( ( word ) => word.charAt( 0 ).toUpperCase() + word.slice( 1 ) )
-				.join( ' ' );
+			switch ( provider ) {
+				case 'jurassic_ninja':
+					return 'Jurassic Ninja';
+				case 'pressable':
+					return 'Pressable';
+			}
+
+			return provider;
 		},
 		render: ( { field, item } ) => field.getValue( { item } ),
 	},

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -195,6 +195,24 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		render: ( { item } ) => <MediaStorage site={ item } />,
 		enableSorting: false,
 	},
+	{
+		id: 'host',
+		label: __( 'Host' ),
+		getValue: ( { item } ) => {
+			const provider = item.hosting_provider_guess;
+			if ( ! provider || provider === 'automattic' ) {
+				return 'WordPress.com';
+			}
+
+			// Normalize the provider name to title case.
+			return provider
+				.replace( /[-_]/g, ' ' )
+				.split( ' ' )
+				.map( ( word ) => word.charAt( 0 ).toUpperCase() + word.slice( 1 ) )
+				.join( ' ' );
+		},
+		render: ( { field, item } ) => field.getValue( { item } ),
+	},
 ];
 
 const DEFAULT_LAYOUTS = {


### PR DESCRIPTION
Ref DOTDASH-46

## Proposed Changes

This PR implements the Host field. Note that WP.com sites doesn't have this property. 

![Screenshot 2025-06-23 at 5 39 52 PM](https://github.com/user-attachments/assets/09236deb-4ffb-4e98-b4a8-4c7dcf58e8f9)

> [!NOTE]
> According to p1750323602906899-slack-C08JZTRS6NA, this field should be sortable. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Sites List v2 development.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Ensure that the Host field works as intended.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?