### PR TITLE
Sites List v2: Fix issue where default filters are not passed to getFetchSitesOptions

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -115,7 +115,7 @@ const getDefaultActions = ( router: AnyRouter ) => {
 };
 
 const getFetchSitesOptions = (
-	view: Partial< ViewTable | ViewGrid > | undefined = {}
+	view: Partial< ViewTable | ViewGrid > | undefined = {},
 	isRestoringAccount: boolean = false
 ): FetchSitesOptions => {
 	const filters = view.filters ?? [];
@@ -132,8 +132,7 @@ const getFetchSitesOptions = (
 	return {
 		// Some P2 sites are not retrievable unless site_visibility is set to 'all'.
 		// See: https://github.com/Automattic/wp-calypso/pull/104220.
-		site_visibility:
-			view.search || shouldIncludeA8COwned || isRestoringAccount ? 'all' : 'visible',
+		site_visibility: view.search || shouldIncludeA8COwned || isRestoringAccount ? 'all' : 'visible',
 		include_a8c_owned: shouldIncludeA8COwned,
 	};
 };

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -115,10 +115,10 @@ const getDefaultActions = ( router: AnyRouter ) => {
 };
 
 const getFetchSitesOptions = (
-	viewOptions: Partial< ViewTable | ViewGrid > | undefined = {},
+	view: Partial< ViewTable | ViewGrid > | undefined = {}
 	isRestoringAccount: boolean = false
 ): FetchSitesOptions => {
-	const filters = viewOptions.filters ?? [];
+	const filters = view.filters ?? [];
 
 	// Include A8C sites unless explicitly excluded from the filter.
 	const shouldIncludeA8COwned = ! filters.some(
@@ -133,7 +133,7 @@ const getFetchSitesOptions = (
 		// Some P2 sites are not retrievable unless site_visibility is set to 'all'.
 		// See: https://github.com/Automattic/wp-calypso/pull/104220.
 		site_visibility:
-			viewOptions.search || shouldIncludeA8COwned || isRestoringAccount ? 'all' : 'visible',
+			view.search || shouldIncludeA8COwned || isRestoringAccount ? 'all' : 'visible',
 		include_a8c_owned: shouldIncludeA8COwned,
 	};
 };
@@ -144,9 +144,6 @@ export default function Sites() {
 	const currentSearchParams = sitesRoute.useSearch();
 	const viewOptions: Partial< ViewTable | ViewGrid > | undefined = currentSearchParams.view;
 	const isRestoringAccount = !! currentSearchParams.restored;
-	const { data: sites, isLoading: isLoadingSites } = useQuery(
-		sitesQuery( getFetchSitesOptions( viewOptions, isRestoringAccount ) )
-	);
 	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
 
 	const defaultView = useMemo(
@@ -181,6 +178,10 @@ export default function Sites() {
 		[ defaultView, viewOptions ]
 	);
 
+	const { data: sites, isLoading: isLoadingSites } = useQuery(
+		sitesQuery( getFetchSitesOptions( view, isRestoringAccount ) )
+	);
+
 	const fields = useMemo( () => {
 		return getFields( { isAutomattician, viewType: view.type } );
 	}, [ isAutomattician, view.type ] );
@@ -189,9 +190,8 @@ export default function Sites() {
 		return getDefaultActions( router );
 	}, [ router ] );
 
-	const [ isModalOpen, setIsModalOpen ] = useState( false );
-
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( sites ?? [], view, fields );
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
 	return (
 		<>


### PR DESCRIPTION
## Proposed Changes

Deleted sites are now showing by default, due to this commit https://github.com/Automattic/wp-calypso/pull/104453/commits/ebec2f9ec9c7a2b0fe51918a264977d011dedb74 which sets site_visibility to 'all' by default. For a12s, the Sites List should have overridden site_visibility to 'visible', since we default to include_a8c_owned = false.

https://github.com/Automattic/wp-calypso/blob/10a6e9984cdbf4abb1c45e37fc20bd94bcfffced/client/dashboard/sites/index.tsx#L92-L112

However, there's an existing issue where even though the filter is_a8c is defaulted to false, it was not passed to getFetchSitesOptions()

https://github.com/Automattic/wp-calypso/blob/10a6e9984cdbf4abb1c45e37fc20bd94bcfffced/client/dashboard/sites/index.tsx#L123-L137

This PR updates the logic to call getFetchSitesOptions() after the view has been fully resolved, ensure the default filters are correctly applied.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Ensure that deleted sites are not shown by default 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
