### PR TITLE
Backport Site Settings: Fix the error and redirection after deleting a site

### DIFF
--- a/client/dashboard/app/queries/site.ts
+++ b/client/dashboard/app/queries/site.ts
@@ -27,7 +27,11 @@ export const siteByIdQuery = ( siteId: number ) => ( {
 export const siteDeleteMutation = ( siteId: number ) => ( {
 	mutationFn: () => deleteSite( siteId ),
 	onSuccess: () => {
-		queryClient.invalidateQueries( siteByIdQuery( siteId ) );
+		// Delay the invalidation for the redirection to complete first
+		window.setTimeout( () => {
+			queryClient.invalidateQueries( siteByIdQuery( siteId ) );
+			queryClient.invalidateQueries( { queryKey: [ 'sites' ] } );
+		}, 1000 );
 	},
 } );
 

--- a/client/sites/v2/site-settings/router.tsx
+++ b/client/sites/v2/site-settings/router.tsx
@@ -36,6 +36,17 @@ import { getRouterOptions, createBrowserHistoryAndMemoryRouterSync } from '../ut
 
 const rootRoute = createRootRoute( { component: Root } );
 
+const dashboardSitesCompatibilityRoute = createRoute( {
+	getParentRoute: () => rootRoute,
+	path: 'sites',
+	beforeLoad: ( { cause } ) => {
+		if ( cause !== 'enter' ) {
+			return;
+		}
+		page.show( '/sites' );
+	},
+} );
+
 const dashboardSiteSettingsCompatibilityRouteRoot = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'sites/$siteSlug/settings',
@@ -301,6 +312,7 @@ const createRouteTree = () =>
 			transferSiteRoute,
 			sftpSshRoute,
 		] ),
+		dashboardSitesCompatibilityRoute,
 		dashboardSiteSettingsCompatibilityRouteRoot,
 		dashboardSiteSettingsCompatibilityRouteWithFeature,
 	] );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of p1750860834019429-slack-CRWCHQGUB

## Proposed Changes

* Fix the error by delaying the query invalidation
* Fix the redirection since the `/sites` route was not registered by backport.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Go to /sites
* Select any site > Settings > Delete site
* Ensure you won't see the error screen
* Ensure the page is redirected to /sites correctly after the deletion

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?