### PR TITLE
Help Center: Update Email fallback notice

### DIFF
--- a/packages/help-center/src/components/_variables.scss
+++ b/packages/help-center/src/components/_variables.scss
@@ -1,3 +1,5 @@
 $head-foot-height: 56px;
 $help-center-z-index: 100000;
 $help-center-blue: #3858e9;
+$help-center-notice-background: #FDF7E9;
+$help-center-notice-color: #644B1C;

--- a/packages/help-center/src/components/help-center-chat-history.tsx
+++ b/packages/help-center/src/components/help-center-chat-history.tsx
@@ -11,11 +11,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useGetHistoryChats } from '../hooks';
 import { HelpCenterSupportChatMessage } from './help-center-support-chat-message';
 import { getLastMessage } from './utils';
-import type {
-	Conversations,
-	SupportInteraction,
-	ZendeskConversation,
-} from '@automattic/odie-client';
+import type { ZendeskConversation } from '@automattic/odie-client';
 
 const EmptyStateArtWork = () => {
 	return (
@@ -63,17 +59,11 @@ const EmptyStateArtWork = () => {
 	);
 };
 
-const Conversations = ( {
-	conversations,
-	isLoadingInteractions,
-}: {
-	conversations: Conversations;
-	supportInteractions: SupportInteraction[];
-	isLoadingInteractions?: boolean;
-} ) => {
+export const HelpCenterChatHistory = () => {
+	const { isLoadingInteractions, recentConversations } = useGetHistoryChats();
 	const { __ } = useI18n();
 
-	if ( isLoadingInteractions && ! conversations.length ) {
+	if ( isLoadingInteractions && ! recentConversations.length ) {
 		return (
 			<div className="help-center-chat-history__loading">
 				<Spinner />
@@ -81,7 +71,7 @@ const Conversations = ( {
 		);
 	}
 
-	if ( ! conversations.length ) {
+	if ( ! recentConversations.length ) {
 		if (
 			translationExists( 'Nothing here yet' ) &&
 			translationExists( 'Start a new conversation if you need any help.' )
@@ -114,7 +104,7 @@ const Conversations = ( {
 
 	return (
 		<>
-			{ conversations.map( ( conversation ) => {
+			{ recentConversations.map( ( conversation ) => {
 				const { numberOfUnreadMessages } = calculateUnread( [
 					conversation as ZendeskConversation,
 				] );
@@ -135,16 +125,5 @@ const Conversations = ( {
 				);
 			} ) }
 		</>
-	);
-};
-
-export const HelpCenterChatHistory = () => {
-	const { supportInteractions, isLoadingInteractions, recentConversations } = useGetHistoryChats();
-	return (
-		<Conversations
-			conversations={ recentConversations }
-			supportInteractions={ supportInteractions }
-			isLoadingInteractions={ isLoadingInteractions }
-		/>
 	);
 };

--- a/packages/help-center/src/components/help-center-chat-history.tsx
+++ b/packages/help-center/src/components/help-center-chat-history.tsx
@@ -8,9 +8,8 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { useChatStatus, useGetHistoryChats } from '../hooks';
+import { useGetHistoryChats } from '../hooks';
 import { HelpCenterSupportChatMessage } from './help-center-support-chat-message';
-import { EmailFallbackNotice } from './notices';
 import { getLastMessage } from './utils';
 import type {
 	Conversations,
@@ -141,16 +140,11 @@ const Conversations = ( {
 
 export const HelpCenterChatHistory = () => {
 	const { supportInteractions, isLoadingInteractions, recentConversations } = useGetHistoryChats();
-	const { forceEmailSupport } = useChatStatus();
-
 	return (
-		<>
-			{ forceEmailSupport && <EmailFallbackNotice /> }
-			<Conversations
-				conversations={ recentConversations }
-				supportInteractions={ supportInteractions }
-				isLoadingInteractions={ isLoadingInteractions }
-			/>
-		</>
+		<Conversations
+			conversations={ recentConversations }
+			supportInteractions={ supportInteractions }
+			isLoadingInteractions={ isLoadingInteractions }
+		/>
 	);
 };

--- a/packages/help-center/src/components/notices.scss
+++ b/packages/help-center/src/components/notices.scss
@@ -1,11 +1,29 @@
 .help-center__notice {
-	background-color: var( --studio-yellow-0 );
-	border-left: 4px solid var( --studio-yellow-20 );
+	background-color: #FDF7E9;
+	border-radius: 8px;
+	color: #644B1C;
 	padding: 8px 16px;
-    
-    &.cookie-warning{
-        margin-bottom: 30px;
-    }
+	display: flex;
+	column-gap: 8px;
+	align-items: flex-start;
+	
+	&.email-fallback-notice {
+		padding: 8px;
+	}
+
+	&.cookie-warning {
+		margin-bottom: 30px;
+	}
+
+	.help-center__notice-link {
+		color: inherit;
+	}
+
+	.help-center__notice-icon {
+		display: block;
+		color: #644B1C;
+		flex: 0 0 auto;
+	}
 
 	p {
 		margin: 0;

--- a/packages/help-center/src/components/notices.scss
+++ b/packages/help-center/src/components/notices.scss
@@ -1,7 +1,9 @@
+@import "variables";
+
 .help-center__notice {
-	background-color: #FDF7E9;
+	background-color: $help-center-notice-background;
 	border-radius: 8px;
-	color: #644B1C;
+	color: $help-center-notice-color;
 	padding: 8px 16px;
 	display: flex;
 	column-gap: 8px;
@@ -21,7 +23,7 @@
 
 	.help-center__notice-icon {
 		display: block;
-		color: #644B1C;
+		fill: $help-center-notice-color;
 		flex: 0 0 auto;
 	}
 

--- a/packages/help-center/src/components/notices.tsx
+++ b/packages/help-center/src/components/notices.tsx
@@ -5,6 +5,7 @@ import { Button } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Icon, info } from '@wordpress/icons';
 import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
@@ -66,18 +67,17 @@ export const EmailFallbackNotice: React.FC = () => {
 	params.set( 'wapuuFlow', 'true' );
 	const url = '/contact-form?' + params.toString();
 	return (
-		<div className="help-center__notice">
+		<div className="help-center__notice email-fallback-notice">
+			<Icon icon={ info } className="help-center__notice-icon" />
 			<p>
-				<strong>
-					{ __(
-						'Live chat is temporarily unavailable for scheduled maintenance.',
-						__i18n_text_domain__
-					) }
-				</strong>
+				{ __(
+					'Live chat is temporarily unavailable for scheduled maintenance.',
+					__i18n_text_domain__
+				) }
 				&nbsp;
 				{ createInterpolateElement(
 					__(
-						'We’re sorry for the inconvenience and appreciate your patience. Please feel free to reach out via <email>email</email> or check our <guides>Support Guides</guides> in the meantime.',
+						'Please reach out via <email>email</email> if you need immediate assistance.',
 						__i18n_text_domain__
 					),
 					{
@@ -86,13 +86,6 @@ export const EmailFallbackNotice: React.FC = () => {
 								variant="link"
 								className="help-center__notice-link"
 								onClick={ () => navigate( url ) }
-							/>
-						),
-						guides: (
-							<Button
-								variant="link"
-								className="help-center__notice-link"
-								onClick={ () => navigate( '/' ) }
 							/>
 						),
 					}

--- a/packages/odie-client/src/components/message/get-support.tsx
+++ b/packages/odie-client/src/components/message/get-support.tsx
@@ -65,23 +65,14 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 
 		if ( isUserEligibleForPaidSupport || contextIsUserEligibleForPaidSupport ) {
 			if ( forceEmailSupport || contextForceEmailSupport ) {
-				buttons.push(
-					{
-						text: __( 'Send an email', __i18n_text_domain__ ),
-						action: async () => {
-							onClickAdditionalEvent?.( 'email' );
-							params.set( 'wapuuFlow', 'true' );
-							navigate( '/contact-form?' + params.toString() );
-						},
+				buttons.push( {
+					text: __( 'Send an email', __i18n_text_domain__ ),
+					action: async () => {
+						onClickAdditionalEvent?.( 'email' );
+						params.set( 'wapuuFlow', 'true' );
+						navigate( '/contact-form?' + params.toString() );
 					},
-					{
-						text: __( 'Browse support guides', __i18n_text_domain__ ),
-						action: async () => {
-							onClickAdditionalEvent?.( 'support-guides' );
-							window.open( localizeUrl( 'https://wordpress.com/support' ), '_blank' );
-						},
-					}
-				);
+				} );
 			} else {
 				if ( supportInteraction ) {
 					buttons.push( {
@@ -134,13 +125,6 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 				action: async () => {
 					onClickAdditionalEvent?.( 'forum' );
 					window.open( localizeUrl( 'https://wordpress.com/forums/?new=1' ), '_blank' );
-				},
-			},
-			{
-				text: __( 'Browse support guides', __i18n_text_domain__ ),
-				action: async () => {
-					onClickAdditionalEvent?.( 'support-guides' );
-					window.open( localizeUrl( 'https://wordpress.com/support' ), '_blank' );
 				},
 			},
 		];

--- a/packages/odie-client/src/components/message/get-support.tsx
+++ b/packages/odie-client/src/components/message/get-support.tsx
@@ -65,14 +65,23 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 
 		if ( isUserEligibleForPaidSupport || contextIsUserEligibleForPaidSupport ) {
 			if ( forceEmailSupport || contextForceEmailSupport ) {
-				buttons.push( {
-					text: __( 'Email support', __i18n_text_domain__ ),
-					action: async () => {
-						onClickAdditionalEvent?.( 'email' );
-						params.set( 'wapuuFlow', 'true' );
-						navigate( '/contact-form?' + params.toString() );
+				buttons.push(
+					{
+						text: __( 'Send an email', __i18n_text_domain__ ),
+						action: async () => {
+							onClickAdditionalEvent?.( 'email' );
+							params.set( 'wapuuFlow', 'true' );
+							navigate( '/contact-form?' + params.toString() );
+						},
 					},
-				} );
+					{
+						text: __( 'Browse support guides', __i18n_text_domain__ ),
+						action: async () => {
+							onClickAdditionalEvent?.( 'support-guides' );
+							window.open( localizeUrl( 'https://wordpress.com/support' ), '_blank' );
+						},
+					}
+				);
 			} else {
 				if ( supportInteraction ) {
 					buttons.push( {
@@ -125,6 +134,13 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 				action: async () => {
 					onClickAdditionalEvent?.( 'forum' );
 					window.open( localizeUrl( 'https://wordpress.com/forums/?new=1' ), '_blank' );
+				},
+			},
+			{
+				text: __( 'Browse support guides', __i18n_text_domain__ ),
+				action: async () => {
+					onClickAdditionalEvent?.( 'support-guides' );
+					window.open( localizeUrl( 'https://wordpress.com/support' ), '_blank' );
 				},
 			},
 		];

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -91,7 +91,16 @@ export const UserMessage = ( {
 			</div>
 			{ isMessageWithEscalationOption && (
 				<>
-					{ ! isRequestingHumanSupport && (
+					{ isRequestingHumanSupport ? (
+						<GetSupport
+							onClickAdditionalEvent={ ( destination ) => {
+								trackEvent( 'chat_get_support', {
+									location: 'user-message',
+									destination,
+								} );
+							} }
+						/>
+					) : (
 						<>
 							{ ! interactionHasZendeskEvent( currentSupportInteraction ) && (
 								<BotMessageActions message={ message } />
@@ -104,18 +113,6 @@ export const UserMessage = ( {
 							</div>
 						</>
 					) }
-					<div>
-						{ isRequestingHumanSupport && (
-							<GetSupport
-								onClickAdditionalEvent={ ( destination ) => {
-									trackEvent( 'chat_get_support', {
-										location: 'user-message',
-										destination,
-									} );
-								} }
-							/>
-						) }
-					</div>
 				</>
 			) }
 		</>

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -9,7 +9,11 @@ import {
 } from '../../constants';
 import { useOdieAssistantContext } from '../../context';
 import { useCurrentSupportInteraction } from '../../data/use-current-support-interaction';
-import { interactionHasZendeskEvent, getIsRequestingHumanSupport } from '../../utils';
+import {
+	interactionHasZendeskEvent,
+	getIsRequestingHumanSupport,
+	getIsLastBotMessage,
+} from '../../utils';
 import BotMessageActions from './bot-message-actions';
 import CustomALink from './custom-a-link';
 import { GetSupport } from './get-support';
@@ -55,13 +59,14 @@ export const UserMessage = ( {
 	message: Message;
 	isMessageWithEscalationOption?: boolean;
 } ) => {
-	const { isUserEligibleForPaidSupport, trackEvent, canConnectToZendesk, forceEmailSupport } =
+	const { isUserEligibleForPaidSupport, trackEvent, canConnectToZendesk, forceEmailSupport, chat } =
 		useOdieAssistantContext();
 
 	const { data: currentSupportInteraction } = useCurrentSupportInteraction();
 
 	const hasCannedResponse = message.context?.flags?.canned_response;
 	const isRequestingHumanSupport = getIsRequestingHumanSupport( message );
+	const isLastBotMessage = getIsLastBotMessage( chat, message );
 
 	const isMessageShowingDisclaimer =
 		message.context?.question_tags?.inquiry_type !== 'request-for-human-support';
@@ -91,7 +96,7 @@ export const UserMessage = ( {
 			</div>
 			{ isMessageWithEscalationOption && (
 				<>
-					{ isRequestingHumanSupport ? (
+					{ isRequestingHumanSupport && isLastBotMessage && (
 						<GetSupport
 							onClickAdditionalEvent={ ( destination ) => {
 								trackEvent( 'chat_get_support', {
@@ -100,7 +105,8 @@ export const UserMessage = ( {
 								} );
 							} }
 						/>
-					) : (
+					) }{ ' ' }
+					{ ! isRequestingHumanSupport && (
 						<>
 							{ ! interactionHasZendeskEvent( currentSupportInteraction ) && (
 								<BotMessageActions message={ message } />

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -80,10 +80,10 @@ export const getOdieThirdPartyMessageContent = (): string =>
 	) }`;
 
 export const getOdieEmailFallbackMessageContent = (): string =>
-	__(
-		'We’re sorry, but live chat is temporarily unavailable for scheduled maintenance. Please feel free to reach out via email or check our Support Guides in the meantime.',
+	`${ __(
+		"We’re sorry, but live chat is temporarily unavailable for scheduled maintenance, but I'm here and happy to assist.",
 		__i18n_text_domain__
-	);
+	) } \n\n ${ __( 'What can I help you with?', __i18n_text_domain__ ) }`;
 
 export const getOdieEmailFallbackMessage = (): Message => ( {
 	content: getOdieEmailFallbackMessageContent(),

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -81,7 +81,7 @@ export const getOdieThirdPartyMessageContent = (): string =>
 
 export const getOdieEmailFallbackMessageContent = (): string =>
 	`${ __(
-		"We’re sorry, but live chat is temporarily unavailable for scheduled maintenance, but I'm here and happy to assist.",
+		"I’m sorry, our human chat support is down for maintenance, but I'm here and ready to assist.",
 		__i18n_text_domain__
 	) } \n\n ${ __( 'What can I help you with?', __i18n_text_domain__ ) }`;
 

--- a/packages/odie-client/src/utils/index.ts
+++ b/packages/odie-client/src/utils/index.ts
@@ -10,8 +10,16 @@ export {
 } from './support-interaction-utils';
 export { isCSATMessage, hasCSATMessage, hasSubmittedCSATRating } from './csat';
 export { userProvidedEnoughInformation } from './user-provided-enough-information';
-import type { Message } from '../types';
+import type { Chat, Message } from '../types';
 
 export const getIsRequestingHumanSupport = ( message: Message ) => {
 	return message.context?.flags?.forward_to_human_support ?? false;
+};
+
+export const getIsLastBotMessage = ( chat: Chat, message: Message ) => {
+	return (
+		chat?.messages?.length > 0 &&
+		chat?.messages[ chat?.messages?.length - 1 ].role === 'bot' &&
+		chat?.messages[ chat?.messages?.length - 1 ].message_id === message.message_id
+	);
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-13695/help-center-update-email-fallback-notice

## Proposed Changes

| Before | After |
|--------|--------|
| <img width="437" height="167" alt="image" src="https://github.com/user-attachments/assets/ebe46f21-db93-4004-8c56-107177bae0b0" /> | <img width="582" height="196" alt="image" src="https://github.com/user-attachments/assets/e562b003-903a-481e-ba4b-a2e7c7c442ae" /> |

<img width="451" height="287" alt="image" src="https://github.com/user-attachments/assets/078a78de-13c4-4178-921a-52beefa50572" />

Removed the notice from History


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In https://wordpress.com/wp-admin/network/admin.php?page=livechat_options, set Help Center Email Fallback to Test.
* Test the Help Center going into History, going into a previous opened human chat and starting a new AI chat, try to escalate to a human chat
* Remember to set Help Center Email Fallback back to False
