### PR TITLE
A4A > Report:  UI improvements 

### DIFF
--- a/client/a8c-for-agencies/components/a4a-select-site/modal.tsx
+++ b/client/a8c-for-agencies/components/a4a-select-site/modal.tsx
@@ -2,10 +2,7 @@ import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import A4AModal from 'calypso/a8c-for-agencies/components/a4a-modal';
-import { A4A_SITES_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { type SiteItem } from 'calypso/a8c-for-agencies/sections/migrations/hooks/use-fetch-all-managed-sites';
-import { useDispatch } from 'calypso/state';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import A4ASelectSiteTable from './site-table';
 import type { SelectSiteModalProps } from './types';
 
@@ -17,7 +14,6 @@ const SelectSiteModal = ( {
 	selectedSiteId,
 }: SelectSiteModalProps ) => {
 	const translate = useTranslate();
-	const dispatch = useDispatch();
 
 	const [ selectedSite, setSelectedSite ] = useState< SiteItem | null >( null );
 
@@ -35,26 +31,7 @@ const SelectSiteModal = ( {
 	return (
 		<A4AModal
 			title={ title || translate( 'Select a site' ) }
-			subtile={
-				subtitle ||
-				translate(
-					"If you don't see the site in the list, connect it first via the {{a}}Sites Dashboard{{/a}}.",
-					{
-						components: {
-							a: (
-								<a
-									href={ A4A_SITES_LINK }
-									onClick={ () =>
-										dispatch(
-											recordTracksEvent( 'calypso_a4a_select_site_modal_sites_dashboard_click' )
-										)
-									}
-								/>
-							),
-						},
-					}
-				)
-			}
+			subtile={ subtitle }
 			onClose={ onClose }
 			extraActions={
 				<Button variant="primary" onClick={ handleSelectSite } disabled={ ! selectedSite }>

--- a/client/a8c-for-agencies/sections/reports/lib/get-site-reports.ts
+++ b/client/a8c-for-agencies/sections/reports/lib/get-site-reports.ts
@@ -8,6 +8,11 @@ export const getSiteReports = ( reports: Report[] ): SiteReports[] => {
 
 	const grouped = reports.reduce(
 		( acc, report ) => {
+			// Only include reports with "sent" status
+			if ( report.status !== 'sent' ) {
+				return acc;
+			}
+
 			const url = urlToSlug( report.data.managed_site_url );
 			if ( ! acc[ url ] ) {
 				acc[ url ] = [];

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/index.tsx
@@ -14,7 +14,11 @@ import LayoutHeader, {
 } from 'calypso/layout/hosting-dashboard/header';
 import { useDispatch } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
-import { A4A_REPORTS_LINK, A4A_REPORTS_BUILD_LINK } from '../../constants';
+import {
+	A4A_REPORTS_LINK,
+	A4A_REPORTS_BUILD_LINK,
+	A4A_REPORTS_DASHBOARD_LINK,
+} from '../../constants';
 import { useFormValidation } from '../../hooks/use-build-report-form-validation';
 import { useDuplicateReportFormData } from '../../hooks/use-duplicate-report-form-data';
 import usePollReportStatus from '../../hooks/use-poll-report-status';
@@ -65,9 +69,13 @@ const BuildReport = () => {
 					{
 						duration: 5000,
 						id: isPreview ? 'send-report-preview-success' : 'send-report-success',
+						displayOnNextPage: ! isPreview,
 					}
 				)
 			);
+			if ( ! isPreview ) {
+				page.redirect( A4A_REPORTS_DASHBOARD_LINK );
+			}
 		},
 		onError: ( error ) => {
 			dispatch(

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/steps/step-1-details.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/steps/step-1-details.tsx
@@ -8,6 +8,7 @@ import {
 import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback } from 'react';
 import A4ASelectSite from 'calypso/a8c-for-agencies/components/a4a-select-site';
+import { A4A_SITES_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { formatDate } from '../../../lib/format-date';
@@ -76,6 +77,36 @@ export default function Step1Details( { formData, state, handlers }: StepProps )
 
 			<div className="build-report__field">
 				<A4ASelectSite
+					subtitle={
+						<div className="build-report__select-site-subtitle">
+							<span>
+								{ translate(
+									"If you don't see the site in the list, connect it first via the {{a}}Sites Dashboard{{/a}}.",
+									{
+										components: {
+											a: (
+												<a
+													href={ A4A_SITES_LINK }
+													onClick={ () =>
+														dispatch(
+															recordTracksEvent(
+																'calypso_a4a_select_site_modal_sites_dashboard_click'
+															)
+														)
+													}
+												/>
+											),
+										},
+									}
+								) }
+							</span>
+							<span>
+								{ translate(
+									'Only live WordPress.com or Pressable sites using Jetpack or the Automattic for Agencies plugin are supported.'
+								) }
+							</span>
+						</div>
+					}
 					isDisabled={ isLoadingState }
 					selectedSiteId={ selectedSite?.blogId }
 					onSiteSelect={ ( site: A4ASelectSiteItem ) => {

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/style.scss
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/style.scss
@@ -86,6 +86,12 @@
 	}
 }
 
+.build-report__select-site-subtitle {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
 .build-report__content-header {
 	display: flex;
 	flex-direction: column;

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/empty-state.tsx
@@ -23,45 +23,51 @@ const ReportsDashboardEmptyState = () => {
 	}, [ dispatch ] );
 
 	return (
-		<div className="reports-dashboard-empty-state__content">
-			<div>
-				<div className="reports-dashboard-empty-state__heading">
-					{ translate( 'Create detailed reports for your clients' ) }
-				</div>
-				<div className="reports-dashboard-empty-state__description">
-					{ translate(
-						'Build professional reports in three simple steps. Include website stats, showcase your value, and keep clients informed.'
-					) }
-				</div>
-			</div>
-			<StepSection heading={ translate( 'How to get started' ) }>
-				<StepSectionItem
-					heading={ translate( 'Create your first report' ) }
-					description={ translate(
-						'Choose a site, select the content to include, add a personal message, then preview and send it to your client.'
-					) }
-				>
-					<div className="reports-dashboard-empty-state__buttons">
-						<Button
-							__next40pxDefaultSize
-							variant="primary"
-							onClick={ handleBuildNewReport }
-							href={ A4A_REPORTS_BUILD_LINK }
-						>
-							{ translate( 'Build a new report' ) }
-						</Button>
-						<Button __next40pxDefaultSize variant="secondary" onClick={ handleViewExampleReport }>
-							{ translate( 'View example report' ) }
-						</Button>
+		<>
+			<div className="reports-dashboard-empty-state__content">
+				<div>
+					<div className="reports-dashboard-empty-state__heading">
+						{ translate( 'Create detailed reports for your clients' ) }
 					</div>
-				</StepSectionItem>
-			</StepSection>
-
+					<div className="reports-dashboard-empty-state__description">
+						{ translate(
+							'Build professional reports in three simple steps. Include website stats, showcase your value, and keep clients informed.'
+						) }
+					</div>
+				</div>
+				<StepSection heading={ translate( 'How to get started' ) }>
+					<StepSectionItem
+						heading={ translate( 'Create your first report' ) }
+						description={ translate(
+							'Choose a site, select the content to include, add a personal message, then preview and send it to your client.'
+						) }
+					>
+						<div className="reports-dashboard-empty-state__buttons">
+							<Button
+								__next40pxDefaultSize
+								variant="primary"
+								onClick={ handleBuildNewReport }
+								href={ A4A_REPORTS_BUILD_LINK }
+							>
+								{ translate( 'Build a new report' ) }
+							</Button>
+							<Button __next40pxDefaultSize variant="secondary" onClick={ handleViewExampleReport }>
+								{ translate( 'View example report' ) }
+							</Button>
+						</div>
+					</StepSectionItem>
+				</StepSection>
+			</div>
+			<div className="reports-dashboard-empty-state__footnote">
+				{ translate(
+					'*Only live WordPress.com or Pressable sites using Jetpack or the Automattic for Agencies plugin are supported.'
+				) }
+			</div>
 			<ExampleReportModal
 				isVisible={ showExampleModal }
 				onClose={ () => setShowExampleModal( false ) }
 			/>
-		</div>
+		</>
 	);
 };
 

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/index.tsx
@@ -38,11 +38,11 @@ export default function ReportsDashboard() {
 
 	const { data: reports, isLoading } = useFetchReports();
 
-	const showEmptyState = ! isLoading && ( ! reports || reports.length === 0 );
-
 	const siteReports = useMemo( () => {
 		return getSiteReports( reports );
 	}, [ reports ] );
+
+	const showEmptyState = ! isLoading && ( ! siteReports || siteReports.length === 0 );
 
 	const handleBuildNewReport = () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_reports_build_new_report_click' ) );

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
@@ -1,4 +1,5 @@
 import { type BadgeType, Gridicon, Tooltip } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
 import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
@@ -9,15 +10,15 @@ import type { ReportStatus } from '../../types';
 
 export const ReportSiteColumn = ( { site }: { site: string } ) => urlToSlug( site );
 
-export const ReportCountColumn = ( { count }: { count: number } ) => {
+export const ReportCountColumn = ( { count, onClick }: { count: number; onClick: () => void } ) => {
 	const translate = useTranslate();
 	return (
-		<span className="reports-list__count">
+		<Button variant="tertiary" onClick={ onClick }>
 			{ translate( '%(count)d report', '%(count)d reports', {
 				count,
 				args: { count },
 			} ) }
-		</span>
+		</Button>
 	);
 };
 

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/reports-list.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/reports-list.tsx
@@ -60,7 +60,10 @@ export default function ReportsList( {
 							label: translate( 'Reports' ),
 							getValue: () => '-',
 							render: ( { item }: { item: SiteReports } ) => (
-								<ReportCountColumn count={ item.totalReports } />
+								<ReportCountColumn
+									count={ item.totalReports }
+									onClick={ () => openReportPreviewPane( item ) }
+								/>
 							),
 							enableHiding: false,
 							enableSorting: false,
@@ -88,7 +91,7 @@ export default function ReportsList( {
 				  ]
 				: [] ),
 		],
-		[ translate, isDesktop, dataViewsState.selectedItem ]
+		[ translate, isDesktop, dataViewsState.selectedItem, openReportPreviewPane ]
 	);
 
 	const { data, paginationInfo } = useMemo( () => {

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/style.scss
@@ -126,3 +126,8 @@
 		}
 	}
 }
+
+.reports-dashboard-empty-state__footnote {
+	@include body-medium;
+	color: var(--color-neutral-50);
+}

--- a/client/a8c-for-agencies/sections/reports/reports-details/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/reports-details/index.tsx
@@ -170,6 +170,10 @@ export default function ReportsDetails( { siteReports, closeSitePreviewPane }: P
 					onConfirm={ () => {
 						dispatch( recordTracksEvent( 'calypso_a4a_reports_delete_report_confirm_click' ) );
 						handleDeleteReport( reportToDelete, () => {
+							// If there is only one report left, close the preview pane
+							if ( siteReports.reports.length === 1 ) {
+								closeSitePreviewPane();
+							}
 							setReportToDelete( null );
 						} );
 					} }


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1203/overall-minor-ui-improvements

## Proposed Changes

This PR makes some UI improvements to Reports, including:

- Updating the subtitle of the select site modal and empty state messages to set expectations with the Reports feature
- Showing only "Sent" reports
- Making the `Reports` column clickable to open the preview pane.
- Refactor the delete report functionality to remove the onMutate logic

## Why are these changes being made?

* To make some UI improvements to Reports

## Testing Instructions

* Open the A4A live link
* Go to Reports > Build a new report > Open the site selector > Verify the subtitle is updated as shown below:

<img width="934" alt="Screenshot 2025-06-30 at 7 21 17 PM" src="https://github.com/user-attachments/assets/be9a7d01-3464-446b-a741-c39edd22eae5" />

* Go to Reports > Dashboard > Verify that only "Sent" reports are shown
* Verify the Reports column is clickable, and clicking it opens the preview pane for the site

<img width="1919" alt="Screenshot 2025-06-30 at 7 18 54 PM" src="https://github.com/user-attachments/assets/ace26228-e99c-40fd-b062-b0f6253a229e" />

* Verify the empty state is updated as shown below

<img width="1919" alt="Screenshot 2025-06-30 at 7 19 23 PM" src="https://github.com/user-attachments/assets/dd64c4cd-c152-46c3-8cd3-79dfc0e32188" />

* Delete report when there is more than one report for a site > Verify everything works as expected.
* Delete report when there is only one report for a site > Verify the report gets deleted and the preview is closed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
