### PR TITLE
Dashboard v2: always remove version suffix from WP version

### DIFF
--- a/client/dashboard/utils/wp-version.ts
+++ b/client/dashboard/utils/wp-version.ts
@@ -20,10 +20,8 @@ export function getFormattedWordPressVersion(
 		return '';
 	}
 
-	if ( ! site.is_wpcom_atomic ) {
-		// On Simple sites, the version string has suffix e.g. 6.8.1-alpha-60199
-		wpVersion = wpVersion.split( '-' )[ 0 ];
-	}
+	// The version string could have suffix like 6.8.1-alpha-60199, e.g. on Simple sites
+	wpVersion = wpVersion.split( '-' )[ 0 ];
 
 	if ( versionTag ) {
 		wpVersion = `${ wpVersion } (${ getWordPressVersionTagName( versionTag ) })`;


### PR DESCRIPTION
Fixes p1751009356589719-slack-C029GN3KD

## Proposed Changes

This PR always removes the suffix from WP version. Somehow, it returns the suffix even on Atomic sites. Maybe there's a race condition between setting the options and setting the `is_wpcom_atomic` from the server side.

## Testing Instructions

1. Go to `/v2/sites/:siteSlug/settings` for both Simple and Atomic sites
2. Verify they both show the WP version without any suffix.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?