### PR TITLE
useCreateZendeskConversation: Log stack trace on interactions without chat id

### DIFF
--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -3,10 +3,17 @@ import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { useUpdateZendeskUserFields } from '@automattic/zendesk-client';
 import { useSelect } from '@wordpress/data';
 import Smooch from 'smooch';
+import { logToLogstash } from 'calypso/lib/logstash'; // eslint-disable-line no-restricted-imports -- this import is safe, not introudcing any circular deps; also, it should be removed shortly after investigating the chats with missing zd ids issue
 import { ODIE_ON_ERROR_TRANSFER_MESSAGE, ODIE_TRANSFER_MESSAGE } from '../constants';
 import { useOdieAssistantContext } from '../context';
 import { useManageSupportInteraction } from '../data';
 import { setHelpCenterZendeskConversationStarted } from '../utils';
+
+declare const process: {
+	env: {
+		NODE_ENV: unknown;
+	};
+};
 
 export const useCreateZendeskConversation = (): ( ( {
 	avoidTransfer,
@@ -75,6 +82,25 @@ export const useCreateZendeskConversation = (): ( ( {
 				  ],
 			status: 'transfer',
 		} ) );
+
+		if ( ! chatId ) {
+			const stackTrace = Error().stack;
+
+			process.env.NODE_ENV === 'production' &&
+				logToLogstash( {
+					feature: 'calypso_client',
+					message: 'No chat ID on Zendesk chat',
+					extra: {
+						createdFrom,
+						selectedSiteId,
+						selectedSiteURL,
+						userFieldFlowName,
+						section,
+						stackTrace,
+					},
+					tags: [ 'no-chat-id-on-zd-chat' ],
+				} );
+		}
 
 		await submitUserFields( {
 			messaging_initial_message: userFieldMessage || undefined,

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -15,6 +15,37 @@ declare const process: {
 	};
 };
 
+const logMessageData = ( {
+	createdFrom,
+	selectedSiteId,
+	selectedSiteURL,
+	userFieldFlowName,
+	section,
+}: {
+	createdFrom: string;
+	selectedSiteId?: number | null;
+	selectedSiteURL?: string | null;
+	userFieldFlowName?: string | null;
+	section: string | null;
+} ) => {
+	const stackTrace = Error().stack;
+
+	process.env.NODE_ENV === 'production' &&
+		logToLogstash( {
+			feature: 'calypso_client',
+			message: 'No chat ID on Zendesk chat',
+			extra: {
+				createdFrom,
+				selectedSiteId,
+				selectedSiteURL,
+				userFieldFlowName,
+				section,
+				stackTrace,
+			},
+			tags: [ 'no-chat-id-on-zd-chat' ],
+		} );
+};
+
 export const useCreateZendeskConversation = (): ( ( {
 	avoidTransfer,
 	interactionId,
@@ -84,22 +115,13 @@ export const useCreateZendeskConversation = (): ( ( {
 		} ) );
 
 		if ( ! chatId ) {
-			const stackTrace = Error().stack;
-
-			process.env.NODE_ENV === 'production' &&
-				logToLogstash( {
-					feature: 'calypso_client',
-					message: 'No chat ID on Zendesk chat',
-					extra: {
-						createdFrom,
-						selectedSiteId,
-						selectedSiteURL,
-						userFieldFlowName,
-						section,
-						stackTrace,
-					},
-					tags: [ 'no-chat-id-on-zd-chat' ],
-				} );
+			logMessageData( {
+				createdFrom,
+				selectedSiteId,
+				selectedSiteURL,
+				userFieldFlowName,
+				section,
+			} );
 		}
 
 		await submitUserFields( {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTSUP-28

## Proposed Changes

* Log the stack trace to elastic on messages without chat id.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* After the changes made on https://github.com/Automattic/wp-calypso/pull/104278, there are still zendesk tickets like 9763499-zd-a8c that have been originated on the Help Center but don't include the chat transcript on the elastic logs. I've been unable to reproduce the scenario neither on calypso nor on wpadmin, so I'm adding logs capturing the stack trace to see if I can get some clues.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Help Canter and check that you can send a message.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?