### PR TITLE
Help Center: keep the Help Center open across canvas modes

### DIFF
--- a/apps/help-center/help-center-gutenberg.js
+++ b/apps/help-center/help-center-gutenberg.js
@@ -6,9 +6,8 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Button, Fill } from '@wordpress/components';
 import { useMediaQuery } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useCallback, useEffect, useState, useReducer } from '@wordpress/element';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
-import { useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { useCanvasMode } from './hooks/use-canvas-mode';
 import { getEditorType } from './utils';
@@ -17,7 +16,6 @@ import './help-center.scss';
 const queryClient = new QueryClient();
 
 function HelpCenterContent() {
-	const [ , forceUpdate ] = useReducer( ( x ) => x + 1, 0 );
 	const isDesktop = useMediaQuery( '(min-width: 480px)' );
 	const [ showHelpIcon, setShowHelpIcon ] = useState( false );
 	const { setShowHelpCenter } = useDispatch( 'automattic/help-center' );
@@ -25,7 +23,6 @@ function HelpCenterContent() {
 	const show = useSelect( ( select ) => select( 'automattic/help-center' ).isHelpCenterShown() );
 
 	const canvasMode = useCanvasMode();
-	const previousCanvasMode = useRef( canvasMode );
 
 	const handleToggleHelpCenter = useCallback( () => {
 		recordTracksEvent( `calypso_inlinehelp_${ show ? 'close' : 'show' }`, {
@@ -43,19 +40,6 @@ function HelpCenterContent() {
 		const timeout = setTimeout( () => setShowHelpIcon( true ), 0 );
 		return () => clearTimeout( timeout );
 	}, [] );
-
-	useEffect( () => {
-		// Close the Help Center when the canvas mode changes.
-		if ( previousCanvasMode.current !== canvasMode ) {
-			setShowHelpCenter( false );
-
-			// Force to re-render to ensure the sidebar is available.
-			if ( canvasMode === 'view' ) {
-				forceUpdate();
-			}
-			previousCanvasMode.current = canvasMode;
-		}
-	}, [ canvasMode, previousCanvasMode, setShowHelpCenter ] );
 
 	const closeCallback = useCallback( () => setShowHelpCenter( false ), [ setShowHelpCenter ] );
 


### PR DESCRIPTION
Fixes DOTSUP-213

## Proposed Changes

Keeps the HC open across canvas modes.

## Why are these changes being made?
To keep chat sessions going. 

## Testing Instructions
1. In `apps/help-center`, run `yarn dev --sync`.
2. Go to /wp-admin/site-editor.php?p=%2F&canvas=edit 
3. Open the HC from the sidebar.
4. Click the canvas to make it full-screen.
5. The HC should remain open.
6. Re-open the sidebar by clicking the WP logo.
7. The HC should remain open.
