### PR TITLE
Stats: Fix the post editor links

### DIFF
--- a/client/my-sites/stats/sections/all-time-highlights-section/latest-post-card.tsx
+++ b/client/my-sites/stats/sections/all-time-highlights-section/latest-post-card.tsx
@@ -1,9 +1,9 @@
-import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import QueryPostStats from 'calypso/components/data/query-post-stats';
 import PostStatsCard from 'calypso/components/post-stats-card';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import { getPostStat, isRequestingPostStats } from 'calypso/state/stats/posts/selectors';
 import { getProcessedText, truncateWithLimit } from '../../text-utils';
 
@@ -35,7 +35,6 @@ export default function LatestPostCard( {
 } ) {
 	const translate = useTranslate();
 	const userLocale = useSelector( getCurrentUserLocale );
-	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
 	const lastesPostViewCount = useSelector( ( state ) =>
 		getPostStat( state, siteId, latestPost?.ID, 'views' )
@@ -55,6 +54,10 @@ export default function LatestPostCard( {
 		commentCount: latestPost?.discussion?.comment_count,
 	};
 
+	const latestPostEditLink = useSelector( ( state ) =>
+		getEditorUrl( state, siteId, latestPost?.ID )
+	);
+
 	return (
 		<>
 			{ siteId && latestPost && (
@@ -69,7 +72,7 @@ export default function LatestPostCard( {
 					viewCount={ latestPostData?.viewCount }
 					commentCount={ latestPostData?.commentCount }
 					titleLink={ `/stats/post/${ latestPost?.ID }/${ siteSlug }` }
-					uploadHref={ ! isOdysseyStats ? `/post/${ siteSlug }/${ latestPost?.ID }` : undefined }
+					uploadHref={ latestPostEditLink }
 					locale={ userLocale }
 					isLoading={ isLoadingLatestPost }
 				/>

--- a/client/my-sites/stats/sections/all-time-highlights-section/post-cards-group.tsx
+++ b/client/my-sites/stats/sections/all-time-highlights-section/post-cards-group.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { ComponentSwapper, DotPager } from '@automattic/components';
 import { createSelector } from '@automattic/state-utils';
 import { useTranslate } from 'i18n-calypso';
@@ -17,6 +16,7 @@ import {
 	isRequestingPostsForQuery,
 	countPostLikes,
 } from 'calypso/state/posts/selectors';
+import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import {
 	getTopPostAndPage,
@@ -72,7 +72,6 @@ export default function PostCardsGroup( {
 } ) {
 	const translate = useTranslate();
 	const userLocale = useSelector( getCurrentUserLocale );
-	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
 	// Prepare the latest post card.
 	const posts = useSelector( ( state ) =>
@@ -127,6 +126,10 @@ export default function PostCardsGroup( {
 
 	const cards = [];
 
+	const popularPostLink = useSelector( ( state ) =>
+		getEditorUrl( state, siteId, mostPopularPost?.ID )
+	);
+
 	// Show two cards when the latest post is not the most popular post or both cards are loading.
 	if ( isRequestingPosts || isPreparingMostPopularPost || latestPost?.ID !== mostPopularPost?.ID ) {
 		cards.push(
@@ -151,7 +154,7 @@ export default function PostCardsGroup( {
 				viewCount={ mostPopularPostData?.viewCount }
 				commentCount={ mostPopularPostData?.commentCount }
 				titleLink={ `/stats/post/${ mostPopularPost?.ID }/${ siteSlug }` }
-				uploadHref={ ! isOdysseyStats ? `/post/${ siteSlug }/${ mostPopularPost?.ID }` : undefined }
+				uploadHref={ popularPostLink }
 				locale={ userLocale }
 				isLoading={ isPreparingMostPopularPost }
 			/>

--- a/client/state/selectors/get-editor-url.ts
+++ b/client/state/selectors/get-editor-url.ts
@@ -1,9 +1,7 @@
 import { addQueryArgs } from 'calypso/lib/route';
-import { getEditorPath } from 'calypso/state/editor/selectors';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { shouldCalypsoifyJetpack } from 'calypso/state/selectors/should-calypsoify-jetpack';
-import shouldLoadGutenframe from 'calypso/state/selectors/should-load-gutenframe';
-import { getSiteAdminUrl, getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import { AppState } from 'calypso/types';
 
 export const getEditorUrl = (
@@ -12,31 +10,18 @@ export const getEditorUrl = (
 	postId: string | number | null | undefined = '',
 	postType = 'post'
 ): string => {
-	if ( ! shouldLoadGutenframe( state, siteId, postType ) ) {
-		const siteAdminUrl = getSiteAdminUrl( state, siteId );
-		let url = `${ siteAdminUrl }post-new.php?post_type=${ postType }`;
-
-		if ( postId ) {
-			url = `${ siteAdminUrl }post.php?post=${ postId }&action=edit`;
-		}
-
-		if ( ! isVipSite( state, siteId ) && shouldCalypsoifyJetpack( state, siteId ) ) {
-			url = addQueryArgs( { calypsoify: '1' }, url );
-		}
-
-		return url;
-	}
+	const siteAdminUrl = getSiteAdminUrl( state, siteId );
+	let url = `${ siteAdminUrl }post-new.php?post_type=${ postType }`;
 
 	if ( postId ) {
-		return getEditorPath( state, siteId, postId, postType );
+		url = `${ siteAdminUrl }post.php?post=${ postId }&action=edit`;
 	}
 
-	const siteSlug = getSiteSlug( state, siteId );
-
-	if ( 'post' === postType || 'page' === postType ) {
-		return `/${ postType }/${ siteSlug }`;
+	if ( ! isVipSite( state, siteId ) && shouldCalypsoifyJetpack( state, siteId ) ) {
+		url = addQueryArgs( { calypsoify: '1' }, url );
 	}
-	return `/edit/${ postType }/${ siteSlug }`;
+
+	return url;
 };
 
 export default getEditorUrl;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

When clicking on the "Add featured image" button from Stats > Insights, the users were redirected to the Calypso iframe editor and then again to the editor. Even more, on WP-Admin Stats, the links were broken.

This PR fixes this problem by replacing the links to point to WP-Admin post editor directly.

Part of DOTCOM-13688

## Proposed Changes

* Fix the Add featured image links in Stats > Insights

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* bugfix

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Use the live link and apply this on your sandbox (using install-plugin odyssey-stats)
* Go to WP-Admin > Stats > Insights
* Click on the "Add featured image" button
* It should redirect you to the Post Editor
* Repeat the steps with WP-Admin stats (wp-admin/admin.php?page=stats)

![Screenshot 2025-06-25 at 17 57 19](https://github.com/user-attachments/assets/a8d0400c-eae1-491a-b0dc-1637a2e8deb6)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
