### PR TITLE
Sites List v2: Add site actions eligibility check

### DIFF
--- a/client/dashboard/data/site.ts
+++ b/client/dashboard/data/site.ts
@@ -23,6 +23,7 @@ export const SITE_FIELDS = [
 	'site_owner',
 	'options',
 	'jetpack',
+	'jetpack_connection',
 	'jetpack_modules',
 ];
 
@@ -97,6 +98,7 @@ export interface Site {
 	};
 	site_owner: number;
 	jetpack: boolean;
+	jetpack_connection: boolean;
 	jetpack_modules: string[] | null;
 	hosting_provider_guess?: string;
 }

--- a/client/dashboard/sites/features.ts
+++ b/client/dashboard/sites/features.ts
@@ -1,5 +1,6 @@
 import { DotcomFeatures } from '../data/constants';
 import { hasAtomicFeature, hasPlanFeature } from '../utils/site-features';
+import { isJetpackNotAtomic, isP2 } from '../utils/site-types';
 import type { Site, User } from '../data/types';
 
 export const HostingFeatures = {
@@ -16,6 +17,29 @@ export const HostingFeatures = {
 } as const;
 
 export type HostingFeatures = ( typeof HostingFeatures )[ keyof typeof HostingFeatures ];
+
+export function canManageSite( site: Site ) {
+	if ( site.is_deleted || ! site.capabilities.manage_options ) {
+		return false;
+	}
+
+	// P2 sites are not supported.
+	if ( isP2( site ) ) {
+		return false;
+	}
+
+	// VIP sites are not supported, yet.
+	if ( site.is_vip ) {
+		return false;
+	}
+
+	// Jetpack sites are not supported, yet.
+	if ( isJetpackNotAtomic( site ) ) {
+		return false;
+	}
+
+	return true;
+}
 
 // Settings -> General
 
@@ -87,8 +111,7 @@ export function canTransferSite( site: Site, user: User ) {
 		( site.jetpack && ! site.is_wpcom_atomic ) ||
 		site.is_wpcom_staging_site ||
 		site.is_vip ||
-		!! site.options?.p2_hub_blog_id ||
-		site.options?.is_wpforteams_site
+		isP2( site )
 	);
 
 	const isSiteOwner = site.site_owner === user.ID;

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -15,6 +15,7 @@ import TimeSince from '../components/time-since';
 import { STATUS_LABELS, getSiteStatus } from '../utils/site-status';
 import { getFormattedWordPressVersion } from '../utils/wp-version';
 import AddNewSite from './add-new-site';
+import { canManageSite } from './features';
 import {
 	EngagementStat,
 	LastBackup,
@@ -269,7 +270,7 @@ const getDefaultActions = ( router: AnyRouter ) => {
 				const site = sites[ 0 ];
 				window.open( `/domains/manage/${ site.slug }` );
 			},
-			isEligible: ( item: Site ) => ! item.is_deleted,
+			isEligible: ( item: Site ) => canManageSite( item ),
 		},
 		{
 			id: 'settings',
@@ -278,7 +279,7 @@ const getDefaultActions = ( router: AnyRouter ) => {
 				const site = sites[ 0 ];
 				router.navigate( { to: '/sites/$siteSlug/settings', params: { siteSlug: site.slug } } );
 			},
-			isEligible: ( item: Site ) => ! item.is_deleted,
+			isEligible: ( item: Site ) => canManageSite( item ),
 		},
 	];
 };

--- a/client/dashboard/utils/site-types.ts
+++ b/client/dashboard/utils/site-types.ts
@@ -1,0 +1,9 @@
+import type { Site } from '../data/types';
+
+export function isJetpackNotAtomic( site: Site ) {
+	return site.jetpack_connection && ! site.is_wpcom_atomic;
+}
+
+export function isP2( site: Site ) {
+	return !! site.options?.p2_hub_blog_id || site.options?.is_wpforteams_site;
+}


### PR DESCRIPTION
Ref DOTDASH-42

## Proposed Changes

This PR implements eligibility checks to the "Domains" and "Settings" actions.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Sites List v2 development.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2.
* Ensure that non-eligible sites no longer see the actions "Domains" and "Settings" 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
