### PR TITLE
A4A: Fix incorrect VIP request demo link in the marketplace.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/enterprise-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/enterprise-agency-hosting/index.tsx
@@ -57,7 +57,11 @@ export default function EnterpriseAgencyHosting( { isReferMode }: { isReferMode:
 
 					<Button
 						className="enterprise-agency-hosting__cta-button"
-						href="https://wpvip.com/partner-application/?utm_source=partner&utm_medium=referral&utm_campaign=a4a"
+						href={
+							isReferMode
+								? 'https://wpvip.com/partner-application/?utm_source=partner&utm_medium=referral&utm_campaign=a4a'
+								: 'https://wpvip.com/get-a-demo/?utm_source=partner&utm_medium=referral&utm_campaign=a4a'
+						}
 						onClick={ isReferMode ? onReferClientClick : onRequestDemoClick }
 						target="_blank"
 						variant="primary"


### PR DESCRIPTION
This PR fixes a bug where the **'Request a demo'** button in the Enterprise hosting section redirects to the wrong VIP page.

<img width="545" alt="Screenshot 2025-06-26 at 12 32 22 AM" src="https://github.com/user-attachments/assets/fb74a23f-e688-41b8-bb93-000dcd09f913" />

## Proposed Changes

* Clicking the 'Request a demo' button should redirect to `https://wpvip.com/get-a-demo/?utm_source=partner&utm_medium=referral&utm_campaign=a4a`

## Why are these changes being made?

* Users are not being redirected to the correct page, and we are not assisting them in reaching the right destination.

## Testing Instructions

* Use the A4A live link and navigate to the `/marketplace/hosting/vip` page.
* Click the **'Request a demo'** button.
* Confirm you are redirected to the correct page.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
