### PR TITLE
Dashboard v2: Fix untranslated strings

### DIFF
--- a/client/dashboard/sites/site-delete-modal/index.tsx
+++ b/client/dashboard/sites/site-delete-modal/index.tsx
@@ -174,7 +174,9 @@ function SiteDeleteConfirmContent( { site, onClose }: { site: Site; onClose: () 
 			<Notice variant="warning" density="medium">
 				<Text>
 					{ createInterpolateElement(
-						'Before deleting your site, consider <link>exporting your content as a backup</link>.',
+						__(
+							'Before deleting your site, consider <link>exporting your content as a backup</link>.'
+						),
 						{
 							link: <ExternalLink href={ `/export/${ site.slug }` } children={ null } />,
 						}

--- a/client/dashboard/sites/site-leave-modal/content-info.tsx
+++ b/client/dashboard/sites/site-leave-modal/content-info.tsx
@@ -139,7 +139,7 @@ function ContentLeaveSite( { site, onClose }: ContentInfoProps ) {
 			<VStack spacing={ 6 }>
 				<Text as="p">
 					{ createInterpolateElement(
-						/* translators: %s: site domain */
+						/* translators: <siteDomain />: site domain */
 						__( 'Are you sure to leave the site <siteDomain />?' ),
 						{
 							siteDomain: <strong>{ site.slug }</strong>,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Fix untranslated strings because it's missing `__()`
* Adjust the comment of the translation

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
