### PR TITLE
E2E: Fix settings URL

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/site-settings-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/site-settings-page.ts
@@ -24,7 +24,8 @@ export class SiteSettingsPage {
 	 * @param {string} tab      Settings tab.
 	 */
 	async visit( siteSlug: string, tab: string = 'site' ): Promise< void > {
-		await this.page.goto( getCalypsoURL( `sites/settings/${ tab }/${ siteSlug }` ), {
+		// Patch for redirectToHostingDashboardBackportIfEnabled bug that doesn't account for tabs.
+		await this.page.goto( getCalypsoURL( `sites/settings/v2/${ siteSlug }/${ tab }` ), {
 			timeout: 20 * 1000,
 		} );
 	}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

In #104382 setting URL changes were enabled, which broke an E2E test, since the redirect in `redirectToHostingDashboardBackportIfEnabled()` didn't account for settings tabs in here:

https://github.com/Automattic/wp-calypso/blob/trunk/client/sites/settings/v2/controller.tsx#L9

For example, I'd expect `/sites/settings/{tab}/{site}` to redirect to `/sites/settings/v2/{site}/{tab}`, but it redirects to `/sites/settings/v2/{site}`.

This PR fixes the test by bypassing this redirect for now, instead using the new structure, but ideally the root issue would be fixed, as this would affect any links to the old URL structure as well.

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This should now pass:
```
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION="ecomm-plan" TEST_ON_ATOMIC="true" VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests debug "test/e2e/specs/settings/settings__database-phpmyadmin.ts"
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?