### PR TITLE
Site list v2: default to grid view of total sites is <= 10

### DIFF
--- a/client/dashboard/sites/views.tsx
+++ b/client/dashboard/sites/views.tsx
@@ -1,0 +1,96 @@
+import type { User } from '../data/types';
+import type {
+	Operator,
+	SortDirection,
+	View,
+	ViewTable,
+	ViewGrid,
+	SupportedLayouts,
+} from '@automattic/dataviews';
+
+export const DEFAULT_LAYOUTS: SupportedLayouts = {
+	table: {
+		mediaField: 'icon.ico',
+		fields: [ 'status', 'visitors', 'subscribers_count', 'wp_version' ],
+		titleField: 'name',
+		descriptionField: 'URL',
+	},
+	grid: {
+		mediaField: 'preview',
+		fields: [ 'status' ],
+		titleField: 'name',
+		descriptionField: 'URL',
+	},
+};
+
+const DEFAULT_PER_PAGE = 10;
+
+const DEFAULT_VIEW = {
+	page: 1,
+	perPage: DEFAULT_PER_PAGE,
+	sort: { field: 'name', direction: 'asc' as SortDirection },
+	search: '',
+} as View;
+
+function getDefaultView( {
+	user,
+	isAutomattician,
+	isRestoringAccount,
+}: {
+	user: User;
+	isAutomattician?: boolean;
+	isRestoringAccount?: boolean;
+} ): View {
+	const defaultView = { ...DEFAULT_VIEW };
+
+	if ( isAutomattician ) {
+		defaultView.filters = [
+			{
+				field: 'is_a8c',
+				operator: 'is' as Operator,
+				value: false,
+			},
+		];
+	}
+
+	if ( isRestoringAccount || user.site_count > DEFAULT_PER_PAGE ) {
+		defaultView.type = 'table' as const;
+	} else {
+		defaultView.type = 'grid' as const;
+	}
+
+	return {
+		...defaultView,
+		...DEFAULT_LAYOUTS[ defaultView.type ],
+	} as View;
+}
+
+export function getView( {
+	user,
+	isAutomattician,
+	isRestoringAccount,
+	viewOptions,
+}: {
+	user: User;
+	isAutomattician?: boolean;
+	isRestoringAccount?: boolean;
+	viewOptions?: Partial< ViewTable | ViewGrid >;
+} ): {
+	defaultView: View;
+	view: View;
+} {
+	const defaultView = getDefaultView( { user, isAutomattician, isRestoringAccount } );
+
+	return {
+		defaultView,
+		view: {
+			...defaultView,
+			...DEFAULT_LAYOUTS[ viewOptions?.type ?? defaultView.type ],
+			...( viewOptions
+				? Object.fromEntries(
+						Object.entries( viewOptions ).filter( ( [ , v ] ) => v !== undefined )
+				  )
+				: {} ),
+		} as View,
+	};
+}

--- a/client/dashboard/sites/views.tsx
+++ b/client/dashboard/sites/views.tsx
@@ -30,7 +30,7 @@ const DEFAULT_VIEW = {
 	perPage: DEFAULT_PER_PAGE,
 	sort: { field: 'name', direction: 'asc' as SortDirection },
 	search: '',
-} as View;
+} as Partial< View >;
 
 function getDefaultView( {
 	user,
@@ -41,7 +41,13 @@ function getDefaultView( {
 	isAutomattician?: boolean;
 	isRestoringAccount?: boolean;
 } ): View {
-	const defaultView = { ...DEFAULT_VIEW };
+	const type = isRestoringAccount || user.site_count > DEFAULT_PER_PAGE ? 'table' : 'grid';
+
+	const defaultView = {
+		type,
+		...DEFAULT_VIEW,
+		...DEFAULT_LAYOUTS[ type ],
+	} as View;
 
 	if ( isAutomattician ) {
 		defaultView.filters = [
@@ -53,16 +59,7 @@ function getDefaultView( {
 		];
 	}
 
-	if ( isRestoringAccount || user.site_count > DEFAULT_PER_PAGE ) {
-		defaultView.type = 'table' as const;
-	} else {
-		defaultView.type = 'grid' as const;
-	}
-
-	return {
-		...defaultView,
-		...DEFAULT_LAYOUTS[ defaultView.type ],
-	} as View;
+	return defaultView;
 }
 
 export function getView( {
@@ -81,18 +78,13 @@ export function getView( {
 } {
 	const defaultView = getDefaultView( { user, isAutomattician, isRestoringAccount } );
 
-	let view = { ...defaultView };
-	if ( viewOptions ) {
-		if ( viewOptions.type ) {
-			view = { ...view, ...DEFAULT_LAYOUTS[ viewOptions.type ] } as View;
-		}
-		view = {
-			...view,
-			...Object.fromEntries(
-				Object.entries( viewOptions ).filter( ( [ , v ] ) => v !== undefined )
-			),
-		};
-	}
+	const view = {
+		...defaultView,
+		...DEFAULT_LAYOUTS[ viewOptions?.type ?? defaultView.type ],
+		...Object.fromEntries(
+			Object.entries( viewOptions ?? {} ).filter( ( [ , v ] ) => v !== undefined )
+		),
+	} as View;
 
 	return { defaultView, view };
 }

--- a/client/dashboard/sites/views.tsx
+++ b/client/dashboard/sites/views.tsx
@@ -81,16 +81,18 @@ export function getView( {
 } {
 	const defaultView = getDefaultView( { user, isAutomattician, isRestoringAccount } );
 
-	return {
-		defaultView,
-		view: {
-			...defaultView,
-			...DEFAULT_LAYOUTS[ viewOptions?.type ?? defaultView.type ],
-			...( viewOptions
-				? Object.fromEntries(
-						Object.entries( viewOptions ).filter( ( [ , v ] ) => v !== undefined )
-				  )
-				: {} ),
-		} as View,
-	};
+	let view = { ...defaultView };
+	if ( viewOptions ) {
+		if ( viewOptions.type ) {
+			view = { ...view, ...DEFAULT_LAYOUTS[ viewOptions.type ] } as View;
+		}
+		view = {
+			...view,
+			...Object.fromEntries(
+				Object.entries( viewOptions ).filter( ( [ , v ] ) => v !== undefined )
+			),
+		};
+	}
+
+	return { defaultView, view };
 }


### PR DESCRIPTION
Fixes DOTDASH-87

## Proposed Changes

This PR makes it so that if the user has <= 10 sites (i.e., the number of items in one page in DataViews), we show the grid view in `/v2/sites` by default. Otherwise we show table.

## Why are these changes being made?

To optimize the default view.

## Testing Instructions

Verify the above statement for user accounts with <= 10 and > 10 sites. If you don't have such users, you can modify `user.site_count` manually before:

https://github.com/Automattic/wp-calypso/blob/9a393e0dab54ea608eb47bc73d63345b95a0db76/client/dashboard/app/auth/index.tsx#L48 

Play around with pagination, layout switcher etc; verify no regression.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
