### PR TITLE
DS Site: Set up for production URL

### DIFF
--- a/apps/design-system-docs/docusaurus.config.ts
+++ b/apps/design-system-docs/docusaurus.config.ts
@@ -9,11 +9,9 @@ const config: Config = {
 	tagline: 'Build sustainably with WordPress and Automattic components.',
 	favicon: 'img/ds-favicon.png',
 
-	// TODO: Set the production url here
-	url: 'https://your-docusaurus-site.example.com',
-	// Set the /<baseUrl>/ pathname under which your site is served
-	// For GitHub pages deployment, it is often '/<projectName>/'
+	url: 'https://system.automattic.design',
 	baseUrl: '/',
+	noIndex: true,
 
 	onBrokenLinks: 'throw',
 	onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION
Part of DS-252

## Proposed Changes

Swaps out the example URL config with the real URL, and adds a site-wide `noindex` setting to prevent the site from showing up in search engines.

## Why are these changes being made?

We are just about to map the site to the production domain.

## Testing Instructions

Inspect source on the live link and check the `robots` meta tag.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
