### PR TITLE
Staging Sites: Update site environment switcher and add `Production` badge to Production sites without Staging sites

### DIFF
--- a/client/layout/hosting-dashboard/item-view/item-view-header/index.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/index.tsx
@@ -124,6 +124,14 @@ export default function ItemViewHeader( {
 											itemData.subtitle
 										) }
 
+										{ extraProps && extraProps.subtitleExtra ? (
+											<span>
+												<extraProps.subtitleExtra />
+											</span>
+										) : (
+											''
+										) }
+
 										{ showAddStagingButton && isEnabled( 'hosting/staging-sites-redesign' ) && (
 											<Button
 												variant="link"
@@ -134,14 +142,6 @@ export default function ItemViewHeader( {
 											>
 												{ translate( 'Add staging site' ) }
 											</Button>
-										) }
-
-										{ extraProps && extraProps.subtitleExtra ? (
-											<span>
-												<extraProps.subtitleExtra />
-											</span>
-										) : (
-											''
 										) }
 									</div>
 

--- a/client/layout/hosting-dashboard/item-view/item-view-header/style.scss
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/style.scss
@@ -46,6 +46,10 @@ $blueberry-color: #3858e9;
 				&:hover {
 					text-decoration: none;
 				}
+
+				&.components-button.has-icon {
+					padding: 0;
+				}
 			}
 		}
 

--- a/client/layout/hosting-dashboard/item-view/item-view-header/style.scss
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/style.scss
@@ -48,7 +48,7 @@ $blueberry-color: #3858e9;
 				}
 
 				&.components-button.has-icon {
-					padding: 0;
+					padding: 0 0 0 2px;
 				}
 			}
 		}

--- a/client/layout/hosting-dashboard/item-view/item-view-header/style.scss
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/style.scss
@@ -115,6 +115,12 @@ $blueberry-color: #3858e9;
 							outline: thin dotted;
 						}
 					}
+
+					> span {
+						display: inline-flex;
+						align-items: center;
+						height: 24px;
+					}
 				}
 			}
 		}

--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -200,17 +200,11 @@ const DotcomPreviewPane = ( {
 		selectedFeatureId: selectedSiteFeature,
 	} );
 
-	const isReverting =
-		stagingStatus === StagingSiteStatus.INITIATE_REVERTING ||
-		stagingStatus === StagingSiteStatus.REVERTING;
-	const isTransfering =
-		stagingStatus === StagingSiteStatus.INITIATE_TRANSFERRING ||
-		stagingStatus === StagingSiteStatus.TRANSFERRING;
 	const isProduction = site.is_wpcom_atomic && ! site.is_wpcom_staging_site;
 	const hasNoStagingSites = ! site.options?.wpcom_staging_blog_ids?.length;
 
 	const shouldShowProductionBadge =
