### PR TITLE
Reader subscriptions management: Fix mobile padding and header after

### DIFF
--- a/client/reader/site-subscriptions-manager/style.scss
+++ b/client/reader/site-subscriptions-manager/style.scss
@@ -32,16 +32,15 @@ body.is-section-reader .layout.is-section-reader .site-subscriptions-manager {
 		min-height: 100vh;
 		margin: 0 auto;
 
-		@media (max-width: $break-small) {
-			padding: 16px;
-		}
-
 		@extend %search-component-subscriptions-style;
 	}
 
+	.site-subscriptions-list-actions-bar,
+	.site-subscriptions-list,
+	.recommended-sites,
 	.navigation-header {
 		@media (max-width: $break-small) {
-			padding: 0;
+			padding: 0 16px;
 		}
 	}
 

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -76,6 +76,11 @@ body.is-section-reader {
 				height: 1px;
 				background: var(--color-border-secondary);
 
+				@media (max-width: $break-medium) {
+					left: 0;
+					width: 100%;
+				}
+
 				@media screen and (min-width: $break-medium) {
 					margin: 24px 0;
 				}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/CML-594/add-recommended-blogs-column-to-subscribers-management-data-view

## Proposed Changes

* Add padding to the subscription management page elements on mobile to be consistent with other Reader pages.
* Center the navigation header `::after` border on all Reader pages, on mobile.

Before | After
---- | ----
<img width="282" alt="Screenshot 2025-06-30 at 1 29 50 PM" src="https://github.com/user-attachments/assets/516889ae-eacb-43ea-a2ad-6507f4b8ed07" /> | <img width="282" alt="Screenshot 2025-06-30 at 1 30 09 PM" src="https://github.com/user-attachments/assets/1d461741-6e64-4a4e-b9f2-28eee0ca37e9" />

Bottom of the page:
<img width="215" alt="Screenshot 2025-06-30 at 11 58 40 AM" src="https://github.com/user-attachments/assets/e32a9c9b-cd29-45ad-a030-460f675e0927" />

Discover for comparison:
<img width="345" alt="Screenshot 2025-06-30 at 1 33 06 PM" src="https://github.com/user-attachments/assets/2fe641a3-3e37-43c8-9767-d23966fb66e2" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the UI.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /reader/subscriptions and check that there's padding at screen sizes < 600px.
* Go to /discover > Add new and check that there are no regressions (mobile padding is the same).
* Check that on all Reader pages on screen sizes < 782px, the navigation header `::after` bottom border is centered and not off to one side.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
