### PR TITLE
Dashboard: Adjust paddings to 24px to align with the new dataviews styles

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -10,8 +10,12 @@ $brand-display: "SF Pro Display", sans-serif;
 	}
 
 	@media (max-width: $break-small) {
-		padding-inline: 16px;	
-	}	
+		padding-inline: 16px;
+	}
+
+	body:has(.is-global-sidebar-visible) & {
+		padding-inline: 24px;
+	}
 }
 
 .scheduled-updates-list.main.is-full-width-layout {

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -5,7 +5,7 @@
 .navigation-header {
 	box-sizing: border-box;
 	width: 100%;
-	padding: 0 0 24px 0;
+	padding: 0 0 16px 0;
 	margin-bottom: 0;
 
 	@media (max-width: $break-small) {

--- a/client/dashboard/components/dataviews-card/index.tsx
+++ b/client/dashboard/components/dataviews-card/index.tsx
@@ -3,7 +3,7 @@ import { Card, CardBody } from '@wordpress/components';
 function DataViewsCard( { children }: { children: React.ReactNode } ) {
 	return (
 		<Card>
-			<CardBody style={ { paddingLeft: 0, paddingRight: 0 } }>{ children }</CardBody>
+			<CardBody>{ children }</CardBody>
 		</Card>
 	);
 }

--- a/client/layout/hosting-dashboard/style.scss
+++ b/client/layout/hosting-dashboard/style.scss
@@ -85,7 +85,7 @@
 }
 
 .hosting-dashboard-layout__top-wrapper {
-	padding-block-start: 24px;
+	padding-block-start: 16px;
 	border-block-end: 1px solid var(--color-neutral-5);
 
 	@include breakpoint-deprecated( "<660px" ) {
@@ -105,7 +105,7 @@
 
 	// If we don't have a navigation, we will require some spacing on the borders.
 	&:not(.has-navigation) {
-		padding-block-end: 24px;
+		padding-block-end: 16px;
 	}
 }
 

--- a/client/my-sites/domains/domain-management/dataviews/style.scss
+++ b/client/my-sites/domains/domain-management/dataviews/style.scss
@@ -14,7 +14,7 @@ body.is-section-domains.is-bulk-all-domains-page {
 		overflow-y: auto;
 
 		.navigation-header {
-			padding-top: 24px;
+			padding-top: 16px;
 
 			.formatted-header {
 				max-height: 41px;

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -47,8 +47,8 @@ const domainsDataViewsGlobalStyles = css`
 
 		header.navigation-header {
 			border-block-end: 1px solid var( --color-neutral-5 );
-			padding-block-start: 24px;
-			padding-block-end: 24px;
+			padding-block-start: 16px;
+			padding-block-end: 16px;
 		}
 
 		div.layout.is-global-sidebar-visible {

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -162,7 +162,7 @@
 
 				.navigation-header__main {
 					margin: 0 auto;
-					padding-inline: 48px;
+					padding-inline: 24px;
 				}
 			}
 		}

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -150,11 +150,7 @@
 			padding-inline: 0;
 
 			.navigation-header__main {
-				padding-inline: 21px;
-
-				@include break-mobile {
-					padding-inline: 24px;
-				}
+				padding-inline: 24px;
 			}
 
 			@include break-huge {

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -153,7 +153,7 @@
 				padding-inline: 21px;
 
 				@include break-mobile {
-					padding-inline: 48px;
+					padding-inline: 24px;
 				}
 			}
 

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -37,9 +37,6 @@ import SearchCategories from '../search-categories';
 
 import './style.scss';
 
-const THRESHOLD = 10;
-const SEARCH_CATEGORIES_HEIGHT = 36;
-const LAYOUT_PADDING = 16;
 const MASTERBAR_HEIGHT = 32;
 
 // If adding new, longer search terms, ensure that the search input field is wide enough to accommodate it.
@@ -83,12 +80,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 	const loggedInSearchBoxRef = useRef( null );
 	const isLoggedInSearchBoxSticky =
 		useIsVisible( loggedInSearchBoxRef, {
-			rootMargin: `${
-				-1 *
-				( THRESHOLD +
-					SEARCH_CATEGORIES_HEIGHT +
-					( selectedSite ? MASTERBAR_HEIGHT : LAYOUT_PADDING ) )
-			}px 0px 0px 0px`,
+			rootMargin: selectedSite ? `${ -1 * MASTERBAR_HEIGHT }px 0px 0px 0px` : '0px',
 		} ) === false;
 
 	const jetpackNonAtomic = useSelector(
@@ -189,14 +181,17 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 					<JetpackConnectionHealthBanner siteId={ siteId } />
 				) }
 				{ isLoggedIn ? (
-					<SearchCategories
-						category={ category }
-						isSearching={ isFetchingPluginsBySearchTerm }
-						isSticky={ isLoggedInSearchBoxSticky }
-						searchRef={ searchRef }
-						searchTerm={ search }
-						searchTerms={ searchTerms }
-					/>
+					<>
+						<div ref={ loggedInSearchBoxRef } />
+						<SearchCategories
+							category={ category }
+							isSearching={ isFetchingPluginsBySearchTerm }
+							isSticky={ isLoggedInSearchBoxSticky }
+							searchRef={ searchRef }
+							searchTerm={ search }
+							searchTerms={ searchTerms }
+						/>
+					</>
 				) : (
 					<>
 						<SearchBoxHeader
@@ -222,7 +217,6 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 						</div>
 					</>
 				) }
-				{ isLoggedIn && <div ref={ loggedInSearchBoxRef } /> }
 				<div className="plugins-browser__main-container">{ renderList() }</div>
 				{ ! category && ! search && (
 					<div className="plugins-browser__marketplace-footer">

--- a/client/my-sites/plugins/plugins-dashboard/style.scss
+++ b/client/my-sites/plugins/plugins-dashboard/style.scss
@@ -36,7 +36,7 @@
 	}
 
 	.hosting-dashboard-layout__top-wrapper:not( .preview-hidden ) {
-		padding-block-start: 24px;
+		padding-block-start: 16px;
 	}
 
 	.plugin-manage-sites-pane {

--- a/client/my-sites/plugins/plugins-navigation-header/style.scss
+++ b/client/my-sites/plugins/plugins-navigation-header/style.scss
@@ -2,7 +2,7 @@
 @import "@wordpress/base-styles/mixins";
 
 .plugins-navigation-header.navigation-header {
-	padding-inline: 48px;
+	padding-inline: 24px;
 
 	.navigation-header__main {
 		align-items: center;

--- a/client/my-sites/plugins/search-categories/style.scss
+++ b/client/my-sites/plugins/search-categories/style.scss
@@ -1,14 +1,15 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-$search-categories-padding-top: 16px;
+$search-categories-padding-block: 16px;
+$search-categories-height: 40px;
 
 .search-categories {
+
 	display: flex;
 	align-items: center;
 	gap: 12px;
-	padding-inline: 0;
-	padding-top: $search-categories-padding-top;
+	padding: $search-categories-padding-block 0 0;
 
 	.components-search-control {
 		width: 100%;
@@ -97,48 +98,54 @@ $search-categories-padding-top: 16px;
 		padding: 0;
 	}
 
-	&.fixed-top {
-		@include break-medium {
-			position: fixed;
-			z-index: 20;
-			top: calc(var(--masterbar-height) + 16px);
-			padding: 10px 32px;
+	@include break-medium {
+		position: sticky;
+		top: 0;
+		z-index: 20;
+
+		&.fixed-top {
+			padding: $search-categories-padding-block 32px;
+			margin: 0 -32px;
 			box-sizing: border-box;
-			border-top-left-radius: 4px;
 			border-bottom: 1px solid var(--studio-gray-5);
 			background-color: var(--studio-white);
+		}
+
+		// The parent `layout__content` has the `overflow: hidden;` so we need to use fixed position.
+		.plugins-browser--site-view &.fixed-top {
+			position: fixed;
+			top: var(--masterbar-height);
+			padding: $search-categories-padding-block 24px;
+			margin: 0 auto;
+			box-sizing: border-box;
+			border-bottom: 0;
 
 			.layout__secondary ~ .layout__primary & {
 				left: var(--sidebar-width-max);
-				width: calc(100% - var(--sidebar-width-max) - 31px);
+				right: 0;
+				max-width: 1040px;
 			}
-		}
-	}
 
-	.plugins-browser--site-view &.fixed-top {
-		top: var(--masterbar-height);
-		box-sizing: content-box;
-
-		@include break-medium {
-			padding: 10px max(2rem, calc((100% - var(--sidebar-width-max) - (1040px - 2 * 2rem)) / 2));
-
-			.layout__secondary ~ .layout__primary & {
-				width: calc(100vw - var(--sidebar-width-max) - 2 * 2rem);
-			}
-		}
-
-		@include break-wide {
-			padding: 10px calc((100% - var(--sidebar-width-max) - (1040px - 2 * 2rem)) / 2);
-
-			.layout__secondary ~ .layout__primary & {
-				width: calc(1040px - 2 * 2rem);
+			&::after {
+				content: '';
+				position: absolute;
+				bottom: 0;
+				left: 50%;
+				transform: translateX(-50%);
+				width: calc(100vw - var(--sidebar-width-max));
+				height: 0;
+				border-bottom: 1px solid var(--studio-gray-5);
 			}
 		}
 	}
 }
 
 .search-categories__sticky-placeholder {
-	// This is the height + padding of the .search-categories box when it's not fixed to the top
-	// We add this whitespace so the content doesn't jump when the search box becomes fixed
-	height: calc(#{$search-categories-padding-top} + 16px);
+	height: 0;
+
+	@include break-medium {
+		// This is the height + padding of the .search-categories box when it's not fixed to the top
+		// We add this whitespace so the content doesn't jump when the search box becomes fixed
+		height: calc(#{$search-categories-height} + #{$search-categories-padding-block});
+	}
 }

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -30,7 +30,7 @@
 		margin-bottom: 0;
 
 		@include breakpoint-deprecated( "<660px" ) {
-			margin: 16px;
+			margin: 16px 0 0;
 		}
 	}
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -466,7 +466,7 @@ body.is-section-plugins header .select-dropdown__item {
 }
 
 body.is-section-plugins .is-logged-in .navigation-header {
-	padding-top: 24px;
+	padding-block: 16px;
 }
 
 body.is-section-plugins #primary {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -74,7 +74,7 @@ body.is-section-plugins {
 	.is-logged-in main:not(.hosting-dashboard-layout):not(.hosting-dashboard-layout-column) {
 		&:not(.plugins-browser),
 		&.plugins-browser .plugins-browser__content-wrapper {
-			padding-inline: 48px;
+			padding-inline: 24px;
 
 			@media (max-width: $break-medium) {
 				padding-inline: 2rem;

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -44,7 +44,7 @@
 			}
 		}
 		.navigation-header {
-			padding-top: 24px;
+			padding-block: 16px;
 			padding-inline: 24px;
 			@media (max-width: 402px) {
 				padding-inline: 24px;

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -45,7 +45,7 @@
 		}
 		.navigation-header {
 			padding-top: 24px;
-			padding-inline: 48px;
+			padding-inline: 24px;
 			@media (max-width: 402px) {
 				padding-inline: 24px;
 			}
@@ -90,13 +90,14 @@
 			.theme-showcase__all-themes {
 				@media (min-width: $break-mobile) and (min-height: $break-mobile) {
 					overflow-y: auto;
+					overflow-x: hidden;
 				}
 				height: 100%;
 			}
 
 			.themes__controls .theme__search-container, .themes__controls .themes__filters, .themes__showcase .theme-showcase__all-themes {
 				margin: 0 auto;
-				padding-inline: 48px;
+				padding-inline: 24px;
 				@media (max-width: 402px) {
 					padding-inline: 24px;
 				}

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -541,8 +541,8 @@
 		}
 
 		@include break-medium {
-			padding-top: 24px;
-			margin-top: -24px;
+			padding-top: 16px;
+			margin-top: -16px;
 			box-sizing: content-box;
 
 			.is-global-sidebar-visible & {

--- a/client/sites/components/dotcom-style.scss
+++ b/client/sites/components/dotcom-style.scss
@@ -15,7 +15,7 @@
 	.hosting-dashboard-layout__top-wrapper {
 		> * {
 			// FIXME: Maybe this should be moved to layout/hosting-dashboard/style.scss once we have integrated DataViews without overrides across pages.
-			padding-inline: 48px;
+			padding-inline: 24px;
 			// TODO: This is currently overridden as `none` in the Sites Dashboard for both Dotcom and A4A to align with Core's DataViews.
 			// Consider removing this max-width as the default across all layouts.
 			max-width: revert;
@@ -35,7 +35,7 @@
 		display: flex;
 		justify-content: center;
 		margin: 24px auto 8px;
-		padding-inline: 48px;
+		padding-inline: 24px;
 		width: 100%;
 	}
 

--- a/client/sites/components/sites-dataviews/dataview-style.scss
+++ b/client/sites/components/sites-dataviews/dataview-style.scss
@@ -46,3 +46,23 @@
 		}
 	}
 }
+
+// Apply consistent 24px paddings to dataviews.
+.wpcom-site:has(.is-global-sidebar-visible) .dataviews-wrapper {
+	.dataviews__view-actions,
+	.dataviews-filters__container,
+	.dataviews-footer,
+	.dataviews-view-grid {
+		padding-inline: $grid-unit-30;
+	}
+
+	.dataviews-view-table tr td:first-child,
+	.dataviews-view-table tr th:first-child {
+		padding-inline-start: $grid-unit-30;
+	}
+
+	.dataviews-view-table tr td:last-child,
+	.dataviews-view-table tr th:last-child {
+		padding-inline-end: $grid-unit-30;
+	}
+}

--- a/client/sites/components/style.scss
+++ b/client/sites/components/style.scss
@@ -27,7 +27,7 @@
 	}
 
 	.hosting-dashboard-layout__top-wrapper {
-		padding-block-start: 24px;
+		padding-block-start: 16px;
 	}
 
 	.sites-dataviews__site {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-71

## Proposed Changes

* Since we've adjusted the paddings of the `DataViews` to 24px when placed inside the `Card` component via [#104479](https://github.com/Automattic/wp-calypso/pull/104479), and given our plan to backport this change to the v1 dashboard, it would be beneficial to update all global pages to use 24px paddings as well. This will ensure consistent spacing across the interface, particularly when the backported Sites List is enabled.

**Current Screens**

| Sites | P2s | Domains | Themes | Plugins |
| - | - | - | - | - |
|![image](https://github.com/user-attachments/assets/c2c401b0-7d24-4d96-a838-0b3a0fa414f8)|![image](https://github.com/user-attachments/assets/6dbfef37-3170-4ad0-b5a0-23fec520d6f0)|![image](https://github.com/user-attachments/assets/13926ecc-d87d-40f7-981f-49f715d989e4)|![image](https://github.com/user-attachments/assets/eeb01d4b-b1de-4ada-bb66-9cb0dcc27bc0)|![image](https://github.com/user-attachments/assets/7aa32aec-9f8f-46a0-aa73-48e72bd8790c)|

**Backport Sites List**

![image](https://github.com/user-attachments/assets/3757512c-7bc7-41af-ab38-54b586be9b2e)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Consistent paddings

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Ensure that both the header and content paddings are set to 24px
* Navigate to other pages, P2s, domains, themes, plugins
* Ensure that both the header and content paddings are still set to 24px
* Go to /sites?flags=dashboard/v2/backport/sites-list
* Ensure that both the header and content paddings are still set to 24px when the feature is enabled

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
