### PR TITLE
Staging Sites Redesign: Move staging sites sync modal from V2 dashboard to sites

### DIFF
--- a/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
@@ -2,7 +2,7 @@ import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { chevronDown, cloudDownload, cloudUpload } from '@wordpress/icons';
-import SyncModal from '../staging-site-sync-modal';
+import AsyncLoad from 'calypso/components/async-load';
 
 interface SyncDropdownProps {
 	className?: string;
@@ -19,12 +19,12 @@ export default function SyncDropdown( { className, environment, siteSlug }: Sync
 	const pushLabel =
 		environment === 'staging' ? __( 'Push to Production' ) : __( 'Push to Staging' );
 
-	const handleOpenModal = ( type: 'pull' | 'push' ) => {
+	const handleOpenModal = ( type: 'pull' | 'push' ): void => {
 		setSyncType( type );
 		setIsModalOpen( true );
 	};
 
-	const handleCloseModal = () => {
+	const handleCloseModal = (): void => {
 		setIsModalOpen( false );
 	};
 
@@ -72,7 +72,8 @@ export default function SyncDropdown( { className, environment, siteSlug }: Sync
 				) }
 			/>
 			{ isModalOpen && (
-				<SyncModal
+				<AsyncLoad
+					require="calypso/sites/staging-site/components/staging-site-sync-modal"
 					onClose={ handleCloseModal }
 					syncType={ syncType }
 					environment={ environment }

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -59,7 +59,6 @@ const EnvironmentLabel = ( { label, environmentType }: EnvironmentLabelProps ) =
 
 interface SyncModalProps {
 	onClose: () => void;
-	onProceed?: () => void;
 	syncType: 'pull' | 'push';
 	environment: 'production' | 'staging';
 	siteSlug: string;

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -14,9 +14,11 @@ import {
 import { createInterpolateElement } from '@wordpress/element';
 import { __, isRTL } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
-import InlineSupportLink from '../../components/inline-support-link';
-import { SectionHeader } from '../../components/section-header';
-import SiteEnvironmentBadge, { EnvironmentType } from '../../components/site-environment-badge';
+import InlineSupportLink from 'calypso/dashboard/components/inline-support-link';
+import { SectionHeader } from 'calypso/dashboard/components/section-header';
+import SiteEnvironmentBadge, {
+	EnvironmentType,
+} from 'calypso/dashboard/components/site-environment-badge';
 
 const DirectionArrow = () => {
 	return (
@@ -57,6 +59,7 @@ const EnvironmentLabel = ( { label, environmentType }: EnvironmentLabelProps ) =
 
 interface SyncModalProps {
 	onClose: () => void;
+	onProceed?: () => void;
 	syncType: 'pull' | 'push';
 	environment: 'production' | 'staging';
 	siteSlug: string;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DOTDEV-171
Resolves DOTDEV-194

## Proposed Changes

* move the new staging sync modal from `/dashboard/sites/staging-site-sync-modal/` to `client/sites/staging-site/components/staging-site-sync-modal/`
* adjust required logic and rely on `AsyncLoad` component to load the sync modal through the dropdown component that still lives in the new V2 dashboard

> [!NOTE]
> Depending on the progress in https://github.com/Automattic/wp-calypso/pull/104540 we may still replace the use of `AsyncLoad` with `lazyModal` in this PR.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Please see the related discussion in https://github.com/Automattic/wp-calypso/pull/104511#issuecomment-3023887164.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start` (or use Calypso Live).
2. Ensure the `hosting/staging-sites-redesign` feature flag is enabled (by using `?flags=hosting/staging-sites-redesign` query parameter).
3. Head over to the `/sites` dashboard and select an Atomic test site that has a staging site created.
4. Open the Sync dropdown in the (`https://calypso.localhost:3000/overview/{site-slug}?flags=hosting/staging-sites-redesign`) and try both its options.
5. Modal should open with correct content, matching the action user wants to take.
7. Switch to related staging site and repeat the steps 4 to 5.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
