### PR TITLE
Stats: Remove Ads tab when WordAds is disabled

### DIFF
--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -117,8 +117,8 @@ export const items = withSchemaValidation( sitesSchema, ( state = null, action )
 					memo[ site.ID ] = {
 						...site,
 						...memo[ site.ID ],
-						options: { ...site?.options, ...memo[ site.ID ]?.options },
-						capabilities: { ...site?.capabilities, ...memo[ site.ID ]?.capabilities },
+						options: { ...memo[ site.ID ]?.options, ...site?.options },
+						capabilities: { ...memo[ site.ID ]?.capabilities, ...site?.capabilities },
 					};
 					return memo;
 				},


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

The options and capabilities have to be overridden with the data from the action. Otherwise, some options are not updated (e.g. WordAds).

Part of DOTCOM-13697

## Proposed Changes

* Fix an issue in the reducer for Odyssey Stats

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* bugfix

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use install-plugin.sh odyssey-stats command on your sandbox
* Go to wp-admin/admin.php?page=stats
* Notice that there's no Ads tab
* Go to Tools > Monetize > Ads and enable WordAds
* Go back to wp-admin/admin.php?page=stats and notice that "Ads" tab is displayed
![Screenshot 2025-06-25 at 20 00 01](https://github.com/user-attachments/assets/dbdcdfbe-5724-4098-8dcd-8afbe0672ee2)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
