### PR TITLE
A4A > Reports: fix redirection logic

### DIFF
--- a/client/a8c-for-agencies/sections/reports/landing/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/landing/index.tsx
@@ -1,9 +1,10 @@
 import page from '@automattic/calypso-router';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import PagePlaceholder from 'calypso/a8c-for-agencies/components/page-placeholder';
 import { A4A_REPORTS_DASHBOARD_LINK, A4A_REPORTS_OVERVIEW_LINK } from '../constants';
 import useFetchReports from '../hooks/use-fetch-reports';
+import type { Report } from '../types';
 
 const ReportsLanding = () => {
 	const translate = useTranslate();
@@ -11,16 +12,20 @@ const ReportsLanding = () => {
 
 	const { data: reports, isFetched } = useFetchReports();
 
+	const hasSentReports = useMemo( () => {
+		return reports?.some( ( report: Report ) => report.status === 'sent' );
+	}, [ reports ] );
+
 	useEffect( () => {
 		if ( ! isFetched ) {
 			return;
 		}
-		if ( reports?.length ) {
+		if ( hasSentReports ) {
 			page.redirect( A4A_REPORTS_DASHBOARD_LINK );
 			return;
 		}
 		page.redirect( A4A_REPORTS_OVERVIEW_LINK );
-	}, [ reports, isFetched ] );
+	}, [ hasSentReports, isFetched ] );
 
 	return <PagePlaceholder title={ title } />;
 };


### PR DESCRIPTION
## Proposed Changes

* Fix redirection for Reports


## Testing Instructions

* Open the A4A live link
* Go to Reports > Verify you are redirected to the Overview page when there are no "sent" reports.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
