### PR TITLE
Entrepreneur flow: Use `site-migration` flow to create sites when the user wants to migrate a store

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/entrepreneur-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/entrepreneur-flow/entrepreneur-flow.ts
@@ -1,9 +1,11 @@
 import { getTracksAnonymousUserId } from '@automattic/calypso-analytics';
+import { isEnabled } from '@automattic/calypso-config';
 import { ENTREPRENEUR_FLOW, SITE_MIGRATION_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useEffect, useState } from 'react';
 import { anonIdCache, useCachedAnswers } from 'calypso/data/segmentaton-survey';
+import { HOW_TO_MIGRATE_OPTIONS } from 'calypso/landing/stepper/constants';
 import { useEntrepreneurAdminDestination } from 'calypso/landing/stepper/hooks/use-entrepreneur-admin-destination';
 import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
 import { useSelector } from 'calypso/state';
@@ -83,6 +85,24 @@ const entrepreneurFlow: Flow = {
 						setlastQuestionPath( providedDependencies.lastQuestionPath as string );
 					}
 
+					if (
+						isEnabled( 'entrepreneur/skip-trial-for-migration' ) &&
+						providedDependencies.isMigrationFlow
+					) {
+						const migrationFlowUrl = addQueryArgs(
+							`/setup/${ SITE_MIGRATION_FLOW }/${ STEPS.SITE_CREATION_STEP.slug }`,
+							{
+								siteSlug: siteSlug || siteSlugDependency,
+								siteId: siteId || siteIdDependency,
+								ref: 'entrepreneur-signup',
+								how: HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME,
+								action: 'migrate',
+							}
+						);
+
+						return window.location.assign( migrationFlowUrl );
+					}
+
 					return navigate( STEPS.TRIAL_ACKNOWLEDGE.slug );
 				}
 
@@ -117,11 +137,12 @@ const entrepreneurFlow: Flow = {
 						if ( isMigrationFlow ) {
 							// If the user is migrating a site, send them to the DIFM credentials step in the site migration flow.
 							const migrationFlowUrl = addQueryArgs(
-								`/setup/${ SITE_MIGRATION_FLOW }/${ STEPS.SITE_MIGRATION_CREDENTIALS.slug }`,
+								`/setup/${ SITE_MIGRATION_FLOW }/${ STEPS.SITE_CREATION_STEP.slug }`,
 								{
 									siteSlug: siteSlug || siteSlugDependency,
 									siteId: siteId || siteIdDependency,
 									ref: 'entrepreneur-signup',
+									how: HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME,
 								}
 							);
 

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -256,6 +256,17 @@ const siteMigration: FlowV2< typeof initialize > = {
 
 					//NOTE: There are links pointing to this step with the action=migrate query param, so we need to ignore the platform
 					if ( actionQueryParam === 'migrate' ) {
+						if ( urlQueryParams.get( 'how' ) === HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME ) {
+							return navigate(
+								paths.upgradePlanPath( {
+									siteId,
+									from: fromQueryParam,
+									siteSlug,
+									how: HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME,
+								} )
+							);
+						}
+
 						return navigate( paths.howToMigratePath( { siteId, siteSlug, from: fromQueryParam } ) );
 					}
 

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/test/site-migration-flow.tsx
@@ -215,6 +215,33 @@ describe( 'Site Migration Flow', () => {
 				} );
 			} );
 
+			it( 'redirects to SITE_MIGRATION_UPGRADE_PLAN when the action=migrate and how=difm', () => {
+				const destination = runNavigation( {
+					from: STEPS.PROCESSING,
+					dependencies: {
+						siteCreated: true,
+						siteId: 123,
+						siteSlug: 'example.wordpress.com',
+					},
+					query: {
+						from: 'https://site-to-be-migrated.com',
+						platform: 'wordpress',
+						how: HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME,
+						action: 'migrate',
+					},
+				} );
+
+				expect( destination ).toMatchDestination( {
+					step: STEPS.SITE_MIGRATION_UPGRADE_PLAN,
+					query: {
+						siteId: 123,
+						siteSlug: 'example.wordpress.com',
+						from: 'https://site-to-be-migrated.com',
+						how: HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME,
+					},
+				} );
+			} );
+
 			it( 'redirects to the import flow if there is no from query parameter', () => {
 				runNavigation( {
 					from: STEPS.PROCESSING,

--- a/config/development.json
+++ b/config/development.json
@@ -134,6 +134,7 @@
 		"onboarding/import-from-wordpress": true,
 		"onboarding/interval-dropdown": true,
 		"onboarding/user-on-stepper-hosting": true,
+		"entrepreneur/skip-trial-for-migration": true,
 		"p2/p2-plus": true,
 		"page/export": true,
 		"plans/hosting-trial": true,


### PR DESCRIPTION
Part of DOTCON-85

## Proposed Changes
* Use the `/setup/site-migration` site creation/upgrade plan steps when the user indicates they want to migrate a store.
* Add support to skip the `how to migrate` step when any flow has already defined the migration strategy. 

### Why are these changes being made?
Nowadays, the `/setup/entrepreneur` flow is creating a site with a trial plan and redirecting to the `site-migration`> DIFM > `credential step` directly.  The issue is that the trial plan doesn't support plugin installation, which is a blocker for running the migration. This also causes a bad user experience because customers need to upgrade to the business plan, and the HEs have more work to update the site to the correct plan.

This PR aims to change the  /setup/entrepreneur` to enable the site to be created on the site-migration flow with the correct plan. 

> [!CAUTION]
>  Please ignore issues with the back button for now; I plan to fix it in a future PR before enable the feature flag




## Testing Instructions
* Go to `/setup/entrepreneur?flags=entrepreneur/skip-trial-for-migration` flow
* Select `Migrate my Store` 
* Check if you can see the `There is a plan for you` 
* Choose any plan and make the payment
* Check that you can see the `Tell us about your WordPress site`
* Continue the flow steps

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
