### PR TITLE
Dashboard v2: prevent new URL() crash by explicitly removing protocol

### DIFF
--- a/client/dashboard/sites/fields.tsx
+++ b/client/dashboard/sites/fields.tsx
@@ -4,8 +4,10 @@ import { __experimentalHStack as HStack, __experimentalText as Text } from '@wor
 import { useResizeObserver } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import TimeSince from '../components/time-since';
+import { getSiteName } from '../utils/site-name';
 import { STATUS_LABELS, getSiteStatus } from '../utils/site-status';
 import { isP2 } from '../utils/site-types';
+import { getSiteUrlWithoutProtocol } from '../utils/site-url';
 import { getFormattedWordPressVersion } from '../utils/wp-version';
 import { canManageSite } from './features';
 import { isSitePlanTrial } from './plans';
@@ -51,7 +53,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		id: 'name',
 		label: __( 'Site' ),
 		enableGlobalSearch: true,
-		getValue: ( { item } ) => item.name || new URL( item.URL ).hostname,
+		getValue: ( { item } ) => getSiteName( item ),
 		render: ( { field, item } ) => (
 			<Link to={ getSiteManagementUrl( item ) } disabled={ item.is_deleted }>
 				<HStack alignment="center" spacing={ 1 }>
@@ -73,7 +75,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		id: 'URL',
 		label: __( 'URL' ),
 		enableGlobalSearch: true,
-		getValue: ( { item } ) => new URL( item.URL ).hostname,
+		getValue: ( { item } ) => getSiteUrlWithoutProtocol( item ),
 		render: ( { field, item } ) => (
 			<Text
 				as="span"

--- a/client/dashboard/sites/fields.tsx
+++ b/client/dashboard/sites/fields.tsx
@@ -7,7 +7,7 @@ import TimeSince from '../components/time-since';
 import { getSiteName } from '../utils/site-name';
 import { STATUS_LABELS, getSiteStatus } from '../utils/site-status';
 import { isP2 } from '../utils/site-types';
-import { getSiteUrlWithoutProtocol } from '../utils/site-url';
+import { getSiteHostname } from '../utils/site-url';
 import { getFormattedWordPressVersion } from '../utils/wp-version';
 import { canManageSite } from './features';
 import { isSitePlanTrial } from './plans';
@@ -75,7 +75,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		id: 'URL',
 		label: __( 'URL' ),
 		enableGlobalSearch: true,
-		getValue: ( { item } ) => getSiteUrlWithoutProtocol( item ),
+		getValue: ( { item } ) => getSiteHostname( item ),
 		render: ( { field, item } ) => (
 			<Text
 				as="span"

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -13,6 +13,7 @@ import { siteEngagementStatsQuery } from '../../app/queries/site-stats';
 import { siteRoute } from '../../app/router';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import { getSiteName } from '../../utils/site-name';
 import CommentsCard from './comments-card';
 import LikesCard from './likes-card';
 import OverviewSection from './overview-section';
@@ -38,7 +39,7 @@ function SiteOverview() {
 		<PageLayout
 			header={
 				<PageHeader
-					title={ site.name || new URL( site.URL ).hostname }
+					title={ getSiteName( site ) }
 					actions={
 						site.options?.admin_url && (
 							<Button

--- a/client/dashboard/sites/site-restore-modal/content-info.tsx
+++ b/client/dashboard/sites/site-restore-modal/content-info.tsx
@@ -10,7 +10,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { siteRestoreMutation } from '../../app/queries/site';
-import { getSiteUrlWithoutProtocol } from '../../utils/site-url';
+import { getSiteHostname } from '../../utils/site-url';
 import type { Site } from '../../data/types';
 
 interface ContentInfoProps {
@@ -21,7 +21,7 @@ interface ContentInfoProps {
 export default function SiteRestoreContentInfo( { site, onClose }: ContentInfoProps ) {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const mutation = useMutation( siteRestoreMutation( site.ID ) );
-	const siteSlug = getSiteUrlWithoutProtocol( site );
+	const siteSlug = getSiteHostname( site );
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();

--- a/client/dashboard/sites/site-restore-modal/content-info.tsx
+++ b/client/dashboard/sites/site-restore-modal/content-info.tsx
@@ -10,6 +10,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { siteRestoreMutation } from '../../app/queries/site';
+import { getSiteUrlWithoutProtocol } from '../../utils/site-url';
 import type { Site } from '../../data/types';
 
 interface ContentInfoProps {
@@ -20,7 +21,7 @@ interface ContentInfoProps {
 export default function SiteRestoreContentInfo( { site, onClose }: ContentInfoProps ) {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const mutation = useMutation( siteRestoreMutation( site.ID ) );
-	const siteSlug = new URL( site.URL ).hostname;
+	const siteSlug = getSiteUrlWithoutProtocol( site );
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -7,6 +7,7 @@ import { siteBySlugQuery } from '../../app/queries/site';
 import { siteRoute } from '../../app/router';
 import HeaderBar from '../../components/header-bar';
 import MenuDivider from '../../components/menu-divider';
+import { getSiteName } from '../../utils/site-name';
 import { canManageSite } from '../features';
 import SiteIcon from '../site-icon';
 import SiteMenu from '../site-menu';
@@ -35,8 +36,7 @@ function Site() {
 									onClick={ () => onToggle() }
 								>
 									<div style={ { display: 'flex', gap: '8px', alignItems: 'center' } }>
-										<SiteIcon site={ site } size={ 16 } />{ ' ' }
-										{ site.name || new URL( site.URL ).hostname }
+										<SiteIcon site={ site } size={ 16 } /> { getSiteName( site ) }
 									</div>
 								</Button>
 							) }

--- a/client/dashboard/sites/site/switcher.tsx
+++ b/client/dashboard/sites/site/switcher.tsx
@@ -6,6 +6,7 @@ import { plus } from '@wordpress/icons';
 import { useState } from 'react';
 import { sitesQuery } from '../../app/queries/sites';
 import RouterLinkMenuItem from '../../components/router-link-menu-item';
+import { getSiteName } from '../../utils/site-name';
 import AddNewSite from '../add-new-site';
 import SiteIcon from '../site-icon';
 import type { Site } from '../../data/types';
@@ -16,7 +17,7 @@ import './switcher.scss';
 const fields = [
 	{
 		id: 'name',
-		getValue: ( { item }: { item: Site } ) => item.name || new URL( item.URL ).hostname,
+		getValue: ( { item }: { item: Site } ) => getSiteName( item ),
 		enableGlobalSearch: true,
 	},
 ];

--- a/client/dashboard/utils/site-name.ts
+++ b/client/dashboard/utils/site-name.ts
@@ -1,0 +1,6 @@
+import { getSiteUrlWithoutProtocol } from './site-url';
+import type { Site } from '../data/types';
+
+export function getSiteName( site: Site ) {
+	return site.name || getSiteUrlWithoutProtocol( site );
+}

--- a/client/dashboard/utils/site-name.ts
+++ b/client/dashboard/utils/site-name.ts
@@ -1,6 +1,6 @@
-import { getSiteUrlWithoutProtocol } from './site-url';
+import { getSiteHostname } from './site-url';
 import type { Site } from '../data/types';
 
 export function getSiteName( site: Site ) {
-	return site.name || getSiteUrlWithoutProtocol( site );
+	return site.name || getSiteHostname( site );
 }

--- a/client/dashboard/utils/site-url.ts
+++ b/client/dashboard/utils/site-url.ts
@@ -1,5 +1,8 @@
 import type { Site } from '../data/types';
 
 export function getSiteUrlWithoutProtocol( site: Site ) {
+	if ( site.URL === '' ) {
+		return site.URL;
+	}
 	return site.URL.replace( 'https://', '' ).replace( 'http://', '' );
 }

--- a/client/dashboard/utils/site-url.ts
+++ b/client/dashboard/utils/site-url.ts
@@ -1,6 +1,6 @@
 import type { Site } from '../data/types';
 
-export function getSiteUrlWithoutProtocol( site: Site ) {
+export function getSiteHostname( site: Site ) {
 	if ( site.URL === '' ) {
 		return site.URL;
 	}

--- a/client/dashboard/utils/site-url.ts
+++ b/client/dashboard/utils/site-url.ts
@@ -1,0 +1,5 @@
+import type { Site } from '../data/types';
+
+export function getSiteUrlWithoutProtocol( site: Site ) {
+	return site.URL.replace( 'https://', '' ).replace( 'http://', '' );
+}

--- a/client/dashboard/utils/site-url.ts
+++ b/client/dashboard/utils/site-url.ts
@@ -4,5 +4,5 @@ export function getSiteUrlWithoutProtocol( site: Site ) {
 	if ( site.URL === '' ) {
 		return site.URL;
 	}
-	return site.URL.replace( 'https://', '' ).replace( 'http://', '' );
+	return new URL( site.URL ).hostname;
 }


### PR DESCRIPTION
Related to: https://github.com/Automattic/wp-calypso/pull/104289/files#r2155802354

## Proposed Changes

`site.URL` could be an empty string when an Atomic site is reverted... sometimes. This PR updates the new dashboard v2 code so that it doesn't rely on `new URL( site.URL )` which crashes when `site.URL` is empty.

## Why are these changes being made?

Fixes a crash.

## Testing Instructions

1. Revert an Atomic site back to simple using the MC tool.
2. In production (wpcalypso), go to `/v2/sites` and try searching that site.
    - Verify you see crash.
    - NOTE THAT IT DOES NOT ALWAYS HAPPEN. But regardless I think the PR still stands. 😓 
3. Use the Calypso live from this PR instead.
    - Verify you see the site normally.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
