### PR TITLE
Fix reauth pathname

### DIFF
--- a/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
@@ -282,7 +282,7 @@ export default function SshCard( {
 
 	if ( userSshKeysError?.code === 'reauthorization_required' ) {
 		const currentPath = window.location.pathname;
-		const loginUrl = `/reauth-required?redirect_to=${ encodeURIComponent( currentPath ) }`;
+		const loginUrl = `/me/reauth-required?redirect_to=${ encodeURIComponent( currentPath ) }`;
 		window.location.href = loginUrl;
 		return null;
 	}

--- a/client/reauth-required/index.js
+++ b/client/reauth-required/index.js
@@ -9,5 +9,5 @@ import { render as clientRender } from 'calypso/controller';
 import { reauthRequired, makeReauthLayout } from './controller';
 
 export default function () {
-	page( '/reauth-required', reauthRequired, makeReauthLayout, clientRender );
+	page( '/me/reauth-required', reauthRequired, makeReauthLayout, clientRender );
 }

--- a/client/sections.js
+++ b/client/sections.js
@@ -10,7 +10,7 @@ const sections = [
 	},
 	{
 		name: 'reauth-required',
-		paths: [ '/reauth-required' ],
+		paths: [ '/me/reauth-required' ],
 		module: 'calypso/reauth-required',
 	},
 	{


### PR DESCRIPTION
## Proposed Changes

This changes the pathname of the reauthing route to `/me/reauth-required` instead of `/reauth-required`. Because /me is already mapped to Calypso but `/reauth-required` is not.

## Why are these changes being made?
Because `/reauth-required` is 404 in production.

## Testing Instructions

1. Go to `/sites/settings/v2/YOUR_ATOMIC_SITE`.
2. Click "SFTP/SSH".
3. You should be redirected to `/me/reauth-required`.
4. You should be able to reauth.
5. You should be taken back to the SSH settings.
