### PR TITLE
Staging Sites Redesign: Simplify conditions for displaying Add staging site button

### DIFF
--- a/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
@@ -7,10 +7,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { translate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useAddStagingSiteMutation } from 'calypso/sites/staging-site/hooks/use-add-staging-site';
-import {
-	useGetLockQuery,
-	USE_STAGING_SITE_LOCK_QUERY_KEY,
-} from 'calypso/sites/staging-site/hooks/use-get-lock-query';
+import { USE_STAGING_SITE_LOCK_QUERY_KEY } from 'calypso/sites/staging-site/hooks/use-get-lock-query';
 import { useStagingSite } from 'calypso/sites/staging-site/hooks/use-staging-site';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -22,12 +19,14 @@ import { StagingSiteStatus } from 'calypso/state/staging-site/constants';
 interface HeaderStagingSiteButtonProps {
 	siteId: number;
 	isAtomic: boolean;
+	isStagingSite: boolean;
 	hideEnvDataInHeader?: boolean;
 }
 
 export default function HeaderStagingSiteButton( {
 	siteId,
 	isAtomic,
+	isStagingSite,
 	hideEnvDataInHeader = false,
 }: HeaderStagingSiteButtonProps ) {
 	const dispatch = useDispatch();
@@ -37,7 +36,7 @@ export default function HeaderStagingSiteButton( {
 	// Notice IDs for staging site operations
 	const stagingSiteAddFailureNoticeId = 'staging-site-add-failure';
 
-	const { data: stagingSites = [], isLoading: isLoadingStagingSites } = useStagingSite( siteId, {
+	const { data: stagingSites = [] } = useStagingSite( siteId, {
 		enabled: ! hideEnvDataInHeader && isAtomic,
 	} );
 
@@ -78,19 +77,7 @@ export default function HeaderStagingSiteButton( {
 		}
 	);
 
-	const { data: lock, isLoading: isLoadingLockQuery } = useGetLockQuery( siteId, {
-		enabled: isAtomic,
-		refetchInterval: () => {
-			return isLoadingAddStagingSite ? 5000 : 0;
-		},
-	} );
-
-	const showAddStagingButton =
-		! isLoadingStagingSites &&
-		! isLoadingLockQuery &&
-		stagingSites.length === 0 &&
-		isAtomic &&
-		! lock;
+	const showAddStagingButton = stagingSites.length === 0 && isAtomic && ! isStagingSite;
 
 	const onAddClick = useCallback( () => {
 		dispatch( setStagingSiteStatus( siteId, StagingSiteStatus.INITIATE_TRANSFERRING ) );

--- a/client/layout/hosting-dashboard/item-view/item-view-header/index.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/index.tsx
@@ -120,6 +120,7 @@ export default function ItemViewHeader( {
 										<HeaderStagingSiteButton
 											siteId={ siteId }
 											isAtomic={ isAtomic }
+											isStagingSite={ isStagingSite }
 											hideEnvDataInHeader={ itemData.hideEnvDataInHeader }
 										/>
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes DOTDEV-183

## Proposed Changes

This PR ensures that the `Add staging site` button is available only on production sites and not on staging sites. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Currently, the `Add staging site` button appears on the staging site header.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch and start the dev env with yarn start
* Ensure that you have an Atomic site
* Navigate to `/staging-site/{yourAtomicSite}`
* Click on the Add staging site button in the header
* Confirm that the staging site is created and that you see the notice about the successful site creation
* Switch to the staging site
* Wait for 20 seconds
* Confirm that the `Add staging site` button is not present there
* Repeat these steps on trunk
* Observe that the `Add staging site` button appears in the staging site header after about 10 seconds of waiting

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
