### PR TITLE
Help Center: Remove unused event

### DIFF
--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -5,11 +5,7 @@ import { useSelect } from '@wordpress/data';
 import { createContext, useCallback, useContext, useState } from 'react';
 import { useOdieBroadcastWithCallbacks } from '../data';
 import { useGetCombinedChat } from '../hooks';
-import {
-	isOdieAllowedBot,
-	getHelpCenterZendeskConversationStarted,
-	getIsRequestingHumanSupport,
-} from '../utils';
+import { isOdieAllowedBot, getIsRequestingHumanSupport } from '../utils';
 import type {
 	Chat,
 	Message,
@@ -52,9 +48,7 @@ export const OdieAssistantContext = createContext< OdieAssistantContextInterface
 	setChatStatus: noop,
 	setExperimentVariationName: noop,
 	setMessageLikedStatus: noop,
-	setWaitAnswerToFirstMessageFromHumanSupport: noop,
 	trackEvent: noop,
-	waitAnswerToFirstMessageFromHumanSupport: false,
 	forceEmailSupport: false,
 } );
 
@@ -140,9 +134,6 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 		resetSupportInteraction();
 	}, [ trackEvent, resetSupportInteraction, setMainChatState ] );
 
-	const [ waitAnswerToFirstMessageFromHumanSupport, setWaitAnswerToFirstMessageFromHumanSupport ] =
-		useState( getHelpCenterZendeskConversationStarted() !== null );
-
 	/**
 	 * Add a new message to the chat.
 	 */
@@ -213,10 +204,8 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 				setChatStatus,
 				setExperimentVariationName,
 				setMessageLikedStatus,
-				setWaitAnswerToFirstMessageFromHumanSupport,
 				trackEvent,
 				version: overriddenVersion,
