### PR TITLE
Update Domains page background color to white

### DIFF
--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -24,6 +24,7 @@ import {
 	getDomainNameValidationErrorMessage,
 } from 'calypso/components/domains/use-my-domain/utilities';
 import FormattedHeader from 'calypso/components/formatted-header';
+import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getWpcomRegistrationStatus } from 'calypso/lib/domains/get-wpcom-registration-status';
 import wpcom from 'calypso/lib/wp';
 import { fetchSiteDomains } from 'calypso/my-sites/domains/domain-management/domains-table-fetch-functions';
@@ -413,6 +414,7 @@ function UseMyDomain( props ) {
 
 		return (
 			<>
+				<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 				{ goBack && (
 					<BackButton className={ baseClassName + '__go-back' } onClick={ onGoBack }>
 						<Gridicon icon="arrow-left" size={ 18 } />

--- a/client/my-sites/domains/domain-search/index.tsx
+++ b/client/my-sites/domains/domain-search/index.tsx
@@ -15,6 +15,7 @@ import { useMyDomainInputMode } from 'calypso/components/domains/connect-domain-
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
+import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import {
 	hasPlan,
 	domainTransfer,
@@ -475,6 +476,7 @@ class DomainSearch extends Component< DomainSearchProps > {
 		return (
 			<Main className={ classes } wideLayout>
 				<QueryProductsList />
+				<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 				<QuerySiteDomains siteId={ selectedSiteId } />
 				{ content }
 			</Main>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Task related: https://linear.app/a8c/issue/DOTOBRD-211/update-domains-page-background-to-white

## Proposed Changes

* Updated domain search and "Use a domain I own" background to white

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/022334b5-3b1f-43fe-9166-474e5eead6d7) | ![image](https://github.com/user-attachments/assets/383ee680-08c6-4f00-a6f2-a1daa0438b5c) |
| ![image](https://github.com/user-attachments/assets/c9bf2d80-101b-46b4-89af-d4c315b2dc6a) | ![image](https://github.com/user-attachments/assets/52287cbd-d6e0-421c-8a1b-26f8f286a61e) | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Design consistency with the previous and other domain screens

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access https://wordpress.com/domains/add/{siteDomain} and https://wordpress.com/domains/add/use-my-domain/{siteDomain}?initialQuery=somedomain.com and make sure both uses white background

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
