### PR TITLE
Backport Sites List: Keep the loading state active to prevent displaying a white screen during the redirection

### DIFF
--- a/client/sites/v2/sites-list/router.tsx
+++ b/client/sites/v2/sites-list/router.tsx
@@ -11,6 +11,9 @@ import { queryClient } from 'calypso/dashboard/app/query-client';
 import Root from '../components/root';
 import { getRouterOptions, createBrowserHistoryAndMemoryRouterSync } from '../utils/router';
 
+// Keep the loading state active to prevent displaying a white screen during the redirection.
+const infiniteLoader = () => new Promise( () => {} );
+
 const rootRoute = createRootRoute( { component: Root } );
 
 const sitesRoute = createRoute( {
@@ -33,6 +36,7 @@ const sitesRoute = createRoute( {
 const dummySitesOverviewRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'overview/$siteSlug',
+	loader: infiniteLoader,
 	component: () => null,
 } );
 
@@ -50,6 +54,7 @@ const sitesOverviewCompatibilityRoute = createRoute( {
 const dummySitesSettingsRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'sites/settings/v2/$siteSlug',
+	loader: infiniteLoader,
 	component: () => null,
 } );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-80

## Proposed Changes

* Keep the loading state active to prevent displaying a white screen during the redirection

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the user experience

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites?flags=dashboard/v2/backport/sites-list
* Select any site or click `... > Settings` to open the site preview
* Ensure the sites list won't become white screen during the redirection

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
