### PR TITLE
Help Center: Remove . from links

### DIFF
--- a/packages/odie-client/src/components/message/direct-escalation-link.tsx
+++ b/packages/odie-client/src/components/message/direct-escalation-link.tsx
@@ -1,8 +1,8 @@
 import { HelpCenterSelect } from '@automattic/data-stores';
 import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { useSelect } from '@wordpress/data';
-import { useCallback, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { useCallback, useState, createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 import { useNavigate } from 'react-router-dom';
 import { useOdieAssistantContext } from '../../context';
 import { useCreateZendeskConversation } from '../../hooks';
@@ -75,18 +75,27 @@ export const DirectEscalationLink = ( { messageId }: { messageId: number | undef
 	const getButtonText = () => {
 		if ( isUserEligibleForPaidSupport && canConnectToZendesk ) {
 			return forceEmailSupport
-				? __( 'Contact our support team by email.', __i18n_text_domain__ )
-				: __( 'Contact our support team.', __i18n_text_domain__ );
+				? __( 'Contact our support team by email', __i18n_text_domain__ )
+				: __( 'Contact our support team', __i18n_text_domain__ );
 		}
-		return __( 'Ask in our forums.', __i18n_text_domain__ );
+		return __( 'Ask in our forums', __i18n_text_domain__ );
 	};
 
 	return (
 		<div className="disclaimer">
 			{ __( 'Feeling stuck?', __i18n_text_domain__ ) }{ ' ' }
-			<button onClick={ handleClick } className="odie-button-link">
-				{ getButtonText() }
-			</button>
+			{ createInterpolateElement(
+				sprintf(
+					/* translators: the website could be any domain (eg: "yourname.com") that is built with a platform (eg: Wix, Squarespace, Blogger, etc.) */
+					'<button>%(website)s</button>.',
+					{
+						website: getButtonText(),
+					}
+				),
+				{
+					button: <button onClick={ handleClick } className="odie-button-link" />,
+				}
+			) }
 		</div>
 	);
 };

--- a/packages/odie-client/src/components/message/direct-escalation-link.tsx
+++ b/packages/odie-client/src/components/message/direct-escalation-link.tsx
@@ -85,13 +85,9 @@ export const DirectEscalationLink = ( { messageId }: { messageId: number | undef
 		<div className="disclaimer">
 			{ __( 'Feeling stuck?', __i18n_text_domain__ ) }{ ' ' }
 			{ createInterpolateElement(
-				sprintf(
-					/* translators: the website could be any domain (eg: "yourname.com") that is built with a platform (eg: Wix, Squarespace, Blogger, etc.) */
-					'<button>%(website)s</button>.',
-					{
-						website: getButtonText(),
-					}
-				),
+				sprintf( '<button>%(button_text)s</button>.', {
+					button_text: getButtonText(),
+				} ),
 				{
 					button: <button onClick={ handleClick } className="odie-button-link" />,
 				}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTSUP-225/remove-linked-period-from-feeling-stuck-he-escalation-link

## Proposed Changes

Remove the period from the link.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This link includes a hyperlinked period, which is inconsistent with our approach across the WPcom UI: 

![image](https://github.com/user-attachments/assets/c3b0548a-cc95-4f1d-9bb9-270ce5aca7d2)

## After

![image](https://github.com/user-attachments/assets/e1bbcebd-b9a5-46d0-831c-f9743a20efdb)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Help center.
* Talk with Odie and check that `Contact our support team.` doesn't include the period in the link.
