### PR TITLE
A4A > Reports: Report builder accessibility improvements

### DIFF
--- a/client/a8c-for-agencies/sections/reports/controller.tsx
+++ b/client/a8c-for-agencies/sections/reports/controller.tsx
@@ -17,7 +17,7 @@ export const reportsOverviewContext: Callback = ( context, next ) => {
 	context.secondary = <ReportsSidebar path={ context.path } />;
 	context.primary = (
 		<>
-			<PageViewTracker title="Reports  > Overview" path={ context.path } />
+			<PageViewTracker title="Reports > Overview" path={ context.path } />
 			<ReportsOverview />
 		</>
 	);

--- a/client/a8c-for-agencies/sections/reports/lib/stat-options.tsx
+++ b/client/a8c-for-agencies/sections/reports/lib/stat-options.tsx
@@ -7,7 +7,7 @@ export const getStatsOptions = (
 	return [
 		{ label: translate( 'Visitors and Views in this timeframe' ), value: 'total_traffic' },
 		{ label: translate( 'Top 5 posts' ), value: 'top_pages' },
-		{ label: translate( 'Top 5 referrers' ), value: 'top_devices' },
+		{ label: translate( 'Top 5 referrers' ), value: 'top_referrers' },
 		{ label: translate( 'Top 5 cities' ), value: 'top_locations' },
 		{ label: translate( 'Device breakdown' ), value: 'device_breakdown' },
 		{

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/steps/step-1-details.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/steps/step-1-details.tsx
@@ -70,7 +70,7 @@ export default function Step1Details( { formData, state, handlers }: StepProps )
 
 	return (
 		<>
-			<h2 className="build-report__step-title">
+			<h2 className="build-report__step-title" aria-current="step">
 				{ translate( 'Step 1 of 3: Enter report details' ) }
 			</h2>
 
@@ -85,9 +85,18 @@ export default function Step1Details( { formData, state, handlers }: StepProps )
 					buttonLabel={ selectedSite?.domain || translate( 'Choose a site to report on' ) }
 					trackingEvent="calypso_a4a_reports_select_site_button_click"
 					data-field="selectedSite"
+					aria-required="true"
+					aria-describedby="selected-site-error"
 				/>
 				{ hasFieldError( 'selectedSite' ) && (
-					<div className="build-report__error-message">{ getFieldError( 'selectedSite' ) }</div>
+					<div
+						role="alert"
+						id="selected-site-error"
+						aria-live="polite"
+						className="build-report__error-message"
+					>
+						{ getFieldError( 'selectedSite' ) }
+					</div>
 				) }
 			</div>
 
@@ -114,18 +123,31 @@ export default function Step1Details( { formData, state, handlers }: StepProps )
 							__nextHasNoMarginBottom
 							id="start-date"
 							label={ translate( 'Start date' ) }
+							aria-label={ translate( 'Start date' ) }
 							value={ formatDate( startDate ) }
 							placeholder={ translate( 'Select start date' ) }
 							onChange={ () => {} }
 							onClick={ () => setIsStartDatePickerOpen( true ) }
+							onKeyDown={ ( event ) => {
+								if ( event.key === 'Enter' || event.key === ' ' ) {
+									event.preventDefault();
+									setIsStartDatePickerOpen( true );
+								}
+							} }
 							readOnly
 							className="build-report__date-input"
+							role="button"
+							aria-expanded={ isStartDatePickerOpen }
+							aria-haspopup="dialog"
 						/>
 						{ isStartDatePickerOpen && (
 							<Popover
 								onClose={ () => setIsStartDatePickerOpen( false ) }
 								placement="bottom-start"
 								className="build-report__date-popover"
+								onFocusOutside={ () => setIsStartDatePickerOpen( false ) }
+								role="dialog"
+								aria-label={ translate( 'Start date picker' ) }
 							>
 								<DatePicker
 									currentDate={ startDate }
@@ -161,14 +183,26 @@ export default function Step1Details( { formData, state, handlers }: StepProps )
 							placeholder={ translate( 'Select end date' ) }
 							onChange={ () => {} }
 							onClick={ () => setIsEndDatePickerOpen( true ) }
+							onKeyDown={ ( event ) => {
+								if ( event.key === 'Enter' || event.key === ' ' ) {
+									event.preventDefault();
+									setIsEndDatePickerOpen( true );
+								}
+							} }
 							readOnly
 							className="build-report__date-input"
+							role="button"
+							aria-expanded={ isEndDatePickerOpen }
+							aria-haspopup="dialog"
 						/>
 						{ isEndDatePickerOpen && (
 							<Popover
 								onClose={ () => setIsEndDatePickerOpen( false ) }
 								placement="bottom-start"
 								className="build-report__date-popover"
+								onFocusOutside={ () => setIsEndDatePickerOpen( false ) }
+								role="dialog"
+								aria-label={ translate( 'End date picker' ) }
 							>
 								<DatePicker
 									currentDate={ endDate }
@@ -212,9 +246,19 @@ export default function Step1Details( { formData, state, handlers }: StepProps )
 					}
 					data-field="clientEmail"
 					disabled={ isLoadingState }
+					aria-required="true"
+					aria-describedby="client-email-error"
+					aria-invalid={ hasFieldError( 'clientEmail' ) }
 				/>
 				{ hasFieldError( 'clientEmail' ) && (
-					<div className="build-report__error-message">{ getFieldError( 'clientEmail' ) }</div>
+					<div
+						role="alert"
+						id="client-email-error"
+						aria-live="polite"
+						className="build-report__error-message"
+					>
+						{ getFieldError( 'clientEmail' ) }
+					</div>
 				) }
 			</div>
 			<CheckboxControl
@@ -246,9 +290,19 @@ export default function Step1Details( { formData, state, handlers }: StepProps )
 						placeholder={ translate( 'colleague1@example.com, colleague2@example.com' ) }
 						data-field="teammateEmails"
 						disabled={ isLoadingState }
+						aria-required="true"
+						aria-describedby="teammate-emails-error"
+						aria-invalid={ hasFieldError( 'teammateEmails' ) }
 					/>
 					{ hasFieldError( 'teammateEmails' ) && (
-						<div className="build-report__error-message">{ getFieldError( 'teammateEmails' ) }</div>
+						<div
+							role="alert"
+							id="teammate-emails-error"
+							aria-live="polite"
+							className="build-report__error-message"
+						>
+							{ getFieldError( 'teammateEmails' ) }
+						</div>
 					) }
 				</div>
 			) }

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/steps/step-2-content.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/steps/step-2-content.tsx
@@ -1,6 +1,8 @@
 import { CheckboxControl, TextareaControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLegend from 'calypso/components/forms/form-legend';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getStatsOptions } from '../../../lib/stat-options';
@@ -59,7 +61,7 @@ export default function Step2Content( { formData, state, handlers }: StepProps )
 
 	return (
 		<>
-			<h2 className="build-report__step-title">
+			<h2 className="build-report__step-title" aria-current="step">
 				{ translate( 'Step 2 of 3: Choose report content' ) }
 			</h2>
 
@@ -79,20 +81,33 @@ export default function Step2Content( { formData, state, handlers }: StepProps )
 				disabled={ isLoadingState }
 			/>
 
-			<h3 className="build-report__group-label">{ translate( 'Stats' ) }</h3>
-			{ statsOptions.map( ( item ) => (
-				<CheckboxControl
-					__nextHasNoMarginBottom
-					key={ item.value }
-					label={ item.label }
-					checked={ statsCheckedItems[ item.value ] }
-					onChange={ () => handleStep2CheckboxChange( item.value ) }
-					disabled={ isLoadingState }
-				/>
-			) ) }
-			{ hasFieldError( 'statsCheckedItems' ) && (
-				<div className="build-report__error-message">{ getFieldError( 'statsCheckedItems' ) }</div>
-			) }
+			<FormFieldset className="build-report__stats-fieldset">
+				<FormLegend className="build-report__group-label">{ translate( 'Stats' ) }</FormLegend>
+				{ statsOptions.map( ( item ) => (
+					<CheckboxControl
+						__nextHasNoMarginBottom
+						key={ item.value }
+						label={ item.label }
+						checked={ statsCheckedItems[ item.value ] }
+						onChange={ () => handleStep2CheckboxChange( item.value ) }
+						disabled={ isLoadingState }
+						aria-describedby={
+							hasFieldError( 'statsCheckedItems' ) ? 'stats-checked-items-error' : undefined
+						}
+					/>
+				) ) }
+				{ hasFieldError( 'statsCheckedItems' ) && (
+					<div
+						role="alert"
+						id="stats-checked-items-error"
+						aria-live="polite"
+						className="build-report__error-message"
+					>
+						{ getFieldError( 'statsCheckedItems' ) }
+					</div>
+				) }
+			</FormFieldset>
+
 			<p className="build-report__step-note">
 				{ translate( 'Preview, confirm, and send to your client in the next step.' ) }
 			</p>

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/steps/step-3-send.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/steps/step-3-send.tsx
@@ -33,11 +33,19 @@ export default function Step3Send( { state }: StepProps ) {
 		if ( isReportPending ) {
 			return (
 				<>
-					<h2 className="build-report__step-title">
+					<h2 className="build-report__step-title" aria-current="step">
 						{ translate( 'Step 3 of 3: Preparing your report' ) }
 					</h2>
-					<p className="build-report__loading-state build-report__content-description">
-						<Spinner /> { translate( 'Please wait while we prepare your report…' ) }
+					<p
+						className="build-report__loading-state build-report__content-description"
+						role="status"
+						aria-live="polite"
+						aria-label={ translate( 'Please wait while we prepare your report…' ) }
+					>
+						<Spinner aria-hidden="true" />
+						<span aria-hidden="true">
+							{ translate( 'Please wait while we prepare your report…' ) }
+						</span>
 					</p>
 				</>
 			);
@@ -46,10 +54,10 @@ export default function Step3Send( { state }: StepProps ) {
 		if ( isReportErrorStatus ) {
 			return (
 				<>
-					<h2 className="build-report__step-title">
+					<h2 className="build-report__step-title" aria-current="step">
 						{ translate( 'Step 3 of 3: Report preparation failed' ) }
 					</h2>
-					<p className="build-report__step-description">
+					<p className="build-report__step-description" role="alert" aria-live="assertive">
 						{ translate( 'There was an error preparing your report.' ) }
 					</p>
 				</>
@@ -59,16 +67,17 @@ export default function Step3Send( { state }: StepProps ) {
 		if ( isProcessed ) {
 			return (
 				<>
-					<h2 className="build-report__step-title">
+					<h2 className="build-report__step-title" aria-current="step">
 						{ translate( 'Step 3 of 3: Send your report' ) }
 					</h2>
 
-					<p className="build-report__step-description">
-						{ translate(
-							'Your report is ready for sending. Checkout the preview, then click "Send to client now".'
-						) }
-						<br />
-						{ translate( "We'll take it from there!" ) }
+					<p className="build-report__step-description" role="status" aria-live="polite">
+						<span>
+							{ translate(
+								'Your report is ready for sending. Checkout the preview, then click "Send to client now".'
+							) }
+						</span>
+						<span>{ translate( "We'll take it from there!" ) }</span>
 					</p>
 					<Button
 						variant="secondary"
@@ -87,11 +96,11 @@ export default function Step3Send( { state }: StepProps ) {
 	}
 	return (
 		<>
-			<h2 className="build-report__step-title">
+			<h2 className="build-report__step-title" aria-current="step">
 				{ translate( 'Step 3 of 3: Unknown report status' ) }
 			</h2>
 
-			<p className="build-report__step-description">
+			<p className="build-report__step-description" role="alert" aria-live="assertive">
 				{ translate( 'There was an error preparing your report.' ) }
 			</p>
 		</>

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/style.scss
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/style.scss
@@ -27,10 +27,14 @@
 		@include body-medium;
 		color: var( --color-neutral-70 );
 		margin-block-end: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
 	}
 
 	.build-report__group-label {
 		@include heading-medium;
+		margin-block-end: 16px;
 	}
 
 	// Fixing margins from StyledHelp-deprecatedMarginHelp which is being inserted by the component
@@ -135,4 +139,10 @@
 	@include body-small;
 	color: var(--color-neutral-50);
 	margin-block: 0.5rem -0.5rem;
+}
+
+.build-report__stats-fieldset {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
 }


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1194/report-builder-improve-accessibilty

## Proposed Changes

This PR adds accessibility improvements to the report builder.

## Why are these changes being made?

* To improve the accessibility of the report builder.

## Testing Instructions

* Open the A4A live link
* Go to Reports > Click the `Build a new report` button > Test the accessibility of all three steps.

You can use the built-in VoiceOver tool on Mac by activating it using the Cmd + F5 keys. Also, you can use the keyboard to navigate.

Step 1: 

- Click the `Next` button > Verify all the validation errors are announced.
- Select the custom timeframe, and you can use the keyboard to navigate and the `Voiceover` tool announces the necessary messages. 

Step 2:

- Unselect all the checkboxes and click the `Prepare report` button > Verify the error message is announced.

Step 3:

- Ensure the current status is announced here

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
