### PR TITLE
Restore the post-cancellation survey success notice

### DIFF
--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -125,8 +125,6 @@ class CancelPurchaseButton extends Component {
 	};
 
 	closeDialog = () => {
-		const wasCancellationCompleted = this.state.cancellationCompleted;
-
 		this.setState( {
 			showDialog: false,
 			isShowingMarketplaceSubscriptionsDialog: false,
@@ -135,10 +133,8 @@ class CancelPurchaseButton extends Component {
 			isLoading: false,
 		} );
 
-		if ( wasCancellationCompleted ) {
-			// Redirect to purchases page if cancellation was completed
-			page( this.props.purchaseListUrl );
-		}
+		// Always redirect to purchases page when dialog is closed
+		page( this.props.purchaseListUrl );
 	};
 
 	cancelPurchase = async ( purchase ) => {

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -139,10 +139,6 @@ class CancelPurchaseButton extends Component {
 			// Redirect to purchases page if cancellation was completed
 			page( this.props.purchaseListUrl );
 		}
-
-		if ( this.props.onSurveyComplete ) {
-			this.props.onSurveyComplete();
-		}
 	};
 
 	cancelPurchase = async ( purchase ) => {
@@ -315,13 +311,8 @@ class CancelPurchaseButton extends Component {
 			}
 		}
 
-		if ( this.props.onSurveyComplete ) {
-			this.props.onSurveyComplete();
-		}
-
 		// Close dialog and redirect after handling the completion
 		this.closeDialog();
-		page( this.props.purchaseListUrl );
 	};
 
 	cancellationFailed = ( errorMessage ) => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Too many page calls prevent the message from appearing
* There's a circular reference between handleSurveyComplete and closeDialog
* I simplified the redirects so the only real way to not have one is on failure

## Why are these changes being made?

* The Notice was moved to the previous step but it should've appeared again at the end of the survey as the code was in place for it and didn't produce a notice. I was aware of it and wanted to try figuring it out post-launch
* Prioritized it after the problem was also reported by @DavidRothstein on p2

## Testing Instructions

* You'll need to try to cancel twice - once within the refund period, and once outside. As a bonus, you can cancel a domain
* Completing the cancellation survey should show a notice for 10 seconds, it auto-closes

<img width="1398" alt="Screenshot 2025-07-02 at 8 20 47" src="https://github.com/user-attachments/assets/7cd670f5-fa26-42d1-9a8a-a5070d32c62e" />

* The failure case can be tested by hardcoding the WPCOM_REST_API_V2_Endpoint_Purchase_Manager::cancel_purchase

<img width="1391" alt="Screenshot 2025-07-02 at 11 03 02" src="https://github.com/user-attachments/assets/4ac3cecf-c91a-43f5-ac39-63915793a30e" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
