### PR TITLE
Dashboard v2: throw 404 when accessing an unsupported site

### DIFF
--- a/client/dashboard/app/queries/site.ts
+++ b/client/dashboard/app/queries/site.ts
@@ -1,3 +1,4 @@
+import { notFound } from '@tanstack/react-router';
 import { fetchSite, deleteSite, launchSite, SITE_FIELDS, SITE_OPTIONS } from '../../data/site';
 import { queryClient } from '../query-client';
 import type { Site } from '../../data/site';
@@ -5,7 +6,16 @@ import type { Query } from '@tanstack/react-query';
 
 export const siteBySlugQuery = ( siteSlug: string ) => ( {
 	queryKey: [ 'site-by-slug', siteSlug, SITE_FIELDS, SITE_OPTIONS ],
-	queryFn: () => fetchSite( siteSlug ),
+	queryFn: async () => {
+		try {
+			return await fetchSite( siteSlug );
+		} catch ( e: any ) /* eslint-disable-line @typescript-eslint/no-explicit-any */ {
+			if ( e.error === 'unknown_blog' ) {
+				throw notFound();
+			}
+			throw e;
+		}
+	},
 } );
 
 export const siteByIdQuery = ( siteId: number ) => ( {

--- a/client/dashboard/app/queries/site.ts
+++ b/client/dashboard/app/queries/site.ts
@@ -9,7 +9,7 @@ export const siteBySlugQuery = ( siteSlug: string ) => ( {
 	queryFn: async () => {
 		try {
 			return await fetchSite( siteSlug );
-		} catch ( e: any ) /* eslint-disable-line @typescript-eslint/no-explicit-any */ {
+		} catch ( e: { error?: string } ) {
 			if ( e.error === 'unknown_blog' ) {
 				throw notFound();
 			}

--- a/client/dashboard/app/queries/site.ts
+++ b/client/dashboard/app/queries/site.ts
@@ -9,7 +9,7 @@ export const siteBySlugQuery = ( siteSlug: string ) => ( {
 	queryFn: async () => {
 		try {
 			return await fetchSite( siteSlug );
-		} catch ( e: { error?: string } ) {
+		} catch ( e: any ) /* eslint-disable-line @typescript-eslint/no-explicit-any */ {
 			if ( e.error === 'unknown_blog' ) {
 				throw notFound();
 			}

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { Outlet } from '@tanstack/react-router';
+import { Outlet, notFound } from '@tanstack/react-router';
 import { __experimentalHStack as HStack, Dropdown, Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { chevronDownSmall } from '@wordpress/icons';
@@ -7,6 +7,7 @@ import { siteBySlugQuery } from '../../app/queries/site';
 import { siteRoute } from '../../app/router';
 import HeaderBar from '../../components/header-bar';
 import MenuDivider from '../../components/menu-divider';
+import { canManageSite } from '../features';
 import SiteIcon from '../site-icon';
 import SiteMenu from '../site-menu';
 import Switcher from './switcher';
@@ -15,6 +16,10 @@ function Site() {
 	const isDesktop = useViewportMatch( 'medium' );
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+
+	if ( ! canManageSite( site ) ) {
+		throw notFound();
+	}
 
 	return (
 		<>

--- a/client/sites/v2/site-settings/router.tsx
+++ b/client/sites/v2/site-settings/router.tsx
@@ -1,3 +1,4 @@
+import page from '@automattic/calypso-router';
 import {
 	Outlet,
 	Router,
@@ -57,7 +58,7 @@ const siteRoute = createRoute( {
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		if ( ! canManageSite( site ) ) {
-			window.location.href = '/sites';
+			page.redirect( '/sites' );
 		}
 		queryClient.ensureQueryData( siteSettingsQuery( site.ID ) );
 	},

--- a/client/sites/v2/site-settings/router.tsx
+++ b/client/sites/v2/site-settings/router.tsx
@@ -19,6 +19,7 @@ import { siteStaticFile404SettingQuery } from 'calypso/dashboard/app/queries/sit
 import { siteWordPressVersionQuery } from 'calypso/dashboard/app/queries/site-wordpress-version';
 import { queryClient } from 'calypso/dashboard/app/query-client';
 import {
+	canManageSite,
 	canViewWordPressSettings,
 	canViewPHPSettings,
 	canViewDefensiveModeSettings,
@@ -55,6 +56,9 @@ const siteRoute = createRoute( {
 	path: '$siteSlug',
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( ! canManageSite( site ) ) {
+			window.location.href = '/sites';
+		}
 		queryClient.ensureQueryData( siteSettingsQuery( site.ID ) );
 	},
 	component: () => <Outlet />,

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -8,6 +8,7 @@ export const SITE_REQUEST_FIELDS = [
 	'is_coming_soon',
 	'is_vip',
 	'jetpack',
+	'jetpack_connection',
 	'jetpack_modules',
 	'name',
 	'options',


### PR DESCRIPTION
Fixes DOTDASH-85

## Proposed Changes

This PR prevents the users from accessing site management routes (overview, settings, ...) when the site is not "supported".

1. Prepare a Jetpack-connected jurassic ninja site.
1. Go to `/v2/sites/:siteSlug` of that site
    - Verify you see 404 screen
1. Go to `/v2/sites/bogusasdfasdfasdfdsafsd`
    - Verify you see 404 screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
