### PR TITLE
Fix feedback animation

### DIFF
--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -481,7 +481,6 @@ $feedback-button-size: 28px;
 
 		.odie-feedback-component-button {
 			font-family: $a8c-font-family-sans;
-			background: transparent;
 			border-style: solid;
 			border-width: 1px;
 			cursor: pointer;
@@ -502,17 +501,12 @@ $feedback-button-size: 28px;
 			border-color: var( --color-neutral-10 );
 			display: flex;
 			height: $feedback-button-size;
-			padding: 0 1px;
+			width: $feedback-button-size;
 			justify-content: center;
 			align-items: center;
 
-			&:hover {
-				border-color: var( --color-neutral-20 );
-				color: var( --color-neutral-70 );
-			}
-
-			&.is-active {
-				border-width: 1px;
+			&:focus {
+				outline: 0;
 			}
 		}
 
@@ -668,11 +662,13 @@ $custom-border-corner-size: 16px;
 }
 
 .odie-feedback-message {
-	position: relative;
 	font-weight: 500;
 	font-size: 1rem;
 	width: 100%;
 	height: 100%;
+	min-height: 45px;
+	display: flex;
+	align-items: center;
 	color: var( --studio-gray-100 );
 
 	.odie-feedback-component-thanks,
@@ -680,7 +676,6 @@ $custom-border-corner-size: 16px;
 		display: flex;
 		align-items: center;
 		transition: opacity 0.3s ease;
-		position: absolute;
 		height: 100%;
 	}
 

--- a/packages/odie-client/src/components/message/was-this-helpful-buttons.tsx
+++ b/packages/odie-client/src/components/message/was-this-helpful-buttons.tsx
@@ -79,12 +79,16 @@ const WasThisHelpfulButtons = ( {
 	return (
 		<div className={ containerClasses }>
 			<div className="odie-feedback-message">
-				<span className={ questionClasses } aria-hidden={ rated }>
-					{ __( 'Was this helpful?', __i18n_text_domain__ ) }
-				</span>
-				<span className={ thanksClasses } aria-hidden={ ! rated }>
-					{ __( 'We appreciate your feedback.', __i18n_text_domain__ ) }
-				</span>
+				{ ! rated && (
+					<span className={ questionClasses }>
+						{ __( 'Was this helpful?', __i18n_text_domain__ ) }
+					</span>
+				) }
+				{ rated && (
+					<span className={ thanksClasses }>
+						{ __( 'We appreciate your feedback.', __i18n_text_domain__ ) }
+					</span>
+				) }
 			</div>
 			<div className="odie-feedback-component-button-container">
 				<button

--- a/packages/odie-client/src/components/message/was-this-helpful-buttons.tsx
+++ b/packages/odie-client/src/components/message/was-this-helpful-buttons.tsx
@@ -86,7 +86,7 @@ const WasThisHelpfulButtons = ( {
 					{ __( 'We appreciate your feedback.', __i18n_text_domain__ ) }
 				</span>
 			</div>
-			<span className="odie-feedback-component-button-container">
+			<div className="odie-feedback-component-button-container">
 				<button
 					className={ buttonLikedClasses }
 					onClick={ () => handleIsHelpful( true ) }
@@ -105,7 +105,7 @@ const WasThisHelpfulButtons = ( {
 				>
 					<ThumbsDownIcon className={ thumbsDownClasses } />
 				</button>
-			</span>
+			</div>
 		</div>
 	);
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTSUP-81
Fixes https://linear.app/a8c/issue/DOTSUP-19/fix-feedback-button-for-odie-chats

| Before  | After |
| ------------- | ------------- |
| https://github.com/user-attachments/assets/e1217483-9b98-44d0-8c0b-9701bd44044c |  https://github.com/user-attachments/assets/aa4cabd3-2b86-4cbe-a6e2-142efa710f1a |


## Proposed Changes

* Fix feedback animation

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Better UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR or use PR build
* Open a chat with odie and use the feedback buttons to trigger the animation
