### PR TITLE
Happy Blocks: Full width for pills

### DIFF
--- a/apps/happy-blocks/block-library/search-card/style.scss
+++ b/apps/happy-blocks/block-library/search-card/style.scss
@@ -124,7 +124,6 @@ $breakpoint-desktop: 1440px; //Desktop size.
 			align-items: flex-start;
 			gap: 16px;
 			list-style: none;
-			padding: 0;
 
 			overflow-x: auto;
 			white-space: nowrap;
@@ -133,6 +132,11 @@ $breakpoint-desktop: 1440px; //Desktop size.
 			&::-webkit-scrollbar {
 				display: none;
 			}
+
+			width: calc(100% + 32px);
+			margin-left: -16px !important;
+			padding-left: 16px;
+			padding-right: 16px;
 
 			@media ( max-width: $breakpoint-mobile ) {
 				gap: 8px;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTSUP-29/landing-page-updates#comment-7d43087d

## Proposed Changes

## Before

![image](https://github.com/user-attachments/assets/d7105925-9673-4c57-9071-90ac97d0973f)


## After

![image](https://github.com/user-attachments/assets/7bbeee8e-9e5e-470a-9dcd-67982c5065d4)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn dev --sync` from `cd apps/happy-blocks`
* Sandbox widgets
* Visit https://wordpress.com/support/support_lp_2025/
