### PR TITLE
ZD Client: list JP cloud prod and a4a prod as prod envs

### DIFF
--- a/packages/zendesk-client/src/util.tsx
+++ b/packages/zendesk-client/src/util.tsx
@@ -3,7 +3,13 @@ import { isInSupportSession } from '@automattic/data-stores';
 
 const IS_TEST_MODE_ENVIRONMENT = true;
 const IS_PRODUCTION_ENVIRONMENT = false;
-const PRODUCTION_ENVIRONMENTS = [ 'desktop', 'production', 'wpcalypso' ];
+const PRODUCTION_ENVIRONMENTS = [
+	'desktop',
+	'production',
+	'wpcalypso',
+	'jetpack-cloud-production',
+	'a8c-for-agencies-production',
+];
 
 export const isTestModeEnvironment = () => {
 	const currentEnvironment = config( 'env_id' ) as string;


### PR DESCRIPTION
Fixes DOTSUP-234


## Why are these changes being made?
Production users where landing at ZD staging.

