### PR TITLE
Admin Bar: Make the plan sub-item clickable

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -506,8 +506,8 @@ class MasterbarLoggedIn extends Component {
 								),
 								onClick: () => {
 									this.props.recordTracksEvent( 'calypso_masterbar_plan_clicked' );
+									page( `/plans/${ siteSlug }` );
 								},
-								url: `/plans/${ siteSlug }`,
 							},
 					  ]
 					: [] ),

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -493,6 +493,24 @@ class MasterbarLoggedIn extends Component {
 		const menuItems = [
 			[ { label: translate( 'Visit Site' ), url: siteUrl }, siteHomeOrAdminItem ],
 			[
+				...( ! site?.is_wpcom_staging_site
+					? [
+							{
+								label: (
+									<div className="masterbar__site-info">
+										<span className="masterbar__site-info-label">{ translate( 'Plan' ) }</span>
+										<div className="masterbar__info-badges">
+											<Badge className="masterbar__info-badge">{ sitePlanName }</Badge>
+										</div>
+									</div>
+								),
+								onClick: () => {
+									this.props.recordTracksEvent( 'calypso_masterbar_plan_clicked' );
+								},
+								url: `/plans/${ siteSlug }`,
+							},
+					  ]
+					: [] ),
 				{
 					label: (
 						<div className="masterbar__site-infos">
@@ -500,14 +518,6 @@ class MasterbarLoggedIn extends Component {
 								<div className="masterbar__site-info">
 									<span className="masterbar__site-info-label">{ translate( 'Status' ) }</span>
 									<div className="masterbar__info-badges">{ siteBadges }</div>
-								</div>
-							) }
-							{ ! site?.is_wpcom_staging_site && (
-								<div className="masterbar__site-info">
-									<span className="masterbar__site-info-label">{ translate( 'Plan' ) }</span>
-									<div className="masterbar__info-badges">
-										<Badge className="masterbar__info-badge">{ sitePlanName }</Badge>
-									</div>
 								</div>
 							) }
 						</div>

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -959,11 +959,11 @@ body.is-mobile-app-view {
 	flex-direction: row;
 	justify-content: space-between;
 	align-items: center;
-	
+
 	.masterbar__site-info-label {
 		margin-bottom: 4px;
 	}
-	
+
 	.masterbar__info-badges {
 		display: flex;
 		flex-wrap: wrap;
@@ -973,8 +973,12 @@ body.is-mobile-app-view {
 	// TODO: Remove this once the new Badge APIs are implemented (DS-203).
 	.masterbar__info-badge {
 		background-color: var(--color-global-masterbar-site-info-badge-background, rgba(255, 255, 255, 0.1));
-		color: var(--color-global-masterbar-site-info-badge-color);
+		color: var(--color-global-masterbar-site-info-badge-color, var(--color-masterbar-submenu-text)) !important; //override the link color
 	}
+}
+
+.button > .masterbar__site-info {
+	padding: 6px 0;
 }
 
 .masterbar__item-reader-label {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13657

## Proposed Changes

* On the Calypso admin bar, make the Plan sub-item clickable, sending to `wordpress.com/plans/{SITE}`.
* Clicking the item records a `calypso_masterbar_plan_clicked` event.
  * Apologies for the naming, it's to keep it consistent with all the other events of the section.
* Also reorder the menu so that the clickable Plan item is adjacent the other clickable items, instead of being separated by the Status item.

| Before | After |
|--------|--------|
| ![Screenshot 2025-07-01 at 18 02 47](https://github.com/user-attachments/assets/9a0d9ebe-0acf-48f1-88ac-1b80e84dbf91) | ![Screenshot 2025-07-01 at 18 03 03](https://github.com/user-attachments/assets/249a0dbf-865a-44f0-a7c0-556a087f2c2c) | 


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

DOTCOM-13657

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check the site context in Calypso (e.g. `/home/:SITE`). Front-end or wp-admin require a separate change.
* Look at the primary menu of the admin bar, the one displaying the site title. Hover on it to open it.
* Confirm the Plan item is clickable, looks as expected, and opens wordpress.com/plans/{SITE}.
* Also confirm it records a `calypso_masterbar_plan_clicked` event.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
