### PR TITLE
Connect Refresh: Update `Step.TopBar` with `compact` view. Avoid passing custom WP logo

### DIFF
--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -1,5 +1,4 @@
 import page from '@automattic/calypso-router';
-import { WordPressLogo } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Step } from '@automattic/onboarding';
 import clsx from 'clsx';
@@ -554,14 +553,6 @@ export class Login extends Component {
 			translate
 		);
 
-		const brandLogo = (
-			<WordPressLogo
-				size={ 21 }
-				className="step-container-v2__top-bar-wordpress-logo"
-				color="currentColor"
-			/>
-		);
-
 		const isLostPassword =
 			currentRoute === '/log-in/lostpassword' || currentRoute === '/log-in/jetpack/lostpassword';
 
@@ -582,9 +573,7 @@ export class Login extends Component {
 					<Step.CenteredColumnLayout
 						columnWidth={ 6 }
 						{ ...( shouldUseWideHeading && { columnWidthHeading: 8 } ) }
-						topBar={
-							<Step.TopBar rightElement={ this.renderLoginHeaderNavigation() } logo={ brandLogo } />
-						}
+						topBar={ <Step.TopBar rightElement={ this.renderLoginHeaderNavigation() } compact /> }
 						heading={
 							<Step.Heading
 								text={

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -573,7 +573,12 @@ export class Login extends Component {
 					<Step.CenteredColumnLayout
 						columnWidth={ 6 }
 						{ ...( shouldUseWideHeading && { columnWidthHeading: 8 } ) }
-						topBar={ <Step.TopBar rightElement={ this.renderLoginHeaderNavigation() } compact /> }
+						topBar={
+							<Step.TopBar
+								rightElement={ this.renderLoginHeaderNavigation() }
+								compactLogo="always"
+							/>
+						}
 						heading={
 							<Step.Heading
 								text={

--- a/packages/onboarding/src/step-container-v2/components/TopBar/TopBar.tsx
+++ b/packages/onboarding/src/step-container-v2/components/TopBar/TopBar.tsx
@@ -8,13 +8,17 @@ interface TopBarProps {
 	leftElement?: ReactNode;
 	rightElement?: ReactNode;
 	logo?: ReactNode;
-	compact?: boolean;
+	compactLogo?: 'always';
 }
 
-export const TopBar = ( { leftElement, rightElement, logo, compact }: TopBarProps ) => {
+export const TopBar = ( { leftElement, rightElement, logo, compactLogo }: TopBarProps ) => {
 	const defaultLogo = (
-		<>
-			{ ! compact && (
+		<div
+			className={ clsx( 'step-container-v2__top-bar-wordpress-logo-wrapper', {
+				'is-compact': compactLogo,
+			} ) }
+		>
+			{ ! compactLogo && (
 				<WordPressWordmark
 					className="step-container-v2__top-bar-wordpress-logo step-container-v2__top-bar-wordpress-logo--wordmark"
 					color="currentColor"
@@ -22,12 +26,9 @@ export const TopBar = ( { leftElement, rightElement, logo, compact }: TopBarProp
 			) }
 			<WordPressLogo
 				size={ 21 }
-				className={ clsx(
-					'step-container-v2__top-bar-wordpress-logo step-container-v2__top-bar-wordpress-logo--logo',
-					{ 'is-compact': compact }
-				) }
+				className="step-container-v2__top-bar-wordpress-logo step-container-v2__top-bar-wordpress-logo--logo"
 			/>
-		</>
+		</div>
 	);
 	return (
 		<div className="step-container-v2__top-bar">

--- a/packages/onboarding/src/step-container-v2/components/TopBar/TopBar.tsx
+++ b/packages/onboarding/src/step-container-v2/components/TopBar/TopBar.tsx
@@ -8,6 +8,12 @@ interface TopBarProps {
 	leftElement?: ReactNode;
 	rightElement?: ReactNode;
 	logo?: ReactNode;
+	/**
+	 * Hide the WordPress wordmark when `compactLogo` is set.
+	 * Always show the WordPress logo instead.
+	 * - This is critical for current Login views, where the logo (WordPressLogo) is always visible
+	 * - Confirm with Design before changing functionality around this
+	 */
 	compactLogo?: 'always';
 }
 

--- a/packages/onboarding/src/step-container-v2/components/TopBar/TopBar.tsx
+++ b/packages/onboarding/src/step-container-v2/components/TopBar/TopBar.tsx
@@ -1,4 +1,5 @@
 import { WordPressLogo, WordPressWordmark } from '@automattic/components';
+import clsx from 'clsx';
 import { ReactNode } from 'react';
 
 import './style.scss';
@@ -7,18 +8,24 @@ interface TopBarProps {
 	leftElement?: ReactNode;
 	rightElement?: ReactNode;
 	logo?: ReactNode;
+	compact?: boolean;
 }
 
-export const TopBar = ( { leftElement, rightElement, logo }: TopBarProps ) => {
+export const TopBar = ( { leftElement, rightElement, logo, compact }: TopBarProps ) => {
 	const defaultLogo = (
 		<>
-			<WordPressWordmark
-				className="step-container-v2__top-bar-wordpress-logo step-container-v2__top-bar-wordpress-logo--wordmark"
-				color="currentColor"
-			/>
+			{ ! compact && (
+				<WordPressWordmark
+					className="step-container-v2__top-bar-wordpress-logo step-container-v2__top-bar-wordpress-logo--wordmark"
+					color="currentColor"
+				/>
+			) }
 			<WordPressLogo
 				size={ 21 }
-				className="step-container-v2__top-bar-wordpress-logo step-container-v2__top-bar-wordpress-logo--logo"
+				className={ clsx(
+					'step-container-v2__top-bar-wordpress-logo step-container-v2__top-bar-wordpress-logo--logo',
+					{ 'is-compact': compact }
+				) }
 			/>
 		</>
 	);

--- a/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
@@ -50,7 +50,12 @@
 	display: block;
 
 	@include break-small {
-		&:not( .is-compact ) {
+		/**
+		 * Hide the logo only when the wrapper is not compact.
+		 * This is important for current Login views, where the logo is always visible.
+		 * -- Confirm with Design before changing this --
+		 */
+		.step-container-v2__top-bar-wordpress-logo-wrapper:not( .is-compact ) & {
 			display: none;
 		}
 	}

--- a/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
@@ -2,11 +2,7 @@
 @import '@wordpress/base-styles/mixins';
 
 .step-container-v2__top-bar {
-	&,
-	&-wrapper {
-		width: 100%;
-	}
-
+	width: 100%;
 	box-sizing: border-box;
 	display: flex;
 	align-items: center;
@@ -15,66 +11,71 @@
 	@include break-small {
 		padding-inline: 1.5rem;
 	}
+}
 
-	&-left-element,
-	&-right-element,
-	&-wordpress-logo {
-		height: 24px;
+.step-container-v2__top-bar-wrapper {
+	width: 100%;
+}
+
+.step-container-v2__top-bar-left-element,
+.step-container-v2__top-bar-right-element,
+.step-container-v2__top-bar-wordpress-logo {
+	height: 24px;
+}
+
+.step-container-v2__top-bar-left-element,
+.step-container-v2__top-bar-right-element {
+	display: flex;
+	align-items: center;
+}
+
+.step-container-v2__top-bar-wordpress-logo {
+	color: var( --color-text );
+	margin: 0;
+
+	@include break-small {
+		margin-right: 0.5rem;
 	}
+}
 
-	&-left-element,
-	&-right-element {
-		display: flex;
-		align-items: center;
+.step-container-v2__top-bar-wordpress-logo--wordmark {
+	display: none;
+
+	@include break-small {
+		display: block;
 	}
+}
 
-	&-wordpress-logo {
-		color: var( --color-text );
-		margin: 0;
+.step-container-v2__top-bar-wordpress-logo--logo {
+	display: block;
 
-		@include break-small {
-			margin-right: 0.5rem;
-		}
-
-		&--wordmark {
+	@include break-small {
+		&:not( .is-compact ) {
 			display: none;
-
-			@include break-small {
-				display: block;
-			}
-		}
-
-		&--logo {
-			display: block;
-
-			@include break-small {
-				display: none;
-			}
 		}
 	}
+}
 
-	&-divider {
-		width: 1px;
-		height: 1rem;
-		background-color: var( --color-border-subtle );
+.step-container-v2__top-bar-divider {
+	width: 1px;
+	height: 1rem;
+	background-color: var( --color-border-subtle );
+	margin-inline: 1rem 0;
 
-		margin-inline: 1rem 0;
-
-		@include break-small {
-			margin-inline: 1.5rem 0.75rem;
-		}
+	@include break-small {
+		margin-inline: 1.5rem 0.75rem;
 	}
+}
 
-	&-right-element {
-		margin-left: auto;
-		font-size: 0.875rem;
-		line-height: 1;
+.step-container-v2__top-bar-right-element {
+	margin-left: auto;
+	font-size: 0.875rem;
+	line-height: 1;
 
-		a,
-		button {
-			&.components-button:not(.is-destructive).is-link {
-				--wp-components-color-accent: var( --color-neutral-100 );
-			}
+	a,
+	button {
+		&.components-button:not(.is-destructive).is-link {
+			--wp-components-color-accent: var( --color-neutral-100 );
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13220/login-make-the-two-columnwhite-layout-the-default-across-all-contexts

## Proposed Changes

- The `WordPressLogo` component passed so far into Login's `Step.TopBar` component was more of an intermediate state until the remaining client logos have effectively/gradually removed completely
- `TopBar` along with `WordPressLogo` are being migrated to CSS modules, so we need to steer away from utilising these internal `step-container-v2__top-bar-wordpress-logo`. As brought up by @zaguiini in https://github.com/Automattic/wp-calypso/pull/103758#discussion_r2137207232
- The current approach is one way, making it a little more trivial for the consumer side - to just specify "compact" and get the compact logo view. There are alternatives, probably better ones (not touching top-bar).
- Also, some cleanup to `topbar.scss` file (replace all the class name concatenators - these just make the classes impossible to search and debug)

<img width="500" alt="Screenshot 2025-06-25 at 12 19 31 PM" src="https://github.com/user-attachments/assets/0ca9c4eb-c377-4260-b6c7-ea7d2bc0c712" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Follow-up to https://github.com/Automattic/wp-calypso/pull/103758#discussion_r2137207232

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to any of the [Login screens](https://linear.app/a8c/issue/DOTCOM-13220/login-make-the-two-columnwhite-layout-the-default-across-all-contexts) and confirm top-left WP logo renders in all cases (mobile/desktop views) _without_ the watermark next to it

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