-				waitAnswerToFirstMessageFromHumanSupport,
 				forceEmailSupport,
 			} }
 		>

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -65,7 +65,6 @@ export const useCreateZendeskConversation = (): ( ( {
 		userFieldMessage,
 		userFieldFlowName,
 		setChat,
-		setWaitAnswerToFirstMessageFromHumanSupport,
 		chat,
 		trackEvent,
 	} = useOdieAssistantContext();
@@ -148,7 +147,6 @@ export const useCreateZendeskConversation = (): ( ( {
 			messaging_url: selectedSiteURL || null,
 		} );
 
-		setWaitAnswerToFirstMessageFromHumanSupport( true );
 		const updatedInteraction = await addEventToInteraction.mutateAsync( {
 			interactionId: currentInteractionID,
 			eventData: { event_source: 'zendesk', event_external_id: conversation.id },

--- a/packages/odie-client/src/hooks/use-send-chat-message.ts
+++ b/packages/odie-client/src/hooks/use-send-chat-message.ts
@@ -1,7 +1,6 @@
 import { useCallback } from '@wordpress/element';
 import { useOdieAssistantContext } from '../context';
 import { broadcastOdieMessage, useSendOdieMessage } from '../data';
-import { getHelpCenterZendeskConversationStartedElapsedTime } from '../utils';
 import { useSendZendeskMessage } from './use-send-zendesk-message';
 import type { Message } from '../types';
 
@@ -9,14 +8,7 @@ import type { Message } from '../types';
  * This is the gate that manages which message provider to use.
  */
 export const useSendChatMessage = () => {
-	const {
-		addMessage,
-		odieBroadcastClientId,
-		waitAnswerToFirstMessageFromHumanSupport,
-		setWaitAnswerToFirstMessageFromHumanSupport,
-		trackEvent,
-		chat,
-	} = useOdieAssistantContext();
+	const { addMessage, odieBroadcastClientId, chat } = useOdieAssistantContext();
 
 	const { mutateAsync: sendOdieMessage } = useSendOdieMessage();
 	const sendZendeskMessage = useSendZendeskMessage();
@@ -31,38 +23,12 @@ export const useSendChatMessage = () => {
 			}
 
 			if ( chat.provider === 'zendesk' ) {
-				if (
-					message.role === 'user' &&
-					message.type === 'message' &&
-					waitAnswerToFirstMessageFromHumanSupport
-				) {
-					//track the time it took to send the first message for the user
-					const elapsedTime = getHelpCenterZendeskConversationStartedElapsedTime();
-					if ( elapsedTime ) {
-						trackEvent( 'first_answer_to_human_support', {
-							elapsed_time_less_than_900s: elapsedTime < 900 * 1000,
-							role: message.role,
-							user_id: chat?.wpcomUserId,
-						} );
-					}
-					setWaitAnswerToFirstMessageFromHumanSupport( false );
-				}
 				return sendZendeskMessage( message );
 			}
 
 			return sendOdieMessage( message );
 		},
-		[
-			sendOdieMessage,
-			sendZendeskMessage,
-			addMessage,
-			odieBroadcastClientId,
-			waitAnswerToFirstMessageFromHumanSupport,
-			setWaitAnswerToFirstMessageFromHumanSupport,
-			trackEvent,
-			chat?.wpcomUserId,
-			chat?.provider,
-		]
+		[ sendOdieMessage, sendZendeskMessage, addMessage, odieBroadcastClientId, chat?.provider ]
 	);
 
 	return sendMessage;

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -20,7 +20,6 @@ export type OdieAssistantContextInterface = {
 	selectedSiteURL?: string | null;
 	userFieldMessage?: string | null;
 	userFieldFlowName?: string | null;
-	waitAnswerToFirstMessageFromHumanSupport: boolean;
 	forceEmailSupport: boolean;
 	setExperimentVariationName: ( variationName: string | null | undefined ) => void;
 	setMessageLikedStatus: ( message: Message, liked: boolean ) => void;
@@ -28,9 +27,6 @@ export type OdieAssistantContextInterface = {
 	setChatStatus: ( status: ChatStatus ) => void;
 	trackEvent: ( event: string, properties?: Record< string, unknown > ) => void;
 	version?: string | null;
-	setWaitAnswerToFirstMessageFromHumanSupport: (
-		waitAnswerToFirstMessageFromHumanSupport: boolean
-	) => void;
 };
 
 export type OdieAssistantProviderProps = {

--- a/packages/odie-client/src/utils/index.ts
+++ b/packages/odie-client/src/utils/index.ts
@@ -5,7 +5,6 @@ export { generateUUID } from './generate-uuid';
 export {
 	setHelpCenterZendeskConversationStarted,
 	getHelpCenterZendeskConversationStarted,
-	getHelpCenterZendeskConversationStartedElapsedTime,
 } from './storage-utils';
 export {
 	interactionHasZendeskEvent,

--- a/packages/odie-client/src/utils/storage-utils.ts
+++ b/packages/odie-client/src/utils/storage-utils.ts
@@ -25,15 +25,3 @@ export const clearHelpCenterZendeskConversationStarted = () =>
 	ignoreFatalsForSessionStorage(
 		() => sessionStorage?.removeItem( 'help_center_zendesk_conversation_started' )
 	);
-
-export const getHelpCenterZendeskConversationStartedElapsedTime = () => {
-	const startTime = getHelpCenterZendeskConversationStarted();
-
-	if ( startTime == null ) {
-		return null;
-	}
-
-	clearHelpCenterZendeskConversationStarted();
-
-	return Math.floor( performance.now() - ( startTime as number ) );
-};


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-13734/help-center-remove-unused-calypso-odie-first-answer-to-human-support

## Proposed Changes

We have a lot of logic set in place in the Help Center (state, cookies) to fire the calypso_odie_first_answer_to_human_support event, but it is not used.

Let's remove it and cleanup.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Help Center
* Make sure you can send messages to Odie and to Zendesk

