### PR TITLE
Sites List v2: Don't fetch domain_only nor redirect sites

### DIFF
--- a/client/dashboard/data/me-sites.ts
+++ b/client/dashboard/data/me-sites.ts
@@ -14,8 +14,8 @@ export async function fetchSites( { site_visibility }: FetchSitesOptions ): Prom
 		},
 		{
 			site_visibility,
-			include_domain_only: 'false',
-			include_redirect: 'false',
+			include_domain_only: false,
+			include_redirect: false,
 			site_activity: 'active',
 			fields: JOINED_SITE_FIELDS,
 			options: JOINED_SITE_OPTIONS,

--- a/client/dashboard/data/me-sites.ts
+++ b/client/dashboard/data/me-sites.ts
@@ -14,7 +14,8 @@ export async function fetchSites( { site_visibility }: FetchSitesOptions ): Prom
 		},
 		{
 			site_visibility,
-			include_domain_only: 'true',
+			include_domain_only: 'false',
+			include_redirect: 'false',
 			site_activity: 'active',
 			fields: JOINED_SITE_FIELDS,
 			options: JOINED_SITE_OPTIONS,

--- a/client/dashboard/data/site.ts
+++ b/client/dashboard/data/site.ts
@@ -61,8 +61,6 @@ export interface SiteCapabilities {
 
 export interface SiteOptions {
 	admin_url: string;
-	is_domain_only?: boolean;
-	is_redirect?: boolean;
 	is_wpforteams_site?: boolean;
 	p2_hub_blog_id?: number;
 	site_creation_flow?: string;

--- a/client/dashboard/data/site.ts
+++ b/client/dashboard/data/site.ts
@@ -31,6 +31,7 @@ export const JOINED_SITE_FIELDS = SITE_FIELDS.join( ',' );
 
 export const SITE_OPTIONS = [
 	'admin_url',
+	'is_domain_only',
 	'is_redirect',
 	'is_wpforteams_site',
 	'p2_hub_blog_id',
@@ -60,6 +61,7 @@ export interface SiteCapabilities {
 
 export interface SiteOptions {
 	admin_url: string;
+	is_domain_only?: boolean;
 	is_redirect?: boolean;
 	is_wpforteams_site?: boolean;
 	p2_hub_blog_id?: number;

--- a/client/dashboard/utils/site-status.ts
+++ b/client/dashboard/utils/site-status.ts
@@ -6,7 +6,6 @@ export const STATUS_LABELS = {
 	private: __( 'Private' ),
 	coming_soon: __( 'Coming soon' ),
 	deleted: __( 'Deleted' ),
-	redirect: __( 'Redirect' ),
 	migration_pending: __( 'Migration pending' ),
 	migration_started: __( 'Migration started' ),
 };
@@ -22,10 +21,6 @@ export function getSiteStatus( item: Site ) {
 
 	if ( item.is_deleted ) {
 		return 'deleted';
-	}
-
-	if ( item.options?.is_redirect ) {
-		return 'redirect';
 	}
 
 	if ( item.is_coming_soon || ( item.is_private && item.launch_status === 'unlaunched' ) ) {


### PR DESCRIPTION
Ref DOTDASH-74

## Proposed Changes

This PR updates Sites List v2 to pass include_domain_only and include_redirect to /me/sites in order to not fetch domain-only and redirect sites. Note that this PR needs to be tested with 186366-ghe-Automattic/wpcom.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Sites List v2 development.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Ensure that your domain-only and redirect sites are no longer showing
* Ensure that the rest of the sites should be displayed as before

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?