### PR TITLE
Login: Add username support to lost-password form

### DIFF
--- a/client/blocks/login/login-header.tsx
+++ b/client/blocks/login/login-header.tsx
@@ -127,6 +127,8 @@ export function getHeaderText(
 
 	if ( action === 'lostpassword' ) {
 		headerText = translate( 'Forgot your password?' );
+	} else if ( currentQuery.lostpassword_flow === 'true' ) {
+		headerText = translate( "You've got mail" );
 	} else if ( oauth2Client ) {
 		if ( isJetpackCloudOAuth2Client( oauth2Client ) ) {
 			headerText = translate( 'Howdy! Log in to Jetpack.com with your WordPress.com account.' );
@@ -148,10 +150,7 @@ export function getHeaderText(
 			} );
 		}
 	} else if ( isWooJPC ) {
-		const isLostPasswordFlow = currentQuery.lostpassword_flow === 'true';
-		if ( isLostPasswordFlow ) {
-			headerText = translate( "You've got mail" );
-		} else if ( twoFactorEnabled ) {
+		if ( twoFactorEnabled ) {
 			headerText = translate( 'Authenticate your login' );
 		} else {
 			headerText = translate( 'Log in to your account' );

--- a/client/blocks/login/lost-password-form.jsx
+++ b/client/blocks/login/lost-password-form.jsx
@@ -148,7 +148,14 @@ const LostPasswordForm = ( {
 					value={ userLogin }
 					isError={ showError }
 					onBlur={ validateUserLogin }
-					onChange={ ( event ) => setUserLogin( event.target.value.trim() ) }
+					onChange={ ( event ) => {
+						const newValue = event.target.value.trim();
+						setUserLogin( newValue );
+						// Clear error immediately when user starts typing to fix input
+						if ( error ) {
+							setError( null );
+						}
+					} }
 				/>
 				{ showError && <FormInputValidation isError text={ error } /> }
 			</div>

--- a/client/blocks/login/lost-password-form.jsx
+++ b/client/blocks/login/lost-password-form.jsx
@@ -17,22 +17,32 @@ const LostPasswordForm = ( {
 	isWoo,
 } ) => {
 	const translate = useTranslate();
-	const [ email, setEmail ] = useState( '' );
+	const [ userLogin, setUserLogin ] = useState( '' );
 	const [ error, setError ] = useState( null );
 	const [ isBusy, setBusy ] = useState( false );
 	const dispatch = useDispatch();
 
-	const validateEmail = () => {
-		if ( email.length === 0 || email.includes( '@' ) ) {
+	const validateUserLogin = () => {
+		// Allow empty input or any non-empty value (username or email)
+		if ( userLogin.length === 0 ) {
 			setError( null );
+		} else if ( userLogin.includes( '@' ) ) {
+			// If it contains @, validate as email
+			const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+			if ( emailRegex.test( userLogin ) ) {
+				setError( null );
+			} else {
+				setError( translate( 'Please enter a valid email address.' ) );
+			}
 		} else {
-			setError( translate( 'This email address is not valid. It must include a single @' ) );
+			// Username - accept any non-empty value
+			setError( null );
 		}
 	};
 
-	const getAuthAccountTypeRequest = async ( emailAddress ) => {
+	const getAuthAccountTypeRequest = async ( userNameOrEmail ) => {
 		const resp = await window.fetch(
-			`https://public-api.wordpress.com/rest/v1.1/users/${ emailAddress }/auth-options`,
+			`https://public-api.wordpress.com/rest/v1.1/users/${ userNameOrEmail }/auth-options`,
 			{
 				method: 'GET',
 			}
@@ -45,7 +55,7 @@ const LostPasswordForm = ( {
 
 	const lostPasswordRequest = async () => {
 		const formData = new FormData();
-		formData.set( 'user_login', email );
+		formData.set( 'user_login', userLogin );
 
 		const origin = typeof window !== 'undefined' ? window.location.origin : '';
 		const resp = await window.fetch( `${ origin }/wp-login.php?action=lostpassword`, {
@@ -64,10 +74,10 @@ const LostPasswordForm = ( {
 		event.preventDefault();
 
 		if ( isWooJPC ) {
-			const accountType = await getAuthAccountTypeRequest( email );
+			const accountType = await getAuthAccountTypeRequest( userLogin );
 			if ( accountType?.passwordless === true ) {
 				await dispatch(
-					sendEmailLogin( email, {
+					sendEmailLogin( userLogin, {
 						redirectTo: redirectToAfterLoginUrl,
 						loginFormFlow: true,
 						showGlobalNotices: true,
@@ -81,7 +91,7 @@ const LostPasswordForm = ( {
 						twoFactorAuthType: 'link',
 						locale: locale,
 						from: from,
-						emailAddress: email,
+						emailAddress: userLogin,
 					} )
 				);
 				return;
@@ -103,7 +113,7 @@ const LostPasswordForm = ( {
 					oauth2ClientId,
 					locale,
 					redirectTo: redirectToAfterLoginUrl,
-					emailAddress: email,
+					emailAddress: userLogin,
 					lostpasswordFlow: true,
 					action: isWooJPC ? 'jetpack' : null,
 					from,
@@ -126,19 +136,19 @@ const LostPasswordForm = ( {
 			onSubmit={ onSubmit }
 		>
 			<div className="login__form-userdata">
-				<FormLabel htmlFor="email">{ translate( 'Your email' ) }</FormLabel>
+				<FormLabel htmlFor="userLogin">{ translate( 'Username or email address' ) }</FormLabel>
 				<FormTextInput
 					autoCapitalize="off"
 					autoCorrect="off"
 					spellCheck="false"
-					autoComplete="email"
-					id="email"
-					name="email"
-					type="email"
-					value={ email }
+					autoComplete="username"
+					id="userLogin"
+					name="userLogin"
+					type="text"
+					value={ userLogin }
 					isError={ showError }
-					onBlur={ validateEmail }
-					onChange={ ( event ) => setEmail( event.target.value.trim() ) }
+					onBlur={ validateUserLogin }
+					onChange={ ( event ) => setUserLogin( event.target.value.trim() ) }
 				/>
 				{ showError && <FormInputValidation isError text={ error } /> }
 			</div>
@@ -146,7 +156,7 @@ const LostPasswordForm = ( {
 				<Button
 					variant="primary"
 					type="submit"
-					disabled={ email.length === 0 || showError || isBusy }
+					disabled={ userLogin.length === 0 || showError || isBusy }
 					isBusy={ isBusy }
 					__next40pxDefaultSize
 				>

--- a/client/blocks/login/test/lost-password-form.jsx
+++ b/client/blocks/login/test/lost-password-form.jsx
@@ -14,8 +14,8 @@ describe( 'LostPasswordForm', () => {
 	test( 'displays a lost password form without errors', () => {
 		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );
 
-		const email = screen.getByLabelText( /Your email/i );
-		expect( email ).toBeInTheDocument();
+		const userLogin = screen.getByLabelText( /Username or email address/i );
+		expect( userLogin ).toBeInTheDocument();
 
 		const btn = screen.getByRole( 'button', { name: /Reset my password/i } );
 		expect( btn ).toBeInTheDocument();
@@ -27,7 +27,10 @@ describe( 'LostPasswordForm', () => {
 	test( 'displays an error message when email is invalid', async () => {
 		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );
 
-		await userEvent.type( screen.getByRole( 'textbox', { name: 'Your email' } ), 'invalid email' );
+		await userEvent.type(
+			screen.getByRole( 'textbox', { name: 'Username or email address' } ),
+			'invalid@email'
+		);
 		// The error message is displayed after the user blurs the input.
 		userEvent.tab();
 
@@ -43,7 +46,7 @@ describe( 'LostPasswordForm', () => {
 		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );
 
 		await userEvent.type(
-			screen.getByRole( 'textbox', { name: 'Your email' } ),
+			screen.getByRole( 'textbox', { name: 'Username or email address' } ),
 			'user@example.com'
 		);
 		// The error message is displayed after the user blurs the input.
@@ -56,12 +59,16 @@ describe( 'LostPasswordForm', () => {
 	test( 'reset error message when email is valid', async () => {
 		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );
 
-		await userEvent.type( screen.getByRole( 'textbox', { name: 'Your email' } ), 'invalid email' );
+		await userEvent.type(
+			screen.getByRole( 'textbox', { name: 'Username or email address' } ),
+			'invalid@email'
+		);
 		// The error message is displayed after the user blurs the input.
 		userEvent.tab();
 
+		await userEvent.clear( screen.getByRole( 'textbox', { name: 'Username or email address' } ) );
 		await userEvent.type(
-			screen.getByRole( 'textbox', { name: 'Your email' } ),
+			screen.getByRole( 'textbox', { name: 'Username or email address' } ),
 			'user@example.com'
 		);
 		// The error message is displayed after the user blurs the input.
@@ -72,19 +79,66 @@ describe( 'LostPasswordForm', () => {
 		} );
 	} );
 
-	test( 'reset error message when email is empty', async () => {
+	test( 'reset error message when input is empty', async () => {
 		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );
 
-		await userEvent.type( screen.getByRole( 'textbox', { name: 'Your email' } ), 'invalid email' );
+		await userEvent.type(
+			screen.getByRole( 'textbox', { name: 'Username or email address' } ),
+			'invalid@email'
+		);
 		// The error message is displayed after the user blurs the input.
 		userEvent.tab();
 
-		await userEvent.clear( screen.getByRole( 'textbox', { name: 'Your email' } ) );
+		await userEvent.clear( screen.getByRole( 'textbox', { name: 'Username or email address' } ) );
 		// The error message is displayed after the user blurs the input.
 		userEvent.tab();
 
 		await waitFor( () => {
 			expect( screen.queryByRole( 'alert' ) ).toBeNull();
 		} );
+	} );
+
+	test( 'enable submit button when username is valid', async () => {
+		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );
+
+		await userEvent.type(
+			screen.getByRole( 'textbox', { name: 'Username or email address' } ),
+			'validusername'
+		);
+		// The validation happens after the user blurs the input.
+		userEvent.tab();
+
+		const btn = screen.getByRole( 'button', { name: /Reset my password/i } );
+		expect( btn ).toBeEnabled();
+	} );
+
+	test( 'enable submit button when short username is entered', async () => {
+		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );
+
+		await userEvent.type(
+			screen.getByRole( 'textbox', { name: 'Username or email address' } ),
+			'ab'
+		);
+		// The validation happens after the user blurs the input.
+		userEvent.tab();
+
+		const btn = screen.getByRole( 'button', { name: /Reset my password/i } );
+		expect( btn ).toBeEnabled();
+		expect( screen.queryByRole( 'alert' ) ).toBeNull();
+	} );
+
+	test( 'enable submit button when username with special characters is entered', async () => {
+		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );
+
+		await userEvent.type(
+			screen.getByRole( 'textbox', { name: 'Username or email address' } ),
+			'user123'
+		);
+		// The validation happens after the user blurs the input.
+		userEvent.tab();
+
+		const btn = screen.getByRole( 'button', { name: /Reset my password/i } );
+		expect( btn ).toBeEnabled();
+		expect( screen.queryByRole( 'alert' ) ).toBeNull();
 	} );
 } );


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/104367

## Proposed Changes

Updated the lost-password form to accept both usernames and email addresses

* Changed form label from "Your email" to "Username or email address"
* Modified validation logic to handle both input types appropriately
* Updated form input attributes (id, name, type, autocomplete) to reflect new functionality
* Added comprehensive test coverage for username input scenarios

## Why are these changes being made?

The backend endpoints already support both username and email for password reset requests, but the frontend form was artificially limiting users to only email addresses. This change improves user experience by allowing users to reset their password using either their username or email address, matching the flexibility already available in the backend API.

This is particularly helpful for users who:
- Remember their username but not their email address
- Have multiple email addresses and are unsure which one is associated with their account
- Prefer to use their username for account recovery

## Testing Instructions

The lost password APIs only works with specfic domains like wordpress.com, so you need to use a proxy to test the functionality

1. Proxy wordpress.com PCYsg-5YE-p2
1. Navigate to the lost password form (e.g., `/wp-login.php?action=lostpassword`). [Link](https://wordpress.com/log-in/lostpassword?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D9e6a286cc5036b14fdeb0928b9c7b83ab16cc7d12bfc939ae18cd68a77606a5d%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26from-calypso%3D1&client_id=50916) for testing Woo flow.
2. Test email input:
   - Enter a valid email address (e.g., `user@example.com`)
   - Form should accept it and submit successfully
   - Enter an invalid email (e.g., `invalid@email`) 
   - Form should show validation error
3. Test username input:
   - Enter a valid username (e.g., `testuser123`)
   - Form should accept it without validation errors
   - Enter any non-empty username value
   - Form should accept it (no username validation restrictions)
4. Test empty input:
   - Leave field empty and try to submit
   - Submit button should be disabled
5. Submit form with valid email or username
6. Verify you are redirected to the Login page
7. Verify you receive the reset password email


<img width="1137" alt="Screenshot 2025-06-24 at 10 37 18" src="https://github.com/user-attachments/assets/e54963a9-2b72-4dc7-beaa-8ecfe4e29e6b" />
<img width="1141" alt="Screenshot 2025-06-24 at 10 37 50" src="https://github.com/user-attachments/assets/8536cd10-a151-410e-90ec-c57e1796cdef" />


https://github.com/user-attachments/assets/4de0e95c-32b9-47fc-a64b-8201a0883a12


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.ai/code)