### PR TITLE
Sites list v2: implement Plan and Status columns

### DIFF
--- a/client/dashboard/components/component-view-tracker/index.tsx
+++ b/client/dashboard/components/component-view-tracker/index.tsx
@@ -1,12 +1,18 @@
 import { useEffect } from 'react';
 import { useAnalytics } from '../../app/analytics';
 
-export default function ComponentViewTracker( { eventName }: { eventName: string } ) {
+export default function ComponentViewTracker( {
+	eventName,
+	properties,
+}: {
+	eventName: string;
+	properties?: Record< string, unknown >;
+} ) {
 	const { recordTracksEvent } = useAnalytics();
 
 	useEffect( () => {
-		recordTracksEvent( eventName );
-	}, [ recordTracksEvent, eventName ] );
+		recordTracksEvent( eventName, properties );
+	}, [ recordTracksEvent, eventName, properties ] );
 
 	return null;
 }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -1,29 +1,29 @@
 import { DataViews, filterSortAndPaginate } from '@automattic/dataviews';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate, useRouter, Link } from '@tanstack/react-router';
-import {
-	__experimentalText as Text,
-	Button,
-	Modal,
-	ExternalLink,
-	Icon,
-} from '@wordpress/components';
+import { __experimentalText as Text, Button, Modal, Icon } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 import { useMemo, useState } from 'react';
-import { useAnalytics } from '../app/analytics';
 import { sitesQuery } from '../app/queries/sites';
 import { sitesRoute } from '../app/router';
-import ComponentViewTracker from '../components/component-view-tracker';
 import DataViewsCard from '../components/dataviews-card';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
 import TimeSince from '../components/time-since';
-import { STATUS_LABELS, getSiteStatus, getSiteStatusLabel } from '../utils/site-status';
+import { STATUS_LABELS, getSiteStatus } from '../utils/site-status';
 import { getFormattedWordPressVersion } from '../utils/wp-version';
 import AddNewSite from './add-new-site';
-import { EngagementStat, LastBackup, Uptime, PHPVersion, MediaStorage } from './site-fields';
+import {
+	EngagementStat,
+	LastBackup,
+	MediaStorage,
+	PHPVersion,
+	Plan,
+	Status,
+	Uptime,
+} from './site-fields';
 import SiteIcon from './site-icon';
 import SitePreview from './site-preview';
 import type { FetchSitesOptions, Site } from '../data/types';
@@ -79,6 +79,12 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		enableSorting: false,
 	},
 	{
+		id: 'plan',
+		label: __( 'Plan' ),
+		getValue: ( { item } ) => item.plan?.product_name_short ?? '',
+		render: ( { item } ) => <Plan site={ item } />,
+	},
+	{
 		id: 'status',
 		label: __( 'Status' ),
 		getValue: ( { item } ) => getSiteStatus( item ),
@@ -86,16 +92,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		filterBy: {
 			operators: [ 'is' ],
 		},
-		render: ( { item } ) => {
-			const label = getSiteStatusLabel( item );
-			if ( item.launch_status === 'unlaunched' && ! item.is_deleted ) {
-				return (
-					<UnlaunchedStatusLink href={ `/home/${ item.slug }` }>{ label }</UnlaunchedStatusLink>
-				);
-			}
-
-			return label;
-		},
+		render: ( { item } ) => <Status site={ item } />,
 	},
 	{
 		id: 'wp_version',
@@ -412,26 +409,6 @@ export default function Sites() {
 					/>
 				</DataViewsCard>
 			</PageLayout>
-		</>
-	);
-}
-
-function UnlaunchedStatusLink( { href, children }: { href: string; children: React.ReactNode } ) {
-	const { recordTracksEvent } = useAnalytics();
-
-	// TODO: We have to fix the obscured focus ring issue as the dataview's field value container
-	// uses `overflow:hidden` to prevent any of the fields from overflowing.
-	return (
-		<>
-			<ComponentViewTracker eventName="calypso_dashboard_site_launch_nag_impression" />
-			<ExternalLink
-				href={ href }
-				onClick={ () => {
-					recordTracksEvent( 'calypso_dashboard_site_launch_nag_click' );
-				} }
-			>
-				{ children }
-			</ExternalLink>
 		</>
 	);
 }

