### PR TITLE
Payment Method: Refactor payment method removal modal

### DIFF
--- a/client/components/confirm-dialog/index.tsx
+++ b/client/components/confirm-dialog/index.tsx
@@ -5,24 +5,26 @@ import './style.scss';
 
 interface DialogFooterProps {
 	children: React.ReactNode;
+	className?: string;
 }
 
-export const DialogFooter = ( { children }: DialogFooterProps ) => {
-	return <div className="confirm-dialog__footer">{ children }</div>;
+export const DialogFooter = ( { children, className }: DialogFooterProps ) => {
+	return <div className={ clsx( 'confirm-dialog__footer', className ) }>{ children }</div>;
 };
 
 interface DialogContentProps {
 	children: React.ReactNode;
+	className?: string;
 }
 
-export const DialogContent = ( { children }: DialogContentProps ) => {
-	return <div className="confirm-dialog__content">{ children }</div>;
+export const DialogContent = ( { children, className }: DialogContentProps ) => {
+	return <div className={ clsx( 'confirm-dialog__content', className ) }>{ children }</div>;
 };
 
 interface ConfirmDialogProps {
 	onRequestClose: ComponentProps< typeof Modal >[ 'onRequestClose' ];
 	children: React.ReactNode;
-	title: string;
+	title?: string;
 	style?: React.CSSProperties;
 	className?: string;
 }

--- a/client/me/purchases/payment-methods/payment-method-delete-dialog.tsx
+++ b/client/me/purchases/payment-methods/payment-method-delete-dialog.tsx
@@ -1,12 +1,11 @@
-import { Dialog, Gridicon } from '@automattic/components';
+import { Gridicon } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
-import { FunctionComponent } from 'react';
-import CardHeading from 'calypso/components/card-heading';
+import { ConfirmDialog, DialogContent, DialogFooter } from 'calypso/components/confirm-dialog';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { getPaymentMethodImageURL, isCreditCard } from 'calypso/lib/checkout/payment-methods';
 import type { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
 import type { Purchase } from 'calypso/lib/purchases/types';
-
 import 'calypso/me/purchases/payment-methods/style.scss';
 
 interface Props {
@@ -18,14 +17,14 @@ interface Props {
 	onConfirm: () => void;
 }
 
-const PaymentMethodDeleteDialog: FunctionComponent< Props > = ( {
+const PaymentMethodDeleteDialog = ( {
 	card,
 	paymentMethodSummary,
 	purchases,
-	isVisible,
 	onClose,
+	isVisible,
 	onConfirm,
-} ) => {
+}: Props ) => {
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
 	const associatedSubscriptions = purchases?.filter(
@@ -33,83 +32,84 @@ const PaymentMethodDeleteDialog: FunctionComponent< Props > = ( {
 			purchase.payment?.storedDetailsId === card.stored_details_id && purchase.isAutoRenewEnabled
 	);
 
+	const handleClose = () => {
+		onClose();
+	};
+
+	if ( ! isVisible ) {
+		return null;
+	}
+
 	return (
-		<Dialog
-			isVisible={ isVisible }
-			additionalClassNames="payment-method-delete-dialog"
-			onClose={ onClose }
-			buttons={ [
-				{ action: 'cancel', label: translate( 'Cancel' ), onClick: onClose },
-				{
-					action: 'confirm',
-					label: translate( 'Remove' ),
-					isPrimary: true,
-					additionalClassNames: 'is-scary',
-					onClick: onConfirm,
-				},
-			] }
+		<ConfirmDialog
+			onRequestClose={ handleClose }
+			className="payment-method-delete-dialog"
+			title={ translate( 'Remove payment method' ) }
 		>
-			<CardHeading tagName="h2" size={ 24 }>
-				{ translate( 'Remove payment method' ) }
-			</CardHeading>
-			<p>
-				{ translate(
-					'The payment method {{paymentMethodSummary/}} will be removed from your account and from all the associated subscriptions.',
-					{
-						components: {
-							paymentMethodSummary: <strong>{ paymentMethodSummary }</strong>,
-						},
-					}
-				) }
-			</p>
-			{ associatedSubscriptions.length > 0 && (
-				<div className="payment-method-delete-dialog__affected-subscriptions-wrapper">
-					<div className="payment-method-delete-dialog__affected-subscriptions-title-wrapper">
-						<CardHeading tagName="h2" size={ 20 }>
-							{ translate( 'Associated subscriptions' ) }
-						</CardHeading>
-						{ isCreditCard( card ) && (
-							<img src={ getPaymentMethodImageURL( card?.card_type ) } alt="" />
+			<DialogContent className="payment-method-delete-dialog__content">
+				<div className="payment-method-delete-dialog__explanation">
+					{ isCreditCard( card ) && (
+						<img src={ getPaymentMethodImageURL( card?.card_type ) } alt="" />
+					) }
+					<p>
+						{ translate(
+							'The payment method {{paymentMethodSummary/}} will be removed from your account and from all the associated subscriptions.',
+							{
+								components: {
+									paymentMethodSummary: <strong>{ paymentMethodSummary }</strong>,
+								},
+							}
 						) }
-					</div>
-					{ associatedSubscriptions.map( ( subscription: Purchase ) => (
-						<div
-							className="payment-method-delete-dialog__affected-subscription"
-							key={ subscription.id }
-						>
-							<div>
-								<span>{ subscription.productName }</span>
-								<span className="payment-method-delete-dialog__affected-subscription-domain">
-									{ subscription.meta || subscription.domain }
-								</span>
-							</div>
-							<div>
-								<span className="payment-method-delete-dialog__affected-subscription-date">
-									<span>
-										{ translate( 'Auto-renews', {
-											comment: 'followed by a date - eg. "Auto-renews 21 Apr 2025"',
-										} ) }
-									</span>
-									<span>{ moment( subscription.renewDate ).format( 'll' ) }</span>
-								</span>
-							</div>
-						</div>
-					) ) }
-					<div className="payment-method-delete-dialog__warning">
-						<Gridicon icon="notice-outline" size={ 24 } />
-						<p>
-							{ translate(
-								'This subscription will no longer auto-renew until an alternative payment method is added.',
-								'These subscriptions will no longer auto-renew until an alternative payment method is added.',
-								{
-									count: associatedSubscriptions.length,
-								}
-							) }
-						</p>
-					</div>
+					</p>
 				</div>
-			) }
-		</Dialog>
+
+				{ associatedSubscriptions.length > 0 && (
+					<div className="payment-method-delete-dialog__affected-subscriptions-wrapper">
+						<table className="payment-method-delete-dialog__affected-subscriptions-table">
+							<thead>
+								<tr>
+									<th>{ translate( 'Subscription' ) }</th>
+									<th>{ translate( 'Renew date' ) }</th>
+								</tr>
+							</thead>
+							<tbody>
+								{ associatedSubscriptions.map( ( subscription: Purchase ) => (
+									<tr key={ subscription.id }>
+										<td className="payment-method-delete-dialog__affected-subscription-details-product">
+											<strong>{ subscription.productName }</strong>
+											<span className="payment-method-delete-dialog__affected-subscription-domain">
+												{ subscription.meta || subscription.domain }
+											</span>
+										</td>
+										<td className="payment-method-delete-dialog__affected-subscription-details-renew-date fixed">
+											{ moment( subscription.renewDate ).format( 'll' ) }
+										</td>
+									</tr>
+								) ) }
+							</tbody>
+						</table>
+						<div className="payment-method-delete-dialog__warning">
+							<Gridicon icon="notice-outline" size={ 24 } />
+							<p>
+								{ translate(
+									'This subscription will no longer auto-renew until an alternative payment method is added.',
+									'These subscriptions will no longer auto-renew until an alternative payment method is added.',
+									{
+										count: associatedSubscriptions.length,
+									}
+								) }
+							</p>
+						</div>
+					</div>
+				) }
+			</DialogContent>
+			<DialogFooter>
+				<Button onClick={ onClose }>{ translate( 'Cancel' ) }</Button>
+				<Button variant="primary" isDestructive onClick={ onConfirm }>
+					{ translate( 'Remove' ) }
+				</Button>
+			</DialogFooter>
+		</ConfirmDialog>
 	);
 };
 

--- a/client/me/purchases/payment-methods/payment-method-delete-dialog.tsx
+++ b/client/me/purchases/payment-methods/payment-method-delete-dialog.tsx
@@ -73,16 +73,16 @@ const PaymentMethodDeleteDialog = ( {
 								</tr>
 							</thead>
 							<tbody>
-								{ associatedSubscriptions.map( ( subscription: Purchase ) => (
-									<tr key={ subscription.id }>
+								{ associatedSubscriptions.map( ( purchase: Purchase ) => (
+									<tr key={ purchase.id }>
 										<td className="payment-method-delete-dialog__affected-subscription-details-product">
-											<strong>{ subscription.productName }</strong>
+											<strong>{ purchase.productName }</strong>
 											<span className="payment-method-delete-dialog__affected-subscription-domain">
-												{ subscription.meta || subscription.domain }
+												{ purchase.meta || purchase.domain }
 											</span>
 										</td>
 										<td className="payment-method-delete-dialog__affected-subscription-details-renew-date fixed">
-											{ moment( subscription.renewDate ).format( 'll' ) }
+											{ moment( purchase.renewDate ).format( 'll' ) }
 										</td>
 									</tr>
 								) ) }

--- a/client/me/purchases/payment-methods/style.scss
+++ b/client/me/purchases/payment-methods/style.scss
@@ -158,43 +158,74 @@ $card_width: $font-body * 3.75; // roughly 60px wide
 }
 
 .payment-method-delete-dialog {
-	&.dialog {
-		max-width: 660px;
+	--max-width: 660px;
 
-		span {
-			display: block;
-			font-size: $font-body-small;
+	&__explanation {
+		display: flex;
+		gap: 12px;
+		align-items: flex-start;
+	}
 
-			&.payment-method-delete-dialog__affected-subscription-domain {
-				color: var( --color-text-subtle );
-				font-size: $font-body-extra-small;
-			}
+	&__header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
 
-			&.payment-method-delete-dialog__affected-subscription-date span {
-				color: var( --color-error );
-				font-size: $font-body-extra-small;
-				text-align: center;
-			}
+	&__affected-subscriptions-wrapper {
+		margin-top: 12px;
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+
+
+	&__affected-subscriptions-table {
+		border-collapse: collapse;
+		table-layout: fixed;
+		width: 100%;
+		thead tr {
+			border-bottom: 1px solid #ddd ;
+		}
+		th, td {
+			padding: 12px 4px;
+		}
+		th:first-child {
+			width: 70%;
+
 		}
 	}
-
-	.payment-method-delete-dialog__affected-subscriptions-wrapper {
-		border-top: 1px solid var( --color-border-subtle );
-		padding-top: 12px;
+	&__affected-subscription-details-product {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		padding-right: 12px;
+		text-wrap: nowrap;
+		overflow-x: auto;
+		scrollbar-width: thin;
+		scrollbar-gutter: stable;
 	}
 
-	.payment-method-delete-dialog__warning {
-		display: flex;
-		margin-top: 12px;
-		gap: 12px;
+	&__affected-subscription-details-renew-date {
+		vertical-align: middle;
+		text-wrap: nowrap;
+	}
 
+
+	&__warning {
+		display: flex;
+		gap: 8px;
 		.gridicon {
 			fill: var( --color-warning );
 		}
+		border: 1px solid var(--color-warning);
+		padding: 8px;
+		border-radius: 4px;
 
 		p {
 			color: var( --color-warning );
 			font-size: $font-body-small;
+			margin: 0;
 		}
 	}
 }

--- a/client/me/purchases/payment-methods/test/payment-method.tsx
+++ b/client/me/purchases/payment-methods/test/payment-method.tsx
@@ -73,6 +73,7 @@ const mockPurchases = [
 		payment: { storedDetailsId: '1234' },
 		isAutoRenewEnabled: true,
 		renewDate: '2080-12-31',
+		id: '1234',
 	},
 ];
 
@@ -156,7 +157,7 @@ describe( 'PaymentMethod', () => {
 			await screen.findByLabelText( `Remove the "${ card.card_last_4 }" payment method` )
 		);
 
-		expect( await screen.findByText( 'Associated subscriptions' ) ).toBeInTheDocument();
+		expect( await screen.findByText( 'Subscription' ) ).toBeInTheDocument();
 		expect( await screen.findByText( 'associatedsubscription.wordpress.com' ) ).toBeInTheDocument();
 	} );
 
@@ -178,7 +179,7 @@ describe( 'PaymentMethod', () => {
 			await screen.findByLabelText( `Remove the "${ card.card_last_4 }" payment method` )
 		);
 
-		expect( await screen.queryByText( 'Associated subscriptions' ) ).not.toBeInTheDocument();
+		expect( await screen.queryByText( 'Subscription' ) ).not.toBeInTheDocument();
 		expect(
 			await screen.queryByText( 'associatedsubscription.wordpress.com' )
 		).not.toBeInTheDocument();


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes DOTCON-79

## Proposed Changes
* Refactor the payment method removal modal to use core components and fix style issues. 
* Move the Credit card flag/brand to be near of the card information

## Why are these changes being made?
The current version has a broken layout.

Before 

![CleanShot 2025-06-24 at 13 49 46@2x](https://github.com/user-attachments/assets/f629da75-ffe3-4b61-83ad-9b58d8a4cf9e)

After 

![CleanShot 2025-06-24 at 13 48 54@2x](https://github.com/user-attachments/assets/c9422a36-4f19-476b-a10a-c6c520fd10f9)


After (Mobile)

![CleanShot 2025-06-24 at 13 51 24@2x](https://github.com/user-attachments/assets/3b7c2394-809c-4b38-86b8-b3e3394c9d52)

## Testing Instructions
* Go to https://wordpress.com/me/purchases/payment-methods
* Add credit card as a payment method
* Go to //me/purchases
* Assign the payment method to a site with a plan [image [1] below]. 
* Go to [Payment Methods](https://wordpress.com/me/purchases/payment-methods)
* Click on `Remove payment method`
* Check the before/after images


Assigning a payment method to a site
![CleanShot 2025-06-24 at 13 57 16@2x](https://github.com/user-attachments/assets/ec199826-06d0-4b93-8f1e-13519abf79c5)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
