### PR TITLE
File browser no redux

### DIFF
--- a/client/dashboard/components/file-browser/context.tsx
+++ b/client/dashboard/components/file-browser/context.tsx
@@ -1,0 +1,220 @@
+import { createContext, useContext, useReducer, ReactNode } from 'react';
+import { FileBrowserState, FileBrowserNode, FileBrowserCheckState } from './types';
+
+interface FileBrowserContextType {
+	state: FileBrowserState;
+	addChildNodes: ( parentPath: string, children: Omit< FileBrowserNode, 'checkState' >[] ) => void;
+	setNodeCheckState: ( path: string, checkState: FileBrowserCheckState ) => void;
+	setActiveNodePath: ( path: string ) => void;
+	getNodeCheckState: ( path: string ) => FileBrowserCheckState;
+}
+
+const FileBrowserContext = createContext< FileBrowserContextType | undefined >( undefined );
+
+type FileBrowserAction =
+	| {
+			type: 'ADD_CHILD_NODES';
+			payload: { parentPath: string; children: Omit< FileBrowserNode, 'checkState' >[] };
+	  }
+	| { type: 'SET_NODE_CHECK_STATE'; payload: { path: string; checkState: FileBrowserCheckState } }
+	| { type: 'SET_ACTIVE_NODE_PATH'; payload: { path: string } };
+
+const calculateCheckState = (
+	nodes: Record< string, FileBrowserNode >,
+	parentPath: string,
+	targetPath: string,
+	newCheckState: FileBrowserCheckState
+): FileBrowserCheckState => {
+	const childPaths = Object.keys( nodes ).filter(
+		( path ) =>
+			path.startsWith( parentPath ) &&
+			path !== parentPath &&
+			path.indexOf( '/', parentPath.length + 1 ) === -1
+	);
+
+	if ( childPaths.length === 0 ) {
+		return newCheckState;
+	}
+
+	const childStates = childPaths.map( ( path ) => {
+		if ( path === targetPath ) {
+			return newCheckState;
+		}
+		return nodes[ path ]?.checkState || 'unchecked';
+	} );
+
+	const checkedCount = childStates.filter( ( state ) => state === 'checked' ).length;
+	const uncheckedCount = childStates.filter( ( state ) => state === 'unchecked' ).length;
+	const mixedCount = childStates.filter( ( state ) => state === 'mixed' ).length;
+
+	if ( checkedCount === childStates.length ) {
+		return 'checked';
+	}
+	if ( uncheckedCount === childStates.length ) {
+		return 'unchecked';
+	}
+	return 'mixed';
+};
+
+const updateParentCheckStates = (
+	nodes: Record< string, FileBrowserNode >,
+	targetPath: string,
+	newCheckState: FileBrowserCheckState
+): Record< string, FileBrowserNode > => {
+	const updatedNodes = { ...nodes };
+
+	const pathParts = targetPath.split( '/' ).filter( ( part ) => part !== '' );
+
+	for ( let i = pathParts.length - 1; i > 0; i-- ) {
+		const parentPath = '/' + pathParts.slice( 0, i ).join( '/' ) + '/';
+		const normalizedParentPath = parentPath === '//' ? '/' : parentPath;
+
+		if ( updatedNodes[ normalizedParentPath ] ) {
+			const calculatedState = calculateCheckState(
+				updatedNodes,
+				normalizedParentPath,
+				targetPath,
+				newCheckState
+			);
+			updatedNodes[ normalizedParentPath ] = {
+				...updatedNodes[ normalizedParentPath ],
+				checkState: calculatedState,
+			};
+		}
+	}
+
+	return updatedNodes;
+};
+
+const updateChildCheckStates = (
+	nodes: Record< string, FileBrowserNode >,
+	parentPath: string,
+	newCheckState: FileBrowserCheckState
+): Record< string, FileBrowserNode > => {
+	const updatedNodes = { ...nodes };
+
+	Object.keys( updatedNodes ).forEach( ( path ) => {
+		if ( path.startsWith( parentPath ) && path !== parentPath ) {
+			updatedNodes[ path ] = {
+				...updatedNodes[ path ],
+				checkState: newCheckState === 'mixed' ? 'unchecked' : newCheckState,
+			};
+		}
+	} );
+
+	return updatedNodes;
+};
+
+const fileBrowserReducer = (
+	state: FileBrowserState,
+	action: FileBrowserAction
+): FileBrowserState => {
+	switch ( action.type ) {
+		case 'ADD_CHILD_NODES': {
+			const { parentPath, children } = action.payload;
+			const newNodes = { ...state.nodes };
+
+			children.forEach( ( child ) => {
+				const childPath = `${ parentPath }${ child.path }/`;
+				newNodes[ childPath ] = {
+					...child,
+					path: childPath,
+					checkState: 'unchecked',
+				};
+			} );
+
+			return {
+				...state,
+				nodes: newNodes,
+			};
+		}
+		case 'SET_NODE_CHECK_STATE': {
+			const { path, checkState } = action.payload;
+			let updatedNodes = { ...state.nodes };
+
+			if ( updatedNodes[ path ] ) {
+				updatedNodes[ path ] = {
+					...updatedNodes[ path ],
+					checkState,
+				};
+
+				updatedNodes = updateChildCheckStates( updatedNodes, path, checkState );
+				updatedNodes = updateParentCheckStates( updatedNodes, path, checkState );
+			}
+
+			return {
+				...state,
+				nodes: updatedNodes,
+			};
+		}
+		case 'SET_ACTIVE_NODE_PATH': {
+			return {
+				...state,
+				activeNodePath: action.payload.path,
+			};
+		}
+		default:
+			return state;
+	}
+};
+
+const initialState: FileBrowserState = {
+	nodes: {},
+	activeNodePath: '',
+};
+
+interface FileBrowserProviderProps {
+	children: ReactNode;
+}
+
+export const FileBrowserProvider = ( { children }: FileBrowserProviderProps ) => {
+	const [ state, dispatch ] = useReducer( fileBrowserReducer, initialState );
+
+	const addChildNodes = (
+		parentPath: string,
+		childNodes: Omit< FileBrowserNode, 'checkState' >[]
+	) => {
+		dispatch( {
+			type: 'ADD_CHILD_NODES',
+			payload: { parentPath, children: childNodes },
+		} );
+	};
+
+	const setNodeCheckState = ( path: string, checkState: FileBrowserCheckState ) => {
+		dispatch( {
+			type: 'SET_NODE_CHECK_STATE',
+			payload: { path, checkState },
+		} );
+	};
+
+	const setActiveNodePath = ( path: string ) => {
+		dispatch( {
+			type: 'SET_ACTIVE_NODE_PATH',
+			payload: { path },
+		} );
+	};
+
+	const getNodeCheckState = ( path: string ): FileBrowserCheckState => {
+		return state.nodes[ path ]?.checkState || 'unchecked';
+	};
+
+	const contextValue: FileBrowserContextType = {
+		state,
+		addChildNodes,
+		setNodeCheckState,
+		setActiveNodePath,
+		getNodeCheckState,
+	};
+
+	return (
+		<FileBrowserContext.Provider value={ contextValue }>{ children }</FileBrowserContext.Provider>
+	);
+};
+
+export const useFileBrowser = (): FileBrowserContextType => {
+	const context = useContext( FileBrowserContext );
+	if ( ! context ) {
+		throw new Error( 'useFileBrowser must be used within a FileBrowserProvider' );
+	}
+	return context;
+};

