### PR TITLE
Sites List v2: Add Restore site feature

### DIFF
--- a/client/dashboard/app/queries/site-users.ts
+++ b/client/dashboard/app/queries/site-users.ts
@@ -1,4 +1,6 @@
 import { fetchCurrentSiteUser, deleteSiteUser } from '../../data/site-users';
+import { queryClient } from '../query-client';
+import { siteByIdQuery } from './site';
 
 export const siteCurrentUserQuery = ( siteId: number ) => ( {
 	queryKey: [ 'site', siteId, 'users', 'current' ],
@@ -8,5 +10,10 @@ export const siteCurrentUserQuery = ( siteId: number ) => ( {
 export function siteUserDeleteMutation( siteId: number ) {
 	return {
 		mutationFn: ( userId: number ) => deleteSiteUser( siteId, userId ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( siteByIdQuery( siteId ) );
+			queryClient.invalidateQueries( { queryKey: [ 'site', siteId ] } );
+			queryClient.invalidateQueries( { queryKey: [ 'sites' ] } );
+		},
 	};
 }

--- a/client/dashboard/app/queries/site.ts
+++ b/client/dashboard/app/queries/site.ts
@@ -1,5 +1,12 @@
 import { notFound } from '@tanstack/react-router';
-import { fetchSite, deleteSite, launchSite, SITE_FIELDS, SITE_OPTIONS } from '../../data/site';
+import {
+	fetchSite,
+	deleteSite,
+	launchSite,
+	restoreSite,
+	SITE_FIELDS,
+	SITE_OPTIONS,
+} from '../../data/site';
 import { queryClient } from '../query-client';
 import type { Site } from '../../data/site';
 import type { Query } from '@tanstack/react-query';
@@ -30,6 +37,7 @@ export const siteDeleteMutation = ( siteId: number ) => ( {
 		// Delay the invalidation for the redirection to complete first
 		window.setTimeout( () => {
 			queryClient.invalidateQueries( siteByIdQuery( siteId ) );
+			queryClient.invalidateQueries( { queryKey: [ 'site', siteId ] } );
 			queryClient.invalidateQueries( { queryKey: [ 'sites' ] } );
 		}, 1000 );
 	},
@@ -39,5 +47,14 @@ export const siteLaunchMutation = ( siteId: number ) => ( {
 	mutationFn: () => launchSite( siteId ),
 	onSuccess: () => {
 		queryClient.invalidateQueries( siteByIdQuery( siteId ) );
+	},
+} );
+
+export const siteRestoreMutation = ( siteId: number ) => ( {
+	mutationFn: () => restoreSite( siteId ),
+	onSuccess: () => {
+		queryClient.invalidateQueries( siteByIdQuery( siteId ) );
+		queryClient.invalidateQueries( { queryKey: [ 'site', siteId ] } );
+		queryClient.invalidateQueries( { queryKey: [ 'sites' ] } );
 	},
 } );

--- a/client/dashboard/data/site.ts
+++ b/client/dashboard/data/site.ts
@@ -122,3 +122,16 @@ export async function launchSite( siteId: number ) {
 		path: `/sites/${ siteId }/launch`,
 	} );
 }
+
+export async function restoreSite( siteId: number ) {
+	return wpcom.req.post(
+		{
+			path: '/restore-site',
+			apiNamespace: 'wpcom/v2',
+			method: 'put',
+		},
+		{
+			site_id: siteId,
+		}
+	);
+}

--- a/client/dashboard/sites/actions.tsx
+++ b/client/dashboard/sites/actions.tsx
@@ -77,7 +77,7 @@ export function getActions( router: AnyRouter ): Action< Site >[] {
 			icon: backup,
 			label: __( 'Restore site' ),
 			isEligible: ( item: Site ) =>
-				!! item.is_deleted && ! isP2( item ) && ! isSelfHostedJetpackConnected( item ),
+				item.is_deleted && ! isP2( item ) && ! isSelfHostedJetpackConnected( item ),
 			RenderModal: ( { items, closeModal }: RenderModalProps< Site > ) => {
 				return (
 					<AsyncLoad

--- a/client/dashboard/sites/actions.tsx
+++ b/client/dashboard/sites/actions.tsx
@@ -1,9 +1,9 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { wordpress } from '@wordpress/icons';
+import { backup, wordpress } from '@wordpress/icons';
 import AsyncLoad from 'calypso/components/async-load';
-import { isP2 } from '../utils/site-types';
+import { isP2, isSelfHostedJetpackConnected } from '../utils/site-types';
 import { canManageSite } from './features';
 import type { Site } from '../data/types';
 import type { Action, RenderModalProps } from '@automattic/dataviews';
@@ -70,6 +70,24 @@ export function getActions( router: AnyRouter ): Action< Site >[] {
 				router.navigate( { to: '/sites/$siteSlug/settings', params: { siteSlug: site.slug } } );
 			},
 			isEligible: ( item: Site ) => canManageSite( item ),
+		},
+		{
+			id: 'restore',
+			isPrimary: true,
+			icon: backup,
+			label: __( 'Restore site' ),
+			isEligible: ( item: Site ) =>
+				!! item.is_deleted && ! isP2( item ) && ! isSelfHostedJetpackConnected( item ),
+			RenderModal: ( { items, closeModal }: RenderModalProps< Site > ) => {
+				return (
+					<AsyncLoad
+						require="./site-restore-modal/content-info"
+						placeholder={ null }
+						site={ items[ 0 ] }
+						onClose={ closeModal }
+					/>
+				);
+			},
 		},
 		{
 			id: 'leave',

--- a/client/dashboard/sites/fields.tsx
+++ b/client/dashboard/sites/fields.tsx
@@ -53,7 +53,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		enableGlobalSearch: true,
 		getValue: ( { item } ) => item.name || new URL( item.URL ).hostname,
 		render: ( { field, item } ) => (
-			<Link to={ getSiteManagementUrl( item ) }>
+			<Link to={ getSiteManagementUrl( item ) } disabled={ item.is_deleted }>
 				<HStack alignment="center" spacing={ 1 }>
 					<Text
 						as="span"
@@ -145,6 +145,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 			return (
 				<Link
 					to={ getSiteManagementUrl( item ) }
+					disabled={ item.is_deleted }
 					style={ { display: 'block', height: '100%', width: '100%' } }
 				>
 					{ resizeListener }

--- a/client/dashboard/sites/fields.tsx
+++ b/client/dashboard/sites/fields.tsx
@@ -58,6 +58,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 					<Text
 						as="span"
 						style={ { overflowX: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }
+						{ ...( item.is_deleted ? { variant: 'muted' } : {} ) }
 					>
 						{ field.getValue( { item } ) }
 					</Text>

--- a/client/dashboard/sites/site-restore-modal/content-info.tsx
+++ b/client/dashboard/sites/site-restore-modal/content-info.tsx
@@ -20,6 +20,7 @@ interface ContentInfoProps {
 export default function SiteRestoreContentInfo( { site, onClose }: ContentInfoProps ) {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const mutation = useMutation( siteRestoreMutation( site.ID ) );
+	const siteSlug = new URL( site.URL ).hostname;
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
@@ -28,7 +29,7 @@ export default function SiteRestoreContentInfo( { site, onClose }: ContentInfoPr
 			onSuccess: () => {
 				createSuccessNotice(
 					/* translators: %s: site domain */
-					sprintf( __( '%s has been restored.' ), site.slug ),
+					sprintf( __( '%s has been restored.' ), siteSlug ),
 					{ type: 'snackbar' }
 				);
 
@@ -56,7 +57,7 @@ export default function SiteRestoreContentInfo( { site, onClose }: ContentInfoPr
 						/* translators: %s: site domain */
 						__( 'Are you sure to restore the site <siteDomain />?' ),
 						{
-							siteDomain: <strong>{ new URL( site.URL ).hostname }</strong>,
+							siteDomain: <strong>{ siteSlug }</strong>,
 						}
 					) }
 				</Text>

--- a/client/dashboard/sites/site-restore-modal/content-info.tsx
+++ b/client/dashboard/sites/site-restore-modal/content-info.tsx
@@ -1,0 +1,74 @@
+import { useMutation } from '@tanstack/react-query';
+import {
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	Button,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
+import { sprintf, __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { siteRestoreMutation } from '../../app/queries/site';
+import type { Site } from '../../data/types';
+
+interface ContentInfoProps {
+	site: Site;
+	onClose: () => void;
+}
+
+export default function SiteRestoreContentInfo( { site, onClose }: ContentInfoProps ) {
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const mutation = useMutation( siteRestoreMutation( site.ID ) );
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+
+		mutation.mutate( undefined, {
+			onSuccess: () => {
+				createSuccessNotice(
+					/* translators: %s: site domain */
+					sprintf( __( '%s has been restored.' ), site.slug ),
+					{ type: 'snackbar' }
+				);
+
+				onClose();
+			},
+			onError: ( error: Error & { status?: number } ) => {
+				if ( error.status === 403 ) {
+					createErrorNotice( __( 'Only an administrator can restore a deleted site.' ), {
+						type: 'snackbar',
+					} );
+				} else {
+					createErrorNotice( __( 'Failed to restore site' ), { type: 'snackbar' } );
+				}
+
+				onClose();
+			},
+		} );
+	};
+
+	return (
+		<form onSubmit={ handleSubmit }>
+			<VStack spacing={ 6 }>
+				<Text as="p">
+					{ createInterpolateElement(
+						/* translators: %s: site domain */
+						__( 'Are you sure to restore the site <siteDomain />?' ),
+						{
+							siteDomain: <strong>{ new URL( site.URL ).hostname }</strong>,
+						}
+					) }
+				</Text>
+				<HStack spacing={ 4 } justify="flex-end" expanded={ false }>
+					<Button variant="tertiary" onClick={ onClose }>
+						{ __( 'Cancel' ) }
+					</Button>
+					<Button variant="primary" type="submit" isBusy={ mutation.isPending }>
+						{ __( 'Restore site' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		</form>
+	);
+}

--- a/client/sites/v2/components/root.tsx
+++ b/client/sites/v2/components/root.tsx
@@ -1,4 +1,5 @@
 import { Outlet } from '@tanstack/react-router';
+import ReactDOM from 'react-dom';
 import Snackbars from 'calypso/dashboard/app/snackbars';
 import { PageViewTracker } from 'calypso/dashboard/components/page-view-tracker';
 
@@ -6,7 +7,7 @@ export default function Root() {
 	return (
 		<>
 			<Outlet />
-			<Snackbars />
+			{ ReactDOM.createPortal( <Snackbars />, document.body ) }
 			<PageViewTracker />
 		</>
 	);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-89

## Proposed Changes

* Add "Restore site" feature

| Action | Modal |
| - | - |
| ![image](https://github.com/user-attachments/assets/03c1464a-c704-4b48-a272-a3cc89825adb) | ![image](https://github.com/user-attachments/assets/fbc3dace-5169-4f62-ab5e-7bd584683a3d) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Add status filter to list deleted sites
* Click the "Restore site" action
* Ensure the modal shows
* Click the "Restore site" button
* Ensure the site can be restored
* Ensure the site is removed from the deleted site list

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
