### PR TITLE
[ui]: publish @automattic/ui@1.0.2

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-## Next
+## 1.0.2
 
 ### Enhancements
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/ui",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Automattic Design System UI components.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of WOOA7S-147

## Proposed Changes

* Bump package version of `@automattic/ui` from `1.0.1` to `1.0.2`.
* Move changelog entry from "Next" to new `1.0.2` section.

## Why are these changes being made?

This is a follow-up to publish a new version of the `@automattic/ui` package. The `1.0.2` release includes an enhancement to ensure proper stacking context and background handling in `DateCalendar` and `DateRangeCalendar`, improving compatibility with pseudo-element styling.

## Testing Instructions

* Confirm the version bump to `1.0.2` in `package.json`.
* Confirm that the changelog reflects the correct version and PR reference.
* Follow the standard publishing workflow for npm packages if applicable.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you confirmed that this release includes only the intended changes?
- [ ] Have you tested the build output and verified the package works as expected?
- [ ] Has the correct version tag been added or planned after merging?
- [ ] Have you checked that no breaking changes are being introduced?
