### PR TITLE
Reader Discover: Add compact layout for subscriptions.

### DIFF
--- a/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
@@ -318,16 +318,14 @@ const SiteSubscriptionRow = ( {
 					</ExternalLink>
 				</span>
 			</span>
-			{ ! isCompactLayout && (
-				<span className="date-cell" role="cell">
-					<TimeSince
-						date={
-							( date_subscribed.valueOf() ? date_subscribed : new Date( 0 ) ).toISOString?.() ??
-							date_subscribed
-						}
-					/>
-				</span>
-			) }
+			<span className="date-cell" role="cell">
+				<TimeSince
+					date={
+						( date_subscribed.valueOf() ? date_subscribed : new Date( 0 ) ).toISOString?.() ??
+						date_subscribed
+					}
+				/>
+			</span>
 			{ isLoggedIn && ! isCompactLayout && (
 				<span className="new-posts-cell" role="cell">
 					<SelectedNewPostDeliveryMethods

--- a/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
@@ -64,7 +64,9 @@ const SelectedNewPostDeliveryMethods = ( {
 	return <>{ selectedNewPostDeliveryMethods }</>;
 };
 
-type SiteRowProps = Reader.SiteSubscriptionsResponseItem;
+type SiteRowProps = Reader.SiteSubscriptionsResponseItem & {
+	layout?: 'full' | 'compact';
+};
 
 const scrollToFirstRow = () => {
 	const firstRow = document.querySelector( '.site-subscriptions-list li.site-subscription-row' );
@@ -91,9 +93,12 @@ const SiteSubscriptionRow = ( {
 	isDeleted,
 	is_rss,
 	resubscribed,
+	layout = 'full',
 }: SiteRowProps ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+
+	const isCompactLayout = layout === 'compact';
 
 	const unsubscribeInProgress = useRef( false );
 	const resubscribePending = useRef( false );
@@ -313,15 +318,17 @@ const SiteSubscriptionRow = ( {
 					</ExternalLink>
 				</span>
 			</span>
-			<span className="date-cell" role="cell">
-				<TimeSince
-					date={
-						( date_subscribed.valueOf() ? date_subscribed : new Date( 0 ) ).toISOString?.() ??
-						date_subscribed
-					}
-				/>
-			</span>
-			{ isLoggedIn && (
+			{ ! isCompactLayout && (
+				<span className="date-cell" role="cell">
+					<TimeSince
+						date={
+							( date_subscribed.valueOf() ? date_subscribed : new Date( 0 ) ).toISOString?.() ??
+							date_subscribed
+						}
+					/>
+				</span>
+			) }
+			{ isLoggedIn && ! isCompactLayout && (
 				<span className="new-posts-cell" role="cell">
 					<SelectedNewPostDeliveryMethods
 						isEmailMeNewPostsSelected={ !! delivery_methods.email?.send_posts }
@@ -329,7 +336,7 @@ const SiteSubscriptionRow = ( {
 					/>
 				</span>
 			) }
-			{ isLoggedIn && (
+			{ isLoggedIn && ! isCompactLayout && (
 				<span className="new-comments-cell" role="cell">
 					<InfoPopover
 						position="top"

--- a/client/landing/subscriptions/components/site-subscriptions-list/site-subscriptions-list.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-subscriptions-list.tsx
@@ -8,17 +8,21 @@ import './styles/site-subscriptions-list.scss';
 type SiteSubscriptionsListProps = {
 	emptyComponent?: React.ComponentType;
 	notFoundComponent?: React.ComponentType;
+	layout?: 'full' | 'compact';
 };
 
 const SiteSubscriptionsList: React.FC< SiteSubscriptionsListProps > = ( {
 	emptyComponent: EmptyComponent,
 	notFoundComponent: NotFoundComponent,
+	layout = 'full',
 } ) => {
 	const translate = useTranslate();
 	const { isLoggedIn } = SubscriptionManager.useIsLoggedIn();
 	const { filterOption, searchTerm } = SubscriptionManager.useSiteSubscriptionsQueryProps();
 	const { data, isLoading, error } = SubscriptionManager.useSiteSubscriptionsQuery();
 	const { subscriptions, totalCount } = data;
+
+	const isCompactLayout = layout === 'compact';
 
 	if ( error ) {
 		return (
@@ -69,15 +73,17 @@ const SiteSubscriptionsList: React.FC< SiteSubscriptionsListProps > = ( {
 				<span className="title-cell" role="columnheader">
 					{ translate( 'Subscribed site' ) }
 				</span>
-				<span className="date-cell" role="columnheader">
-					{ translate( 'Since' ) }
-				</span>
-				{ isLoggedIn && (
+				{ ! isCompactLayout && (
+					<span className="date-cell" role="columnheader">
+						{ translate( 'Since' ) }
+					</span>
+				) }
+				{ isLoggedIn && ! isCompactLayout && (
 					<span className="new-posts-cell" role="columnheader">
 						{ translate( 'New posts' ) }
 					</span>
 				) }
-				{ isLoggedIn && (
+				{ isLoggedIn && ! isCompactLayout && (
 					<span className="new-comments-cell" role="columnheader">
 						{ translate( 'New comments' ) }
 					</span>
@@ -93,6 +99,7 @@ const SiteSubscriptionsList: React.FC< SiteSubscriptionsListProps > = ( {
 			{ subscriptions.map( ( siteSubscription ) => (
 				<SiteSubscriptionRow
 					key={ `sites.siteRow.${ siteSubscription.ID }` }
+					layout={ layout }
 					{ ...siteSubscription }
 				/>
 			) ) }

--- a/client/landing/subscriptions/components/site-subscriptions-list/site-subscriptions-list.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-subscriptions-list.tsx
@@ -68,7 +68,12 @@ const SiteSubscriptionsList: React.FC< SiteSubscriptionsListProps > = ( {
 	}
 
 	return (
-		<ul className="site-subscriptions-list" role="table">
+		<ul
+			className={ `site-subscriptions-list${
+				isCompactLayout ? ' site-subscriptions-list--compact' : ''
+			}` }
+			role="table"
+		>
 			<HStack className="row header" role="row" as="li" alignment="center">
 				<span className="title-cell" role="columnheader">
 					{ translate( 'Subscribed site' ) }

--- a/client/landing/subscriptions/components/site-subscriptions-list/site-subscriptions-list.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-subscriptions-list.tsx
@@ -73,11 +73,9 @@ const SiteSubscriptionsList: React.FC< SiteSubscriptionsListProps > = ( {
 				<span className="title-cell" role="columnheader">
 					{ translate( 'Subscribed site' ) }
 				</span>
-				{ ! isCompactLayout && (
-					<span className="date-cell" role="columnheader">
-						{ translate( 'Since' ) }
-					</span>
-				) }
+				<span className="date-cell" role="columnheader">
+					{ translate( 'Since' ) }
+				</span>
 				{ isLoggedIn && ! isCompactLayout && (
 					<span className="new-posts-cell" role="columnheader">
 						{ translate( 'New posts' ) }

--- a/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list.scss
+++ b/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list.scss
@@ -113,6 +113,13 @@
 		}
 	}
 
+	// Compact layout adjustments
+	.discover-add-new & {
+		.title-cell {
+			flex: 2.5; // Give more space to title in compact layout
+		}
+	}
+
 	@media (max-width: $break-xlarge) {
 		.new-comments-cell {
 			display: none;

--- a/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list.scss
+++ b/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list.scss
@@ -116,7 +116,7 @@
 	// Compact layout adjustments
 	.discover-add-new & {
 		.title-cell {
-			flex: 2.5; // Give more space to title in compact layout
+			flex: 2; // Give more space to title in compact layout
 		}
 	}
 

--- a/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list.scss
+++ b/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list.scss
@@ -114,7 +114,7 @@
 	}
 
 	// Compact layout adjustments
-	.discover-add-new & {
+	&.site-subscriptions-list--compact {
 		.title-cell {
 			flex: 2; // Give more space to title in compact layout
 		}

--- a/client/reader/discover/components/add-new/index.tsx
+++ b/client/reader/discover/components/add-new/index.tsx
@@ -59,7 +59,7 @@ const DiscoverAddNew = () => {
 						<h2 className="discover-add-new__subscriptions-title">
 							{ translate( 'Your subscriptions' ) }
 						</h2>
-						<SiteSubscriptionsList />
+						<SiteSubscriptionsList layout="compact" />
 					</div>
 				) }
 			</SubscriptionManagerContextProvider>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/CML-594/add-recommended-blogs-column-to-subscribers-management-data-view

## Proposed Changes

* Add a compact layout prop for the subscriptions list on Discover > Add New, so that future columns like Recommend don't cause overlaps.

Before | After
---- | ----
<img width="753" alt="Screenshot 2025-06-26 at 2 25 59 PM" src="https://github.com/user-attachments/assets/a2e3f101-770c-4cf7-88b6-89c818c5bfdf" /> | <img width="777" alt="Screenshot 2025-06-26 at 2 25 47 PM" src="https://github.com/user-attachments/assets/f4cd948d-4e71-4c66-879e-82369527064c" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the UI and prevent column overlap, which we'll see when adding the "Recommend" column without this change.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /discover/add-new
* Verify that you can see the Subscribed site, Since, Email frequency, Action, and three dots columns. New posts and New comments should no longer be visible.
* Test at different screen sizes.
* Go to /reader/subscriptions and regression test that nothing's changed.
* Go to /subscriptions/sites and regression test that nothing's changed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
