### PR TITLE
Site list v2: show badge when site is still being built via DIFM

### DIFF
--- a/client/dashboard/data/site.ts
+++ b/client/dashboard/data/site.ts
@@ -31,6 +31,7 @@ export const JOINED_SITE_FIELDS = SITE_FIELDS.join( ',' );
 
 export const SITE_OPTIONS = [
 	'admin_url',
+	'is_difm_lite_in_progress',
 	'is_domain_only',
 	'is_redirect',
 	'is_wpforteams_site',
@@ -61,6 +62,7 @@ export interface SiteCapabilities {
 
 export interface SiteOptions {
 	admin_url: string;
+	is_difm_lite_in_progress?: boolean;
 	is_wpforteams_site?: boolean;
 	p2_hub_blog_id?: number;
 	site_creation_flow?: string;
@@ -79,8 +81,7 @@ export interface Site {
 	plan?: SitePlan;
 	capabilities: SiteCapabilities;
 	subscribers_count: number;
-	// Can be undefined for deleted sites.
-	options?: SiteOptions;
+	options?: SiteOptions; // Can be undefined for deleted sites.
 	is_a4a_dev_site: boolean;
 	is_a8c: boolean;
 	is_deleted: boolean;

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -1,3 +1,4 @@
+import { Badge } from '@automattic/ui';
 import { useQuery } from '@tanstack/react-query';
 import {
 	__experimentalText as Text,
@@ -20,7 +21,7 @@ import { TextBlur } from '../../components/text-blur';
 import TimeSince from '../../components/time-since';
 import { JetpackModules } from '../../data/constants';
 import { hasAtomicFeature, hasJetpackModule } from '../../utils/site-features';
-import { getSiteStatusLabel } from '../../utils/site-status';
+import { getSiteStatus, getSiteStatusLabel } from '../../utils/site-status';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { HostingFeatures } from '../features';
 import { isSitePlanTrial } from '../plans';
@@ -218,8 +219,15 @@ function PlanRenewNag( { site, source }: { site: Site; source: string } ) {
 }
 
 export function Status( { site }: { site: Site } ) {
-	if ( site.is_deleted ) {
-		return <Text isDestructive>{ __( 'Deleted' ) }</Text>;
+	const status = getSiteStatus( site );
+	const label = getSiteStatusLabel( site );
+
+	if ( status === 'deleted' ) {
+		return <Text isDestructive>{ label }</Text>;
+	}
+
+	if ( status === 'difm_lite_in_progress' ) {
+		return <Badge>{ label }</Badge>;
 	}
 
 	if ( site.plan?.expired ) {
@@ -235,7 +243,7 @@ export function Status( { site }: { site: Site } ) {
 		return <SiteLaunchNag site={ site } />;
 	}
 
-	return getSiteStatusLabel( site );
+	return label;
 }
 
 export function Plan( { site }: { site: Site } ) {

--- a/client/dashboard/sites/site-fields/test/plan.tsx
+++ b/client/dashboard/sites/site-fields/test/plan.tsx
@@ -13,7 +13,7 @@ function render( ui: React.ReactElement ) {
 }
 
 describe( '<Plan>', () => {
-	test( 'for staging sites, it renders "Staging"', async () => {
+	test( 'for staging sites, it renders "Staging"', () => {
 		const site = {
 			is_wpcom_staging_site: true,
 		} as Site;
@@ -21,7 +21,7 @@ describe( '<Plan>', () => {
 		expect( container.textContent ).toBe( 'Staging' );
 	} );
 
-	test( 'for self-hosted, Jetpack-connected sites, active Jetpack plugin, it renders the Jetpack logo and plan name', async () => {
+	test( 'for self-hosted, Jetpack-connected sites, active Jetpack plugin, it renders the Jetpack logo and plan name', () => {
 		const site = {
 			is_wpcom_atomic: false,
 			jetpack_connection: true,
@@ -35,7 +35,7 @@ describe( '<Plan>', () => {
 		expect( container.textContent ).toBe( 'Free' );
 	} );
 
-	test( 'for self-hosted, Jetpack-connected sites, inactive Jetpack plugin, it renders dash', async () => {
+	test( 'for self-hosted, Jetpack-connected sites, inactive Jetpack plugin, it renders dash', () => {
 		const site = {
 			is_wpcom_atomic: false,
 			jetpack_connection: true,
@@ -48,7 +48,7 @@ describe( '<Plan>', () => {
 		expect( container.textContent ).toBe( '-' );
 	} );
 
-	test( 'for WordPress.com Simple sites, it renders the plan name', async () => {
+	test( 'for WordPress.com Simple sites, it renders the plan name', () => {
 		const site = {
 			is_wpcom_atomic: false,
 			jetpack_connection: false,
@@ -61,7 +61,7 @@ describe( '<Plan>', () => {
 		expect( container.textContent ).toBe( 'Premium' );
 	} );
 
-	test( 'for WordPress.com Atomic sites, it renders the plan name', async () => {
+	test( 'for WordPress.com Atomic sites, it renders the plan name', () => {
 		const site = {
 			is_wpcom_atomic: true,
 			jetpack_connection: true,
@@ -74,7 +74,7 @@ describe( '<Plan>', () => {
 		expect( container.textContent ).toBe( 'Business' );
 	} );
 
-	test( 'for sites with expired plan, it renders the plan name with "-expired" suffix', async () => {
+	test( 'for sites with expired plan, it renders the plan name with "-expired" suffix', () => {
 		const site = {
 			plan: {
 				product_name_short: 'Business',
@@ -85,7 +85,7 @@ describe( '<Plan>', () => {
 		expect( container.textContent ).toBe( 'Business-expired' );
 	} );
 
-	test( 'for sites with expired plan, it renders the plan name with "-expired" suffix and a renewal nag for the site owner', async () => {
+	test( 'for sites with expired plan, it renders the plan name with "-expired" suffix and a renewal nag for the site owner', () => {
 		const site = {
 			slug: 'test.wordpress.com',
 			site_owner: 1,
@@ -103,7 +103,7 @@ describe( '<Plan>', () => {
 		);
 	} );
 
-	test( 'for Trial sites with expired plan, it renders the plan name with "-expired" suffix and an upgrade nag for the site owner', async () => {
+	test( 'for Trial sites with expired plan, it renders the plan name with "-expired" suffix and an upgrade nag for the site owner', () => {
 		const site = {
 			slug: 'test.wordpress.com',
 			site_owner: 1,

--- a/client/dashboard/sites/site-fields/test/plan.tsx
+++ b/client/dashboard/sites/site-fields/test/plan.tsx
@@ -6,9 +6,11 @@ import { AuthContext } from '../../../app/auth';
 import { Plan } from '../index';
 import type { User, Site } from '../../../data/types';
 
+const userId = 1;
+
 function render( ui: React.ReactElement ) {
 	return testingLibraryRender(
-		<AuthContext.Provider value={ { user: { ID: 1 } as User } }>{ ui }</AuthContext.Provider>
+		<AuthContext.Provider value={ { user: { ID: userId } as User } }>{ ui }</AuthContext.Provider>
 	);
 }
 
@@ -88,7 +90,7 @@ describe( '<Plan>', () => {
 	test( 'for sites with expired plan, it renders the plan name with "-expired" suffix and a renewal nag for the site owner', () => {
 		const site = {
 			slug: 'test.wordpress.com',
-			site_owner: 1,
+			site_owner: userId,
 			plan: {
 				product_slug: 'business-bundle',
 				product_name_short: 'Business',
@@ -106,7 +108,7 @@ describe( '<Plan>', () => {
 	test( 'for Trial sites with expired plan, it renders the plan name with "-expired" suffix and an upgrade nag for the site owner', () => {
 		const site = {
 			slug: 'test.wordpress.com',
-			site_owner: 1,
+			site_owner: userId,
 			plan: {
 				product_slug: 'ecommerce-trial-bundle-monthly',
 				product_name_short: 'Trial',

--- a/client/dashboard/sites/site-fields/test/status.tsx
+++ b/client/dashboard/sites/site-fields/test/status.tsx
@@ -1,0 +1,88 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render as testingLibraryRender } from '@testing-library/react';
+import { AuthContext } from '../../../app/auth';
+import { Status } from '../index';
+import type { User, Site } from '../../../data/types';
+
+function render( ui: React.ReactElement ) {
+	return testingLibraryRender(
+		<AuthContext.Provider value={ { user: { ID: 1 } as User } }>{ ui }</AuthContext.Provider>
+	);
+}
+
+describe( '<Status>', () => {
+	test( 'for unlaunched sites, it renders a "Coming soon" link', () => {
+		const site = {
+			slug: 'test.wordpress.com',
+			site_migration: {},
+			launch_status: 'unlaunched',
+			is_private: true,
+		} as Site;
+		const { container, getByRole } = render( <Status site={ site } /> );
+		expect( container.textContent ).toBe( 'Coming soon↗' );
+		expect( getByRole( 'link', { name: /Coming soon/ } ) ).toHaveAttribute(
+			'href',
+			'/home/test.wordpress.com'
+		);
+	} );
+
+	test( 'for launched sites, it renders the site visibility', () => {
+		const site = {
+			site_migration: {},
+			is_private: true,
+		} as Site;
+		const { container } = render( <Status site={ site } /> );
+		expect( container.textContent ).toBe( 'Private' );
+	} );
+
+	test( 'for deleted sites, it renders "Deleted"', () => {
+		const site = {
+			site_migration: {},
+			is_deleted: true,
+		} as Site;
+		const { container } = render( <Status site={ site } /> );
+		expect( container.textContent ).toBe( 'Deleted' );
+	} );
+
+	test( 'for sites still being built via DIFM, it renders "Express service"', () => {
+		const site = {
+			site_migration: {},
+			options: { is_difm_lite_in_progress: true },
+		} as Site;
+		const { container } = render( <Status site={ site } /> );
+		expect( container.textContent ).toBe( 'Express service' );
+	} );
+
+	test( 'for sites with expired plan, it renders "Plan expired"', () => {
+		const site = {
+			site_migration: {},
+			plan: {
+				product_name_short: 'Business',
+				expired: true,
+			},
+		} as Site;
+		const { container } = render( <Status site={ site } /> );
+		expect( container.textContent ).toBe( 'Plan expired' );
+	} );
+
+	test( 'for sites with expired plan, it renders "Plan expired" and a renewal nag for the site owner', () => {
+		const site = {
+			slug: 'test.wordpress.com',
+			site_owner: 1,
+			site_migration: {},
+			plan: {
+				product_slug: 'business-bundle',
+				product_name_short: 'Business',
+				expired: true,
+			},
+		} as Site;
+		const { getByText, getByRole } = render( <Status site={ site } /> );
+		expect( getByText( 'Plan expired' ) ).toBeInTheDocument();
+		expect( getByRole( 'link', { name: /Renew plan/ } ) ).toHaveAttribute(
+			'href',
+			'/checkout/test.wordpress.com/business-bundle'
+		);
+	} );
+} );

--- a/client/dashboard/sites/site-fields/test/status.tsx
+++ b/client/dashboard/sites/site-fields/test/status.tsx
@@ -6,9 +6,11 @@ import { AuthContext } from '../../../app/auth';
 import { Status } from '../index';
 import type { User, Site } from '../../../data/types';
 
+const userId = 1;
+
 function render( ui: React.ReactElement ) {
 	return testingLibraryRender(
-		<AuthContext.Provider value={ { user: { ID: 1 } as User } }>{ ui }</AuthContext.Provider>
+		<AuthContext.Provider value={ { user: { ID: userId } as User } }>{ ui }</AuthContext.Provider>
 	);
 }
 
@@ -70,7 +72,7 @@ describe( '<Status>', () => {
 	test( 'for sites with expired plan, it renders "Plan expired" and a renewal nag for the site owner', () => {
 		const site = {
 			slug: 'test.wordpress.com',
-			site_owner: 1,
+			site_owner: userId,
 			site_migration: {},
 			plan: {
 				product_slug: 'business-bundle',

--- a/client/dashboard/utils/site-status.ts
+++ b/client/dashboard/utils/site-status.ts
@@ -6,6 +6,7 @@ export const STATUS_LABELS = {
 	private: __( 'Private' ),
 	coming_soon: __( 'Coming soon' ),
 	deleted: __( 'Deleted' ),
+	difm_lite_in_progress: __( 'Express service' ),
 	migration_pending: __( 'Migration pending' ),
 	migration_started: __( 'Migration started' ),
 };
@@ -21,6 +22,10 @@ export function getSiteStatus( item: Site ) {
 
 	if ( item.is_deleted ) {
 		return 'deleted';
+	}
+
+	if ( item.options?.is_difm_lite_in_progress ) {
+		return 'difm_lite_in_progress';
 	}
 
 	if ( item.is_coming_soon || ( item.is_private && item.launch_status === 'unlaunched' ) ) {

--- a/client/dashboard/utils/site-status.ts
+++ b/client/dashboard/utils/site-status.ts
@@ -12,16 +12,16 @@ export const STATUS_LABELS = {
 };
 
 export function getSiteStatus( item: Site ) {
+	if ( item.is_deleted ) {
+		return 'deleted';
+	}
+
 	if ( item.site_migration.migration_status?.startsWith( 'migration-pending' ) ) {
 		return 'migration_pending';
 	}
 
 	if ( item.site_migration.migration_status?.startsWith( 'migration-started' ) ) {
 		return 'migration_started';
-	}
-
-	if ( item.is_deleted ) {
-		return 'deleted';
 	}
 
 	if ( item.options?.is_difm_lite_in_progress ) {


### PR DESCRIPTION
Part of DOTDASH-92

## Proposed Changes

This PR ports the "Express service" DIFM badge from sites list v1 to v2:

|v1|v2|
|-|-|
|<img width="152" alt="image" src="https://github.com/user-attachments/assets/b6092e1f-d52f-49a3-8dda-3b86efd11424" />|<img width="163" alt="image" src="https://github.com/user-attachments/assets/3dc4e012-4476-4383-92ca-fec0639b9a86" />|


## Testing Instructions

1. Go to https://wordpress.com/start/do-it-for-me
2. Select an existing site
3. Complete the purchase
4. Go back to /v2/sites
5. Verify the badge in the Status column.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