--- a/client/dashboard/components/file-browser/file-browser-header.tsx
+++ b/client/dashboard/components/file-browser/file-browser-header.tsx
@@ -1,0 +1,49 @@
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { download } from '@wordpress/icons';
+import { useFileBrowser } from './context';
+
+interface FileBrowserHeaderProps {
+	siteId: number;
+	rewindId: number;
+}
+
+const FileBrowserHeader = ( { siteId, rewindId }: FileBrowserHeaderProps ) => {
+	const { state } = useFileBrowser();
+
+	const selectedNodes = Object.values( state.nodes ).filter(
+		( node ) => node.checkState === 'checked'
+	);
+
+	const handleDownload = () => {
+		// Implementation for download functionality would go here
+		console.log( 'Download selected files:', selectedNodes );
+	};
+
+	return (
+		<div className="file-browser-header">
+			<div className="file-browser-header__info">
+				{ selectedNodes.length > 0 && (
+					<span>
+						{ __( '%d items selected', 'calypso' ).replace(
+							'%d',
+							selectedNodes.length.toString()
+						) }
+					</span>
+				) }
+			</div>
+			<div className="file-browser-header__actions">
+				<Button
+					variant="primary"
+					icon={ download }
+					disabled={ selectedNodes.length === 0 }
+					onClick={ handleDownload }
+				>
+					{ __( 'Download selected', 'calypso' ) }
+				</Button>
+			</div>
+		</div>
+	);
+};
+
+export default FileBrowserHeader;

--- a/client/dashboard/components/file-browser/file-browser-node.tsx
+++ b/client/dashboard/components/file-browser/file-browser-node.tsx
@@ -1,0 +1,236 @@
+import { Button, CheckboxControl, Icon } from '@wordpress/components';
+import { chevronDown, chevronRight } from '@wordpress/icons';
+import clsx from 'clsx';
+import { useCallback, useEffect, useState } from 'react';
+import { useFileBrowser } from './context';
+import FileInfoCard from './file-info-card';
+import FileTypeIcon from './file-type-icon';
+import { useBackupContentsQuery } from './hooks';
+import { FileBrowserItem, FileBrowserCheckState } from './types';
+import { useTruncatedFileName } from './utils';
+
+interface FileBrowserNodeProps {
+	item: FileBrowserItem;
+	path: string;
+	siteId: number;
+	rewindId: number;
+	isAlternate: boolean;
+	parentItem?: FileBrowserItem;
+}
+
+const FileBrowserNode = ( {
+	item,
+	path,
+	siteId,
+	rewindId,
+	isAlternate,
+	parentItem,
+}: FileBrowserNodeProps ) => {
+	const isRoot = path === '/';
+	const { state, addChildNodes, setNodeCheckState, setActiveNodePath, getNodeCheckState } =
+		useFileBrowser();
+	const isCurrentNodeClicked = state.activeNodePath === path;
+	const [ fetchContentsOnMount, setFetchContentsOnMount ] = useState< boolean >( isRoot );
+	const [ isOpen, setIsOpen ] = useState< boolean >( isRoot );
+	const [ addedAnyChildren, setAddedAnyChildren ] = useState< boolean >( false );
+
+	const {
+		isSuccess,
+		isLoading,
+		data: backupFiles,
+	} = useBackupContentsQuery( siteId, rewindId, path, fetchContentsOnMount );
+
+	const shouldAddChildNode = useCallback(
+		( childItem: FileBrowserItem ) => {
+			if ( childItem.type === 'wordpress' ) {
+				return false;
+			}
+
+			if ( childItem.type !== 'archive' ) {
+				return true;
+			}
+
+			if ( childItem.extensionType === 'changed' ) {
+				return false;
+			}
+
+			if ( ! item.extensionVersion ) {
+				return false;
+			}
+
+			return true;
+		},
+		[ item.extensionVersion ]
+	);
+
+	const addChildrenWhenLoaded = useCallback(
+		( parentPath: string, backupFiles: FileBrowserItem[] ) => {
+			if ( backupFiles ) {
+				addChildNodes(
+					parentPath,
+					backupFiles.filter( shouldAddChildNode ).map( ( childItem: FileBrowserItem ) => {
+						return {
+							id: childItem.id ?? '',
+							path: childItem.name,
+							type: childItem.type,
+							totalItems: childItem.totalItems,
+						};
+					} )
+				);
+			}
+		},
+		[ addChildNodes, shouldAddChildNode ]
+	);
+
+	useEffect( () => {
+		if ( isSuccess ) {
+			if ( item.hasChildren && ! addedAnyChildren ) {
+				addChildrenWhenLoaded( path, backupFiles );
+				setAddedAnyChildren( true );
+			}
+		}
+	}, [ addChildrenWhenLoaded, addedAnyChildren, backupFiles, isSuccess, item.hasChildren, path ] );
+
+	useEffect( () => {
+		if ( ! isCurrentNodeClicked && ! isRoot ) {
+			setIsOpen( false );
+		}
+	}, [ isCurrentNodeClicked, isRoot ] );
+
+	const onCheckboxChange = () => {
+		const currentState = getNodeCheckState( path );
+		const newState: FileBrowserCheckState = currentState === 'unchecked' ? 'checked' : 'unchecked';
+		setNodeCheckState( path, newState );
+	};
+
+	const handleClick = useCallback( () => {
+		if ( ! isOpen ) {
+			setFetchContentsOnMount( true );
+		}
+
+		if ( ! item.hasChildren ) {
+			if ( ! isOpen ) {
+				setActiveNodePath( path );
+			} else {
+				setActiveNodePath( '' );
+			}
+		}
+
+		setIsOpen( ! isOpen );
+	}, [ isOpen, item, path, setActiveNodePath ] );
+
+	const renderChildren = () => {
+		if ( isLoading ) {
+			return (
+				<>
+					<div className="file-browser-node__loading placeholder" />
+					<div className="file-browser-node__loading placeholder" />
+					<div className="file-browser-node__loading placeholder" />
+				</>
+			);
+		}
+
+		if ( isSuccess && addedAnyChildren ) {
+			let childIsAlternate = isAlternate;
+
+			return backupFiles.map( ( childItem ) => {
+				if (
+					( childItem.type === 'archive' && ! item.extensionVersion ) ||
+					childItem.extensionType === 'changed'
+				) {
+					return null;
+				}
+
+				childIsAlternate = ! childIsAlternate;
+
+				return (
+					<FileBrowserNode
+						key={ childItem.name }
+						item={ childItem }
+						path={ `${ path }${ childItem.name }/` }
+						siteId={ siteId }
+						rewindId={ rewindId }
+						isAlternate={ childIsAlternate }
+						{ ...( childItem.type === 'archive' ? { parentItem: item } : {} ) }
+					/>
+				);
+			} );
+		}
+
+		return null;
+	};
+
+	const renderCheckbox = () => {
+		if ( item.type === 'wordpress' ) {
+			return null;
+		}
+
+		const checkState = getNodeCheckState( path );
+
+		return (
+			<CheckboxControl
+				__nextHasNoMarginBottom
+				checked={ checkState === 'checked' }
+				indeterminate={ checkState === 'mixed' }
+				onChange={ onCheckboxChange }
+			/>
+		);
+	};
+
+	const renderExpandIcon = () => {
+		if ( ! item.hasChildren ) {
+			return null;
+		}
+
+		return <Icon icon={ isOpen ? chevronDown : chevronRight } />;
+	};
+
+	const nodeItemClassName = clsx( 'file-browser-node__item', {
+		'is-alternate': isAlternate,
+	} );
+	const [ label, isLabelTruncated ] = useTruncatedFileName( item.name, 30, item.type );
+
+	const nodeClassName = clsx( 'file-browser-node', item.type, {
+		'is-root': isRoot,
+	} );
+
+	return (
+		<div className={ nodeClassName }>
+			<div className={ nodeItemClassName }>
+				{ ! isRoot && (
+					<>
+						{ renderCheckbox() }
+						<Button
+							icon={ renderExpandIcon }
+							className="file-browser-node__title has-icon"
+							onClick={ handleClick }
+							showTooltip={ isLabelTruncated }
+							label={ item.name }
+							variant="tertiary"
+						>
+							<FileTypeIcon type={ item.type } /> { label }
+						</Button>
+					</>
+				) }
+			</div>
+			{ isCurrentNodeClicked && (
+				<FileInfoCard
+					siteId={ siteId }
+					rewindId={ rewindId }
+					item={ item }
+					parentItem={ parentItem }
+					path={ path }
+				/>
+			) }
+			{ isOpen && (
+				<>
+					{ item.hasChildren && (
+						<div className="file-browser-node__contents">{ renderChildren() }</div>
+					) }
+				</>
+			) }
+		</div>
+	);
+};
+
+export default FileBrowserNode;

