### PR TITLE
A4A > Reports: Update the build report flow

### DIFF
--- a/client/a8c-for-agencies/sections/reports/hooks/use-duplicate-report-form-data.tsx
+++ b/client/a8c-for-agencies/sections/reports/hooks/use-duplicate-report-form-data.tsx
@@ -3,42 +3,27 @@ import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useCallback } from 'react';
 import { useSelector } from 'calypso/state';
 import getSites from 'calypso/state/selectors/get-sites';
+import { getStatsOptions } from '../lib/stat-options';
+import { getAvailableTimeframes } from '../lib/timeframes';
 import useFetchReportById from './use-fetch-report-by-id';
 import type {
 	BuildReportFormData,
 	BuildReportCheckedItemsState,
 	ReportFormAPIResponse,
-	TimeframeOption,
-	TimeframeValue,
+	UseDuplicateReportFormDataReturn,
 } from '../types';
 import type { A4ASelectSiteItem } from 'calypso/a8c-for-agencies/components/a4a-select-site/types';
 
-interface UseDuplicateReportFormDataReturn {
-	formData: BuildReportFormData;
-	setSelectedTimeframe: ( value: TimeframeValue ) => void;
-	setSelectedSite: ( site: A4ASelectSiteItem | null ) => void;
-	setClientEmail: ( value: string ) => void;
-	setCustomIntroText: ( value: string ) => void;
-	setSendCopyToTeam: ( value: boolean ) => void;
-	setTeammateEmails: ( value: string ) => void;
-	setStartDate: ( value: string | undefined ) => void;
-	setEndDate: ( value: string | undefined ) => void;
-	setStatsCheckedItems: ( value: BuildReportCheckedItemsState ) => void;
-	isLoading: boolean;
-	isDuplicating: boolean;
-	error: Error | null;
-}
-
-export const useDuplicateReportFormData = (
-	availableTimeframes: TimeframeOption[],
-	statsOptions: { label: string; value: string }[]
-): UseDuplicateReportFormDataReturn => {
+export const useDuplicateReportFormData = (): UseDuplicateReportFormDataReturn => {
 	const translate = useTranslate();
 	const sites = useSelector( getSites );
 
 	// Get sourceId from URL parameters
 	const sourceId = getQueryArg( window.location.href, 'sourceId' ) as unknown as number;
 	const isDuplicating = Boolean( sourceId );
+
+	const availableTimeframes = getAvailableTimeframes( translate );
+	const statsOptions = getStatsOptions( translate );
 
 	const {
 		data: reportDetails,
@@ -119,15 +104,17 @@ export const useDuplicateReportFormData = (
 
 	return {
 		formData,
-		setSelectedTimeframe,
-		setSelectedSite,
-		setClientEmail,
-		setCustomIntroText,
-		setSendCopyToTeam,
-		setTeammateEmails,
-		setStartDate,
-		setEndDate,
-		setStatsCheckedItems,
+		handlers: {
+			setSelectedTimeframe,
+			setSelectedSite,
+			setClientEmail,
+			setCustomIntroText,
+			setSendCopyToTeam,
+			setTeammateEmails,
+			setStartDate,
+			setEndDate,
+			setStatsCheckedItems,
+		},
 		isLoading,
 		isDuplicating,
 		error,

--- a/client/a8c-for-agencies/sections/reports/hooks/use-duplicate-report-form-data.tsx
+++ b/client/a8c-for-agencies/sections/reports/hooks/use-duplicate-report-form-data.tsx
@@ -11,6 +11,7 @@ import type {
 	BuildReportCheckedItemsState,
 	ReportFormAPIResponse,
 	UseDuplicateReportFormDataReturn,
+	TimeframeValue,
 } from '../types';
 import type { A4ASelectSiteItem } from 'calypso/a8c-for-agencies/components/a4a-select-site/types';
 
@@ -37,7 +38,7 @@ export const useDuplicateReportFormData = (): UseDuplicateReportFormDataReturn =
 	yesterday.setDate( today.getDate() - 1 );
 
 	// Form state
-	const [ selectedTimeframe, setSelectedTimeframe ] = useState(
+	const [ selectedTimeframe, setSelectedTimeframe ] = useState< TimeframeValue >(
 		availableTimeframes[ 0 ]?.value || '30_days'
 	);
 	const [ selectedSite, setSelectedSite ] = useState< A4ASelectSiteItem | null >( null );

--- a/client/a8c-for-agencies/sections/reports/hooks/use-fetch-report-by-id.tsx
+++ b/client/a8c-for-agencies/sections/reports/hooks/use-fetch-report-by-id.tsx
@@ -2,12 +2,12 @@ import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
-import type { Report } from '../types';
+import type { Report, ReportError } from '../types';
 
 export default function useFetchReportById( reportId: number | null ) {
 	const agencyId = useSelector( getActiveAgencyId );
 
-	return useQuery< Report, Error >( {
+	return useQuery< Report, ReportError >( {
 		queryKey: [ 'a4a-report', agencyId, reportId ],
 		queryFn: async () => {
 			return wpcom.req.get( {
@@ -17,7 +17,10 @@ export default function useFetchReportById( reportId: number | null ) {
 		},
 		enabled: !! agencyId && !! reportId,
 		refetchOnWindowFocus: false,
-		retry: ( failureCount ) => {
+		retry: ( failureCount, error ) => {
+			if ( error.data.status === 404 ) {
+				return false;
+			}
 			return failureCount < 3;
 		},
 	} );

--- a/client/a8c-for-agencies/sections/reports/hooks/use-poll-report-status.tsx
+++ b/client/a8c-for-agencies/sections/reports/hooks/use-poll-report-status.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useRef } from 'react';
+import useFetchReportById from './use-fetch-report-by-id';
+import type { Report, ReportStatus } from '../types';
+
+interface PollReportStatusResult {
+	data: Report | undefined;
+	status: ReportStatus | undefined;
+	isLoading: boolean;
+	isError: boolean;
+	error: Error | null;
+	isProcessed: boolean;
+	isPending: boolean;
+	isErrorStatus: boolean;
+}
+
+const POLL_INTERVAL = 10000; // 10 seconds
+
+export default function usePollReportStatus( reportId: number | null ): PollReportStatusResult {
+	const intervalRef = useRef< NodeJS.Timeout | null >( null );
+
+	// Use the existing fetch hook
+	const { data, isLoading, isError, error, refetch } = useFetchReportById( reportId );
+
+	const status = data?.status;
+	const isProcessed = status ? [ 'sent', 'processed' ].includes( status ) : false;
+	const isPending = status === 'pending';
+	const isErrorStatus = status === 'error';
+
+	// Set up polling when the report is still pending
+	useEffect( () => {
+		if ( ! reportId ) {
+			return;
+		}
+
+		// Only poll if the status is pending
+		if ( isPending ) {
+			intervalRef.current = setInterval( () => {
+				refetch();
+			}, POLL_INTERVAL );
+		}
+
+		// Clear interval if status is not pending
+		if ( ! isPending && intervalRef.current ) {
+			clearInterval( intervalRef.current );
+			intervalRef.current = null;
+		}
+
+		// Cleanup interval on unmount
+		return () => {
+			if ( intervalRef.current ) {
+				clearInterval( intervalRef.current );
+				intervalRef.current = null;
+			}
+		};
+	}, [ reportId, isPending, refetch ] );
+
+	return {
+		data,
+		status,
+		isLoading,
+		isError,
+		error,
+		isProcessed,
+		isPending: isPending || isLoading,
+		isErrorStatus,
+	};
+}

--- a/client/a8c-for-agencies/sections/reports/lib/stat-options.tsx
+++ b/client/a8c-for-agencies/sections/reports/lib/stat-options.tsx
@@ -1,0 +1,20 @@
+/**
+ * Get stats options for the report
+ */
+export const getStatsOptions = (
+	translate: ( key: string, args?: Record< string, unknown > ) => string
+) => {
+	return [
+		{ label: translate( 'Visitors and Views in this timeframe' ), value: 'total_traffic' },
+		{ label: translate( 'Top 5 posts' ), value: 'top_pages' },
+		{ label: translate( 'Top 5 referrers' ), value: 'top_devices' },
+		{ label: translate( 'Top 5 cities' ), value: 'top_locations' },
+		{ label: translate( 'Device breakdown' ), value: 'device_breakdown' },
+		{
+			label: translate( 'Total Visitors and Views since the site was created' ),
+			value: 'total_traffic_all_time',
+		},
+		{ label: translate( 'Most popular time of day' ), value: 'most_popular_time_of_day' },
+		{ label: translate( 'Most popular day of week' ), value: 'most_popular_day_of_week' },
+	];
+};

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/build-report-actions.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/build-report-actions.tsx
@@ -1,0 +1,93 @@
+import page from '@automattic/calypso-router';
+import { Button } from '@wordpress/components';
+import { removeQueryArgs } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import type { BuildReportState } from '../../types';
+
+interface BuildReportActionsProps {
+	currentStep: number;
+	state: BuildReportState;
+	handlers: {
+		setCurrentStep: ( step: number ) => void;
+		handleNextStep: () => void;
+		handlePrevStep: () => void;
+	};
+}
+
+export default function BuildReportActions( {
+	currentStep,
+	state,
+	handlers,
+}: BuildReportActionsProps ) {
+	const translate = useTranslate();
+
+	const { isDuplicateLoading, sendReportMutation, reportId, isProcessed, isReportError } = state;
+
+	const { setCurrentStep, handleNextStep, handlePrevStep } = handlers;
+
+	const handleBuildNewReport = useCallback( () => {
+		page.redirect( removeQueryArgs( window.location.pathname, 'reportId' ) );
+		setCurrentStep( 1 );
+	}, [ setCurrentStep ] );
+
+	const handleBackToStep2 = useCallback( () => {
+		page.redirect( removeQueryArgs( window.location.pathname, 'reportId' ) );
+		setCurrentStep( 2 );
+	}, [ setCurrentStep ] );
+
+	const isCreatingReport = sendReportMutation.isPending;
+	const isLoadingState = isDuplicateLoading || isCreatingReport;
+
+	const handleSendReport = useCallback( () => {
+		// TODO: Implement send report functionality
+	}, [] );
+
+	return (
+		<>
+			{ currentStep < 2 && (
+				<div className="build-report__actions">
+					<Button variant="primary" onClick={ handleNextStep } disabled={ isLoadingState }>
+						{ translate( 'Next' ) }
+					</Button>
+				</div>
+			) }
+			{ currentStep === 2 && (
+				<div className="build-report__actions">
+					<Button variant="secondary" onClick={ handlePrevStep } disabled={ isLoadingState }>
+						{ translate( 'Back' ) }
+					</Button>
+					<Button
+						variant="primary"
+						onClick={ handleNextStep }
+						isBusy={ isCreatingReport }
+						disabled={ isLoadingState }
+					>
+						{ isCreatingReport ? translate( 'Preparing report…' ) : translate( 'Prepare Report' ) }
+					</Button>
+				</div>
+			) }
+			{ currentStep === 3 && reportId && (
+				<>
+					{ isProcessed && (
+						<div className="build-report__actions">
+							<Button variant="secondary" onClick={ handleBackToStep2 }>
+								{ translate( 'Back' ) }
+							</Button>
+							<Button variant="primary" onClick={ handleSendReport }>
+								{ translate( 'Send to client now' ) }
+							</Button>
+						</div>
+					) }
+					{ isReportError && (
+						<div className="build-report__actions">
+							<Button variant="primary" onClick={ handleBuildNewReport }>
+								{ translate( 'Build a new report' ) }
+							</Button>
+						</div>
+					) }
+				</>
+			) }
+		</>
+	);
+}

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/build-report-content.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/build-report-content.tsx
@@ -1,0 +1,394 @@
+import {
+	CheckboxControl,
+	DatePicker,
+	Popover,
+	SelectControl,
+	Spinner,
+	TextareaControl,
+	TextControl,
+	Button,
+} from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState, useCallback } from 'react';
+import A4ASelectSite from 'calypso/a8c-for-agencies/components/a4a-select-site';
+import { formatDate } from '../../lib/format-date';
+import { getStatsOptions } from '../../lib/stat-options';
+import { getAvailableTimeframes } from '../../lib/timeframes';
+import type {
+	BuildReportFormData,
+	BuildReportState,
+	UseDuplicateReportFormDataHandlers,
+} from '../../types';
+import type { A4ASelectSiteItem } from 'calypso/a8c-for-agencies/components/a4a-select-site/types';
+
+interface BuildReportContentProps {
+	currentStep: number;
+	formData: BuildReportFormData;
+	state: BuildReportState;
+	handlers: UseDuplicateReportFormDataHandlers;
+}
+
+export default function BuildReportContent( {
+	currentStep,
+	formData,
+	state,
+
+	handlers,
+}: BuildReportContentProps ) {
+	const translate = useTranslate();
+
+	// Internal state for date pickers
+	const [ isStartDatePickerOpen, setIsStartDatePickerOpen ] = useState( false );
+	const [ isEndDatePickerOpen, setIsEndDatePickerOpen ] = useState( false );
+
+	const {
+		selectedSite,
+		selectedTimeframe,
+		startDate,
+		endDate,
+		clientEmail,
+		sendCopyToTeam,
+		teammateEmails,
+		customIntroText,
+		statsCheckedItems,
+	} = formData;
+
+	const {
+		isDuplicateLoading,
+		sendReportMutation,
+		reportId,
+		isReportPending,
+		isReportErrorStatus,
+		isProcessed,
+		showValidationErrors,
+		validationErrors,
+	} = state;
+	const {
+		setSelectedSite,
+		setSelectedTimeframe,
+		setStartDate,
+		setEndDate,
+		setClientEmail,
+		setSendCopyToTeam,
+		setTeammateEmails,
+		setCustomIntroText,
+		setStatsCheckedItems,
+	} = handlers;
+
+	const getFieldError = useCallback(
+		( fieldName: string ): string | undefined => {
+			if ( ! showValidationErrors ) {
+				return undefined;
+			}
+			return validationErrors.find( ( error ) => error.field === fieldName )?.message;
+		},
+		[ showValidationErrors, validationErrors ]
+	);
+
+	const hasFieldError = useCallback(
+		( fieldName: string ): boolean => {
+			return (
+				showValidationErrors && validationErrors.some( ( error ) => error.field === fieldName )
+			);
+		},
+		[ showValidationErrors, validationErrors ]
+	);
+
+	const handleStep2CheckboxChange = useCallback(
+		( itemName: string ) => {
+			setStatsCheckedItems( {
+				...statsCheckedItems,
+				[ itemName ]: ! statsCheckedItems[ itemName ],
+			} );
+		},
+		[ statsCheckedItems, setStatsCheckedItems ]
+	);
+
+	const isCreatingReport = sendReportMutation.isPending;
+	const isLoadingState = isDuplicateLoading || isCreatingReport;
+
+	const availableTimeframes = getAvailableTimeframes( translate );
+	const statsOptions = getStatsOptions( translate );
+
+	switch ( currentStep ) {
+		case 1:
+			return (
+				<>
+					<h2 className="build-report__step-title">
+						{ translate( 'Step 1 of 3: Enter report details' ) }
+					</h2>
+
+					<div className="build-report__field">
+						<A4ASelectSite
+							isDisabled={ isLoadingState }
+							selectedSiteId={ selectedSite?.blogId }
+							onSiteSelect={ ( site: A4ASelectSiteItem ) => setSelectedSite( site ) }
+							buttonLabel={ selectedSite?.domain || translate( 'Choose a site to report on' ) }
+							trackingEvent="calypso_a4a_reports_select_site_button_click"
+							data-field="selectedSite"
+						/>
+						{ hasFieldError( 'selectedSite' ) && (
+							<div className="build-report__error-message">{ getFieldError( 'selectedSite' ) }</div>
+						) }
+					</div>
+
+					<SelectControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ translate( 'Report date range' ) }
+						value={ selectedTimeframe }
+						options={ availableTimeframes }
+						onChange={ setSelectedTimeframe }
+						disabled={ isLoadingState }
+					/>
+
+					{ selectedTimeframe === 'custom' && (
+						<div className="build-report__date-fields-container">
+							<div className="build-report__date-field">
+								<TextControl
+									__next40pxDefaultSize
+									__nextHasNoMarginBottom
+									id="start-date"
+									label={ translate( 'Start date' ) }
+									value={ formatDate( startDate ) }
+									placeholder={ translate( 'Select start date' ) }
+									onChange={ () => {} }
+									onClick={ () => setIsStartDatePickerOpen( true ) }
+									readOnly
+									className="build-report__date-input"
+								/>
+								{ isStartDatePickerOpen && (
+									<Popover
+										onClose={ () => setIsStartDatePickerOpen( false ) }
+										placement="bottom-start"
+										className="build-report__date-popover"
+									>
+										<DatePicker
+											currentDate={ startDate }
+											onChange={ ( date ) => {
+												setStartDate( date );
+												// If end date is set and is before or equal to the new start date,
+												// set end date to the day after start date
+												if ( endDate && new Date( date ) >= new Date( endDate ) ) {
+													const nextDay = new Date( date );
+													nextDay.setDate( nextDay.getDate() + 1 );
+													setEndDate( nextDay.toISOString().split( 'T' )[ 0 ] );
+												}
+												setIsStartDatePickerOpen( false );
+											} }
+											isInvalidDate={ ( date ) => {
+												// Disable dates from today onwards (only yesterday and earlier allowed)
+												const today = new Date();
+												today.setHours( 0, 0, 0, 0 ); // Start of today
+												return new Date( date ) >= today;
+											} }
+										/>
+									</Popover>
+								) }
+							</div>
+							<div className="build-report__date-field">
+								<TextControl
+									__next40pxDefaultSize
+									__nextHasNoMarginBottom
+									id="end-date"
+									label={ translate( 'End date' ) }
+									value={ formatDate( endDate ) }
+									placeholder={ translate( 'Select end date' ) }
+									onChange={ () => {} }
+									onClick={ () => setIsEndDatePickerOpen( true ) }
+									readOnly
+									className="build-report__date-input"
+								/>
+								{ isEndDatePickerOpen && (
+									<Popover
+										onClose={ () => setIsEndDatePickerOpen( false ) }
+										placement="bottom-start"
+										className="build-report__date-popover"
+									>
+										<DatePicker
+											currentDate={ endDate }
+											onChange={ ( date ) => {
+												setEndDate( date );
+												setIsEndDatePickerOpen( false );
+											} }
+											isInvalidDate={ ( date ) => {
+												// Disable dates after today (only today and earlier allowed)
+												const today = new Date();
+												today.setHours( 23, 59, 59, 999 ); // End of today
+												if ( new Date( date ) > today ) {
+													return true;
+												}
+
+												// Disable dates before the start date
+												if ( ! startDate ) {
+													return false;
+												}
+												return new Date( date ) < new Date( startDate );
+											} }
+										/>
+									</Popover>
+								) }
+							</div>
+						</div>
+					) }
+					<div className="build-report__field">
+						<TextControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label={ translate( 'Client email(s)' ) }
+							value={ clientEmail }
+							onChange={ setClientEmail }
+							type="text"
+							help={
+								! hasFieldError( 'clientEmail' )
+									? translate( "We'll email the report here. Use commas to separate addresses." )
+									: undefined
+							}
+							data-field="clientEmail"
+							disabled={ isLoadingState }
+						/>
+						{ hasFieldError( 'clientEmail' ) && (
+							<div className="build-report__error-message">{ getFieldError( 'clientEmail' ) }</div>
+						) }
+					</div>
+					<CheckboxControl
+						__nextHasNoMarginBottom
+						label={ translate( 'Also send to your team' ) }
+						checked={ sendCopyToTeam }
+						onChange={ setSendCopyToTeam }
+						disabled={ isLoadingState }
+					/>
+					{ sendCopyToTeam && (
+						<div>
+							<TextControl
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+								label={ translate( 'Teammate email(s)' ) }
+								value={ teammateEmails }
+								onChange={ setTeammateEmails }
+								type="text"
+								help={
+									! hasFieldError( 'teammateEmails' )
+										? translate( 'Use commas to separate addresses.' )
+										: undefined
+								}
+								placeholder={ translate( 'colleague1@example.com, colleague2@example.com' ) }
+								data-field="teammateEmails"
+								disabled={ isLoadingState }
+							/>
+							{ hasFieldError( 'teammateEmails' ) && (
+								<div className="build-report__error-message">
+									{ getFieldError( 'teammateEmails' ) }
+								</div>
+							) }
+						</div>
+					) }
+				</>
+			);
+		case 2:
+			return (
+				<>
+					<h2 className="build-report__step-title">
+						{ translate( 'Step 2 of 3: Choose report content' ) }
+					</h2>
+
+					<TextareaControl
+						__nextHasNoMarginBottom
+						label={ translate( 'Intro message (optional)' ) }
+						value={ customIntroText }
+						onChange={ setCustomIntroText }
+						rows={ 3 }
+						help={ translate( 'Add a short note or update for your client.' ) }
+						disabled={ isLoadingState }
+					/>
+
+					<h3 className="build-report__group-label">{ translate( 'Stats' ) }</h3>
+					{ statsOptions.map( ( item ) => (
+						<CheckboxControl
+							__nextHasNoMarginBottom
+							key={ item.value }
+							label={ item.label }
+							checked={ statsCheckedItems[ item.value ] }
+							onChange={ () => handleStep2CheckboxChange( item.value ) }
+							disabled={ isLoadingState }
+						/>
+					) ) }
+					{ hasFieldError( 'statsCheckedItems' ) && (
+						<div className="build-report__error-message">
+							{ getFieldError( 'statsCheckedItems' ) }
+						</div>
+					) }
+					<p className="build-report__step-note">
+						{ translate( 'Preview, confirm, and send to your client in the next step.' ) }
+					</p>
+				</>
+			);
+		case 3:
+			if ( reportId ) {
+				if ( isReportPending ) {
+					return (
+						<>
+							<h2 className="build-report__step-title">
+								{ translate( 'Step 3 of 3: Preparing your report' ) }
+							</h2>
+							<p className="build-report__loading-state build-report__content-description">
+								<Spinner /> { translate( 'Please wait while we prepare your report…' ) }
+							</p>
+						</>
+					);
+				}
+
+				if ( isReportErrorStatus ) {
+					return (
+						<>
+							<h2 className="build-report__step-title">
+								{ translate( 'Step 3 of 3: Report preparation failed' ) }
+							</h2>
+							<p className="build-report__step-description">
+								{ translate( 'There was an error preparing your report.' ) }
+							</p>
+						</>
+					);
+				}
+
+				if ( isProcessed ) {
+					return (
+						<>
+							<h2 className="build-report__step-title">
+								{ translate( 'Step 3 of 3: Send your report' ) }
+							</h2>
+
+							<p className="build-report__step-description">
+								{ translate(
+									'Your report is ready for sending. Checkout the preview, then click "Send to client now".'
+								) }
+								<br />
+								{ translate( "We'll take it from there!" ) }
+							</p>
+							<Button
+								variant="secondary"
+								onClick={ () => alert( 'Send test report clicked' ) }
+								className="build-report__preview-button"
+							>
+								{ translate( 'Send me a preview' ) }
+							</Button>
+						</>
+					);
+				}
+			}
+			return (
+				<>
+					<h2 className="build-report__step-title">
+						{ translate( 'Step 3 of 3: Unknown report status' ) }
+					</h2>
+
+					<p className="build-report__step-description">
+						{ translate( 'There was an error preparing your report.' ) }
+					</p>
+				</>
+			);
+
+		default:
+			return null;
+	}
+}

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/build-report-content.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/build-report-content.tsx
@@ -63,6 +63,7 @@ export default function BuildReportContent( {
 		showValidationErrors,
 		validationErrors,
 	} = state;
+
 	const {
 		setSelectedSite,
 		setSelectedTimeframe,

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/index.tsx
@@ -7,10 +7,12 @@ import {
 	TextControl,
 	DatePicker,
 	Popover,
+	Spinner,
 } from '@wordpress/components';
 import { Icon, error } from '@wordpress/icons';
+import { getQueryArg, addQueryArgs, removeQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useEffect } from 'react';
 import A4ASelectSite from 'calypso/a8c-for-agencies/components/a4a-select-site';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
@@ -22,10 +24,15 @@ import LayoutHeader, {
 	LayoutHeaderActions as Actions,
 } from 'calypso/layout/hosting-dashboard/header';
 import { useDispatch } from 'calypso/state';
-import { successNotice, errorNotice } from 'calypso/state/notices/actions';
-import { A4A_REPORTS_LINK, A4A_REPORTS_DASHBOARD_LINK } from '../../constants';
+import { errorNotice } from 'calypso/state/notices/actions';
+import {
+	A4A_REPORTS_LINK,
+	A4A_REPORTS_DASHBOARD_LINK,
+	A4A_REPORTS_BUILD_LINK,
+} from '../../constants';
 import { useFormValidation } from '../../hooks/use-build-report-form-validation';
 import { useDuplicateReportFormData } from '../../hooks/use-duplicate-report-form-data';
+import usePollReportStatus from '../../hooks/use-poll-report-status';
 import useSendReportMutation from '../../hooks/use-send-report-mutation';
 import { formatDate } from '../../lib/format-date';
 import type { BuildReportCheckedItemsState } from '../../types';
@@ -57,6 +64,8 @@ const BuildReport = () => {
 		[ translate ]
 	);
 
+	const [ currentStep, setCurrentStep ] = useState( 1 );
+
 	// Use the custom hook for form data management
 	const {
 		formData,
@@ -74,27 +83,37 @@ const BuildReport = () => {
 		error: duplicateError,
 	} = useDuplicateReportFormData( availableTimeframes, statsOptions );
 
-	// Mutation hook for sending reports
 	const sendReportMutation = useSendReportMutation( {
-		onSuccess: () => {
-			dispatch(
-				successNotice(
-					translate( 'Report queued successfully! Your client will receive it shortly.' ),
-					{ duration: 5000, displayOnNextPage: true, id: 'send-report-success' }
-				)
-			);
-			// Redirect to reports dashboard
-			page( A4A_REPORTS_DASHBOARD_LINK );
+		onSuccess: ( data ) => {
+			page.redirect( addQueryArgs( A4A_REPORTS_BUILD_LINK, { reportId: data.id } ) );
 		},
 		onError: ( error ) => {
 			dispatch(
-				errorNotice( error?.message || translate( 'Failed to send report. Please try again.' ), {
-					duration: 8000,
-					id: 'send-report-error',
-				} )
+				errorNotice(
+					error?.message || translate( 'Failed to generate report. Please try again.' ),
+					{
+						duration: 8000,
+						id: 'generate-report-error',
+					}
+				)
 			);
 		},
 	} );
+
+	const reportId = getQueryArg( window.location.href, 'reportId' ) as unknown as number;
+
+	// Poll report status when reportId exists
+	const {
+		isProcessed,
+		isPending: isReportPending,
+		isErrorStatus: isReportErrorStatus,
+	} = usePollReportStatus( reportId );
+
+	useEffect( () => {
+		if ( reportId ) {
+			setCurrentStep( 3 );
+		}
+	}, [ reportId ] );
 
 	const {
 		selectedSite,
@@ -113,8 +132,6 @@ const BuildReport = () => {
 	const [ isStartDatePickerOpen, setIsStartDatePickerOpen ] = useState( false );
 	const [ isEndDatePickerOpen, setIsEndDatePickerOpen ] = useState( false );
 	const [ showValidationErrors, setShowValidationErrors ] = useState( false );
-
-	const [ currentStep, setCurrentStep ] = useState( 1 );
 
 	// Get validation errors for current step
 	const validationErrors = useFormValidation( currentStep, formData );
@@ -155,8 +172,14 @@ const BuildReport = () => {
 		}
 
 		setShowValidationErrors( false );
-		setCurrentStep( ( prev ) => prev + 1 );
-	}, [ hasErrors, validationErrors ] );
+
+		// If moving from step 2, create the report
+		if ( currentStep === 2 ) {
+			sendReportMutation.mutate( formData );
+		} else {
+			setCurrentStep( ( prev ) => prev + 1 );
+		}
+	}, [ hasErrors, validationErrors, currentStep, sendReportMutation, formData ] );
 
 	const handlePrevStep = useCallback( () => {
 		setShowValidationErrors( false );
@@ -164,8 +187,8 @@ const BuildReport = () => {
 	}, [] );
 
 	const handleSendReport = useCallback( () => {
-		sendReportMutation.mutate( formData );
-	}, [ sendReportMutation, formData ] );
+		// TODO: Implement send report functionality
+	}, [] );
 
 	const handleStep2CheckboxChange = useCallback(
 		( groupKey: 'stats', itemName: string ) => {
@@ -181,6 +204,9 @@ const BuildReport = () => {
 	);
 
 	const stepContent = useMemo( () => {
+		const isCreatingReport = sendReportMutation.isPending;
+		const isLoading = isDuplicateLoading || isCreatingReport;
+
 		switch ( currentStep ) {
 			case 1:
 				return (
@@ -191,7 +217,7 @@ const BuildReport = () => {
 
 						<div className="build-report__field">
 							<A4ASelectSite
-								isDisabled={ isDuplicateLoading }
+								isDisabled={ isLoading }
 								selectedSiteId={ selectedSite?.blogId }
 								onSiteSelect={ ( site: A4ASelectSiteItem ) => setSelectedSite( site ) }
 								buttonLabel={ selectedSite?.domain || translate( 'Choose a site to report on' ) }
@@ -212,7 +238,7 @@ const BuildReport = () => {
 							value={ selectedTimeframe }
 							options={ availableTimeframes }
 							onChange={ setSelectedTimeframe }
-							disabled={ isDuplicateLoading }
+							disabled={ isLoading }
 						/>
 
 						{ selectedTimeframe === 'custom' && (
@@ -318,7 +344,7 @@ const BuildReport = () => {
 										: undefined
 								}
 								data-field="clientEmail"
-								disabled={ isDuplicateLoading }
+								disabled={ isLoading }
 							/>
 							{ hasFieldError( 'clientEmail' ) && (
 								<div className="build-report__error-message">
@@ -331,7 +357,7 @@ const BuildReport = () => {
 							label={ translate( 'Also send to your team' ) }
 							checked={ sendCopyToTeam }
 							onChange={ setSendCopyToTeam }
-							disabled={ isDuplicateLoading }
+							disabled={ isLoading }
 						/>
 						{ sendCopyToTeam && (
 							<div>
@@ -349,7 +375,7 @@ const BuildReport = () => {
 									}
 									placeholder={ translate( 'colleague1@example.com, colleague2@example.com' ) }
 									data-field="teammateEmails"
-									disabled={ isDuplicateLoading }
+									disabled={ isLoading }
 								/>
 								{ hasFieldError( 'teammateEmails' ) && (
 									<div className="build-report__error-message">
@@ -374,6 +400,7 @@ const BuildReport = () => {
 							onChange={ setCustomIntroText }
 							rows={ 3 }
 							help={ translate( 'Add a short note or update for your client.' ) }
+							disabled={ isLoading }
 						/>
 
 						<h3 className="build-report__group-label">{ translate( 'Stats' ) }</h3>
@@ -384,6 +411,7 @@ const BuildReport = () => {
 								label={ item.label }
 								checked={ statsCheckedItems[ item.value ] }
 								onChange={ () => handleStep2CheckboxChange( 'stats', item.value ) }
+								disabled={ isLoading }
 							/>
 						) ) }
 						{ hasFieldError( 'statsCheckedItems' ) && (
@@ -394,104 +422,186 @@ const BuildReport = () => {
 					</>
 				);
 			case 3:
+				if ( reportId ) {
+					if ( isReportPending ) {
+						return (
+							<>
+								<h2 className="build-report__step-title">
+									{ translate( 'Step 3 of 3: Generating your report' ) }
+								</h2>
+								<p className="build-report__loading-state build-report__content-description">
+									<Spinner /> { translate( 'Please wait while we generate your report…' ) }
+								</p>
+							</>
+						);
+					}
+
+					if ( isReportErrorStatus ) {
+						return (
+							<>
+								<h2 className="build-report__step-title">
+									{ translate( 'Step 3 of 3: Report generation failed' ) }
+								</h2>
+								<p className="build-report__step-description">
+									{ translate( 'There was an error generating your report.' ) }
+								</p>
+							</>
+						);
+					}
+
+					if ( isProcessed ) {
+						return (
+							<>
+								<h2 className="build-report__step-title">
+									{ translate( 'Step 3 of 3: Send your report' ) }
+								</h2>
+
+								<p className="build-report__step-description">
+									{ translate(
+										'Your report is ready for sending. Checkout the preview, then click "Send to client now".'
+									) }
+									<br />
+									{ translate( "We'll take it from there!" ) }
+								</p>
+
+								<Button
+									variant="secondary"
+									onClick={ () => alert( 'Send test report clicked' ) }
+									className="build-report__preview-button"
+								>
+									{ translate( 'Send me a preview' ) }
+								</Button>
+							</>
+						);
+					}
+				}
 				return (
 					<>
 						<h2 className="build-report__step-title">
-							{ translate( 'Step 3 of 3: Send your report' ) }
+							{ translate( 'Step 3 of 3: Unkown report status' ) }
 						</h2>
 
 						<p className="build-report__step-description">
-							{ translate(
-								'Your report is ready for sending. Checkout the preview, then click "Send to client now".'
-							) }
-							<br />
-							{ translate( "We'll take it from there!" ) }
+							{ translate( 'There was an error generating your report.' ) }
 						</p>
-
-						<Button
-							variant="secondary"
-							onClick={ () => alert( 'Send test report clicked' ) }
-							className="build-report__preview-button"
-						>
-							{ translate( 'Send me a preview' ) }
-						</Button>
 					</>
 				);
+
 			default:
 				return null;
 		}
 	}, [
+		availableTimeframes,
+		clientEmail,
 		currentStep,
-		translate,
+		customIntroText,
+		endDate,
+		getFieldError,
+		handleStep2CheckboxChange,
+		hasFieldError,
 		isDuplicateLoading,
+		isEndDatePickerOpen,
+		isProcessed,
+		isReportErrorStatus,
+		isReportPending,
+		isStartDatePickerOpen,
+		reportId,
 		selectedSite?.blogId,
 		selectedSite?.domain,
-		hasFieldError,
-		getFieldError,
 		selectedTimeframe,
-		availableTimeframes,
-		setSelectedTimeframe,
-		startDate,
-		isStartDatePickerOpen,
-		endDate,
-		isEndDatePickerOpen,
-		clientEmail,
-		setClientEmail,
 		sendCopyToTeam,
-		setSendCopyToTeam,
-		teammateEmails,
-		setTeammateEmails,
-		customIntroText,
+		sendReportMutation.isPending,
+		setClientEmail,
 		setCustomIntroText,
-		statsOptions,
-		setSelectedSite,
-		setStartDate,
 		setEndDate,
+		setSelectedSite,
+		setSelectedTimeframe,
+		setSendCopyToTeam,
+		setStartDate,
+		setTeammateEmails,
+		startDate,
 		statsCheckedItems,
-		handleStep2CheckboxChange,
+		statsOptions,
+		teammateEmails,
+		translate,
 	] );
 
-	const actions = useMemo(
-		() => (
+	const actions = useMemo( () => {
+		const isCreatingReport = sendReportMutation.isPending;
+		const isLoading = isDuplicateLoading || isCreatingReport;
+
+		return (
 			<div className="build-report__actions">
-				{ currentStep > 1 && (
-					<Button
-						variant="secondary"
-						onClick={ handlePrevStep }
-						disabled={ sendReportMutation.isPending }
-					>
-						{ translate( 'Back' ) }
-					</Button>
-				) }
-				{ currentStep < 3 && (
-					<Button variant="primary" onClick={ handleNextStep } disabled={ isDuplicateLoading }>
+				{ currentStep < 2 && (
+					<Button variant="primary" onClick={ handleNextStep } disabled={ isLoading }>
 						{ translate( 'Next' ) }
 					</Button>
 				) }
+				{ currentStep === 2 && (
+					<>
+						<Button variant="secondary" onClick={ handlePrevStep } disabled={ isLoading }>
+							{ translate( 'Back' ) }
+						</Button>
+						<Button
+							variant="primary"
+							onClick={ handleNextStep }
+							isBusy={ isCreatingReport }
+							disabled={ isLoading }
+						>
+							{ isCreatingReport
+								? translate( 'Generating report…' )
+								: translate( 'Generate Report' ) }
+						</Button>
+					</>
+				) }
 				{ currentStep === 3 && (
-					<Button
-						variant="primary"
-						onClick={ handleSendReport }
-						isBusy={ sendReportMutation.isPending }
-						disabled={ sendReportMutation.isPending }
-					>
-						{ sendReportMutation.isPending
-							? translate( 'Sending…' )
-							: translate( 'Send to client now' ) }
-					</Button>
+					<>
+						{ reportId && isProcessed ? (
+							<>
+								<Button
+									variant="secondary"
+									onClick={ () => {
+										page.redirect( removeQueryArgs( window.location.pathname, 'reportId' ) );
+										setCurrentStep( 1 );
+									} }
+								>
+									{ translate( 'Start over' ) }
+								</Button>
+								<Button variant="primary" onClick={ handleSendReport }>
+									{ translate( 'Send to client now' ) }
+								</Button>
+							</>
+						) : (
+							<>
+								<Button
+									variant="secondary"
+									onClick={ () => {
+										page.redirect( removeQueryArgs( window.location.pathname, 'reportId' ) );
+										setCurrentStep( 1 );
+									} }
+								>
+									{ translate( 'Start over' ) }
+								</Button>
+								<Button variant="primary" href={ A4A_REPORTS_DASHBOARD_LINK }>
+									{ translate( 'Send later' ) }
+								</Button>
+							</>
+						) }
+					</>
 				) }
 			</div>
-		),
-		[
-			currentStep,
-			handlePrevStep,
-			translate,
-			handleNextStep,
-			isDuplicateLoading,
-			handleSendReport,
-			sendReportMutation.isPending,
-		]
-	);
+		);
+	}, [
+		sendReportMutation.isPending,
+		isDuplicateLoading,
+		currentStep,
+		handleNextStep,
+		translate,
+		handlePrevStep,
+		handleSendReport,
+		reportId,
+		isProcessed,
+	] );
 
 	return (
 		<Layout className="build-report" title={ title } wide>

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/index.tsx
@@ -1,23 +1,11 @@
 import page from '@automattic/calypso-router';
-import {
-	Button,
-	SelectControl,
-	TextareaControl,
-	CheckboxControl,
-	TextControl,
-	DatePicker,
-	Popover,
-	Spinner,
-} from '@wordpress/components';
 import { Icon, error } from '@wordpress/icons';
-import { getQueryArg, addQueryArgs, removeQueryArgs } from '@wordpress/url';
+import { getQueryArg, addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useMemo, useCallback, useEffect } from 'react';
-import A4ASelectSite from 'calypso/a8c-for-agencies/components/a4a-select-site';
+import { useState, useCallback, useEffect } from 'react';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
-import { getAvailableTimeframes } from 'calypso/a8c-for-agencies/sections/reports/lib/timeframes';
 import LayoutBody from 'calypso/layout/hosting-dashboard/body';
 import LayoutHeader, {
 	LayoutHeaderBreadcrumb as Breadcrumb,
@@ -25,18 +13,14 @@ import LayoutHeader, {
 } from 'calypso/layout/hosting-dashboard/header';
 import { useDispatch } from 'calypso/state';
 import { errorNotice } from 'calypso/state/notices/actions';
-import {
-	A4A_REPORTS_LINK,
-	A4A_REPORTS_DASHBOARD_LINK,
-	A4A_REPORTS_BUILD_LINK,
-} from '../../constants';
+import { A4A_REPORTS_LINK, A4A_REPORTS_BUILD_LINK } from '../../constants';
 import { useFormValidation } from '../../hooks/use-build-report-form-validation';
 import { useDuplicateReportFormData } from '../../hooks/use-duplicate-report-form-data';
 import usePollReportStatus from '../../hooks/use-poll-report-status';
 import useSendReportMutation from '../../hooks/use-send-report-mutation';
-import { formatDate } from '../../lib/format-date';
-import type { BuildReportCheckedItemsState } from '../../types';
-import type { A4ASelectSiteItem } from 'calypso/a8c-for-agencies/components/a4a-select-site/types';
+import BuildReportActions from './build-report-actions';
+import BuildReportContent from './build-report-content';
+import type { BuildReportState } from '../../types';
 
 import './style.scss';
 
@@ -44,44 +28,15 @@ const BuildReport = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const availableTimeframes = useMemo( () => getAvailableTimeframes( translate ), [ translate ] );
-
-	// Checkbox groups for Step 2
-	const statsOptions = useMemo(
-		() => [
-			{ label: translate( 'Visitors and Views in this timeframe' ), value: 'total_traffic' },
-			{ label: translate( 'Top 5 posts' ), value: 'top_pages' },
-			{ label: translate( 'Top 5 referrers' ), value: 'top_devices' },
-			{ label: translate( 'Top 5 cities' ), value: 'top_locations' },
-			{ label: translate( 'Device breakdown' ), value: 'device_breakdown' },
-			{
-				label: translate( 'Total Visitors and Views since the site was created' ),
-				value: 'total_traffic_all_time',
-			},
-			{ label: translate( 'Most popular time of day' ), value: 'most_popular_time_of_day' },
-			{ label: translate( 'Most popular day of week' ), value: 'most_popular_day_of_week' },
-		],
-		[ translate ]
-	);
-
 	const [ currentStep, setCurrentStep ] = useState( 1 );
 
-	// Use the custom hook for form data management
 	const {
 		formData,
-		setSelectedTimeframe,
-		setSelectedSite,
-		setClientEmail,
-		setCustomIntroText,
-		setSendCopyToTeam,
-		setTeammateEmails,
-		setStartDate,
-		setEndDate,
-		setStatsCheckedItems,
+		handlers,
 		isLoading: isDuplicateLoading,
 		isDuplicating,
 		error: duplicateError,
-	} = useDuplicateReportFormData( availableTimeframes, statsOptions );
+	} = useDuplicateReportFormData();
 
 	const sendReportMutation = useSendReportMutation( {
 		onSuccess: ( data ) => {
@@ -89,13 +44,10 @@ const BuildReport = () => {
 		},
 		onError: ( error ) => {
 			dispatch(
-				errorNotice(
-					error?.message || translate( 'Failed to generate report. Please try again.' ),
-					{
-						duration: 8000,
-						id: 'generate-report-error',
-					}
-				)
+				errorNotice( error?.message || translate( 'Failed to prepare report. Please try again.' ), {
+					duration: 8000,
+					id: 'prepare-report-error',
+				} )
 			);
 		},
 	} );
@@ -105,6 +57,7 @@ const BuildReport = () => {
 	// Poll report status when reportId exists
 	const {
 		isProcessed,
+		isError: isReportError,
 		isPending: isReportPending,
 		isErrorStatus: isReportErrorStatus,
 	} = usePollReportStatus( reportId );
@@ -115,48 +68,13 @@ const BuildReport = () => {
 		}
 	}, [ reportId ] );
 
-	const {
-		selectedSite,
-		selectedTimeframe,
-		startDate,
-		endDate,
-		clientEmail,
-		sendCopyToTeam,
-		teammateEmails,
-		customIntroText,
-		statsCheckedItems,
-	} = formData;
-
 	const title = isDuplicating ? translate( 'Duplicate Report' ) : translate( 'Build Report' );
 
-	const [ isStartDatePickerOpen, setIsStartDatePickerOpen ] = useState( false );
-	const [ isEndDatePickerOpen, setIsEndDatePickerOpen ] = useState( false );
 	const [ showValidationErrors, setShowValidationErrors ] = useState( false );
 
 	// Get validation errors for current step
 	const validationErrors = useFormValidation( currentStep, formData );
 	const hasErrors = validationErrors.length > 0;
-
-	// Helper to get error message for a specific field
-	const getFieldError = useCallback(
-		( fieldName: string ): string | undefined => {
-			if ( ! showValidationErrors ) {
-				return undefined;
-			}
-			return validationErrors.find( ( error ) => error.field === fieldName )?.message;
-		},
-		[ showValidationErrors, validationErrors ]
-	);
-
-	// Helper to check if field has error
-	const hasFieldError = useCallback(
-		( fieldName: string ): boolean => {
-			return (
-				showValidationErrors && validationErrors.some( ( error ) => error.field === fieldName )
-			);
-		},
-		[ showValidationErrors, validationErrors ]
-	);
 
 	const handleNextStep = useCallback( () => {
 		setShowValidationErrors( true );
@@ -186,422 +104,17 @@ const BuildReport = () => {
 		setCurrentStep( ( prev ) => prev - 1 );
 	}, [] );
 
-	const handleSendReport = useCallback( () => {
-		// TODO: Implement send report functionality
-	}, [] );
-
-	const handleStep2CheckboxChange = useCallback(
-		( groupKey: 'stats', itemName: string ) => {
-			const setterMap: Record< string, ( value: BuildReportCheckedItemsState ) => void > = {
-				stats: ( value: BuildReportCheckedItemsState ) => setStatsCheckedItems( value ),
-			};
-			setterMap[ groupKey ]?.( {
-				...statsCheckedItems,
-				[ itemName ]: ! statsCheckedItems[ itemName ],
-			} );
-		},
-		[ statsCheckedItems, setStatsCheckedItems ]
-	);
-
-	const stepContent = useMemo( () => {
-		const isCreatingReport = sendReportMutation.isPending;
-		const isLoading = isDuplicateLoading || isCreatingReport;
-
-		switch ( currentStep ) {
-			case 1:
-				return (
-					<>
-						<h2 className="build-report__step-title">
-							{ translate( 'Step 1 of 3: Enter report details' ) }
-						</h2>
-
-						<div className="build-report__field">
-							<A4ASelectSite
-								isDisabled={ isLoading }
-								selectedSiteId={ selectedSite?.blogId }
-								onSiteSelect={ ( site: A4ASelectSiteItem ) => setSelectedSite( site ) }
-								buttonLabel={ selectedSite?.domain || translate( 'Choose a site to report on' ) }
-								trackingEvent="calypso_a4a_reports_select_site_button_click"
-								data-field="selectedSite"
-							/>
-							{ hasFieldError( 'selectedSite' ) && (
-								<div className="build-report__error-message">
-									{ getFieldError( 'selectedSite' ) }
-								</div>
-							) }
-						</div>
-
-						<SelectControl
-							__next40pxDefaultSize
-							__nextHasNoMarginBottom
-							label={ translate( 'Report date range' ) }
-							value={ selectedTimeframe }
-							options={ availableTimeframes }
-							onChange={ setSelectedTimeframe }
-							disabled={ isLoading }
-						/>
-
-						{ selectedTimeframe === 'custom' && (
-							<div className="build-report__date-fields-container">
-								<div className="build-report__date-field">
-									<TextControl
-										__next40pxDefaultSize
-										__nextHasNoMarginBottom
-										id="start-date"
-										label={ translate( 'Start date' ) }
-										value={ formatDate( startDate ) }
-										placeholder={ translate( 'Select start date' ) }
-										onChange={ () => {} }
-										onClick={ () => setIsStartDatePickerOpen( true ) }
-										readOnly
-										className="build-report__date-input"
-									/>
-									{ isStartDatePickerOpen && (
-										<Popover
-											onClose={ () => setIsStartDatePickerOpen( false ) }
-											placement="bottom-start"
-											className="build-report__date-popover"
-										>
-											<DatePicker
-												currentDate={ startDate }
-												onChange={ ( date ) => {
-													setStartDate( date );
-													// If end date is set and is before or equal to the new start date,
-													// set end date to the day after start date
-													if ( endDate && new Date( date ) >= new Date( endDate ) ) {
-														const nextDay = new Date( date );
-														nextDay.setDate( nextDay.getDate() + 1 );
-														setEndDate( nextDay.toISOString().split( 'T' )[ 0 ] );
-													}
-													setIsStartDatePickerOpen( false );
-												} }
-												isInvalidDate={ ( date ) => {
-													// Disable dates from today onwards (only yesterday and earlier allowed)
-													const today = new Date();
-													today.setHours( 0, 0, 0, 0 ); // Start of today
-													return new Date( date ) >= today;
-												} }
-											/>
-										</Popover>
-									) }
-								</div>
-								<div className="build-report__date-field">
-									<TextControl
-										__next40pxDefaultSize
-										__nextHasNoMarginBottom
-										id="end-date"
-										label={ translate( 'End date' ) }
-										value={ formatDate( endDate ) }
-										placeholder={ translate( 'Select end date' ) }
-										onChange={ () => {} }
-										onClick={ () => setIsEndDatePickerOpen( true ) }
-										readOnly
-										className="build-report__date-input"
-									/>
-									{ isEndDatePickerOpen && (
-										<Popover
-											onClose={ () => setIsEndDatePickerOpen( false ) }
-											placement="bottom-start"
-											className="build-report__date-popover"
-										>
-											<DatePicker
-												currentDate={ endDate }
-												onChange={ ( date ) => {
-													setEndDate( date );
-													setIsEndDatePickerOpen( false );
-												} }
-												isInvalidDate={ ( date ) => {
-													// Disable dates after today (only today and earlier allowed)
-													const today = new Date();
-													today.setHours( 23, 59, 59, 999 ); // End of today
-													if ( new Date( date ) > today ) {
-														return true;
-													}
-
-													// Disable dates before the start date
-													if ( ! startDate ) {
-														return false;
-													}
-													return new Date( date ) < new Date( startDate );
-												} }
-											/>
-										</Popover>
-									) }
-								</div>
-							</div>
-						) }
-						<div className="build-report__field">
-							<TextControl
-								__next40pxDefaultSize
-								__nextHasNoMarginBottom
-								label={ translate( 'Client email(s)' ) }
-								value={ clientEmail }
-								onChange={ setClientEmail }
-								type="text"
-								help={
-									! hasFieldError( 'clientEmail' )
-										? translate( "We'll email the report here. Use commas to separate addresses." )
-										: undefined
-								}
-								data-field="clientEmail"
-								disabled={ isLoading }
-							/>
-							{ hasFieldError( 'clientEmail' ) && (
-								<div className="build-report__error-message">
-									{ getFieldError( 'clientEmail' ) }
-								</div>
-							) }
-						</div>
-						<CheckboxControl
-							__nextHasNoMarginBottom
-							label={ translate( 'Also send to your team' ) }
-							checked={ sendCopyToTeam }
-							onChange={ setSendCopyToTeam }
-							disabled={ isLoading }
-						/>
-						{ sendCopyToTeam && (
-							<div>
-								<TextControl
-									__next40pxDefaultSize
-									__nextHasNoMarginBottom
-									label={ translate( 'Teammate email(s)' ) }
-									value={ teammateEmails }
-									onChange={ setTeammateEmails }
-									type="text"
-									help={
-										! hasFieldError( 'teammateEmails' )
-											? translate( 'Use commas to separate addresses.' )
-											: undefined
-									}
-									placeholder={ translate( 'colleague1@example.com, colleague2@example.com' ) }
-									data-field="teammateEmails"
-									disabled={ isLoading }
-								/>
-								{ hasFieldError( 'teammateEmails' ) && (
-									<div className="build-report__error-message">
-										{ getFieldError( 'teammateEmails' ) }
-									</div>
-								) }
-							</div>
-						) }
-					</>
-				);
-			case 2:
-				return (
-					<>
-						<h2 className="build-report__step-title">
-							{ translate( 'Step 2 of 3: Choose report content' ) }
-						</h2>
-
-						<TextareaControl
-							__nextHasNoMarginBottom
-							label={ translate( 'Intro message (optional)' ) }
-							value={ customIntroText }
-							onChange={ setCustomIntroText }
-							rows={ 3 }
-							help={ translate( 'Add a short note or update for your client.' ) }
-							disabled={ isLoading }
-						/>
-
-						<h3 className="build-report__group-label">{ translate( 'Stats' ) }</h3>
-						{ statsOptions.map( ( item ) => (
-							<CheckboxControl
-								__nextHasNoMarginBottom
-								key={ item.value }
-								label={ item.label }
-								checked={ statsCheckedItems[ item.value ] }
-								onChange={ () => handleStep2CheckboxChange( 'stats', item.value ) }
-								disabled={ isLoading }
-							/>
-						) ) }
-						{ hasFieldError( 'statsCheckedItems' ) && (
-							<div className="build-report__error-message">
-								{ getFieldError( 'statsCheckedItems' ) }
-							</div>
-						) }
-					</>
-				);
-			case 3:
-				if ( reportId ) {
-					if ( isReportPending ) {
-						return (
-							<>
-								<h2 className="build-report__step-title">
-									{ translate( 'Step 3 of 3: Generating your report' ) }
-								</h2>
-								<p className="build-report__loading-state build-report__content-description">
-									<Spinner /> { translate( 'Please wait while we generate your report…' ) }
-								</p>
-							</>
-						);
-					}
-
-					if ( isReportErrorStatus ) {
-						return (
-							<>
-								<h2 className="build-report__step-title">
-									{ translate( 'Step 3 of 3: Report generation failed' ) }
-								</h2>
-								<p className="build-report__step-description">
-									{ translate( 'There was an error generating your report.' ) }
-								</p>
-							</>
-						);
-					}
-
-					if ( isProcessed ) {
-						return (
-							<>
-								<h2 className="build-report__step-title">
-									{ translate( 'Step 3 of 3: Send your report' ) }
-								</h2>
-
-								<p className="build-report__step-description">
-									{ translate(
-										'Your report is ready for sending. Checkout the preview, then click "Send to client now".'
-									) }
-									<br />
-									{ translate( "We'll take it from there!" ) }
-								</p>
-
-								<Button
-									variant="secondary"
-									onClick={ () => alert( 'Send test report clicked' ) }
-									className="build-report__preview-button"
-								>
-									{ translate( 'Send me a preview' ) }
-								</Button>
-							</>
-						);
-					}
-				}
-				return (
-					<>
-						<h2 className="build-report__step-title">
-							{ translate( 'Step 3 of 3: Unkown report status' ) }
-						</h2>
-
-						<p className="build-report__step-description">
-							{ translate( 'There was an error generating your report.' ) }
-						</p>
-					</>
-				);
-
-			default:
-				return null;
-		}
-	}, [
-		availableTimeframes,
-		clientEmail,
-		currentStep,
-		customIntroText,
-		endDate,
-		getFieldError,
-		handleStep2CheckboxChange,
-		hasFieldError,
+	const state: BuildReportState = {
 		isDuplicateLoading,
-		isEndDatePickerOpen,
-		isProcessed,
-		isReportErrorStatus,
+		sendReportMutation,
+		reportId,
 		isReportPending,
-		isStartDatePickerOpen,
-		reportId,
-		selectedSite?.blogId,
-		selectedSite?.domain,
-		selectedTimeframe,
-		sendCopyToTeam,
-		sendReportMutation.isPending,
-		setClientEmail,
-		setCustomIntroText,
-		setEndDate,
-		setSelectedSite,
-		setSelectedTimeframe,
-		setSendCopyToTeam,
-		setStartDate,
-		setTeammateEmails,
-		startDate,
-		statsCheckedItems,
-		statsOptions,
-		teammateEmails,
-		translate,
-	] );
-
-	const actions = useMemo( () => {
-		const isCreatingReport = sendReportMutation.isPending;
-		const isLoading = isDuplicateLoading || isCreatingReport;
-
-		return (
-			<div className="build-report__actions">
-				{ currentStep < 2 && (
-					<Button variant="primary" onClick={ handleNextStep } disabled={ isLoading }>
-						{ translate( 'Next' ) }
-					</Button>
-				) }
-				{ currentStep === 2 && (
-					<>
-						<Button variant="secondary" onClick={ handlePrevStep } disabled={ isLoading }>
-							{ translate( 'Back' ) }
-						</Button>
-						<Button
-							variant="primary"
-							onClick={ handleNextStep }
-							isBusy={ isCreatingReport }
-							disabled={ isLoading }
-						>
-							{ isCreatingReport
-								? translate( 'Generating report…' )
-								: translate( 'Generate Report' ) }
-						</Button>
-					</>
-				) }
-				{ currentStep === 3 && (
-					<>
-						{ reportId && isProcessed ? (
-							<>
-								<Button
-									variant="secondary"
-									onClick={ () => {
-										page.redirect( removeQueryArgs( window.location.pathname, 'reportId' ) );
-										setCurrentStep( 1 );
-									} }
-								>
-									{ translate( 'Start over' ) }
-								</Button>
-								<Button variant="primary" onClick={ handleSendReport }>
-									{ translate( 'Send to client now' ) }
-								</Button>
-							</>
-						) : (
-							<>
-								<Button
-									variant="secondary"
-									onClick={ () => {
-										page.redirect( removeQueryArgs( window.location.pathname, 'reportId' ) );
-										setCurrentStep( 1 );
-									} }
-								>
-									{ translate( 'Start over' ) }
-								</Button>
-								<Button variant="primary" href={ A4A_REPORTS_DASHBOARD_LINK }>
-									{ translate( 'Send later' ) }
-								</Button>
-							</>
-						) }
-					</>
-				) }
-			</div>
-		);
-	}, [
-		sendReportMutation.isPending,
-		isDuplicateLoading,
-		currentStep,
-		handleNextStep,
-		translate,
-		handlePrevStep,
-		handleSendReport,
-		reportId,
+		isReportErrorStatus,
 		isProcessed,
-	] );
+		showValidationErrors,
+		validationErrors,
+		isReportError,
+	};
 
 	return (
 		<Layout className="build-report" title={ title } wide>
@@ -645,8 +158,21 @@ const BuildReport = () => {
 						) }
 					</div>
 					<div className="build-report__form">
-						{ stepContent }
-						{ actions }
+						<BuildReportContent
+							currentStep={ currentStep }
+							formData={ formData }
+							state={ state }
+							handlers={ handlers }
+						/>
+						<BuildReportActions
+							currentStep={ currentStep }
+							state={ state }
+							handlers={ {
+								setCurrentStep,
+								handleNextStep,
+								handlePrevStep,
+							} }
+						/>
 					</div>
 				</div>
 			</LayoutBody>

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/style.scss
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/style.scss
@@ -127,3 +127,9 @@
 	display: flex;
 	gap: 8px;
 }
+
+.build-report__step-note {
+	@include body-small;
+	color: var(--color-neutral-50);
+	margin-block: 0.5rem -0.5rem;
+}

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/style.scss
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/style.scss
@@ -111,3 +111,19 @@
 		padding: 16px;
 	}
 }
+
+.build-report__loading-state {
+	display: flex;
+	padding-block: 16px;
+	align-items: center;
+
+	svg {
+		margin: 5px 10px 5px 0;
+	}
+}
+
+.build-report__loading-actions,
+.build-report__error-actions {
+	display: flex;
+	gap: 8px;
+}

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
@@ -25,9 +25,9 @@ export const ReportStatusColumn = ( { status }: { status: ReportStatus } ) => {
 	const translate = useTranslate();
 
 	const statusConfig = {
-		sent: { type: 'success', text: translate( 'Sent' ) },
 		pending: { type: 'warning', text: translate( 'Pending' ) },
-		processed: { type: 'warning', text: translate( 'Pending' ) },
+		processed: { type: 'success', text: translate( 'Ready' ) },
+		sent: { type: 'success', text: translate( 'Ready' ) },
 		error: { type: 'error', text: translate( 'Error' ) },
 	};
 

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
@@ -27,7 +27,7 @@ export const ReportStatusColumn = ( { status }: { status: ReportStatus } ) => {
 	const statusConfig = {
 		pending: { type: 'warning', text: translate( 'Pending' ) },
 		processed: { type: 'success', text: translate( 'Ready' ) },
-		sent: { type: 'success', text: translate( 'Ready' ) },
+		sent: { type: 'success', text: translate( 'Sent' ) },
 		error: { type: 'error', text: translate( 'Error' ) },
 	};
 

--- a/client/a8c-for-agencies/sections/reports/types.ts
+++ b/client/a8c-for-agencies/sections/reports/types.ts
@@ -57,3 +57,42 @@ export type BuildReportFormData = {
 	customIntroText: string;
 	statsCheckedItems: BuildReportCheckedItemsState;
 };
+
+export interface ReportError extends Error {
+	data: {
+		status: number;
+		message: string;
+	};
+}
+
+export interface UseDuplicateReportFormDataHandlers {
+	setSelectedTimeframe: ( value: TimeframeValue ) => void;
+	setSelectedSite: ( site: A4ASelectSiteItem | null ) => void;
+	setClientEmail: ( value: string ) => void;
+	setCustomIntroText: ( value: string ) => void;
+	setSendCopyToTeam: ( value: boolean ) => void;
+	setTeammateEmails: ( value: string ) => void;
+	setStartDate: ( value: string | undefined ) => void;
+	setEndDate: ( value: string | undefined ) => void;
+	setStatsCheckedItems: ( value: BuildReportCheckedItemsState ) => void;
+}
+
+export interface UseDuplicateReportFormDataReturn {
+	formData: BuildReportFormData;
+	handlers: UseDuplicateReportFormDataHandlers;
+	isLoading: boolean;
+	isDuplicating: boolean;
+	error: Error | null;
+}
+
+export interface BuildReportState {
+	sendReportMutation: { isPending: boolean };
+	reportId: number | null;
+	isDuplicateLoading: boolean;
+	isReportPending: boolean;
+	isReportError: boolean;
+	isReportErrorStatus: boolean;
+	isProcessed: boolean;
+	showValidationErrors: boolean;
+	validationErrors: Array< { field: string; message: string } >;
+}


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1137/report-builder-update-the-logic-to-create-the-report-in-step-2

## Proposed Changes

This PR updates the build report flow by generating the report in step 2, including showing a pending state and polling the GET /reports/id API to get the status. 

This PR also refactors the content & actions to a different components to keep it clean

## Why are these changes being made?

* To improve the build report flow

## Testing Instructions

* Open the A4A live link
* Ensure you are not sandboxing the public API or have the latest trunk
* Please keep the network tab open
* Go to Reports > Click the `Build a new report` button > Enter the fields in step 1 > Go to step 2, verify the button text is changes to `Prepare Report` > Click the `Prepare Report` button > Verify the button loading text is shown.

<img width="1405" alt="Screenshot 2025-06-25 at 9 35 53 AM" src="https://github.com/user-attachments/assets/9898e4a6-0f26-4590-bd3b-b1094e83cf8d" />

<img width="1405" alt="Screenshot 2025-06-25 at 9 35 57 AM" src="https://github.com/user-attachments/assets/7629db4f-0677-43e1-b94f-fed80745057c" />

* Verify you are redirected to step 3, and the URL is appended with the report id. Verify that an API call is made every 10 seconds to retrieve the report status. Verify the UI shows the loading state as displayed below.

<img width="1405" alt="Screenshot 2025-06-25 at 9 36 09 AM" src="https://github.com/user-attachments/assets/5afa3212-eefb-4860-89d6-2039991548da" />

* Verify that the API call is made until the report status is no longer pending. Verify the UI is updated as shown below.

<img width="1405" alt="Screenshot 2025-06-25 at 9 36 27 AM" src="https://github.com/user-attachments/assets/75c279af-f804-40a0-9316-cb2f9b1fef14" />

Error state:

We will test this in another PR

<img width="1405" alt="Screenshot 2025-06-25 at 10 41 22 AM" src="https://github.com/user-attachments/assets/d10bc0ba-ad0d-4ea3-9ccf-44b5e9499c2c" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?