### PR TITLE
Sites List v2: Implement restoring notices

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -108,7 +108,8 @@ const getFetchSitesOptions = (
 	return {
 		// Some P2 sites are not retrievable unless site_visibility is set to 'all'.
 		// See: https://github.com/Automattic/wp-calypso/pull/104220.
-		site_visibility: viewOptions.search || shouldIncludeA8COwned || isRestoringAccount ? 'all' : 'visible',
+		site_visibility:
+			viewOptions.search || shouldIncludeA8COwned || isRestoringAccount ? 'all' : 'visible',
 		include_a8c_owned: shouldIncludeA8COwned,
 	};
 };

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -172,10 +172,10 @@ export default function Sites() {
 	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
 
 	const defaultView = useMemo(
-		() =>
-			isAutomattician
+		() => ( {
+			...DEFAULT_VIEW,
+			...( isAutomattician
 				? {
-						...DEFAULT_VIEW,
 						filters: [
 							{
 								field: 'is_a8c',
@@ -184,14 +184,16 @@ export default function Sites() {
 							},
 						],
 				  }
-				: DEFAULT_VIEW,
-		[ isAutomattician ]
+				: {} ),
+			...( isRestoringAccount ? { type: 'table' as const } : {} ),
+		} ),
+		[ isAutomattician, isRestoringAccount ]
 	);
 
 	const view = useMemo(
 		() => ( {
 			...defaultView,
-			...DEFAULT_LAYOUTS[ viewOptions?.type ?? DEFAULT_VIEW.type ],
+			...DEFAULT_LAYOUTS[ viewOptions?.type ?? defaultView.type ],
 			...( viewOptions
 				? Object.fromEntries(
 						Object.entries( viewOptions ).filter( ( [ , v ] ) => v !== undefined )

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -1,7 +1,8 @@
 import { DataViews, filterSortAndPaginate } from '@automattic/dataviews';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate, useRouter } from '@tanstack/react-router';
-import { Button, Modal, Icon } from '@wordpress/components';
+import { __experimentalVStack as VStack, Button, Modal, Icon } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 import { useMemo, useState } from 'react';
@@ -9,6 +10,8 @@ import { isAutomatticianQuery } from '../app/queries/a8c';
 import { sitesQuery } from '../app/queries/sites';
 import { sitesRoute } from '../app/router';
 import DataViewsCard from '../components/dataviews-card';
+import InlineSupportLink from '../components/inline-support-link';
+import Notice from '../components/notice';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
 import AddNewSite from './add-new-site';
@@ -90,7 +93,8 @@ const getDefaultActions = ( router: AnyRouter ) => {
 };
 
 const getFetchSitesOptions = (
-	viewOptions: Partial< ViewTable | ViewGrid > | undefined = {}
+	viewOptions: Partial< ViewTable | ViewGrid > | undefined = {},
+	isRestoringAccount: boolean = false
 ): FetchSitesOptions => {
 	const filters = viewOptions.filters ?? [];
 
@@ -106,17 +110,64 @@ const getFetchSitesOptions = (
 	return {
 		// Some P2 sites are not retrievable unless site_visibility is set to 'all'.
 		// See: https://github.com/Automattic/wp-calypso/pull/104220.
-		site_visibility: viewOptions.search || shouldIncludeA8COwned ? 'all' : 'visible',
+		site_visibility: viewOptions.search || shouldIncludeA8COwned || isRestoringAccount ? 'all' : 'visible',
 		include_a8c_owned: shouldIncludeA8COwned,
 	};
+};
+
+// We still need to implement MigrationPendingNotice and A8CForAgencies.
+// See client/sites/components/sites-dashboard-banners-manager.tsx.
+const SitesNotices = () => {
+	const navigate = useNavigate( { from: sitesRoute.fullPath } );
+	const currentSearchParams = sitesRoute.useSearch();
+	const isRestoringAccount = !! currentSearchParams.restored;
+
+	const notices = [
+		isRestoringAccount && (
+			<Notice
+				title={ __( 'Choose which sites you’d like to restore' ) }
+				onClose={ () =>
+					navigate( {
+						search: {
+							...currentSearchParams,
+							restored: undefined,
+						},
+						replace: true,
+					} )
+				}
+			>
+				{ createInterpolateElement(
+					__(
+						'<restoreSiteLink>Restore sites</restoreSiteLink> from the action menu. You’ll also need to <invitePeopleLink>invite any users</invitePeopleLink> that previously had access to your sites.'
+					),
+					{
+						restoreSiteLink: <InlineSupportLink supportContext="restore-site" />,
+						invitePeopleLink: <InlineSupportLink supportContext="invite-people" />,
+					}
+				) }
+			</Notice>
+		),
+	].filter( ( value ) => !! value );
+
+	if ( ! notices.length ) {
+		return null;
+	}
+
+	return (
+		<VStack className="sites-notices" spacing={ 6 }>
+			{ notices }
+		</VStack>
+	);
 };
 
 export default function Sites() {
 	const navigate = useNavigate( { from: sitesRoute.fullPath } );
 	const router = useRouter();
-	const viewOptions: Partial< ViewTable | ViewGrid > | undefined = sitesRoute.useSearch().view;
+	const currentSearchParams = sitesRoute.useSearch();
+	const viewOptions: Partial< ViewTable | ViewGrid > | undefined = currentSearchParams.view;
+	const isRestoringAccount = !! currentSearchParams.restored;
 	const { data: sites, isLoading: isLoadingSites } = useQuery(
-		sitesQuery( getFetchSitesOptions( viewOptions ) )
+		sitesQuery( getFetchSitesOptions( viewOptions, isRestoringAccount ) )
 	);
 	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
 
@@ -185,6 +236,7 @@ export default function Sites() {
 					/>
 				}
 			>
+				<SitesNotices />
 				<DataViewsCard>
 					<DataViews< Site >
 						getItemId={ ( item ) => item.ID.toString() }
@@ -200,6 +252,7 @@ export default function Sites() {
 							const _defaultView = { ...defaultView, ...DEFAULT_LAYOUTS[ view.type ] };
 							navigate( {
 								search: {
+									...currentSearchParams,
 									view: Object.fromEntries(
 										Object.entries( view ).filter( ( [ key, value ] ) => {
 											return value !== _defaultView[ key as keyof typeof _defaultView ];

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -1,8 +1,7 @@
 import { DataViews, filterSortAndPaginate } from '@automattic/dataviews';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate, useRouter } from '@tanstack/react-router';
-import { __experimentalVStack as VStack, Button, Modal, Icon } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
+import { Button, Modal, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 import { useMemo, useState } from 'react';
@@ -10,13 +9,12 @@ import { isAutomatticianQuery } from '../app/queries/a8c';
 import { sitesQuery } from '../app/queries/sites';
 import { sitesRoute } from '../app/router';
 import DataViewsCard from '../components/dataviews-card';
-import InlineSupportLink from '../components/inline-support-link';
-import Notice from '../components/notice';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
 import AddNewSite from './add-new-site';
 import { canManageSite } from './features';
 import { getFields } from './fields';
+import { SitesNotices } from './notices';
 import type { FetchSitesOptions, Site } from '../data/types';
 import type { Operator, SortDirection, ViewTable, ViewGrid, Filter } from '@automattic/dataviews';
 import type { AnyRouter } from '@tanstack/react-router';
@@ -113,51 +111,6 @@ const getFetchSitesOptions = (
 		site_visibility: viewOptions.search || shouldIncludeA8COwned || isRestoringAccount ? 'all' : 'visible',
 		include_a8c_owned: shouldIncludeA8COwned,
 	};
-};
-
-// We still need to implement MigrationPendingNotice and A8CForAgencies.
-// See client/sites/components/sites-dashboard-banners-manager.tsx.
-const SitesNotices = () => {
-	const navigate = useNavigate( { from: sitesRoute.fullPath } );
-	const currentSearchParams = sitesRoute.useSearch();
-	const isRestoringAccount = !! currentSearchParams.restored;
-
-	const notices = [
-		isRestoringAccount && (
-			<Notice
-				title={ __( 'Choose which sites you’d like to restore' ) }
-				onClose={ () =>
-					navigate( {
-						search: {
-							...currentSearchParams,
-							restored: undefined,
-						},
-						replace: true,
-					} )
-				}
-			>
-				{ createInterpolateElement(
-					__(
-						'<restoreSiteLink>Restore sites</restoreSiteLink> from the action menu. You’ll also need to <invitePeopleLink>invite any users</invitePeopleLink> that previously had access to your sites.'
-					),
-					{
-						restoreSiteLink: <InlineSupportLink supportContext="restore-site" />,
-						invitePeopleLink: <InlineSupportLink supportContext="invite-people" />,
-					}
-				) }
-			</Notice>
-		),
-	].filter( ( value ) => !! value );
-
-	if ( ! notices.length ) {
-		return null;
-	}
-
-	return (
-		<VStack className="sites-notices" spacing={ 6 }>
-			{ notices }
-		</VStack>
-	);
 };
 
 export default function Sites() {

--- a/client/dashboard/sites/notices.tsx
+++ b/client/dashboard/sites/notices.tsx
@@ -6,7 +6,7 @@ import { sitesRoute } from '../app/router';
 import InlineSupportLink from '../components/inline-support-link';
 import Notice from '../components/notice';
 
-const RestoringAccountNotices = ( { onClose }: { onClose?: () => void } ) => {
+const RestoringSitesNotices = ( { onClose }: { onClose?: () => void } ) => {
 	return (
 		<Notice title={ __( 'Choose which sites you’d like to restore' ) } onClose={ onClose }>
 			{ createInterpolateElement(
@@ -22,36 +22,31 @@ const RestoringAccountNotices = ( { onClose }: { onClose?: () => void } ) => {
 	);
 };
 
-// We still need to implement MigrationPendingNotice and A8CForAgenciesNotice.
+// We still need to implement MigrationPendingNotice and A8CForAgenciesNotice,
+// and then display the first available notice.
 // See client/sites/components/sites-dashboard-banners-manager.tsx.
 export const SitesNotices = () => {
 	const navigate = useNavigate( { from: sitesRoute.fullPath } );
 	const currentSearchParams = sitesRoute.useSearch();
 	const isRestoringAccount = !! currentSearchParams.restored;
 
-	const notices = [
-		isRestoringAccount && (
-			<RestoringAccountNotices
-				onClose={ () =>
-					navigate( {
-						search: {
-							...currentSearchParams,
-							restored: undefined,
-						},
-						replace: true,
-					} )
-				}
-			/>
-		),
-	].filter( ( value ) => !! value );
-
-	if ( ! notices.length ) {
-		return null;
+	if ( isRestoringAccount ) {
+		return (
+			<VStack className="sites-notices">
+				<RestoringSitesNotices
+					onClose={ () =>
+						navigate( {
+							search: {
+								...currentSearchParams,
+								restored: undefined,
+							},
+							replace: true,
+						} )
+					}
+				/>
+			</VStack>
+		);
 	}
 
-	return (
-		<VStack className="sites-notices" spacing={ 6 }>
-			{ notices }
-		</VStack>
-	);
+	return null;
 };

--- a/client/dashboard/sites/notices.tsx
+++ b/client/dashboard/sites/notices.tsx
@@ -1,0 +1,57 @@
+import { useNavigate } from '@tanstack/react-router';
+import { __experimentalVStack as VStack } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { sitesRoute } from '../app/router';
+import InlineSupportLink from '../components/inline-support-link';
+import Notice from '../components/notice';
+
+const RestoringAccountNotices = ( { onClose }: { onClose?: () => void } ) => {
+	return (
+		<Notice title={ __( 'Choose which sites you’d like to restore' ) } onClose={ onClose }>
+			{ createInterpolateElement(
+				__(
+					'<restoreSiteLink>Restore sites</restoreSiteLink> from the action menu. You’ll also need to <invitePeopleLink>invite any users</invitePeopleLink> that previously had access to your sites.'
+				),
+				{
+					restoreSiteLink: <InlineSupportLink supportContext="restore-site" />,
+					invitePeopleLink: <InlineSupportLink supportContext="invite-people" />,
+				}
+			) }
+		</Notice>
+	);
+};
+
+// We still need to implement MigrationPendingNotice and A8CForAgenciesNotice.
+// See client/sites/components/sites-dashboard-banners-manager.tsx.
+export const SitesNotices = () => {
+	const navigate = useNavigate( { from: sitesRoute.fullPath } );
+	const currentSearchParams = sitesRoute.useSearch();
+	const isRestoringAccount = !! currentSearchParams.restored;
+
+	const notices = [
+		isRestoringAccount && (
+			<RestoringAccountNotices
+				onClose={ () =>
+					navigate( {
+						search: {
+							...currentSearchParams,
+							restored: undefined,
+						},
+						replace: true,
+					} )
+				}
+			/>
+		),
+	].filter( ( value ) => !! value );
+
+	if ( ! notices.length ) {
+		return null;
+	}
+
+	return (
+		<VStack className="sites-notices" spacing={ 6 }>
+			{ notices }
+		</VStack>
+	);
+};

--- a/client/sites/components/sites-dashboard-banners/use-restore-sites-reminder-banner.tsx
+++ b/client/sites/components/sites-dashboard-banners/use-restore-sites-reminder-banner.tsx
@@ -1,7 +1,8 @@
-import { NoticeBanner } from '@automattic/components';
-import { translate } from 'i18n-calypso';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import Notice from 'calypso/dashboard/components/notice';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 import './styles.scss';
@@ -29,27 +30,26 @@ export function useRestoreSitesBanner() {
 		},
 		render() {
 			return (
-				<NoticeBanner
-					title={ translate( 'Choose which sites you’d like to restore' ) }
-					onClose={ dismissNotice }
-					level="info"
-				>
-					<div>
-						{ translate(
-							"{{restoreSiteLink}}Restore sites{{/restoreSiteLink}} from the action menu. You'll also need to {{invitePeopleLink}}invite any users{{/invitePeopleLink}} that previously had access to your sites.",
+				<div style={ { width: '100%' } }>
+					<Notice
+						title={ __( 'Choose which sites you’d like to restore' ) }
+						onClose={ dismissNotice }
+					>
+						{ createInterpolateElement(
+							__(
+								'<restoreSiteLink>Restore sites</restoreSiteLink> from the action menu. You’ll also need to <invitePeopleLink>invite any users</invitePeopleLink> that previously had access to your sites.'
+							),
 							{
-								components: {
-									restoreSiteLink: (
-										<InlineSupportLink showIcon={ false } supportContext="restore-site" />
-									),
-									invitePeopleLink: (
-										<InlineSupportLink showIcon={ false } supportContext="invite-people" />
-									),
-								},
+								restoreSiteLink: (
+									<InlineSupportLink showIcon={ false } supportContext="restore-site" />
+								),
+								invitePeopleLink: (
+									<InlineSupportLink showIcon={ false } supportContext="invite-people" />
+								),
 							}
 						) }
-					</div>
-				</NoticeBanner>
+					</Notice>
+				</div>
 			);
 		},
 	};

--- a/client/sites/v2/sites-list/style.scss
+++ b/client/sites/v2/sites-list/style.scss
@@ -6,6 +6,7 @@
 
 	.dashboard-page-layout {
 		height: 100%;
+		max-width: 100% !important; // Override the max-width on backport.
 		justify-content: flex-start;
 		align-self: center;
 		margin: 0;

--- a/client/sites/v2/sites-list/style.scss
+++ b/client/sites/v2/sites-list/style.scss
@@ -25,6 +25,10 @@
 		padding: 0;
 	}
 
+	.sites-notices {
+		display: none;
+	}
+
 	.dataviews-wrapper {
 		iframe {
 			max-width: unset;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9502, https://github.com/Automattic/wp-calypso/pull/104069#issuecomment-2957537224
Fixes DOTCOM-13564

## Proposed Changes

* Implement restoring notices on dashboard v2

<img width="480" alt="image" src="https://github.com/user-attachments/assets/5559295c-7852-446d-a62f-bb4f606703f9" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2/sites?restored=true
* Ensure you can see the restoring notice
* Ensure the restoring notice is still there when you change the view options of the dataview
* Ensure the restoring notice can be dismissed
* Ensure you can see the deleted sites
* Go to /sites?restored=true&flags=dashboard/v2/backport/sites-list (the backport sites list)
* Ensure you can see the v1 banners. Keep using the v1 banners because v2 doesn't have migration pending banner and a4a banner

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?