### PR TITLE
Billing History: Preserve and restore view state in URL

### DIFF
--- a/client/me/purchases/billing-history/constants.ts
+++ b/client/me/purchases/billing-history/constants.ts
@@ -1,9 +1,10 @@
-import type { View } from '@wordpress/dataviews';
+import type { SortDirection, View } from '@wordpress/dataviews';
 
 export const DEFAULT_PAGE = 1;
 export const DEFAULT_PER_PAGE = 10;
 
 export const defaultSortField: string = 'date';
+export const defaultSortDirection: SortDirection = 'desc';
 
 export const wideFields = [ 'date', 'service', 'type', 'amount' ];
 export const desktopFields = [ 'date', 'service' ];
@@ -17,7 +18,7 @@ export const defaultDataViewsState: View = {
 	perPage: DEFAULT_PER_PAGE,
 	sort: {
 		field: defaultSortField,
-		direction: 'desc',
+		direction: defaultSortDirection,
 	},
 	fields: wideFields,
 	layout: {

--- a/client/me/purchases/billing-history/hooks/use-view-state-update.ts
+++ b/client/me/purchases/billing-history/hooks/use-view-state-update.ts
@@ -1,8 +1,120 @@
 import { DESKTOP_BREAKPOINT, WIDE_BREAKPOINT } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
-import { View } from '@wordpress/dataviews';
+import { View, Filter, SortDirection, Field } from '@wordpress/dataviews';
+import { isShallowEqualArrays } from '@wordpress/is-shallow-equal';
 import { useState, useMemo, useEffect } from 'react';
-import { defaultDataViewsState, desktopFields, mobileFields, wideFields } from '../constants';
+import { reduxDispatch } from 'calypso/lib/redux-bridge';
+import { useMemoCompare } from 'calypso/lib/use-memo-compare';
+import { setRoute } from 'calypso/state/route/actions';
+import {
+	DEFAULT_PER_PAGE,
+	defaultDataViewsState,
+	defaultSortField,
+	defaultSortDirection,
+	desktopFields,
+	mobileFields,
+	wideFields,
+} from '../constants';
+
+function alterUrlForViewProp(
+	url: URL,
+	urlKey: string,
+	currentViewPropValue: string | number | string[] | number[] | undefined,
+	defaultValue?: string | number | undefined
+): void {
+	if ( currentViewPropValue && defaultValue && currentViewPropValue !== defaultValue ) {
+		url.searchParams.set( urlKey, String( currentViewPropValue ) );
+	} else if ( currentViewPropValue && ! defaultValue ) {
+		url.searchParams.set( urlKey, String( currentViewPropValue ) );
+	} else {
+		url.searchParams.delete( urlKey );
+	}
+}
+
+function writeUrlAfterUpdates( url: URL ): void {
+	if ( url.search === window.location.search ) {
+		return;
+	}
+	window.history.pushState( undefined, '', url );
+	// getPreviousRoute will not find this updated route unless we set it
+	// explicitly. It only records the route when the page first loads.
+	// This seems like a bug but it appears to be how it works.
+	reduxDispatch( setRoute( window.location.pathname, Object.fromEntries( url.searchParams ) ) );
+}
+
+const urlSortField = 'sortField';
+const urlSortDirection = 'sortDir';
+const urlPaginationPage = 'pageNumber';
+const urlPaginationPerPage = 'perPage';
+
+export function updateUrlForView< F >( view: View, fields: Field< F >[] ) {
+	const url = new URL( window.location.href );
+
+	const filterKeys = fields.map( ( field ) => field.id );
+
+	filterKeys.forEach( ( filterKey ) => {
+		const thisFilter = view.filters?.find( ( filter ) => filter.field === filterKey );
+		alterUrlForViewProp( url, filterKey, thisFilter?.value );
+	} );
+
+	const pageNumber = view.page;
+	alterUrlForViewProp( url, urlPaginationPage, pageNumber, 1 );
+
+	const perPage = view.perPage;
+	alterUrlForViewProp( url, urlPaginationPerPage, perPage, DEFAULT_PER_PAGE );
+
+	const sort = view.sort;
+	alterUrlForViewProp( url, urlSortField, sort?.field, defaultSortField );
+	alterUrlForViewProp( url, urlSortDirection, sort?.direction, defaultSortDirection );
+
+	writeUrlAfterUpdates( url );
+}
+
+function useUpdateViewFromUrl< F >( {
+	setView,
+	fields,
+}: {
+	setView: ( setter: View | ( ( currentView: View ) => View ) ) => void;
+	fields: Field< F >[];
+} ) {
+	const filterKeys = useMemoCompare(
+		fields.map( ( field ) => field.id ),
+		isShallowEqualArrays
+	);
+
+	const currentUrl = window.location.href;
+
+	// Apply view from URL
+	useEffect( () => {
+		const url = new URL( currentUrl );
+		const filters: Filter[] = [];
+		url.searchParams.forEach( ( searchParamValue, searchParamKey ) => {
+			if ( filterKeys.includes( searchParamKey ) ) {
+				// NOTE: If this needs to handle filter operators other than
+				// "is", more work will need to be done to generalize this
+				// logic!
+				filters.push( {
+					value: searchParamValue,
+					operator: 'is',
+					field: searchParamKey,
+				} );
+			}
+		} );
+		const pageNumber = url.searchParams.get( urlPaginationPage );
+		const perPage = url.searchParams.get( urlPaginationPerPage );
+		const sortField = url.searchParams.get( urlSortField );
+		const sortDir = (
+			url.searchParams.get( urlSortDirection ) === 'asc' ? 'asc' : 'desc'
+		) as SortDirection;
+		setView( ( currentView ) => ( {
+			...currentView,
+			...( filters.length > 0 ? { filters } : {} ),
+			...( pageNumber ? { page: parseInt( pageNumber ) } : {} ),
+			...( perPage ? { perPage: parseInt( perPage ) } : {} ),
+			...( sortField ? { sort: { field: sortField, direction: sortDir } } : {} ),
+		} ) );
+	}, [ setView, currentUrl, filterKeys ] );
+}
 
 function useHidePurchasesFieldsAtCertainWidths( {
 	setView,
@@ -62,9 +174,10 @@ function useHidePurchasesFieldsAtCertainWidths( {
 	}, [ currentWidth, setView ] );
 }
 
-export function useViewStateUpdate() {
+export function useViewStateUpdate< F >( fields: Field< F >[] ) {
 	const [ view, setView ] = useState< View >( defaultDataViewsState );
 
+	useUpdateViewFromUrl( { setView, fields } );
 	useHidePurchasesFieldsAtCertainWidths( { setView } );
 
 	return useMemo( () => {

--- a/client/me/purchases/billing-history/hooks/use-view-state-update.ts
+++ b/client/me/purchases/billing-history/hooks/use-view-state-update.ts
@@ -42,10 +42,10 @@ function writeUrlAfterUpdates( url: URL ): void {
 	reduxDispatch( setRoute( window.location.pathname, Object.fromEntries( url.searchParams ) ) );
 }
 
-const urlSortField = 'sortField';
-const urlSortDirection = 'sortDir';
-const urlPaginationPage = 'pageNumber';
-const urlPaginationPerPage = 'perPage';
+const urlSortField = 'billingSortField';
+const urlSortDirection = 'billingSortDir';
+const urlPaginationPage = 'billingPageNumber';
+const urlPaginationPerPage = 'billingPerPage';
 
 export function updateUrlForView< F >( view: View, fields: Field< F >[] ) {
 	const url = new URL( window.location.href );

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -57,6 +57,11 @@ import type { FormEvent } from 'react';
 import './style.scss';
 
 function getBillingHistoryUrl( previousRoute: string ): string {
+	/**
+	 * Preserve the previous route if it's the billing history page because it
+	 * may contain a query string with pagination and other view properties
+	 * that we want to return to.
+	 */
 	if ( previousRoute.includes( '/purchases/billing' ) ) {
 		return previousRoute;
 	}

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -33,6 +33,7 @@ import {
 	requestBillingTransaction,
 } from 'calypso/state/billing-transactions/individual-transactions/actions';
 import getPastBillingTransaction from 'calypso/state/selectors/get-past-billing-transaction';
+import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import isPastBillingTransactionError from 'calypso/state/selectors/is-past-billing-transaction-error';
 import {
 	getTransactionTermLabel,
@@ -55,6 +56,13 @@ import type { FormEvent } from 'react';
 
 import './style.scss';
 
+function getBillingHistoryUrl( previousRoute: string ): string {
+	if ( previousRoute.includes( '/purchases/billing' ) ) {
+		return previousRoute;
+	}
+	return billingHistory;
+}
+
 interface BillingReceiptProps {
 	transactionId: number;
 	recordGoogleEvent: ( key: string, message: string ) => void;
@@ -65,6 +73,7 @@ interface BillingReceiptConnectedProps {
 	transactionFetchError?: string;
 	transaction: BillingTransaction | undefined;
 	translate: LocalizeProps[ 'translate' ];
+	previousRoute: string;
 }
 
 class BillingReceipt extends Component< BillingReceiptProps & BillingReceiptConnectedProps > {
@@ -97,7 +106,7 @@ class BillingReceipt extends Component< BillingReceiptProps & BillingReceiptConn
 	}
 
 	render() {
-		const { transaction, transactionId, translate } = this.props;
+		const { transaction, transactionId, translate, previousRoute } = this.props;
 
 		return (
 			<Main wideLayout className="receipt">
@@ -111,7 +120,7 @@ class BillingReceipt extends Component< BillingReceiptProps & BillingReceiptConn
 
 				<QueryBillingTransaction transactionId={ transactionId } />
 
-				<ReceiptTitle backHref={ billingHistory } />
+				<ReceiptTitle backHref={ getBillingHistoryUrl( previousRoute ) } />
 
 				{ transaction ? (
 					<ReceiptBody
@@ -746,6 +755,7 @@ export default connect(
 		return {
 			transaction: transaction && 'service' in transaction ? transaction : undefined,
 			transactionFetchError: isPastBillingTransactionError( state, transactionId ),
+			previousRoute: getPreviousRoute( state ),
 		};
 	},
 	{

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -79,13 +79,13 @@ function usePreservePurchasesViewInUrl( {
 	currentView: View;
 	setView: ( setter: View | ( ( currentView: View ) => View ) ) => void;
 } ) {
-	const urlSortField = 'sortField';
-	const urlSortDirection = 'sortDir';
-	const urlPaginationPage = 'pageNumber';
-	const urlPaginationPerPage = 'perPage';
-	const urlSiteFilterKey = 'siteFilter';
-	const urlTypeFilterKey = 'typeFilter';
-	const urlExpiringSoonFilter = 'expiringSoonFilter';
+	const urlSortField = 'purchaseSortField';
+	const urlSortDirection = 'purchaseSortDir';
+	const urlPaginationPage = 'purchasePageNumber';
+	const urlPaginationPerPage = 'purchasePerPage';
+	const urlSiteFilterKey = 'purchaseSiteFilter';
+	const urlTypeFilterKey = 'purchaseTypeFilter';
+	const urlExpiringSoonFilter = 'purchaseExpiringSoonFilter';
 	const currentUrl = window.location.href;
 
 	// Apply view from URL

--- a/client/my-sites/purchases/billing-history/index.tsx
+++ b/client/my-sites/purchases/billing-history/index.tsx
@@ -23,6 +23,7 @@ import PurchasesNavigation from 'calypso/my-sites/purchases/navigation';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import getPastBillingTransaction from 'calypso/state/selectors/get-past-billing-transaction';
+import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getReceiptUrlFor, getBillingHistoryUrlFor } from '../paths';
 import useRedirectToHistoryPageOnInvalidTransaction from './use-redirect-to-history-page-on-invalid-transaction';
@@ -36,6 +37,18 @@ function useLogBillingHistoryError( message: string ) {
 		},
 		[ message ]
 	);
+}
+
+function getBillingHistoryUrl( previousRoute: string, site: string ): string {
+	/**
+	 * Preserve the previous route if it's the billing history page because it
+	 * may contain a query string with pagination and other view properties
+	 * that we want to return to.
+	 */
+	if ( previousRoute.includes( '/purchases/billing' ) ) {
+		return previousRoute;
+	}
+	return getBillingHistoryUrlFor( site );
 }
 
 export function BillingHistory( { siteSlug }: { siteSlug: string } ) {
@@ -92,6 +105,7 @@ export function ReceiptView( { siteSlug, receiptId }: { siteSlug: string; receip
 	const transaction = useSelector( ( state: IAppState ) =>
 		getPastBillingTransaction( state, receiptId )
 	);
+	const previousRoute = useSelector( getPreviousRoute );
 	const logBillingHistoryError = useLogBillingHistoryError( 'site level receipt view load error' );
 	const reduxDispatch = useDispatch();
 
@@ -122,7 +136,7 @@ export function ReceiptView( { siteSlug, receiptId }: { siteSlug: string; receip
 				errorMessage={ translate( 'Sorry, there was an error loading this page.' ) }
 				onError={ logBillingHistoryError }
 			>
-				<ReceiptTitle backHref={ getBillingHistoryUrlFor( siteSlug ) } />
+				<ReceiptTitle backHref={ getBillingHistoryUrl( previousRoute, siteSlug ) } />
 				{ transaction && isCorrectSite ? (
 					<ReceiptBody transaction={ transaction } handlePrintLinkClick={ handlePrintLinkClick } />
 				) : (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CHE-214/billing-history-view-properties-are-not-preserved-on-navigation

## Proposed Changes

This PR adds logic to the billing history DataViews page to preserve and restore its View state using the URL, like we do for the purchases list.

## Testing Instructions

- Visit http://calypso.localhost:3000/me/purchases/billing for a user with more than 10 (ideally more than 20) receipts.
- Use the pagination controls to change the page, then reload and verify that the pagination remains the same.
- Click through to a receipt and then back to the list **using the browser's "Back" button**; verify that the pagination remains the same.
- Click through to a receipt and then back to the list **using the "Back" button on the page**; verify that the pagination remains the same.
- Repeat the above steps for the filters.
