### PR TITLE
DataViews: Add translation context for date filter strings

### DIFF
--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -17,6 +17,7 @@
 - Add new filter operators: `on` and `notOn` for date fields that use proper date comparison instead of string equality. Filter labels use "Date is:" and "Date is not:" for consistency.
 - Add new filter operator: `inThePast`, `over` for date fields.
 - Adjust the padding when the component is placed inside a `Card`.
+- Add translation context for date filter strings to improve internationalization support.
 
 ## 0.2.1
 

--- a/packages/dataviews/src/constants.ts
+++ b/packages/dataviews/src/constants.ts
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { arrowDown, arrowUp } from '@wordpress/icons';
 
 /**
@@ -159,11 +159,11 @@ export const OPERATORS: Record< Operator, { key: string; label: string } > = {
 	},
 	[ OPERATOR_IN_THE_PAST ]: {
 		key: 'in-the-past-filter',
-		label: __( 'In the past' ),
+		label: _x( 'In the past', 'date filter operator' ),
 	},
 	[ OPERATOR_OVER ]: {
 		key: 'over-filter',
-		label: __( 'Over' ),
+		label: _x( 'Over', 'date filter operator' ),
 	},
 };
 

--- a/packages/dataviews/src/dataform-controls/datetime.tsx
+++ b/packages/dataviews/src/dataform-controls/datetime.tsx
@@ -10,7 +10,7 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -20,16 +20,36 @@ import { OPERATOR_IN_THE_PAST, OPERATOR_OVER } from '../constants';
 
 const TIME_UNITS_OPTIONS = {
 	[ OPERATOR_IN_THE_PAST ]: [
-		{ value: 'days', label: __( 'Days' ) },
-		{ value: 'weeks', label: __( 'Weeks' ) },
-		{ value: 'months', label: __( 'Months' ) },
-		{ value: 'years', label: __( 'Years' ) },
+		/* translators: Time unit for date filtering - e.g. "in the past 5 Days" */
+		{ value: 'days', label: _x( 'Days', 'date filter time unit' ) },
+		/* translators: Time unit for date filtering - e.g. "in the past 3 Weeks" */
+		{ value: 'weeks', label: _x( 'Weeks', 'date filter time unit' ) },
+		/* translators: Time unit for date filtering - e.g. "in the past 2 Months" */
+		{ value: 'months', label: _x( 'Months', 'date filter time unit' ) },
+		/* translators: Time unit for date filtering - e.g. "in the past 1 Years" */
+		{ value: 'years', label: _x( 'Years', 'date filter time unit' ) },
 	],
 	[ OPERATOR_OVER ]: [
-		{ value: 'days', label: __( 'Days ago' ) },
-		{ value: 'weeks', label: __( 'Weeks ago' ) },
-		{ value: 'months', label: __( 'Months ago' ) },
-		{ value: 'years', label: __( 'Years ago' ) },
+		/* translators: Time unit for date filtering - e.g. "over 5 Days ago" */
+		{
+			value: 'days',
+			label: _x( 'Days ago', 'used with date filter operator' ),
+		},
+		/* translators: Time unit for date filtering - e.g. "over 3 Weeks ago" */
+		{
+			value: 'weeks',
+			label: _x( 'Weeks ago', 'used with date filter operator' ),
+		},
+		/* translators: Time unit for date filtering - e.g. "over 2 Months ago" */
+		{
+			value: 'months',
+			label: _x( 'Months ago', 'used with date filter operator' ),
+		},
+		/* translators: Time unit for date filtering - e.g. "over 1 Years ago" */
+		{
+			value: 'years',
+			label: _x( 'Years ago', 'used with date filter operator' ),
+		},
 	],
 };
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the
  issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to #104390

## Proposed Changes

- Add translation context to date filter operator labels ("In the past" and "Over") using
  `_x()` function
* Add translation context to time unit labels ("Days", "Weeks", "Months", "Years", "Days
ago", "Weeks ago", "Months ago", "Years ago") using `_x()` function


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

German translation reviewers identified translation issues with date filter strings, such as `"Over x days ago."` Direct translation creates awkward results - `"x days ago"` becomes `"vor x Tagen"` while `"over x days ago"` becomes `"vor mehr als x Tagen."` Without context, terms like "Over" and "Days ago" could conflict with other uses, making `_x()` with context essential for accurate translations.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Run `yarn dataviews:storybook:start`
* Go to http://localhost:57863/?path=/story/dataviews-fieldtypes--date-time
* Select the `In the past` or `Over` operator.
* Verify that date filter functionality still works correctly with the new translation
context

<img width="208" alt="Screenshot 2025-06-30 at 13 34 17" src="https://github.com/user-attachments/assets/5cef9cec-d89a-44b9-a12b-0fee6b40755f" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable
items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new
tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and
self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable
with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and
assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with
create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils
/src/create-selector/README.md) and [Using memoizing
selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our
Approach to
Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were
ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example,
ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates"
  label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?