### PR TITLE
A4A > Reports: Display report timeframe on the report's details page

### DIFF
--- a/client/a8c-for-agencies/sections/reports/hooks/use-duplicate-report-form-data.tsx
+++ b/client/a8c-for-agencies/sections/reports/hooks/use-duplicate-report-form-data.tsx
@@ -8,12 +8,14 @@ import type {
 	BuildReportFormData,
 	BuildReportCheckedItemsState,
 	ReportFormAPIResponse,
+	TimeframeOption,
+	TimeframeValue,
 } from '../types';
 import type { A4ASelectSiteItem } from 'calypso/a8c-for-agencies/components/a4a-select-site/types';
 
 interface UseDuplicateReportFormDataReturn {
 	formData: BuildReportFormData;
-	setSelectedTimeframe: ( value: string ) => void;
+	setSelectedTimeframe: ( value: TimeframeValue ) => void;
 	setSelectedSite: ( site: A4ASelectSiteItem | null ) => void;
 	setClientEmail: ( value: string ) => void;
 	setCustomIntroText: ( value: string ) => void;
@@ -28,7 +30,7 @@ interface UseDuplicateReportFormDataReturn {
 }
 
 export const useDuplicateReportFormData = (
-	availableTimeframes: { label: string; value: string }[],
+	availableTimeframes: TimeframeOption[],
 	statsOptions: { label: string; value: string }[]
 ): UseDuplicateReportFormDataReturn => {
 	const translate = useTranslate();
@@ -93,7 +95,7 @@ export const useDuplicateReportFormData = (
 
 		const site = findSiteById( reportData );
 		setSelectedSite( site );
-		setSelectedTimeframe( reportData.timeframe );
+		setSelectedTimeframe( reportData.timeframe || '30_days' );
 		setClientEmail( reportData.client_emails?.join( ', ' ) || '' );
 		setCustomIntroText( reportData.custom_intro_text );
 		setSendCopyToTeam( reportData.send_copy_to_team );

--- a/client/a8c-for-agencies/sections/reports/lib/timeframes.ts
+++ b/client/a8c-for-agencies/sections/reports/lib/timeframes.ts
@@ -1,0 +1,25 @@
+import type { TimeframeOption } from '../types';
+
+/**
+ * Get available timeframes for report building
+ */
+export const getAvailableTimeframes = (
+	translate: ( key: string, args?: Record< string, unknown > ) => string
+): TimeframeOption[] => [
+	{ label: translate( 'Last 30 days' ), value: '30_days' },
+	{ label: translate( 'Last 7 days' ), value: '7_days' },
+	{ label: translate( 'Last 24 hours' ), value: '24_hours' },
+	{ label: translate( 'Custom range' ), value: 'custom' },
+];
+
+/**
+ * Get display text for a specific timeframe value
+ */
+export const getTimeframeText = (
+	timeframe: string,
+	translate: ( key: string, args?: Record< string, unknown > ) => string
+): string => {
+	const availableTimeframes = getAvailableTimeframes( translate );
+	const matchingTimeframe = availableTimeframes.find( ( option ) => option.value === timeframe );
+	return matchingTimeframe?.label || timeframe;
+};

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/index.tsx
@@ -15,6 +15,7 @@ import A4ASelectSite from 'calypso/a8c-for-agencies/components/a4a-select-site';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import { getAvailableTimeframes } from 'calypso/a8c-for-agencies/sections/reports/lib/timeframes';
 import LayoutBody from 'calypso/layout/hosting-dashboard/body';
 import LayoutHeader, {
 	LayoutHeaderBreadcrumb as Breadcrumb,
@@ -36,15 +37,7 @@ const BuildReport = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const availableTimeframes = useMemo(
-		() => [
-			{ label: translate( 'Last 30 days' ), value: '30_days' },
-			{ label: translate( 'Last 7 days' ), value: '7_days' },
-			{ label: translate( 'Last 24 hours' ), value: '24_hours' },
-			{ label: translate( 'Custom range' ), value: 'custom' },
-		],
-		[ translate ]
-	);
+	const availableTimeframes = useMemo( () => getAvailableTimeframes( translate ), [ translate ] );
 
 	// Checkbox groups for Step 2
 	const statsOptions = useMemo(

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
@@ -1,6 +1,8 @@
-import { type BadgeType, Gridicon } from '@automattic/components';
+import { type BadgeType, Gridicon, Tooltip } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { useRef, useState } from 'react';
 import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
+import { getTimeframeText } from 'calypso/a8c-for-agencies/sections/reports/lib/timeframes';
 import FormattedDate from 'calypso/components/formatted-date';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import type { ReportStatus } from '../../types';
@@ -45,4 +47,47 @@ export const ReportDateColumn = ( { date }: { date: number | null } ) => {
 
 	const dateObj = new Date( date * 1000 );
 	return <FormattedDate date={ dateObj } format="DD MMM YYYY HH:mm" />;
+};
+
+export const ReportTimeframeColumn = ( {
+	timeframe,
+	startDate,
+	endDate,
+}: {
+	timeframe: string;
+	startDate?: string;
+	endDate?: string;
+} ) => {
+	const translate = useTranslate();
+	const tooltipRef = useRef( null );
+	const [ showTooltip, setShowTooltip ] = useState( false );
+
+	const timeframeText = getTimeframeText( timeframe, translate );
+
+	// Show tooltip with date range for custom timeframes
+	if ( timeframe === 'custom' && startDate && endDate ) {
+		const startDateObj = new Date( startDate );
+		const endDateObj = new Date( endDate );
+
+		return (
+			<>
+				<span
+					onMouseEnter={ () => setShowTooltip( true ) }
+					onMouseLeave={ () => setShowTooltip( false ) }
+					onMouseDown={ () => setShowTooltip( false ) }
+					role="button"
+					tabIndex={ 0 }
+					ref={ tooltipRef }
+				>
+					{ timeframeText }
+				</span>
+				<Tooltip context={ tooltipRef.current } isVisible={ showTooltip } position="top">
+					<FormattedDate date={ startDateObj } format="DD MMM YYYY" /> -
+					<FormattedDate date={ endDateObj } format="DD MMM YYYY" />
+				</Tooltip>
+			</>
+		);
+	}
+
+	return timeframeText;
 };

--- a/client/a8c-for-agencies/sections/reports/reports-details/reports.tsx
+++ b/client/a8c-for-agencies/sections/reports/reports-details/reports.tsx
@@ -4,7 +4,11 @@ import { useMemo, useState } from 'react';
 import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
-import { ReportDateColumn, ReportStatusColumn } from '../primary/dashboard/report-columns';
+import {
+	ReportDateColumn,
+	ReportStatusColumn,
+	ReportTimeframeColumn,
+} from '../primary/dashboard/report-columns';
 import type { Report } from '../types';
 import type { Action } from 'calypso/a8c-for-agencies/components/list-item-cards';
 
@@ -13,7 +17,7 @@ export default function Reports( { reports, actions }: { reports: Report[]; acti
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
 		...initialDataViewsState,
-		fields: [ 'status', 'createdAt' ],
+		fields: [ 'status', 'timeframe', 'createdAt' ],
 	} );
 
 	const fields = useMemo(
@@ -23,6 +27,20 @@ export default function Reports( { reports, actions }: { reports: Report[]; acti
 				label: translate( 'Status' ),
 				getValue: () => '-',
 				render: ( { item }: { item: Report } ) => <ReportStatusColumn status={ item.status } />,
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'timeframe',
+				label: translate( 'Timeframe' ),
+				getValue: () => '-',
+				render: ( { item }: { item: Report } ) => (
+					<ReportTimeframeColumn
+						timeframe={ item.data.timeframe }
+						startDate={ item.data.start_date }
+						endDate={ item.data.end_date }
+					/>
+				),
 				enableHiding: false,
 				enableSorting: false,
 			},

--- a/client/a8c-for-agencies/sections/reports/types.ts
+++ b/client/a8c-for-agencies/sections/reports/types.ts
@@ -1,8 +1,15 @@
 import type { A4ASelectSiteItem } from 'calypso/a8c-for-agencies/components/a4a-select-site/types';
 
+export type TimeframeValue = '7_days' | '24_hours' | '30_days' | 'custom';
+
+export interface TimeframeOption {
+	label: string;
+	value: TimeframeValue;
+}
+
 export interface ReportFormData {
 	managed_site_id: number;
-	timeframe: string;
+	timeframe: TimeframeValue;
 	client_emails: string[];
 	start_date?: string;
 	end_date?: string;
@@ -41,7 +48,7 @@ export type BuildReportCheckedItemsState = Record< string, boolean >;
 
 export type BuildReportFormData = {
 	selectedSite: A4ASelectSiteItem | null;
-	selectedTimeframe: string;
+	selectedTimeframe: TimeframeValue;
 	clientEmail: string;
 	startDate?: string;
 	endDate?: string;


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1163/reports-dashboard-show-the-timeframe-on-the-reports-details

## Proposed Changes

This PR displays the report timeframe on the report's details page.

## Why are these changes being made?

* To display the report timeframe

## Testing Instructions

* Open the A4A live link
* Go to Reports > Dashboard. Create a report if you don't have one. 
* Open any report details > Verify that the "TIMEFRAME" is displayed as shown below.

<img width="1910" alt="Screenshot 2025-06-23 at 2 58 46 PM" src="https://github.com/user-attachments/assets/acecb543-9a53-49af-ab4a-8f92ed72bfd9" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
