### PR TITLE
E2E tests: Fix domain selection step

### DIFF
--- a/client/signup/steps/domains/domains-mini-cart.jsx
+++ b/client/signup/steps/domains/domains-mini-cart.jsx
@@ -184,6 +184,7 @@ export class DomainsMiniCart extends Component {
 					primary
 					className="domains__domain-cart-continue"
 					onClick={ this.props.goToNext }
+					disabled={ this.props.isMiniCartContinueButtonBusy }
 					busy={ this.props.isMiniCartContinueButtonBusy }
 				>
 					{ translate( 'Continue' ) }
@@ -260,6 +261,7 @@ export class DomainsMiniCart extends Component {
 					primary
 					className="domains__domain-cart-continue"
 					onClick={ this.props.goToNext }
+					disabled={ this.props.isMiniCartContinueButtonBusy }
 					busy={ this.props.isMiniCartContinueButtonBusy }
 				>
 					{ translate( 'Continue' ) }

--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -40,7 +40,7 @@ export async function waitForElementEnabled(
 	page: Page,
 	selector: string,
 	options?: { timeout?: number }
-): Promise< void > {
+) {
 	const elementHandle = await page.waitForSelector( selector, options );
 	await Promise.all( [
 		elementHandle.waitForElementState( 'enabled', options ),
@@ -49,6 +49,8 @@ export async function waitForElementEnabled(
 			elementHandle
 		),
 	] );
+
+	return elementHandle;
 }
 
 /**

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection.ts
@@ -50,7 +50,7 @@ describe(
 		it( 'Select a domain name', async function () {
 			domainSearchComponent = new DomainSearchComponent( page );
 			await domainSearchComponent.search( blogName + '.blog' );
-			selectedDomain = await domainSearchComponent.selectDomain( '.blog', false );
+			selectedDomain = await domainSearchComponent.selectDomain( '.blog' );
 		} );
 
 		it( `Pick the ${ planName } plan`, async function () {
@@ -58,7 +58,6 @@ describe(
 
 			await Promise.all( [
 				plansPage.selectPlan( planName ),
-				page.click( '.domains__domain-cart-continue' ),
 				page.waitForURL( /.*\/checkout\/.*/, { timeout: 30 * 1000 } ),
 			] );
 		} );

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection__pre-selected-plan.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection__pre-selected-plan.ts
@@ -58,8 +58,7 @@ describe(
 			await domainSearchComponent.search( blogName + '.blog' );
 
 			const promises = await Promise.all( [
-				domainSearchComponent.selectDomain( '.blog', false ),
-				page.click( '.domains__domain-cart-continue' ),
+				domainSearchComponent.selectDomain( '.blog' ),
 				page.waitForURL( /.*\/checkout\/.*/, { timeout: 30 * 1000 } ),
 			] );
 

--- a/test/e2e/specs/onboarding/onboarding__write.ts
+++ b/test/e2e/specs/onboarding/onboarding__write.ts
@@ -7,6 +7,7 @@ import {
 	StartSiteFlow,
 	RestAPIClient,
 	DomainSearchComponent,
+	envVariables,
 	SignupPickPlanPage,
 	NewUserResponse,
 	LoginPage,
@@ -52,7 +53,10 @@ describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () 
 		it( 'Select a .wordpress.com domain name', async function () {
 			const domainSearchComponent = new DomainSearchComponent( page );
 			await domainSearchComponent.search( blogName );
-			selectedFreeDomain = await domainSearchComponent.selectDomain( '.wordpress.com' );
+			selectedFreeDomain = await domainSearchComponent.selectDomain(
+				'.wordpress.com',
+				envVariables.VIEWPORT_NAME === 'mobile'
+			);
 		} );
 
 		it( 'Select WordPress.com Free plan', async function () {

--- a/test/e2e/specs/onboarding/signup__with-theme-LOHP.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-LOHP.ts
@@ -89,7 +89,7 @@ describe( 'Lifecyle: Logged Out Home Page, signup, onboard, launch and cancel su
 			const domainSearch = new DomainSearchComponent( page );
 
 			await domainSearch.search( testUser.siteName );
-			await domainSearch.selectDomain( `${ testUser.siteName }.wordpress.com` );
+			await domainSearch.selectDomain( `${ testUser.siteName }.wordpress.com`, false );
 		} );
 
 		it( `Select WordPress.com ${ planName } plan`, async function () {

--- a/test/e2e/specs/onboarding/signup__with-theme-premium.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-premium.ts
@@ -82,7 +82,7 @@ describe( 'Lifecyle: Premium theme signup, onboard, launch and cancel subscripti
 			const domainSearch = new DomainSearchComponent( page );
 
 			await domainSearch.search( testUser.siteName );
-			await domainSearch.selectDomain( `${ testUser.siteName }.wordpress.com` );
+			await domainSearch.selectDomain( `${ testUser.siteName }.wordpress.com`, false );
 		} );
 
 		it( `Select WordPress.com ${ planName } plan`, async function () {


### PR DESCRIPTION
Fixes p1751308916632509-slack-C02DQP0FP.

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?