### PR TITLE
Sites List v2: Add Overview action for the retrofitted Sites List

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -4,7 +4,7 @@ import { useNavigate, useRouter, Link } from '@tanstack/react-router';
 import { __experimentalText as Text, Button, Modal, Icon } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { wordpress } from '@wordpress/icons';
+import { drawerLeft, wordpress } from '@wordpress/icons';
 import { useMemo, useState } from 'react';
 import { sitesQuery } from '../app/queries/sites';
 import { sitesRoute } from '../app/router';
@@ -238,7 +238,24 @@ const DEFAULT_VIEW = {
 };
 
 const getDefaultActions = ( router: AnyRouter ) => {
+	const isBackport = ! router.basepath.startsWith( '/v2' );
+
 	return [
+		...( isBackport
+			? [
+					{
+						id: 'overview',
+						label: __( 'Overview' ),
+						isPrimary: true,
+						icon: <Icon icon={ drawerLeft } />,
+						callback: ( sites: Site[] ) => {
+							const site = sites[ 0 ];
+							window.location.href = `/overview/${ site.slug }`;
+						},
+						isEligible: ( item: Site ) => canManageSite( item ),
+					},
+			  ]
+			: [] ),
 		{
 			id: 'admin',
 			isPrimary: true,


### PR DESCRIPTION
Ref DOTDASH-76

## Proposed Changes

Adds the Overview action for the retrofitted Sites List.
![SCR-20250624-truj](https://github.com/user-attachments/assets/80eb8433-59ce-4325-bf62-ab1ae297b886)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Sites List v2 development.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2 and ensure that the Overview action is not available
* Retrofitted Sites List is still in progress, so it's not testable on that end yet. In the meantime, you can test this by changing the `isBackport` logic to make the Overview action to show up 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
