### PR TITLE
Scan: Add Jetpack > Scan upsell for Simple Sites

### DIFF
--- a/client/components/jetpack/business-at-switch/index.tsx
+++ b/client/components/jetpack/business-at-switch/index.tsx
@@ -3,7 +3,7 @@ import { translate } from 'i18n-calypso';
 import { ComponentType } from 'react';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import FormattedHeader from 'calypso/components/formatted-header';
-import WPCOMBusinessAT from 'calypso/components/jetpack/wpcom-business-at';
+import WPCOMBusinessAT, { AtomicContentSwitch } from 'calypso/components/jetpack/wpcom-business-at';
 import Main from 'calypso/components/main';
 import { useSelector } from 'calypso/state';
 import getFeaturesBySiteId from 'calypso/state/selectors/get-site-features';
@@ -15,6 +15,7 @@ import './style.scss';
 
 type Props = {
 	UpsellComponent: ComponentType;
+	content?: AtomicContentSwitch;
 };
 
 const Placeholder = () => (
@@ -35,7 +36,7 @@ const Placeholder = () => (
  * If the plan is an Atomic plan, we show a component to activate the
  * automated transfer process. If it's not, we show the upsell component.
  */
-const BusinessATSwitch = ( { UpsellComponent }: Props ) => {
+const BusinessATSwitch = ( { UpsellComponent, content }: Props ) => {
 	const siteId = useSelector( getSelectedSiteId ) as number;
 
 	const featuresNotLoaded: boolean = useSelector(
@@ -59,7 +60,7 @@ const BusinessATSwitch = ( { UpsellComponent }: Props ) => {
 	// We know the site is not AT as it's not Jetpack,
 	// so show the activation for Atomic plans.
 	if ( canTransfer ) {
-		return <WPCOMBusinessAT />;
+		return <WPCOMBusinessAT { ...( content && { content } ) } />;
 	}
 
 	// Show the upsell if it's not an Atomic plan.

--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -43,6 +43,7 @@ import 'calypso/blocks/eligibility-warnings/style.scss';
 
 interface BlockingHoldNoticeProps {
 	siteId: number;
+	productName: string;
 }
 
 // This gets the values of the object transferStates.
@@ -50,9 +51,22 @@ export type TransferStatus = ( typeof transferStates )[ keyof typeof transferSta
 
 interface TransferFailureNoticeProps {
 	transferStatus: TransferStatus | null;
+	productName: string;
 }
 
-const content = {
+export interface AtomicContentSwitch {
+	documentHeadTitle: string;
+	header: string;
+	primaryPromo: {
+		image: { path: string };
+		promoCTA: { loadingText: string; text: string };
+		title: string;
+		content: string;
+	};
+	getProductUrl: ( siteSlug: string ) => string;
+}
+
+const vaultpressContent: AtomicContentSwitch = {
 	documentHeadTitle: 'Activate Jetpack VaultPress Backup now',
 	header: String( translate( 'Jetpack VaultPress Backup' ) ),
 	primaryPromo: {
@@ -66,9 +80,11 @@ const content = {
 			loadingText: translate( 'Activating Jetpack VaultPress Backup' ),
 		},
 	},
+
+	getProductUrl: ( siteSlug: string ) => `/backup/${ siteSlug }`,
 };
 
-function BlockingHoldNotice( { siteId }: BlockingHoldNoticeProps ) {
+function BlockingHoldNotice( { siteId, productName }: BlockingHoldNoticeProps ) {
 	const { eligibilityHolds: holds } = useSelector( ( state ) => getEligibility( state, siteId ) );
 	if ( ! holds ) {
 		return null;
@@ -79,7 +95,7 @@ function BlockingHoldNotice( { siteId }: BlockingHoldNoticeProps ) {
 	blockingMessages.BLOCKED_ATOMIC_TRANSFER.message = String(
 		translate(
 			'This site is currently not eligible for %s. Please contact our support team for help.',
-			{ args: [ content.header ] }
+			{ args: [ productName ] }
 		)
 	);
 
@@ -92,7 +108,7 @@ function BlockingHoldNotice( { siteId }: BlockingHoldNoticeProps ) {
 	);
 }
 
-function TransferFailureNotice( { transferStatus }: TransferFailureNoticeProps ) {
+function TransferFailureNotice( { transferStatus, productName }: TransferFailureNoticeProps ) {
 	if ( transferStatus !== transferStates.FAILURE && transferStatus !== transferStates.ERROR ) {
 		return null;
 	}
@@ -100,7 +116,7 @@ function TransferFailureNotice( { transferStatus }: TransferFailureNoticeProps )
 	const errorMessage = translate(
 		'There is an issue activating %s. Please contact our support team for help.',
 		{
-			args: [ content.header ],
+			args: [ productName ],
 			comment: '%s is a Jetpack product name like: Jetpack Backup, Jetpack Scan, Jetpack Anti-spam',
 		}
 	);
@@ -114,7 +130,9 @@ function TransferFailureNotice( { transferStatus }: TransferFailureNoticeProps )
 	);
 }
 
-export default function WPCOMBusinessAT() {
+export default function WPCOMBusinessAT( {
+	content = vaultpressContent,
+}: { content?: AtomicContentSwitch } = {} ) {
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const siteSlug = useSelector( getSelectedSiteSlug ) as string;
 
@@ -184,7 +202,7 @@ export default function WPCOMBusinessAT() {
 			)
 		);
 		// Reload the page, whatever siteSlug is
-		page( `/backup/${ siteSlug }` );
+		page( content.getProductUrl( siteSlug ) );
 	}, [ automatedTransferStatus, isJetpack ] );
 
 	// If there are any issues, show a dialog.
@@ -210,8 +228,11 @@ export default function WPCOMBusinessAT() {
 				align="left"
 				brandFont
 			/>
-			<BlockingHoldNotice siteId={ siteId } />
-			<TransferFailureNotice transferStatus={ automatedTransferStatus as TransferStatus } />
+			<BlockingHoldNotice siteId={ siteId } productName={ content.header } />
+			<TransferFailureNotice
+				transferStatus={ automatedTransferStatus as TransferStatus }
+				productName={ content.header }
+			/>
 			<PromoCard
 				title={ content.primaryPromo.title }
 				image={ content.primaryPromo.image }

--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -67,7 +67,7 @@ export interface AtomicContentSwitch {
 }
 
 const vaultpressContent: AtomicContentSwitch = {
-	documentHeadTitle: 'Activate Jetpack VaultPress Backup now',
+	documentHeadTitle: String( translate( 'Activate Jetpack VaultPress Backup now' ) ),
 	header: String( translate( 'Jetpack VaultPress Backup' ) ),
 	primaryPromo: {
 		title: translate( 'Get time travel for your site with Jetpack VaultPress Backup' ),

--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -67,8 +67,8 @@ export interface AtomicContentSwitch {
 }
 
 const vaultpressContent: AtomicContentSwitch = {
-	documentHeadTitle: String( translate( 'Activate Jetpack VaultPress Backup now' ) ),
-	header: String( translate( 'Jetpack VaultPress Backup' ) ),
+	documentHeadTitle: translate( 'Activate Jetpack VaultPress Backup now' ) as string,
+	header: translate( 'Jetpack VaultPress Backup' ) as string,
 	primaryPromo: {
 		title: translate( 'Get time travel for your site with Jetpack VaultPress Backup' ),
 		image: { path: JetpackBackupSVG },

--- a/client/lib/jetpack/wpcom-atomic-transfer.tsx
+++ b/client/lib/jetpack/wpcom-atomic-transfer.tsx
@@ -1,12 +1,14 @@
 import { isEnabled } from '@automattic/calypso-config';
 import BusinessATSwitch from 'calypso/components/jetpack/business-at-switch';
+import { AtomicContentSwitch } from 'calypso/components/jetpack/wpcom-business-at';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { Context } from './types';
 import type { ComponentType } from 'react';
 
 export default function wpcomAtomicTransfer(
-	UpsellComponent: ComponentType
+	UpsellComponent: ComponentType,
+	content: AtomicContentSwitch
 ): ( context: Context, next: () => void ) => void {
 	return ( context, next ) => {
 		const getState = context.store.getState;
@@ -14,7 +16,9 @@ export default function wpcomAtomicTransfer(
 		const isJetpack = isJetpackSite( getState(), siteId );
 
 		if ( ! isJetpack && ! isEnabled( 'jetpack-cloud' ) && context.primary ) {
-			context.primary = <BusinessATSwitch UpsellComponent={ UpsellComponent } />;
+			context.primary = (
+				<BusinessATSwitch UpsellComponent={ UpsellComponent } content={ content } />
+			);
 		}
 
 		next();

--- a/client/lib/jetpack/wpcom-atomic-transfer.tsx
+++ b/client/lib/jetpack/wpcom-atomic-transfer.tsx
@@ -8,7 +8,7 @@ import type { ComponentType } from 'react';
 
 export default function wpcomAtomicTransfer(
 	UpsellComponent: ComponentType,
-	content: AtomicContentSwitch
+	content?: AtomicContentSwitch
 ): ( context: Context, next: () => void ) => void {
 	return ( context, next ) => {
 		const getState = context.store.getState;

--- a/client/my-sites/scan/index.js
+++ b/client/my-sites/scan/index.js
@@ -14,6 +14,7 @@ import {
 	scan,
 	scanHistory,
 } from 'calypso/my-sites/scan/controller';
+import { wpcomJetpackScanAtomicTransfer } from 'calypso/my-sites/scan/wpcom-atomic-transfer';
 import WPCOMScanUpsellPage from 'calypso/my-sites/scan/wpcom-upsell';
 import isJetpackSectionEnabledForSite from 'calypso/state/selectors/is-jetpack-section-enabled-for-site';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
@@ -46,12 +47,11 @@ export default function () {
 		scan,
 		wrapInSiteOffsetProvider,
 		showUpsellIfNoScan,
-		wpcomAtomicTransfer( WPCOMScanUpsellPage ),
+		wpcomJetpackScanAtomicTransfer(),
 		showUnavailableForVaultPressSites,
 		showJetpackIsDisconnected,
 		showUnavailableForMultisites,
 		showNotAuthorizedForNonAdmins,
-		notFoundIfNotEnabled( { allowOnAtomic: true } ),
 		makeLayout,
 		clientRender
 	);
@@ -63,7 +63,7 @@ export default function () {
 		scanHistory,
 		wrapInSiteOffsetProvider,
 		showUpsellIfNoScanHistory,
-		wpcomAtomicTransfer( WPCOMScanUpsellPage ),
+		wpcomJetpackScanAtomicTransfer(),
 		showUnavailableForVaultPressSites,
 		showJetpackIsDisconnected,
 		showUnavailableForMultisites,

--- a/client/my-sites/scan/index.js
+++ b/client/my-sites/scan/index.js
@@ -1,7 +1,6 @@
 import page from '@automattic/calypso-router';
 import { notFound, makeLayout, render as clientRender } from 'calypso/controller';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import wpcomAtomicTransfer from 'calypso/lib/jetpack/wpcom-atomic-transfer';
 import wrapInSiteOffsetProvider from 'calypso/lib/wrap-in-site-offset';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import {
@@ -15,7 +14,6 @@ import {
 	scanHistory,
 } from 'calypso/my-sites/scan/controller';
 import { wpcomJetpackScanAtomicTransfer } from 'calypso/my-sites/scan/wpcom-atomic-transfer';
-import WPCOMScanUpsellPage from 'calypso/my-sites/scan/wpcom-upsell';
 import isJetpackSectionEnabledForSite from 'calypso/state/selectors/is-jetpack-section-enabled-for-site';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
@@ -80,7 +78,7 @@ export default function () {
 		scan,
 		wrapInSiteOffsetProvider,
 		showUpsellIfNoScan,
-		wpcomAtomicTransfer( WPCOMScanUpsellPage ),
+		wpcomJetpackScanAtomicTransfer(),
 		showUnavailableForVaultPressSites,
 		showJetpackIsDisconnected,
 		showUnavailableForMultisites,

--- a/client/my-sites/scan/wpcom-atomic-transfer.tsx
+++ b/client/my-sites/scan/wpcom-atomic-transfer.tsx
@@ -5,7 +5,7 @@ import WPCOMScanUpsellPage from 'calypso/my-sites/scan/wpcom-upsell';
 
 export function wpcomJetpackScanAtomicTransfer() {
 	const content = {
-		documentHeadTitle: 'Activate Jetpack Scan now',
+		documentHeadTitle: String( translate( 'Activate Jetpack Scan now' ) ),
 		header: String( translate( 'Jetpack Scan' ) ),
 		primaryPromo: {
 			title: translate( 'We guard your site. You run your business.' ),

--- a/client/my-sites/scan/wpcom-atomic-transfer.tsx
+++ b/client/my-sites/scan/wpcom-atomic-transfer.tsx
@@ -1,0 +1,26 @@
+import { translate } from 'i18n-calypso';
+import JetpackScanSVG from 'calypso/assets/images/illustrations/jetpack-scan.svg';
+import wpcomAtomicTransfer from 'calypso/lib/jetpack/wpcom-atomic-transfer';
+import WPCOMScanUpsellPage from 'calypso/my-sites/scan/wpcom-upsell';
+
+export function wpcomJetpackScanAtomicTransfer() {
+	const content = {
+		documentHeadTitle: 'Activate Jetpack Scan now',
+		header: String( translate( 'Jetpack Scan' ) ),
+		primaryPromo: {
+			title: translate( 'We guard your site. You run your business.' ),
+			image: { path: JetpackScanSVG },
+			content: translate(
+				'Scan gives you automated scanning and one-click fixes to keep your site ahead of security threats.'
+			),
+			promoCTA: {
+				text: translate( 'Activate Jetpack Scan now' ),
+				loadingText: translate( 'Activating Jetpack Scan' ),
+			},
+		},
+
+		getProductUrl: ( siteSlug: string ) => `/scan/${ siteSlug }`,
+	};
+
+	return wpcomAtomicTransfer( WPCOMScanUpsellPage, content );
+}

--- a/client/my-sites/scan/wpcom-atomic-transfer.tsx
+++ b/client/my-sites/scan/wpcom-atomic-transfer.tsx
@@ -5,8 +5,8 @@ import WPCOMScanUpsellPage from 'calypso/my-sites/scan/wpcom-upsell';
 
 export function wpcomJetpackScanAtomicTransfer() {
 	const content = {
-		documentHeadTitle: String( translate( 'Activate Jetpack Scan now' ) ),
-		header: String( translate( 'Jetpack Scan' ) ),
+		documentHeadTitle: translate( 'Activate Jetpack Scan now' ) as string,
+		header: translate( 'Jetpack Scan' ) as string,
 		primaryPromo: {
 			title: translate( 'We guard your site. You run your business.' ),
 			image: { path: JetpackScanSVG },

--- a/client/my-sites/scan/wpcom-upsell.tsx
+++ b/client/my-sites/scan/wpcom-upsell.tsx
@@ -84,7 +84,7 @@ export default function WPCOMScanUpsellPage() {
 							},
 						} ),
 						action: {
-							url: `/checkout/${ siteSlug }/pro`,
+							url: `/checkout/${ siteSlug }/${ PLAN_BUSINESS }`,
 							onClick: onUpgradeClick,
 							selfTarget: true,
 						},

--- a/client/my-sites/scan/wpcom-upsell.tsx
+++ b/client/my-sites/scan/wpcom-upsell.tsx
@@ -1,24 +1,16 @@
-import {
-	WPCOM_FEATURES_BACKUPS,
-	WPCOM_FEATURES_FULL_ACTIVITY_LOG,
-	PLAN_BUSINESS,
-	getPlan,
-} from '@automattic/calypso-products';
-import { Gridicon } from '@automattic/components';
+import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import JetpackScanSVG from 'calypso/assets/images/illustrations/jetpack-scan.svg';
 import DocumentHead from 'calypso/components/data/document-head';
 import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
-import PromoSection, { Props as PromoSectionProps } from 'calypso/components/promo-section';
 import PromoCard from 'calypso/components/promo-section/promo-card';
 import PromoCardCTA from 'calypso/components/promo-section/promo-card/cta';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
 import { useSelector } from 'calypso/state';
-import siteHasFeature from 'calypso/state/selectors/site-has-feature';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
@@ -26,36 +18,7 @@ export default function WPCOMScanUpsellPage() {
 	const translate = useTranslate();
 	const onUpgradeClick = useTrackCallback( undefined, 'calypso_jetpack_scan_business_upsell' );
 	const siteSlug = useSelector( getSelectedSiteSlug );
-	const siteId = useSelector( getSelectedSiteId );
-	const hasBackups = useSelector( ( state ) =>
-		siteHasFeature( state, siteId, WPCOM_FEATURES_BACKUPS )
-	);
-	const hasFullActivityLog = useSelector( ( state ) =>
-		siteHasFeature( state, siteId, WPCOM_FEATURES_FULL_ACTIVITY_LOG )
-	);
 
-	const promos = [
-		{
-			title: translate( 'Jetpack VaultPress Backup' ),
-			body: translate(
-				'Granular control over your site, with the ability ' +
-					'to restore it to any previous state, and export it at any time.'
-			),
-			image: <Gridicon icon="cloud-upload" className="scan__upsell-icon" />,
-			isShown: ! hasBackups,
-		},
-		{
-			title: translate( 'Activity Log' ),
-			body: translate(
-				'A complete record of everything that happens on your site, with history that spans over 30 days.'
-			),
-			image: <Gridicon icon="history" className="scan__upsell-icon" />,
-			isShown: ! hasFullActivityLog,
-		},
-	];
-
-	// Only show promos for features the blog does not already have.
-	const filteredPromos: PromoSectionProps = { promos: promos.filter( ( p ) => p.isShown ) };
 	const businessPlanName = getPlan( PLAN_BUSINESS )?.getTitle() ?? '';
 
 	return (
@@ -91,19 +54,6 @@ export default function WPCOMScanUpsellPage() {
 					} }
 				/>
 			</PromoCard>
-
-			{ filteredPromos.promos.length > 0 && (
-				<>
-					<h2 className="scan__subheader">
-						{ translate( 'Also included in the %(planName)s Plan', {
-							args: {
-								planName: businessPlanName,
-							},
-						} ) }
-					</h2>
-					<PromoSection { ...filteredPromos } />
-				</>
-			) }
 
 			<WhatIsJetpack />
 		</Main>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Add a Jetpack Scan upsell for Simple sites.

Note: this doesn't add the admin menu. You'll need to go to /scan/ directly.

Part of DOTCOM-13640

## Proposed Changes

* Add upsell for Jetpack Scan on Simple Sites

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Untangling Calypso

## Testing Instructions
**Free Simple Site**
![Screenshot 2025-07-02 at 19 16 32](https://github.com/user-attachments/assets/490703ed-64b3-4f4c-8245-9c35b362614b)

**Business Simple Site**
![Screenshot 2025-07-02 at 19 18 33](https://github.com/user-attachments/assets/669ec143-50d2-4429-b925-d130ab09b772)




<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the live link and go to WordPress.com/scan/your-site
* Go with a free site and notice the upsell
* Go with a SImple Business and see the AT transfer notification

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