--- a/client/dashboard/components/file-browser/file-info-card.tsx
+++ b/client/dashboard/components/file-browser/file-info-card.tsx
@@ -1,0 +1,119 @@
+import { Card, CardBody, Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { download } from '@wordpress/icons';
+import { FileBrowserItem } from './types';
+import { useBackupFileQuery } from './hooks';
+import { convertBytes } from './utils';
+
+interface FileInfoCardProps {
+	siteId: number;
+	rewindId: number;
+	item: FileBrowserItem;
+	parentItem?: FileBrowserItem;
+	path: string;
+}
+
+const FileInfoCard = ( { siteId, rewindId, item, parentItem, path }: FileInfoCardProps ) => {
+	const {
+		data: fileInfo,
+		isLoading,
+		isError,
+	} = useBackupFileQuery( siteId, rewindId, path, ! item.hasChildren );
+
+	const handleDownload = () => {
+		if ( fileInfo?.downloadUrl ) {
+			window.open( fileInfo.downloadUrl, '_blank' );
+		}
+	};
+
+	const formatDate = ( timestamp?: number ) => {
+		if ( ! timestamp ) return __( 'Unknown', 'calypso' );
+		return new Date( timestamp * 1000 ).toLocaleString();
+	};
+
+	const formatSize = ( bytes?: number ) => {
+		if ( typeof bytes !== 'number' ) return __( 'Unknown', 'calypso' );
+		const { unitAmount, unit } = convertBytes( bytes );
+		return `${ unitAmount } ${ unit }`;
+	};
+
+	if ( item.hasChildren ) {
+		return (
+			<Card>
+				<CardBody>
+					<h3>{ item.name }</h3>
+					<p>{ __( 'Directory', 'calypso' ) }</p>
+					{ item.totalItems && (
+						<p>{ __( '%d items', 'calypso' ).replace( '%d', item.totalItems.toString() ) }</p>
+					) }
+				</CardBody>
+			</Card>
+		);
+	}
+
+	if ( isLoading ) {
+		return (
+			<Card>
+				<CardBody>
+					<div className="file-info-card__loading">
+						<div className="placeholder" />
+						<div className="placeholder" />
+						<div className="placeholder" />
+					</div>
+				</CardBody>
+			</Card>
+		);
+	}
+
+	if ( isError ) {
+		return (
+			<Card>
+				<CardBody>
+					<h3>{ item.name }</h3>
+					<p>{ __( 'Error loading file information', 'calypso' ) }</p>
+				</CardBody>
+			</Card>
+		);
+	}
+
+	return (
+		<Card>
+			<CardBody>
+				<div className="file-info-card__header">
+					<h3>{ item.name }</h3>
+					{ fileInfo?.downloadUrl && (
+						<Button variant="secondary" icon={ download } onClick={ handleDownload }>
+							{ __( 'Download', 'calypso' ) }
+						</Button>
+					) }
+				</div>
+				<div className="file-info-card__details">
+					<div className="file-info-card__detail">
+						<strong>{ __( 'Type:', 'calypso' ) }</strong>
+						<span>{ item.type }</span>
+					</div>
+					{ fileInfo?.size && (
+						<div className="file-info-card__detail">
+							<strong>{ __( 'Size:', 'calypso' ) }</strong>
+							<span>{ formatSize( fileInfo.size ) }</span>
+						</div>
+					) }
+					{ fileInfo?.mtime && (
+						<div className="file-info-card__detail">
+							<strong>{ __( 'Modified:', 'calypso' ) }</strong>
+							<span>{ formatDate( fileInfo.mtime ) }</span>
+						</div>
+					) }
+					{ fileInfo?.hash && (
+						<div className="file-info-card__detail">
+							<strong>{ __( 'Hash:', 'calypso' ) }</strong>
+							<span className="file-info-card__hash">{ fileInfo.hash }</span>
+						</div>
+					) }
+				</div>
+			</CardBody>
+		</Card>
+	);
+};
+
+export default FileInfoCard;

--- a/client/dashboard/components/file-browser/file-type-icon.tsx
+++ b/client/dashboard/components/file-browser/file-type-icon.tsx
@@ -1,0 +1,58 @@
+import { Icon } from '@wordpress/components';
+import {
+	code,
+	folder,
+	media,
+	page,
+	plugins,
+	audio,
+	video,
+	desktop,
+	typography,
+	globe,
+	archive,
+} from '@wordpress/icons';
+import { FileType } from './types';
+
+interface FileTypeIconProps {
+	type: FileType;
+}
+
+const FileTypeIcon = ( { type }: FileTypeIconProps ) => {
+	const getIcon = () => {
+		switch ( type ) {
+			case 'dir':
+				return folder;
+			case 'image':
+				return media;
+			case 'text':
+				return page;
+			case 'plugin':
+				return plugins;
+			case 'theme':
+				return desktop;
+			case 'table':
+				return page;
+			case 'audio':
+				return audio;
+			case 'video':
+				return video;
+			case 'fonts':
+				return typography;
+			case 'translations':
+				return globe;
+			case 'code':
+				return code;
+			case 'wordpress':
+				return globe;
+			case 'archive':
+				return archive;
+			default:
+				return page;
+		}
+	};
+
+	return <Icon icon={ getIcon() } size={ 18 } />;
+};
+
+export default FileTypeIcon;

--- a/client/dashboard/components/file-browser/hooks.ts
+++ b/client/dashboard/components/file-browser/hooks.ts
@@ -1,0 +1,57 @@
+import { useQuery } from '@tanstack/react-query';
+import wp from 'calypso/lib/wp';
+import { parseBackupContentsData, parseBackupPathInfo } from './utils';
+
+export const useBackupContentsQuery = (
+	siteId: number,
+	rewindId: number,
+	path: string,
+	shouldFetch = true
+) => {
+	return useQuery( {
+		queryKey: [ 'dashboard-backup-contents-ls', siteId, rewindId, path ],
+		queryFn: async () => {
+			return wp.req.post(
+				{
+					path: `/sites/${ siteId }/rewind/backup/ls`,
+					apiNamespace: 'wpcom/v2',
+				},
+				{
+					backup_id: rewindId,
+					path: path,
+				}
+			);
+		},
+		enabled: !! siteId && !! rewindId && !! path && shouldFetch,
+		meta: { persist: false },
+		select: parseBackupContentsData,
+		staleTime: Infinity,
+	} );
+};
+
+export const useBackupFileQuery = (
+	siteId: number,
+	rewindId: number,
+	path: string,
+	shouldFetch = true
+) => {
+	return useQuery( {
+		queryKey: [ 'dashboard-backup-file-info', siteId, rewindId, path ],
+		queryFn: async () => {
+			return wp.req.post(
+				{
+					path: `/sites/${ siteId }/rewind/backup/path-info`,
+					apiNamespace: 'wpcom/v2',
+				},
+				{
+					backup_id: rewindId,
+					path: path,
+				}
+			);
+		},
+		enabled: !! siteId && !! rewindId && !! path && shouldFetch,
+		meta: { persist: false },
+		select: parseBackupPathInfo,
+		staleTime: Infinity,
+	} );
+};

--- a/client/dashboard/components/file-browser/index.tsx
+++ b/client/dashboard/components/file-browser/index.tsx
@@ -1,0 +1,36 @@
+import { VStack } from '@wordpress/components';
+import { FileBrowserProvider } from './context';
+import FileBrowserHeader from './file-browser-header';
+import FileBrowserNode from './file-browser-node';
+import { FileBrowserItem } from './types';
+import './style.scss';
+
+interface FileBrowserProps {
+	siteId: number;
+	rewindId: number;
+}
+
+const FileBrowser = ( { siteId, rewindId }: FileBrowserProps ) => {
+	const rootItem: FileBrowserItem = {
+		name: '/',
+		hasChildren: true,
+		type: 'dir',
+	};
+
+	return (
+		<FileBrowserProvider>
+			<VStack spacing={ 0 }>
+				<FileBrowserHeader siteId={ siteId } rewindId={ rewindId } />
+				<FileBrowserNode
+					siteId={ siteId }
+					rewindId={ rewindId }
+					item={ rootItem }
+					path="/"
+					isAlternate
+				/>
+			</VStack>
+		</FileBrowserProvider>
+	);
+};
+
+export default FileBrowser;

--- a/client/dashboard/components/file-browser/style.scss
+++ b/client/dashboard/components/file-browser/style.scss
@@ -1,0 +1,143 @@
+.file-browser-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 16px;
+	border-bottom: 1px solid #ddd;
+	background: #f9f9f9;
+
+	&__info {
+		font-size: 14px;
+		color: #666;
+	}
+
+	&__actions {
+		display: flex;
+		gap: 8px;
+	}
+}
+
+.file-browser-node {
+	&__item {
+		display: flex;
+		align-items: center;
+		padding: 8px 16px;
+		border-bottom: 1px solid #f0f0f0;
+
+		&.is-alternate {
+			background-color: #f9f9f9;
+		}
+
+		.components-checkbox-control {
+			margin-right: 12px;
+		}
+	}
+
+	&__title {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		flex: 1;
+
+		&.has-icon {
+			padding-left: 0;
+		}
+	}
+
+	&__contents {
+		margin-left: 40px;
+		border-left: 1px solid #ddd;
+	}
+
+	&__loading {
+		height: 40px;
+		margin: 4px 16px;
+		border-radius: 4px;
+		background: #f0f0f0;
+
+		&.placeholder {
+			animation: pulse 1.5s ease-in-out infinite;
+		}
+	}
+
+	&.is-root {
+		.file-browser-node__item {
+			display: none;
+		}
+
+		.file-browser-node__contents {
+			margin-left: 0;
+			border-left: none;
+		}
+	}
+}
+
+.file-info-card {
+	margin: 16px;
+	border: 1px solid #ddd;
+	border-radius: 4px;
+
+	&__header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 16px;
+
+		h3 {
+			margin: 0;
+			font-size: 16px;
+			font-weight: 600;
+		}
+	}
+
+	&__details {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	&__detail {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 4px 0;
+
+		strong {
+			min-width: 80px;
+			margin-right: 16px;
+		}
+
+		span {
+			flex: 1;
+			text-align: right;
+		}
+	}
+
+	&__hash {
+		font-family: monospace;
+		font-size: 12px;
+		word-break: break-all;
+	}
+
+	&__loading {
+		.placeholder {
+			height: 20px;
+			margin: 8px 0;
+			border-radius: 4px;
+			background: #f0f0f0;
+			animation: pulse 1.5s ease-in-out infinite;
+		}
+	}
+}
+
+@keyframes pulse {
+	0% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.5;
+	}
+	100% {
+		opacity: 1;
+	}
+}

