### PR TITLE
Stats: Reset the `localStatType` when the query changes from page navigation

### DIFF
--- a/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
+++ b/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { SimplifiedSegmentedControl, StatsCard } from '@automattic/components';
 import { postList } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -63,10 +63,12 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 		? 'stats-top-posts-and-pages-analyze-content-performance-jetpack'
 		: 'stats-top-posts-and-pages-analyze-content-performance';
 
-	const query = {
-		...queryFromProps,
-		skip_archives: isArchiveBreakdownEnabled ? '1' : '0',
-	};
+	const query = useMemo( () => {
+		return {
+			...queryFromProps,
+			skip_archives: isArchiveBreakdownEnabled ? '1' : '0',
+		};
+	}, [ queryFromProps, isArchiveBreakdownEnabled ] );
 
 	const mainStatType = MAIN_STAT_TYPE;
 	const subStatType = SUB_STAT_TYPE;
@@ -79,6 +81,10 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 
 		setLocalStatType( option.value );
 	};
+	// Reset the localStatType when the query changes from page navigation.
+	useEffect( () => {
+		setLocalStatType( null );
+	}, [ query ] );
 
 	const isRequestingTopPostsData = useSelector( ( state: StatsStateProps ) =>
 		isRequestingSiteStatsForQuery( state, siteId, mainStatType, query )


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Reset the `localStatType` when the query changes from page navigation to avoid showing the empty state without the tab toggle.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The `localStatType` was used to determine the applied statType as the highest priority, which made checking the available tab ineffective.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page.
* Select the `Archive` tab on the `Most viewed` module.
* Change the selected date period with the navigation arrows.
* Ensure the tab is applied with the option that has data.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
