### PR TITLE
Connect Refresh: Migrate partner-portals clients to unified Login

### DIFF
--- a/client/login/wp-login/components/heading-logo.tsx
+++ b/client/login/wp-login/components/heading-logo.tsx
@@ -9,6 +9,7 @@ import wpJobManagerLogo from 'calypso/assets/images/icons/wp-job-manager.png';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import JetpackPlusWpComLogo from 'calypso/components/jetpack-plus-wpcom-logo';
 import SVGIcon from 'calypso/components/svg-icon';
+import WPCloudLogo from 'calypso/components/wp-cloud-logo';
 import {
 	isCrowdsignalOAuth2Client,
 	isGravPoweredOAuth2Client,
@@ -17,6 +18,7 @@ import {
 	isBlazeProOAuth2Client,
 	isA4AOAuth2Client,
 	isJetpackCloudOAuth2Client,
+	isPartnerPortalOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { useSelector } from 'calypso/state';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
@@ -59,6 +61,11 @@ const HeadingLogo = ( { isFromAkismet, isJetpack }: Props ) => {
 		logo = <JetpackLogo size={ 64 } />;
 	} else if ( isJetpackCloudOAuth2Client( oauth2Client ) ) {
 		logo = <JetpackPlusWpComLogo size={ 32 } />;
+	} else if (
+		isPartnerPortalOAuth2Client( oauth2Client ) &&
+		document.location.search?.includes( 'wpcloud' )
+	) {
+		logo = <WPCloudLogo size={ 120 } />;
 	} else if ( isGravPoweredOAuth2Client( oauth2Client ) ) {
 		/**
 		 * Leave last to avoid overriding other grav-powered client logos.

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -13,7 +13,6 @@ import { getHeaderText } from 'calypso/blocks/login/login-header';
 import DocumentHead from 'calypso/components/data/document-head';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import Main from 'calypso/components/main';
-import WPCloudLogo from 'calypso/components/wp-cloud-logo';
 import isAkismetRedirect from 'calypso/lib/akismet/is-akismet-redirect';
 import { getSignupUrl, pathWithLeadingSlash } from 'calypso/lib/login';
 import {
@@ -555,22 +554,13 @@ export class Login extends Component {
 			translate
 		);
 
-		let brandLogo;
-
-		if (
-			isPartnerPortalOAuth2Client( oauth2Client ) &&
-			document.location.search?.includes( 'wpcloud' )
-		) {
-			brandLogo = <WPCloudLogo className="login__wpcloud-logo" size={ 120 } />;
-		} else {
-			brandLogo = (
-				<WordPressLogo
-					size={ 21 }
-					className="step-container-v2__top-bar-wordpress-logo"
-					color="currentColor"
-				/>
-			);
-		}
+		const brandLogo = (
+			<WordPressLogo
+				size={ 21 }
+				className="step-container-v2__top-bar-wordpress-logo"
+				color="currentColor"
+			/>
+		);
 
 		const isLostPassword =
 			currentRoute === '/log-in/lostpassword' || currentRoute === '/log-in/jetpack/lostpassword';
@@ -583,7 +573,8 @@ export class Login extends Component {
 			isJetpack ||
 			isJetpackCloudOAuth2Client( oauth2Client ) ||
 			isWoo ||
-			isVIPOAuth2Client( oauth2Client );
+			isVIPOAuth2Client( oauth2Client ) ||
+			isPartnerPortalOAuth2Client( oauth2Client );
 
 		return (
 			<>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13595/partner-portals

## Proposed Changes

* Updates the Partner Portal OAuth cliend Login to join the unified design
  * This was already part of `is-white-signup` so changes are about logo and heading

| Before | After |
|--------|--------|
| <img width="986" alt="Screenshot 2025-06-25 at 12 19 51 PM" src="https://github.com/user-attachments/assets/f05dbee1-34df-40c3-ace2-8b7110551ba2" /> | <img width="981" alt="Screenshot 2025-06-25 at 12 19 31 PM" src="https://github.com/user-attachments/assets/2428de53-f80f-4e55-a0f5-9cd657ec8e7f" /> |  

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13595/partner-portals

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Navigate to https://hosts.automattic.com/wpcloud/.
- You should be presented with the generic WPCOM oAuth login.
- In the URL bar of your browser, replace the `https://wordpress.com` part with `https://calypso.localhost:3000`.
- You should now verify that you see a WP Cloud branded login that looks like the screenshot.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