--- a/client/dashboard/components/file-browser/types.ts
+++ b/client/dashboard/components/file-browser/types.ts
@@ -1,0 +1,87 @@
+export type ApiFileType = 'file' | 'dir' | 'wordpress' | 'table' | 'theme' | 'plugin' | 'archive';
+
+export type FileType =
+	| 'dir'
+	| 'image'
+	| 'text'
+	| 'plugin'
+	| 'theme'
+	| 'table'
+	| 'audio'
+	| 'video'
+	| 'fonts'
+	| 'translations'
+	| 'code'
+	| 'wordpress'
+	| 'archive'
+	| 'other';
+
+export interface FileBrowserItem {
+	id?: string;
+	name: string;
+	type: FileType;
+	hasChildren: boolean;
+	period?: string;
+	sort?: number;
+	rowCount?: number;
+	children?: FileBrowserItem[];
+	extensionVersion?: string;
+	manifestPath?: string;
+	extensionType?: string;
+	totalItems?: number;
+}
+
+export interface BackupLsResponse {
+	ok: boolean;
+	error: string;
+	contents: BackupLsResponseContents;
+}
+
+export interface BackupLsResponseContents {
+	[ key: string ]: {
+		id?: string;
+		type: ApiFileType;
+		has_children: boolean;
+		period?: string;
+		sort?: number;
+		manifest_path?: string;
+		label?: string;
+		row_count?: number;
+		extension_version?: string;
+		total_items?: number;
+	};
+}
+
+export interface BackupPathInfoResponse {
+	download_url?: string;
+	mtime?: number;
+	size?: number;
+	hash?: string;
+	data_type?: number;
+	manifest_filter?: string;
+	error?: string;
+}
+
+export interface FileBrowserItemInfo {
+	downloadUrl?: string;
+	mtime?: number;
+	size?: number;
+	hash?: string;
+	dataType?: number;
+	manifestFilter?: string;
+}
+
+export type FileBrowserCheckState = 'checked' | 'unchecked' | 'mixed';
+
+export interface FileBrowserNode {
+	id: string;
+	path: string;
+	type: FileType;
+	totalItems?: number;
+	checkState: FileBrowserCheckState;
+}
+
+export interface FileBrowserState {
+	nodes: Record< string, FileBrowserNode >;
+	activeNodePath: string;
+}

