### PR TITLE
Site list v2: handle non-wpcom sites in Plan column

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -8,9 +8,11 @@ module.exports = {
 						group: [
 							'calypso/*',
 							// Allowed: calypso/components/async-load
+							// Allowed: calypso/components/jetpack-logo
 							'!calypso/components',
 							'calypso/components/*',
 							'!calypso/components/async-load',
+							'!calypso/components/jetpack-logo',
 							// Allowed: calypso/data/php-versions
 							'!calypso/data',
 							'calypso/data/*',

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -8,7 +8,7 @@ export const AUTH_QUERY_KEY = [ 'auth', 'user' ];
 interface AuthContextType {
 	user: User;
 }
-const AuthContext = createContext< AuthContextType | undefined >( undefined );
+export const AuthContext = createContext< AuthContextType | undefined >( undefined );
 
 /**
  * This component:

--- a/client/dashboard/sites/features.ts
+++ b/client/dashboard/sites/features.ts
@@ -1,6 +1,6 @@
 import { DotcomFeatures } from '../data/constants';
 import { hasAtomicFeature, hasPlanFeature } from '../utils/site-features';
-import { isJetpackNotAtomic, isP2 } from '../utils/site-types';
+import { isSelfHostedJetpackConnected, isP2 } from '../utils/site-types';
 import type { Site, User } from '../data/types';
 
 export const HostingFeatures = {
@@ -33,8 +33,8 @@ export function canManageSite( site: Site ) {
 		return false;
 	}
 
-	// Jetpack sites are not supported, yet.
-	if ( isJetpackNotAtomic( site ) ) {
+	// Self-hosted Jetpack-connected sites are not supported, yet.
+	if ( isSelfHostedJetpackConnected( site ) ) {
 		return false;
 	}
 

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -1,27 +1,30 @@
 import { useQuery } from '@tanstack/react-query';
 import {
 	__experimentalText as Text,
+	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	ExternalLink,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useInView } from 'react-intersection-observer';
-import { useAnalytics } from '../app/analytics';
-import { useAuth } from '../app/auth';
-import { siteBackupLastEntryQuery } from '../app/queries/site-backups';
-import { siteMediaStorageQuery } from '../app/queries/site-media-storage';
-import { sitePHPVersionQuery } from '../app/queries/site-php-version';
-import { siteEngagementStatsQuery } from '../app/queries/site-stats';
-import { siteUptimeQuery } from '../app/queries/site-uptime';
-import ComponentViewTracker from '../components/component-view-tracker';
-import { TextBlur } from '../components/text-blur';
-import TimeSince from '../components/time-since';
-import { JetpackModules } from '../data/constants';
-import { hasAtomicFeature, hasJetpackModule } from '../utils/site-features';
-import { getSiteStatusLabel } from '../utils/site-status';
-import { HostingFeatures } from './features';
-import { isSitePlanTrial } from './plans';
-import type { Site } from '../data/types';
+import JetpackLogo from 'calypso/components/jetpack-logo';
+import { useAnalytics } from '../../app/analytics';
+import { useAuth } from '../../app/auth';
+import { siteBackupLastEntryQuery } from '../../app/queries/site-backups';
+import { siteMediaStorageQuery } from '../../app/queries/site-media-storage';
+import { sitePHPVersionQuery } from '../../app/queries/site-php-version';
+import { siteEngagementStatsQuery } from '../../app/queries/site-stats';
+import { siteUptimeQuery } from '../../app/queries/site-uptime';
+import ComponentViewTracker from '../../components/component-view-tracker';
+import { TextBlur } from '../../components/text-blur';
+import TimeSince from '../../components/time-since';
+import { JetpackModules } from '../../data/constants';
+import { hasAtomicFeature, hasJetpackModule } from '../../utils/site-features';
+import { getSiteStatusLabel } from '../../utils/site-status';
+import { isSelfHostedJetpackConnected } from '../../utils/site-types';
+import { HostingFeatures } from '../features';
+import { isSitePlanTrial } from '../plans';
+import type { Site } from '../../data/types';
 
 function IneligibleIndicator() {
 	return <Text color="#CCCCCC">-</Text>;
@@ -236,6 +239,23 @@ export function Status( { site }: { site: Site } ) {
 }
 
 export function Plan( { site }: { site: Site } ) {
+	if ( site.is_wpcom_staging_site ) {
+		// translator: this is the label of a staging site.
+		return __( 'Staging' );
+	}
+
+	if ( isSelfHostedJetpackConnected( site ) ) {
+		if ( ! site.jetpack ) {
+			return <IneligibleIndicator />;
+		}
+		return (
+			<HStack spacing={ 1 } expanded={ false }>
+				<JetpackLogo size={ 16 } />
+				<span>{ site.plan?.product_name_short }</span>
+			</HStack>
+		);
+	}
+
 	if ( site.plan?.expired ) {
 		return (
 			<VStack spacing={ 1 }>

--- a/client/dashboard/sites/site-fields/test/index.tsx
+++ b/client/dashboard/sites/site-fields/test/index.tsx
@@ -1,0 +1,123 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render as testingLibraryRender } from '@testing-library/react';
+import { AuthContext } from '../../../app/auth';
+import { Plan } from '../index';
+import type { User, Site } from '../../../data/types';
+
+function render( ui: React.ReactElement ) {
+	return testingLibraryRender(
+		<AuthContext.Provider value={ { user: { ID: 1 } as User } }>{ ui }</AuthContext.Provider>
+	);
+}
+
+describe( '<Plan>', () => {
+	test( 'for staging sites, it renders "Staging"', async () => {
+		const site = {
+			is_wpcom_staging_site: true,
+		} as Site;
+		const { container } = render( <Plan site={ site } /> );
+		expect( container.textContent ).toBe( 'Staging' );
+	} );
+
+	test( 'for self-hosted, Jetpack-connected sites, active Jetpack plugin, it renders the Jetpack logo and plan name', async () => {
+		const site = {
+			is_wpcom_atomic: false,
+			jetpack_connection: true,
+			jetpack: true,
+			plan: {
+				product_name_short: 'Free',
+			},
+		} as Site;
+		const { container } = render( <Plan site={ site } /> );
+		expect( container.querySelector( 'svg' ) ).toBeInTheDocument();
+		expect( container.textContent ).toBe( 'Free' );
+	} );
+
+	test( 'for self-hosted, Jetpack-connected sites, inactive Jetpack plugin, it renders dash', async () => {
+		const site = {
+			is_wpcom_atomic: false,
+			jetpack_connection: true,
+			jetpack: false,
+			plan: {
+				product_name_short: 'Free',
+			},
+		} as Site;
+		const { container } = render( <Plan site={ site } /> );
+		expect( container.textContent ).toBe( '-' );
+	} );
+
+	test( 'for WordPress.com Simple sites, it renders the plan name', async () => {
+		const site = {
+			is_wpcom_atomic: false,
+			jetpack_connection: false,
+			jetpack: false,
+			plan: {
+				product_name_short: 'Premium',
+			},
+		} as Site;
+		const { container } = render( <Plan site={ site } /> );
+		expect( container.textContent ).toBe( 'Premium' );
+	} );
+
+	test( 'for WordPress.com Atomic sites, it renders the plan name', async () => {
+		const site = {
+			is_wpcom_atomic: true,
+			jetpack_connection: true,
+			jetpack: true,
+			plan: {
+				product_name_short: 'Business',
+			},
+		} as Site;
+		const { container } = render( <Plan site={ site } /> );
+		expect( container.textContent ).toBe( 'Business' );
+	} );
+
+	test( 'for sites with expired plan, it renders the plan name with "-expired" suffix', async () => {
+		const site = {
+			plan: {
+				product_name_short: 'Business',
+				expired: true,
+			},
+		} as Site;
+		const { container } = render( <Plan site={ site } /> );
+		expect( container.textContent ).toBe( 'Business-expired' );
+	} );
+
+	test( 'for sites with expired plan, it renders the plan name with "-expired" suffix and a renewal nag for the site owner', async () => {
+		const site = {
+			slug: 'test.wordpress.com',
+			site_owner: 1,
+			plan: {
+				product_slug: 'business-bundle',
+				product_name_short: 'Business',
+				expired: true,
+			},
+		} as Site;
+		const { getByText, getByRole } = render( <Plan site={ site } /> );
+		expect( getByText( 'Business-expired' ) ).toBeInTheDocument();
+		expect( getByRole( 'link', { name: /Renew plan/ } ) ).toHaveAttribute(
+			'href',
+			'/checkout/test.wordpress.com/business-bundle'
+		);
+	} );
+
+	test( 'for Trial sites with expired plan, it renders the plan name with "-expired" suffix and an upgrade nag for the site owner', async () => {
+		const site = {
+			slug: 'test.wordpress.com',
+			site_owner: 1,
+			plan: {
+				product_slug: 'ecommerce-trial-bundle-monthly',
+				product_name_short: 'Trial',
+				expired: true,
+			},
+		} as Site;
+		const { getByText, getByRole } = render( <Plan site={ site } /> );
+		expect( getByText( 'Trial-expired' ) ).toBeInTheDocument();
+		expect( getByRole( 'link', { name: /Upgrade/ } ) ).toHaveAttribute(
+			'href',
+			'/plans/test.wordpress.com'
+		);
+	} );
+} );

--- a/client/dashboard/utils/site-types.ts
+++ b/client/dashboard/utils/site-types.ts
@@ -1,6 +1,6 @@
 import type { Site } from '../data/types';
 
-export function isJetpackNotAtomic( site: Site ) {
+export function isSelfHostedJetpackConnected( site: Site ) {
 	return site.jetpack_connection && ! site.is_wpcom_atomic;
 }
 


### PR DESCRIPTION
Fixes DOTDASH-82

## Proposed Changes

This PR handles the following site types in the Plan column of the Site List v2:

|||
|-|-|
|Staging site|<img width="440" alt="image" src="https://github.com/user-attachments/assets/65963354-5f1c-4d20-a8e7-223d08d103f2" />|
|Self-hosted, Jetpack-connected, active plugin|<img width="414" alt="image" src="https://github.com/user-attachments/assets/0dcc74da-8562-4315-8bc9-ba56249a9b3b" />|
|Self-hosted, Jetpack-connected, deactivated plugin|<img width="409" alt="image" src="https://github.com/user-attachments/assets/dc683222-4c82-4a0e-92d5-ac1a362d4121" />


## Testing Instructions

Test the above cases.

For the third case, follow the instruction in this PR:

- https://github.com/Automattic/wp-calypso/pull/95779

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
