### PR TITLE
Trigger search when clicking pill links

### DIFF
--- a/apps/happy-blocks/block-library/search-card/includes.php
+++ b/apps/happy-blocks/block-library/search-card/includes.php
@@ -21,5 +21,7 @@ if ( ! function_exists( 'happy_blocks_get_search_card_asset' ) ) {
 	}
 }
 
-$css = happy_blocks_get_search_card_asset( is_rtl() ? 'view.rtl.css' : 'view.css' );
-wp_enqueue_style( 'happy-blocks-support-search-card-style', $css['path'], array(), $css['version'] );
+$happy_blocks_get_search_card_css = happy_blocks_get_search_card_asset( is_rtl() ? 'view.rtl.css' : 'view.css' );
+$happy_blocks_get_search_card_js  = happy_blocks_get_search_card_asset( 'view.js' );
+wp_enqueue_style( 'happy-blocks-support-search-card-style', $happy_blocks_get_search_card_css['path'], array(), $happy_blocks_get_search_card_css['version'] );
+wp_enqueue_script( 'happy-blocks-support-search-card-script', $happy_blocks_get_search_card_js['path'], array(), $happy_blocks_get_search_card_js['version'], true );

--- a/apps/happy-blocks/block-library/search-card/index.php
+++ b/apps/happy-blocks/block-library/search-card/index.php
@@ -51,10 +51,10 @@ if ( ! function_exists( 'get_support_search_link_for_query' ) ) {
 			</form>
 
 			<ul class="search-terms">
-				<li><a href="<?php echo esc_url( get_support_search_link_for_query( 'connect a domain' ) ); ?>"><?php echo esc_html( __( 'Connect a domain', 'happy-blocks' ) ); ?></a></li>
-				<li><a href="<?php echo esc_url( get_support_search_link_for_query( 'upgrade my plan' ) ); ?>"><?php echo esc_html( __( 'Upgrade my plan', 'happy-blocks' ) ); ?></a></li>
-				<li><a href="<?php echo esc_url( get_support_search_link_for_query( 'grow an audience' ) ); ?>"><?php echo esc_html( __( 'Grow an audience', 'happy-blocks' ) ); ?></a></li>
-				<li><a href="<?php echo esc_url( get_support_search_link_for_query( 'reset my password' ) ); ?>"><?php echo esc_html( __( 'Reset my password', 'happy-blocks' ) ); ?></a></li>
+				<li><a data-search-query="<?php echo esc_attr( __( 'Connect a domain', 'happy-blocks' ) ); ?>" href="<?php echo esc_url( get_support_search_link_for_query( 'connect a domain' ) ); ?>"><?php echo esc_html( __( 'Connect a domain', 'happy-blocks' ) ); ?></a></li>
+				<li><a data-search-query="<?php echo esc_attr( __( 'Upgrade my plan', 'happy-blocks' ) ); ?>" href="<?php echo esc_url( get_support_search_link_for_query( 'upgrade my plan' ) ); ?>"><?php echo esc_html( __( 'Upgrade my plan', 'happy-blocks' ) ); ?></a></li>
+				<li><a data-search-query="<?php echo esc_attr( __( 'Grow an audience', 'happy-blocks' ) ); ?>" href="<?php echo esc_url( get_support_search_link_for_query( 'grow an audience' ) ); ?>"><?php echo esc_html( __( 'Grow an audience', 'happy-blocks' ) ); ?></a></li>
+				<li><a data-search-query="<?php echo esc_attr( __( 'Reset my password', 'happy-blocks' ) ); ?>" href="<?php echo esc_url( get_support_search_link_for_query( 'reset my password' ) ); ?>"><?php echo esc_html( __( 'Reset my password', 'happy-blocks' ) ); ?></a></li>
 			</ul>
 	</div>
 </div>

--- a/apps/happy-blocks/block-library/search-card/view.js
+++ b/apps/happy-blocks/block-library/search-card/view.js
@@ -1,1 +1,24 @@
 import './style.scss';
+document.addEventListener( 'DOMContentLoaded', function () {
+	const links = document.querySelectorAll( 'a[data-search-query]' );
+	const input = document.getElementById( 'support-search-input' );
+	const submitButton = document.querySelector( '.search-submit-button' );
+
+	links.forEach( ( link ) => {
+		link.addEventListener( 'click', function ( e ) {
+			const query = this.getAttribute( 'data-search-query' );
+			if ( ! input || ! query || ! submitButton ) {
+				return;
+			}
+
+			e.preventDefault();
+
+			input.value = query;
+			submitButton.click();
+
+			setTimeout( () => {
+				input.value = '';
+			}, 100 );
+		} );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #
Avoid reloading the page when we trigger search from the links.
This PR simulates the form submit to mimic user behaviour and avoid page reload

## Proposed Changes

* Fill in search on button click and submit the form

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To avoid page reload and the link is clicked
* To simulate user search and bring identical results

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR
* Navigiate to app/happy-blocks
* Run `yarn dev --sync`
* Sandbox wordpress.com
* Open the new support landing page
* Click the links below the search 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