-		isProduction && ( hasNoStagingSites || isTransfering || isReverting );
+		isProduction && ( hasNoStagingSites || ! isStagingStatusFinished );
 
 	return (
 		<ItemView

--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -8,6 +8,7 @@ import ItemView from 'calypso/layout/hosting-dashboard/item-view';
 import { useSetTabBreadcrumb } from 'calypso/sites/hooks/breadcrumbs/use-set-tab-breadcrumb';
 import HostingFeaturesIcon from 'calypso/sites/hosting/components/hosting-features-icon';
 import { useStagingSite } from 'calypso/sites/staging-site/hooks/use-staging-site';
+import SitesProductionBadge from 'calypso/sites-dashboard/components/sites-production-badge';
 import { useSelector } from 'calypso/state';
 import { canCurrentUserSwitchEnvironment } from 'calypso/state/sites/selectors/can-current-user-switch-environment';
 import { StagingSiteStatus } from 'calypso/state/staging-site/constants';
@@ -202,6 +203,14 @@ const DotcomPreviewPane = ( {
 		selectedFeatureId: selectedSiteFeature,
 	} );
 
+	const isReverting =
+		stagingStatus === StagingSiteStatus.INITIATE_REVERTING ||
+		stagingStatus === StagingSiteStatus.REVERTING;
+	const isProduction = site.is_wpcom_atomic && ! site.is_wpcom_staging_site;
+	const hasNoStagingSites = ! site.options?.wpcom_staging_blog_ids?.length;
+
+	const shouldShowProductionBadge = isProduction && ( hasNoStagingSites || isReverting );
+
 	return (
 		<ItemView
 			itemData={ itemData }
@@ -216,6 +225,10 @@ const DotcomPreviewPane = ( {
 				subtitleExtra: () => {
 					if ( isInProgress ) {
 						return <SiteStatus site={ site } />;
+					}
+
+					if ( stagingSitesRedesign && shouldShowProductionBadge ) {
+						return <SitesProductionBadge>{ __( 'Production' ) }</SitesProductionBadge>;
 					}
 
 					if ( hasEnvironmentPermission && isStagingStatusFinished ) {

--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -1,5 +1,4 @@
 import config from '@automattic/calypso-config';
-import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { SiteExcerptData } from '@automattic/sites';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { useMemo } from 'react';
@@ -59,7 +58,6 @@ const DotcomPreviewPane = ( {
 	changeSitePreviewPane,
 }: Props ) => {
 	const { __ } = useI18n();
-	const hasEnTranslation = useHasEnTranslation();
 
 	const isAtomicSite = !! site.is_wpcom_atomic || !! site.is_wpcom_staging_site;
 	const isSimpleSite = ! site.jetpack && ! site.is_wpcom_atomic;
@@ -160,7 +158,6 @@ const DotcomPreviewPane = ( {
 		isAtomicSite,
 		isPlanExpired,
 		__,
-		hasEnTranslation,
 		isSimpleSite,
 		site,
 		selectedSiteFeature,

--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -203,10 +203,14 @@ const DotcomPreviewPane = ( {
 	const isReverting =
 		stagingStatus === StagingSiteStatus.INITIATE_REVERTING ||
 		stagingStatus === StagingSiteStatus.REVERTING;
+	const isTransfering =
+		stagingStatus === StagingSiteStatus.INITIATE_TRANSFERRING ||
+		stagingStatus === StagingSiteStatus.TRANSFERRING;
 	const isProduction = site.is_wpcom_atomic && ! site.is_wpcom_staging_site;
 	const hasNoStagingSites = ! site.options?.wpcom_staging_blog_ids?.length;
 
-	const shouldShowProductionBadge = isProduction && ( hasNoStagingSites || isReverting );
+	const shouldShowProductionBadge =
+		isProduction && ( hasNoStagingSites || isTransfering || isReverting );
 
 	return (
 		<ItemView

--- a/client/sites/components/site-preview-pane/site-environment-switcher.scss
+++ b/client/sites/components/site-preview-pane/site-environment-switcher.scss
@@ -1,20 +1,24 @@
 .site-preview-pane__site-switcher-dropdown-menu {
 	.components-popover__content {
-		width: 189px;
-		padding: calc(4px * 1);
+		width: 180px;
+		padding: calc( 4px * 1 );
+	}
+
+	.components-dropdown-menu__menu-item {
+		justify-content: flex-start;
 	}
 
 	.components-dropdown-menu__menu-item.is-active {
-		background-color: var(--color-primary);
-		color: var(--color-light-backdrop);
+		background-color: var( --color-primary );
+		color: var( --color-light-backdrop );
 	}
 
 	.components-dropdown-menu__menu-item:focus {
 		box-shadow: initial;
 	}
 
-	.components-dropdown-menu__menu-item:hover:not(.is-active) {
-		color: var(--color-primary);
+	.components-dropdown-menu__menu-item:hover:not( .is-active ) {
+		color: var( --color-primary );
 	}
 }
 
@@ -27,4 +31,3 @@
 .site-preview-pane__site-environment-switcher.components-button.has-icon.has-text {
 	gap: 0;
 }
-

--- a/client/sites/components/site-preview-pane/site-environment-switcher.tsx
+++ b/client/sites/components/site-preview-pane/site-environment-switcher.tsx
@@ -56,7 +56,7 @@ export default function SiteEnvironmentSwitcher( {
 				),
 			} }
 			popoverProps={ {
-				position: 'bottom',
+				placement: 'bottom-start',
 				className: 'site-preview-pane__site-switcher-dropdown-menu',
 			} }
 			controls={ [


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DOTDEV-173.

## Proposed Changes

* add `Production` badge to Atomic sites that do not have staging site created
* fix site environment switcher alignment and styling
* update `Add staging site` button order and styling
* remove unused `hasEnTranslation`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* related discussion: DOTDEV-173-linear-issue#comment-faf020e6

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start` (or use Calypso Live).
2. Navigate to the Sites dashboard and select one of the Atomic sites that has staging site created. 

### Testing the environment switcher

3. The updated design of the environment switcher should be used - as can be seen in the screenshot:

| Before | After |
|--------|--------|
| ![Markup on 2025-06-23 at 17:48:01](https://github.com/user-attachments/assets/c33b51a9-f607-4647-9d89-4e1226f846f3) | ![Markup on 2025-06-23 at 17:47:15](https://github.com/user-attachments/assets/19baf46a-d2c8-4206-aae2-8f4e3fd505db) | 

### Testing the new `Production` badge

4. With the `hosting/staging-sites-redesign` feature flag enabled (`?flags=hosting%2Fstaging-sites-redesign`):
- Atomic, non-staging sites that do not have the staging site created should display `Production` badge and `Add staging site` button should follow the badge:

![Markup on 2025-06-23 at 17:34:01](https://github.com/user-attachments/assets/fa76b896-59c3-40db-9296-3b4fce11c890)

- Atomic, staging or non-staging sites that have staging site linked should display the environment switcher:

![Markup on 2025-06-23 at 17:46:48](https://github.com/user-attachments/assets/2ae40d77-4794-4191-bf68-fe8672bb3643)

- other sites shouldn't display neither the badge, nor the environment switcher

6. With the feature flag disabled, there should be no change / no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?