### PR TITLE
Purchases: Update DataViews links to use links instead of buttons

### DIFF
--- a/client/me/purchases/billing-history/field-definitions.tsx
+++ b/client/me/purchases/billing-history/field-definitions.tsx
@@ -1,5 +1,3 @@
-import page from '@automattic/calypso-router';
-import { Button } from '@wordpress/components';
 import { type Operator } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { capitalPDangit } from 'calypso/lib/formatting';
@@ -150,16 +148,12 @@ export function getFieldDefinitions(
 			render: ( { item }: { item: BillingTransaction } ) => {
 				return (
 					<div className="billing-history__item-service">
-						<Button
-							variant="link"
+						<a
 							title={ translate( 'View receipt', { textOnly: true } ) }
-							label={ translate( 'View receipt', { textOnly: true } ) }
-							onClick={ () => {
-								page( getReceiptUrlFor( item.id ) );
-							} }
+							href={ getReceiptUrlFor( item.id ) }
 						>
 							{ renderServiceName( item, translate ) }
-						</Button>
+						</a>
 					</div>
 				);
 			},

--- a/client/me/purchases/billing-history/style-data-view.scss
+++ b/client/me/purchases/billing-history/style-data-view.scss
@@ -257,8 +257,10 @@
 	}
 }
 
