### PR TITLE
VAT: enable VAT Checkout form in all environments

### DIFF
--- a/client/my-sites/checkout/src/components/domain-contact-details.tsx
+++ b/client/my-sites/checkout/src/components/domain-contact-details.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { Fragment } from 'react';
 import ManagedContactDetailsFormFields from 'calypso/components/domains/contact-details-form-fields/managed-contact-details-form-fields';
@@ -45,8 +44,6 @@ export default function DomainContactDetails( {
 	const needsAlternateEmailForGSuite = needsOnlyGoogleAppsDetails;
 	const tlds = getAllTopLevelTlds( domainNames );
 
-	const isVatSupported = config.isEnabled( 'checkout/vat-form' );
-
 	return (
 		<Fragment>
 			<ManagedContactDetailsFormFields
@@ -91,13 +88,11 @@ export default function DomainContactDetails( {
 					}
 				/>
 			) }
-			{ isVatSupported && (
-				<VatForm
-					section="domain-contact-form"
-					isDisabled={ isDisabled }
-					countryCode={ contactDetails.countryCode }
-				/>
-			) }
+			<VatForm
+				section="domain-contact-form"
+				isDisabled={ isDisabled }
+				countryCode={ contactDetails.countryCode }
+			/>
 		</Fragment>
 	);
 }

--- a/client/my-sites/checkout/src/components/tax-fields.tsx
+++ b/client/my-sites/checkout/src/components/tax-fields.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	Field,
 	tryToGuessPostalCodeFormat,
@@ -88,7 +87,6 @@ export default function TaxFields( {
 		countriesList.length && countryCode?.value
 			? getCountryTaxRequirements( countriesList, countryCode?.value )
 			: {};
-	const isVatSupported = config.isEnabled( 'checkout/vat-form' ) && allowVat;
 	const fields: ReactElement[] = [
 		<CountrySelectMenu
 			onChange={ ( event: ChangeEvent< HTMLSelectElement > ) => {
@@ -274,7 +272,7 @@ export default function TaxFields( {
 						{ fields[ index * 2 + 1 ] && <RightColumn>{ fields[ index * 2 + 1 ] }</RightColumn> }
 					</FieldRow>
 				) ) }
-			{ isVatSupported && (
+			{ allowVat && (
 				<VatForm section={ section } isDisabled={ isDisabled } countryCode={ countryCode?.value } />
 			) }
 			{ allowIsForBusinessUseCheckbox && handleIsForBusinessChange && (

--- a/config/development.json
+++ b/config/development.json
@@ -44,7 +44,6 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/razorpay": true,
-		"checkout/vat-form": true,
 		"comments/filters-in-posts": true,
 		"cookie-banner": false,
 		"current-site/domain-warning": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -22,7 +22,6 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/razorpay": false,
-		"checkout/vat-form": true,
 		"cookie-banner": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -33,7 +33,6 @@
 		"always_use_logout_url": true,
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": false,
-		"checkout/vat-form": true,
 		"checkout/checkout-version": false,
 		"checkout/razorpay": false,
 		"current-site/domain-warning": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -30,7 +30,6 @@
 		"always_use_logout_url": false,
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
-		"checkout/vat-form": true,
 		"checkout/checkout-version": false,
 		"checkout/razorpay": false,
 		"current-site/domain-warning": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -32,7 +32,6 @@
 		"always_use_logout_url": true,
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": false,
-		"checkout/vat-form": true,
 		"checkout/checkout-version": false,
 		"checkout/razorpay": false,
 		"current-site/domain-warning": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -32,7 +32,6 @@
 		"always_use_logout_url": true,
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": false,
-		"checkout/vat-form": true,
 		"checkout/checkout-version": false,
 		"checkout/razorpay": false,
 		"current-site/domain-warning": false,

--- a/config/production.json
+++ b/config/production.json
@@ -35,7 +35,6 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/razorpay": false,
-		"checkout/vat-form": true,
 		"cookie-banner": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -33,7 +33,6 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/razorpay": false,
-		"checkout/vat-form": true,
 		"cookie-banner": false,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/test.json
+++ b/config/test.json
@@ -33,7 +33,6 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/razorpay": true,
-		"checkout/vat-form": true,
 		"cookie-banner": false,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -30,7 +30,6 @@
 		"catch-js-errors": false,
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
-		"checkout/vat-form": true,
 		"checkout/checkout-version": true,
 		"checkout/razorpay": false,
 		"current-site/domain-warning": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/A4A-1200/

## Proposed Changes

This removes the `checkout/vat-form`, enabling the functionality in all environments.

## Why are these changes being made?

Now that A4A is using WPcom Billing, we need to enable the ability for users to add VAT details in Checkout. This is handled via the `checkout/vat-form` feature flag. Since A4A was the only environment not using the feature, we no longer need the flag.

<img width="693" alt="Screenshot 2025-06-26 at 22 21 50" src="https://github.com/user-attachments/assets/0fea48b6-c2d6-40cb-90c4-986e0d794514" />

## Testing Instructions

- Create a referral request for a test user via agencies.automattic.com
- As the test user, modify the referral checkout email url to use the A4A calypso.live address and add a `/v2` (e.g. `https://container-vigorous-proskuriakova.calypso.live/client/checkout/v2…`)
- Verify that in the Billing Information step, you see a checkbox to select that you're a business and checking it allows you to save your VAT details
