### PR TITLE
STATS-113: Remove `stats/archive-breakdown` feature flag.

### DIFF
--- a/client/my-sites/stats/features/modules/stats-top-posts/nav-tabs.tsx
+++ b/client/my-sites/stats/features/modules/stats-top-posts/nav-tabs.tsx
@@ -1,13 +1,10 @@
 import page from '@automattic/calypso-router';
 import { TabPanel } from '@wordpress/components';
 import { useMemo } from 'react';
-import { useSelector } from 'react-redux';
 import {
 	getPathWithUpdatedQueryString,
 	trackStatsAnalyticsEvent,
 } from 'calypso/my-sites/stats/utils';
-import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import useOptionLabels, {
 	MAIN_STAT_TYPE,
 	StatsModulePostsProps,
@@ -15,11 +12,6 @@ import useOptionLabels, {
 } from './use-option-labels';
 
 function NavTabs( { query }: StatsModulePostsProps ) {
-	const siteId = useSelector( getSelectedSiteId );
-	const { supportsArchiveStats } = useSelector( ( state: object ) =>
-		getEnvStatsFeatureSupportChecks( state, siteId )
-	);
-
 	const optionLabels = useOptionLabels();
 	const tabPanelTabs = useMemo( () => {
 		return Object.entries( optionLabels ).map( ( [ key, item ] ) => {
@@ -35,8 +27,7 @@ function NavTabs( { query }: StatsModulePostsProps ) {
 		} );
 	}, [ optionLabels ] );
 
-	const selectedTab =
-		getValidQueryViewType( query.viewType, supportsArchiveStats ) || MAIN_STAT_TYPE;
+	const selectedTab = getValidQueryViewType( query.viewType ) || MAIN_STAT_TYPE;
 
 	return (
 		<TabPanel

--- a/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
+++ b/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { SimplifiedSegmentedControl, StatsCard } from '@automattic/components';
 import { postList } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -9,7 +8,6 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import StatsInfoArea from 'calypso/my-sites/stats/features/modules/shared/stats-info-area';
 import { trackStatsAnalyticsEvent } from 'calypso/my-sites/stats/utils';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import {
 	isRequestingSiteStatsForQuery,
 	getSiteStatsNormalizedData,
@@ -48,12 +46,6 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
-	const { supportsArchiveStats } = useSelector( ( state: object ) =>
-		getEnvStatsFeatureSupportChecks( state, siteId )
-	);
-
-	const isArchiveBreakdownEnabled: boolean =
-		config.isEnabled( 'stats/archive-breakdown' ) && supportsArchiveStats;
 
 	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
@@ -62,10 +54,7 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 		? 'stats-top-posts-and-pages-analyze-content-performance-jetpack'
 		: 'stats-top-posts-and-pages-analyze-content-performance';
 
-	const query = {
-		...queryFromProps,
-		skip_archives: isArchiveBreakdownEnabled ? '1' : '0',
-	};
+	const query = { ...queryFromProps, skip_archives: '1' };
 
 	const mainStatType = MAIN_STAT_TYPE;
 	const subStatType = SUB_STAT_TYPE;
@@ -76,9 +65,7 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 	const isRequestingArchivesData = useSelector( ( state: StatsStateProps ) =>
 		isRequestingSiteStatsForQuery( state, siteId, subStatType, query )
 	);
-	const isRequestingData = isArchiveBreakdownEnabled
-		? isRequestingTopPostsData || isRequestingArchivesData
-		: isRequestingTopPostsData;
+	const isRequestingData = isRequestingTopPostsData || isRequestingArchivesData;
 
 	const [ localStatType, setLocalStatType ] = useState< StatType | null >( null );
 	const onStatTypeChange = ( option: StatTypeOptionType ) => {
@@ -89,8 +76,7 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 		setLocalStatType( option.value );
 	};
 
-	const statType =
-		localStatType || getValidQueryViewType( query.viewType, supportsArchiveStats ) || mainStatType;
+	const statType = localStatType || getValidQueryViewType( query.viewType ) || mainStatType;
 
 	const data = useSelector( ( state ) =>
 		getSiteStatsNormalizedData( state, siteId, statType, query )
@@ -108,12 +94,7 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 			label: item.tabLabel,
 			mainItemLabel: item.mainItemLabel,
 			analyticsId: item.analyticsId,
-			// TODO: This is a temporary solution to disable the archives option when the archives data is not available.
-			disabled:
-				isArchiveBreakdownEnabled &&
-				key === subStatType &&
-				! isRequestingArchivesData &&
-				! archivesData.length,
+			disabled: key === subStatType && ! isRequestingArchivesData && ! archivesData.length,
 		};
 	} );
 
@@ -144,12 +125,9 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 				<QuerySiteStats statType={ mainStatType } siteId={ siteId } query={ query } />
 			) }
 
-			{ ! shouldGateStatsModule &&
-				siteId &&
-				isArchiveBreakdownEnabled &&
-				shouldQuerySubStatType && (
-					<QuerySiteStats statType={ subStatType } siteId={ siteId } query={ query } />
-				) }
+			{ ! shouldGateStatsModule && siteId && shouldQuerySubStatType && (
+				<QuerySiteStats statType={ subStatType } siteId={ siteId } query={ query } />
+			) }
 
 			{ presentLoadingUI && (
 				<StatsCardSkeleton
@@ -165,33 +143,19 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 					path="posts"
 					titleNodes={
 						<StatsInfoArea>
-							{ isArchiveBreakdownEnabled
-								? translate(
-										'Most viewed {{link}}posts, pages and archive{{/link}}. Learn about what content resonates the most.',
-										{
-											comment: '{{link}} links to support documentation.',
-											components: {
-												link: (
-													<InlineSupportLink supportContext={ supportContext } showIcon={ false } />
-												),
-											},
-											context:
-												'Stats: Link in a popover for the Posts & Pages when the module has data',
-										}
-								  )
-								: translate(
-										'{{link}}Posts and pages{{/link}} sorted by most visited. Learn about what content resonates the most.',
-										{
-											comment: '{{link}} links to support documentation.',
-											components: {
-												link: (
-													<InlineSupportLink supportContext={ supportContext } showIcon={ false } />
-												),
-											},
-											context:
-												'Stats: Link in a popover for the Posts & Pages when the module has data',
-										}
-								  ) }
+							{ translate(
+								'Most viewed {{link}}posts, pages and archive{{/link}}. Learn about what content resonates the most.',
+								{
+									comment: '{{link}} links to support documentation.',
+									components: {
+										link: (
+											<InlineSupportLink supportContext={ supportContext } showIcon={ false } />
+										),
+									},
+									context:
+										'Stats: Link in a popover for the Posts & Pages when the module has data',
+								}
+							) }
 						</StatsInfoArea>
 					}
 					moduleStrings={ moduleStrings }
@@ -206,7 +170,6 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 					skipQuery
 					isRealTime={ isRealTime }
 					toggleControl={
-						isArchiveBreakdownEnabled &&
 						! summary && (
 							<SimplifiedSegmentedControl
 								options={ options }
@@ -215,10 +178,7 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 							/>
 						)
 					}
-					mainItemLabel={
-						isArchiveBreakdownEnabled &&
-						options.find( ( option ) => option.value === statType )?.mainItemLabel
-					}
+					mainItemLabel={ options.find( ( option ) => option.value === statType )?.mainItemLabel }
 				/>
 			) }
 			{ presentEmptyUI && (

--- a/client/my-sites/stats/features/modules/stats-top-posts/use-option-labels.ts
+++ b/client/my-sites/stats/features/modules/stats-top-posts/use-option-labels.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import type { StatsDefaultModuleProps, StatsQueryType } from '../types';
 
@@ -11,17 +10,7 @@ export interface StatsModulePostsProps extends StatsDefaultModuleProps {
 	query: StatsQueryType & { viewType?: StatType };
 }
 
-export function getValidQueryViewType(
-	statType: StatType = MAIN_STAT_TYPE,
-	supportsArchiveStats = false
-) {
-	const isArchiveBreakdownFlag = config.isEnabled( 'stats/archive-breakdown' );
-	const isArchiveBreakdownEnabled = isArchiveBreakdownFlag && supportsArchiveStats;
-
-	if ( ! isArchiveBreakdownEnabled ) {
-		return MAIN_STAT_TYPE;
-	}
-
+export function getValidQueryViewType( statType: StatType = MAIN_STAT_TYPE ) {
 	return [ MAIN_STAT_TYPE, SUB_STAT_TYPE ].includes( statType ) ? statType : MAIN_STAT_TYPE;
 }
 

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -170,7 +170,6 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 		supportsDevicesStats: supportsDevicesStatsFeature,
 		isOldJetpack,
 		supportUserFeedback,
-		supportsArchiveStats,
 	} = useSelector( ( state ) => getEnvStatsFeatureSupportChecks( state, siteId ) );
 
 	const { period } = props.period;
@@ -180,7 +179,7 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 	);
 	const queryDate = date.format( DATE_FORMAT );
 
-	const moduleStrings = statsStrings( supportsArchiveStats );
+	const moduleStrings = statsStrings();
 
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );

--- a/client/my-sites/stats/stats-email-module/index.jsx
+++ b/client/my-sites/stats/stats-email-module/index.jsx
@@ -37,7 +37,7 @@ class StatsEmailModule extends Component {
 	render() {
 		const { path, data, postId, statType, query, isLoading } = this.props;
 		// Only show loading indicators when nothing is in state tree, and request in-flight
-		const moduleStrings = statsStrings( false, this.props.isJetpack )[ path ];
+		const moduleStrings = statsStrings( this.props.isJetpack )[ path ];
 		// TODO: Support error state in redux store
 		const hasError = false;
 		const metricLabel = statType === 'clicks' ? translate( 'Clicks' ) : translate( 'Opens' );

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { includes, isEqual } from 'lodash';
@@ -218,11 +217,6 @@ class StatsModule extends Component {
 			'statsEmailsOpen',
 			'statsEmailsClick',
 		];
-
-		// TODO: Remove this once the archive breakdown is enabled by default.
-		if ( ! config.isEnabled( 'stats/archive-breakdown' ) ) {
-			summarizedTypes.push( 'statsTopPosts' );
-		}
 
 		return summary && includes( summarizedTypes, statType );
 	}

--- a/client/my-sites/stats/stats-strings.js
+++ b/client/my-sites/stats/stats-strings.js
@@ -1,19 +1,13 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { SUPPORT_URL, INSIGHTS_SUPPORT_URL, JETPACK_SUPPORT_URL_TRAFFIC } from './const';
 
-export default function ( supportsArchiveStats = false, isSiteJetpackNotAtomic = false ) {
-	const isArchiveBreakdownFlag = isEnabled( 'stats/archive-breakdown' );
-	const isArchiveBreakdownEnabled = isArchiveBreakdownFlag && supportsArchiveStats;
-
+export default function ( isSiteJetpackNotAtomic = false ) {
 	const statsStrings = {};
 
 	statsStrings.posts = {
-		title: isArchiveBreakdownEnabled
-			? translate( 'Most viewed', { context: 'Stats: title of module', textOnly: true } )
-			: translate( 'Posts & pages', { context: 'Stats: title of module', textOnly: true } ),
+		title: translate( 'Most viewed', { context: 'Stats: title of module', textOnly: true } ),
 		item: translate( 'Title', { context: 'Stats: module row header for post title.' } ),
 		value: translate( 'Views', { context: 'Stats: module row header for number of post views.' } ),
 		empty: translate(

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -51,7 +51,6 @@ class StatsSummary extends Component {
 	constructor( props ) {
 		super( props );
 		this.cachedStatsStrings = null;
-		this.cachedSupportsArchiveStats = null;
 	}
 
 	componentDidMount() {
@@ -135,17 +134,13 @@ class StatsSummary extends Component {
 			statsQueryOptions,
 			siteId,
 			supportsUTMStats,
-			supportsArchiveStats,
 			shouldGateStatsCsvDownload,
 			lastScreen,
 		} = this.props;
 
 		// Simple memoization for StatsStrings
 		// TODO: Refactor to use useMemo
-		if ( this.cachedSupportsArchiveStats !== supportsArchiveStats ) {
-			this.cachedStatsStrings = statsStringsFactory( supportsArchiveStats );
-			this.cachedSupportsArchiveStats = supportsArchiveStats;
-		}
+		this.cachedStatsStrings = statsStringsFactory();
 		const StatsStrings = this.cachedStatsStrings;
 
 		const summaryViews = [];
@@ -155,9 +150,6 @@ class StatsSummary extends Component {
 		let barChart;
 		let path;
 		let statType;
-
-		const isArchiveBreakdownEnabled =
-			isEnabled( 'stats/archive-breakdown' ) && supportsArchiveStats;
 
 		const { period, endOf } = this.props.period;
 		const query = {
@@ -180,7 +172,7 @@ class StatsSummary extends Component {
 		const moduleQuery = merge( {}, statsQueryOptions, query );
 		// TODO: Refactor the query params for posts module.
 		if ( 'posts' === this.props.context.params.module ) {
-			moduleQuery.skip_archives = isArchiveBreakdownEnabled ? '1' : '0';
+			moduleQuery.skip_archives = '1';
 		}
 
 		const urlParams = new URLSearchParams( this.props.context.querystring );
@@ -275,7 +267,7 @@ class StatsSummary extends Component {
 			case 'posts':
 				title = StatsStrings.posts.title;
 				path = 'posts';
-				statType = getValidQueryViewType( moduleQuery?.viewType, supportsArchiveStats );
+				statType = getValidQueryViewType( moduleQuery?.viewType );
 				summaryView = (
 					<Fragment key="posts-summary">
 						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
@@ -479,7 +471,7 @@ class StatsSummary extends Component {
 					) }
 
 					{ /* TODO: Refactor to use the same component for both locations and posts */ }
-					{ isArchiveBreakdownEnabled && this.props.context.params.module === 'posts' && (
+					{ this.props.context.params.module === 'posts' && (
 						<div className="stats-navigation stats-navigation--improved">
 							<PostsNavTabs query={ moduleQuery } />
 						</div>
@@ -525,18 +517,13 @@ const StatsSummaryWrapper = ( props ) => {
 
 export default connect( ( state, { context, postId } ) => {
 	const siteId = getSelectedSiteId( state );
-
-	const { supportsUTMStats, supportsArchiveStats } = getEnvStatsFeatureSupportChecks(
-		state,
-		siteId
-	);
+	const { supportsUTMStats } = getEnvStatsFeatureSupportChecks( state, siteId );
 
 	return {
 		siteId: getSelectedSiteId( state ),
 		siteSlug: getSelectedSiteSlug( state, siteId ),
 		media: context.params.module === 'videodetails' ? getMediaItem( state, siteId, postId ) : false,
 		supportsUTMStats,
-		supportsArchiveStats,
 		shouldGateStatsCsvDownload: shouldGateStats( state, siteId, STATS_FEATURE_DOWNLOAD_CSV ),
 	};
 } )( localize( StatsSummaryWrapper ) );

--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -63,11 +63,6 @@ function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null )
 			'0.24.0',
 			isOdysseyStats
 		),
-		supportsArchiveStats: version_greater_than_or_equal(
-			statsAdminVersion,
-			'0.27.0',
-			isOdysseyStats
-		),
 		shouldUseStatsBuiltInPurchasesApi: version_greater_than_or_equal(
 			statsAdminVersion,
 			'0.21.0-alpha',

--- a/config/client.json
+++ b/config/client.json
@@ -20,7 +20,6 @@
 	"oauth_url",
 	"readerFollowingSource",
 	"siftscience_key",
-	"stats/archive-breakdown",
 	"stats/chart-library",
 	"stats/empty-module-traffic",
 	"stats/real-time-tab",

--- a/config/development.json
+++ b/config/development.json
@@ -172,7 +172,6 @@
 		"site-profiler/metrics": true,
 		"sites/drive-migrations": true,
 		"ssr/prefetch-timebox": false,
-		"stats/archive-breakdown": true,
 		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
 		"stats/locations": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -111,7 +111,6 @@
 		"site-profiler/metrics": true,
 		"sites/drive-migrations": true,
 		"ssr/prefetch-timebox": true,
-		"stats/archive-breakdown": true,
 		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
 		"stats/paid-wpcom-v2": true,

--- a/config/production.json
+++ b/config/production.json
@@ -142,7 +142,6 @@
 		"ssr/log-prefetch-errors": true,
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,
-		"stats/archive-breakdown": true,
 		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
 		"stats/locations": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -138,7 +138,6 @@
 		"site-profiler/metrics": false,
 		"sites/drive-migrations": true,
 		"ssr/prefetch-timebox": true,
-		"stats/archive-breakdown": true,
 		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
 		"stats/locations": true,

--- a/config/test.json
+++ b/config/test.json
@@ -102,7 +102,6 @@
 		"site-indicator": true,
 		"sites/drive-migrations": true,
 		"ssr/prefetch-timebox": true,
-		"stats/archive-breakdown": true,
 		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -144,7 +144,6 @@
 		"site-profiler/metrics": true,
 		"sites/drive-migrations": true,
 		"ssr/prefetch-timebox": true,
-		"stats/archive-breakdown": true,
 		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
 		"stats/locations": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #STATS-113

## Proposed Changes

* Remove `stats/archive-breakdown` feature flag.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* N/A

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* There shouldn't be any change.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
