### PR TITLE
A4A: Add Pressable Titan Addon info card

### DIFF
--- a/client/a8c-for-agencies/components/pressable-usage-details/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-usage-details/index.tsx
@@ -37,7 +37,11 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 		}
 
 		const date = new Date( dateString );
-		return new Intl.DateTimeFormat( 'en-US', { month: 'short', day: 'numeric' } ).format( date );
+		return new Intl.DateTimeFormat( 'en-US', {
+			month: 'long',
+			day: 'numeric',
+			timeZone: 'UTC',
+		} ).format( date );
 	};
 
 	if ( ! planInfo ) {
@@ -177,13 +181,13 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 											<span className="pressable-usage-details__titan-plan-label">
 												{ translate( 'standard' ) }
 											</span>
-											{ order.order_plan === 'trial' && order.trial_end_at && (
+											{ order.trial_end_at && (
 												<>
 													<span className="pressable-usage-details__titan-trial-badge">
 														{ translate( 'trial' ) }
 													</span>
 													<span className="pressable-usage-details__titan-trial-text">
-														{ translate( 'Trial ends on %(date)s', {
+														{ translate( 'The trial ends by %(date)s', {
 															args: {
 																date: formatTrialEndDate( order.trial_end_at ),
 															},

--- a/client/a8c-for-agencies/components/pressable-usage-details/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-usage-details/index.tsx
@@ -1,5 +1,5 @@
 import { ProgressBar } from '@automattic/components';
-import { formatNumber } from '@automattic/number-formatters';
+import { formatNumber, formatCurrency } from '@automattic/number-formatters';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
@@ -143,9 +143,9 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 					<div className="pressable-usage-details__info-item">
 						<div className="pressable-usage-details__info-header">
 							<div className="pressable-usage-details__info-label">
-								{ translate( 'Titan Email' ) }{ ' ' }
+								{ translate( 'Titan Email' ) }
 								<span className="pressable-usage-details__addon-tag">
-									{ translate( 'ADD-ON' ) }
+									{ translate( 'add-on' ) }
 								</span>
 							</div>
 							<div className="pressable-titan-usage-details__info-top-right">
@@ -156,7 +156,12 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 									comment: '%(total_inboxes)s is the total number of active email inboxes.',
 								} ) }
 								<div className="pressable-titan-usage-details__info-inbox-price">
-									$3.5 per inbox monthly
+									{ translate( '%(inbox_price)s per inbox monthly', {
+										args: {
+											inbox_price: formatCurrency( 3.5, 'USD' ),
+										},
+										comment: '%(inbox_price)s is the price per inbox.',
+									} ) }
 								</div>
 							</div>
 						</div>
@@ -175,7 +180,7 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 											{ order.order_plan === 'trial' && order.trial_end_at && (
 												<>
 													<span className="pressable-usage-details__titan-trial-badge">
-														{ translate( 'TRIAL' ) }
+														{ translate( 'trial' ) }
 													</span>
 													<span className="pressable-usage-details__titan-trial-text">
 														{ translate( 'Trial ends on %(date)s', {

--- a/client/a8c-for-agencies/components/pressable-usage-details/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-usage-details/index.tsx
@@ -5,6 +5,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import getPressablePlan from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { TitanOrder } from 'calypso/state/a8c-for-agencies/types';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 
 import './style.scss';
@@ -17,12 +18,34 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 	const translate = useTranslate();
 	const agency = useSelector( getActiveAgency );
 	const planUsage = agency?.third_party?.pressable?.usage;
+	const titanUsage = agency?.third_party?.pressable?.titan_usage;
 
 	const planInfo = existingPlan?.slug ? getPressablePlan( existingPlan?.slug ) : null;
+
+	// Filter active Titan orders and calculate total active inboxes
+	const activeOrders =
+		titanUsage?.orders?.filter( ( order: TitanOrder ) => order.status === 'active' ) || [];
+	const totalActiveInboxes = activeOrders.reduce(
+		( total: number, order: TitanOrder ) => total + order.billable_inboxes,
+		0
+	);
+
+	// Format trial end date
+	const formatTrialEndDate = ( dateString: string ): string => {
+		if ( ! dateString ) {
+			return '';
+		}
+
+		const date = new Date( dateString );
+		return new Intl.DateTimeFormat( 'en-US', { month: 'short', day: 'numeric' } ).format( date );
+	};
 
 	if ( ! planInfo ) {
 		return null;
 	}
+
+	// Only render the Titan card if there are active orders
+	const shouldRenderTitanCard = titanUsage?.orders && activeOrders.length > 0;
 
 	return (
 		<div
@@ -115,6 +138,72 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 					</div>
 				</div>
 			</div>
+			{ shouldRenderTitanCard && (
+				<div className="pressable-usage-details__info">
+					<div className="pressable-usage-details__info-item">
+						<div className="pressable-usage-details__info-header">
+							<div className="pressable-usage-details__info-label">
+								{ translate( 'Titan Email' ) }{ ' ' }
+								<span className="pressable-usage-details__addon-tag">
+									{ translate( 'ADD-ON' ) }
+								</span>
+							</div>
+							<div className="pressable-titan-usage-details__info-top-right">
+								{ translate( '%(total_inboxes)s inboxes', {
+									args: {
+										total_inboxes: totalActiveInboxes,
+									},
+									comment: '%(total_inboxes)s is the total number of active email inboxes.',
+								} ) }
+								<div className="pressable-titan-usage-details__info-inbox-price">
+									$3.5 per inbox monthly
+								</div>
+							</div>
+						</div>
+						<hr />
+						<div className="pressable-usage-details__info-value">
+							<div className="pressable-usage-details__titan-domains">
+								{ activeOrders.map( ( order: TitanOrder ) => (
+									<div key={ order.domain } className="pressable-usage-details__titan-domain-item">
+										<div className="pressable-usage-details__titan-domain-info">
+											<span className="pressable-usage-details__titan-domain">
+												{ order.domain }
+											</span>
+											<span className="pressable-usage-details__titan-plan-label">
+												{ translate( 'standard' ) }
+											</span>
+											{ order.order_plan === 'trial' && order.trial_end_at && (
+												<>
+													<span className="pressable-usage-details__titan-trial-badge">
+														{ translate( 'TRIAL' ) }
+													</span>
+													<span className="pressable-usage-details__titan-trial-text">
+														{ translate( 'Trial ends on %(date)s', {
+															args: {
+																date: formatTrialEndDate( order.trial_end_at ),
+															},
+															comment: '%(date)s is the formatted trial end date.',
+														} ) }
+													</span>
+												</>
+											) }
+										</div>
+										<div className="pressable-usage-details__titan-inboxes">
+											{ translate( '%(inboxes)s inbox', '%(inboxes)s inboxes', {
+												count: order.billable_inboxes,
+												args: {
+													inboxes: order.billable_inboxes,
+												},
+												comment: '%(inboxes)s is the number of email inboxes.',
+											} ) }
+										</div>
+									</div>
+								) ) }
+							</div>
+						</div>
+					</div>
+				</div>
+			) }
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/components/pressable-usage-details/style.scss
+++ b/client/a8c-for-agencies/components/pressable-usage-details/style.scss
@@ -132,10 +132,9 @@
 	}
 
 	.pressable-usage-details__titan-plan-label {
-		@include body-small;
+		@include heading-small;
 		background-color: var(--color-primary-5);
 		color: var(--color-primary-40);
-        font-weight: 500;
 		padding: 2px 6px;
         margin-inline-start: 6px;
 		border-radius: 4px;
@@ -162,8 +161,7 @@
 	}
 
     .pressable-titan-usage-details__info-top-right {
-        @include body-medium;
-        font-weight: 500;
+        @include heading-medium;
         text-align: right;
     }
 

--- a/client/a8c-for-agencies/components/pressable-usage-details/style.scss
+++ b/client/a8c-for-agencies/components/pressable-usage-details/style.scss
@@ -95,7 +95,7 @@
         font-size: 11px;
 		padding: 2px 6px;
 		border-radius: 4px;
-		margin-left: 6px;
+		margin-inline-start: 6px;
 		text-transform: uppercase;
 	}
 
@@ -138,7 +138,7 @@
 		color: var(--color-primary-40);
         font-weight: 500;
 		padding: 2px 6px;
-        margin-left: 6px;
+        margin-inline-start: 6px;
 		border-radius: 4px;
 	}
 
@@ -148,7 +148,8 @@
 		color: var(--color-warning-40);
 		padding: 2px 6px;
 		border-radius: 4px;
-		margin-right: 6px;
+		margin-inline-start: 6px;
+        text-transform: uppercase;
 	}
 
 	.pressable-usage-details__titan-trial-text {
@@ -162,15 +163,13 @@
 	}
 
     .pressable-titan-usage-details__info-top-right {
-        @include body-small;
+        @include body-medium;
         font-weight: 500;
-        font-size: 13px;
         text-align: right;
     }
 
     .pressable-titan-usage-details__info-inbox-price {
         @include body-small;
         font-style: italic;
-        font-size: 12px;
     }
 }

--- a/client/a8c-for-agencies/components/pressable-usage-details/style.scss
+++ b/client/a8c-for-agencies/components/pressable-usage-details/style.scss
@@ -86,4 +86,91 @@
 		@include heading-large;
 		margin-top: 5px;
 	}
+
+	/* Titan Email Addon styles */
+	.pressable-usage-details__addon-tag {
+		@include body-small;
+		background-color: var(--color-neutral-5);
+		color: var(--color-neutral-70);
+        font-size: 11px;
+		padding: 2px 6px;
+		border-radius: 4px;
+		margin-left: 6px;
+		text-transform: uppercase;
+	}
+
+	.pressable-usage-details__titan-domains {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+		margin-top: 16px;
+        font-size: 14px;
+        font-weight: 600;
+	}
+
+	.pressable-usage-details__titan-domain-item {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 8px 0;
+		border-bottom: 1px solid var(--color-neutral-5);
+
+		&:last-child {
+			border-bottom: none;
+		}
+	}
+
+	.pressable-usage-details__titan-domain-info {
+		display: flex;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: 8px;
+	}
+
+	.pressable-usage-details__titan-domain {
+		@include body-medium;
+		font-weight: 500;
+	}
+
+	.pressable-usage-details__titan-plan-label {
+		@include body-small;
+		background-color: var(--color-primary-5);
+		color: var(--color-primary-40);
+        font-weight: 500;
+		padding: 2px 6px;
+        margin-left: 6px;
+		border-radius: 4px;
+	}
+
+	.pressable-usage-details__titan-trial-badge {
+		@include body-small;
+		background-color: var(--color-warning-5);
+		color: var(--color-warning-40);
+		padding: 2px 6px;
+		border-radius: 4px;
+		margin-right: 6px;
+	}
+
+	.pressable-usage-details__titan-trial-text {
+		@include body-small;
+		color: var(--color-neutral-60);
+	}
+
+	.pressable-usage-details__titan-inboxes {
+		@include body-small;
+		color: var(--color-neutral-60);
+	}
+
+    .pressable-titan-usage-details__info-top-right {
+        @include body-small;
+        font-weight: 500;
+        font-size: 13px;
+        text-align: right;
+    }
+
+    .pressable-titan-usage-details__info-inbox-price {
+        @include body-small;
+        font-style: italic;
+        font-size: 12px;
+    }
 }

--- a/client/a8c-for-agencies/components/pressable-usage-details/style.scss
+++ b/client/a8c-for-agencies/components/pressable-usage-details/style.scss
@@ -128,8 +128,7 @@
 	}
 
 	.pressable-usage-details__titan-domain {
-		@include body-medium;
-		font-weight: 500;
+		@include heading-medium;
 	}
 
 	.pressable-usage-details__titan-plan-label {

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -10,6 +10,19 @@ export interface APIError {
 	data?: any;
 }
 
+// Define interfaces for Titan Email data
+export interface TitanOrder {
+	domain: string;
+	status: string;
+	order_plan: string;
+	billable_inboxes: number;
+	trial_end_at: string | null;
+}
+
+export interface TitanUsage {
+	orders: TitanOrder[];
+}
+
 export interface Agency {
 	id: number;
 	name: string;
@@ -33,6 +46,7 @@ export interface Agency {
 				end_date: string;
 				created_at: number;
 			};
+			titan_usage?: null | TitanUsage;
 		};
 	};
 	profile: {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of L-Issue: A4A-1210

## Proposed Changes

This is the draft design reference:

![image](https://github.com/user-attachments/assets/bf8692b1-3a16-4b59-ba75-5ace4e63a632)

This is the current first (urgent) design to be able to ship it today:

<img width="1025" alt="image" src="https://github.com/user-attachments/assets/772a6235-5d14-443f-9841-91f622175335" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- The Pressable Addon info card is displayed on the Marketplace section and on the Purchase section (License item)
- If you don't have a Pressable Titan account:
  - You won't see the card
- If you don't have a Titan account, you can SU a user, for example: `203814119`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