--- a/client/dashboard/sites/plans.ts
+++ b/client/dashboard/sites/plans.ts
@@ -46,3 +46,11 @@ export const isSitePlanLaunchable = ( site: Site ) => {
 		DotcomPlans.MIGRATION_TRIAL_MONTHLY,
 	] );
 };
+
+export function isSitePlanTrial( site: Site ) {
+	return [
+		DotcomPlans.ECOMMERCE_TRIAL_MONTHLY,
+		DotcomPlans.HOSTING_TRIAL_MONTHLY,
+		DotcomPlans.MIGRATION_TRIAL_MONTHLY,
+	].includes( site.plan?.product_slug as DotcomPlans );
+}

--- a/client/dashboard/sites/site-fields.tsx
+++ b/client/dashboard/sites/site-fields.tsx
@@ -1,16 +1,26 @@
 import { useQuery } from '@tanstack/react-query';
-import { __experimentalText as Text } from '@wordpress/components';
+import {
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	ExternalLink,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
 import { useInView } from 'react-intersection-observer';
+import { useAnalytics } from '../app/analytics';
+import { useAuth } from '../app/auth';
 import { siteBackupLastEntryQuery } from '../app/queries/site-backups';
 import { siteMediaStorageQuery } from '../app/queries/site-media-storage';
 import { sitePHPVersionQuery } from '../app/queries/site-php-version';
 import { siteEngagementStatsQuery } from '../app/queries/site-stats';
 import { siteUptimeQuery } from '../app/queries/site-uptime';
+import ComponentViewTracker from '../components/component-view-tracker';
 import { TextBlur } from '../components/text-blur';
 import TimeSince from '../components/time-since';
 import { JetpackModules } from '../data/constants';
 import { hasAtomicFeature, hasJetpackModule } from '../utils/site-features';
+import { getSiteStatusLabel } from '../utils/site-status';
 import { HostingFeatures } from './features';
+import { isSitePlanTrial } from './plans';
 import type { Site } from '../data/types';
 
 function IneligibleIndicator() {
@@ -147,4 +157,96 @@ export function MediaStorage( { site }: { site: Site } ) {
 	);
 
 	return <span ref={ ref }>{ ! isLoading ? value : <LoadingIndicator label="100%" /> }</span>;
+}
+
+function SiteLaunchNag( { site }: { site: Site } ) {
+	const { recordTracksEvent } = useAnalytics();
+
+	// TODO: We have to fix the obscured focus ring issue as the dataview's field value container
+	// uses `overflow:hidden` to prevent any of the fields from overflowing.
+	return (
+		<>
+			<ComponentViewTracker eventName="calypso_dashboard_sites_site_launch_nag_impression" />
+			<ExternalLink
+				href={ `/home/${ site.slug }` }
+				onClick={ () => {
+					recordTracksEvent( 'calypso_dashboard_sites_site_launch_nag_click' );
+				} }
+			>
+				{ getSiteStatusLabel( site ) }
+			</ExternalLink>
+		</>
+	);
+}
+
+function PlanRenewNag( { site, source }: { site: Site; source: string } ) {
+	const { user } = useAuth();
+	const { recordTracksEvent } = useAnalytics();
+
+	if ( site.site_owner !== user.ID ) {
+		return null;
+	}
+
+	const isTrial = isSitePlanTrial( site );
+
+	return (
+		<>
+			<ComponentViewTracker eventName="calypso_dashboard_sites_plan_renew_nag_impression" />
+			<ExternalLink
+				href={
+					isTrial
+						? `/plans/${ site.slug }`
+						: `/checkout/${ site.slug }/${ site.plan?.product_slug }`
+				}
+				onClick={ () => {
+					recordTracksEvent( 'calypso_dashboard_sites_plan_renew_nag_click', {
+						product_slug: site.plan?.product_slug,
+						source,
+					} );
+				} }
+			>
+				{ isTrial ? __( 'Upgrade' ) : __( 'Renew plan' ) }
+			</ExternalLink>
+		</>
+	);
+}
+
+export function Status( { site }: { site: Site } ) {
+	if ( site.is_deleted ) {
+		return <IneligibleIndicator />;
+	}
+
+	if ( site.plan?.expired ) {
+		return (
+			<VStack spacing={ 1 }>
+				<Text isDestructive>{ __( 'Plan expired' ) }</Text>
+				<PlanRenewNag site={ site } source="status" />
+			</VStack>
+		);
+	}
+
+	if ( site.launch_status === 'unlaunched' ) {
+		return <SiteLaunchNag site={ site } />;
+	}
+
+	return getSiteStatusLabel( site );
+}
+
+export function Plan( { site }: { site: Site } ) {
+	if ( site.plan?.expired ) {
+		return (
+			<VStack spacing={ 1 }>
+				<Text isDestructive>
+					{ sprintf(
+						/* translators: %s: plan name */
+						__( '%s-expired' ),
+						site.plan?.product_name_short
+					) }
+				</Text>
+				<PlanRenewNag site={ site } source="plan" />
+			</VStack>
+		);
+	}
+
+	return site.plan?.product_name_short;
 }

--- a/client/dashboard/sites/site-fields.tsx
+++ b/client/dashboard/sites/site-fields.tsx
@@ -213,7 +213,7 @@ function PlanRenewNag( { site, source }: { site: Site; source: string } ) {
 
 export function Status( { site }: { site: Site } ) {
 	if ( site.is_deleted ) {
-		return <IneligibleIndicator />;
+		return __( 'Deleted' );
 	}
 
 	if ( site.plan?.expired ) {

--- a/client/dashboard/sites/site-fields.tsx
+++ b/client/dashboard/sites/site-fields.tsx
@@ -213,7 +213,7 @@ function PlanRenewNag( { site, source }: { site: Site; source: string } ) {
 
 export function Status( { site }: { site: Site } ) {
 	if ( site.is_deleted ) {
-		return __( 'Deleted' );
+		return <Text isDestructive>{ __( 'Deleted' ) }</Text>;
 	}
 
 	if ( site.plan?.expired ) {

--- a/client/dashboard/sites/site-fields.tsx
+++ b/client/dashboard/sites/site-fields.tsx
@@ -191,7 +191,10 @@ function PlanRenewNag( { site, source }: { site: Site; source: string } ) {
 
 	return (
 		<>
-			<ComponentViewTracker eventName="calypso_dashboard_sites_plan_renew_nag_impression" />
+			<ComponentViewTracker
+				eventName="calypso_dashboard_sites_plan_renew_nag_impression"
+				properties={ { product_slug: site.plan?.product_slug, source } }
+			/>
 			<ExternalLink
 				href={
 					isTrial


### PR DESCRIPTION
Fixes DOTDASH-45
Fixes DOTDASH-48

## Proposed Changes

This PR implements the Plan column for the sites list v2.

As discussed in the linked issue, this PR also the Status column to include the plan renewal nag when applicable. This is because unlike Status, the Plan column is not shown by default.

For the renewal nags, I am following the copy from v1 as follows:

|v1 expired plan| v1 expired trial plan|
|-|-|
|<img width="166" alt="image" src="https://github.com/user-attachments/assets/5ae3bce3-65e6-46cd-9008-519358c132d1" />|<img width="136" alt="image" src="https://github.com/user-attachments/assets/4264270b-7dbb-4866-a991-e1b3d4da2827" />|

### Screenshots

|||
|-|-|
|Normal|<img width="206" alt="image" src="https://github.com/user-attachments/assets/f111ae0b-7fe9-44da-9569-a6d76b26226d" />|
|Expired|<img width="304" alt="image" src="https://github.com/user-attachments/assets/bdba3dcc-718e-4f1b-b93a-fef7320e1d52" />|
|Expired Trial|<img width="254" alt="image" src="https://github.com/user-attachments/assets/2395f8eb-8fe9-4312-ba3e-70395f329440" />|


## Testing Instructions

1. Go to /v2/sites.
1. Show the Plan and Status columns.
2. Normal case:
    - Verify the Plan and Status columns are correct.
3. Expired case:
    - In your Store Admin, update the plan's expiry of one of your sites to e.g. yesterday's date
    - Verify the Plan and Status columns are correct.
3. Expired Trial case:
    - Create a new Commerce Trial from https://wordpress.com/ecommerce/
    - In your Store Admin, update the plan's expiry to e.g. yesterday's date
    - Verify the Plan and Status columns are correct.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