--- a/client/dashboard/components/file-browser/utils.ts
+++ b/client/dashboard/components/file-browser/utils.ts
@@ -1,0 +1,205 @@
+import {
+	BackupLsResponse,
+	BackupLsResponseContents,
+	BackupPathInfoResponse,
+	FileBrowserItem,
+	FileBrowserItemInfo,
+	FileType,
+} from './types';
+
+const extensionToFileType: Record< string, FileType > = {
+	jpg: 'image',
+	jpeg: 'image',
+	gif: 'image',
+	ico: 'image',
+	png: 'image',
+	webp: 'image',
+	svg: 'image',
+	mp4: 'video',
+	ogg: 'video',
+	ogv: 'video',
+	webm: 'video',
+	avi: 'video',
+	mp3: 'audio',
+	aac: 'audio',
+	pdf: 'text',
+	md: 'text',
+	txt: 'text',
+	eot: 'fonts',
+	woff: 'fonts',
+	ttf: 'fonts',
+	mo: 'translations',
+	po: 'translations',
+	pot: 'translations',
+	html: 'code',
+	php: 'code',
+	css: 'code',
+	js: 'code',
+	scss: 'code',
+	sass: 'code',
+	less: 'code',
+	crt: 'code',
+};
+
+const getFileExtension = ( filename: string ): string => {
+	const lastDotIndex = filename.lastIndexOf( '.' );
+	return lastDotIndex !== -1 ? filename.slice( lastDotIndex + 1 ).toLowerCase() : '';
+};
+
+export const getFileTypeByExtension = ( filename: string ): FileType | null => {
+	const extension = getFileExtension( filename ) || '';
+	return extensionToFileType[ extension ] || null;
+};
+
+export const transformFileType = (
+	name: string,
+	item: BackupLsResponseContents[ string ]
+): FileType => {
+	switch ( item.type ) {
+		case 'dir':
+		case 'wordpress':
+		case 'theme':
+		case 'plugin':
+		case 'table':
+		case 'archive':
+			return item.type;
+		case 'file':
+			if ( item.has_children ) {
+				return 'dir';
+			}
+			return getFileTypeByExtension( name ) ?? 'other';
+		default:
+			return 'other';
+	}
+};
+
+export const parseBackupContentsData = ( payload: BackupLsResponse ): FileBrowserItem[] => {
+	if ( ! payload || ! payload.contents || ! payload.ok ) {
+		return [];
+	}
+
+	const transformedData = Object.entries( payload.contents ).map( ( [ name, item ] ) => {
+		const type = transformFileType( name, item );
+		const label = item.label ?? name;
+
+		return {
+			name: label,
+			type,
+			hasChildren: item.has_children ?? false,
+			...( item.period && { period: item.period } ),
+			...( item.sort && { sort: item.sort } ),
+			...( item.type === 'archive' && { extensionType: name.replace( '*', '' ) } ),
+			...( item.type === 'table' && { rowCount: item.row_count } ),
+			...( item.extension_version && { extensionVersion: item.extension_version } ),
+			...( item.manifest_path && { manifestPath: item.manifest_path } ),
+			...( item.id && { id: item.id } ),
+			...( item.type !== 'wordpress' && { totalItems: item.total_items ?? 1 } ),
+		};
+	} );
+
+	return transformedData.sort( ( a, b ) => {
+		if ( a.sort !== undefined && b.sort !== undefined ) {
+			return a.sort - b.sort;
+		}
+
+		if ( a.sort !== undefined ) {
+			return -1;
+		}
+		if ( b.sort !== undefined ) {
+			return 1;
+		}
+
+		if ( a.hasChildren === true && b.hasChildren !== true ) {
+			return -1;
+		}
+		if ( b.hasChildren === true && a.hasChildren !== true ) {
+			return 1;
+		}
+
+		if ( a.name < b.name ) {
+			return -1;
+		}
+		if ( a.name > b.name ) {
+			return 1;
+		}
+
+		return a.name.localeCompare( b.name );
+	} );
+};
+
+export const parseBackupPathInfo = ( payload: BackupPathInfoResponse ): FileBrowserItemInfo => {
+	if ( ! payload ) {
+		return {};
+	}
+
+	const result: FileBrowserItemInfo = {};
+
+	if ( payload.download_url !== undefined ) {
+		result.downloadUrl = payload.download_url;
+	}
+
+	if ( payload.mtime !== undefined ) {
+		result.mtime = payload.mtime;
+	}
+
+	if ( payload.size !== undefined ) {
+		result.size = Number( payload.size );
+	}
+
+	if ( payload.hash !== undefined ) {
+		result.hash = payload.hash;
+	}
+
+	if ( payload.data_type !== undefined ) {
+		result.dataType = Number( payload.data_type );
+	}
+
+	if ( payload.manifest_filter !== undefined ) {
+		result.manifestFilter = payload.manifest_filter;
+	}
+
+	return result;
+};
+
+export const convertBytes = (
+	bytes: number,
+	decimals = 1
+): { unitAmount: string; unit: string } => {
+	const units = [ 'B', 'KB', 'MB', 'GB', 'TB' ];
+	let size = bytes;
+
+	let i = 0;
+	while ( size >= 1024 && i < units.length - 1 ) {
+		size /= 1024;
+		i++;
+	}
+
+	return { unitAmount: size.toFixed( decimals ), unit: units[ i ] };
+};
+
+export const encodeToBase64 = ( text: string ): string => {
+	const encoder = new TextEncoder();
+	const charCodes = encoder.encode( text );
+	return window.btoa( String.fromCharCode( ...charCodes ) );
+};
+
+type TruncatedFileNameResult = [ string, boolean ];
+
+export const useTruncatedFileName = (
+	name: string,
+	maxLength: number,
+	type: FileType
+): TruncatedFileNameResult => {
+	if ( type === 'archive' ) {
+		return [ name, false ];
+	}
+
+	const isTruncated = name.length > maxLength;
+	const extension = getFileExtension( name ) || '';
+	const basename = name.replace( `.${ extension }`, '' );
+	const truncatedName = isTruncated
+		? `${ basename.slice( 0, maxLength - 3 - extension.length ) }...${ extension }`
+		: name;
+
+	return [ truncatedName, isTruncated ];
+};

