### PR TITLE
Automatically add https in profile url

### DIFF
--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -23,6 +23,7 @@ import EmailVerificationBanner from 'calypso/me/email-verification-banner';
 import withFormBase from 'calypso/me/form-base/with-form-base';
 import ReauthRequired from 'calypso/me/reauth-required';
 import { getUserProfileUrl } from 'calypso/reader/user-profile/user-profile.utils';
+import { getValidUrl } from 'calypso/site-profiler/utils/get-valid-url';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
 import WPAndGravatarLogo from './wp-and-gravatar-logo';
@@ -52,7 +53,10 @@ class Profile extends Component {
 		const { value } = event.target;
 		const normalizedUrl = addSchemeIfMissing( value, 'https' );
 		if ( normalizedUrl !== value ) {
-			this.props.setUserSetting( 'user_URL', normalizedUrl );
+			const validUrl = getValidUrl( normalizedUrl );
+			if ( validUrl ) {
+				this.props.setUserSetting( 'user_URL', validUrl );
+			}
 		}
 	};
 

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -54,7 +54,7 @@ class Profile extends Component {
 		}
 
 		const trimmedUrl = url.trim();
-		const domainRegex = /^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/;
+		const domainRegex = /^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}(\/.*)?$/;
 		if ( domainRegex.test( trimmedUrl ) ) {
 			return `https://${ trimmedUrl }`;
 		}

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -43,6 +43,37 @@ class Profile extends Component {
 		this.props.setUserSetting( 'is_dev_account', isDevAccount );
 	};
 
+	/**
+	 * Normalizes a URL by adding https:// if no protocol is present
+	 * @param {string} url - The URL to normalize
+	 * @returns {string} - The normalized URL
+	 */
+	normalizeUrl = ( url ) => {
+		if ( ! url || typeof url !== 'string' ) {
+			return url;
+		}
+
+		const trimmedUrl = url.trim();
+		const domainRegex = /^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/;
+		if ( domainRegex.test( trimmedUrl ) ) {
+			return `https://${ trimmedUrl }`;
+		}
+
+		return url;
+	};
+
+	/**
+	 * Handles URL normalization on blur
+	 * @param {Event} event - The blur event
+	 */
+	handleUrlBlur = ( event ) => {
+		const { value } = event.target;
+		const normalizedUrl = this.normalizeUrl( value );
+		if ( normalizedUrl !== value ) {
+			this.props.setUserSetting( 'user_URL', normalizedUrl );
+		}
+	};
+
 	render() {
 		// We want to use a relative URL so we can test effectively in each
 		// environment, but show the absolute URL in the UI for end users.
@@ -130,6 +161,7 @@ class Profile extends Component {
 								onFocus={ this.getFocusHandler( 'Web Address Field' ) }
 								placeholder="https://example.com"
 								value={ this.props.getSetting( 'user_URL' ) }
+								onBlur={ this.handleUrlBlur }
 							/>
 						</FormFieldset>
 

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -17,6 +17,7 @@ import { CompleteLaunchpadTaskWithNoticeOnLoad } from 'calypso/launchpad/hooks/u
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { protectForm } from 'calypso/lib/protect-form';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import { addSchemeIfMissing } from 'calypso/lib/url/scheme-utils';
 import DomainUpsell from 'calypso/me/domain-upsell';
 import EmailVerificationBanner from 'calypso/me/email-verification-banner';
 import withFormBase from 'calypso/me/form-base/with-form-base';
@@ -44,31 +45,12 @@ class Profile extends Component {
 	};
 
 	/**
-	 * Normalizes a URL by adding https:// if no protocol is present
-	 * @param {string} url - The URL to normalize
-	 * @returns {string} - The normalized URL
-	 */
-	normalizeUrl = ( url ) => {
-		if ( ! url || typeof url !== 'string' ) {
-			return url;
-		}
-
-		const trimmedUrl = url.trim();
-		const domainRegex = /^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}(\/.*)?$/;
-		if ( domainRegex.test( trimmedUrl ) ) {
-			return `https://${ trimmedUrl }`;
-		}
-
-		return url;
-	};
-
-	/**
 	 * Handles URL normalization on blur
 	 * @param {Event} event - The blur event
 	 */
 	handleUrlBlur = ( event ) => {
 		const { value } = event.target;
-		const normalizedUrl = this.normalizeUrl( value );
+		const normalizedUrl = addSchemeIfMissing( value, 'https' );
 		if ( normalizedUrl !== value ) {
 			this.props.setUserSetting( 'user_URL', normalizedUrl );
 		}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTOTHR-15

## Proposed Changes

* Automatically add https:// on blur of the url, turning domain-looking strings to urls 

## Why are these changes being made?

* It's very common for people to try entering something like veselin.blog or www.veselin.blog and seeing a validation error

## Testing Instructions

* Go to /me
* Enter various urls and domains
* Observe that https:// gets automatically added if you don't have it but it looks like a domain
* https:// doesn't get auto-added if it's already present (for example, you enter https://veselin.blog or ftp://something)
* It doesn't get auto-added if the text doesn't look like a domain or subdomain ("for example this")

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
