### PR TITLE
Importer: Enable users to import again after the success screen

### DIFF
--- a/client/my-sites/importer/file-importer.jsx
+++ b/client/my-sites/importer/file-importer.jsx
@@ -51,6 +51,7 @@ class FileImporter extends PureComponent {
 		} ),
 		fromSite: PropTypes.string,
 		hideActionButtons: PropTypes.bool,
+		onImportSuccessClose: PropTypes.func,
 	};
 
 	handleClick = ( shouldStartImport ) => {
@@ -79,7 +80,7 @@ class FileImporter extends PureComponent {
 			optionalUrl,
 			acceptedFileTypes,
 		} = this.props.importerData;
-		const { importerStatus, site, fromSite, hideActionButtons } = this.props;
+		const { importerStatus, site, fromSite, hideActionButtons, onImportSuccessClose } = this.props;
 		const { errorData, importerState } = importerStatus;
 		const isEnabled = appStates.DISABLED !== importerState;
 		const showStart = includes( compactStates, importerState );
@@ -148,7 +149,13 @@ class FileImporter extends PureComponent {
 						hideActionButtons={ hideActionButtons }
 					/>
 				) }
-				{ isImportSuccess && <SuccessPanel site={ site } importerStatus={ importerStatus } /> }
+				{ isImportSuccess && (
+					<SuccessPanel
+						site={ site }
+						importerStatus={ importerStatus }
+						onClose={ onImportSuccessClose }
+					/>
+				) }
 			</Card>
 		);
 	}

--- a/client/my-sites/importer/success-panel.scss
+++ b/client/my-sites/importer/success-panel.scss
@@ -1,7 +1,12 @@
 .importer__success-panel {
-	.importer__success-panel-message {
-		margin: 24px 0 32px 0 ;
+	padding-bottom: 16px;
+	&-message {
+		margin: 24px 0 32px 0;
 		font-size: $font-body-small;
 		color: var(--color-text-subtle);
+	}
+	&-buttons {
+		display: flex;
+		gap: 8px;
 	}
 }

--- a/client/my-sites/importer/success-panel.tsx
+++ b/client/my-sites/importer/success-panel.tsx
@@ -1,21 +1,52 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import page from '@automattic/calypso-router';
+import { SiteDetails } from '@automattic/data-stores';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import ImporterActionButtonContainer from './importer-action-buttons/container';
-import DoneButton from './importer-action-buttons/done-button';
+import { useCallback, useEffect } from 'react';
+import { useDispatch } from 'calypso/state';
+import { resetImport } from 'calypso/state/imports/actions';
 
 import './success-panel.scss';
 
 interface SuccessPanelProps {
-	site: {
-		title: string;
-	};
+	site: SiteDetails;
+
 	importerStatus: {
 		importerId: string;
 		type: string;
 	};
+	onClose?: () => void;
 }
 
-const SuccessPanel = ( { site, importerStatus }: SuccessPanelProps ) => {
+const SuccessPanel = ( { site, importerStatus, onClose }: SuccessPanelProps ) => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const engine = importerStatus.type;
+
+	useEffect( () => {
+		dispatch( resetImport( site.ID, importerStatus.importerId ) );
+	}, [ dispatch, site.ID, importerStatus.importerId ] );
+
+	const handleClick = useCallback( () => {
+		recordTracksEvent( 'calypso_importer_main_done_clicked', {
+			blog_id: site.ID,
+			importer_id: engine,
+			action: 'customize',
+		} );
+
+		page( '/customize/' + ( site.slug || '' ) );
+	}, [ engine, site.ID, site.slug ] );
+
+	const handleImportMoreContent = useCallback( () => {
+		recordTracksEvent( 'calypso_importer_main_done_clicked', {
+			blog_id: site.ID,
+			importer_id: engine,
+			action: 'import-more-content',
+		} );
+		onClose?.();
+	}, [ engine, onClose, site.ID ] );
+
 	return (
 		<div className="importer__success-panel">
 			<h2>{ translate( 'Success!' ) } 🎉</h2>
@@ -25,10 +56,14 @@ const SuccessPanel = ( { site, importerStatus }: SuccessPanelProps ) => {
 					comment: '%(title)s is the title of the site which user is importing content to.',
 				} ) }
 			</p>
-			<ImporterActionButtonContainer>
-				<DoneButton customizeSiteVariant importerStatus={ importerStatus } site={ site } />
-				<DoneButton importerStatus={ importerStatus } site={ site } />
-			</ImporterActionButtonContainer>
+			<div className="importer__success-panel-buttons">
+				<Button variant="primary" onClick={ handleClick }>
+					{ translate( 'Customize site' ) }
+				</Button>
+				<Button variant="tertiary" onClick={ handleImportMoreContent }>
+					{ translate( 'Import more content' ) }
+				</Button>
+			</div>
 		</div>
 	);
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes DOTCON-86


## Proposed Changes
* Reset the backend importing state when the success panel is rendered 
* Add a button to import more content. 


## Why are these changes being made?
The importing state is stored on our backend, and we only enable users to run new imports after this state is cleared and the current implementation attempts to reset the state during the CTA (button) componentWillUnmount, as you can see [here](https://github.com/Automattic/wp-calypso/blob/08fa8d3160fb1d9887baf71616a7f2d6ae5262cd/client/my-sites/importer/importer-action-buttons/done-button.jsx#L56). This strategy is not working because the browser processes the page change before React triggers the componentWillUnmount event, so the state is never updated.

This PR aims to refactor the code to reset the state when the success state is rendered.
Check the Linear issue for more contextual details.



## Video

https://github.com/user-attachments/assets/b50ce4be-75da-4ae2-88ff-ba2805c5a16d





## Testing Instructions
* Create a free site
* Go to /import/[YOUR_SITE_SLUG]
* Select WordPress as Importer
* Import a WordPress backup file
* Wait until you see the success state
* Reload the page
* Check if you can import again



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
