### PR TITLE
Sites List v2: Add Prepare for launch feature for a4a sites

### DIFF
--- a/client/dashboard/sites/actions.tsx
+++ b/client/dashboard/sites/actions.tsx
@@ -44,6 +44,22 @@ export function getActions( router: AnyRouter ): Action< Site >[] {
 			isEligible: ( item: Site ) => canManageSite( item ),
 		},
 		{
+			id: 'prepare-for-launch',
+			label: __( 'Prepare for launch' ),
+			callback: ( sites ) => {
+				const site = sites[ 0 ];
+				router.navigate( {
+					to: '/sites/$siteSlug/settings/site-visibility',
+					params: { siteSlug: site.slug },
+				} );
+			},
+			isEligible: ( item: Site ) =>
+				canManageSite( item ) &&
+				item.is_a4a_dev_site &&
+				! item.is_wpcom_staging_site &&
+				item.launch_status === 'unlaunched',
+		},
+		{
 			id: 'settings',
 			label: __( 'Settings' ),
 			callback: ( sites: Site[] ) => {

--- a/client/dashboard/sites/actions.tsx
+++ b/client/dashboard/sites/actions.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
@@ -52,6 +53,8 @@ export function getActions( router: AnyRouter ): Action< Site >[] {
 					to: '/sites/$siteSlug/settings/site-visibility',
 					params: { siteSlug: site.slug },
 				} );
+
+				recordTracksEvent( 'calypso_sites_dashboard_site_action_prepare_for_launch_click' );
 			},
 			isEligible: ( item: Site ) =>
 				canManageSite( item ) &&

--- a/client/layout/hosting-dashboard/item-view/item-view-header/index.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useMediaQuery } from '@wordpress/compose';
@@ -138,7 +139,11 @@ export default function ItemViewHeader( {
 													WordPress{ ' ' }
 													<a
 														className="hosting-dashboard-item-view__header-env-data-item-link"
-														href={ `/hosting-config/${ selectedSite?.domain }#wp` }
+														href={
+															isEnabled( 'dashboard/v2/backport/site-settings' )
+																? `/sites/settings/v2/${ selectedSite?.domain }/wordpress`
+																: `/hosting-config/${ selectedSite?.domain }#wp`
+														}
 														onClick={ handleWpVersionClick }
 													>
 														{ wpVersion }
@@ -153,7 +158,11 @@ export default function ItemViewHeader( {
 													<a
 														className="hosting-dashboard-item-view__header-env-data-item-link"
 														onClick={ handlePhpVersionClick }
-														href={ `/hosting-config/${ selectedSite?.domain }#php` }
+														href={
+															isEnabled( 'dashboard/v2/backport/site-settings' )
+																? `/sites/settings/v2/${ selectedSite?.domain }/php`
+																: `/hosting-config/${ selectedSite?.domain }#php`
+														}
 													>
 														{ phpVersion }
 													</a>

--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { getPlanPath, WPCOM_FEATURES_COPY_SITE } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { useLocalizeUrl } from '@automattic/i18n-utils';
@@ -385,7 +386,11 @@ export function useActions( {
 				id: 'prepare-for-launch',
 				label: __( 'Prepare for launch' ),
 				callback: ( sites ) => {
-					page( `/sites/settings/site/${ sites[ 0 ].ID }` );
+					const url = isEnabled( 'dashboard/v2/backport/site-settings' )
+						? `/sites/settings/v2/${ sites[ 0 ].slug }/site-visibility`
+						: `/sites/settings/site/${ sites[ 0 ].ID }`;
+
+					page( url );
 					dispatch(
 						recordTracksEvent( 'calypso_sites_dashboard_site_action_prepare_for_launch_click' )
 					);

--- a/client/sites/v2/sites-list/router.tsx
+++ b/client/sites/v2/sites-list/router.tsx
@@ -64,6 +64,17 @@ const sitesSettingsCompatibilityRoute = createRoute( {
 	},
 } );
 
+const dashboardSiteSettingsWithFeatureCompatibilityRoute = createRoute( {
+	getParentRoute: () => rootRoute,
+	path: 'sites/$siteSlug/settings/$feature',
+	beforeLoad: ( { cause, params: { siteSlug, feature } } ) => {
+		if ( cause !== 'enter' ) {
+			return;
+		}
+		throw redirect( { to: `/sites/settings/v2/${ siteSlug }/${ feature }` } );
+	},
+} );
+
 const createRouteTree = () =>
 	rootRoute.addChildren( [
 		sitesRoute,
@@ -71,9 +82,14 @@ const createRouteTree = () =>
 		sitesOverviewCompatibilityRoute,
 		dummySitesSettingsRoute,
 		sitesSettingsCompatibilityRoute,
+		dashboardSiteSettingsWithFeatureCompatibilityRoute,
 	] );
 
-const compatibilityRoutes = [ sitesOverviewCompatibilityRoute, sitesSettingsCompatibilityRoute ];
+const compatibilityRoutes = [
+	sitesOverviewCompatibilityRoute,
+	sitesSettingsCompatibilityRoute,
+	dashboardSiteSettingsWithFeatureCompatibilityRoute,
+];
 
 export const { syncBrowserHistoryToRouter, syncMemoryRouterToBrowserHistory } =
 	createBrowserHistoryAndMemoryRouterSync( { compatibilityRoutes } );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-93

## Proposed Changes

* Add Prepare for launch feature for a4a sites

![image](https://github.com/user-attachments/assets/4f2b50a4-32ca-43c9-9fd5-fbe776304cc5)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Click `...` on your a4a unlaunched site, and then click "Prepare for launch"
* Ensure it opens the site visibility page correctly
* Go to /sites?flags=dashboard/v2/backport/sites-list
* Repeat the above steps
* Go to /sites
* Open the site preview for your AT site
* Click the wordpress & php link on the top
  ![image](https://github.com/user-attachments/assets/4df1e13e-84d4-4909-b3f3-7f19c7450085)
* Ensure it opens the corresponding setting page correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
