### PR TITLE
Reader - Gravatar hovercards - update for new version.

### DIFF
--- a/client/components/gravatar-with-hovercards/index.jsx
+++ b/client/components/gravatar-with-hovercards/index.jsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { Hovercards } from '@gravatar-com/hovercards/react';
+import { useHovercards } from '@gravatar-com/hovercards/react';
 import { useEffect, useRef, useState } from 'react';
 import Gravatar from '../gravatar';
 import HovercardContentPortal from './hovercard-content';
@@ -11,46 +11,41 @@ function GravatarWithHovercards( props ) {
 	const [ mountNode, setMountNode ] = useState( null );
 	const [ gravatarData, setGravatarData ] = useState( {} );
 
-	useEffect( () => {
-		return () => {
-			// Remove any lingering hovercards on unmount
-			const hovercards = document.querySelectorAll( '.gravatar-hovercard' );
-			hovercards.forEach( ( card ) => card.remove() );
-		};
-	}, [] );
+	const hovercards = useHovercards( {
+		onHovercardShown: ( hash, hovercardElement ) => {
+			// Customize the hovercard.
+			if ( hovercardElement ) {
+				const inner = hovercardElement.querySelector( '.gravatar-hovercard__inner' );
+				if ( inner ) {
+					inner.innerHTML = '';
 
-	const handleHovercardShown = ( hash, hovercardElement ) => {
-		// Customize the hovercard.
-		if ( hovercardElement ) {
-			const inner = hovercardElement.querySelector( '.gravatar-hovercard__inner' );
-			if ( inner ) {
-				inner.innerHTML = '';
-
-				// Our custom components for the card will render through this portal.
-				setMountNode( inner );
+					// Our custom components for the card will render through this portal.
+					setMountNode( inner );
+				}
 			}
+		},
+		onFetchProfileSuccess: ( hash, data ) => {
+			setGravatarData( data );
+		},
+	} );
+
+	useEffect( () => {
+		// Attach hovercards to the container when it's available
+		if ( containerRef.current ) {
+			hovercards.attach( containerRef.current );
 		}
-	};
 
-	const shouldShowHovercard = () => {
-		// Only show the hovercard if the container is in the dom.
-		return containerRef.current && document.body.contains( containerRef.current );
-	};
-
-	const onFetchProfileSuccess = ( hash, data ) => {
-		setGravatarData( data );
-	};
+		return () => {
+			// Use the detach method to properly clean up hovercards on unmount
+			hovercards.detach();
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] ); // Empty array is correct here. We only want this to run on mount and unmount.
 
 	return (
 		<div ref={ containerRef }>
 			<HovercardContentPortal mountNode={ mountNode } gravatarData={ gravatarData } { ...props } />
-			<Hovercards
-				onHovercardShown={ handleHovercardShown }
-				onCanShowHovercard={ shouldShowHovercard }
-				onFetchProfileSuccess={ onFetchProfileSuccess }
-			>
-				<Gravatar { ...props } />
-			</Hovercards>
+			<Gravatar { ...props } />
 		</div>
 	);
 }

--- a/client/components/gravatar-with-hovercards/index.jsx
+++ b/client/components/gravatar-with-hovercards/index.jsx
@@ -11,7 +11,7 @@ function GravatarWithHovercards( props ) {
 	const [ mountNode, setMountNode ] = useState( null );
 	const [ gravatarData, setGravatarData ] = useState( {} );
 
-	const hovercards = useHovercards( {
+	const { attach, detach } = useHovercards( {
 		onHovercardShown: ( hash, hovercardElement ) => {
 			// Customize the hovercard.
 			if ( hovercardElement ) {
@@ -32,15 +32,14 @@ function GravatarWithHovercards( props ) {
 	useEffect( () => {
 		// Attach hovercards to the container when it's available
 		if ( containerRef.current ) {
-			hovercards.attach( containerRef.current );
+			attach( containerRef.current );
 		}
 
 		return () => {
 			// Use the detach method to properly clean up hovercards on unmount
-			hovercards.detach();
+			detach();
 		};
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] ); // Empty array is correct here. We only want this to run on mount and unmount.
+	}, [ attach, detach ] );
 
 	return (
 		<div ref={ containerRef }>

--- a/client/package.json
+++ b/client/package.json
@@ -83,7 +83,7 @@
 		"@emotion/styled": "^11.11.0",
 		"@fingerprintjs/fingerprintjs": "3.4.2",
 		"@github/webauthn-json": "^2.1.1",
-		"@gravatar-com/hovercards": "^0.13.0",
+		"@gravatar-com/hovercards": "^0.14.0",
 		"@paypal/react-paypal-js": "^8.7.0",
 		"@stripe/react-stripe-js": "^2.1.0",
 		"@stripe/stripe-js": "^1.54.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5937,10 +5937,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gravatar-com/hovercards@npm:^0.13.0":
-  version: 0.13.0
-  resolution: "@gravatar-com/hovercards@npm:0.13.0"
-  checksum: 4e11057a0bec726aa282941ac82b7d25f5c29543a973de0f0dbb4adc9c2b1dc3ed8b7ad6ae93caca424f6f7e47cf3e6dad2651f67e4463de5c5f5805c82ea5f2
+"@gravatar-com/hovercards@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "@gravatar-com/hovercards@npm:0.14.0"
+  checksum: 07fdc6ec383b7658445abebf7b2254650644cba9c192efd3fba9ddd8b2e448230b5d3047f3ec359c4519d736fa9b20467e8cabb0504a1ad291a2abb4b51576bc
   languageName: node
   linkType: hard
 
@@ -14952,7 +14952,7 @@ __metadata:
     "@emotion/styled": "npm:^11.11.0"
     "@fingerprintjs/fingerprintjs": "npm:3.4.2"
     "@github/webauthn-json": "npm:^2.1.1"
-    "@gravatar-com/hovercards": "npm:^0.13.0"
+    "@gravatar-com/hovercards": "npm:^0.14.0"
     "@paypal/react-paypal-js": "npm:^8.7.0"
     "@sentry/webpack-plugin": "npm:^1.21.0"
     "@stripe/react-stripe-js": "npm:^2.1.0"


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/CML-629/update-gravatar-hovercards-package-and-implementation

## Proposed Changes

* Updates the package to the next version. This allows us to replace some custom behavior with the `detach` method as it has been improved to suit our needs.
* Changes the implementation to use the hook version of the component so we can access the detach method which has recently been updated to also remove hovercards.
    * Originally we had 2 issues with hovercards here:
        1. Hovercards did not disappear when their parent containers unmounted. This is why we had a query to remove elements in our useEffect on unmount. Now we can simply call detach on unmount which will also remove the hovercard.
        2. Similarly, hovercards could still appear (after their delayToShow timer) after their parents had unmounted. This is why we had a check for the containerRef on `onCanShowHovercard`. The new updates to the detach method seem to handle this case as well.

In the end this is slightly more red than green. We have to do slightly more hovercard setup to use the hook version. We still need a dismount hook to call `detach`, but that is better than dom queries and removals. We still need a containerRef to tell the hook version where to work, but we don't have to babysit and verify its presence anymore.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Mostly code cleanup. We implemented this with slight hackyness to manage some concerns, but the package has been udpated so we can now remove that hackyness.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the reader. 
* If using calypso live and not development environment, add the `?flags=gravatar/hovercards` flag to the url.
* Hover over an author avatar on a post until the hovercard appears.
* Click the author avatar and verify the hovercard is gone when navigation occurs.
* Hover over an author avatar and click to navigate just before the hovercard appears.
* Verify the hovercard does not later appear on the next page. (there is a 0.5sec timer on hovercards to appear, in the past if one had clicked the avatar to navigate before the hovercard appeared, it would still appear after the timer completed on the next page).
* Smoke test hovercards, there should be no regressions. They should behave the same as they did before this change.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
