### PR TITLE
Purchases: Handle case where site.capabilities does not exist

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
@@ -63,7 +63,9 @@ export const ScheduleForm = ( { onNavBack, scheduleForEdit, onRecordSuccessEvent
 	const translate = useTranslate();
 
 	const siteFilter = ( site: SiteExcerptData ): boolean => {
-		return ( site as SiteDetails ).capabilities?.update_plugins && ! site.is_wpcom_staging_site;
+		return Boolean(
+			( site as SiteDetails ).capabilities?.update_plugins && ! site.is_wpcom_staging_site
+		);
 	};
 
 	const { data: sites } = useSiteExcerptsQuery( [ 'atomic' ], siteFilter, 'all', [

--- a/client/me/purchases/purchases-list/purchases-by-other-admins-notice.tsx
+++ b/client/me/purchases/purchases-list/purchases-by-other-admins-notice.tsx
@@ -12,10 +12,10 @@ export function PurchasesByOtherAdminsNotice( { sites }: { sites: SiteDetails[] 
 	const affectedSites = sites
 		.filter( ( site ) => {
 			if ( ! site?.plan?.is_free ) {
-				return site.capabilities.manage_options;
+				return site.capabilities?.manage_options;
 			}
 			if ( site?.products && site?.products?.length > 0 ) {
-				return site.capabilities.manage_options;
+				return site.capabilities?.manage_options;
 			}
 			return false;
 		} )

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -54,12 +54,12 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 		const isAtomic = site?.options?.is_automated_transfer ?? false;
 		const isWpcomStagingSite = site?.is_wpcom_staging_site ?? false;
 
-		return (
+		return Boolean(
 			site?.capabilities?.manage_options &&
-			! ( site.jetpack && ! isAtomic ) && // Simple and Atomic sites. Not Jetpack sites.
-			! isWpcomStagingSite &&
-			! ( site?.options?.is_domain_only ?? false ) &&
-			site.ID !== this.props.selectedSite?.ID
+				! ( site.jetpack && ! isAtomic ) && // Simple and Atomic sites. Not Jetpack sites.
+				! isWpcomStagingSite &&
+				! ( site?.options?.is_domain_only ?? false ) &&
+				site.ID !== this.props.selectedSite?.ID
 		);
 	};
 

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -122,7 +122,7 @@ export interface DifmLiteSiteOptions {
 export interface SiteDetails {
 	ID: number;
 	URL: string;
-	capabilities: SiteDetailsCapabilities;
+	capabilities?: SiteDetailsCapabilities;
 	description: string;
 	domain: string;
 	icon?: { ico: string; img: string; media_id: number };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CHE-204/investigate-blank-purchases-page-with-js-error-for-user-without

## Proposed Changes

The TypeScript type for `SiteDetails` appears to be incorrect in that it assumes every site object has a `capabilities` property, but actual experience shows that this is not always the case, causing fatal errors.

This PR updates the type so that it will show up as possibly undefined, and fixes the Purchases page so that it won't fatal if that property does not exist.

## Testing Instructions

I'm not sure how to reproduce this but a visual check should be sufficient.