### PR TITLE
A4A > Reports: Add event tracking

### DIFF
--- a/client/a8c-for-agencies/sections/reports/primary/build-report/build-report-actions.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/build-report-actions.tsx
@@ -3,6 +3,8 @@ import { Button } from '@wordpress/components';
 import { addQueryArgs, getQueryArg, removeQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import type { BuildReportState } from '../../types';
 
 interface BuildReportActionsProps {
@@ -21,6 +23,7 @@ export default function BuildReportActions( {
 	handlers,
 }: BuildReportActionsProps ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const [ isSendToClient, setIsSendToClient ] = useState( false );
 
@@ -36,11 +39,13 @@ export default function BuildReportActions( {
 	const { setCurrentStep, handleNextStep, handlePrevStep } = handlers;
 
 	const handleBuildNewReport = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_reports_build_new_after_error_click' ) );
 		page.redirect( removeQueryArgs( window.location.pathname, 'reportId' ) );
 		setCurrentStep( 1 );
-	}, [ setCurrentStep ] );
+	}, [ setCurrentStep, dispatch ] );
 
 	const handleBackToStep2 = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_reports_send_report_back_click' ) );
 		// We need to replace the reportId with the sourceId so that
 		// we can prefill the form with the previous data
 		const currentReportId = getQueryArg( window.location.href, 'reportId' );
@@ -48,7 +53,7 @@ export default function BuildReportActions( {
 		const urlWithSourceId = addQueryArgs( urlWithoutReportId, { sourceId: currentReportId } );
 		page.redirect( urlWithSourceId );
 		setCurrentStep( 2 );
-	}, [ setCurrentStep ] );
+	}, [ setCurrentStep, dispatch ] );
 
 	const isCreatingReport = sendReportMutation.isPending;
 	const isSendingReport = sendReportEmailMutation.isPending;
