### PR TITLE
STATS-43: Handle unicode archive types in UI.

### DIFF
--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -1188,6 +1188,43 @@ describe( 'utils', () => {
 					},
 				] );
 			} );
+
+			test( 'should properly parse unicode archive types', () => {
+				const statsArchivesNormalized = normalizers.statsArchives(
+					{
+						date: '2025-06-02',
+						period: 'day',
+						summary: {
+							cat: [
+								{
+									href: 'http://jetpack.com/category/rrr/',
+									value: '%E5%A4%A9%E9%B8%BD',
+									views: 51,
+								},
+							],
+							tax: {
+								topics: [
+									{
+										href: 'http://jetpack.com/?taxonomy=topics&term=aaa',
+										value: '%E9%B8%A6',
+										views: 6,
+									},
+								],
+							},
+						},
+					},
+					{
+						period: 'day',
+						start_date: '2025-06-01',
+						date: '2025-06-02',
+						summarize: 1,
+						max: 10,
+					}
+				);
+
+				expect( statsArchivesNormalized[ 0 ].children[ 0 ].label ).toEqual( '天鸽' );
+				expect( statsArchivesNormalized[ 1 ].children[ 0 ].children[ 0 ].label ).toEqual( '鸦' );
+			} );
 		} );
 
 		describe( 'statsCountryViews()', () => {

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -3,6 +3,7 @@ import { sortBy, camelCase, get, filter, map, flatten, capitalize } from 'lodash
 import moment from 'moment';
 import { PUBLICIZE_SERVICES_LABEL_ICON } from './constants';
 
+/** @type ( key: string ) => string */
 function getArchiveKeyLabel( key ) {
 	const archiveKeyLabelMap = {
 		author: translate( 'Authors' ),
@@ -448,7 +449,7 @@ export const normalizers = {
 							totalTaxViews += item.views;
 
 							return {
-								label: item.value,
+								label: decodeURIComponent( item.value ),
 								value: item.views,
 								link: item.href,
 							};
@@ -484,7 +485,9 @@ export const normalizers = {
 							totalViews += item.views;
 
 							return {
-								label: [ 'home' ].includes( archiveKey ) ? item.href : item.value,
+								label: [ 'home' ].includes( archiveKey )
+									? item.href
+									: decodeURIComponent( item.value ),
 								value: item.views,
 								link: item.href,
 							};

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -22,6 +22,15 @@ function getArchiveKeyLabel( key ) {
 	return archiveKeyLabelMap[ key ] ?? capitalize( key );
 }
 
+/** @type ( str: string ) => string */
+function decodeUriEncoding( str ) {
+	try {
+		return decodeURIComponent( str );
+	} catch ( _ ) {
+		return str;
+	}
+}
+
 /**
  * Returns a string of the moment format for the period. Supports store stats
  * isoWeek and shortened formats.
@@ -449,7 +458,7 @@ export const normalizers = {
 							totalTaxViews += item.views;
 
 							return {
-								label: decodeURIComponent( item.value ),
+								label: decodeUriEncoding( item.value ),
 								value: item.views,
 								link: item.href,
 							};
@@ -487,7 +496,7 @@ export const normalizers = {
 							return {
 								label: [ 'home' ].includes( archiveKey )
 									? item.href
-									: decodeURIComponent( item.value ),
+									: decodeUriEncoding( item.value ),
 								value: item.views,
 								link: item.href,
 							};


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #STATS-43

## Proposed Changes

* Archive types can contain unicode characters which are URL-encoded. So, decode before displaying them.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Same as above

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a category called '天鸽` (or any other unicode string) in your wordpress site.
* Assign a post to this category.
* Visit your category listing `http://YOUR_SITE/category/天鸽` to increase view count. Visit in incognito mode if necessary.
* The unicode category type should appear properly in the traffic page under stats plugin.

| Before | After |
|--------|--------|
| <img width="475" alt="image" src="https://github.com/user-attachments/assets/691fe895-c3d9-47f3-8efa-1f59897f5ad2" /> | <img width="599" alt="image" src="https://github.com/user-attachments/assets/e444b928-ddee-487d-9242-e715ed1415c0" /> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
