### PR TITLE
A4A: Set default PHP version to recommended when provisioning WPCOM site.

### DIFF
--- a/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
@@ -42,7 +42,7 @@ export default function SiteConfigurationsModal( {
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
 	const translate = useTranslate();
 	const dataCenterOptions = getDataCenterOptions();
-	const { phpVersions } = getPHPVersions();
+	const { phpVersions, recommendedValue } = getPHPVersions();
 	const siteName = useSiteName( randomSiteName, isRandomSiteNameLoading );
 	const { mutate: createWPCOMSite } = useCreateWPCOMSiteMutation();
 	const { mutate: createWPCOMDevSite } = useCreateWPCOMDevSiteMutation();
@@ -57,7 +57,11 @@ export default function SiteConfigurationsModal( {
 		}
 
 		return (
-			<option value={ version.value } key={ version.value }>
+			<option
+				value={ version.value }
+				key={ version.value }
+				selected={ version.value === recommendedValue }
+			>
 				{ version.label }
 			</option>
 		);


### PR DESCRIPTION
This PR sets the default PHP version in the WPCOM configuration modal to the recommended version.

<img width="668" alt="Screenshot 2025-06-26 at 12 54 07 AM" src="https://github.com/user-attachments/assets/c9010477-c477-437a-b295-6ab36689fc97" />


Closes https://linear.app/a8c/issue/A4A-1152/confirm-default-php-version-for-new-wpcom-sites-on-a4a

## Proposed Changes

* Use the suggested value from the `getPHPVersions` helper function as the default selected PHP version.

## Why are these changes being made?

* This ensures that our users select the recommended settings when provisioning WPCOM sites.

## Testing Instructions

* Use the A4A live link and navigate to `/marketplace`.
* Purchase a WPCOM license.
* Create a site using the WPCOM license.
* Confirm that the Configuration modal shows that the selected PHP version is the recommended one by default.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
