### PR TITLE
Support links on Google Analytics

### DIFF
--- a/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
@@ -10,7 +10,6 @@ import {
 	FormLabel,
 	Button,
 } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
 import { useEffect } from 'react';
 import googleIllustration from 'calypso/assets/images/illustrations/google-analytics-logo.svg';
@@ -36,13 +35,11 @@ const GoogleAnalyticsSimpleForm = ( {
 	isSavingSettings,
 	isSubmitButtonDisabled,
 	placeholderText,
-	recordSupportLinkClick,
 	setDisplayForm,
 	showUpgradeNudge,
 	site,
 	translate,
 } ) => {
-	const analyticsSupportUrl = localizeUrl( 'https://wordpress.com/support/google-analytics/' );
 	const nudgeTitle = translate(
 		'Connect your site to Google Analytics in seconds with the %(premiumPlanName)s plan',
 		{ args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() } }
@@ -101,16 +98,6 @@ const GoogleAnalyticsSimpleForm = ( {
 									'A free analytics tool that offers additional insights into your site.'
 								) }{ ' ' }
 							</p>
-							<p>
-								<InlineSupportLink
-									onClick={ recordSupportLinkClick }
-									showIcon={ false }
-									supportPostId={ 98905 }
-									supportLink={ analyticsSupportUrl }
-								>
-									{ translate( 'Learn more' ) }
-								</InlineSupportLink>
-							</p>
 						</div>
 					</div>
 					{ displayForm && (
@@ -136,7 +123,10 @@ const GoogleAnalyticsSimpleForm = ( {
 										text={ translate( 'Invalid Google Analytics Measurement ID.' ) }
 									/>
 								) }
-								<InlineSupportLink supportContext="google-analytics-measurement-id">
+								<InlineSupportLink
+									supportContext="google-analytics-measurement-id"
+									tracksEvent="calypso_traffic_settings_google_support_click"
+								>
 									{ translate( 'Where can I find my Measurement ID?' ) }
 								</InlineSupportLink>
 							</FormFieldset>
@@ -149,22 +139,6 @@ const GoogleAnalyticsSimpleForm = ( {
 									{
 										components: {
 											a: <a href={ '/stats/' + site.domain } />,
-										},
-									}
-								) }
-							</p>
-							<p>
-								{ translate(
-									'Learn more about using {{a}}Google Analytics with WordPress.com{{/a}}.',
-									{
-										components: {
-											a: (
-												<InlineSupportLink
-													showIcon={ false }
-													supportPostId={ 98905 }
-													supportLink={ analyticsSupportUrl }
-												/>
-											),
 										},
 									}
 								) }

--- a/client/my-sites/site-settings/analytics/form-google-analytics.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics.jsx
@@ -61,10 +61,6 @@ export const GoogleAnalyticsForm = ( props ) => {
 		handleFieldChange( 'code', code );
 	};
 
-	const recordSupportLinkClick = () => {
-		trackTracksEvent( 'calypso_traffic_settings_google_support_click' );
-	};
-
 	const handleFieldFocus = () => {
 		trackTracksEvent( 'calypso_google_analytics_key_field_focused', { path } );
 		eventTracker( 'Focused Analytics Key Field' )();
@@ -88,7 +84,6 @@ export const GoogleAnalyticsForm = ( props ) => {
 		isCodeValid,
 		isSubmitButtonDisabled,
 		placeholderText,
-		recordSupportLinkClick,
 		setDisplayForm,
 		isAtomic,
 		enableForm,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTSUP-230/support-links-on-google-analytics

## Proposed Changes

The Google Analytics settings at Tools > Marketing > Traffic contain three support links to the same doc:

![image](https://github.com/user-attachments/assets/8367e540-4504-41f2-82da-ab536564bb07)


That's overkill - let's definitely remove #3 and #1 labeled above.

#2 - "Where can I find my Measurement ID?" is the most action-oriented link and that should be kept.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check that the links are gone.