### PR TITLE
Reader Lists: Update actions to use TypeScript.

### DIFF
--- a/client/reader/list-manage/feed-item.tsx
+++ b/client/reader/list-manage/feed-item.tsx
@@ -83,10 +83,13 @@ export default function FeedItem( props: {
 	const translate = useTranslate();
 
 	const [ showDeleteConfirmation, setShowDeleteConfirmation ] = useState( false );
-	const addItem = () => dispatch( addReaderListFeed( list.ID, owner, list.slug, item.feed_ID ) );
+	const addItem = () =>
+		item.feed_ID && dispatch( addReaderListFeed( list.ID, owner, list.slug, item.feed_ID ) );
 	const deleteItem = ( shouldDelete: boolean ) => {
 		setShowDeleteConfirmation( false );
-		shouldDelete && dispatch( deleteReaderListFeed( list.ID, owner, list.slug, item.feed_ID ) );
+		shouldDelete &&
+			item.feed_ID &&
+			dispatch( deleteReaderListFeed( list.ID, owner, list.slug, item.feed_ID ) );
 	};
 
 	if ( isInList && props.hideIfInList ) {

--- a/client/reader/list-manage/site-item.tsx
+++ b/client/reader/list-manage/site-item.tsx
@@ -78,10 +78,13 @@ export default function SiteItem( props: {
 	);
 
 	const [ showDeleteConfirmation, setShowDeleteConfirmation ] = useState( false );
-	const addItem = () => dispatch( addReaderListSite( list.ID, owner, list.slug, item.site_ID ) );
+	const addItem = () =>
+		item.site_ID && dispatch( addReaderListSite( list.ID, owner, list.slug, item.site_ID ) );
 	const deleteItem = ( shouldDelete: boolean ) => {
 		setShowDeleteConfirmation( false );
-		shouldDelete && dispatch( deleteReaderListSite( list.ID, owner, list.slug, item.site_ID ) );
+		shouldDelete &&
+			item.site_ID &&
+			dispatch( deleteReaderListSite( list.ID, owner, list.slug, item.site_ID ) );
 	};
 
 	if ( isInList && props.hideIfInList ) {

--- a/client/reader/list-manage/tag-item.tsx
+++ b/client/reader/list-manage/tag-item.tsx
@@ -32,18 +32,15 @@ export default function TagItem( props: {
 
 	const [ showDeleteConfirmation, setShowDeleteConfirmation ] = useState( false );
 	const addItem = () =>
-		dispatch( addReaderListTag( list.ID, owner, list.slug, item.meta?.data?.tag?.tag.slug ) );
+		item.meta?.data?.tag?.tag.slug &&
+		dispatch( addReaderListTag( list.ID, owner, list.slug, item.meta.data.tag.tag.slug ) );
 	const deleteItem = ( shouldDelete: boolean ) => {
 		setShowDeleteConfirmation( false );
 		shouldDelete &&
+			item.tag_ID &&
+			item.meta?.data?.tag?.tag.slug &&
 			dispatch(
-				deleteReaderListTag(
-					list.ID,
-					owner,
-					list.slug,
-					item.tag_ID,
-					item.meta?.data?.tag?.tag.slug
-				)
+				deleteReaderListTag( list.ID, owner, list.slug, item.tag_ID, item.meta.data.tag.tag.slug )
 			);
 	};
 

--- a/client/reader/list-manage/types.d.ts
+++ b/client/reader/list-manage/types.d.ts
@@ -6,6 +6,19 @@ export type List = {
 	owner: string;
 	slug: string;
 	title: string;
+	is_immutable?: boolean;
+};
+
+// Flexible version for actions and API calls where some fields might be optional
+export type ReaderList = {
+	ID?: number;
+	title: string;
+	slug: string;
+	description?: string;
+	owner: string;
+	is_owner?: boolean;
+	is_public?: boolean;
+	is_immutable?: boolean;
 };
 
 export type Item = {

--- a/client/state/reader/lists/actions.ts
+++ b/client/state/reader/lists/actions.ts
@@ -35,31 +35,26 @@ import 'calypso/state/data-layer/wpcom/read/lists/tags/delete';
 import 'calypso/state/data-layer/wpcom/read/lists/tags/new';
 import 'calypso/state/data-layer/wpcom/read/lists/feeds/new';
 import 'calypso/state/reader/init';
+import type { ReaderList, Item as ListItem } from 'calypso/reader/list-manage/types';
 
-// Type definitions based on API usage patterns
-interface ReaderList {
-	ID?: number;
-	title: string;
-	slug: string;
-	description?: string;
-	owner: string;
-	is_owner?: boolean;
-	is_public?: boolean;
-	is_immutable?: boolean;
-}
-
+// Local type definitions
 interface ErrorInfo {
 	error: unknown;
 	owner?: string;
 	slug?: string;
 }
 
+interface ReaderListAction {
+	type: string;
+	[ key: string ]: unknown;
+}
+
 /**
  * Returns an action object to signal that list objects have been received.
- * @param  {Array}  lists Lists received
- * @returns {Object}       Action object
+ * @param lists - Lists received
+ * @returns Action object
  */
-export function receiveLists( lists: ReaderList[] ) {
+export function receiveLists( lists: ReaderList[] ): ReaderListAction {
 	return {
 		type: READER_LISTS_RECEIVE,
 		lists,
@@ -68,39 +63,39 @@ export function receiveLists( lists: ReaderList[] ) {
 
 /**
  * Request the current user's subscribed lists.
- * @returns {Object}       Action object
+ * @returns Action object
  */
-export function requestSubscribedLists() {
+export function requestSubscribedLists(): ReaderListAction {
 	return {
 		type: READER_LISTS_REQUEST,
 	};
 }
 
-export function createReaderList( list: ReaderList ) {
+export function createReaderList( list: ReaderList ): ReaderListAction {
 	return { type: READER_LIST_CREATE, list };
 }
 
 /**
  * Request a single Reader list.
- * @param  {string}  listOwner List owner
- * @param  {string}  listSlug List slug
- * @returns {Object}       Action object
+ * @param listOwner - List owner
+ * @param listSlug - List slug
+ * @returns Action object
  */
-export function requestList( listOwner: string, listSlug: string ) {
+export function requestList( listOwner: string, listSlug: string ): ReaderListAction {
 	return { type: READER_LIST_REQUEST, listOwner, listSlug };
 }
 
 /**
  * Receive a single Reader list.
- * @param  {Object}  data List data
- * @param  {Object}  data.list Reader list object
- * @returns {Object}       Action object
+ * @param data - List data
+ * @param data.list - Reader list object
+ * @returns Action object
  */
-export function receiveReaderList( data: { list: ReaderList } ) {
+export function receiveReaderList( data: { list: ReaderList } ): ReaderListAction {
 	return { type: READER_LIST_RECEIVE, data };
 }
 
-export function handleRequestListFailure( errorInfo: ErrorInfo ) {
+export function handleRequestListFailure( errorInfo: ErrorInfo ): ReaderListAction {
 	return {
 		type: READER_LIST_REQUEST_FAILURE,
 		error: errorInfo.error,
@@ -109,14 +104,14 @@ export function handleRequestListFailure( errorInfo: ErrorInfo ) {
 	};
 }
 
-export function receiveCreateReaderList( data: { list: ReaderList } ) {
+export function receiveCreateReaderList( data: { list: ReaderList } ): ReaderListAction {
 	return {
 		type: READER_LIST_CREATE_SUCCESS,
 		data,
 	};
 }
 
-export function handleCreateReaderListFailure( errorInfo: ErrorInfo ) {
+export function handleCreateReaderListFailure( errorInfo: ErrorInfo ): ReaderListAction {
 	return {
 		type: READER_LIST_CREATE_FAILURE,
 		error: errorInfo.error,
@@ -127,11 +122,11 @@ export function handleCreateReaderListFailure( errorInfo: ErrorInfo ) {
 
 /**
  * Follow a list.
- * @param  {string}  listOwner List owner
- * @param  {string}  listSlug List slug
- * @returns {Object}       Action object
+ * @param listOwner - List owner
+ * @param listSlug - List slug
+ * @returns Action object
  */
-export function followList( listOwner: string, listSlug: string ) {
+export function followList( listOwner: string, listSlug: string ): ReaderListAction {
 	return {
 		type: READER_LIST_FOLLOW,
 		listOwner,
@@ -141,10 +136,10 @@ export function followList( listOwner: string, listSlug: string ) {
 
 /**
  * Receive a successful list follow.
- * @param  {Object} list Followed list
- * @returns {Object} Action object
+ * @param list - Followed list
+ * @returns Action object
  */
-export function receiveFollowList( list: ReaderList ) {
+export function receiveFollowList( list: ReaderList ): ReaderListAction {
 	return {
 		type: READER_LIST_FOLLOW_RECEIVE,
 		list,
@@ -153,11 +148,11 @@ export function receiveFollowList( list: ReaderList ) {
 
 /**
  * Unfollow a list.
- * @param  {string}  listOwner List owner
- * @param  {string}  listSlug List slug
- * @returns {Object}       Action object
+ * @param listOwner - List owner
+ * @param listSlug - List slug
+ * @returns Action object
  */
-export function unfollowList( listOwner: string, listSlug: string ) {
+export function unfollowList( listOwner: string, listSlug: string ): ReaderListAction {
 	return {
 		type: READER_LIST_UNFOLLOW,
 		listOwner,
@@ -167,10 +162,10 @@ export function unfollowList( listOwner: string, listSlug: string ) {
 
 /**
  * Receive a successful list unfollow.
- * @param  {Object} list Unfollowed list
- * @returns {Object}    Action object
+ * @param list - Unfollowed list
+ * @returns Action object
  */
-export function receiveUnfollowList( list: ReaderList ) {
+export function receiveUnfollowList( list: ReaderList ): ReaderListAction {
 	return {
 		type: READER_LIST_UNFOLLOW_RECEIVE,
 		list,
@@ -179,14 +174,10 @@ export function receiveUnfollowList( list: ReaderList ) {
 
 /**
  * Triggers a network request to update a list's details.
- * @param   {Object} list List details to save
- * @returns {Object} Action object
+ * @param list - List details to save
+ * @returns Action object
  */
-export function updateReaderList( list: ReaderList ) {
-	if ( ! list || ! list.owner || ! list.slug || ! list.title ) {
-		throw new Error( 'List owner, slug and title are required' );
-	}
-
+export function updateReaderList( list: ReaderList ): ReaderListAction {
 	return {
 		type: READER_LIST_UPDATE,
 		list,
@@ -195,11 +186,11 @@ export function updateReaderList( list: ReaderList ) {
 
 /**
  * Handle updated list object from the API.
- * @param   {Object} data List data
- * @param   {Object} data.list List to save
- * @returns {Object} Action object
+ * @param data - List data
+ * @param data.list - List to save
+ * @returns Action object
  */
-export function receiveUpdatedListDetails( data: { list: ReaderList } ) {
+export function receiveUpdatedListDetails( data: { list: ReaderList } ): ReaderListAction {
 	return {
 		type: READER_LIST_UPDATE_SUCCESS,
 		data,
@@ -208,11 +199,11 @@ export function receiveUpdatedListDetails( data: { list: ReaderList } ) {
 
 /**
  * Handle an error from the list update API.
- * @param   {Error}  error Error during the list update process
- * @param   {Object} list List details to save
- * @returns {Object} Action object
+ * @param error - Error during the list update process
+ * @param list - List details to save
+ * @returns Action object
  */
-export function handleUpdateListDetailsError( error: unknown, list: ReaderList ) {
+export function handleUpdateListDetailsError( error: unknown, list: ReaderList ): ReaderListAction {
 	return {
 		type: READER_LIST_UPDATE_FAILURE,
 		error,
@@ -220,13 +211,19 @@ export function handleUpdateListDetailsError( error: unknown, list: ReaderList )
 	};
 }
 
-export const requestReaderListItems = ( listOwner: string, listSlug: string ) => ( {
+export const requestReaderListItems = (
+	listOwner: string,
+	listSlug: string
+): ReaderListAction => ( {
 	type: READER_LIST_ITEMS_REQUEST,
 	listOwner,
 	listSlug,
 } );
 
-export const receiveReaderListItems = ( listId: number, listItems: unknown ) => ( {
+export const receiveReaderListItems = (
+	listId: number,
+	listItems: ListItem[]
+): ReaderListAction => ( {
 	type: READER_LIST_ITEMS_RECEIVE,
 	listId,
 	listItems,
@@ -237,7 +234,7 @@ export const deleteReaderListFeed = (
 	listOwner: string,
 	listSlug: string,
 	feedId: number
-) => ( {
+): ReaderListAction => ( {
 	type: READER_LIST_ITEM_DELETE_FEED,
 	listId,
 	listOwner,
@@ -250,7 +247,7 @@ export const deleteReaderListSite = (
 	listOwner: string,
 	listSlug: string,
 	siteId: number
-) => ( {
+): ReaderListAction => ( {
 	type: READER_LIST_ITEM_DELETE_SITE,
 	listId,
 	listOwner,
@@ -264,7 +261,7 @@ export const deleteReaderListTag = (
 	listSlug: string,
 	tagId: number,
 	tagSlug: string
-) => ( {
+): ReaderListAction => ( {
 	type: READER_LIST_ITEM_DELETE_TAG,
 	listId,
 	listOwner,
@@ -278,7 +275,7 @@ export const addReaderListFeed = (
 	listOwner: string,
 	listSlug: string,
 	feedId: number
-) => ( {
+): ReaderListAction => ( {
 	type: READER_LIST_ITEM_ADD_FEED,
 	listId,
 	listOwner,
@@ -291,7 +288,7 @@ export const addReaderListFeedByUrl = (
 	listOwner: string,
 	listSlug: string,
 	feedUrl: string
-) => ( {
+): ReaderListAction => ( {
 	type: READER_LIST_ITEM_ADD_FEED,
 	listId,
 	listOwner,
@@ -304,7 +301,7 @@ export const addReaderListSite = (
 	listOwner: string,
 	listSlug: string,
 	siteId: number
-) => ( {
+): ReaderListAction => ( {
 	type: READER_LIST_ITEM_ADD_FEED,
 	listId,
 	listOwner,
@@ -317,7 +314,7 @@ export const addReaderListTag = (
 	listOwner: string,
 	listSlug: string,
 	tagSlug: string
-) => ( {
+): ReaderListAction => ( {
 	type: READER_LIST_ITEM_ADD_TAG,
 	listId,
 	listOwner,
@@ -330,7 +327,7 @@ export const receiveAddReaderListFeed = (
 	listOwner: string,
 	listSlug: string,
 	feedId: number
-) => ( {
+): ReaderListAction => ( {
 	type: READER_LIST_ITEM_ADD_FEED_RECEIVE,
 	listId,
 	listOwner,
@@ -344,7 +341,7 @@ export const receiveAddReaderListTag = (
 	listSlug: string,
 	tagSlug: string,
 	tagId: number
-) => ( {
+): ReaderListAction => ( {
 	type: READER_LIST_ITEM_ADD_TAG_RECEIVE,
 	listId,
 	listOwner,
@@ -353,14 +350,18 @@ export const receiveAddReaderListTag = (
 	tagId,
 } );
 
-export const deleteReaderList = ( listId: number, listOwner: string, listSlug: string ) => ( {
+export const deleteReaderList = (
+	listId: number,
+	listOwner: string,
+	listSlug: string
+): ReaderListAction => ( {
 	type: READER_LIST_DELETE,
 	listId,
 	listOwner,
 	listSlug,
 } );
 
-export function requestUserLists( userLogin: string ) {
+export function requestUserLists( userLogin: string ): ReaderListAction {
 	return {
 		type: READER_USER_LISTS_REQUEST,
 		userLogin,

--- a/client/state/reader/lists/actions.ts
+++ b/client/state/reader/lists/actions.ts
@@ -34,7 +34,6 @@ import 'calypso/state/data-layer/wpcom/read/lists/sites/delete';
 import 'calypso/state/data-layer/wpcom/read/lists/tags/delete';
 import 'calypso/state/data-layer/wpcom/read/lists/tags/new';
 import 'calypso/state/data-layer/wpcom/read/lists/feeds/new';
-import 'calypso/state/data-layer/wpcom/read/lists/recommended-blogs';
 import 'calypso/state/reader/init';
 
 // Type definitions based on API usage patterns

--- a/client/state/reader/lists/actions.ts
+++ b/client/state/reader/lists/actions.ts
@@ -178,6 +178,11 @@ export function receiveUnfollowList( list: ReaderList ): ReaderListAction {
  * @returns Action object
  */
 export function updateReaderList( list: ReaderList ): ReaderListAction {
+	// Validate required properties to prevent runtime errors in JavaScript components
+	if ( ! list || ! list.title || ! list.slug || ! list.owner ) {
+		throw new Error( 'updateReaderList: list must have title, slug, and owner properties' );
+	}
+
 	return {
 		type: READER_LIST_UPDATE,
 		list,

--- a/client/state/reader/lists/actions.ts
+++ b/client/state/reader/lists/actions.ts
@@ -34,14 +34,33 @@ import 'calypso/state/data-layer/wpcom/read/lists/sites/delete';
 import 'calypso/state/data-layer/wpcom/read/lists/tags/delete';
 import 'calypso/state/data-layer/wpcom/read/lists/tags/new';
 import 'calypso/state/data-layer/wpcom/read/lists/feeds/new';
+import 'calypso/state/data-layer/wpcom/read/lists/recommended-blogs';
 import 'calypso/state/reader/init';
+
+// Type definitions based on API usage patterns
+interface ReaderList {
+	ID?: number;
+	title: string;
+	slug: string;
+	description?: string;
+	owner: string;
+	is_owner?: boolean;
+	is_public?: boolean;
+	is_immutable?: boolean;
+}
+
+interface ErrorInfo {
+	error: unknown;
+	owner?: string;
+	slug?: string;
+}
 
 /**
  * Returns an action object to signal that list objects have been received.
  * @param  {Array}  lists Lists received
  * @returns {Object}       Action object
  */
-export function receiveLists( lists ) {
+export function receiveLists( lists: ReaderList[] ) {
 	return {
 		type: READER_LISTS_RECEIVE,
 		lists,
@@ -58,7 +77,7 @@ export function requestSubscribedLists() {
 	};
 }
 
-export function createReaderList( list ) {
+export function createReaderList( list: ReaderList ) {
 	return { type: READER_LIST_CREATE, list };
 }
 
@@ -68,20 +87,21 @@ export function createReaderList( list ) {
  * @param  {string}  listSlug List slug
  * @returns {Object}       Action object
  */
-export function requestList( listOwner, listSlug ) {
+export function requestList( listOwner: string, listSlug: string ) {
 	return { type: READER_LIST_REQUEST, listOwner, listSlug };
 }
 
 /**
  * Receive a single Reader list.
- * @param  {Object}  data List
+ * @param  {Object}  data List data
+ * @param  {Object}  data.list Reader list object
  * @returns {Object}       Action object
  */
-export function receiveReaderList( data ) {
+export function receiveReaderList( data: { list: ReaderList } ) {
 	return { type: READER_LIST_RECEIVE, data };
 }
 
-export function handleRequestListFailure( errorInfo ) {
+export function handleRequestListFailure( errorInfo: ErrorInfo ) {
 	return {
 		type: READER_LIST_REQUEST_FAILURE,
 		error: errorInfo.error,
@@ -90,14 +110,14 @@ export function handleRequestListFailure( errorInfo ) {
 	};
 }
 
-export function receiveCreateReaderList( data ) {
+export function receiveCreateReaderList( data: { list: ReaderList } ) {
 	return {
 		type: READER_LIST_CREATE_SUCCESS,
 		data,
 	};
 }
 
-export function handleCreateReaderListFailure( errorInfo ) {
+export function handleCreateReaderListFailure( errorInfo: ErrorInfo ) {
 	return {
 		type: READER_LIST_CREATE_FAILURE,
 		error: errorInfo.error,
@@ -112,7 +132,7 @@ export function handleCreateReaderListFailure( errorInfo ) {
  * @param  {string}  listSlug List slug
  * @returns {Object}       Action object
  */
-export function followList( listOwner, listSlug ) {
+export function followList( listOwner: string, listSlug: string ) {
 	return {
 		type: READER_LIST_FOLLOW,
 		listOwner,
@@ -125,7 +145,7 @@ export function followList( listOwner, listSlug ) {
  * @param  {Object} list Followed list
  * @returns {Object} Action object
  */
-export function receiveFollowList( list ) {
+export function receiveFollowList( list: ReaderList ) {
 	return {
 		type: READER_LIST_FOLLOW_RECEIVE,
 		list,
@@ -138,7 +158,7 @@ export function receiveFollowList( list ) {
  * @param  {string}  listSlug List slug
  * @returns {Object}       Action object
  */
-export function unfollowList( listOwner, listSlug ) {
+export function unfollowList( listOwner: string, listSlug: string ) {
 	return {
 		type: READER_LIST_UNFOLLOW,
 		listOwner,
@@ -151,7 +171,7 @@ export function unfollowList( listOwner, listSlug ) {
  * @param  {Object} list Unfollowed list
  * @returns {Object}    Action object
  */
-export function receiveUnfollowList( list ) {
+export function receiveUnfollowList( list: ReaderList ) {
 	return {
 		type: READER_LIST_UNFOLLOW_RECEIVE,
 		list,
@@ -163,7 +183,7 @@ export function receiveUnfollowList( list ) {
  * @param   {Object} list List details to save
  * @returns {Object} Action object
  */
-export function updateReaderList( list ) {
+export function updateReaderList( list: ReaderList ) {
 	if ( ! list || ! list.owner || ! list.slug || ! list.title ) {
 		throw new Error( 'List owner, slug and title are required' );
 	}
@@ -176,10 +196,11 @@ export function updateReaderList( list ) {
 
 /**
  * Handle updated list object from the API.
- * @param   {Object} data List to save
+ * @param   {Object} data List data
+ * @param   {Object} data.list List to save
  * @returns {Object} Action object
  */
-export function receiveUpdatedListDetails( data ) {
+export function receiveUpdatedListDetails( data: { list: ReaderList } ) {
 	return {
 		type: READER_LIST_UPDATE_SUCCESS,
 		data,
@@ -192,7 +213,7 @@ export function receiveUpdatedListDetails( data ) {
  * @param   {Object} list List details to save
  * @returns {Object} Action object
  */
-export function handleUpdateListDetailsError( error, list ) {
+export function handleUpdateListDetailsError( error: unknown, list: ReaderList ) {
 	return {
 		type: READER_LIST_UPDATE_FAILURE,
 		error,
@@ -200,19 +221,24 @@ export function handleUpdateListDetailsError( error, list ) {
 	};
 }
 
-export const requestReaderListItems = ( listOwner, listSlug ) => ( {
+export const requestReaderListItems = ( listOwner: string, listSlug: string ) => ( {
 	type: READER_LIST_ITEMS_REQUEST,
 	listOwner,
 	listSlug,
 } );
 
-export const receiveReaderListItems = ( listId, listItems ) => ( {
+export const receiveReaderListItems = ( listId: number, listItems: unknown ) => ( {
 	type: READER_LIST_ITEMS_RECEIVE,
 	listId,
 	listItems,
 } );
 
-export const deleteReaderListFeed = ( listId, listOwner, listSlug, feedId ) => ( {
+export const deleteReaderListFeed = (
+	listId: number,
+	listOwner: string,
+	listSlug: string,
+	feedId: number
+) => ( {
 	type: READER_LIST_ITEM_DELETE_FEED,
 	listId,
 	listOwner,
@@ -220,7 +246,12 @@ export const deleteReaderListFeed = ( listId, listOwner, listSlug, feedId ) => (
 	feedId,
 } );
 
-export const deleteReaderListSite = ( listId, listOwner, listSlug, siteId ) => ( {
+export const deleteReaderListSite = (
+	listId: number,
+	listOwner: string,
+	listSlug: string,
+	siteId: number
+) => ( {
 	type: READER_LIST_ITEM_DELETE_SITE,
 	listId,
 	listOwner,
@@ -228,7 +259,13 @@ export const deleteReaderListSite = ( listId, listOwner, listSlug, siteId ) => (
 	siteId,
 } );
 
-export const deleteReaderListTag = ( listId, listOwner, listSlug, tagId, tagSlug ) => ( {
+export const deleteReaderListTag = (
+	listId: number,
+	listOwner: string,
+	listSlug: string,
+	tagId: number,
+	tagSlug: string
+) => ( {
 	type: READER_LIST_ITEM_DELETE_TAG,
 	listId,
 	listOwner,
@@ -237,7 +274,12 @@ export const deleteReaderListTag = ( listId, listOwner, listSlug, tagId, tagSlug
 	tagSlug,
 } );
 
-export const addReaderListFeed = ( listId, listOwner, listSlug, feedId ) => ( {
+export const addReaderListFeed = (
+	listId: number,
+	listOwner: string,
+	listSlug: string,
+	feedId: number
+) => ( {
 	type: READER_LIST_ITEM_ADD_FEED,
 	listId,
 	listOwner,
@@ -245,7 +287,12 @@ export const addReaderListFeed = ( listId, listOwner, listSlug, feedId ) => ( {
 	feedId,
 } );
 
-export const addReaderListFeedByUrl = ( listId, listOwner, listSlug, feedUrl ) => ( {
+export const addReaderListFeedByUrl = (
+	listId: number,
+	listOwner: string,
+	listSlug: string,
+	feedUrl: string
+) => ( {
 	type: READER_LIST_ITEM_ADD_FEED,
 	listId,
 	listOwner,
@@ -253,7 +300,12 @@ export const addReaderListFeedByUrl = ( listId, listOwner, listSlug, feedUrl ) =
 	feedUrl,
 } );
 
-export const addReaderListSite = ( listId, listOwner, listSlug, siteId ) => ( {
+export const addReaderListSite = (
+	listId: number,
+	listOwner: string,
+	listSlug: string,
+	siteId: number
+) => ( {
 	type: READER_LIST_ITEM_ADD_FEED,
 	listId,
 	listOwner,
@@ -261,7 +313,12 @@ export const addReaderListSite = ( listId, listOwner, listSlug, siteId ) => ( {
 	siteId,
 } );
 
-export const addReaderListTag = ( listId, listOwner, listSlug, tagSlug ) => ( {
+export const addReaderListTag = (
+	listId: number,
+	listOwner: string,
+	listSlug: string,
+	tagSlug: string
+) => ( {
 	type: READER_LIST_ITEM_ADD_TAG,
 	listId,
 	listOwner,
@@ -269,7 +326,12 @@ export const addReaderListTag = ( listId, listOwner, listSlug, tagSlug ) => ( {
 	tagSlug,
 } );
 
-export const receiveAddReaderListFeed = ( listId, listOwner, listSlug, feedId ) => ( {
+export const receiveAddReaderListFeed = (
+	listId: number,
+	listOwner: string,
+	listSlug: string,
+	feedId: number
+) => ( {
 	type: READER_LIST_ITEM_ADD_FEED_RECEIVE,
 	listId,
 	listOwner,
@@ -277,7 +339,13 @@ export const receiveAddReaderListFeed = ( listId, listOwner, listSlug, feedId ) 
 	feedId,
 } );
 
-export const receiveAddReaderListTag = ( listId, listOwner, listSlug, tagSlug, tagId ) => ( {
+export const receiveAddReaderListTag = (
+	listId: number,
+	listOwner: string,
+	listSlug: string,
+	tagSlug: string,
+	tagId: number
+) => ( {
 	type: READER_LIST_ITEM_ADD_TAG_RECEIVE,
 	listId,
 	listOwner,
@@ -286,14 +354,14 @@ export const receiveAddReaderListTag = ( listId, listOwner, listSlug, tagSlug, t
 	tagId,
 } );
 
-export const deleteReaderList = ( listId, listOwner, listSlug ) => ( {
+export const deleteReaderList = ( listId: number, listOwner: string, listSlug: string ) => ( {
 	type: READER_LIST_DELETE,
 	listId,
 	listOwner,
 	listSlug,
 } );
 
-export function requestUserLists( userLogin ) {
+export function requestUserLists( userLogin: string ) {
 	return {
 		type: READER_USER_LISTS_REQUEST,
 		userLogin,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/CML-594/add-recommended-blogs-column-to-subscribers-management-data-view

## Proposed Changes

* Change reader/list/actions.js to a TypeScript file to support changes in https://github.com/Automattic/wp-calypso/pull/104429.
* Add null checks to `list-manage` items to fix Type errors.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Modernize this file and support feature work.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Regression test in Reader > Lists: add and remove sites from your lists.
* Add and remove lists.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
