### PR TITLE
Dashboard v2: display correct site url for multisite

### DIFF
--- a/client/dashboard/sites/fields.tsx
+++ b/client/dashboard/sites/fields.tsx
@@ -4,10 +4,10 @@ import { __experimentalHStack as HStack, __experimentalText as Text } from '@wor
 import { useResizeObserver } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import TimeSince from '../components/time-since';
-import { getSiteName } from '../utils/site-name';
+import { getSiteDisplayName } from '../utils/site-name';
 import { STATUS_LABELS, getSiteStatus } from '../utils/site-status';
 import { isP2 } from '../utils/site-types';
-import { getSiteHostname } from '../utils/site-url';
+import { getSiteDisplayUrl } from '../utils/site-url';
 import { getFormattedWordPressVersion } from '../utils/wp-version';
 import { canManageSite } from './features';
 import { isSitePlanTrial } from './plans';
@@ -53,7 +53,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		id: 'name',
 		label: __( 'Site' ),
 		enableGlobalSearch: true,
-		getValue: ( { item } ) => getSiteName( item ),
+		getValue: ( { item } ) => getSiteDisplayName( item ),
 		render: ( { field, item } ) => (
 			<Link to={ getSiteManagementUrl( item ) } disabled={ item.is_deleted }>
 				<HStack alignment="center" spacing={ 1 }>
@@ -75,7 +75,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		id: 'URL',
 		label: __( 'URL' ),
 		enableGlobalSearch: true,
-		getValue: ( { item } ) => getSiteHostname( item ),
+		getValue: ( { item } ) => getSiteDisplayUrl( item ),
 		render: ( { field, item } ) => (
 			<Text
 				as="span"

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -13,7 +13,7 @@ import { siteEngagementStatsQuery } from '../../app/queries/site-stats';
 import { siteRoute } from '../../app/router';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { getSiteName } from '../../utils/site-name';
+import { getSiteDisplayName } from '../../utils/site-name';
 import CommentsCard from './comments-card';
 import LikesCard from './likes-card';
 import OverviewSection from './overview-section';
@@ -39,7 +39,7 @@ function SiteOverview() {
 		<PageLayout
 			header={
 				<PageHeader
-					title={ getSiteName( site ) }
+					title={ getSiteDisplayName( site ) }
 					actions={
 						site.options?.admin_url && (
 							<Button

--- a/client/dashboard/sites/site-restore-modal/content-info.tsx
+++ b/client/dashboard/sites/site-restore-modal/content-info.tsx
@@ -10,7 +10,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { siteRestoreMutation } from '../../app/queries/site';
-import { getSiteHostname } from '../../utils/site-url';
+import { getSiteDisplayUrl } from '../../utils/site-url';
 import type { Site } from '../../data/types';
 
 interface ContentInfoProps {
@@ -21,7 +21,7 @@ interface ContentInfoProps {
 export default function SiteRestoreContentInfo( { site, onClose }: ContentInfoProps ) {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const mutation = useMutation( siteRestoreMutation( site.ID ) );
-	const siteSlug = getSiteHostname( site );
+	const siteSlug = getSiteDisplayUrl( site );
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -7,7 +7,7 @@ import { siteBySlugQuery } from '../../app/queries/site';
 import { siteRoute } from '../../app/router';
 import HeaderBar from '../../components/header-bar';
 import MenuDivider from '../../components/menu-divider';
-import { getSiteName } from '../../utils/site-name';
+import { getSiteDisplayName } from '../../utils/site-name';
 import { canManageSite } from '../features';
 import SiteIcon from '../site-icon';
 import SiteMenu from '../site-menu';
@@ -36,7 +36,7 @@ function Site() {
 									onClick={ () => onToggle() }
 								>
 									<div style={ { display: 'flex', gap: '8px', alignItems: 'center' } }>
-										<SiteIcon site={ site } size={ 16 } /> { getSiteName( site ) }
+										<SiteIcon site={ site } size={ 16 } /> { getSiteDisplayName( site ) }
 									</div>
 								</Button>
 							) }

--- a/client/dashboard/sites/site/switcher.tsx
+++ b/client/dashboard/sites/site/switcher.tsx
@@ -6,7 +6,7 @@ import { plus } from '@wordpress/icons';
 import { useState } from 'react';
 import { sitesQuery } from '../../app/queries/sites';
 import RouterLinkMenuItem from '../../components/router-link-menu-item';
-import { getSiteName } from '../../utils/site-name';
+import { getSiteDisplayName } from '../../utils/site-name';
 import AddNewSite from '../add-new-site';
 import SiteIcon from '../site-icon';
 import type { Site } from '../../data/types';
@@ -17,7 +17,7 @@ import './switcher.scss';
 const fields = [
 	{
 		id: 'name',
-		getValue: ( { item }: { item: Site } ) => getSiteName( item ),
+		getValue: ( { item }: { item: Site } ) => getSiteDisplayName( item ),
 		enableGlobalSearch: true,
 	},
 ];

--- a/client/dashboard/utils/site-name.ts
+++ b/client/dashboard/utils/site-name.ts
@@ -1,12 +1,12 @@
 import { __ } from '@wordpress/i18n';
 import { getSiteStatus } from './site-status';
-import { getSiteHostname } from './site-url';
+import { getSiteDisplayUrl } from './site-url';
 import type { Site } from '../data/types';
 
-export function getSiteName( site: Site ) {
+export function getSiteDisplayName( site: Site ) {
 	const status = getSiteStatus( site );
 	if ( status === 'migration_pending' || status === 'migration_started' ) {
 		return __( 'Incoming Migration' );
 	}
-	return site.name || getSiteHostname( site );
+	return site.name || getSiteDisplayUrl( site );
 }

--- a/client/dashboard/utils/site-url.ts
+++ b/client/dashboard/utils/site-url.ts
@@ -1,8 +1,8 @@
 import type { Site } from '../data/types';
 
-export function getSiteHostname( site: Site ) {
+export function getSiteDisplayUrl( site: Site ) {
 	if ( site.URL === '' ) {
 		return site.URL;
 	}
-	return new URL( site.URL ).hostname;
+	return site.URL.replace( 'https://', '' ).replace( 'http://', '' );
 }

--- a/client/dashboard/utils/site-url.ts
+++ b/client/dashboard/utils/site-url.ts
@@ -1,8 +1,13 @@
 import type { Site } from '../data/types';
 
+/**
+ * Returns the site's URL without the protocol.
+ *
+ * This is useful for displaying the site's URL in a user-friendly way.
+ * Note that we cannot just return the URL's hostname, because the URL
+ * could contain the path to the site's subdirectory in case of multi-site
+ * installations.
+ */
 export function getSiteDisplayUrl( site: Site ) {
-	if ( site.URL === '' ) {
-		return site.URL;
-	}
 	return site.URL.replace( 'https://', '' ).replace( 'http://', '' );
 }

--- a/client/dashboard/utils/site-url.ts
+++ b/client/dashboard/utils/site-url.ts
@@ -1,11 +1,10 @@
 import type { Site } from '../data/types';
 
 /**
- * Returns the site's URL without the protocol.
+ * Returns a user-friendly version of the site's URL.
  *
- * This is useful for displaying the site's URL in a user-friendly way.
- * Note that we cannot just return the URL's hostname, because the URL
- * could contain the path to the site's subdirectory in case of multi-site
+ * This not only produces a clean version of the site's domain, but
+ * also deals with the case of Jetpack multi-sites using subdirectory
  * installations.
  */
 export function getSiteDisplayUrl( site: Site ) {


### PR DESCRIPTION
Following up https://github.com/Automattic/wp-calypso/pull/104495#discussion_r2177101091

## Proposed Changes

This PR shows the correct multisite URL in the URL field/column.

|Before|After|
|-|-|
|<img width="261" alt="image" src="https://github.com/user-attachments/assets/6665b671-b66e-48f8-af05-306083ef67b0" />|<img width="342" alt="image" src="https://github.com/user-attachments/assets/8c048aa2-20fb-4594-832a-aef4c85d863a" />|


In addition, this PR renames the functions as follows, because they're not "actual" name and URL properties of the site.

- `getSiteName()` => `getSiteDisplayName()`
- `getSiteHostname()` => `getSiteDisplayUrl()`


## Testing Instructions

1. Create a multisite in Jurassic Ninja.
2. Go to wp-admin and add a new site in the network.
3. Go to the site's wp-admin.
4. Go to Plugins and activate Jetpack.
5. Connect Jetpack to your account.
6. Go to Settings -> General and remove the site name.
7. Go to /v2/sites.
8. Verify the subdir is shown correctly for that site.
9. Verify other site rows are still showing the correct things.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
