### PR TITLE
Help Center: Open users support links in HC

### DIFF
--- a/client/my-sites/people/subscribers-team/index.tsx
+++ b/client/my-sites/people/subscribers-team/index.tsx
@@ -68,6 +68,7 @@ function SubscribersTeam( props: Props ) {
 							learnMore: (
 								<InlineSupportLink
 									showIcon={ false }
+									supportPostId={ 1221 }
 									supportLink={ localizeUrl( 'https://wordpress.com/support/invite-people/' ) }
 								/>
 							),

--- a/client/my-sites/people/team-invite/invite-form.tsx
+++ b/client/my-sites/people/team-invite/invite-form.tsx
@@ -8,6 +8,7 @@ import { useDebouncedCallback } from 'use-debounce';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextarea from 'calypso/components/forms/form-textarea';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import ContractorSelect from 'calypso/my-sites/people/contractor-select';
 import RoleSelect from 'calypso/my-sites/people/role-select';
 import { useSelector, useDispatch } from 'calypso/state';
@@ -157,16 +158,16 @@ function InviteForm( props: Props ) {
 	 */
 	function getRoleLearnMoreLink() {
 		return (
-			<Button
-				className="team-invite-form-learn-more__link"
-				plain
-				target="_blank"
-				href={ localizeUrl( 'https://wordpress.com/support/user-roles/' ) }
+			<InlineSupportLink
+				showIcon={ false }
+				supportPostId={ 226531 }
+				supportLink={ localizeUrl( 'https://wordpress.com/support/user-roles/' ) }
 			>
 				{ translate( 'Learn more' ) }
-			</Button>
+			</InlineSupportLink>
 		);
 	}
+	q;
 
 	return (
 		<form

--- a/client/my-sites/people/team-invite/invite-form.tsx
+++ b/client/my-sites/people/team-invite/invite-form.tsx
@@ -167,7 +167,6 @@ function InviteForm( props: Props ) {
 			</InlineSupportLink>
 		);
 	}
-	q;
 
 	return (
 		<form


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
- [DOTSUP-62](https://linear.app/a8c/issue/DOTSUP-62/open-users-support-links-in-help-center)

## Proposed Changes

* The support links shown on the users' administration screens now open the link in the Help Center instead of opening the post in a new tab.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* These changes are part of our efforts to improve the Help Center.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link
* Go to: https://{container}/people/team/{site_slug}
* The `Learn more` link should open in the Help Center
![Screenshot 2025-06-26 at 13 39 36](https://github.com/user-attachments/assets/5fe742f6-7e61-4a8f-a621-b34a177e05d0)
* Go to: https://{container}/people/new/{site_slug}
* When adding a new user, the link below the selector should open in the HC
* Switch between different user roles and check that the links open in the HC. 
![Screenshot 2025-06-26 at 13 39 25](https://github.com/user-attachments/assets/8ecc25c8-c754-4308-9e41-60b84ec34c69)

 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
