### PR TITLE
Staging Sites Redesign: Move deletion of staging sites to general settings

### DIFF
--- a/client/sites/settings/administration/controller.ts
+++ b/client/sites/settings/administration/controller.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import canCurrentUserStartSiteOwnerTransfer from 'calypso/state/selectors/can-current-user-start-site-owner-transfer';
@@ -17,7 +18,15 @@ function canDeleteSite( state: AppState, siteId: number | null ) {
 		return false;
 	}
 
-	if ( isSiteWpcomStaging( state, siteId ) ) {
+	// Allow staging sites to be deleted only when the feature flag is enabled
+	const isStaging = isSiteWpcomStaging( state, siteId );
+	const isStagingRedesignEnabled = config.isEnabled( 'hosting/staging-sites-redesign' );
+	if ( isStaging && isStagingRedesignEnabled ) {
+		return true;
+	}
+
+	// Block staging sites when feature flag is disabled
+	if ( isStaging ) {
 		return false;
 	}
 

--- a/client/sites/settings/administration/tools/index.jsx
+++ b/client/sites/settings/administration/tools/index.jsx
@@ -87,6 +87,8 @@ class SiteTools extends Component {
 			siteId,
 			headerTitle,
 			source,
+			isStaging,
+			isStagingRedesignEnabled,
 		} = this.props;
 
 		const { modalOpen } = this.state;
@@ -113,10 +115,17 @@ class SiteTools extends Component {
 			"Remove all posts, pages, and media to start fresh while keeping your site's address."
 		);
 
-		const deleteSite = translate( 'Delete your site permanently' );
-		const deleteSiteText = translate(
-			"Delete all your posts, pages, media, and data, and give up your site's address."
-		);
+		const deleteSite =
+			isStaging && isStagingRedesignEnabled
+				? translate( 'Delete staging site' )
+				: translate( 'Delete your site permanently' );
+		const deleteSiteText =
+			isStaging && isStagingRedesignEnabled
+				? translate( 'Delete staging site and all of its posts, pages, media, and data.' )
+				: translate(
+						"Delete all your posts, pages, media, and data, and give up your site's address."
+				  );
+
 		const manageConnectionTitle = translate( 'Manage your connection' );
 		const manageConnectionText = translate(
 			'Sync your site content for a faster experience, change site owner, repair or terminate your connection.'
@@ -294,6 +303,8 @@ export default connect(
 				showLeaveSite: false,
 				siteId,
 				hasCancelablePurchases: hasCancelableSitePurchases( state, siteId ),
+				isStaging,
+				isStagingRedesignEnabled,
 			};
 		}
 
@@ -314,6 +325,8 @@ export default connect(
 			showLeaveSite,
 			siteId,
 			hasCancelablePurchases: hasCancelableSitePurchases( state, siteId ),
+			isStaging,
+			isStagingRedesignEnabled,
 		};
 	},
 	{

--- a/client/sites/settings/administration/tools/index.jsx
+++ b/client/sites/settings/administration/tools/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { addQueryArgs } from '@wordpress/url';
 import { localize, fixMe } from 'i18n-calypso';
 import { Component } from 'react';
@@ -17,6 +18,7 @@ import getRewindState from 'calypso/state/selectors/get-rewind-state';
 import hasCancelableSitePurchases from 'calypso/state/selectors/has-cancelable-site-purchases';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
+import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { isJetpackSite, getSite } from 'calypso/state/sites/selectors';
@@ -255,6 +257,8 @@ export default connect(
 		const isVip = isVipSite( state, siteId );
 		const isP2 = isSiteWPForTeams( state, siteId );
 		const isP2Hub = isSiteP2Hub( state, siteId );
+		const isStaging = isSiteWpcomStaging( state, siteId );
+		const isStagingRedesignEnabled = config.isEnabled( 'hosting/staging-sites-redesign' );
 		const rewindState = getRewindState( state, siteId );
 		const sitePurchasesLoaded = hasLoadedSitePurchasesFromServer( state );
 
@@ -270,6 +274,28 @@ export default connect(
 			! isDevelopmentSite && canCurrentUserStartSiteOwnerTransfer( state, siteId );
 
 		const showLeaveSite = sitePurchasesLoaded && ! isP2;
+
+		// For staging sites, only show delete site action when feature flag is enabled
+		if ( isStaging && isStagingRedesignEnabled ) {
+			return {
+				site,
+				isAtomic,
+				copySiteUrl,
+				siteSlug,
+				purchasesError: getPurchasesError( state ),
+				cloneUrl,
+				showChangeAddress: false,
+				showClone: false,
+				showRestorePlanSoftware: false,
+				showDeleteContent: false,
+				showDeleteSite: sitePurchasesLoaded,
+				showManageConnection: false,
+				showStartSiteTransfer: false,
+				showLeaveSite: false,
+				siteId,
+				hasCancelablePurchases: hasCancelableSitePurchases( state, siteId ),
+			};
+		}
 
 		return {
 			site,

--- a/client/sites/settings/site/index.tsx
+++ b/client/sites/settings/site/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -31,6 +32,7 @@ export function SiteSettings( props: any ) {
 	const isAtomicAndEditingToolkitDeactivated = isAtomic && editingToolkitIsActive === false;
 	const siteIsWpcom = useSelectedSiteSelector( isWpcomSite );
 	const isWpcomStagingSite = useSelectedSiteSelector( isSiteWpcomStaging );
+	const isStagingRedesignEnabled = config.isEnabled( 'hosting/staging-sites-redesign' );
 
 	const additionalProps = {
 		site,
@@ -41,6 +43,10 @@ export function SiteSettings( props: any ) {
 		isWpcomStagingSite,
 	};
 
+	// Show administration tools for staging sites when feature flag is enabled
+	const shouldShowAdministrationTools =
+		! isWpcomStagingSite || ( isWpcomStagingSite && isStagingRedesignEnabled );
+
 	return (
 		<Panel className="settings-site">
 			<NavigationHeader
@@ -48,7 +54,7 @@ export function SiteSettings( props: any ) {
 				subtitle={ translate( 'Manage your site settings, including site visibility, and more.' ) }
 			/>
 			<SiteSettingsForm { ...props } { ...additionalProps } />
-			{ ! isWpcomStagingSite && (
+			{ shouldShowAdministrationTools && (
 				<>
 					<QuerySitePurchases siteId={ siteId } />
 					<AdministrationTools source={ SOURCE_SETTINGS_ADMINISTRATION } />


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDEV-174

## Proposed Changes

TBD

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

TBD

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
