### PR TITLE
Dashboard v2: set default query stale time back to 0

### DIFF
--- a/client/dashboard/app/query-client.ts
+++ b/client/dashboard/app/query-client.ts
@@ -5,7 +5,7 @@ import { persistQueryClient } from '@tanstack/react-query-persist-client';
 export const queryClient = new QueryClient( {
 	defaultOptions: {
 		queries: {
-			staleTime: 1000 * 60 * 1, // 1 minute
+			staleTime: 0,
 			refetchOnWindowFocus: true,
 			refetchOnMount: true,
 		},


### PR DESCRIPTION
(Somehow) related to DOTCOM-13699

## Proposed Changes

This PR reverts the query client's stale time back to 0. This is so that updates to settings in wp-admin will be reflected immediately when we refresh Calypso.

@arthur791004 I don't see any regression in backported Site list / Settings, let me know if you find it does. 🤔 

## Testing Instructions

For example:

1. Go to `/v2/sites/:siteSlug/settings/site-visibility`, note the current setting.
1. Go to `wp-admin/options-reading.php` of that site and update the Site Visibility.
    - Or launch that site from wp-admin.
1. Go to `/v2/sites/:siteSlug/settings/site-visibility` again, note that the current setting is up-to-date.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
