### PR TITLE
Dashboard v2: show AT transfer status in Status column

### DIFF
--- a/client/dashboard/app/queries/site-atomic-transfers.ts
+++ b/client/dashboard/app/queries/site-atomic-transfers.ts
@@ -1,0 +1,12 @@
+import { fetchLatestAtomicTransfer } from '../../data/site-atomic-transfers';
+
+export const siteLatestAtomicTransferQuery = ( siteId: number ) => ( {
+	queryKey: [ 'site', siteId, 'atomic', 'transfers', 'latest' ],
+	queryFn: () => fetchLatestAtomicTransfer( siteId ),
+	retry: ( failureCount: number, error: { code?: string } ) => {
+		if ( error.code === 'no_transfer_record' ) {
+			return false;
+		}
+		return failureCount < 3;
+	},
+} );

--- a/client/dashboard/app/queries/site-atomic-transfers.ts
+++ b/client/dashboard/app/queries/site-atomic-transfers.ts
@@ -3,10 +3,4 @@ import { fetchLatestAtomicTransfer } from '../../data/site-atomic-transfers';
 export const siteLatestAtomicTransferQuery = ( siteId: number ) => ( {
 	queryKey: [ 'site', siteId, 'atomic', 'transfers', 'latest' ],
 	queryFn: () => fetchLatestAtomicTransfer( siteId ),
-	retry: ( failureCount: number, error: { code?: string } ) => {
-		if ( error.code === 'no_transfer_record' ) {
-			return false;
-		}
-		return failureCount < 3;
-	},
 } );

