### PR TITLE
Site list v2: maintenance/improvements pt 1

### DIFF
--- a/client/dashboard/app/queries/sites.ts
+++ b/client/dashboard/app/queries/sites.ts
@@ -3,7 +3,7 @@ import { SITE_FIELDS, SITE_OPTIONS } from '../../data/site';
 import type { FetchSitesOptions } from '../../data/me-sites';
 
 export const sitesQuery = (
-	fetchSitesOptions: FetchSitesOptions = { site_visibility: 'all', include_a8c_owned: true }
+	fetchSitesOptions: FetchSitesOptions = { site_visibility: 'visible', include_a8c_owned: false }
 ) => ( {
 	queryKey: [ 'sites', SITE_FIELDS, SITE_OPTIONS, fetchSitesOptions ],
 	queryFn: () => fetchSites( fetchSitesOptions ),

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -74,7 +74,9 @@ const sitesRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'sites',
 	loader: async () => {
+		// Preload the default sites list response without blocking.
 		queryClient.ensureQueryData( sitesQuery() );
+
 		await queryClient.ensureQueryData( isAutomatticianQuery() );
 	},
 } ).lazy( () =>

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -38,7 +38,6 @@ import { siteSshAccessStatusQuery } from './queries/site-ssh';
 import { siteStaticFile404SettingQuery } from './queries/site-static-file-404';
 import { siteEngagementStatsQuery } from './queries/site-stats';
 import { siteWordPressVersionQuery } from './queries/site-wordpress-version';
-import { sitesQuery } from './queries/sites';
 import { queryClient } from './query-client';
 import Root from './root';
 import type { AppConfig } from './context';
@@ -73,12 +72,7 @@ const overviewRoute = createRoute( {
 const sitesRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'sites',
-	loader: async () => {
-		await Promise.all( [
-			queryClient.ensureQueryData( sitesQuery() ),
-			queryClient.ensureQueryData( isAutomatticianQuery() ),
-		] );
-	},
+	loader: () => queryClient.ensureQueryData( isAutomatticianQuery() ),
 } ).lazy( () =>
 	import( '../sites' ).then( ( d ) =>
 		createLazyRoute( 'sites' )( {

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -38,6 +38,7 @@ import { siteSshAccessStatusQuery } from './queries/site-ssh';
 import { siteStaticFile404SettingQuery } from './queries/site-static-file-404';
 import { siteEngagementStatsQuery } from './queries/site-stats';
 import { siteWordPressVersionQuery } from './queries/site-wordpress-version';
+import { sitesQuery } from './queries/sites';
 import { queryClient } from './query-client';
 import Root from './root';
 import type { AppConfig } from './context';
@@ -72,7 +73,10 @@ const overviewRoute = createRoute( {
 const sitesRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'sites',
-	loader: () => queryClient.ensureQueryData( isAutomatticianQuery() ),
+	loader: async () => {
+		queryClient.ensureQueryData( sitesQuery() );
+		await queryClient.ensureQueryData( isAutomatticianQuery() );
+	},
 } ).lazy( () =>
 	import( '../sites' ).then( ( d ) =>
 		createLazyRoute( 'sites' )( {

--- a/client/dashboard/sites/actions.tsx
+++ b/client/dashboard/sites/actions.tsx
@@ -1,0 +1,71 @@
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { wordpress } from '@wordpress/icons';
+import AsyncLoad from 'calypso/components/async-load';
+import { isP2 } from '../utils/site-types';
+import { canManageSite } from './features';
+import type { Site } from '../data/types';
+import type { Action, RenderModalProps } from '@automattic/dataviews';
+import type { AnyRouter } from '@tanstack/react-router';
+
+export function getActions( router: AnyRouter ): Action< Site >[] {
+	return [
+		{
+			id: 'admin',
+			isPrimary: true,
+			icon: <Icon icon={ wordpress } />,
+			label: __( 'WP admin ↗' ),
+			callback: ( sites: Site[] ) => {
+				const site = sites[ 0 ];
+				if ( site.options?.admin_url ) {
+					window.open( site.options.admin_url, '_blank' );
+				}
+			},
+			isEligible: ( item: Site ) => ( item.is_deleted || ! item.options?.admin_url ? false : true ),
+		},
+		{
+			id: 'site',
+			label: __( 'Visit site ↗' ),
+			callback: ( sites: Site[] ) => {
+				const site = sites[ 0 ];
+				if ( site.URL ) {
+					window.open( site.URL, '_blank' );
+				}
+			},
+			isEligible: ( item: Site ) => ( item.is_deleted || ! item.URL ? false : true ),
+		},
+		{
+			id: 'domains',
+			label: __( 'Domains ↗' ),
+			callback: ( sites: Site[] ) => {
+				const site = sites[ 0 ];
+				window.open( `/domains/manage/${ site.slug }` );
+			},
+			isEligible: ( item: Site ) => canManageSite( item ),
+		},
+		{
+			id: 'settings',
+			label: __( 'Settings' ),
+			callback: ( sites: Site[] ) => {
+				const site = sites[ 0 ];
+				router.navigate( { to: '/sites/$siteSlug/settings', params: { siteSlug: site.slug } } );
+			},
+			isEligible: ( item: Site ) => canManageSite( item ),
+		},
+		{
+			id: 'leave',
+			label: __( 'Leave site' ),
+			isEligible: ( item: Site ) => ! item.is_deleted && ! isP2( item ),
+			RenderModal: ( { items, closeModal }: RenderModalProps< Site > ) => {
+				return (
+					<AsyncLoad
+						require="./site-leave-modal/content-info"
+						placeholder={ null }
+						site={ items[ 0 ] }
+						onClose={ closeModal }
+					/>
+				);
+			},
+		},
+	];
+}

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -1,11 +1,9 @@
 import { DataViews, filterSortAndPaginate } from '@automattic/dataviews';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate, useRouter } from '@tanstack/react-router';
-import { Button, Modal, Icon } from '@wordpress/components';
+import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { wordpress } from '@wordpress/icons';
-import { useMemo, useState } from 'react';
-import AsyncLoad from 'calypso/components/async-load';
+import { useState } from 'react';
 import { useAuth } from '../app/auth';
 import { isAutomatticianQuery } from '../app/queries/a8c';
 import { sitesQuery } from '../app/queries/sites';
@@ -13,82 +11,15 @@ import { sitesRoute } from '../app/router';
 import DataViewsCard from '../components/dataviews-card';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
-import { isP2 } from '../utils/site-types';
+import { getActions } from './actions';
 import AddNewSite from './add-new-site';
-import { canManageSite } from './features';
 import { getFields } from './fields';
 import { SitesNotices } from './notices';
 import { getView, DEFAULT_LAYOUTS } from './views';
 import type { FetchSitesOptions, Site } from '../data/types';
-import type { View, ViewTable, ViewGrid, Filter, RenderModalProps } from '@automattic/dataviews';
-import type { AnyRouter } from '@tanstack/react-router';
+import type { View, ViewTable, ViewGrid, Filter } from '@automattic/dataviews';
 
-const getDefaultActions = ( router: AnyRouter ) => {
-	return [
-		{
-			id: 'admin',
-			isPrimary: true,
-			icon: <Icon icon={ wordpress } />,
-			label: __( 'WP admin ↗' ),
-			callback: ( sites: Site[] ) => {
-				const site = sites[ 0 ];
-				if ( site.options?.admin_url ) {
-					window.open( site.options.admin_url, '_blank' );
-				}
-			},
-			isEligible: ( item: Site ) => ( item.is_deleted || ! item.options?.admin_url ? false : true ),
-		},
-		{
-			id: 'site',
-			label: __( 'Visit site ↗' ),
-			callback: ( sites: Site[] ) => {
-				const site = sites[ 0 ];
-				if ( site.URL ) {
-					window.open( site.URL, '_blank' );
-				}
-			},
-			isEligible: ( item: Site ) => ( item.is_deleted || ! item.URL ? false : true ),
-		},
-		{
-			id: 'domains',
-			label: __( 'Domains ↗' ),
-			callback: ( sites: Site[] ) => {
-				const site = sites[ 0 ];
-				window.open( `/domains/manage/${ site.slug }` );
-			},
-			isEligible: ( item: Site ) => canManageSite( item ),
-		},
-		{
-			id: 'settings',
-			label: __( 'Settings' ),
-			callback: ( sites: Site[] ) => {
-				const site = sites[ 0 ];
-				router.navigate( { to: '/sites/$siteSlug/settings', params: { siteSlug: site.slug } } );
-			},
-			isEligible: ( item: Site ) => canManageSite( item ),
-		},
-		{
-			id: 'leave',
-			label: __( 'Leave site' ),
-			isEligible: ( item: Site ) => ! item.is_deleted && ! isP2( item ),
-			RenderModal: ( { items, closeModal }: RenderModalProps< Site > ) => {
-				return (
-					<AsyncLoad
-						require="./site-leave-modal/content-info"
-						placeholder={ null }
-						site={ items[ 0 ] }
-						onClose={ closeModal }
-					/>
-				);
-			},
-		},
-	];
-};
-
-const getFetchSitesOptions = (
-	view: View,
-	isRestoringAccount: boolean = false
-): FetchSitesOptions => {
+const getFetchSitesOptions = ( view: View, isRestoringAccount: boolean ): FetchSitesOptions => {
 	const filters = view.filters ?? [];
 
 	// Include A8C sites unless explicitly excluded from the filter.
@@ -112,27 +43,25 @@ export default function Sites() {
 	const navigate = useNavigate( { from: sitesRoute.fullPath } );
 	const router = useRouter();
 	const currentSearchParams = sitesRoute.useSearch();
-	const viewOptions: Partial< ViewTable | ViewGrid > | undefined = currentSearchParams.view;
+	const viewOptions: Partial< ViewTable | ViewGrid > = currentSearchParams.view ?? {};
 	const isRestoringAccount = !! currentSearchParams.restored;
 
 	const { user } = useAuth();
-	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
+	const { data: isAutomattician } = useSuspenseQuery( isAutomatticianQuery() );
 
-	const { defaultView, view } = useMemo( () => {
-		return getView( { user, isAutomattician, isRestoringAccount, viewOptions } );
-	}, [ user, isAutomattician, isRestoringAccount, viewOptions ] );
+	const { defaultView, view } = getView( {
+		user,
+		isAutomattician,
+		isRestoringAccount,
+		viewOptions,
+	} );
 
 	const { data: sites, isLoading: isLoadingSites } = useQuery(
 		sitesQuery( getFetchSitesOptions( view, isRestoringAccount ) )
 	);
 
-	const fields = useMemo( () => {
-		return getFields( { isAutomattician, viewType: view.type } );
-	}, [ isAutomattician, view.type ] );
-
-	const actions = useMemo( () => {
-		return getDefaultActions( router );
-	}, [ router ] );
+	const fields = getFields( { isAutomattician, viewType: view.type } );
+	const actions = getActions( router );
 
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( sites ?? [], view, fields );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );

--- a/client/dashboard/sites/views.ts
+++ b/client/dashboard/sites/views.ts
@@ -38,8 +38,8 @@ function getDefaultView( {
 	isRestoringAccount,
 }: {
 	user: User;
-	isAutomattician?: boolean;
-	isRestoringAccount?: boolean;
+	isAutomattician: boolean;
+	isRestoringAccount: boolean;
 } ): View {
 	const type = isRestoringAccount || user.site_count > DEFAULT_PER_PAGE ? 'table' : 'grid';
 
@@ -69,9 +69,9 @@ export function getView( {
 	viewOptions,
 }: {
 	user: User;
-	isAutomattician?: boolean;
-	isRestoringAccount?: boolean;
-	viewOptions?: Partial< ViewTable | ViewGrid >;
+	isAutomattician: boolean;
+	isRestoringAccount: boolean;
+	viewOptions: Partial< ViewTable | ViewGrid >;
 } ): {
 	defaultView: View;
 	view: View;
@@ -80,10 +80,8 @@ export function getView( {
 
 	const view = {
 		...defaultView,
-		...DEFAULT_LAYOUTS[ viewOptions?.type ?? defaultView.type ],
-		...Object.fromEntries(
-			Object.entries( viewOptions ?? {} ).filter( ( [ , v ] ) => v !== undefined )
-		),
+		...DEFAULT_LAYOUTS[ viewOptions.type ?? defaultView.type ],
+		...Object.fromEntries( Object.entries( viewOptions ).filter( ( [ , v ] ) => v !== undefined ) ),
 	} as View;
 
 	return { defaultView, view };

--- a/client/sites/v2/sites-list/router.tsx
+++ b/client/sites/v2/sites-list/router.tsx
@@ -17,7 +17,9 @@ const sitesRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'sites',
 	loader: async () => {
+		// Preload the default sites list response without blocking.
 		queryClient.ensureQueryData( sitesQuery() );
+
 		await queryClient.ensureQueryData( isAutomatticianQuery() );
 	},
 } ).lazy( () =>

--- a/client/sites/v2/sites-list/router.tsx
+++ b/client/sites/v2/sites-list/router.tsx
@@ -6,6 +6,7 @@ import {
 	redirect,
 } from '@tanstack/react-router';
 import { isAutomatticianQuery } from 'calypso/dashboard/app/queries/a8c';
+import { sitesQuery } from 'calypso/dashboard/app/queries/sites';
 import { queryClient } from 'calypso/dashboard/app/query-client';
 import Root from '../components/root';
 import { getRouterOptions, createBrowserHistoryAndMemoryRouterSync } from '../utils/router';
@@ -15,7 +16,10 @@ const rootRoute = createRootRoute( { component: Root } );
 const sitesRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'sites',
-	loader: () => queryClient.ensureQueryData( isAutomatticianQuery() ),
+	loader: async () => {
+		queryClient.ensureQueryData( sitesQuery() );
+		await queryClient.ensureQueryData( isAutomatticianQuery() );
+	},
 } ).lazy( () =>
 	import( 'calypso/dashboard/sites' ).then( ( d ) =>
 		createLazyRoute( 'sites' )( {

--- a/client/sites/v2/sites-list/router.tsx
+++ b/client/sites/v2/sites-list/router.tsx
@@ -5,7 +5,7 @@ import {
 	createRouter,
 	redirect,
 } from '@tanstack/react-router';
-import { sitesQuery } from 'calypso/dashboard/app/queries/sites';
+import { isAutomatticianQuery } from 'calypso/dashboard/app/queries/a8c';
 import { queryClient } from 'calypso/dashboard/app/query-client';
 import Root from '../components/root';
 import { getRouterOptions, createBrowserHistoryAndMemoryRouterSync } from '../utils/router';
@@ -15,7 +15,7 @@ const rootRoute = createRootRoute( { component: Root } );
 const sitesRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'sites',
-	loader: () => queryClient.ensureQueryData( sitesQuery() ),
+	loader: () => queryClient.ensureQueryData( isAutomatticianQuery() ),
 } ).lazy( () =>
 	import( 'calypso/dashboard/sites' ).then( ( d ) =>
 		createLazyRoute( 'sites' )( {


### PR DESCRIPTION
## Proposed Changes

I took an opportunity to do some clean up of site list code as follows:

- [performance] Removed the `sitesQuery()` from the route loader
   - This was causing redundant blocking call if the URL contains filters / search, as that query is for the default one. We already have loading spinner anyway.
- [performance] Removed `useMemo()` from fields, actions, and views computation
   - We should only use `useMemo()` when we prove that it helps with significant time performance. Otherwise, it will only make the code bloated.
   - Besides, the REAL bottleneck of this screen is the API call and `filterSortAndPaginate()` call, not those above.
- [cleanup] Extracted actions to a separate file
   - With this, the main index file is focused for site fetching and rendering only.

## Why are these changes being made?

General code maintenance / boy scout

## Testing Instructions

Smoke test /v2/sites; verify no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
