### PR TITLE
Connect Refresh: Login Header cleanup

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -22,6 +22,7 @@ import {
 } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
 import { isWebAuthnSupported } from 'calypso/lib/webauthn';
+import GravPoweredLoginBlockHeader from 'calypso/login/wp-login/gravatar/grav-powered-login-block-header';
 import { sendEmailLogin } from 'calypso/state/auth/actions';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
 import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -56,7 +57,6 @@ import isWooJPCFlow from 'calypso/state/selectors/is-woo-jpc-flow';
 import ContinueAsUser from './continue-as-user';
 import ErrorNotice from './error-notice';
 import LoginForm from './login-form';
-import { LoginHeader } from './login-header';
 import { shouldUseMagicCode } from './utils/should-use-magic-code';
 
 import './style.scss';
@@ -614,8 +614,8 @@ class Login extends Component {
 					'is-a4a': isA4AOAuth2Client( oauth2Client ),
 				} ) }
 			>
-				{ ! isWhiteLogin && (
-					<LoginHeader
+				{ isGravPoweredClient && (
+					<GravPoweredLoginBlockHeader
 						action={ action }
 						currentQuery={ currentQuery }
 						fromSite={ fromSite }

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -581,25 +581,17 @@ class Login extends Component {
 			isWCCOM,
 			isFromAutomatticForAgenciesPlugin,
 			action,
-			currentQuery,
 			fromSite,
 			isGravPoweredClient,
 			isGravPoweredLoginPage,
 			isManualRenewalImmediateLoginAttempt,
 			isSignupExistingAccount,
-			isSocialFirst,
 			isWhiteLogin,
-			isBlazePro,
 			linkingSocialService,
 			socialConnect,
-			translate,
 			twoStepNonce,
-			wccomFrom,
-			isWooJPC,
 			twoFactorAuthType,
 			twoFactorEnabled,
-			initialQuery,
-			partnerSlug,
 		} = this.props;
 
 		return (
@@ -617,31 +609,14 @@ class Login extends Component {
 				{ isGravPoweredClient && (
 					<GravPoweredLoginBlockHeader
 						action={ action }
-						currentQuery={ currentQuery }
 						fromSite={ fromSite }
-						isFromAkismet={ isFromAkismet }
-						isFromAutomatticForAgenciesPlugin={ isFromAutomatticForAgenciesPlugin }
-						isGravPoweredClient={ isGravPoweredClient }
 						isGravPoweredLoginPage={ isGravPoweredLoginPage }
-						isJetpack={ isJetpack }
 						isManualRenewalImmediateLoginAttempt={ isManualRenewalImmediateLoginAttempt }
-						isSocialFirst={ isSocialFirst }
-						isWhiteLogin={ isWhiteLogin }
-						isWCCOM={ isWCCOM }
-						isBlazePro={ isBlazePro }
 						linkingSocialService={ linkingSocialService }
-						oauth2Client={ oauth2Client }
 						socialConnect={ socialConnect }
-						translate={ translate }
 						twoStepNonce={ twoStepNonce }
-						wccomFrom={ wccomFrom }
-						isWooJPC={ isWooJPC }
 						twoFactorAuthType={ twoFactorAuthType }
 						twoFactorEnabled={ twoFactorEnabled }
-						initialQuery={ initialQuery }
-						partnerSlug={ partnerSlug }
-						getSignupLinkComponent={ this.getSignupLinkComponent }
-						showContinueAsUser={ this.showContinueAsUser() }
 					/>
 				) }
 

--- a/client/blocks/login/login-header.scss
+++ b/client/blocks/login/login-header.scss
@@ -1,3 +1,0 @@
-.login-header-text__client-name {
-	text-transform: capitalize;
-}

--- a/client/blocks/login/login-header.tsx
+++ b/client/blocks/login/login-header.tsx
@@ -2,9 +2,6 @@ import { useTranslate, TranslateResult, fixMe } from 'i18n-calypso';
 import { capitalize } from 'lodash';
 import VisitSite from 'calypso/blocks/visit-site';
 import GravatarLoginLogo from 'calypso/components/gravatar-login-logo';
-import JetpackPlusWpComLogo from 'calypso/components/jetpack-plus-wpcom-logo';
-import WPCloudLogo from 'calypso/components/wp-cloud-logo';
-import { getPluginTitle } from 'calypso/lib/login';
 import {
 	isJetpackCloudOAuth2Client,
 	isA4AOAuth2Client,
@@ -28,7 +25,6 @@ interface LoginHeaderProps {
 	isManualRenewalImmediateLoginAttempt: boolean;
 	isSignupExistingAccount: boolean;
 	isSocialFirst: boolean;
-	isWhiteLogin: boolean;
 	isWCCOM: boolean;
 	isBlazePro: boolean;
 	linkingSocialService: string;
@@ -170,14 +166,11 @@ export function LoginHeader( {
 	fromSite,
 	isFromAkismet,
 	isFromAutomatticForAgenciesPlugin,
-	isGravPoweredClient,
 	isGravPoweredLoginPage,
 	isJetpack,
 	isManualRenewalImmediateLoginAttempt,
 	isSocialFirst,
-	isWhiteLogin,
 	isWCCOM,
-	isBlazePro,
 	linkingSocialService,
 	oauth2Client,
 	socialConnect,
@@ -185,9 +178,6 @@ export function LoginHeader( {
 	isWooJPC,
 	twoFactorAuthType,
 	twoFactorEnabled,
-	initialQuery,
-	getSignupLinkComponent,
-	showContinueAsUser,
 }: LoginHeaderProps ) {
 	const translate = useTranslate();
 
@@ -204,197 +194,48 @@ export function LoginHeader( {
 		isWCCOM,
 		isFromAkismet,
 		isFromAutomatticForAgenciesPlugin,
-		isGravPoweredClient,
+		true, // isGravPoweredClient is always true
 		twoFactorEnabled,
 		currentQuery,
 		translate,
 		twoStepNonce
 	);
 
-	let preHeader = null;
-	let header = null;
+	const preHeader = null;
+	const header = null;
 	let postHeader = null;
-	const signupLink = getSignupLinkComponent();
 
-	if ( action === 'lostpassword' ) {
-		header = <h3>{ headerText } </h3>;
+	if ( isGravPoweredLoginPage ) {
+		const isFromGravatar3rdPartyApp =
+			isGravatarOAuth2Client( oauth2Client ) && currentQuery?.gravatar_from === '3rd-party';
+		const isFromGravatarQuickEditor =
+			isGravatarOAuth2Client( oauth2Client ) && currentQuery?.gravatar_from === 'quick-editor';
+		const isGravatarFlowWithEmail = !! (
+			isGravatarFlowOAuth2Client( oauth2Client ) && currentQuery?.email_address
+		);
+
 		postHeader = (
-			<p className="login__header-subtitle login__lostpassword-subtitle">
-				{ translate(
-					"It happens to the best of us. Enter the email address associated with your WordPress.com account and we'll send you a link to reset your password."
-				) }
-				{ isWooJPC && (
-					<span>
-						<br />
-						{ translate( "Don't have an account? {{signupLink}}Sign up{{/signupLink}}", {
-							components: {
-								signupLink,
-							},
-						} ) }
-					</span>
-				) }
+			<p className="login__header-subtitle">
+				{ isFromGravatar3rdPartyApp || isFromGravatarQuickEditor || isGravatarFlowWithEmail
+					? translate( 'Please log in with your email and password.' )
+					: translate(
+							'If you prefer logging in with a password, or a social media account, choose below:'
+					  ) }
 			</p>
 		);
-		if ( isBlazePro ) {
-			postHeader = (
-				<p className="login__header-subtitle login__lostpassword-subtitle">
-					{ translate(
-						"It happens to the best of us. Enter the email address associated with your Blaze Pro account and we'll send you a link to reset your password."
-					) }
-				</p>
-			);
-		}
-	} else if ( oauth2Client ) {
-		if ( isPartnerPortalOAuth2Client( oauth2Client ) ) {
-			if ( document.location.search?.includes( 'wpcloud' ) ) {
-				preHeader = (
-					<div>
-						<WPCloudLogo className="login__wpcloud-logo" size={ 256 } />
-					</div>
-				);
-			} else if ( document.location.search?.includes( 'jetpack' ) ) {
-				preHeader = (
-					<div>
-						<JetpackPlusWpComLogo className="login__jetpack-plus-wpcom-logo" size={ 24 } />
-					</div>
-				);
-			}
-		}
-
-		if ( isJetpackCloudOAuth2Client( oauth2Client ) || isA4AOAuth2Client( oauth2Client ) ) {
-			// If users arrived here from the lost password flow, show them a specific message about it
-			postHeader = currentQuery.lostpassword_flow && (
-				<p className="login__form-post-header">
-					{ translate(
-						'Check your e-mail address linked to the account for the confirmation link, including the spam or junk folder.'
-					) }
-				</p>
-			);
-		}
-
-		if ( isGravPoweredClient ) {
-			if ( isGravPoweredLoginPage ) {
-				const isFromGravatar3rdPartyApp =
-					isGravatarOAuth2Client( oauth2Client ) && currentQuery?.gravatar_from === '3rd-party';
-				const isFromGravatarQuickEditor =
-					isGravatarOAuth2Client( oauth2Client ) && currentQuery?.gravatar_from === 'quick-editor';
-				const isGravatarFlowWithEmail = !! (
-					isGravatarFlowOAuth2Client( oauth2Client ) && currentQuery?.email_address
-				);
-
-				postHeader = (
-					<p className="login__header-subtitle">
-						{ isFromGravatar3rdPartyApp || isFromGravatarQuickEditor || isGravatarFlowWithEmail
-							? translate( 'Please log in with your email and password.' )
-							: translate(
-									'If you prefer logging in with a password, or a social media account, choose below:'
-							  ) }
-					</p>
-				);
-			}
-		}
-
-		if ( isBlazeProOAuth2Client( oauth2Client ) ) {
-			header = <h3>{ headerText }</h3>;
-
-			postHeader = (
-				<p className="login__header-subtitle">
-					{ translate( "Don't have an account? {{signupLink}}Sign up here{{/signupLink}}", {
-						components: { signupLink },
-					} ) }
-				</p>
-			);
-
-			if ( showContinueAsUser ) {
-				postHeader = (
-					<p className="login__header-subtitle">
-						{ translate( "Select the account you'd like to use" ) }
-					</p>
-				);
-			}
-		}
-	} else if ( isWooJPC ) {
-		const isLostPasswordFlow = currentQuery.lostpassword_flow === 'true';
-		const isTwoFactorAuthFlow = twoFactorEnabled;
-		const pluginName = getPluginTitle(
-			new URLSearchParams( initialQuery?.redirect_to ).get( 'plugin_name' ),
-			translate
-		);
-		header = <h3>{ headerText }</h3>;
-		let subtitle = null;
-
-		if ( isLostPasswordFlow ) {
-			subtitle = translate(
-				"Your password reset confirmation is on its way to your email address – please check your junk folder if it's not in your inbox! Once you've reset your password, head back to this page to log in to your account."
-			);
-		} else if ( ! isTwoFactorAuthFlow ) {
-			header = <h3>{ headerText }</h3>;
-			subtitle = translate(
-				"To access all of the features and functionality %(pluginName)s, you'll first need to connect your store to a WordPress.com account. Log in now, or {{signupLink}}create a new account{{/signupLink}}. For more information, please {{doc}}review our documentation{{/doc}}.",
-				{
-					components: {
-						signupLink,
-						br: <br />,
-						doc: (
-							<a
-								href="https://woocommerce.com/document/connect-your-store-to-a-wordpress-com-account/"
-								target="_blank"
-								rel="noreferrer"
-							/>
-						),
-					},
-					args: { pluginName },
-				}
-			);
-		}
-		postHeader = <p className="login__header-subtitle">{ subtitle }</p>;
 	} else if ( fromSite ) {
 		// if redirected from Calypso URL with a site slug, offer a link to that site's frontend
 		postHeader = <VisitSite siteSlug={ fromSite } />;
 	}
 
-	if ( isFromAutomatticForAgenciesPlugin ) {
-		preHeader = (
-			<svg
-				width="282"
-				height="58"
-				viewBox="0 0 282 58"
-				fill="none"
-				xmlns="http://www.w3.org/2000/svg"
-			>
-				<g clipPath="url(#clip0_6816_1592)">
-					<path
-						d="M107.202 19.4164C100.972 19.4164 96.9319 14.8051 96.9319 10.0056V9.41077C96.9319 4.52998 100.972 0 107.202 0C113.431 0 117.506 4.52998 117.506 9.41077V10.0056C117.506 14.8051 113.465 19.4164 107.202 19.4164ZM114.174 9.46162C114.174 5.96372 111.698 2.85221 107.202 2.85221C102.706 2.85221 100.269 5.9688 100.269 9.46162V9.89885C100.269 13.3968 102.745 16.5693 107.202 16.5693C111.658 16.5693 114.174 13.3968 114.174 9.89885V9.46162Z"
-						fill="#3499CD"
-					/>
-					<path
-						d="M36.8237 18.7097L34.5013 14.2356H24.1722L21.9093 18.7097H18.4431L27.9503 0.650772H30.6985L40.3641 18.7097H36.8237ZM29.2427 4.17409L25.4151 11.7698H33.204L29.2427 4.17409ZM55.3627 19.4164C49.0493 19.4164 46.1179 15.888 46.1179 11.2004V0.650772H49.3959V11.2512C49.3959 14.5864 51.5351 16.5693 55.6004 16.5693C59.7746 16.5693 61.4879 14.5864 61.4879 11.2512V0.650772H64.7906V11.1851C64.7906 15.6745 62.0177 19.4164 55.3627 19.4164ZM83.1712 3.47248V18.7249H79.8685V3.47248H72.1835V0.650772H90.8562V3.47248H83.1712ZM146.924 18.7097V4.41813L146.052 5.99422L138.684 18.7046H137.075L129.786 5.99422L128.915 4.41813V18.7097H125.691V0.650772H130.261L137.194 13.0409L138.016 14.5661L138.833 13.0409L145.701 0.650772H150.217V18.7097H146.924ZM175.183 18.7097L172.856 14.2356H162.536L160.293 18.7097H156.827L166.334 0.650772H169.078L178.718 18.7097H175.183ZM167.602 4.17409L163.774 11.7698H171.563L167.602 4.17409ZM192.028 3.47248V18.7249H188.731V3.47248H181.046V0.650772H199.713V3.47248H192.028ZM216.247 3.47248V18.7249H212.944V3.47248H205.259V0.650772H223.937V3.47248H216.247ZM232.068 18.7097V2.35905C233.385 2.35905 233.915 1.62693 233.915 0.650772H235.326V18.7097H232.068ZM261.169 5.75018C259.274 3.89647 256.759 2.85774 254.142 2.84713C249.443 2.84713 246.799 6.15691 246.799 9.59889V9.94969C246.799 13.3662 249.468 16.5591 254.38 16.5591C256.95 16.5094 259.409 15.4738 261.272 13.656L263.253 15.7965C260.782 18.1608 257.519 19.4572 254.142 19.4164C247.487 19.4164 243.447 14.9678 243.447 10.087V9.49212C243.447 4.61133 247.858 0 254.301 0C258.024 0 261.406 1.60151 263.214 3.60467L261.169 5.75018ZM107.609 6.69736L104.585 11.507C104.401 11.7992 104.338 12.1544 104.409 12.4945C104.48 12.8346 104.68 13.1317 104.964 13.3205L104.969 13.323C105.11 13.4165 105.267 13.4805 105.432 13.5114C105.597 13.5424 105.767 13.5397 105.931 13.5034C106.095 13.4671 106.25 13.3981 106.388 13.3001C106.526 13.2022 106.644 13.0773 106.735 12.9326L109.76 8.12296C109.943 7.83073 110.006 7.47559 109.935 7.13561C109.864 6.79563 109.664 6.49865 109.379 6.30995L109.375 6.3069C109.234 6.21345 109.076 6.14943 108.911 6.11848C108.746 6.08753 108.577 6.09027 108.413 6.12653C108.249 6.16278 108.094 6.23186 107.956 6.3298C107.818 6.42774 107.7 6.55264 107.609 6.69736Z"
-						fill="black"
-					/>
-				</g>
-				<path
-					d="M18.5267 34.8197H5.95136L5.95136 39.941H15.3091V42.5955H5.95136L5.95136 49.8887H2.62653L2.62653 32.0311H18.5267V34.8197ZM45.7091 41.2817C45.7091 46.0276 41.6067 50.5858 35.252 50.5858C28.9241 50.5858 24.8217 46.0276 24.8217 41.2817V40.6918C24.8217 35.8654 28.9241 31.3876 35.252 31.3876C41.6067 31.3876 45.7091 35.8654 45.7091 40.6918V41.2817ZM42.3307 41.1744V40.7454C42.3307 37.2865 39.8102 34.203 35.252 34.203C30.6938 34.203 28.2002 37.2865 28.2002 40.7454V41.1744C28.2002 44.6333 30.6938 47.7704 35.252 47.7704C39.8102 47.7704 42.3307 44.6333 42.3307 41.1744ZM72.1649 49.8887H69.135C68.2234 49.8887 67.8212 48.6285 67.7139 47.0197L67.6066 45.1964C67.4994 43.4267 66.7754 42.6759 63.4238 42.6759H57.0959V49.8887H53.7443V32.0311H63.4774C68.8401 32.0311 71.2532 34.1762 71.2532 36.9379C71.2532 38.8953 70.2611 40.7454 66.7754 41.3889C70.2611 41.657 71.0119 43.239 71.0387 45.3304L71.0655 46.8052C71.0924 48.0386 71.3069 48.9234 72.1649 49.8082V49.8887ZM67.8748 37.5815V37.3669C67.8748 36.0799 66.8291 34.8197 63.9601 34.8197H57.0959V40.1823H64.255C66.7218 40.1823 67.8748 39.0025 67.8748 37.5815ZM112.979 49.8887H109.386L107.026 45.4645H96.5422L94.2631 49.8887H90.7237L100.376 32.0311H103.165L112.979 49.8887ZM105.712 43.0245L101.69 35.5168L97.8024 43.0245H105.712ZM138.163 49.8887H136.018L135.509 47.4755C133.793 49.4597 131.353 50.5858 128.323 50.5858C121.995 50.5858 117.893 46.2421 117.893 41.2817V40.9599C117.893 35.8922 122.37 31.3876 128.913 31.3876C132.935 31.3876 136.206 33.05 137.976 34.9538L135.884 37.072C134.275 35.5973 131.782 34.203 128.886 34.203C123.899 34.203 121.271 37.3938 121.271 40.8795V41.1744C121.271 44.6601 124.086 47.7704 128.645 47.7704C132.103 47.7704 134.57 45.6522 134.57 43.5072V43.3195H129.074V40.665H138.163V49.8887ZM162.854 49.8887L146.632 49.8887V32.0311L162.854 32.0311V34.8197L149.983 34.8197V39.4047L159.877 39.4047V42.1129L149.983 42.1129V47.1001L162.854 47.1001V49.8887ZM190.009 49.8887L187.113 49.8887L175.503 37.93L174.377 36.6698V49.8887H171.025V32.0311H174.243L185.505 43.963L186.658 45.25V32.0311H190.009V49.8887ZM218.148 34.9538L216.056 37.072C214.448 35.5973 212.088 34.203 208.897 34.203C204.125 34.203 201.443 37.4742 201.443 40.8795V41.228C201.443 44.6065 204.151 47.7704 209.139 47.7704C212.115 47.7704 214.582 46.3493 216.137 44.9014L218.148 47.0197C216.19 48.9502 212.866 50.5858 208.924 50.5858C202.167 50.5858 198.065 46.1885 198.065 41.3621V40.7722C198.065 35.9459 202.543 31.3876 209.085 31.3876C212.866 31.3876 216.298 32.9696 218.148 34.9538ZM229.292 49.8887H225.94V32.0311H229.292V49.8887ZM254.642 49.8887H238.42V32.0311H254.642V34.8197H241.771V39.4047H251.665V42.1129H241.771V47.1001H254.642V49.8887ZM280.51 44.8746C280.51 48.3603 276.702 50.5858 271.393 50.5858C267.774 50.5858 264.422 49.5937 261.66 48.2799L262.894 45.6254C265.709 47.0197 268.685 47.8509 271.554 47.8509C275.415 47.8509 277.131 46.5907 277.131 45.2232C277.131 40.9599 262.17 43.8021 262.17 37.2597C262.17 33.9349 265.763 31.3876 271.42 31.3876C274.933 31.3876 278.204 32.621 280.215 33.9349L278.392 36.1872C276.729 35.1146 273.994 34.1226 271.313 34.1226C267.827 34.1226 265.521 35.3023 265.521 36.8307C265.521 40.7186 280.51 38.1177 280.51 44.8746Z"
-					fill="black"
-				/>
-				<defs>
-					<clipPath id="clip0_6816_1592">
-						<rect width="244.785" height="19.4164" fill="white" transform="translate(18.4431)" />
-					</clipPath>
-				</defs>
-			</svg>
-		);
-	}
-
 	return (
 		<div className="login__form-header-wrapper">
-			{ isGravPoweredClient && (
-				<GravatarLoginLogo
-					iconUrl={ oauth2Client?.icon }
-					alt={ oauth2Client?.title || '' }
-					isCoBrand={ isGravatarFlowOAuth2Client( oauth2Client ) }
-				/>
-			) }
-			{ ! isWhiteLogin && preHeader }
+			<GravatarLoginLogo
+				iconUrl={ oauth2Client?.icon }
+				alt={ oauth2Client?.title || '' }
+				isCoBrand={ isGravatarFlowOAuth2Client( oauth2Client ) }
+			/>
+			{ preHeader }
 			<div className="login__form-header">{ header || headerText }</div>
 			{ postHeader }
 		</div>

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -92,18 +92,6 @@ $breakpoint-mobile: 782px; //Mobile size.
 		}
 	}
 
-	.login__form-header {
-		margin-top: 32px;
-	}
-
-	.login__header-subtitle {
-		color: var(--color-primary-10);
-		margin-top: 1em;
-		font-size: $font-body;
-		line-height: 24px;
-		font-weight: 400;
-	}
-
 	.jetpack-logo__icon-circle {
 		fill: var(--color-neutral-80);
 	}
@@ -214,7 +202,7 @@ $breakpoint-mobile: 782px; //Mobile size.
 	}
 }
 
-.login__form-header-wrapper {
+.grav-powered-login__form-header-wrapper {
 	text-align: center;
 
 	.gridicon {
@@ -239,7 +227,7 @@ $breakpoint-mobile: 782px; //Mobile size.
 	}
 }
 
-.login__form-header {
+.grav-powered-login__form-header {
 	font-size: $font-title-small;
 	margin-bottom: 24px;
 	margin-top: 16px;

--- a/client/blocks/login/two-factor-authentication/verification-code-form.scss
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.scss
@@ -128,15 +128,3 @@
 .security-key-form__add-wait-for-key-heading {
 	font-weight: 600;
 }
-
-.layout.is-white-login {
-	.wp-login__main.is-social-first {
-		.login__form-header {
-			width: $login-container-width;
-			margin: 0 auto;
-			padding: 0 24px;
-			text-align: left;
-			line-height: 40px;
-		}
-	}
-}

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1172,10 +1172,6 @@ $colophon-height: 50px;
 			}
 		}
 	}
-
-	&.is-jetpack-woo-dna-flow .login__form-header-wrapper {
-		display: none;
-	}
 }
 
 .jetpack-connect__features_wrapper {

--- a/client/layout/masterbar/blaze-pro.scss
+++ b/client/layout/masterbar/blaze-pro.scss
@@ -171,25 +171,6 @@ body.is-section-signup {
 		display: none;
 	}
 
-	.login__form-header-wrapper {
-		align-items: center;
-		display: flex;
-		flex-direction: column;
-	}
-
-	.login__form-header {
-		margin-top: 0;
-		width: 360px;
-
-		h3 {
-			font-family: $inter !important;
-			font-size: 2rem;
-			font-weight: 700;
-			line-height: 40px;
-			margin-bottom: 16px; // For 2FA screen
-		}
-	}
-
 	.login__body--continue-as-user {
 		align-items: center;
 		display: flex;
@@ -480,22 +461,8 @@ body.is-section-signup {
 		margin-bottom: 12px;
 	}
 
-	.login__header-subtitle {
-		color: var(--color-neutral-50);
-		font-family: $sfProText !important;
-		font-size: rem(18px);
-		font-weight: 500;
-		line-height: 25px;
-	}
-
 	.login__lostpassword-subtitle {
 		width: 360px;
-	}
-
-	&.two-factor-auth-enabled {
-		.login__header-subtitle {
-			display: none;
-		}
 	}
 
 	.login__form-terms {

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -214,20 +214,6 @@
 			font-weight: 400;
 		}
 
-		.login__form-header {
-			@extend .wp-brand-font;
-			font-size: $font-title-medium;
-			color: var(--color-text);
-			font-weight: 600;
-			margin-bottom: 80px;
-			margin-top: 0;
-
-			@include breakpoint-deprecated(">480px") {
-				font-size: $font-title-large;
-				margin-bottom: 65px;
-			}
-		}
-
 		.auth-form__separator {
 			padding: 10px 0;
 			&::before,

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -371,15 +371,6 @@ $breakpoint-mobile: 660px;
 		}
 	}
 
-	.login__form-header {
-		margin-top: 0;
-		margin-bottom: 8px;
-
-		@media (max-width: $break-mobile) {
-			margin-bottom: 16px;
-		}
-	}
-
 	.form-password-input .form-password-input__toggle-visibility {
 		top: 10px;
 	}
@@ -391,7 +382,6 @@ $breakpoint-mobile: 660px;
 
 	.jetpack-connect__logged-in-form .formatted-header,
 	.jetpack-connect__authorize-form .formatted-header,
-	.login__form-header-wrapper,
 	.signup-form__woo-wrapper {
 		text-align: center;
 		margin: 0 auto;
@@ -409,7 +399,6 @@ $breakpoint-mobile: 660px;
 		}
 	}
 
-	.login__header-subtitle,
 	.formatted-header__subtitle {
 		color: $gray-60;
 		font-size: $font-body;
@@ -502,13 +491,6 @@ $breakpoint-mobile: 660px;
 	.login__two-factor-footer {
 		padding-left: $woo-form-whitespace;
 		padding-right: $woo-form-whitespace;
-		@media (max-width: $break-mobile) {
-			padding-left: $woo-form-whitespace-660;
-			padding-right: $woo-form-whitespace-660;
-		}
-	}
-
-	.login__form-header-wrapper {
 		@media (max-width: $break-mobile) {
 			padding-left: $woo-form-whitespace-660;
 			padding-right: $woo-form-whitespace-660;
@@ -781,17 +763,6 @@ $breakpoint-mobile: 660px;
 		}
 	}
 
-	.formatted-header__subtitle {
-		@media (max-width: $break-mobile) {
-			width: 250px;
-		}
-
-		@media (max-width: $break-mobile) {
-			padding-left: $woo-form-whitespace-660;
-			padding-right: $woo-form-whitespace-660;
-		}
-	}
-
 	&.is-section-signup::before,
 	&.is-section-signup .layout__primary::before {
 		display: none;
@@ -857,7 +828,6 @@ $breakpoint-mobile: 660px;
 			margin-bottom: 16px;
 		}
 
-		.login__form-header h3,
 		.formatted-header .formatted-header__title {
 			margin-bottom: 12px;
 			font-size: $woo-font-title-large;
@@ -869,10 +839,6 @@ $breakpoint-mobile: 660px;
 			}
 		}
 
-		.login__form-header-wrapper h3 {
-			font-weight: 500;
-		}
-
 		form.two-factor-authentication__verification-code-form-wrapper {
 			@media (max-width: $break-mobile) {
 				margin: 0;
@@ -880,7 +846,6 @@ $breakpoint-mobile: 660px;
 			}
 		}
 
-		.login__header-subtitle,
 		.formatted-header__subtitle {
 			color: $gray-700;
 
@@ -1028,7 +993,6 @@ $breakpoint-mobile: 660px;
 		}
 
 		// Log in link on signup page
-		.login__header-subtitle a,
 		.formatted-header__subtitle a {
 			color: var(--wp-admin-theme-color);
 			line-height: inherit;
@@ -1217,7 +1181,6 @@ $breakpoint-mobile: 660px;
 			padding: 48px 0 0;
 		}
 
-		.login__form-header,
 		.formatted-header__title {
 			margin-bottom: 12px;
 
@@ -1228,7 +1191,6 @@ $breakpoint-mobile: 660px;
 			}
 		}
 
-		.login__header-subtitle,
 		.formatted-header__subtitle,
 		.verification-code-form__help-text,
 		.security-key-form__help-text {
@@ -1756,19 +1718,13 @@ $breakpoint-mobile: 660px;
 			}
 		}
 
-		.login__form-header-wrapper {
-			max-width: 615px;
-			text-align: center;
-		}
-
 		.jetpack-connect__main-logo {
 			@media (max-width: $break-mobile) {
 				padding-top: 0;
 			}
 		}
 
-		.formatted-header__subtitle,
-		.login__header-subtitle {
+		.formatted-header__subtitle {
 			color: #757575;
 			text-align: center;
 			font-size: 1rem;
@@ -1789,6 +1745,9 @@ $breakpoint-mobile: 660px;
 			}
 
 			@media (max-width: $break-mobile) {
+				width: 250px;
+				padding-left: $woo-form-whitespace-660;
+				padding-right: $woo-form-whitespace-660;
 				text-align: start;
 				br {
 					display: none;
@@ -1960,11 +1919,6 @@ $breakpoint-mobile: 660px;
 	.calypso-notice__text a,
 	.calypso-notice__text a:visited {
 		@include link-woo;
-	}
-
-	.login__header-subtitle a {
-		@include link-woo;
-		font-weight: 500;
 	}
 
 	.magic-login__footer a {

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -36,13 +36,6 @@
 		margin-bottom: 1rem;
 	}
 
-	.login__form-header-wrapper{
-		padding: 0 16px 0 16px;
-		@include break-small {
-			padding: 0;
-		}
-	}
-
 	.magic-login {
 		max-width: calc(450px + 48px);
 		margin-top: calc(96px - 48px);

--- a/client/login/wp-login/gravatar/grav-powered-login-block-header.tsx
+++ b/client/login/wp-login/gravatar/grav-powered-login-block-header.tsx
@@ -1,23 +1,19 @@
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 import VisitSite from 'calypso/blocks/visit-site';
 import GravatarLoginLogo from 'calypso/components/gravatar-login-logo';
 import { isGravatarFlowOAuth2Client, isGravatarOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { getHeaderText } from 'calypso/login/wp-login/hooks/get-header-text';
+import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 
 interface Props {
 	action: string;
 	currentQuery: Record< string, string >;
 	fromSite: string | null;
 	isGravPoweredLoginPage: boolean;
-	isJetpack: boolean;
 	isManualRenewalImmediateLoginAttempt: boolean;
-	isWCCOM: boolean;
 	linkingSocialService: string;
-	oauth2Client: {
-		title: string;
-		icon: string;
-		name: string;
-	} | null;
 	socialConnect: boolean;
 	twoStepNonce: string | null;
 	twoFactorAuthType: string;
@@ -26,40 +22,32 @@ interface Props {
 
 const GravPoweredLoginBlockHeader = ( {
 	action,
-	currentQuery,
 	fromSite,
 	isGravPoweredLoginPage,
-	isJetpack,
 	isManualRenewalImmediateLoginAttempt,
-	isWCCOM,
 	linkingSocialService,
-	oauth2Client,
 	socialConnect,
 	twoStepNonce,
 	twoFactorAuthType,
 	twoFactorEnabled,
 }: Props ) => {
 	const translate = useTranslate();
+	const oauth2Client = useSelector( getCurrentOAuth2Client );
+	const currentQuery = useSelector( getCurrentQueryArguments );
 
-	const headerText = getHeaderText(
-		false, // isSocialFirst
+	const headerText = getHeaderText( {
 		twoFactorAuthType,
 		isManualRenewalImmediateLoginAttempt,
 		socialConnect,
 		linkingSocialService,
 		action,
 		oauth2Client,
-		false, // isWooJPC
-		isJetpack,
-		isWCCOM,
-		false, // isFromAkismet
-		false, // isFromAutomatticForAgenciesPlugin
-		true, // isGravPoweredClient is always true
 		twoFactorEnabled,
 		currentQuery,
 		translate,
-		twoStepNonce
-	);
+		twoStepNonce,
+		isGravPoweredClient: true,
+	} );
 
 	let postHeader = null;
 

--- a/client/login/wp-login/gravatar/grav-powered-login-block-header.tsx
+++ b/client/login/wp-login/gravatar/grav-powered-login-block-header.tsx
@@ -79,13 +79,13 @@ const GravPoweredLoginBlockHeader = ( {
 	}
 
 	return (
-		<div className="login__form-header-wrapper">
+		<div className="grav-powered-login__form-header-wrapper">
 			<GravatarLoginLogo
 				iconUrl={ oauth2Client?.icon }
 				alt={ oauth2Client?.title || '' }
 				isCoBrand={ isGravatarFlowOAuth2Client( oauth2Client ) }
 			/>
-			<div className="login__form-header">{ headerText }</div>
+			<div className="grav-powered-login__form-header">{ headerText }</div>
 			{ postHeader }
 		</div>
 	);

--- a/client/login/wp-login/gravatar/grav-powered-login-block-header.tsx
+++ b/client/login/wp-login/gravatar/grav-powered-login-block-header.tsx
@@ -1,0 +1,106 @@
+import { useTranslate } from 'i18n-calypso';
+import VisitSite from 'calypso/blocks/visit-site';
+import GravatarLoginLogo from 'calypso/components/gravatar-login-logo';
+import { isGravatarFlowOAuth2Client, isGravatarOAuth2Client } from 'calypso/lib/oauth2-clients';
+import { getHeaderText } from 'calypso/login/wp-login/hooks/get-header-text';
+
+interface Props {
+	action: string;
+	currentQuery: Record< string, string >;
+	fromSite: string | null;
+	isGravPoweredLoginPage: boolean;
+	isJetpack: boolean;
+	isManualRenewalImmediateLoginAttempt: boolean;
+	isWCCOM: boolean;
+	linkingSocialService: string;
+	oauth2Client: {
+		title: string;
+		icon: string;
+		name: string;
+	} | null;
+	socialConnect: boolean;
+	twoStepNonce: string | null;
+	twoFactorAuthType: string;
+	twoFactorEnabled: boolean;
+}
+
+const GravPoweredLoginBlockHeader = ( {
+	action,
+	currentQuery,
+	fromSite,
+	isGravPoweredLoginPage,
+	isJetpack,
+	isManualRenewalImmediateLoginAttempt,
+	isWCCOM,
+	linkingSocialService,
+	oauth2Client,
+	socialConnect,
+	twoStepNonce,
+	twoFactorAuthType,
+	twoFactorEnabled,
+}: Props ) => {
+	const translate = useTranslate();
+
+	const headerText = getHeaderText(
+		false, // isSocialFirst
+		twoFactorAuthType,
+		isManualRenewalImmediateLoginAttempt,
+		socialConnect,
+		linkingSocialService,
+		action,
+		oauth2Client,
+		false, // isWooJPC
+		isJetpack,
+		isWCCOM,
+		false, // isFromAkismet
+		false, // isFromAutomatticForAgenciesPlugin
+		true, // isGravPoweredClient is always true
+		twoFactorEnabled,
+		currentQuery,
+		translate,
+		twoStepNonce
+	);
+
+	let postHeader = null;
+
+	if ( isGravPoweredLoginPage ) {
+		const isFromGravatar3rdPartyApp =
+			isGravatarOAuth2Client( oauth2Client ) && currentQuery?.gravatar_from === '3rd-party';
+		const isFromGravatarQuickEditor =
+			isGravatarOAuth2Client( oauth2Client ) && currentQuery?.gravatar_from === 'quick-editor';
+		const isGravatarFlowWithEmail = !! (
+			isGravatarFlowOAuth2Client( oauth2Client ) && currentQuery?.email_address
+		);
+
+		postHeader = (
+			<p className="login__header-subtitle">
+				{ isFromGravatar3rdPartyApp || isFromGravatarQuickEditor || isGravatarFlowWithEmail
+					? translate( 'Please log in with your email and password.' )
+					: translate(
+							'If you prefer logging in with a password, or a social media account, choose below:'
+					  ) }
+			</p>
+		);
+	} else if ( fromSite ) {
+		/**
+		 * If redirected from Calypso URL with a site slug, offer a link to that site's frontend
+		 *
+		 * TODO clk This should probably migrate to the footer for default Login, if still relevant
+		 */
+		postHeader = <VisitSite siteSlug={ fromSite } />;
+	}
+
+	return (
+		<div className="login__form-header-wrapper">
+			<GravatarLoginLogo
+				iconUrl={ oauth2Client?.icon }
+				alt={ oauth2Client?.title || '' }
+				isCoBrand={ isGravatarFlowOAuth2Client( oauth2Client ) }
+			/>
+			<div className="login__form-header">{ headerText }</div>
+			{ postHeader }
+		</div>
+	);
+};
+
+export default GravPoweredLoginBlockHeader;

--- a/client/login/wp-login/hooks/get-header-text.tsx
+++ b/client/login/wp-login/hooks/get-header-text.tsx
@@ -1,48 +1,12 @@
-import { useTranslate, TranslateResult, fixMe } from 'i18n-calypso';
+import { TranslateResult, fixMe } from 'i18n-calypso';
 import { capitalize } from 'lodash';
-import VisitSite from 'calypso/blocks/visit-site';
-import GravatarLoginLogo from 'calypso/components/gravatar-login-logo';
 import {
 	isJetpackCloudOAuth2Client,
 	isA4AOAuth2Client,
 	isBlazeProOAuth2Client,
-	isGravatarFlowOAuth2Client,
 	isPartnerPortalOAuth2Client,
-	isGravatarOAuth2Client,
 	isVIPOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
-import './login-header.scss';
-
-interface LoginHeaderProps {
-	action: string;
-	currentQuery: Record< string, string >;
-	fromSite: string | null;
-	isFromAkismet: boolean;
-	isFromAutomatticForAgenciesPlugin: boolean;
-	isGravPoweredClient: boolean;
-	isGravPoweredLoginPage: boolean;
-	isJetpack: boolean;
-	isManualRenewalImmediateLoginAttempt: boolean;
-	isSignupExistingAccount: boolean;
-	isSocialFirst: boolean;
-	isWCCOM: boolean;
-	isBlazePro: boolean;
-	linkingSocialService: string;
-	oauth2Client: {
-		title: string;
-		icon: string;
-		name: string;
-	} | null;
-	socialConnect: boolean;
-	twoStepNonce: string | null;
-	wccomFrom: string;
-	isWooJPC: boolean;
-	twoFactorAuthType: string;
-	twoFactorEnabled: boolean;
-	initialQuery: { 'client-id': string; redirect_to: string } | null;
-	getSignupLinkComponent: () => JSX.Element;
-	showContinueAsUser: boolean;
-}
 
 export function getHeaderText(
 	isSocialFirst: boolean,
@@ -88,7 +52,7 @@ export function getHeaderText(
 					text: 'Log in to {{span}}%(client)s{{/span}} with WordPress.com',
 					newCopy: translate( 'Log in to {{span}}%(client)s{{/span}} with WordPress.com', {
 						args: { client: clientName },
-						components: { span: <span className="login-header-text__client-name" /> },
+						components: { span: <span className="wp-login__login-block-header-client-name" /> },
 					} ),
 					oldCopy: translate( 'Log in to WordPress.com' ),
 			  } ) as TranslateResult )
@@ -126,10 +90,6 @@ export function getHeaderText(
 	} else if ( currentQuery.lostpassword_flow === 'true' ) {
 		headerText = translate( "You've got mail" );
 	} else if ( oauth2Client ) {
-		if ( isJetpackCloudOAuth2Client( oauth2Client ) ) {
-			headerText = translate( 'Howdy! Log in to Jetpack.com with your WordPress.com account.' );
-		}
-
 		if ( isPartnerPortalOAuth2Client( oauth2Client ) ) {
 			if ( document.location.search?.includes( 'wpcloud' ) ) {
 				headerText = translate( 'Log in to WP Cloud with WordPress.com' );
@@ -158,86 +118,4 @@ export function getHeaderText(
 	}
 
 	return headerText;
-}
-
-export function LoginHeader( {
-	action,
-	currentQuery,
-	fromSite,
-	isFromAkismet,
-	isFromAutomatticForAgenciesPlugin,
-	isGravPoweredLoginPage,
-	isJetpack,
-	isManualRenewalImmediateLoginAttempt,
-	isSocialFirst,
-	isWCCOM,
-	linkingSocialService,
-	oauth2Client,
-	socialConnect,
-	twoStepNonce,
-	isWooJPC,
-	twoFactorAuthType,
-	twoFactorEnabled,
-}: LoginHeaderProps ) {
-	const translate = useTranslate();
-
-	const headerText = getHeaderText(
-		isSocialFirst,
-		twoFactorAuthType,
-		isManualRenewalImmediateLoginAttempt,
-		socialConnect,
-		linkingSocialService,
-		action,
-		oauth2Client,
-		isWooJPC,
-		isJetpack,
-		isWCCOM,
-		isFromAkismet,
-		isFromAutomatticForAgenciesPlugin,
-		true, // isGravPoweredClient is always true
-		twoFactorEnabled,
-		currentQuery,
-		translate,
-		twoStepNonce
-	);
-
-	const preHeader = null;
-	const header = null;
-	let postHeader = null;
-
-	if ( isGravPoweredLoginPage ) {
-		const isFromGravatar3rdPartyApp =
-			isGravatarOAuth2Client( oauth2Client ) && currentQuery?.gravatar_from === '3rd-party';
-		const isFromGravatarQuickEditor =
-			isGravatarOAuth2Client( oauth2Client ) && currentQuery?.gravatar_from === 'quick-editor';
-		const isGravatarFlowWithEmail = !! (
-			isGravatarFlowOAuth2Client( oauth2Client ) && currentQuery?.email_address
-		);
-
-		postHeader = (
-			<p className="login__header-subtitle">
-				{ isFromGravatar3rdPartyApp || isFromGravatarQuickEditor || isGravatarFlowWithEmail
-					? translate( 'Please log in with your email and password.' )
-					: translate(
-							'If you prefer logging in with a password, or a social media account, choose below:'
-					  ) }
-			</p>
-		);
-	} else if ( fromSite ) {
-		// if redirected from Calypso URL with a site slug, offer a link to that site's frontend
-		postHeader = <VisitSite siteSlug={ fromSite } />;
-	}
-
-	return (
-		<div className="login__form-header-wrapper">
-			<GravatarLoginLogo
-				iconUrl={ oauth2Client?.icon }
-				alt={ oauth2Client?.title || '' }
-				isCoBrand={ isGravatarFlowOAuth2Client( oauth2Client ) }
-			/>
-			{ preHeader }
-			<div className="login__form-header">{ header || headerText }</div>
-			{ postHeader }
-		</div>
-	);
 }

--- a/client/login/wp-login/hooks/get-header-text.tsx
+++ b/client/login/wp-login/hooks/get-header-text.tsx
@@ -7,26 +7,52 @@ import {
 	isPartnerPortalOAuth2Client,
 	isVIPOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
+import { getOAuth2Client } from 'calypso/state/oauth2-clients/selectors';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 
-export function getHeaderText(
-	isSocialFirst: boolean,
-	twoFactorAuthType: string | null,
-	isManualRenewalImmediateLoginAttempt: boolean,
-	socialConnect: boolean,
-	linkingSocialService: string,
-	action: string,
-	oauth2Client: { title: string; icon: string; name: string } | null,
-	isWooJPC: boolean,
-	isJetpack: boolean,
-	isWCCOM: boolean,
-	isFromAkismet: boolean,
-	isFromAutomatticForAgenciesPlugin: boolean,
-	isGravPoweredClient: boolean,
-	twoFactorEnabled: boolean,
-	currentQuery: Record< string, string >,
-	translate: ( arg0: string, arg1?: object ) => TranslateResult,
-	twoStepNonce: string | null = null
-): TranslateResult {
+interface Props {
+	twoFactorAuthType: string | null;
+	isManualRenewalImmediateLoginAttempt: boolean;
+	socialConnect: boolean;
+	linkingSocialService: string;
+	action: string;
+	oauth2Client: ReturnType< typeof getOAuth2Client >;
+	twoFactorEnabled: boolean;
+	currentQuery: ReturnType< typeof getCurrentQueryArguments >;
+	translate: ( arg0: string, arg1?: object ) => TranslateResult;
+	isJetpack?: boolean;
+	twoStepNonce?: string | null;
+	isSocialFirst?: boolean;
+	isWooJPC?: boolean;
+	isWCCOM?: boolean;
+	isFromAkismet?: boolean;
+	isFromAutomatticForAgenciesPlugin?: boolean;
+	isGravPoweredClient?: boolean;
+}
+
+/**
+ * This function is used to get the header text for the login page.
+ * TODO: We'll convert this to hook form in the future.
+ */
+export function getHeaderText( {
+	isSocialFirst,
+	twoFactorAuthType,
+	isManualRenewalImmediateLoginAttempt,
+	socialConnect,
+	linkingSocialService,
+	action,
+	oauth2Client,
+	isWooJPC,
+	isJetpack,
+	isWCCOM,
+	isFromAkismet,
+	isFromAutomatticForAgenciesPlugin,
+	isGravPoweredClient,
+	twoFactorEnabled,
+	currentQuery,
+	translate,
+	twoStepNonce,
+}: Props ): TranslateResult {
 	let headerText = translate( 'Log in to your account' );
 
 	if ( isSocialFirst ) {
@@ -87,7 +113,7 @@ export function getHeaderText(
 
 	if ( action === 'lostpassword' ) {
 		headerText = translate( 'Forgot your password?' );
-	} else if ( currentQuery.lostpassword_flow === 'true' ) {
+	} else if ( currentQuery?.lostpassword_flow === 'true' ) {
 		headerText = translate( "You've got mail" );
 	} else if ( oauth2Client ) {
 		if ( isPartnerPortalOAuth2Client( oauth2Client ) ) {

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -358,7 +358,7 @@ export class Login extends Component {
 			</Main>
 		);
 
-		const headerText = getHeaderText(
+		const headerText = getHeaderText( {
 			isSocialFirst,
 			twoFactorAuthType,
 			isManualRenewalImmediateLoginAttempt,
@@ -374,8 +374,8 @@ export class Login extends Component {
 			isGravPoweredClient,
 			twoFactorEnabled,
 			currentQuery,
-			translate
-		);
+			translate,
+		} );
 
 		const shouldUseWideHeading =
 			'lostpassword' !== action &&

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -9,7 +9,6 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import LoginBlock from 'calypso/blocks/login';
-import { getHeaderText } from 'calypso/blocks/login/login-header';
 import DocumentHead from 'calypso/components/data/document-head';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import Main from 'calypso/components/main';
@@ -28,6 +27,7 @@ import {
 } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
+import { getHeaderText } from 'calypso/login/wp-login/hooks/get-header-text';
 import {
 	recordPageViewWithClientId as recordPageView,
 	recordTracksEventWithClientId as recordTracksEvent,

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -937,3 +937,7 @@ $image-height: 47px;
 :root {
 	--login-form-column-max-width: 327px;
 }
+
+.wp-login__login-block-header-client-name {
+	text-transform: capitalize;
+}

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -229,10 +229,6 @@ $image-height: 47px;
 		font-weight: normal;
 	}
 
-	.login__form-header {
-		color: var(--color-neutral-80);
-	}
-
 	.wp-login__main.main {
 		max-width: 476px;
 	}
@@ -309,17 +305,6 @@ $image-height: 47px;
 	// Specificity bump.
 	.layout__content.layout__content {
 		padding: 0;
-	}
-
-	.login__form-header {
-		@include onboarding-heading-text-mobile;
-		margin-bottom: 0;
-		text-align: left;
-
-		@include break-mobile {
-			@include onboarding-heading-text;
-			text-align: center;
-		}
 	}
 
 	.wp-login__container .card {
@@ -488,11 +473,6 @@ $image-height: 47px;
 				text-underline-offset: 5px;
 			}
 		}
-
-		.login__form-header {
-			text-align: center;
-			font-size: $font-title-large;
-		}
 	}
 
 	.wp-login__login-block-footer {
@@ -646,11 +626,11 @@ $image-height: 47px;
 		}
 	}
 
-	.login__form-header-wrapper {
+	.grav-powered-login__form-header-wrapper {
 		text-align: left;
 	}
 
-	.login__form-header {
+	.grav-powered-login__form-header {
 		font-family: "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 		font-size: 32px;
 		font-weight: 900;
@@ -659,7 +639,7 @@ $image-height: 47px;
 		margin: 24px 0;
 	}
 
-	.login__header-subtitle,
+	.grav-powered-login__header-subtitle,
 	.verification-code-form__help-text,
 	.two-factor-authentication__info {
 		margin-bottom: 24px;
@@ -916,7 +896,7 @@ $image-height: 47px;
 			padding: 40px 56px;
 		}
 
-		.login__form-header {
+		.grav-powered-login__form-header {
 			font-size: 40px;
 		}
 

--- a/client/state/oauth2-clients/selectors.js
+++ b/client/state/oauth2-clients/selectors.js
@@ -4,7 +4,7 @@ import 'calypso/state/oauth2-clients/init';
  * Gets the OAuth2 client data.
  * @param  {Object}   state  Global state tree
  * @param  {number} clientId OAuth2 Client ID
- * @returns {Object}          OAuth2 client data
+ * @returns {{ title: string; icon: string; name: string; } | null} OAuth2 client data
  */
 export const getOAuth2Client = ( state, clientId ) => {
 	return state?.oauth2Clients?.clients?.[ clientId ] ?? null;

--- a/client/state/oauth2-clients/ui/selectors.js
+++ b/client/state/oauth2-clients/ui/selectors.js
@@ -14,7 +14,7 @@ export function getCurrentOAuth2ClientId( state ) {
 /**
  * Gets the OAuth2 client data.
  * @param  {Object}   state  Global state tree
- * @returns {Object}          OAuth2 client data
+ * @returns {{ title: string; icon: string; name: string; } | null} OAuth2 client data
  */
 export const getCurrentOAuth2Client = ( state ) => {
 	const currentClientId = getCurrentOAuth2ClientId( state );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13334/clean-up-loginheader-and-top-bar-components-and-styles
Part of https://linear.app/a8c/issue/DOTCOM-13689/login-do-a-cleaner-separation-between-default-and-grav-powered-login

## Proposed Changes

- Cleans up the `LoginHeader` component and related functions.
- In a similar vein to https://github.com/Automattic/wp-calypso/pull/104424 , we separate Gravatar parts cleanly and refactor the rest into function/hook forms. 
  - Slightly wider cleanup here as the `.login__form-header` class was previously heavily customised. It is now only relevant to Gravatar.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13334/clean-up-loginheader-and-top-bar-components-and-styles
Part of https://linear.app/a8c/issue/DOTCOM-13689/login-do-a-cleaner-separation-between-default-and-grav-powered-login

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to [WP Login](http://calypso.localhost:3000/log-in) and confirm no changes
- Go to any of the [client Logins](https://linear.app/a8c/issue/DOTCOM-13220/login-make-the-two-columnwhite-layout-the-default-across-all-contexts) and confirm no changes
- Go to [Gravatar](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D4a5153e30a28e2ef24ca7e599abd80f3969340cd1f88327c1f5d2fbc88593fa1%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1&client_id=1854) and [WP Job Manager](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fclient_id%3D90057%26response_type%3Dcode%26state%3DeyJyZWRpcmVjdF90byI6Imh0dHBzOlwvXC93cGpvYm1hbmFnZXIuY29tXC9teS1hY2NvdW50In0%26redirect_uri%3Dhttps%253A%252F%252Fwpjobmanager.com%252Fwp-json%252Fwpjmcom-auth%252Fv1%252Fcallback%26blog_id%3D0%26from-calypso%3D1&client_id=90057) and confirm no changes (form header should render as expected - per media above). Compare closely with production.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
