### PR TITLE
Try providing responsive image sizes in dataviews

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -60,6 +60,7 @@ interface GridItemProps< Item > {
 	regularFields: NormalizedField< Item >[];
 	badgeFields: NormalizedField< Item >[];
 	hasBulkActions: boolean;
+	sizes: string;
 }
 
 function GridItem< Item >( {
@@ -78,6 +79,7 @@ function GridItem< Item >( {
 	regularFields,
 	badgeFields,
 	hasBulkActions,
+	sizes,
 }: GridItemProps< Item > ) {
 	const { showTitle = true, showMedia = true, showDescription = true } = view;
 	const hasBulkAction = useHasAPossibleBulkAction( actions, item );
@@ -85,7 +87,7 @@ function GridItem< Item >( {
 	const instanceId = useInstanceId( GridItem );
 	const isSelected = selection.includes( id );
 	const renderedMediaField = mediaField?.render ? (
-		<mediaField.render item={ item } field={ mediaField } />
+		<mediaField.render item={ item } field={ mediaField } sizes={ sizes } />
 	) : null;
 	const renderedTitleField =
 		showTitle && titleField?.render ? (
@@ -293,6 +295,15 @@ function ViewGrid< Item >( {
 				gridTemplateColumns: `repeat(${ usedPreviewSize }, minmax(0, 1fr))`,
 		  }
 		: {};
+
+	// The default grid items don't grow above this size.
+	let sizes = '400px';
+	if ( usedPreviewSize ) {
+		// This is a very approximate calculation dividing the viewport by the number of columns.
+		// It should still provide significant benefits in terms of download size.
+		sizes = `${ 100 / usedPreviewSize }vw`;
+	}
+
 	return (
 		<>
 			{ hasData && (
@@ -323,6 +334,7 @@ function ViewGrid< Item >( {
 								regularFields={ regularFields }
 								badgeFields={ badgeFields }
 								hasBulkActions={ hasBulkActions }
+								sizes={ sizes }
 							/>
 						);
 					} ) }

--- a/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
@@ -14,7 +14,7 @@ import type { ViewGrid } from '../../types';
 const viewportBreaks: {
 	[ key: string ]: { min: number; max: number; default: number };
 } = {
-	xhuge: { min: 3, max: 6, default: 5 },
+	xhuge: { min: 3, max: 6, default: 6 },
 	huge: { min: 2, max: 4, default: 4 },
 	xlarge: { min: 2, max: 3, default: 3 },
 	large: { min: 1, max: 2, default: 2 },

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -117,26 +117,14 @@
 }
 
 .dataviews-view-grid.dataviews-view-grid {
+	grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
 	/**
 	 * Breakpoints were adjusted from media queries breakpoints to account for
 	 * the sidebar width. This was done to match the existing styles we had.
 	 */
 	@container (max-width: 480px) {
-		grid-template-columns: repeat(1, minmax(0, 1fr));
 		padding-left: $grid-unit-30;
 		padding-right: $grid-unit-30;
-	}
-	@container (min-width: 480px) {
-		grid-template-columns: repeat(2, minmax(0, 1fr));
-	}
-	@container (min-width: 780px) {
-		grid-template-columns: repeat(3, minmax(0, 1fr));
-	}
-	@container (min-width: 1140px) {
-		grid-template-columns: repeat(4, minmax(0, 1fr));
-	}
-	@container (min-width: 1520px) {
-		grid-template-columns: repeat(5, minmax(0, 1fr));
 	}
 }
 

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -117,7 +117,7 @@
 }
 
 .dataviews-view-grid.dataviews-view-grid {
-	grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+	grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
 	/**
 	 * Breakpoints were adjusted from media queries breakpoints to account for
 	 * the sidebar width. This was done to match the existing styles we had.

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -199,7 +199,11 @@ function ListItem< Item >( {
 	const renderedMediaField =
 		showMedia && mediaField?.render ? (
 			<div className="dataviews-view-list__media-wrapper">
-				<mediaField.render item={ item } field={ mediaField } />
+				<mediaField.render
+					item={ item }
+					field={ mediaField }
+					sizes="52px"
+				/>
 			</div>
 		) : null;
 

--- a/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
@@ -44,7 +44,11 @@ function ColumnPrimary< Item >( {
 		<HStack spacing={ 3 } justify="flex-start">
 			{ mediaField && (
 				<div className="dataviews-view-table__cell-content-wrapper dataviews-column-primary__media">
-					<mediaField.render item={ item } field={ mediaField } />
+					<mediaField.render
+						item={ item }
+						field={ mediaField }
+						sizes="32px"
+					/>
 				</div>
 			) }
 			<VStack spacing={ 0 }>

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -280,6 +280,7 @@ export type DataFormControlProps< Item > = {
 export type DataViewRenderFieldProps< Item > = {
 	item: Item;
 	field: NormalizedField< Item >;
+	sizes?: string;
 };
 
 /**


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of ARC-382

## Proposed Changes

Dataviews layouts pass a `sizes` string to `mediaField.render` so that, if the media field is an image, it can implement responsive image HTML.

My first attempt [here](https://github.com/WordPress/gutenberg/pull/70493) was overly reliant on the core breakpoints so I've simplified the logic to output a single size, which should be the maximum size for that view.

In order to ensure that the default grid configuration has a maximum image size, I simplified the `grid-template-columns` logic so that there is no maximum number of columns (previously the default maxxed out at 5 cols). 

I also changed tweaked the picker values slightly so it always makes the grid items bigger, not smaller (given the default now displays smaller on big screens).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To allow implementing responsive images, so that users can download substantially less MBs of images each time they load a dataviews screen.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* run `yarn run build-packages` followed by `yarn start` and check `http://calypso.localhost:3000/v2/sites` to see changes to the grid implementation:

Before:
<img width="1487" alt="Screenshot 2025-06-26 at 1 51 16 pm" src="https://github.com/user-attachments/assets/31205f1b-66e0-41d6-9a5a-ab4c4c2e5671" />

After:
<img width="1494" alt="Screenshot 2025-06-26 at 1 51 23 pm" src="https://github.com/user-attachments/assets/01f0cbb2-a7c2-48ba-b00c-870fc667d0ec" />


* check the updated [Gutenberg PR](https://github.com/WordPress/gutenberg/pull/70493) that allows you to test on the Pages section of the site editor.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
