### PR TITLE
Revert "Default fetching the site list to only visible sites (#104220)"

### DIFF
--- a/client/components/data/query-sites/README.md
+++ b/client/components/data/query-sites/README.md
@@ -55,4 +55,4 @@ An optional prop specifying primary and recent sites to be requested.
 	<tr><th>Required</th><td>No</td></tr>
 </table>
 
-An optional prop specifying all sites to be requested. If true, all visible (i.e. excluding deleted etc) sites for the current user will be requested.
+An optional prop specifying all sites to be requested. If true, all sites for the current user will be requested.

--- a/client/data/sites/use-site-excerpts-query.ts
+++ b/client/data/sites/use-site-excerpts-query.ts
@@ -11,10 +11,10 @@ import type { SiteExcerptData, SiteExcerptNetworkData } from '@automattic/sites'
 
 export const USE_SITE_EXCERPTS_QUERY_KEY = 'sites-dashboard-sites-data';
 
-export type SiteVisibility = 'all' | 'visible' | 'deleted';
+export type SiteVisibility = 'all' | 'deleted';
 
 const fetchSites = (
-	site_visibility: SiteVisibility = 'visible',
+	site_visibility: SiteVisibility = 'all',
 	siteFilter = config< string[] >( 'site_filter' ),
 	additional_fields: string[] = [],
 	additional_options: string[] = []
@@ -42,7 +42,7 @@ export const useSiteExcerptsQueryInvalidator = () => {
 export const useSiteExcerptsQuery = (
 	fetchFilter?: string[],
 	sitesFilterFn?: ( site: SiteExcerptData ) => boolean,
-	site_visibility: SiteVisibility = 'visible',
+	site_visibility: SiteVisibility = 'all',
 	additional_fields: string[] = [],
 	additional_options: string[] = [],
 	enabled = true

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -108,7 +108,7 @@ export function requestSites() {
 		return wpcom.req
 			.get( '/me/sites', {
 				apiVersion: '1.2',
-				site_visibility: 'visible',
+				site_visibility: 'all',
 				include_domain_only: true,
 				site_activity: 'active',
 				fields: SITE_REQUEST_FIELDS,

--- a/client/state/sites/selectors/has-all-sites-list.js
+++ b/client/state/sites/selectors/has-all-sites-list.js
@@ -1,7 +1,5 @@
 /**
- * Returns whether all visible sites have been fetched.
- *
- * Visible means excluding deleted sites etc.
+ * Returns whether all sites have been fetched.
  * @param {Object}    state  Global state tree
  * @returns {boolean}        Request State
  */

--- a/packages/sites/src/index.ts
+++ b/packages/sites/src/index.ts
@@ -12,6 +12,7 @@ export {
 	withSitesListSorting,
 } from './use-sites-list-sorting';
 export type { SitesSortOptions, SitesSortKey, SitesSortOrder } from './use-sites-list-sorting';
+export { useFilterDeletedSites } from './use-filter-deleted-sites';
 export {
 	SITE_EXCERPT_COMPUTED_FIELDS,
 	SITE_EXCERPT_REQUEST_OPTIONS,

--- a/packages/sites/src/use-filter-deleted-sites.tsx
+++ b/packages/sites/src/use-filter-deleted-sites.tsx
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+import { MinimumSite } from './site-type';
+
+type SiteForFiltering = Pick< MinimumSite, 'is_deleted' >;
+
+export interface SitesFilterDeletedOptions {
+	shouldApplyFilter: boolean;
+}
+
+export function useFilterDeletedSites< T extends SiteForFiltering >(
+	sites: T[],
+	{ shouldApplyFilter = true }: SitesFilterDeletedOptions
+) {
+	return useMemo( () => {
+		if ( shouldApplyFilter ) {
+			return sites.filter( ( site ) => ! site.is_deleted );
+		}
+
+		return sites;
+	}, [ sites, shouldApplyFilter ] );
+}

--- a/packages/sites/tests/use-sites-list-filter-deleted.test.ts
+++ b/packages/sites/tests/use-sites-list-filter-deleted.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @jest-environment jsdom
+ */
+import { expect } from '@jest/globals';
+import { renderHook } from '@testing-library/react';
+import { useFilterDeletedSites, SitesFilterDeletedOptions } from '../src/use-filter-deleted-sites';
+
+// Mock the MinimumSite type for testing
+interface MockSite {
+	id: number;
+	name: string;
+	status: string;
+	is_deleted: boolean;
+}
+
+describe( 'useFilterDeletedSites', () => {
+	// Sample test data
+	const testSites: MockSite[] = [
+		{ id: 1, name: 'Site 1', status: 'active', is_deleted: false },
+		{ id: 2, name: 'Site 2', status: 'inactive', is_deleted: false },
+		{ id: 3, name: 'Site 3', status: 'active', is_deleted: true },
+		{ id: 4, name: 'Test Site', status: 'pending', is_deleted: false },
+		{ id: 5, name: 'Another Site', status: 'active', is_deleted: false },
+	];
+
+	test( 'returns an empty array when sites list is empty', () => {
+		const options: SitesFilterDeletedOptions = {
+			shouldApplyFilter: true,
+		};
+		const { result } = renderHook( () => useFilterDeletedSites( [], options ) );
+		expect( result.current ).toEqual( [] );
+	} );
+
+	test( 'filters out deleted sites', () => {
+		const options: SitesFilterDeletedOptions = {
+			shouldApplyFilter: true,
+		};
+
+		const { result } = renderHook( () => useFilterDeletedSites( testSites, options ) );
+
+		const filteredSites = result.current;
+		expect( filteredSites ).toHaveLength( 4 );
+		expect( filteredSites.every( ( site ) => ! site.is_deleted ) ).toBe( true );
+		expect( filteredSites.map( ( site ) => site.id ) ).toEqual( [ 1, 2, 4, 5 ] );
+	} );
+
+	test( 'does not filter out deleted sites', () => {
+		const options: SitesFilterDeletedOptions = {
+			shouldApplyFilter: false,
+		};
+		const { result } = renderHook( () => useFilterDeletedSites( testSites, options ) );
+
+		const filteredSites = result.current;
+		expect( filteredSites ).toHaveLength( 5 );
+		expect( filteredSites.every( ( site ) => ! site.is_deleted ) ).toBe( false );
+	} );
+
+	test( 'recalculates when dependencies change', () => {
+		const { result, rerender } = renderHook(
+			( props ) => useFilterDeletedSites( props.sites, props.options ),
+			{
+				initialProps: {
+					sites: testSites,
+					options: {
+						shouldApplyFilter: true,
+					},
+				},
+			}
+		);
+
+		// Initial render with no filters should exclude deleted sites
+		expect( result.current ).toHaveLength( 4 );
+		expect( result.current.every( ( site ) => ! site.is_deleted ) ).toBe( true );
+
+		// Re-render with search, should include all sites
+		rerender( {
+			sites: testSites,
+			options: { shouldApplyFilter: false },
+		} );
+		expect( result.current ).toHaveLength( 5 );
+
+		// Re-render with different sites array
+		const newSites = testSites.slice( 0, 3 );
+		rerender( {
+			sites: newSites,
+			options: {
+				shouldApplyFilter: true,
+			},
+		} );
+		expect( result.current ).toHaveLength( 2 );
+		expect( result.current.map( ( site ) => site.id ) ).toEqual( [ 1, 2 ] );
+	} );
+} );


### PR DESCRIPTION


<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Undoes [https://linear.app/a8c/issue/DOTCOM-13609](https://linear.app/a8c/issue/DOTCOM-13609/reduce-e2e-timeouts-due-to-mesites)

## Proposed Changes

This reverts commit 7107f82079199771d8b18c895561630a3d7bfa74.

It causes problems on /home/:siteSlug for P2s - it no longer gets the current p2 information when calling /me/sites as it uses site_visibility=visible rather than site_visibility=all.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

p1750864807994459-slack-C025Q5RK2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use the live link
2. Go to /home/:site where site is a p2
3. Wait a few seconds
4. It should no longer show a "This page is not available on this site"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?