### PR TITLE
Sites List v2: Determine whether to fetch A8C owned sites via include_a8c_owned parameter

### DIFF
--- a/client/dashboard/app/queries/a8c.ts
+++ b/client/dashboard/app/queries/a8c.ts
@@ -1,7 +1,7 @@
 import { fetchReaderTeams, ReaderTeam } from '../../data/reader-teams';
 
-export const isA8CTeamMemberQuery = () => ( {
-	queryKey: [ 'is-a8c-team-member' ],
+export const isAutomattianQuery = () => ( {
+	queryKey: [ 'me-is-automattian' ],
 	queryFn: fetchReaderTeams,
 	select: ( data: { number: number; teams: ReaderTeam[] } ): boolean =>
 		data.teams.some( ( team: ReaderTeam ) => team.slug === 'a8c' ),

--- a/client/dashboard/app/queries/a8c.ts
+++ b/client/dashboard/app/queries/a8c.ts
@@ -1,7 +1,7 @@
 import { fetchReaderTeams, ReaderTeam } from '../../data/reader-teams';
 
 export const isAutomatticianQuery = () => ( {
-	queryKey: [ 'me-is-automattician' ],
+	queryKey: [ 'me', 'is-automattician' ],
 	queryFn: fetchReaderTeams,
 	select: ( data: { number: number; teams: ReaderTeam[] } ): boolean =>
 		data.teams.some( ( team: ReaderTeam ) => team.slug === 'a8c' ),

--- a/client/dashboard/app/queries/a8c.ts
+++ b/client/dashboard/app/queries/a8c.ts
@@ -1,7 +1,7 @@
 import { fetchReaderTeams, ReaderTeam } from '../../data/reader-teams';
 
-export const isAutomattianQuery = () => ( {
-	queryKey: [ 'me-is-automattian' ],
+export const isAutomatticianQuery = () => ( {
+	queryKey: [ 'me-is-automattician' ],
 	queryFn: fetchReaderTeams,
 	select: ( data: { number: number; teams: ReaderTeam[] } ): boolean =>
 		data.teams.some( ( team: ReaderTeam ) => team.slug === 'a8c' ),

--- a/client/dashboard/app/queries/reader-teams.ts
+++ b/client/dashboard/app/queries/reader-teams.ts
@@ -1,0 +1,8 @@
+import { fetchReaderTeams, ReaderTeam } from '../../data/reader-teams';
+
+export const isA8CTeamMemberQuery = () => ( {
+	queryKey: [ 'is-a8c-team-member' ],
+	queryFn: fetchReaderTeams,
+	select: ( data: { number: number; teams: ReaderTeam[] } ): boolean =>
+		data.teams.some( ( team: ReaderTeam ) => team.slug === 'a8c' ),
+} );

--- a/client/dashboard/app/queries/sites.ts
+++ b/client/dashboard/app/queries/sites.ts
@@ -3,7 +3,7 @@ import { SITE_FIELDS, SITE_OPTIONS } from '../../data/site';
 import type { FetchSitesOptions } from '../../data/me-sites';
 
 export const sitesQuery = (
-	fetchSitesOptions: FetchSitesOptions = { site_visibility: 'visible', include_a8c_owned: false }
+	fetchSitesOptions: FetchSitesOptions = { site_visibility: 'all', include_a8c_owned: true }
 ) => ( {
 	queryKey: [ 'sites', SITE_FIELDS, SITE_OPTIONS, fetchSitesOptions ],
 	queryFn: () => fetchSites( fetchSitesOptions ),

--- a/client/dashboard/app/queries/sites.ts
+++ b/client/dashboard/app/queries/sites.ts
@@ -3,7 +3,7 @@ import { SITE_FIELDS, SITE_OPTIONS } from '../../data/site';
 import type { FetchSitesOptions } from '../../data/me-sites';
 
 export const sitesQuery = (
-	fetchSitesOptions: FetchSitesOptions = { site_visibility: 'visible' }
+	fetchSitesOptions: FetchSitesOptions = { site_visibility: 'visible', include_a8c_owned: false }
 ) => ( {
 	queryKey: [ 'sites', SITE_FIELDS, SITE_OPTIONS, fetchSitesOptions ],
 	queryFn: () => fetchSites( fetchSitesOptions ),

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -20,7 +20,7 @@ import {
 } from '../sites/features';
 import NotFound from './404';
 import UnknownError from './500';
-import { isAutomattianQuery } from './queries/a8c';
+import { isAutomatticianQuery } from './queries/a8c';
 import { domainsQuery } from './queries/domains';
 import { emailsQuery } from './queries/emails';
 import { profileQuery } from './queries/profile';
@@ -76,7 +76,7 @@ const sitesRoute = createRoute( {
 	loader: async () => {
 		await Promise.all( [
 			queryClient.ensureQueryData( sitesQuery() ),
-			queryClient.ensureQueryData( isAutomattianQuery() ),
+			queryClient.ensureQueryData( isAutomatticianQuery() ),
 		] );
 	},
 } ).lazy( () =>

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -20,6 +20,7 @@ import {
 } from '../sites/features';
 import NotFound from './404';
 import UnknownError from './500';
+import { isAutomattianQuery } from './queries/a8c';
 import { domainsQuery } from './queries/domains';
 import { emailsQuery } from './queries/emails';
 import { profileQuery } from './queries/profile';
@@ -72,7 +73,12 @@ const overviewRoute = createRoute( {
 const sitesRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'sites',
-	loader: () => queryClient.ensureQueryData( sitesQuery() ),
+	loader: async () => {
+		await Promise.all( [
+			queryClient.ensureQueryData( sitesQuery() ),
+			queryClient.ensureQueryData( isAutomattianQuery() ),
+		] );
+	},
 } ).lazy( () =>
 	import( '../sites' ).then( ( d ) =>
 		createLazyRoute( 'sites' )( {

--- a/client/dashboard/data/me-sites.ts
+++ b/client/dashboard/data/me-sites.ts
@@ -3,20 +3,25 @@ import { JOINED_SITE_FIELDS, JOINED_SITE_OPTIONS } from './site';
 import type { Site } from './site';
 
 export interface FetchSitesOptions {
+	include_a8c_owned: boolean;
 	site_visibility: 'all' | 'visible' | 'hidden' | 'deleted';
 }
 
-export async function fetchSites( { site_visibility }: FetchSitesOptions ): Promise< Site[] > {
+export async function fetchSites( {
+	include_a8c_owned,
+	site_visibility,
+}: FetchSitesOptions ): Promise< Site[] > {
 	const { sites } = await wpcom.req.get(
 		{
 			path: '/me/sites',
 			apiVersion: '1.2',
 		},
 		{
-			site_visibility,
+			include_a8c_owned,
 			include_domain_only: false,
 			include_redirect: false,
 			site_activity: 'active',
+			site_visibility,
 			fields: JOINED_SITE_FIELDS,
 			options: JOINED_SITE_OPTIONS,
 		}

--- a/client/dashboard/data/me-sites.ts
+++ b/client/dashboard/data/me-sites.ts
@@ -11,6 +11,12 @@ export async function fetchSites( {
 	include_a8c_owned,
 	site_visibility,
 }: FetchSitesOptions ): Promise< Site[] > {
+	// Some P2 sites are not retrievable unless site_visibility is set to 'all'.
+	// See: https://github.com/Automattic/wp-calypso/pull/104220.
+	if ( include_a8c_owned ) {
+		site_visibility = 'all';
+	}
+
 	const { sites } = await wpcom.req.get(
 		{
 			path: '/me/sites',

--- a/client/dashboard/data/me-sites.ts
+++ b/client/dashboard/data/me-sites.ts
@@ -11,12 +11,6 @@ export async function fetchSites( {
 	include_a8c_owned,
 	site_visibility,
 }: FetchSitesOptions ): Promise< Site[] > {
-	// Some P2 sites are not retrievable unless site_visibility is set to 'all'.
-	// See: https://github.com/Automattic/wp-calypso/pull/104220.
-	if ( include_a8c_owned ) {
-		site_visibility = 'all';
-	}
-
 	const { sites } = await wpcom.req.get(
 		{
 			path: '/me/sites',

--- a/client/dashboard/data/reader-teams.ts
+++ b/client/dashboard/data/reader-teams.ts
@@ -1,0 +1,13 @@
+import wpcom from 'calypso/lib/wp';
+
+export interface ReaderTeam {
+	slug: string;
+	title: string;
+}
+
+export async function fetchReaderTeams(): Promise< { number: number; teams: ReaderTeam[] } > {
+	return wpcom.req.get( {
+		path: '/read/teams',
+		apiVersion: '1.2',
+	} );
+}

--- a/client/dashboard/sites/fields.tsx
+++ b/client/dashboard/sites/fields.tsx
@@ -92,7 +92,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 	{
 		id: 'is_a8c',
 		type: 'boolean',
-		label: __( 'Include A8C sites' ),
+		label: __( 'A8C sites only' ),
 		elements: [
 			{ value: true, label: __( 'Yes' ) },
 			{ value: false, label: __( 'No' ) },

--- a/client/dashboard/sites/fields.tsx
+++ b/client/dashboard/sites/fields.tsx
@@ -203,14 +203,14 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 ];
 
 export function getFields( {
-	isAutomattian,
+	isAutomattician,
 	viewType,
 }: {
-	isAutomattian?: boolean;
+	isAutomattician?: boolean;
 	viewType?: string;
 } ) {
 	return DEFAULT_FIELDS.filter( ( field ) => {
-		if ( field.id === 'is_a8c' && ! isAutomattian ) {
+		if ( field.id === 'is_a8c' && ! isAutomattician ) {
 			return false;
 		}
 

--- a/client/dashboard/sites/fields.tsx
+++ b/client/dashboard/sites/fields.tsx
@@ -92,7 +92,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 	{
 		id: 'is_a8c',
 		type: 'boolean',
-		label: __( 'A8C owned' ),
+		label: __( 'Include A8C sites' ),
 		elements: [
 			{ value: true, label: __( 'Yes' ) },
 			{ value: false, label: __( 'No' ) },
@@ -203,14 +203,14 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 ];
 
 export function getFields( {
-	hasA8CSites,
+	isA8CTeamMember,
 	viewType,
 }: {
-	hasA8CSites?: boolean;
+	isA8CTeamMember?: boolean;
 	viewType?: string;
 } ) {
 	return DEFAULT_FIELDS.filter( ( field ) => {
-		if ( field.id === 'is_a8c' && ! hasA8CSites ) {
+		if ( field.id === 'is_a8c' && ! isA8CTeamMember ) {
 			return false;
 		}
 

--- a/client/dashboard/sites/fields.tsx
+++ b/client/dashboard/sites/fields.tsx
@@ -92,10 +92,10 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 	{
 		id: 'is_a8c',
 		type: 'boolean',
-		label: __( 'A8C sites' ),
+		label: __( 'A8C owned' ),
 		elements: [
-			{ value: true, label: __( 'A8C only' ) },
-			{ value: false, label: __( 'Non-A8C only' ) },
+			{ value: true, label: __( 'Yes' ) },
+			{ value: false, label: __( 'No' ) },
 		],
 		filterBy: {
 			operators: [ 'is' as Operator ],

--- a/client/dashboard/sites/fields.tsx
+++ b/client/dashboard/sites/fields.tsx
@@ -203,14 +203,14 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 ];
 
 export function getFields( {
-	isA8CTeamMember,
+	isAutomattian,
 	viewType,
 }: {
-	isA8CTeamMember?: boolean;
+	isAutomattian?: boolean;
 	viewType?: string;
 } ) {
 	return DEFAULT_FIELDS.filter( ( field ) => {
-		if ( field.id === 'is_a8c' && ! isA8CTeamMember ) {
+		if ( field.id === 'is_a8c' && ! isAutomattian ) {
 			return false;
 		}
 

--- a/client/dashboard/sites/fields.tsx
+++ b/client/dashboard/sites/fields.tsx
@@ -92,10 +92,10 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 	{
 		id: 'is_a8c',
 		type: 'boolean',
-		label: __( 'A8C sites only' ),
+		label: __( 'A8C sites' ),
 		elements: [
-			{ value: true, label: __( 'Yes' ) },
-			{ value: false, label: __( 'No' ) },
+			{ value: true, label: __( 'A8C only' ) },
+			{ value: false, label: __( 'Non-A8C only' ) },
 		],
 		filterBy: {
 			operators: [ 'is' as Operator ],

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -5,7 +5,7 @@ import { Button, Modal, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 import { useMemo, useState } from 'react';
-import { isAutomattianQuery } from '../app/queries/a8c';
+import { isAutomatticianQuery } from '../app/queries/a8c';
 import { sitesQuery } from '../app/queries/sites';
 import { sitesRoute } from '../app/router';
 import DataViewsCard from '../components/dataviews-card';
@@ -116,11 +116,11 @@ export default function Sites() {
 	const { data: sites, isLoading: isLoadingSites } = useQuery(
 		sitesQuery( getFetchSitesOptions( viewOptions ) )
 	);
-	const { data: isAutomattian } = useQuery( isAutomattianQuery() );
+	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
 
 	const defaultView = useMemo(
 		() =>
-			isAutomattian
+			isAutomattician
 				? {
 						...DEFAULT_VIEW,
 						filters: [
@@ -132,7 +132,7 @@ export default function Sites() {
 						],
 				  }
 				: DEFAULT_VIEW,
-		[ isAutomattian ]
+		[ isAutomattician ]
 	);
 
 	const view = useMemo(
@@ -149,8 +149,8 @@ export default function Sites() {
 	);
 
 	const fields = useMemo( () => {
-		return getFields( { isAutomattian, viewType: view.type } );
-	}, [ isAutomattian, view.type ] );
+		return getFields( { isAutomattician, viewType: view.type } );
+	}, [ isAutomattician, view.type ] );
 
 	const actions = useMemo( () => {
 		return getDefaultActions( router );

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -93,8 +93,8 @@ const getFetchSitesOptions = (
 	viewOptions: Partial< ViewTable | ViewGrid > | undefined = {}
 ): FetchSitesOptions => {
 	const filters = viewOptions.filters ?? [];
-	const shouldIncludeA8COwned = ! filters.some(
-		( item: Filter ) => item.field === 'is_a8c' && item.value === false
+	const shouldIncludeA8COwned = filters.some(
+		( item: Filter ) => item.field === 'is_a8c' && item.value === true
 	);
 
 	if ( filters.find( ( item: Filter ) => item.field === 'status' && item.value === 'deleted' ) ) {

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -5,7 +5,7 @@ import { Button, Modal, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 import { useMemo, useState } from 'react';
-import { isA8CTeamMemberQuery } from '../app/queries/reader-teams';
+import { isAutomattianQuery } from '../app/queries/a8c';
 import { sitesQuery } from '../app/queries/sites';
 import { sitesRoute } from '../app/router';
 import DataViewsCard from '../components/dataviews-card';
@@ -102,7 +102,9 @@ const getFetchSitesOptions = (
 	}
 
 	return {
-		site_visibility: viewOptions.search ? 'all' : 'visible',
+		// Some P2 sites are not retrievable unless site_visibility is set to 'all'.
+		// See: https://github.com/Automattic/wp-calypso/pull/104220.
+		site_visibility: viewOptions.search || shouldIncludeA8COwned ? 'all' : 'visible',
 		include_a8c_owned: shouldIncludeA8COwned,
 	};
 };
@@ -114,11 +116,11 @@ export default function Sites() {
 	const { data: sites, isLoading: isLoadingSites } = useQuery(
 		sitesQuery( getFetchSitesOptions( viewOptions ) )
 	);
-	const { data: isA8CTeamMember } = useQuery( isA8CTeamMemberQuery() );
+	const { data: isAutomattian } = useQuery( isAutomattianQuery() );
 
 	const defaultView = useMemo(
 		() =>
-			isA8CTeamMember
+			isAutomattian
 				? {
 						...DEFAULT_VIEW,
 						filters: [
@@ -130,7 +132,7 @@ export default function Sites() {
 						],
 				  }
 				: DEFAULT_VIEW,
-		[ isA8CTeamMember ]
+		[ isAutomattian ]
 	);
 
 	const view = useMemo(
@@ -147,8 +149,8 @@ export default function Sites() {
 	);
 
 	const fields = useMemo( () => {
-		return getFields( { isA8CTeamMember, viewType: view.type } );
-	}, [ isA8CTeamMember, view.type ] );
+		return getFields( { isAutomattian, viewType: view.type } );
+	}, [ isAutomattian, view.type ] );
 
 	const actions = useMemo( () => {
 		return getDefaultActions( router );

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -5,6 +5,7 @@ import { Button, Modal, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 import { useMemo, useState } from 'react';
+import { isA8CTeamMemberQuery } from '../app/queries/reader-teams';
 import { sitesQuery } from '../app/queries/sites';
 import { sitesRoute } from '../app/router';
 import DataViewsCard from '../components/dataviews-card';
@@ -91,15 +92,19 @@ const getDefaultActions = ( router: AnyRouter ) => {
 const getFetchSitesOptions = (
 	viewOptions: Partial< ViewTable | ViewGrid > | undefined = {}
 ): FetchSitesOptions => {
-	if (
-		viewOptions.filters?.find(
-			( filter: Filter ) => filter.field === 'status' && filter.value === 'deleted'
-		)
-	) {
-		return { site_visibility: 'deleted' };
+	const filters = viewOptions.filters ?? [];
+	const shouldIncludeA8COwned = ! filters.some(
+		( item: Filter ) => item.field === 'is_a8c' && item.value === false
+	);
+
+	if ( filters.find( ( item: Filter ) => item.field === 'status' && item.value === 'deleted' ) ) {
+		return { site_visibility: 'deleted', include_a8c_owned: shouldIncludeA8COwned };
 	}
 
-	return { site_visibility: viewOptions.search ? 'all' : 'visible' };
+	return {
+		site_visibility: viewOptions.search ? 'all' : 'visible',
+		include_a8c_owned: shouldIncludeA8COwned,
+	};
 };
 
 export default function Sites() {
@@ -109,11 +114,11 @@ export default function Sites() {
 	const { data: sites, isLoading: isLoadingSites } = useQuery(
 		sitesQuery( getFetchSitesOptions( viewOptions ) )
 	);
-	const hasA8CSites = sites?.some( ( site ) => site.is_a8c );
+	const { data: isA8CTeamMember } = useQuery( isA8CTeamMemberQuery() );
 
 	const defaultView = useMemo(
 		() =>
-			hasA8CSites
+			isA8CTeamMember
 				? {
 						...DEFAULT_VIEW,
 						filters: [
@@ -125,7 +130,7 @@ export default function Sites() {
 						],
 				  }
 				: DEFAULT_VIEW,
-		[ hasA8CSites ]
+		[ isA8CTeamMember ]
 	);
 
 	const view = useMemo(
@@ -142,8 +147,8 @@ export default function Sites() {
 	);
 
 	const fields = useMemo( () => {
-		return getFields( { hasA8CSites, viewType: view.type } );
-	}, [ hasA8CSites, view.type ] );
+		return getFields( { isA8CTeamMember, viewType: view.type } );
+	}, [ isA8CTeamMember, view.type ] );
 
 	const actions = useMemo( () => {
 		return getDefaultActions( router );

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -93,8 +93,10 @@ const getFetchSitesOptions = (
 	viewOptions: Partial< ViewTable | ViewGrid > | undefined = {}
 ): FetchSitesOptions => {
 	const filters = viewOptions.filters ?? [];
-	const shouldIncludeA8COwned = filters.some(
-		( item: Filter ) => item.field === 'is_a8c' && item.value === true
+
+	// Include A8C sites unless explicitly excluded from the filter.
+	const shouldIncludeA8COwned = ! filters.some(
+		( item: Filter ) => item.field === 'is_a8c' && item.value === false
 	);
 
 	if ( filters.find( ( item: Filter ) => item.field === 'status' && item.value === 'deleted' ) ) {


### PR DESCRIPTION
Ref DOTDASH-73

## Proposed Changes

The PR 186385-ghe-Automattic/wpcom introduces the include_a8c_owned parameter for /me/sites. This PR updates the logic so that A8C owned sites are fetched only when include_a8c_owned is true.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Sites List v2 development.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Ensure that A8C owned sites are not displayed by default, /me/sites should not include them either
* Set the filter "A8C sites" to true, and now only A8C owned sites should display.
* Remove the filter "A8C sites", and now both A8C and non-A8C owned sites should display.

In short, the filter "A8C sites" work as follows:
* When set to "A8C only", shows only A8C sites.
* When set to "Non-A8C only", shows only non-A8C sites.
* When not set, shows both A8C and non-A8C sites.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?