### PR TITLE
Checkout: List PayPal payment methods before credit cards in Germany

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -380,8 +380,11 @@ export default function CheckoutMain( {
 		} );
 	} );
 
+	const currentTaxCountryCode = responseCart.tax.location.country_code;
+
 	const paymentMethodObjects = useCreatePaymentMethods( {
 		contactDetailsType,
+		currentTaxCountryCode,
 		isStripeLoading,
 		stripeLoadingError,
 		stripeConfiguration,

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -400,6 +400,7 @@ function useCreateRazorpay( {
  */
 export default function useCreatePaymentMethods( {
 	contactDetailsType,
+	currentTaxCountryCode,
 	isStripeLoading,
 	stripeLoadingError,
 	stripeConfiguration,
@@ -410,6 +411,7 @@ export default function useCreatePaymentMethods( {
 	storedCards,
 }: {
 	contactDetailsType: ContactDetailsType;
+	currentTaxCountryCode: string | undefined;
 	isStripeLoading: boolean;
 	stripeLoadingError: StripeLoadingError;
 	stripeConfiguration: StripeConfiguration | null;
@@ -517,8 +519,12 @@ export default function useCreatePaymentMethods( {
 		cartKey,
 	} );
 
-	// The order is the order of Payment Methods in Checkout.
-	return [
+	// The order of this array is the order that Payment Methods will be
+	// displayed in Checkout, although not all payment methods here will be
+	// listed; the list of allowed payment methods is returned by the shopping
+	// cart which will be used to filter this list in
+	// `filterAppropriatePaymentMethods()`.
+	let paymentMethods = [
 		...existingCardMethods,
 		stripeMethod,
 		applePayMethod,
@@ -537,4 +543,30 @@ export default function useCreatePaymentMethods( {
 		bancontactMethod,
 		razorpayMethod,
 	].filter( isValueTruthy );
+
+	// In Germany, PayPal is the preferred option, so we display it before
+	// credit cards. See https://wp.me/pxLjZ-9aA
+	if ( currentTaxCountryCode?.toUpperCase() === 'DE' ) {
+		paymentMethods = [
+			...existingCardMethods,
+			paypalExpressMethod,
+			paypalPPCPMethod,
+			stripeMethod,
+			applePayMethod,
+			googlePayMethod,
+			freePaymentMethod,
+			idealMethod,
+			sofortMethod,
+			netbankingMethod,
+			pixMethod,
+			alipayMethod,
+			p24Method,
+			epsMethod,
+			wechatMethod,
+			bancontactMethod,
+			razorpayMethod,
+		].filter( isValueTruthy );
+	}
+
+	return paymentMethods;
 }


### PR DESCRIPTION
## Proposed Changes

This PR alters the list of payment methods displayed in checkout so that we show PayPal above the credit card option.

Fixes https://linear.app/a8c/issue/CHE-210/default-to-paypal-for-german-checkout-flow

## Why are these changes being made?

Germany historically has a low adoption rate of credit cards and a general mistrust of credit cards, while PayPal remains [the most popular way to make online payments](https://www.billwerk.plus/blog/invoicing-payments/the-most-popular-online-payment-methods-in-germany/). When we default to credit card payment method in Germany and display a grayed-out PayPal logo below, it might discourage some people from completing a purchase.

See pxLjZ-9aA-p2

US             |  Germany
:-------------------------:|:-------------------------:
<img width="664" alt="Screenshot 2025-06-23 at 11 33 49 AM" src="https://github.com/user-attachments/assets/cdf1fede-e56c-4c0d-8935-ff21e5a77237" /> | <img width="658" alt="Screenshot 2025-06-23 at 11 34 25 AM" src="https://github.com/user-attachments/assets/bb4ce97b-ba60-4512-a8e5-814da53c8e38" />


## Testing Instructions

- Add a product to your cart and visit checkout.
- Select 'United States' as the country for your tax information and continue to the last step of checkout.
- Verify that the first payment option (after any saved credit cards) is "Credit or debit card".
- Edit the tax information step of checkout and change your country to 'Germany' and return to the last step of checkout.
- Verify that the first payment option (after any saved credit cards) is "PayPal".