-.billing-history__item-service button.components-button.is-link {
-	font-size: inherit;
-	color: inherit;
-	text-decoration: none;
+.billing-history__item-service a,
+.billing-history__item-service a:visited {
+	/* This is the default style for `.dataviews-title-field a` but since the
+	 * billing-history DataViews is not using the title field yet, we have to
+	 * hack it. */
+	color: #2f2f2f;
 }

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -1,6 +1,4 @@
-import page from '@automattic/calypso-router';
 import { Purchases, SiteDetails } from '@automattic/data-stores';
-import { Button } from '@wordpress/components';
 import { Fields } from '@wordpress/dataviews';
 import { fixMe, LocalizeProps } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
@@ -79,7 +77,7 @@ export function getPurchasesFieldDefinitions( {
 		( paymentMethod ) => paymentMethod.is_backup === true
 	);
 
-	const goToPurchase = ( item: Purchases.Purchase ) => {
+	const getPurchaseUrl = ( item: Purchases.Purchase ) => {
 		const siteUrl = item.siteSlug || item.domain;
 		const subscriptionId = item.id;
 		if ( ! siteUrl ) {
@@ -92,7 +90,7 @@ export function getPurchasesFieldDefinitions( {
 			console.error( 'Cannot display manage purchase page for subscription without ID' );
 			return;
 		}
-		page( getManagePurchaseUrlFor( siteUrl, subscriptionId ) );
+		return getManagePurchaseUrlFor( siteUrl, subscriptionId );
 	};
 
 	const fields: Fields< Purchases.Purchase > = [
@@ -121,15 +119,13 @@ export function getPurchasesFieldDefinitions( {
 			render: ( { item }: { item: Purchases.Purchase } ) => {
 				const site = { ID: item.siteId };
 				return (
-					<Button
+					<a
 						className="purchase-item__icon"
-						variant="link"
 						title={ translate( 'Manage purchase', { textOnly: true } ) }
-						label={ translate( 'Manage purchase', { textOnly: true } ) }
-						onClick={ () => goToPurchase( item ) }
+						href={ getPurchaseUrl( item ) }
 					>
 						<PurchaseItemSiteIcon site={ site } purchase={ item } />
-					</Button>
+					</a>
 				);
 			},
 		},
@@ -159,14 +155,13 @@ export function getPurchasesFieldDefinitions( {
 				return (
 					<div className="purchase-item__information">
 						<div className="purchase-item__title">
-							<Button
-								variant="link"
+							<a
+								className="purchase-item__icon"
 								title={ translate( 'Manage purchase', { textOnly: true } ) }
-								label={ translate( 'Manage purchase', { textOnly: true } ) }
-								onClick={ () => goToPurchase( item ) }
+								href={ getPurchaseUrl( item ) }
 							>
 								{ getDisplayName( item ) }
-							</Button>
+							</a>
 							<OwnerInfo purchase={ item } />
 						</div>
 					</div>
@@ -338,14 +333,14 @@ export function getMembershipsFieldDefinitions( {
 }: {
 	translate: LocalizeProps[ 'translate' ];
 } ): Fields< MembershipSubscription > {
-	const goToPurchase = ( item: MembershipSubscription ) => {
+	const getPurchaseUrl = ( item: MembershipSubscription ) => {
 		const subscriptionId = item.ID;
 		if ( ! subscriptionId ) {
 			// eslint-disable-next-line no-console
 			console.error( 'Cannot display manage purchase page for subscription without ID' );
 			return;
 		}
-		page( `/me/purchases/other/${ subscriptionId }` );
+		return `/me/purchases/other/${ subscriptionId }`;
 	};
 
 	return [
@@ -362,15 +357,13 @@ export function getMembershipsFieldDefinitions( {
 			// Render the site icon
 			render: ( { item }: { item: MembershipSubscription } ) => {
 				return (
-					<Button
+					<a
 						className="purchase-item__icon"
-						variant="link"
 						title={ translate( 'Manage purchase', { textOnly: true } ) }
-						label={ translate( 'Manage purchase', { textOnly: true } ) }
-						onClick={ () => goToPurchase( item ) }
+						href={ getPurchaseUrl( item ) }
 					>
 						<Icon subscription={ item } />
-					</Button>
+					</a>
 				);
 			},
 		},
@@ -388,14 +381,13 @@ export function getMembershipsFieldDefinitions( {
 				return (
 					<div className="membership-item__information purchase-item__information">
 						<div className="membership-item__title purchase-item__title">
-							<Button
-								variant="link"
+							<a
+								className="purchase-item__icon"
 								title={ translate( 'Manage purchase', { textOnly: true } ) }
-								label={ translate( 'Manage purchase', { textOnly: true } ) }
-								onClick={ () => goToPurchase( item ) }
+								href={ getPurchaseUrl( item ) }
 							>
 								{ item.title }
-							</Button>
+							</a>
 						</div>
 					</div>
 				);

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -155,6 +155,7 @@ export function getPurchasesFieldDefinitions( {
 					<div className="purchase-item__information">
 						<div className="purchase-item__title">
 							<a
+								className="purchase-item__title-link"
 								title={ translate( 'Manage purchase', { textOnly: true } ) }
 								href={ getPurchaseUrl( item ) }
 							>

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -120,7 +120,6 @@ export function getPurchasesFieldDefinitions( {
 				const site = { ID: item.siteId };
 				return (
 					<a
-						className="purchase-item__icon"
 						title={ translate( 'Manage purchase', { textOnly: true } ) }
 						href={ getPurchaseUrl( item ) }
 					>
@@ -156,7 +155,6 @@ export function getPurchasesFieldDefinitions( {
 					<div className="purchase-item__information">
 						<div className="purchase-item__title">
 							<a
-								className="purchase-item__icon"
 								title={ translate( 'Manage purchase', { textOnly: true } ) }
 								href={ getPurchaseUrl( item ) }
 							>
@@ -358,7 +356,6 @@ export function getMembershipsFieldDefinitions( {
 			render: ( { item }: { item: MembershipSubscription } ) => {
 				return (
 					<a
-						className="purchase-item__icon"
 						title={ translate( 'Manage purchase', { textOnly: true } ) }
 						href={ getPurchaseUrl( item ) }
 					>
@@ -382,7 +379,6 @@ export function getMembershipsFieldDefinitions( {
 					<div className="membership-item__information purchase-item__information">
 						<div className="membership-item__title purchase-item__title">
 							<a
-								className="purchase-item__icon"
 								title={ translate( 'Manage purchase', { textOnly: true } ) }
 								href={ getPurchaseUrl( item ) }
 							>

--- a/client/me/purchases/purchases-list-in-dataviews/style.scss
+++ b/client/me/purchases/purchases-list-in-dataviews/style.scss
@@ -88,12 +88,6 @@
 			overflow: hidden;
 		}
 
-		.purchase-item__title button.components-button.is-link {
-			font-size: inherit;
-			color: inherit;
-			text-decoration: none;
-		}
-
 		.purchase-item__purchase-type,
 		.purchase-item__purchase-type a.purchase-item__link {
 			overflow: hidden;

--- a/packages/calypso-e2e/src/lib/pages/me/purchases-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/purchases-page.ts
@@ -38,7 +38,7 @@ export class PurchasesPage {
 			.locator( '#purchases-list .dataviews-view-table__row' )
 			.filter( { hasText: name } )
 			.filter( { hasText: siteSlug } )
-			.locator( '.purchase-item__title button' )
+			.locator( '.purchase-item__title-link' )
 			.click();
 	}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-880/purchases-dataviews-make-primary-link-a-link-instead-of-a-button

## Proposed Changes

This PR modifies the links for the DataViews versions of the purchases list and the billing history list so that they use HTML links instead of HTML buttons. This allows normal web operations like right-clicking to open in new tab or command-clicking to work as expected.

<img width="960" alt="Screenshot 2025-07-01 at 8 11 45 PM" src="https://github.com/user-attachments/assets/7dbfe431-5207-4c16-b541-ad201436b1af" />

<img width="950" alt="Screenshot 2025-07-01 at 8 11 23 PM" src="https://github.com/user-attachments/assets/1ca4dba0-0862-425c-aa1c-eb7d34143120" />


> [!NOTE]
> This does not alter the buttons in the "Actions" dropdown list. Those are part of WordPress Core DataViews and cannot easily be changed by us.

## Testing Instructions

- Using a site with multiple purchases, visit `/me/purchases`.
- Click the title or the site icon of a purchase and verify that it takes you to the purchase. Then go back.
- Right-click the title or site icon of a purchase and select "Open in new tab" (or your browser's equivalent) and verify it works as expected.
- Visit `/me/purchases/billing` and repeat the above steps for receipts.
