### PR TITLE
Open WoA upgrade warning Learn More in Help Center

### DIFF
--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -130,12 +130,13 @@ describe( '<EligibilityWarnings>', () => {
 				{
 					name: 'Warning 2',
 					description: 'Describes warning 2',
+					supportPostId: 123,
 					supportUrl: 'https://helpme.com',
 				},
 			],
 		} );
 
-		const { getByText } = renderWithStore(
+		const { getByRole, getByText } = renderWithStore(
 			<EligibilityWarnings backUrl="" onProceed={ noop } />,
 			state
 		);
@@ -145,7 +146,7 @@ describe( '<EligibilityWarnings>', () => {
 		expect( getByText( 'Warning 2' ) ).toBeVisible();
 		expect( getByText( 'Describes warning 2' ) ).toBeVisible();
 
-		expect( getByText( 'Learn more.' ) ).toHaveAttribute( 'href', 'https://helpme.com' );
+		expect( getByRole( 'link' ) ).toHaveAttribute( 'href', 'https://helpme.com' );
 	} );
 
 	it( "doesn't render warnings when there are blocking holds", () => {

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -1,7 +1,7 @@
 import { Card, Badge } from '@automattic/components';
 import DOMPurify from 'dompurify';
 import { localize, LocalizeProps, translate } from 'i18n-calypso';
-import { Fragment, useRef } from 'react';
+import { Fragment } from 'react';
 import ActionPanelLink from 'calypso/components/action-panel/link';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import type { DomainNames, EligibilityWarning } from 'calypso/state/automated-transfer/selectors';
@@ -15,8 +15,6 @@ interface ExternalProps {
 type Props = ExternalProps & LocalizeProps;
 
 export const WarningList = ( { context, translate, warnings, showContact = true }: Props ) => {
-	const descriptionRef = useRef< HTMLSpanElement >( null );
-
 	return (
 		<div>
 			{ warnings.map( ( { name, description, supportPostId, supportUrl, domainNames }, index ) => (
@@ -27,7 +25,7 @@ export const WarningList = ( { context, translate, warnings, showContact = true 
 								<span className="eligibility-warnings__message-title">{ name }</span>:&nbsp;
 							</Fragment>
 						) }
-						<span className="eligibility-warnings__message-description" ref={ descriptionRef }>
+						<span className="eligibility-warnings__message-description">
 							<span
 								dangerouslySetInnerHTML={ { __html: DOMPurify.sanitize( description ) } } // eslint-disable-line react/no-danger
 							/>

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -1,9 +1,9 @@
-import { Card, Badge, ExternalLink } from '@automattic/components';
+import { Card, Badge } from '@automattic/components';
 import DOMPurify from 'dompurify';
 import { localize, LocalizeProps, translate } from 'i18n-calypso';
-import { Fragment, useEffect, useRef } from 'react';
+import { Fragment, useRef } from 'react';
 import ActionPanelLink from 'calypso/components/action-panel/link';
-import useSupportDocData from 'calypso/components/inline-support-link/use-support-doc-data';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import type { DomainNames, EligibilityWarning } from 'calypso/state/automated-transfer/selectors';
 
 interface ExternalProps {
@@ -14,46 +14,12 @@ interface ExternalProps {
 
 type Props = ExternalProps & LocalizeProps;
 
-const WP_ADMIN_HELP_CENTER_LINK_SELECTOR = 'a[data-help-center-link]';
-
 export const WarningList = ( { context, translate, warnings, showContact = true }: Props ) => {
 	const descriptionRef = useRef< HTMLSpanElement >( null );
-	const { openSupportDoc, supportDocData, setSupportDocData } = useSupportDocData( {} );
-
-	useEffect( () => {
-		const link = descriptionRef.current?.querySelector( WP_ADMIN_HELP_CENTER_LINK_SELECTOR );
-
-		if ( link && ! supportDocData?.link ) {
-			setSupportDocData( {
-				link: link.getAttribute( 'href' ) || '',
-			} );
-		}
-	} );
-
-	// Keep the click handler up to date with the latest `openSupportDoc` function.
-	useEffect( () => {
-		const link = descriptionRef.current?.querySelector( WP_ADMIN_HELP_CENTER_LINK_SELECTOR );
-
-		if ( ! link ) {
-			return;
-		}
-
-		const onClick = ( event: Event ) => {
-			event.preventDefault();
-
-			openSupportDoc();
-		};
-
-		link.addEventListener( 'click', onClick );
-
-		return () => {
-			link.removeEventListener( 'click', onClick );
-		};
-	}, [ openSupportDoc ] );
 
 	return (
 		<div>
-			{ warnings.map( ( { name, description, supportUrl, domainNames }, index ) => (
+			{ warnings.map( ( { name, description, supportPostId, supportUrl, domainNames }, index ) => (
 				<div className="eligibility-warnings__warning" key={ index }>
 					<div className="eligibility-warnings__message">
 						{ context !== 'plugin-details' && context !== 'hosting-features' && (
@@ -67,9 +33,9 @@ export const WarningList = ( { context, translate, warnings, showContact = true 
 							/>
 							{ domainNames && displayDomainNames( domainNames ) }
 							{ supportUrl && (
-								<ExternalLink href={ supportUrl } target="_blank">
+								<InlineSupportLink supportLink={ supportUrl } supportPostId={ supportPostId }>
 									{ translate( 'Learn more.' ) }
-								</ExternalLink>
+								</InlineSupportLink>
 							) }
 						</span>
 					</div>

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -14,9 +14,7 @@ interface ExternalProps {
 
 type Props = ExternalProps & LocalizeProps;
 
-const WP_ADMIN_HELP_CENTER_LINK_SELECTOR = 'a';
-// TODO: Update wpcom to match this
-// const WP_ADMIN_HELP_CENTER_LINK_SELECTOR = 'a[data-help-center-link]';
+const WP_ADMIN_HELP_CENTER_LINK_SELECTOR = 'a[data-help-center-link]';
 
 export const WarningList = ( { context, translate, warnings, showContact = true }: Props ) => {
 	const descriptionRef = useRef< HTMLSpanElement >( null );
@@ -42,11 +40,12 @@ export const WarningList = ( { context, translate, warnings, showContact = true 
 
 		const onClick = ( event: Event ) => {
 			event.preventDefault();
-			// TODO: Investigate `findDOMNode` error that's preventing correct scrolling (might get solved once the data attribute is in place?)
+
 			openSupportDoc();
 		};
 
 		link.addEventListener( 'click', onClick );
+
 		return () => {
 			link.removeEventListener( 'click', onClick );
 		};

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -1,8 +1,9 @@
 import { Card, Badge, ExternalLink } from '@automattic/components';
 import DOMPurify from 'dompurify';
 import { localize, LocalizeProps, translate } from 'i18n-calypso';
-import { Fragment } from 'react';
+import { Fragment, useEffect, useRef } from 'react';
 import ActionPanelLink from 'calypso/components/action-panel/link';
+import useSupportDocData from 'calypso/components/inline-support-link/use-support-doc-data';
 import type { DomainNames, EligibilityWarning } from 'calypso/state/automated-transfer/selectors';
 
 interface ExternalProps {
@@ -13,7 +14,44 @@ interface ExternalProps {
 
 type Props = ExternalProps & LocalizeProps;
 
+const WP_ADMIN_HELP_CENTER_LINK_SELECTOR = 'a';
+// TODO: Update wpcom to match this
+// const WP_ADMIN_HELP_CENTER_LINK_SELECTOR = 'a[data-help-center-link]';
+
 export const WarningList = ( { context, translate, warnings, showContact = true }: Props ) => {
+	const descriptionRef = useRef< HTMLSpanElement >( null );
+	const { openSupportDoc, supportDocData, setSupportDocData } = useSupportDocData( {} );
+
+	useEffect( () => {
+		const link = descriptionRef.current?.querySelector( WP_ADMIN_HELP_CENTER_LINK_SELECTOR );
+
+		if ( link && ! supportDocData?.link ) {
+			setSupportDocData( {
+				link: link.getAttribute( 'href' ) || '',
+			} );
+		}
+	} );
+
+	// Keep the click handler up to date with the latest `openSupportDoc` function.
+	useEffect( () => {
+		const link = descriptionRef.current?.querySelector( WP_ADMIN_HELP_CENTER_LINK_SELECTOR );
+
+		if ( ! link ) {
+			return;
+		}
+
+		const onClick = ( event: Event ) => {
+			event.preventDefault();
+			// TODO: Investigate `findDOMNode` error that's preventing correct scrolling (might get solved once the data attribute is in place?)
+			openSupportDoc();
+		};
+
+		link.addEventListener( 'click', onClick );
+		return () => {
+			link.removeEventListener( 'click', onClick );
+		};
+	}, [ openSupportDoc ] );
+
 	return (
 		<div>
 			{ warnings.map( ( { name, description, supportUrl, domainNames }, index ) => (
@@ -24,7 +62,7 @@ export const WarningList = ( { context, translate, warnings, showContact = true 
 								<span className="eligibility-warnings__message-title">{ name }</span>:&nbsp;
 							</Fragment>
 						) }
-						<span className="eligibility-warnings__message-description">
+						<span className="eligibility-warnings__message-description" ref={ descriptionRef }>
 							<span
 								dangerouslySetInnerHTML={ { __html: DOMPurify.sanitize( description ) } } // eslint-disable-line react/no-danger
 							/>

--- a/client/components/inline-support-link/use-support-doc-data.ts
+++ b/client/components/inline-support-link/use-support-doc-data.ts
@@ -1,6 +1,6 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { dispatch } from '@wordpress/data';
-import { useEffect, useState } from 'react';
+import { Dispatch, SetStateAction, useCallback, useEffect, useState } from 'react';
 import type { ContextLinks, SupportDocData } from './types';
 import type { HelpCenterDispatch } from '@automattic/data-stores';
 
@@ -39,6 +39,7 @@ const useSupportDocData = ( {
 } ): {
 	supportDocData: SupportDocData | null;
 	openSupportDoc: () => Promise< void > | void;
+	setSupportDocData: Dispatch< SetStateAction< SupportDocData > >;
 } => {
 	const [ supportDocData, setSupportDocData ] = useState< SupportDocData >( {
 		link: supportLink ? localizeUrl( supportLink ) : supportLink,
@@ -51,11 +52,11 @@ const useSupportDocData = ( {
 
 	const [ isLoading, setIsLoading ] = useState( shouldLoadSupportDocData );
 
-	const openSupportDoc = async () => {
+	const openSupportDoc = useCallback( async () => {
 		// Load `@automattic/data-stores` asynchronously to avoid including it in the main bundle and reduce initial load size.
 		const { setShowSupportDoc } = await loadHelpCenterDispatch();
 		setShowSupportDoc( supportDocData.link, supportDocData.postId, supportDocData.blogId );
-	};
+	}, [ supportDocData.blogId, supportDocData.link, supportDocData.postId ] );
 
 	useEffect( () => {
 		const loadSupportDocDataByContext = async ( context: string ) => {
@@ -86,6 +87,7 @@ const useSupportDocData = ( {
 	return {
 		supportDocData: ! isLoading ? supportDocData : null,
 		openSupportDoc,
+		setSupportDocData,
 	};
 };
 

--- a/client/components/inline-support-link/use-support-doc-data.ts
+++ b/client/components/inline-support-link/use-support-doc-data.ts
@@ -1,6 +1,6 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { dispatch } from '@wordpress/data';
-import { Dispatch, SetStateAction, useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ContextLinks, SupportDocData } from './types';
 import type { HelpCenterDispatch } from '@automattic/data-stores';
 
@@ -39,7 +39,6 @@ const useSupportDocData = ( {
 } ): {
 	supportDocData: SupportDocData | null;
 	openSupportDoc: () => Promise< void > | void;
-	setSupportDocData: Dispatch< SetStateAction< SupportDocData > >;
 } => {
 	const [ supportDocData, setSupportDocData ] = useState< SupportDocData >( {
 		link: supportLink ? localizeUrl( supportLink ) : supportLink,
@@ -52,11 +51,11 @@ const useSupportDocData = ( {
 
 	const [ isLoading, setIsLoading ] = useState( shouldLoadSupportDocData );
 
-	const openSupportDoc = useCallback( async () => {
+	const openSupportDoc = async () => {
 		// Load `@automattic/data-stores` asynchronously to avoid including it in the main bundle and reduce initial load size.
 		const { setShowSupportDoc } = await loadHelpCenterDispatch();
 		setShowSupportDoc( supportDocData.link, supportDocData.postId, supportDocData.blogId );
-	}, [ supportDocData.blogId, supportDocData.link, supportDocData.postId ] );
+	};
 
 	useEffect( () => {
 		const loadSupportDocDataByContext = async ( context: string ) => {
@@ -87,7 +86,6 @@ const useSupportDocData = ( {
 	return {
 		supportDocData: ! isLoading ? supportDocData : null,
 		openSupportDoc,
-		setSupportDocData,
 	};
 };
 

--- a/client/state/automated-transfer/selectors/index.ts
+++ b/client/state/automated-transfer/selectors/index.ts
@@ -22,6 +22,7 @@ export interface EligibilityWarning {
 	description: string;
 	name: string;
 	id: string;
+	supportPostId?: number;
 	supportUrl?: string;
 	domainNames?: DomainNames;
 }

--- a/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
@@ -59,10 +59,11 @@ export const eligibilityHoldsFromApi = ( { errors = [] }, options = {} ) =>
 const eligibilityWarningsFromApi = ( { warnings = {} } ) =>
 	Object.keys( warnings )
 		.reduce( ( list, type ) => list.concat( warnings[ type ] ), [] ) // combine plugin and theme warnings into one list
-		.map( ( { description, name, support_url, id, domain_names } ) => ( {
+		.map( ( { description, name, support_url, support_post_id, id, domain_names } ) => ( {
 			id,
 			name,
 			description,
+			supportPostId: support_post_id,
 			supportUrl: support_url,
 			domainNames: domain_names,
 		} ) );

--- a/packages/help-center/src/components/help-center-article.tsx
+++ b/packages/help-center/src/components/help-center-article.tsx
@@ -37,10 +37,10 @@ export const HelpCenterArticle = () => {
 				if ( anchorId ) {
 					const element = document.getElementById( anchorId );
 					if ( element ) {
-						element.scrollIntoView();
+						element.scrollIntoView( { behavior: 'instant' } );
 					}
 				}
-			}, 0 );
+			}, 100 );
 		}
 	}, [ postUrl, post ] );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTSUP-74

## Proposed Changes

* Handle the link and post id returned by the API so the WoA upgrade warning opens on the Help Center.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout 186398-ghe-Automattic/wpcom on your sandbox
* Sandbox public-api
* Open the live preview
* Go to `/plugins/upload/{siteSlug}` on a simple site
* Click on the `Learn more ↗` link
* Check that it open the Help Center on the `Change a wpcomstaging.com Address` section

![chrome-capture-2025-6-27](https://github.com/user-attachments/assets/6e49841e-1a60-4f30-b27f-0c24f9739fc8)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?