### PR TITLE
Help Center: Open Odie in DIFM

### DIFF
--- a/client/signup/steps/difm-site-picker/index.tsx
+++ b/client/signup/steps/difm-site-picker/index.tsx
@@ -60,16 +60,17 @@ export default function DIFMSitePickerStep( props: Props ) {
 
 	const { data: geoData } = useGeoLocationQuery();
 
-	const isHelpCenterLinkEnabled = geoData?.country_short === 'US';
+	const isPremiumHelpCenterLinkEnabled = geoData?.country_short === 'US';
 
 	const subHeaderText = translate(
 		'Please {{SupportLink}}contact support{{/SupportLink}} if your existing WordPress.com site isn’t listed, or create a {{NewSiteLink}}new site{{/NewSiteLink}} instead.',
 		{
 			components: {
-				SupportLink: isHelpCenterLinkEnabled ? (
-					<HelpCenterInlineButton className="subtitle-link" flowName={ props.flowName } />
-				) : (
-					<a className="subtitle-link" rel="noopener noreferrer" href="/help/contact" />
+				SupportLink: (
+					<HelpCenterInlineButton
+						className="subtitle-link"
+						flowName={ isPremiumHelpCenterLinkEnabled ? props.flowName : undefined }
+					/>
 				),
 				NewSiteLink: (
 					<Button variant="link" className="subtitle-link" onClick={ onNewSiteClicked } />

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -212,11 +212,13 @@ export const setNewMessagingChat = function* ( {
 	section,
 	siteUrl,
 	siteId,
+	userFieldFlowName,
 }: {
 	initialMessage: string;
 	section?: string;
 	siteUrl?: string;
 	siteId?: string;
+	userFieldFlowName?: string;
 } ) {
 	const url = addQueryArgs( '/odie', {
 		provider: 'zendesk',
@@ -224,6 +226,7 @@ export const setNewMessagingChat = function* ( {
 		section,
 		siteUrl,
 		siteId,
+		userFieldFlowName,
 	} );
 	yield setNavigateToRoute( url );
 	yield setShowHelpCenter( true );

--- a/packages/help-center/src/components/help-center-inline-button.tsx
+++ b/packages/help-center/src/components/help-center-inline-button.tsx
@@ -13,6 +13,13 @@ interface HelpCenterInlineButtonProps {
 	className?: string;
 }
 
+/**
+ * Toggles the Help Center. If no flowName is supplied it opens the default
+ * route (/odie).
+ *
+ * If the flowName is supplied and the flow is a premium flow, it will directly open
+ * a chat with Happiness Engineers.
+ */
 const HelpCenterInlineButton: FC< HelpCenterInlineButtonProps > = ( {
 	flowName,
 	children,

--- a/packages/help-center/src/components/help-center-inline-button.tsx
+++ b/packages/help-center/src/components/help-center-inline-button.tsx
@@ -1,9 +1,9 @@
 import { HelpCenterSelect } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { addQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import { useFlowCustomOptions, useFlowZendeskUserFields } from '../hooks';
+import { useResetSupportInteraction } from '../hooks/use-reset-support-interaction';
 import { HELP_CENTER_STORE } from '../stores';
 import type { FC, ReactNode } from 'react';
 
@@ -25,7 +25,9 @@ const HelpCenterInlineButton: FC< HelpCenterInlineButtonProps > = ( {
 	children,
 	className,
 } ) => {
-	const { setShowHelpCenter, setNavigateToRoute } = useDispatch( HELP_CENTER_STORE );
+	const resetSupportInteraction = useResetSupportInteraction();
+	const { setShowHelpCenter, setNavigateToRoute, setNewMessagingChat } =
+		useDispatch( HELP_CENTER_STORE );
 	const isShowingHelpCenter = useSelect(
 		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).isHelpCenterShown(),
 		[]
@@ -40,12 +42,12 @@ const HelpCenterInlineButton: FC< HelpCenterInlineButtonProps > = ( {
 			flowCustomOptions
 		);
 		if ( flowCustomOptions?.hasPremiumSupport ) {
-			const urlWithQueryArgs = addQueryArgs( '/odie?provider=zendesk', {
-				userFieldMessage,
-				userFieldFlowName,
+			setNewMessagingChat( {
+				initialMessage: userFieldMessage || '',
+				userFieldFlowName: userFieldFlowName || '',
 			} );
-			setNavigateToRoute( urlWithQueryArgs );
 		} else {
+			resetSupportInteraction();
 			setNavigateToRoute( '/odie' );
 		}
 	}

--- a/packages/help-center/src/hooks/use-action-hooks.ts
+++ b/packages/help-center/src/hooks/use-action-hooks.ts
@@ -1,13 +1,15 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
+import { useResetSupportInteraction } from './use-reset-support-interaction';
 
 /**
  * Add your conditions here to open the Help Center automatically when they're met.
  */
 export const useActionHooks = () => {
-	const { setShowHelpCenter, setShowSupportDoc, setNavigateToRoute } =
+	const { setShowHelpCenter, setShowSupportDoc, setNavigateToRoute, setNewMessagingChat } =
 		useDispatch( 'automattic/help-center' );
+	const resetSupportInteraction = useResetSupportInteraction();
 	const queryParams = new URLSearchParams( window.location.search );
 
 	const actionHooks = [
@@ -46,7 +48,8 @@ export const useActionHooks = () => {
 			condition() {
 				return queryParams.get( 'help-center' ) === 'wapuu';
 			},
-			action() {
+			async action() {
+				await resetSupportInteraction();
 				setNavigateToRoute( '/odie' );
 				setShowHelpCenter( true );
 			},
@@ -60,14 +63,11 @@ export const useActionHooks = () => {
 				return queryParams.get( 'help-center' ) === 'happiness-engineer';
 			},
 			action() {
-				const message = queryParams.get( 'user-message' ) ?? '';
-				const siteUrl = queryParams.get( 'site-url' ) ?? '';
-				const siteId = queryParams.get( 'site-id' ) ?? '';
-
-				setNavigateToRoute(
-					`/odie?provider=zendesk&userFieldMessage=${ message }&siteUrl=${ siteUrl }&siteId=${ siteId }`
-				);
-				setShowHelpCenter( true );
+				setNewMessagingChat( {
+					initialMessage: queryParams.get( 'user-message' ) ?? '',
+					siteUrl: queryParams.get( 'site-url' ) ?? '',
+					siteId: queryParams.get( 'site-id' ) ?? '',
+				} );
 			},
 		},
 	];

--- a/packages/help-center/src/hooks/use-reset-support-interaction.ts
+++ b/packages/help-center/src/hooks/use-reset-support-interaction.ts
@@ -21,11 +21,11 @@ export const useResetSupportInteraction = () => {
 			await queryClient.invalidateQueries( {
 				queryKey: [ 'support-interactions', 'get-interactions' ],
 			} );
-
-			return await startNewInteraction( {
-				event_source: 'help-center',
-				event_external_id: crypto.randomUUID(),
-			} );
 		}
+
+		return await startNewInteraction( {
+			event_source: 'help-center',
+			event_external_id: crypto.randomUUID(),
+		} );
 	};
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTOBRD-157/fix-location-of-contact-us-button-in-difm-flow

## Proposed Changes

When you click the contact link on the site picker of the DIFM flow, let's open the help center with an Odie chat:

<img width="594" alt="image" src="https://github.com/user-attachments/assets/04259a2f-9d95-40b3-8191-d645c18f2080" />



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* GO to /start/do-it-for-me/difm-site-picker
* Click contact support