### PR TITLE
Domains: Remove domain expired/expiring sidebar nudges

### DIFF
--- a/client/my-sites/current-site/domain-warnings.jsx
+++ b/client/my-sites/current-site/domain-warnings.jsx
@@ -11,10 +11,6 @@ import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 const allowedRules = [
 	'unverifiedDomainsCanManage',
 	'unverifiedDomainsCannotManage',
-	'expiredDomainsCanManage',
-	'expiringDomainsCanManage',
-	'expiredDomainsCannotManage',
-	'expiringDomainsCannotManage',
 	'wrongNSMappedDomains',
 	'pendingGSuiteTosAcceptanceDomains',
 	'transferStatus',


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/NOMADO-191/remove-domain-expiringexpired-sidebar-nudges

## Proposed Changes

This PR removes the domain expired/expiring sidebar nudges:

| Before | After |
| --- | --- |
|  <img width="1276" alt="Screenshot 2025-06-26 at 19 37 50" src="https://github.com/user-attachments/assets/21d268de-815f-4ceb-a7aa-bd5fea6dde2d" /> |  <img width="1280" alt="Screenshot 2025-06-26 at 19 50 52" src="https://github.com/user-attachments/assets/efebc422-26bc-4667-9ab5-3c51bbd66e71" /> |

## Why are these changes being made?

As reported in this Slack thread  (p1750974557476989-slack-C04H4NY6STW), they can stack in an awkward way with other upsells, so they should be removed until we have a better alternative.

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Open a site in which you have a domain that's close to its expiration date or already expired
- Ensure the domain notices aren't shown in the sidebar

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
