### PR TITLE
Personal downgrade can only work during the refund period

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/get-upsell-type.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/get-upsell-type.ts
@@ -39,7 +39,7 @@ export type UpsellType =
  * @returns {UpsellType} The upsell nudge type
  */
 export function getUpsellType( reason: string, opts: UpsellOptions ): UpsellType {
-	const { productSlug, canDowngrade, canOfferFreeMonth } = opts;
+	const { productSlug, canRefund, canDowngrade, canOfferFreeMonth } = opts;
 	const liveChatSupported = config.isEnabled( 'livechat_solution' );
 
 	if ( ! productSlug ) {
@@ -53,7 +53,7 @@ export function getUpsellType( reason: string, opts: UpsellOptions ): UpsellType
 				return '';
 			}
 
-			if ( isWpComPremiumPlan( productSlug ) && isWpComAnnualPlan( productSlug ) ) {
+			if ( isWpComPremiumPlan( productSlug ) && isWpComAnnualPlan( productSlug ) && canRefund ) {
 				return 'downgrade-personal';
 			}
 


### PR DESCRIPTION
This is how it always worked but will not work like that for too long.

Attempting to purchase Personal while we have an expiring Premium doesn't work at the moment.

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Disable out-of-refund-window downgrade to Personal offers
* They trigger an error, as reported by @DavidRothstein 

The downgrade endpoint used to be called only when the plan was in the refund period and the recent refactor modified this behavior

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bugfix, the offer doesn't work because the old plan is still active

## Testing Instructions

* Get a non-refundable Premium with Credits or by adding with the admin
* Go to /me/purchases and try to remove it
* When selecting the cancellation survey, select the first options (too expensive, too expensive)
* There should be no offers

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
