### PR TITLE
Hosting Dashboard: Inline JetpackLogo component into the v2 codebase

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -8,11 +8,9 @@ module.exports = {
 						group: [
 							'calypso/*',
 							// Allowed: calypso/components/async-load
-							// Allowed: calypso/components/jetpack-logo
 							'!calypso/components',
 							'calypso/components/*',
 							'!calypso/components/async-load',
-							'!calypso/components/jetpack-logo',
 							// Allowed: calypso/data/php-versions
 							'!calypso/data',
 							'calypso/data/*',

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -8,7 +8,6 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useInView } from 'react-intersection-observer';
-import JetpackLogo from 'calypso/components/jetpack-logo';
 import { useAnalytics } from '../../app/analytics';
 import { useAuth } from '../../app/auth';
 import { siteBackupLastEntryQuery } from '../../app/queries/site-backups';
@@ -25,6 +24,7 @@ import { getSiteStatus, getSiteStatusLabel } from '../../utils/site-status';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { HostingFeatures } from '../features';
 import { isSitePlanTrial } from '../plans';
+import { JetpackLogo } from './jetpack-logo';
 import type { Site } from '../../data/types';
 
 function IneligibleIndicator() {

--- a/client/dashboard/sites/site-fields/jetpack-logo.tsx
+++ b/client/dashboard/sites/site-fields/jetpack-logo.tsx
@@ -1,0 +1,12 @@
+const primary = '#069e08';
+const secondary = '#ffffff';
+
+export function JetpackLogo( { size }: { size: number } ) {
+	return (
+		<svg height={ size } width={ size } viewBox="0 0 32 32">
+			<path fill={ primary } d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z" />
+			<polygon fill={ secondary } points="15,19 7,19 15,3 " />
+			<polygon fill={ secondary } points="17,29 17,13 25,13 " />
+		</svg>
+	);
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Drop dependency on v1's Jetpack logo
* Inline what we need into v2

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Trying to keep the dashboard's dependencies clean ✨ 

Note that v2 isn't using Color Studio p1747868754451399-slack-CRWCHQGUB

We could maybe put brand colours as variables in `app-dotcom/style.scss` and `app-a4a/style.scss`? 🤷 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The JP logo in the site list should look exactly the same. The logo position looks a bit broken in grid mode, but that's an existing issue.

![CleanShot 2025-07-02 at 13 04 48@2x](https://github.com/user-attachments/assets/2b1012f8-262d-4c1e-a282-ece19b007544)

![CleanShot 2025-07-02 at 13 05 04@2x](https://github.com/user-attachments/assets/7e7092bf-bc6d-4f2e-a911-bad92bd23d88)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?