@@ -56,6 +61,7 @@ export default function BuildReportActions( {
 
 	const handleSendReport = useCallback( () => {
 		if ( reportId ) {
+			dispatch( recordTracksEvent( 'calypso_a4a_reports_send_to_client_now_click' ) );
 			setIsSendToClient( true );
 			sendReportEmailMutation.mutate(
 				{ reportId },
@@ -64,7 +70,7 @@ export default function BuildReportActions( {
 				}
 			);
 		}
-	}, [ reportId, sendReportEmailMutation ] );
+	}, [ reportId, sendReportEmailMutation, dispatch ] );
 
 	const isBusySendingReport = isSendToClient && isSendingReport;
 
@@ -72,19 +78,44 @@ export default function BuildReportActions( {
 		<>
 			{ currentStep < 2 && (
 				<div className="build-report__actions">
-					<Button variant="primary" onClick={ handleNextStep } disabled={ isLoadingState }>
+					<Button
+						variant="primary"
+						onClick={ () => {
+							dispatch(
+								recordTracksEvent( 'calypso_a4a_reports_step_next_click', {
+									from_step: currentStep,
+								} )
+							);
+							handleNextStep();
+						} }
+						disabled={ isLoadingState }
+					>
 						{ translate( 'Next' ) }
 					</Button>
 				</div>
 			) }
 			{ currentStep === 2 && (
 				<div className="build-report__actions">
-					<Button variant="secondary" onClick={ handlePrevStep } disabled={ isLoadingState }>
+					<Button
+						variant="secondary"
+						onClick={ () => {
+							dispatch(
+								recordTracksEvent( 'calypso_a4a_reports_step_back_click', {
+									from_step: currentStep,
+								} )
+							);
+							handlePrevStep();
+						} }
+						disabled={ isLoadingState }
+					>
 						{ translate( 'Back' ) }
 					</Button>
 					<Button
 						variant="primary"
-						onClick={ handleNextStep }
+						onClick={ () => {
+							dispatch( recordTracksEvent( 'calypso_a4a_reports_prepare_report_click' ) );
+							handleNextStep();
+						} }
 						isBusy={ isCreatingReport }
 						disabled={ isLoadingState }
 					>

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/steps/step-1-details.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/steps/step-1-details.tsx
@@ -8,6 +8,8 @@ import {
 import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback } from 'react';
 import A4ASelectSite from 'calypso/a8c-for-agencies/components/a4a-select-site';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { formatDate } from '../../../lib/format-date';
 import { getAvailableTimeframes } from '../../../lib/timeframes';
 import type { StepProps } from './types';
@@ -15,6 +17,7 @@ import type { A4ASelectSiteItem } from 'calypso/a8c-for-agencies/components/a4a-
 
 export default function Step1Details( { formData, state, handlers }: StepProps ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const [ isStartDatePickerOpen, setIsStartDatePickerOpen ] = useState( false );
 	const [ isEndDatePickerOpen, setIsEndDatePickerOpen ] = useState( false );
@@ -75,7 +78,10 @@ export default function Step1Details( { formData, state, handlers }: StepProps )
 				<A4ASelectSite
 					isDisabled={ isLoadingState }
 					selectedSiteId={ selectedSite?.blogId }
-					onSiteSelect={ ( site: A4ASelectSiteItem ) => setSelectedSite( site ) }
+					onSiteSelect={ ( site: A4ASelectSiteItem ) => {
+						dispatch( recordTracksEvent( 'calypso_a4a_reports_select_site_button_click' ) );
+						setSelectedSite( site );
+					} }
 					buttonLabel={ selectedSite?.domain || translate( 'Choose a site to report on' ) }
 					trackingEvent="calypso_a4a_reports_select_site_button_click"
 					data-field="selectedSite"
@@ -91,7 +97,12 @@ export default function Step1Details( { formData, state, handlers }: StepProps )
 				label={ translate( 'Report date range' ) }
 				value={ selectedTimeframe }
 				options={ availableTimeframes }
-				onChange={ setSelectedTimeframe }
+				onChange={ ( value ) => {
+					dispatch(
+						recordTracksEvent( 'calypso_a4a_reports_timeframe_select', { timeframe: value } )
+					);
+					setSelectedTimeframe( value );
+				} }
 				disabled={ isLoadingState }
 			/>
 
@@ -119,6 +130,7 @@ export default function Step1Details( { formData, state, handlers }: StepProps )
 								<DatePicker
 									currentDate={ startDate }
 									onChange={ ( date ) => {
+										dispatch( recordTracksEvent( 'calypso_a4a_reports_custom_start_date_select' ) );
 										setStartDate( date );
 										// If end date is set and is before or equal to the new start date,
 										// set end date to the day after start date
@@ -161,6 +173,7 @@ export default function Step1Details( { formData, state, handlers }: StepProps )
 								<DatePicker
 									currentDate={ endDate }
 									onChange={ ( date ) => {
+										dispatch( recordTracksEvent( 'calypso_a4a_reports_custom_end_date_select' ) );
 										setEndDate( date );
 										setIsEndDatePickerOpen( false );
 									} }
@@ -208,7 +221,12 @@ export default function Step1Details( { formData, state, handlers }: StepProps )
 				__nextHasNoMarginBottom
 				label={ translate( 'Also send to your team' ) }
 				checked={ sendCopyToTeam }
-				onChange={ setSendCopyToTeam }
+				onChange={ ( checked ) => {
+					dispatch(
+						recordTracksEvent( 'calypso_a4a_reports_send_to_team_toggle', { enabled: checked } )
+					);
+					setSendCopyToTeam( checked );
+				} }
 				disabled={ isLoadingState }
 			/>
 			{ sendCopyToTeam && (

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/steps/step-3-send.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/steps/step-3-send.tsx
@@ -1,10 +1,13 @@
 import { Button, Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback } from 'react';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import type { StepProps } from './types';
 
 export default function Step3Send( { state }: StepProps ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const [ isSendPreview, setIsSendPreview ] = useState( false );
 
@@ -13,6 +16,7 @@ export default function Step3Send( { state }: StepProps ) {
 
 	const handleSendPreview = useCallback( () => {
 		if ( reportId ) {
+			dispatch( recordTracksEvent( 'calypso_a4a_reports_send_report_preview_click' ) );
 			setIsSendPreview( true );
 			sendReportEmailMutation.mutate(
 				{ reportId, preview: true },
@@ -21,7 +25,7 @@ export default function Step3Send( { state }: StepProps ) {
 				}
 			);
 		}
-	}, [ reportId, sendReportEmailMutation ] );
+	}, [ reportId, sendReportEmailMutation, dispatch ] );
 
 	const isSendingPreview = isSendPreview && sendReportEmailMutation.isPending;
 


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1172/add-track-events

This PR is built on top of https://github.com/Automattic/wp-calypso/pull/104455

## Proposed Changes

This PR adds event tracking to the reports UI.

## Why are these changes being made?

* To be able to track the events on the reports UI

## Testing Instructions

* Open the A4A live link
* Go to Reports, perform the below actions, and verify the events are being tracked:

1) Click all the buttons on the Overview page
2) Build Report: All fields and button clicks
3) Dashboard: Report details > All actions

<img width="860" alt="Screenshot 2025-06-27 at 3 55 17 PM" src="https://github.com/user-attachments/assets/515e9152-71b2-48ee-92d9-80fdace008a7" />

<img width="860" alt="Screenshot 2025-06-27 at 3 55 19 PM" src="https://github.com/user-attachments/assets/58e60e18-f94f-495f-be69-72fe5fd955ab" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