--- a/client/dashboard/app/query-client.ts
+++ b/client/dashboard/app/query-client.ts
@@ -9,9 +9,8 @@ export const queryClient = new QueryClient( {
 			refetchOnWindowFocus: true,
 			refetchOnMount: true,
 			retry: ( failureCount: number, error: Error ) => {
-				if ( 'status' in error ) {
-					const status = error.status;
-					if ( typeof status === 'number' && status >= 400 && status < 500 ) {
+				if ( 'status' in error && typeof error.status === 'number' ) {
+					if ( error.status >= 400 && error.status < 500 ) {
 						return false;
 					}
 				}

--- a/client/dashboard/app/query-client.ts
+++ b/client/dashboard/app/query-client.ts
@@ -8,6 +8,15 @@ export const queryClient = new QueryClient( {
 			staleTime: 0,
 			refetchOnWindowFocus: true,
 			refetchOnMount: true,
+			retry: ( failureCount: number, error: Error ) => {
+				if ( 'status' in error ) {
+					const status = error.status;
+					if ( typeof status === 'number' && status >= 400 && status < 500 ) {
+						return false;
+					}
+				}
+				return failureCount < 3;
+			},
 		},
 	},
 } );

--- a/client/dashboard/data/site-atomic-transfers.ts
+++ b/client/dashboard/data/site-atomic-transfers.ts
@@ -19,9 +19,7 @@ export interface AtomicTransfer {
 	status: AtomicTransferStatus;
 }
 
-export async function fetchLatestAtomicTransfer(
-	siteId: number
-): Promise< AtomicTransfer | undefined > {
+export async function fetchLatestAtomicTransfer( siteId: number ): Promise< AtomicTransfer > {
 	return wpcom.req.get( {
 		path: `/sites/${ siteId }/atomic/transfers/latest`,
 		apiNamespace: 'wpcom/v2',

--- a/client/dashboard/data/site-atomic-transfers.ts
+++ b/client/dashboard/data/site-atomic-transfers.ts
@@ -1,0 +1,29 @@
+import wpcom from 'calypso/lib/wp';
+
+export type AtomicTransferStatus =
+	| 'pending'
+	| 'active'
+	| 'provisioned'
+	| 'completed'
+	| 'error'
+	| 'reverted'
+	| 'relocating_revert'
+	| 'relocating_switcheroo'
+	| 'reverting'
+	| 'renaming'
+	| 'exporting'
+	| 'importing'
+	| 'cleanup';
+
+export interface AtomicTransfer {
+	status: AtomicTransferStatus;
+}
+
+export async function fetchLatestAtomicTransfer(
+	siteId: number
+): Promise< AtomicTransfer | undefined > {
+	return wpcom.req.get( {
+		path: `/sites/${ siteId }/atomic/transfers/latest`,
+		apiNamespace: 'wpcom/v2',
+	} );
+}

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -6,6 +6,7 @@ export type * from './me-profile';
 export type * from './me-sites';
 export type * from './me-ssh';
 export type * from './site';
+export type * from './site-atomic-transfers';
 export type * from './site-domains';
 export type * from './site-hosting-edge-cache';
 export type * from './site-hosting-sftp';

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -27,7 +27,7 @@ import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { HostingFeatures } from '../features';
 import { isSitePlanTrial } from '../plans';
 import { JetpackLogo } from './jetpack-logo';
-import type { Site } from '../../data/types';
+import type { AtomicTransferStatus, Site } from '../../data/types';
 
 function IneligibleIndicator() {
 	return <Text color="#CCCCCC">-</Text>;
@@ -225,7 +225,7 @@ function WithHostingFeaturesQuery( {
 	children,
 }: {
 	site: Site;
-	children: ( transferStatus?: string ) => React.ReactNode;
+	children: ( transferStatus?: AtomicTransferStatus ) => React.ReactNode;
 } ) {
 	const { ref, inView } = useInView( {
 		triggerOnce: true,

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -220,12 +220,13 @@ function PlanRenewNag( { site, source }: { site: Site; source: string } ) {
 	);
 }
 
-interface WithHostingFeaturesProps {
+function WithHostingFeaturesQuery( {
+	site,
+	children,
+}: {
 	site: Site;
-	children: () => React.ReactNode;
-}
-
-function WithHostingFeaturesQuery( { site, children }: WithHostingFeaturesProps ) {
+	children: ( transferStatus?: string ) => React.ReactNode;
+} ) {
 	const { ref, inView } = useInView( {
 		triggerOnce: true,
 		fallbackInView: true,
@@ -236,27 +237,7 @@ function WithHostingFeaturesQuery( { site, children }: WithHostingFeaturesProps 
 		enabled: inView,
 	} );
 
-	const renderContent = () => {
-		if ( ! data ) {
-			return children();
-		}
-		if ( data.status === 'error' ) {
-			return __( 'Error activating hosting features' );
-		}
-		if ( isAtomicTransferInProgress( data.status ) ) {
-			return __( 'Activating hosting features…' );
-		}
-		return children();
-	};
-
-	return <span ref={ ref }>{ renderContent() }</span>;
-}
-
-function WithHostingFeaturesStatus( { site, children }: WithHostingFeaturesProps ) {
-	if ( hasPlanFeature( site, DotcomFeatures.ATOMIC ) && ! site.is_wpcom_atomic ) {
-		return <WithHostingFeaturesQuery site={ site }>{ children }</WithHostingFeaturesQuery>;
-	}
-	return children();
+	return <span ref={ ref }>{ children( data?.status ) }</span>;
 }
 
 export function Status( { site }: { site: Site } ) {
@@ -288,16 +269,32 @@ export function Status( { site }: { site: Site } ) {
 		);
 	}
 
-	return (
-		<WithHostingFeaturesStatus site={ site }>
-			{ () => {
-				if ( site.launch_status === 'unlaunched' ) {
-					return <SiteLaunchNag site={ site } />;
-				}
-				return label;
-			} }
-		</WithHostingFeaturesStatus>
-	);
+	const renderBasicStatus = () => {
+		if ( site.launch_status === 'unlaunched' ) {
+			return <SiteLaunchNag site={ site } />;
+		}
+		return label;
+	};
+
+	if ( hasPlanFeature( site, DotcomFeatures.ATOMIC ) && ! site.is_wpcom_atomic ) {
+		return (
+			<WithHostingFeaturesQuery site={ site }>
+				{ ( transferStatus ) => {
+					if ( transferStatus ) {
+						if ( transferStatus === 'error' ) {
+							return __( 'Error activating hosting features' );
+						}
+						if ( isAtomicTransferInProgress( transferStatus ) ) {
+							return __( 'Activating hosting features…' );
+						}
+					}
+					return renderBasicStatus();
+				} }
+			</WithHostingFeaturesQuery>
+		);
+	}
+
+	return renderBasicStatus();
 }
 
 export function Plan( { site }: { site: Site } ) {

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -10,6 +10,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useInView } from 'react-intersection-observer';
 import { useAnalytics } from '../../app/analytics';
 import { useAuth } from '../../app/auth';
+import { siteLatestAtomicTransferQuery } from '../../app/queries/site-atomic-transfers';
 import { siteBackupLastEntryQuery } from '../../app/queries/site-backups';
 import { siteMediaStorageQuery } from '../../app/queries/site-media-storage';
 import { sitePHPVersionQuery } from '../../app/queries/site-php-version';
@@ -18,8 +19,9 @@ import { siteUptimeQuery } from '../../app/queries/site-uptime';
 import ComponentViewTracker from '../../components/component-view-tracker';
 import { TextBlur } from '../../components/text-blur';
 import TimeSince from '../../components/time-since';
-import { JetpackModules } from '../../data/constants';
-import { hasAtomicFeature, hasJetpackModule } from '../../utils/site-features';
+import { DotcomFeatures, JetpackModules } from '../../data/constants';
+import { isAtomicTransferInProgress } from '../../utils/site-atomic-transfers';
+import { hasAtomicFeature, hasJetpackModule, hasPlanFeature } from '../../utils/site-features';
 import { getSiteStatus, getSiteStatusLabel } from '../../utils/site-status';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { HostingFeatures } from '../features';
@@ -218,6 +220,45 @@ function PlanRenewNag( { site, source }: { site: Site; source: string } ) {
 	);
 }
 
+interface WithHostingFeaturesProps {
+	site: Site;
+	children: () => React.ReactNode;
+}
+
+function WithHostingFeaturesQuery( { site, children }: WithHostingFeaturesProps ) {
+	const { ref, inView } = useInView( {
+		triggerOnce: true,
+		fallbackInView: true,
+	} );
+
+	const { data } = useQuery( {
+		...siteLatestAtomicTransferQuery( site.ID ),
+		enabled: inView,
+	} );
+
+	const renderContent = () => {
+		if ( ! data ) {
+			return children();
+		}
+		if ( data.status === 'error' ) {
+			return __( 'Error activating hosting features' );
+		}
+		if ( isAtomicTransferInProgress( data.status ) ) {
+			return __( 'Activating hosting features…' );
+		}
+		return children();
+	};
+
+	return <span ref={ ref }>{ renderContent() }</span>;
+}
+
+function WithHostingFeaturesStatus( { site, children }: WithHostingFeaturesProps ) {
+	if ( hasPlanFeature( site, DotcomFeatures.ATOMIC ) && ! site.is_wpcom_atomic ) {
+		return <WithHostingFeaturesQuery site={ site }>{ children }</WithHostingFeaturesQuery>;
+	}
+	return children();
+}
+
 export function Status( { site }: { site: Site } ) {
 	const status = getSiteStatus( site );
 	const label = getSiteStatusLabel( site );
@@ -247,11 +288,16 @@ export function Status( { site }: { site: Site } ) {
 		);
 	}
 
-	if ( site.launch_status === 'unlaunched' ) {
-		return <SiteLaunchNag site={ site } />;
-	}
-
-	return label;
+	return (
+		<WithHostingFeaturesStatus site={ site }>
+			{ () => {
+				if ( site.launch_status === 'unlaunched' ) {
+					return <SiteLaunchNag site={ site } />;
+				}
+				return label;
+			} }
+		</WithHostingFeaturesStatus>
+	);
 }
 
 export function Plan( { site }: { site: Site } ) {

--- a/client/dashboard/utils/site-atomic-transfers.ts
+++ b/client/dashboard/utils/site-atomic-transfers.ts
@@ -1,0 +1,11 @@
+import type { AtomicTransferStatus } from '../data/types';
+
+export function isAtomicTransferInProgress( status: AtomicTransferStatus ) {
+	const inProgressStatuses: AtomicTransferStatus[] = [
+		'pending',
+		'active',
+		'provisioned',
+		'relocating_switcheroo',
+	];
+	return inProgressStatuses.includes( status );
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTDASH-92

## Proposed Changes

This PR indicates that a site is still transferring to Atomic in the sites list v2:

<img width="542" alt="image" src="https://github.com/user-attachments/assets/0ac5fd23-0be2-4b62-8ffe-363daf90c877" />

<br>
<br>

This is the reference PR from v1:

- https://github.com/Automattic/wp-calypso/issues/76949

In v2, we'll keep it simple for this iteration by:

- not having animated spinner
- not polling the status. The sites list needs to be refreshed for the status to update.

## Testing Instructions

1. Purchase a Business / Commerce plan for a site.
2. Activate the hosting features.
3. QUICKLY: go back to the sites list and search for that site.
4. Verify the status column shows `Activating hosting features...`
5. Wait until the AT transfer finishes
6. Refresh the page and verify it continues to show the site visibility status.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
