### PR TITLE
Stats: Determine default statType by available fetched data

### DIFF
--- a/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
+++ b/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { SimplifiedSegmentedControl, StatsCard } from '@automattic/components';
 import { postList } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -34,6 +34,7 @@ type StatTypeOptionType = {
 	label: string;
 	mainItemLabel: string;
 	analyticsId: string;
+	disabled?: boolean;
 };
 
 const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
@@ -70,16 +71,6 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 	const mainStatType = MAIN_STAT_TYPE;
 	const subStatType = SUB_STAT_TYPE;
 
-	const isRequestingTopPostsData = useSelector( ( state: StatsStateProps ) =>
-		isRequestingSiteStatsForQuery( state, siteId, mainStatType, query )
-	);
-	const isRequestingArchivesData = useSelector( ( state: StatsStateProps ) =>
-		isRequestingSiteStatsForQuery( state, siteId, subStatType, query )
-	);
-	const isRequestingData = isArchiveBreakdownEnabled
-		? isRequestingTopPostsData || isRequestingArchivesData
-		: isRequestingTopPostsData;
-
 	const [ localStatType, setLocalStatType ] = useState< StatType | null >( null );
 	const onStatTypeChange = ( option: StatTypeOptionType ) => {
 		trackStatsAnalyticsEvent( 'stats_posts_module_menu_clicked', {
@@ -89,17 +80,24 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 		setLocalStatType( option.value );
 	};
 
-	const statType =
-		localStatType || getValidQueryViewType( query.viewType, supportsArchiveStats ) || mainStatType;
+	const isRequestingTopPostsData = useSelector( ( state: StatsStateProps ) =>
+		isRequestingSiteStatsForQuery( state, siteId, mainStatType, query )
+	);
+	const postsAndPagesData = useSelector( ( state ) =>
+		getSiteStatsNormalizedData( state, siteId, mainStatType, query )
+	) as [ id: number, label: string ];
 
-	const data = useSelector( ( state ) =>
-		getSiteStatsNormalizedData( state, siteId, statType, query )
-	) as [ id: number, label: string ]; // TODO: get post shape and share in an external type file.
-
+	const isRequestingArchivesData = useSelector( ( state: StatsStateProps ) =>
+		isRequestingSiteStatsForQuery( state, siteId, subStatType, query )
+	);
 	// Get the archives data to check if we should disable the archives option.
 	const archivesData = useSelector( ( state ) =>
 		getSiteStatsNormalizedData( state, siteId, subStatType, query )
 	) as [ id: number, label: string ];
+
+	const isRequestingData = isArchiveBreakdownEnabled
+		? isRequestingTopPostsData || isRequestingArchivesData
+		: isRequestingTopPostsData;
 
 	const optionLabels = useOptionLabels();
 	const options: StatTypeOptionType[] = Object.entries( optionLabels ).map( ( [ key, item ] ) => {
@@ -111,11 +109,21 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 			// TODO: This is a temporary solution to disable the archives option when the archives data is not available.
 			disabled:
 				isArchiveBreakdownEnabled &&
-				key === subStatType &&
-				! isRequestingArchivesData &&
-				! archivesData.length,
+				( ( key === subStatType && ! isRequestingArchivesData && ! archivesData.length ) ||
+					( key === mainStatType && ! isRequestingTopPostsData && ! postsAndPagesData.length ) ),
 		};
 	} );
+
+	const availableStatTypes = useMemo( () => {
+		return options.filter( ( option ) => ! option.disabled );
+	}, [ options ] );
+	const defaultStatType =
+		availableStatTypes.length === 1 ? availableStatTypes[ 0 ].value : mainStatType;
+	const statType =
+		localStatType ||
+		getValidQueryViewType( query.viewType || defaultStatType, supportsArchiveStats );
+
+	const data = statType === subStatType ? archivesData : postsAndPagesData;
 
 	// Use StatsModule to display paywall upsell.
 	const shouldGateStatsModule = useShouldGateStats( mainStatType );

--- a/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
+++ b/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
@@ -100,23 +100,36 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 		: isRequestingTopPostsData;
 
 	const optionLabels = useOptionLabels();
-	const options: StatTypeOptionType[] = Object.entries( optionLabels ).map( ( [ key, item ] ) => {
-		return {
-			value: key as StatType,
-			label: item.tabLabel,
-			mainItemLabel: item.mainItemLabel,
-			analyticsId: item.analyticsId,
-			// TODO: This is a temporary solution to disable the archives option when the archives data is not available.
-			disabled:
-				isArchiveBreakdownEnabled &&
-				( ( key === subStatType && ! isRequestingArchivesData && ! archivesData.length ) ||
-					( key === mainStatType && ! isRequestingTopPostsData && ! postsAndPagesData.length ) ),
-		};
-	} );
+	const options: StatTypeOptionType[] = useMemo(
+		() =>
+			Object.entries( optionLabels ).map( ( [ key, item ] ) => {
+				return {
+					value: key as StatType,
+					label: item.tabLabel,
+					mainItemLabel: item.mainItemLabel,
+					analyticsId: item.analyticsId,
+					// TODO: This is a temporary solution to disable the archives option when the archives data is not available.
+					disabled:
+						isArchiveBreakdownEnabled &&
+						( ( key === subStatType && ! isRequestingArchivesData && ! archivesData.length ) ||
+							( key === mainStatType &&
+								! isRequestingTopPostsData &&
+								! postsAndPagesData.length ) ),
+				};
+			} ),
+		[
+			optionLabels,
+			isArchiveBreakdownEnabled,
+			subStatType,
+			isRequestingArchivesData,
+			archivesData.length,
+			mainStatType,
+			isRequestingTopPostsData,
+			postsAndPagesData.length,
+		]
+	);
 
-	const availableStatTypes = useMemo( () => {
-		return options.filter( ( option ) => ! option.disabled );
-	}, [ options ] );
+	const availableStatTypes = options.filter( ( option ) => ! option.disabled );
 	const defaultStatType =
 		availableStatTypes.length === 1 ? availableStatTypes[ 0 ].value : mainStatType;
 	const statType =

--- a/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
+++ b/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
@@ -85,7 +85,7 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 	);
 	const postsAndPagesData = useSelector( ( state ) =>
 		getSiteStatsNormalizedData( state, siteId, mainStatType, query )
-	) as [ id: number, label: string ];
+	) as Array< { id: number; label: string } >;
 
 	const isRequestingArchivesData = useSelector( ( state: StatsStateProps ) =>
 		isRequestingSiteStatsForQuery( state, siteId, subStatType, query )
@@ -93,7 +93,7 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 	// Get the archives data to check if we should disable the archives option.
 	const archivesData = useSelector( ( state ) =>
 		getSiteStatsNormalizedData( state, siteId, subStatType, query )
-	) as [ id: number, label: string ];
+	) as Array< { id: number; label: string } >;
 
 	const isRequestingData = isArchiveBreakdownEnabled
 		? isRequestingTopPostsData || isRequestingArchivesData


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixed STATS-125.

## Proposed Changes

* Check the fetched data of both statTypes to determine the available `Most viewed` tab.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The tab toggle was hidden if the default statType `MAIN_STAT_TYPE` has no data.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page.
* Choose the date period with only `Home page / Archives` data before applying the feature flag: `?flags=-stats/archive-breakdown`.

<img width="636" alt="截圖 2025-07-01 晚上10 42 39" src="https://github.com/user-attachments/assets/f79e0115-d504-4ff6-82e5-fe3f058d9102" />

* Ensure the `Posts & pages` tab is disabled and the `Archive` tab is selected as default.
* Ensure the Archive pages list works with the correct view numbers.

|Before|After|
|-|-|
|<img width="639" alt="截圖 2025-07-01 晚上10 43 49" src="https://github.com/user-attachments/assets/c2e434df-97bc-4f37-91a3-e963f5bf81aa" />|<img width="645" alt="截圖 2025-07-01 晚上10 43 59" src="https://github.com/user-attachments/assets/96a3c9ea-fcbc-46ef-bb41-b454f1c1308b" />|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
