### PR TITLE
Backup: simplify retention plan cards

### DIFF
--- a/client/components/backup-retention-management/index.tsx
+++ b/client/components/backup-retention-management/index.tsx
@@ -345,7 +345,6 @@ const BackupRetentionManagement: FunctionComponent< OwnProps > = ( {
 							</div>
 						) }
 						<RetentionOptionsControl
-							currentRetentionPlan={ currentRetentionPlan }
 							onChange={ onRetentionSelectionChange }
 							retentionSelected={ retentionSelected }
 							retentionOptions={ retentionOptionsCards }

--- a/client/components/backup-retention-management/retention-options/retention-option-card.tsx
+++ b/client/components/backup-retention-management/retention-options/retention-option-card.tsx
@@ -1,3 +1,4 @@
+import { Gridicon } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
@@ -7,7 +8,6 @@ import type { RetentionPeriod } from 'calypso/state/rewind/retention/types';
 interface RetentionOptionCardProps {
 	spaceNeededInBytes: number;
 	upgradeRequired: boolean;
-	isCurrentPlan: boolean;
 	value: RetentionPeriod;
 	checked?: boolean;
 	onChange: ( value: number ) => void;
@@ -16,7 +16,6 @@ interface RetentionOptionCardProps {
 const RetentionOptionCard: FunctionComponent< RetentionOptionCardProps > = ( {
 	spaceNeededInBytes,
 	upgradeRequired,
-	isCurrentPlan,
 	value,
 	checked = false,
 	onChange,
@@ -63,18 +62,11 @@ const RetentionOptionCard: FunctionComponent< RetentionOptionCardProps > = ( {
 				<div className="space-needed__value">{ spaceNeededText }</div>
 			</div>
 			<div
-				className={ clsx( 'retention-option__upgrade-required', {
+				className={ clsx( 'retention-option__highlight-badge', {
 					'is-visible': upgradeRequired,
 				} ) }
 			>
-				{ translate( 'Upgrade required' ) }
-			</div>
-			<div
-				className={ clsx( 'retention-option__current-plan', {
-					'is-visible': isCurrentPlan,
-				} ) }
-			>
-				{ translate( 'Current plan' ) }
+				<Gridicon icon="star" size={ 12 } /> { translate( 'Upgrade required' ) }
 			</div>
 		</div>
 	);

--- a/client/components/backup-retention-management/retention-options/retention-option-card.tsx
+++ b/client/components/backup-retention-management/retention-options/retention-option-card.tsx
@@ -1,4 +1,4 @@
-import { Gridicon } from '@automattic/components';
+import { Icon, starFilled } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
@@ -66,7 +66,8 @@ const RetentionOptionCard: FunctionComponent< RetentionOptionCardProps > = ( {
 					'is-visible': upgradeRequired,
 				} ) }
 			>
-				<Gridicon icon="star" size={ 12 } /> { translate( 'Upgrade required' ) }
+				<Icon icon={ starFilled } size={ 14 } className="icon" />
+				{ translate( 'Upgrade required' ) }
 			</div>
 		</div>
 	);

--- a/client/components/backup-retention-management/retention-options/retention-options-control.tsx
+++ b/client/components/backup-retention-management/retention-options/retention-options-control.tsx
@@ -5,14 +5,12 @@ import type { RetentionOptionInput } from '../types';
 
 interface RetentionOptionsControlProps {
 	retentionOptions: RetentionOptionInput[];
-	currentRetentionPlan?: number;
 	retentionSelected?: number;
 	onChange: ( value: number ) => void;
 }
 
 const RetentionOptionsControl: React.FC< RetentionOptionsControlProps > = ( {
 	retentionOptions,
-	currentRetentionPlan,
 	retentionSelected,
 	onChange,
 } ) => {
@@ -36,7 +34,6 @@ const RetentionOptionsControl: React.FC< RetentionOptionsControlProps > = ( {
 					spaceNeededInBytes={ option.spaceNeededInBytes }
 					upgradeRequired={ option.upgradeRequired }
 					checked={ retentionSelected === option.id }
-					isCurrentPlan={ currentRetentionPlan === option.id }
 					// Given that we are working with a small set of options,
 					// we could use the option id as a key
 					key={ `retention-option-${ option.id }` }

--- a/client/components/backup-retention-management/style.scss
+++ b/client/components/backup-retention-management/style.scss
@@ -176,6 +176,7 @@
 			visibility: hidden;
 
 			.icon {
+				fill: var(--studio-green-60);
 				vertical-align: text-bottom;
 			}
 

--- a/client/components/backup-retention-management/style.scss
+++ b/client/components/backup-retention-management/style.scss
@@ -124,7 +124,7 @@
 
 	.retention-option {
 		box-shadow: 0 0 0 1px var(--color-border-subtle);
-		padding: 16px 10px;
+		padding: 16px 12px;
 		border-radius: 4px;
 		cursor: pointer;
 
@@ -175,8 +175,8 @@
 			padding: 0 8px;
 			visibility: hidden;
 
-			.gridicon {
-				vertical-align: text-top;
+			.icon {
+				vertical-align: text-bottom;
 			}
 
 			&.is-visible {

--- a/client/components/backup-retention-management/style.scss
+++ b/client/components/backup-retention-management/style.scss
@@ -124,7 +124,7 @@
 
 	.retention-option {
 		box-shadow: 0 0 0 1px var(--color-border-subtle);
-		padding: 16px 12px;
+		padding: 16px 10px;
 		border-radius: 4px;
 		cursor: pointer;
 
@@ -164,18 +164,7 @@
 			}
 		}
 
-		&__upgrade-required {
-			font-size: 0.875rem;
-			font-weight: 400;
-			color: var(--studio-red-50);
-			margin-bottom: 8px;
-			visibility: hidden;
-			&.is-visible {
-				visibility: visible;
-			}
-		}
-
-		&__current-plan {
+		&__highlight-badge {
 			background: var(--studio-green-5);
 			border-radius: 2px;
 			color: var(--studio-green-60);
@@ -185,6 +174,11 @@
 			line-height: 24px;
 			padding: 0 8px;
 			visibility: hidden;
+
+			.gridicon {
+				vertical-align: text-top;
+			}
+
 			&.is-visible {
 				visibility: visible;
 			}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes https://linear.app/a8c/issue/BACKUP-127/

## Proposed Changes

- Drop the `Current plan` badge.
- Update the `Upgrade required` badge to the same style as the previous `Current plan`
  - Also add a star icon to it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The current storage retention settings can lead to a bit of confusion. This PR tries to simplify the information being presented, both reducing the amount of notices and also presenting the upgrade required badge as a positive action.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout this branch locally or access the Jetpack Cloud live link provided by the GitHub Actions bot.
- Access the `Settings` page of a site that requires an upgraded plan to increase the retention in at least one of the options presented in the cards.
- The `Current plan` badge shouldn't be there.
- The `Upgrade required` badge should have the updated style.

| Before | After |
| - | - |
| <img alt="image" src="https://github.com/user-attachments/assets/db3df6e6-8eba-4886-92b3-20e12123aa52" /> | <img alt="image" src="https://github.com/user-attachments/assets/48daddfc-5a19-4618-a6c4-b1cb5b89e402" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