--- a/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
@@ -2,15 +2,26 @@ import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { chevronDown, cloudDownload, cloudUpload } from '@wordpress/icons';
+// import { QueryRewindState } from '../../../components/data/query-rewind-state';
 import SyncModal from '../staging-site-sync-modal';
 
 interface SyncDropdownProps {
 	className?: string;
 	environment: 'production' | 'staging';
 	siteSlug: string;
+	productionSiteId: number;
+	stagingSiteId?: number;
+	rewindId: number;
 }
 
-export default function SyncDropdown( { className, environment, siteSlug }: SyncDropdownProps ) {
+export default function SyncDropdown( {
+	className,
+	environment,
+	siteSlug,
+	productionSiteId,
+	stagingSiteId,
+	rewindId,
+}: SyncDropdownProps ) {
 	const [ isModalOpen, setIsModalOpen ] = useState< boolean >( false );
 	const [ syncType, setSyncType ] = useState< 'pull' | 'push' >( 'pull' );
 
@@ -71,13 +82,19 @@ export default function SyncDropdown( { className, environment, siteSlug }: Sync
 					</div>
 				) }
 			/>
-			{ isModalOpen && (
-				<SyncModal
-					onClose={ handleCloseModal }
-					syncType={ syncType }
-					environment={ environment }
-					siteSlug={ siteSlug }
-				/>
+			{ isModalOpen && stagingSiteId && (
+				<>
+					{ /* <QueryRewindState siteId={ stagingSiteId } /> */ }
+					<SyncModal
+						onClose={ handleCloseModal }
+						syncType={ syncType }
+						environment={ environment }
+						siteSlug={ siteSlug }
+						productionSiteId={ productionSiteId }
+						stagingSiteId={ stagingSiteId }
+						rewindId={ rewindId }
+					/>
+				</>
 			) }
 		</>
 	);

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -8,13 +8,24 @@ import {
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { useDispatch, useSelector } from 'react-redux';
+import FileBrowser from '../../../my-sites/backup/backup-contents-page/file-browser';
+import { usePullFromStagingMutation } from '../../../sites/staging-site/hooks/use-staging-sync';
+import { recordTracksEvent } from '../../../state/analytics/actions';
+import getBackupBrowserCheckList from '../../../state/rewind/selectors/get-backup-browser-check-list';
 import InlineSupportLink from '../../components/inline-support-link';
+
+// TODO: Temporary style for the PoC
+import './style.scss';
 
 interface SyncModalProps {
 	onClose: () => void;
 	syncType: 'pull' | 'push';
 	environment: 'production' | 'staging';
 	siteSlug: string;
+	productionSiteId: number;
+	stagingSiteId: number;
+	rewindId: number;
 }
 
 const getCopy = ( type: 'pull' | 'push' ) => {
@@ -61,12 +72,47 @@ const getCopy = ( type: 'pull' | 'push' ) => {
 	};
 };
 
-export default function SyncModal( { onClose, syncType, environment, siteSlug }: SyncModalProps ) {
+export default function SyncModal( {
+	onClose,
+	syncType,
+	environment,
+	siteSlug,
+	productionSiteId,
+	stagingSiteId,
+	rewindId,
+}: SyncModalProps ) {
 	const copy = getCopy( syncType );
 	const modalTitle = copy[ environment ].title;
+	const dispatch = useDispatch();
+	// const [ syncError, setSyncError ] = useState< string | null >( null );
 
 	// TODO: Once we use the component in the Dashbaord V2, let's get siteSlug from Router instead of the passed prop
 	//const { siteSlug } = siteRoute.useParams();
+	const browserCheckList = useSelector( ( state ) =>
+		getBackupBrowserCheckList( state, stagingSiteId )
+	);
+
+	const { pullFromStaging } = usePullFromStagingMutation( productionSiteId, stagingSiteId, {
+		onSuccess: () => {
+			dispatch( recordTracksEvent( 'calypso_hosting_configuration_staging_site_pull_success' ) );
+			// setSyncError( null );
+		},
+		onError: ( error ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_hosting_configuration_staging_site_pull_failure', {
+					code: error.code,
+				} )
+			);
+			// setSyncError( error.code );
+		},
+	} );
+
+	const handleConfirm = () => {
+		if ( syncType === 'pull' ) {
+			const include_paths = browserCheckList.includeList.map( ( item ) => item.id ).join( ',' );
+			pullFromStaging( { types: 'paths', include_paths } );
+		}
+	};
 
 	return (
 		<Modal title={ modalTitle } onRequestClose={ onClose } style={ { maxWidth: '668px' } }>
@@ -83,12 +129,17 @@ export default function SyncModal( { onClose, syncType, environment, siteSlug }:
 							a: <InlineSupportLink onClick={ onClose } supportContext="hosting-staging-site" />,
 						} ) }
 					</Text>
+					<div className="staging-site-card">
+						<FileBrowser rewindId={ rewindId } />
+					</div>
 				</VStack>
 				<HStack spacing={ 4 } justify="flex-end" expanded={ false }>
 					<Button variant="tertiary" onClick={ onClose }>
 						{ __( 'Cancel' ) }
 					</Button>
-					<Button variant="primary">{ copy.submit }</Button>
+					<Button variant="primary" onClick={ handleConfirm }>
+						{ copy.submit }
+					</Button>
 				</HStack>
 			</VStack>
 		</Modal>

--- a/client/dashboard/sites/staging-site-sync-modal/style.scss
+++ b/client/dashboard/sites/staging-site-sync-modal/style.scss
@@ -1,0 +1,302 @@
+/*
+ * Temporary style for the PoC
+ * TODO: Remove this file once the PoC is complete
+*/
+
+
+.staging-site-card {
+	.card {
+		padding: 24px 22px;
+	}
+
+	&__back-button.components-button.is-link {
+		color: #000;
+		padding: 12px 0;
+		text-decoration: none;
+		margin: 4px 0;
+
+		svg {
+			margin-right: 2px;
+		}
+	}
+
+	.status-card__header-content {
+		align-items: center;
+		display: flex;
+		// Given the layout is mobile-first, reverse the div arrangement by default
+		flex-direction: column-reverse;
+	}
+
+	.status-card__learn-about {
+		font-size: $font-body-small;
+		font-weight: 400;
+		text-decoration-line: underline;
+	}
+
+	.status-card__learn-about a {
+		color: var(--studio-gray-80);
+	}
+
+	// We are using the deprecated mixin to match the when the mobile navigation appears
+	// which is at 660px instead of the 600px break-small breakpoint.
+	@include breakpoint-deprecated( ">660px" ) {
+		&__back-button.components-button.is-link {
+			padding: 0 0 12px 0;
+			margin: 0;
+		}
+
+		.status-card__header-content {
+			// Return to the default div arrangement on the desktop
+			flex-direction: row;
+			flex-grow: 1;
+		}
+
+		.status-card__learn-about {
+			margin-left: auto;
+		}
+	}
+
+	&__header {
+		padding-left: 2px;
+		padding-right: 2px;
+
+		&.daily-backup-status {
+			box-shadow: none;
+			margin-bottom: 0;
+		}
+	}
+
+	&__body {
+		overflow-x: auto;
+		padding-bottom: 14px;
+	}
+
+	.file-browser-node {
+		margin-top: 2px;
+		margin-left: 2px;
+		min-width: fit-content;
+
+		&.is-root {
+			margin-left: 0;
+			padding-top: 30px;
+		}
+
+		&.wordpress > .file-card .file-card__actions {
+			margin-top: 0;
+		}
+
+		&__loading {
+			&.placeholder {
+				height: 26px;
+				margin: 6px;
+				@include placeholder();
+			}
+		}
+
+		&__contents {
+			display: flex;
+			flex-direction: column;
+			background-color: #fff;
+			padding-left: 26px;
+		}
+
+		&.is-root > .file-browser-node__contents {
+			padding-left: 0;
+		}
+
+		.file-browser-node__title {
+			white-space: nowrap;
+			overflow: hidden;
+		}
+
+		.components-button.has-icon.has-text svg {
+			width: 22px;
+			height: 22px;
+			margin-right: 4px;
+		}
+
+		.components-button {
+			border: 0;
+			font-size: $font-body-small;
+			font-weight: normal;
+			height: 32px;
+		}
+
+		.is-alternate {
+			background-color: var(--studio-gray-0);
+		}
+
+		.file-card {
+			background: var(--studio-gray-0);
+			margin: 4px 0;
+			padding-top: 20px;
+			padding-bottom: 20px;
+			max-width: 100%;
+
+			span {
+				font-size: $font-body-small;
+			}
+
+			@include break-mobile {
+				&__detail-group {
+					display: flex;
+					flex-wrap: wrap;
+					justify-content: space-between;
+				}
+			}
+
+			&__details,
+			&__actions {
+				margin-left: 24px;
+				margin-right: 24px;
+			}
+
+			&__actions {
+				display: flex;
+				gap: 1rem;
+				margin-top: 16px;
+			}
+
+			&__label {
+				font-weight: bold;
+			}
+
+			&__prepare-download-spinner {
+				display: inline-block;
+				margin-right: 6px;
+				margin-top: -3px;
+				vertical-align: middle;
+			}
+
+			&__preview {
+				margin: 16px auto 0;
+				padding: 0 8px;
+				max-width: 620px;
+				text-align: center;
+
+				&--is-loading {
+					margin-bottom: 0;
+					padding: 0;
+					max-width: 100%;
+
+					.placeholder {
+						height: 100px;
+						margin: 0;
+					}
+				}
+
+				audio,
+				video,
+				img {
+					max-width: 100%;
+				}
+
+				&.image,
+				&.video {
+					padding: 0;
+					margin-bottom: -20px;
+				}
+
+				&.code,
+				&.text {
+					margin-bottom: -12px;
+					text-align: initial;
+				}
+
+				pre {
+					background-color: #fff;
+					font-size: 0.75rem;
+					margin: 0;
+					max-height: 400px;
+				}
+			}
+
+			&__preview-sensitive {
+				background-color: var(--studio-gray-60);
+				color: #fff;
+				margin: 16px auto 0;
+				max-width: 100%;
+				padding: 20px 8px;
+				text-align: center;
+
+				p {
+					font-size: 0.875rem;
+				}
+			}
+		}
+
+		.form-checkbox {
+			margin: 8px;
+			&.mixed {
+				background-color: var(--studio-gray-10);
+			}
+		}
+	}
+
+	.file-browser-header {
+		padding: 0 2px;
+		border-bottom: 1px solid var(--studio-gray-5);
+		.file-browser-header__action-buttons .button {
+			padding: 8px 32px;
+			margin-right: 16px;
+		}
+		.file-browser-header__selecting {
+			display: flex;
+			margin-top: 30px;
+
+			.bulk-select {
+				padding: 6px 0;
+			}
+			.count {
+				border: none;
+				font-weight: 400;
+				padding-top: 2px;
+			}
+			.file-browser-header__selecting-info {
+				flex-grow: 1;
+				font-size: $font-body-extra-small;
+				padding: 6px 0;
+			}
+			.form-checkbox {
+				margin: 8px;
+				&.mixed {
+					background-color: var(--studio-gray-10);
+				}
+			}
+			.button {
+				margin-left: 8px;
+				color: #000;
+				&.is-primary {
+					&:disabled {
+						color: #000;
+					}
+					color: #fff;
+				}
+			}
+		}
+	}
+
+	.components-checkbox-control {
+		float: left;
+
+		.components-checkbox-control__input-container {
+			margin: 8px;
+			line-height: 0;
+			width: 16px;
+			height: 16px;
+		}
+
+		.components-checkbox-control__input {
+			height: 16px;
+			vertical-align: middle;
+			width: 16px;
+			min-width: 16px;
+		}
+
+		svg.components-checkbox-control__checked,
+		svg.components-checkbox-control__indeterminate {
+			height: 20px;
+			width: 20px;
+		}
+	}
+}

--- a/client/sites/components/site-preview-pane/preview-pane-header-buttons.tsx
+++ b/client/sites/components/site-preview-pane/preview-pane-header-buttons.tsx
@@ -7,10 +7,11 @@ import { useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { GuidedTourStep } from 'calypso/components/guided-tour/step';
 import SyncDropdown from 'calypso/dashboard/sites/staging-site-sync-dropdown';
+import { useFirstMatchingBackupAttempt } from 'calypso/my-sites/backup/hooks';
 import hasWpcomStagingSite from 'calypso/state/selectors/has-wpcom-staging-site';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import { useSiteAdminInterfaceData } from 'calypso/state/sites/hooks';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSite } from 'calypso/state/sites/selectors';
 import type { ItemData } from 'calypso/layout/hosting-dashboard/item-view/types';
 
 import './preview-pane-header-buttons.scss';
@@ -36,8 +37,37 @@ const PreviewPaneHeaderButtons = ( { focusRef, itemData }: Props ) => {
 	const shouldShowSyncDropdown = Boolean(
 		stagingSitesRedesign && ( isStagingSite || hasStagingSite )
 	);
+	const site = useSelector( ( state ) => getSite( state, itemData.blogId ) );
 
-	const siteSlug = useSelector( ( state ) => getSiteSlug( state, itemData.blogId ) ) ?? '';
+	const siteSlug = site?.slug ?? '';
+
+	const { backupAttempt: lastKnownBackupAttempt } = useFirstMatchingBackupAttempt(
+		itemData.blogId,
+		{
+			sortOrder: 'desc',
+			successOnly: true,
+		}
+	);
+	const rewindId = lastKnownBackupAttempt?.rewindId;
+	const adminButtonRef = useMergeRefs( [ adminButtonRef, focusRef ] );
+
+	// We should never reach this point, but just in case
+	if ( ! site ) {
+		return null;
+	}
+
+	const productionSiteId = site.is_wpcom_staging_site
+		? site.options?.wpcom_production_blog_id
+		: site.ID;
+
+	// We should never reach this point, but just in case
+	if ( ! productionSiteId ) {
+		return null;
+	}
+
+	const stagingSiteId = ! site.is_wpcom_staging_site
+		? site.options?.wpcom_staging_blog_ids?.[ 0 ]
+		: undefined;
 
 	return (
 		<>
@@ -46,13 +76,16 @@ const PreviewPaneHeaderButtons = ( { focusRef, itemData }: Props ) => {
 					className="item-preview__sync-dropdown"
 					environment={ isStagingSite ? 'staging' : 'production' }
 					siteSlug={ siteSlug }
+					productionSiteId={ productionSiteId }
+					stagingSiteId={ stagingSiteId }
+					rewindId={ rewindId }
 				/>
 			) }
 			<Button
 				primary
 				className="item-preview__admin-button"
 				href={ `${ adminUrl }` }
-				ref={ useMergeRefs( [ adminButtonRef, focusRef ] ) }
+				ref={ adminButtonRef }
 			>
 				{ adminLabel }
 			</Button>

--- a/client/sites/staging-site/hooks/use-staging-sync.ts
+++ b/client/sites/staging-site/hooks/use-staging-sync.ts
@@ -2,7 +2,7 @@ import { useMutation, UseMutationOptions, useIsMutating } from '@tanstack/react-
 import { useCallback } from 'react';
 import wp from 'calypso/lib/wp';
 
-type MutationVariables = string[] | undefined;
+type MutationVariables = string[] | { types: string; include_paths: string } | undefined;
 
 interface PushStagingMutationResponse {
 	message: string;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
