### PR TITLE
Sites: Reset interaction to a new AI chat

### DIFF
--- a/client/sites/overview/components/support-card/index.js
+++ b/client/sites/overview/components/support-card/index.js
@@ -1,6 +1,7 @@
 import { Button } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
 import { useStillNeedHelpURL } from '@automattic/help-center/src/hooks';
+import { useResetSupportInteraction } from '@automattic/help-center/src/hooks/use-reset-support-interaction';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
@@ -31,8 +32,10 @@ export default function SupportCard() {
 	const dispatch = useDispatch();
 	const { setShowHelpCenter, setNavigateToRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
 	const { url } = useStillNeedHelpURL();
+	const resetSupportInteraction = useResetSupportInteraction();
 
-	const onClick = () => {
+	const onClick = async () => {
+		await resetSupportInteraction();
 		setNavigateToRoute( url );
 		setShowHelpCenter( true );
 		dispatch( trackNavigateGetHelpClick() );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-1726/open-new-chat-from-site-overview-page

## Proposed Changes

Open a new AI chat when clicking on the button in "Need some help" in the overview.

![image](https://github.com/user-attachments/assets/3e6a4457-91e2-4fca-8f16-cea2b30b708f)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When you press Get Help from the Site Overview page, the help center modal opens up to an existing chat if you have one open. It takes a moment for me to figure out what's going on here. Let's open a new chat instead.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go into a site overview and click on "Get Help"