### PR TITLE
Reword payment section in promote-post to avoid confusion

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -1428,7 +1428,7 @@ export default function CampaignItemDetails( props: Props ) {
 												<div className="campaign-item-details__weekly-label"></div>
 												<div className="campaign-item-details__weekly-duration">
 													<span className="campaign-item-details__label">
-														{ translate( 'Duration' ) }
+														{ translate( 'Payment Date' ) }
 													</span>
 												</div>
 												<div className="campaign-item-details__weekly-amount">
@@ -1457,17 +1457,7 @@ export default function CampaignItemDetails( props: Props ) {
 													// Format the date for display
 													const formatDuration = ( createdAt: string ) => {
 														const originalDate = moment( createdAt );
-
-														// We only have the "created at" date stored, so we need to subtract a week to match the billing cycle
-														let periodStart = originalDate.clone().subtract( 7, 'days' );
-
-														if ( periodStart.isBefore( moment( start_date ) ) ) {
-															periodStart = moment( start_date );
-														}
-
-														return `${ periodStart.format( 'MMM, D' ) } - ${ originalDate.format(
-															'MMM, D'
-														) }`;
+														return `Paid on ${ originalDate.format( 'LL' ) }`;
 													};
 
 													const durationFormatted = formatDuration( createdAt );
@@ -1480,7 +1470,7 @@ export default function CampaignItemDetails( props: Props ) {
 													return (
 														<div key={ index } className="campaign-item-details__weekly-orders-row">
 															<div className="campaign-item-details__weekly-label">
-																{ is_evergreen ? __( 'Weekly spent' ) : __( 'Weekly total' ) }
+																{ is_evergreen ? __( 'Weekly spent' ) : __( 'Weekly payment' ) }
 															</div>
 															<div className="campaign-item-details__weekly-duration">
 																{ durationFormatted }


### PR DESCRIPTION
Resolves #ADS-246


## Proposed Changes
 
Revise the wording of the payment section in promote-post:

From:
![image](https://github.com/user-attachments/assets/c604cdbd-8fda-4b10-99e4-82558f7ef50b)

To:
![image](https://github.com/user-attachments/assets/a7271295-a9ba-414d-97c6-0472637c41ed)


## Why are these changes being made?
* To avoid user confusion since the dates listed in the table don't actually match the actual campaign run dates, making users falsely think that they are being overcharged for the dates displayed.

## Testing Instructions

* Visit the detail page of a completed Blaze campaign, scroll down to the payment section.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
