### PR TITLE
Checkout: Try to fix the unit tests that are related to cached contact details

### DIFF
--- a/client/my-sites/checkout/src/test/checkout-contact-autocomplete.tsx
+++ b/client/my-sites/checkout/src/test/checkout-contact-autocomplete.tsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 // @ts-nocheck - TODO: Fix TypeScript issues
+import { prettyDOM } from '@testing-library/dom';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { dispatch } from '@wordpress/data';
@@ -82,12 +83,20 @@ describe( 'Checkout contact step', () => {
 	it( 'does not complete the contact step when the contact step button has not been clicked and there are no cached details', async () => {
 		mockCachedContactDetailsEndpoint( {} );
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		const { container } = render(
+			<MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />,
+			{
+				legacyRoot: true,
+			}
+		);
 		// Wait for the cart to load
-		await screen.findByText( 'Country' );
-		expect( screen.queryByTestId( 'payment-method-step--visible' ) ).not.toBeInTheDocument();
+		try {
+			await screen.findByText( 'Country' );
+			expect( screen.queryByTestId( 'payment-method-step--visible' ) ).not.toBeInTheDocument();
+		} catch ( e ) {
+			console.error( prettyDOM( container, Infinity ) );
+			throw e;
+		}
 	} );
 
 	it( 'autocompletes the contact step when there are valid cached details', async () => {
@@ -97,20 +106,29 @@ describe( 'Checkout contact step', () => {
 		} );
 		mockContactDetailsValidationEndpoint( 'tax', { success: true } );
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
-		// Wait for the cart to load
-		await screen.findByLabelText( 'Continue with the entered contact details' );
-		const countryField = await screen.findByLabelText( 'Country' );
+		const { container } = render(
+			<MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />,
+			{
+				legacyRoot: true,
+			}
+		);
 
-		// Validate that fields are pre-filled
-		await waitFor( () => {
-			expect( countryField.selectedOptions[ 0 ].value ).toBe( 'US' );
-		} );
-		expect( await screen.findByLabelText( 'Postal code' ) ).toHaveValue( '10001' );
+		try {
+			// Wait for the cart to load
+			await screen.findByLabelText( 'Continue with the entered contact details' );
+			const countryField = await screen.findByLabelText( 'Country' );
 
-		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
+			// Validate that fields are pre-filled
+			await waitFor( () => {
+				expect( countryField.selectedOptions[ 0 ].value ).toBe( 'US' );
+			} );
+			expect( await screen.findByLabelText( 'Postal code' ) ).toHaveValue( '10001' );
+
+			expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
+		} catch ( e ) {
+			console.error( prettyDOM( container, Infinity ) );
+			throw e;
+		}
 	} );
 
 	it( 'does not autocomplete the contact step when there are invalid cached details', async () => {
@@ -120,12 +138,20 @@ describe( 'Checkout contact step', () => {
 		} );
 		mockContactDetailsValidationEndpoint( 'tax', { success: false, messages: [ 'Invalid' ] } );
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		const { container } = render(
+			<MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />,
+			{
+				legacyRoot: true,
+			}
+		);
 		// Wait for the cart to load
-		await screen.findByText( 'Country' );
-		await expect( screen.findByTestId( 'payment-method-step--visible' ) ).toNeverAppear();
+		try {
+			await screen.findByText( 'Country' );
+			await expect( screen.findByTestId( 'payment-method-step--visible' ) ).toNeverAppear();
+		} catch ( e ) {
+			console.error( prettyDOM( container, Infinity ) );
+			throw e;
+		}
 	} );
 
 	it( 'does not show errors when autocompleting the contact step when there are invalid cached details', async () => {
@@ -138,12 +164,20 @@ describe( 'Checkout contact step', () => {
 			messages: { postal_code: [ 'Postal code error message' ] },
 		} );
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		const { container } = render(
+			<MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />,
+			{
+				legacyRoot: true,
+			}
+		);
 		// Wait for the cart to load
-		await screen.findByText( 'Country' );
-		await expect( screen.findByText( 'Postal code error message' ) ).toNeverAppear();
+		try {
+			await screen.findByText( 'Country' );
+			await expect( screen.findByText( 'Postal code error message' ) ).toNeverAppear();
+		} catch ( e ) {
+			console.error( prettyDOM( container, Infinity ) );
+			throw e;
+		}
 	} );
 
 	it.each( [

--- a/client/my-sites/checkout/src/test/checkout-contact-autocomplete.tsx
+++ b/client/my-sites/checkout/src/test/checkout-contact-autocomplete.tsx
@@ -75,6 +75,10 @@ describe( 'Checkout contact step', () => {
 		mockGetSupportedCountriesEndpoint( countryList );
 	} );
 
+	afterEach( () => {
+		nock.cleanAll();
+	} );
+
 	it( 'does not complete the contact step when the contact step button has not been clicked and there are no cached details', async () => {
 		mockCachedContactDetailsEndpoint( {} );
 		const cartChanges = { products: [ planWithoutDomain ] };

--- a/client/my-sites/checkout/src/test/checkout-vat-form.tsx
+++ b/client/my-sites/checkout/src/test/checkout-vat-form.tsx
@@ -91,6 +91,10 @@ describe( 'Checkout contact step VAT form', () => {
 		mockGetVatInfoEndpoint( {} );
 	} );
 
+	afterEach( () => {
+		nock.cleanAll();
+	} );
+
 	it( 'does not render the VAT field checkbox if the selected country does not support VAT', async () => {
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithoutDomain ] };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Try to fix the unit tests that are related to cached contact details
* Log full html if the test failed

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn run test-client:watch -- client/my-sites/checkout/src/test/checkout-contact-autocomplete.tsx`
* Ensure the following tests should be passed all the time
  * `autocompletes the contact step when there are valid cached details`
  * `does not show errors when autocompleting the contact step when there are invalid cached details`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
