### PR TITLE
Site list v2: handle row click for unsupported sites

### DIFF
--- a/client/dashboard/sites/fields.tsx
+++ b/client/dashboard/sites/fields.tsx
@@ -1,0 +1,223 @@
+import { Link } from '@tanstack/react-router';
+import { __experimentalText as Text } from '@wordpress/components';
+import { useResizeObserver } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+import TimeSince from '../components/time-since';
+import { STATUS_LABELS, getSiteStatus } from '../utils/site-status';
+import { getFormattedWordPressVersion } from '../utils/wp-version';
+import { canManageSite } from './features';
+import {
+	EngagementStat,
+	LastBackup,
+	MediaStorage,
+	PHPVersion,
+	Plan,
+	Status,
+	Uptime,
+} from './site-fields';
+import SiteIcon from './site-icon';
+import SitePreview from './site-preview';
+import type { Site } from '../data/types';
+import type { Field, Operator } from '@automattic/dataviews';
+
+function getSiteManagementUrl( site: Site ) {
+	if ( canManageSite( site ) ) {
+		return `/sites/${ site.slug }`;
+	}
+	return site.options?.admin_url;
+}
+
+const DEFAULT_FIELDS: Field< Site >[] = [
+	{
+		id: 'name',
+		label: __( 'Site' ),
+		enableGlobalSearch: true,
+		getValue: ( { item } ) => item.name || new URL( item.URL ).hostname,
+		render: ( { field, item } ) => (
+			<Link to={ getSiteManagementUrl( item ) }>{ field.getValue( { item } ) }</Link>
+		),
+	},
+	{
+		id: 'URL',
+		label: __( 'URL' ),
+		enableGlobalSearch: true,
+		getValue: ( { item } ) => new URL( item.URL ).hostname,
+		render: ( { field, item } ) => (
+			<Text
+				as="span"
+				variant="muted"
+				style={ { overflowX: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }
+			>
+				{ field.getValue( { item } ) }
+			</Text>
+		),
+	},
+	{
+		id: 'icon.ico',
+		label: __( 'Site icon' ),
+		render: ( { item } ) => <SiteIcon site={ item } />,
+		enableSorting: false,
+	},
+	{
+		id: 'subscribers_count',
+		label: __( 'Subscribers' ),
+	},
+	{
+		id: 'backup',
+		label: __( 'Backup' ),
+		render: ( { item } ) => <LastBackup site={ item } />,
+		enableSorting: false,
+	},
+	{
+		id: 'plan',
+		label: __( 'Plan' ),
+		getValue: ( { item } ) => item.plan?.product_name_short ?? '',
+		render: ( { item } ) => <Plan site={ item } />,
+	},
+	{
+		id: 'status',
+		label: __( 'Status' ),
+		getValue: ( { item } ) => getSiteStatus( item ),
+		elements: Object.entries( STATUS_LABELS ).map( ( [ value, label ] ) => ( { value, label } ) ),
+		filterBy: {
+			operators: [ 'is' ],
+		},
+		render: ( { item } ) => <Status site={ item } />,
+	},
+	{
+		id: 'wp_version',
+		label: __( 'WP version' ),
+		getValue: ( { item } ) => getFormattedWordPressVersion( item ),
+	},
+	{
+		id: 'is_a8c',
+		type: 'boolean',
+		label: __( 'A8C owned' ),
+		elements: [
+			{ value: true, label: __( 'Yes' ) },
+			{ value: false, label: __( 'No' ) },
+		],
+		filterBy: {
+			operators: [ 'is' as Operator ],
+		},
+		render: ( { item } ) => ( item.is_a8c ? __( 'Yes' ) : __( 'No' ) ),
+	},
+	{
+		id: 'preview',
+		label: __( 'Preview' ),
+		render: function PreviewRender( { item } ) {
+			const [ resizeListener, { width } ] = useResizeObserver();
+			const { is_deleted, is_private, URL: url } = item;
+			// If the site is a private A8C site, X-Frame-Options is set to same
+			// origin.
+			const iframeDisabled = is_deleted || ( item.is_a8c && is_private );
+			return (
+				<Link
+					to={ getSiteManagementUrl( item ) }
+					style={ { display: 'block', height: '100%', width: '100%' } }
+				>
+					{ resizeListener }
+					{ iframeDisabled && (
+						<div
+							style={ {
+								fontSize: '24px',
+								display: 'flex',
+								alignItems: 'center',
+								justifyContent: 'center',
+								height: '100%',
+							} }
+						>
+							<SiteIcon site={ item } />
+						</div>
+					) }
+					{ width && ! iframeDisabled && (
+						<SitePreview url={ url } scale={ width / 1200 } height={ 1200 } />
+					) }
+				</Link>
+			);
+		},
+		enableSorting: false,
+	},
+	{
+		id: 'last_published',
+		label: __( 'Last published' ),
+		getValue: ( { item } ) => item.options?.updated_at ?? '',
+		render: ( { item } ) =>
+			item.options?.updated_at ? <TimeSince date={ item.options.updated_at } /> : '',
+	},
+	{
+		id: 'uptime',
+		label: __( 'Uptime' ),
+		render: ( { item } ) => <Uptime site={ item } />,
+		enableSorting: false,
+	},
+	{
+		id: 'visitors',
+		label: __( 'Visitors' ),
+		render: ( { item } ) => <EngagementStat site={ item } type="visitors" />,
+		enableSorting: false,
+	},
+	{
+		id: 'views',
+		label: __( 'Views' ),
+		render: ( { item } ) => <EngagementStat site={ item } type="views" />,
+		enableSorting: false,
+	},
+	{
+		id: 'likes',
+		label: __( 'Likes' ),
+		render: ( { item } ) => <EngagementStat site={ item } type="likes" />,
+		enableSorting: false,
+	},
+	{
+		id: 'php_version',
+		label: __( 'PHP version' ),
+		render: ( { item }: { item: Site } ) => <PHPVersion site={ item } />,
+	},
+	{
+		id: 'storage',
+		label: __( 'Storage' ),
+		render: ( { item } ) => <MediaStorage site={ item } />,
+		enableSorting: false,
+	},
+	{
+		id: 'host',
+		label: __( 'Host' ),
+		getValue: ( { item } ) => {
+			const provider = item.hosting_provider_guess;
+			if ( ! provider || provider === 'automattic' ) {
+				return 'WordPress.com';
+			}
+
+			switch ( provider ) {
+				case 'jurassic_ninja':
+					return 'Jurassic Ninja';
+				case 'pressable':
+					return 'Pressable';
+			}
+
+			return provider;
+		},
+		render: ( { field, item } ) => field.getValue( { item } ),
+	},
+];
+
+export function getFields( {
+	hasA8CSites,
+	viewType,
+}: {
+	hasA8CSites?: boolean;
+	viewType?: string;
+} ) {
+	return DEFAULT_FIELDS.filter( ( field ) => {
+		if ( field.id === 'is_a8c' && ! hasA8CSites ) {
+			return false;
+		}
+
+		if ( field.id === 'icon.ico' && viewType === 'grid' ) {
+			return false;
+		}
+
+		return true;
+	} );
+}

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -1,8 +1,7 @@
 import { DataViews, filterSortAndPaginate } from '@automattic/dataviews';
 import { useQuery } from '@tanstack/react-query';
-import { useNavigate, useRouter, Link } from '@tanstack/react-router';
-import { __experimentalText as Text, Button, Modal, Icon } from '@wordpress/components';
-import { useResizeObserver } from '@wordpress/compose';
+import { useNavigate, useRouter } from '@tanstack/react-router';
+import { Button, Modal, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { drawerLeft, wordpress } from '@wordpress/icons';
 import { useMemo, useState } from 'react';
@@ -11,214 +10,12 @@ import { sitesRoute } from '../app/router';
 import DataViewsCard from '../components/dataviews-card';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
-import TimeSince from '../components/time-since';
-import { STATUS_LABELS, getSiteStatus } from '../utils/site-status';
-import { getFormattedWordPressVersion } from '../utils/wp-version';
 import AddNewSite from './add-new-site';
 import { canManageSite } from './features';
-import {
-	EngagementStat,
-	LastBackup,
-	MediaStorage,
-	PHPVersion,
-	Plan,
-	Status,
-	Uptime,
-} from './site-fields';
-import SiteIcon from './site-icon';
-import SitePreview from './site-preview';
+import { getFields } from './fields';
 import type { FetchSitesOptions, Site } from '../data/types';
-import type {
-	Field,
-	Operator,
-	SortDirection,
-	ViewTable,
-	ViewGrid,
-	Filter,
-} from '@automattic/dataviews';
+import type { Operator, SortDirection, ViewTable, ViewGrid, Filter } from '@automattic/dataviews';
 import type { AnyRouter } from '@tanstack/react-router';
-
-function getSiteManagementUrl( site: Site ) {
-	if ( canManageSite( site ) ) {
-		return `/sites/${ site.slug }`;
-	}
-	return site.options?.admin_url;
-}
-
-const DEFAULT_FIELDS: Field< Site >[] = [
-	{
-		id: 'name',
-		label: __( 'Site' ),
-		enableGlobalSearch: true,
-		getValue: ( { item } ) => item.name || new URL( item.URL ).hostname,
-		render: ( { field, item } ) => (
-			<Link to={ getSiteManagementUrl( item ) }>{ field.getValue( { item } ) }</Link>
-		),
-	},
-	{
-		id: 'URL',
-		label: __( 'URL' ),
-		enableGlobalSearch: true,
-		getValue: ( { item } ) => new URL( item.URL ).hostname,
-		render: ( { field, item } ) => (
-			<Text
-				as="span"
-				variant="muted"
-				style={ { overflowX: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }
-			>
-				{ field.getValue( { item } ) }
-			</Text>
-		),
-	},
-	{
-		id: 'icon.ico',
-		label: __( 'Site icon' ),
-		render: ( { item } ) => <SiteIcon site={ item } />,
-		enableSorting: false,
-	},
-	{
-		id: 'subscribers_count',
-		label: __( 'Subscribers' ),
-	},
-	{
-		id: 'backup',
-		label: __( 'Backup' ),
-		render: ( { item } ) => <LastBackup site={ item } />,
-		enableSorting: false,
-	},
-	{
-		id: 'plan',
-		label: __( 'Plan' ),
-		getValue: ( { item } ) => item.plan?.product_name_short ?? '',
-		render: ( { item } ) => <Plan site={ item } />,
-	},
-	{
-		id: 'status',
-		label: __( 'Status' ),
-		getValue: ( { item } ) => getSiteStatus( item ),
-		elements: Object.entries( STATUS_LABELS ).map( ( [ value, label ] ) => ( { value, label } ) ),
-		filterBy: {
-			operators: [ 'is' ],
-		},
-		render: ( { item } ) => <Status site={ item } />,
-	},
-	{
-		id: 'wp_version',
-		label: __( 'WP version' ),
-		getValue: ( { item } ) => getFormattedWordPressVersion( item ),
-	},
-	{
-		id: 'is_a8c',
-		type: 'boolean',
-		label: __( 'A8C owned' ),
-		elements: [
-			{ value: true, label: __( 'Yes' ) },
-			{ value: false, label: __( 'No' ) },
-		],
-		filterBy: {
-			operators: [ 'is' as Operator ],
-		},
-		render: ( { item } ) => ( item.is_a8c ? __( 'Yes' ) : __( 'No' ) ),
-	},
-	{
-		id: 'preview',
-		label: __( 'Preview' ),
-		render: function PreviewRender( { item } ) {
-			const [ resizeListener, { width } ] = useResizeObserver();
-			const { is_deleted, is_private, URL: url } = item;
-			// If the site is a private A8C site, X-Frame-Options is set to same
-			// origin.
-			const iframeDisabled = is_deleted || ( item.is_a8c && is_private );
-			return (
-				<Link
-					to={ getSiteManagementUrl( item ) }
-					style={ { display: 'block', height: '100%', width: '100%' } }
-				>
-					{ resizeListener }
-					{ iframeDisabled && (
-						<div
-							style={ {
-								fontSize: '24px',
-								display: 'flex',
-								alignItems: 'center',
-								justifyContent: 'center',
-								height: '100%',
-							} }
-						>
-							<SiteIcon site={ item } />
-						</div>
-					) }
-					{ width && ! iframeDisabled && (
-						<SitePreview url={ url } scale={ width / 1200 } height={ 1200 } />
-					) }
-				</Link>
-			);
-		},
-		enableSorting: false,
-	},
-	{
-		id: 'last_published',
-		label: __( 'Last published' ),
-		getValue: ( { item } ) => item.options?.updated_at ?? '',
-		render: ( { item } ) =>
-			item.options?.updated_at ? <TimeSince date={ item.options.updated_at } /> : '',
-	},
-	{
-		id: 'uptime',
-		label: __( 'Uptime' ),
-		render: ( { item } ) => <Uptime site={ item } />,
-		enableSorting: false,
-	},
-	{
-		id: 'visitors',
-		label: __( 'Visitors' ),
-		render: ( { item } ) => <EngagementStat site={ item } type="visitors" />,
-		enableSorting: false,
-	},
-	{
-		id: 'views',
-		label: __( 'Views' ),
-		render: ( { item } ) => <EngagementStat site={ item } type="views" />,
-		enableSorting: false,
-	},
-	{
-		id: 'likes',
-		label: __( 'Likes' ),
-		render: ( { item } ) => <EngagementStat site={ item } type="likes" />,
-		enableSorting: false,
-	},
-	{
-		id: 'php_version',
-		label: __( 'PHP version' ),
-		render: ( { item }: { item: Site } ) => <PHPVersion site={ item } />,
-	},
-	{
-		id: 'storage',
-		label: __( 'Storage' ),
-		render: ( { item } ) => <MediaStorage site={ item } />,
-		enableSorting: false,
-	},
-	{
-		id: 'host',
-		label: __( 'Host' ),
-		getValue: ( { item } ) => {
-			const provider = item.hosting_provider_guess;
-			if ( ! provider || provider === 'automattic' ) {
-				return 'WordPress.com';
-			}
-
-			switch ( provider ) {
-				case 'jurassic_ninja':
-					return 'Jurassic Ninja';
-				case 'pressable':
-					return 'Pressable';
-			}
-
-			return provider;
-		},
-		render: ( { field, item } ) => field.getValue( { item } ),
-	},
-];
 
 const DEFAULT_LAYOUTS = {
 	table: {
@@ -362,17 +159,7 @@ export default function Sites() {
 	);
 
 	const fields = useMemo( () => {
-		return DEFAULT_FIELDS.filter( ( field ) => {
-			if ( field.id === 'is_a8c' && ! hasA8CSites ) {
-				return false;
-			}
-
-			if ( field.id === 'icon.ico' && view.type === 'grid' ) {
-				return false;
-			}
-
-			return true;
-		} );
+		return getFields( { hasA8CSites, viewType: view.type } );
 	}, [ hasA8CSites, view.type ] );
 
 	const actions = useMemo( () => {

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -38,6 +38,13 @@ import type {
 } from '@automattic/dataviews';
 import type { AnyRouter } from '@tanstack/react-router';
 
+function getSiteManagementUrl( site: Site ) {
+	if ( canManageSite( site ) ) {
+		return `/sites/${ site.slug }`;
+	}
+	return site.options?.admin_url;
+}
+
 const DEFAULT_FIELDS: Field< Site >[] = [
 	{
 		id: 'name',
@@ -45,7 +52,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		enableGlobalSearch: true,
 		getValue: ( { item } ) => item.name || new URL( item.URL ).hostname,
 		render: ( { field, item } ) => (
-			<Link to={ `/sites/${ item.slug }` }>{ field.getValue( { item } ) }</Link>
+			<Link to={ getSiteManagementUrl( item ) }>{ field.getValue( { item } ) }</Link>
 		),
 	},
 	{
@@ -124,7 +131,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 			const iframeDisabled = is_deleted || ( item.is_a8c && is_private );
 			return (
 				<Link
-					to={ `/sites/${ item.slug }` }
+					to={ getSiteManagementUrl( item ) }
 					style={ { display: 'block', height: '100%', width: '100%' } }
 				>
 					{ resizeListener }


### PR DESCRIPTION
## Proposed Changes

This PR redirects the user to the site's wp-admin when an "unmanageable" site is clicked from the sits list v2.

**NOTE!!!**: the logic is only in the first commit. Then I thought to extract field-related logic to a separate file, in the second commit, as the current file is too large. Let me know if any of you feel this is unnecessary. 😅 

## Testing Instructions

1. Go to /v2/sites
2. Click on Jurassic Ninja site; verify you land in wp-admin.
3. Click on WP.com site; verify you land in the overview page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
