### PR TITLE
Checkout: show JCB logo for JPY users

### DIFF
--- a/client/my-sites/checkout/src/payment-methods/credit-card/index.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/index.tsx
@@ -3,10 +3,11 @@ import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { Fragment } from 'react';
 import {
-	CBLogo,
-	VisaLogo,
-	MastercardLogo,
 	AmexLogo,
+	CBLogo,
+	JcbLogo,
+	MastercardLogo,
+	VisaLogo,
 } from 'calypso/my-sites/checkout/src/components/payment-logos';
 import { PaymentMethodLogos } from 'calypso/my-sites/checkout/src/components/payment-method-logos';
 import {
@@ -64,6 +65,7 @@ function CreditCardLogos( { currency }: { currency: string | null } ) {
 	return (
 		<PaymentMethodLogos className="credit-card__logos">
 			{ currency === 'EUR' && <CBLogo className="has-background" /> }
+			{ currency === 'JPY' && <JcbLogo /> }
 			<VisaLogo />
 			<MastercardLogo />
 			<AmexLogo />


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CHE-219/

## Proposed Changes

This shows the JCB card logo for users with a JPY currency in both Checkout and the Add/Change Payment Method pages.

| Before | After |
| ----------- | ----------- |
| <img width="588" alt="Screenshot 2025-07-02 at 11 09 27" src="https://github.com/user-attachments/assets/baba15b6-189f-46b2-b141-7eeda53575ce" /> | <img width="591" alt="Screenshot 2025-07-02 at 11 09 05" src="https://github.com/user-attachments/assets/e10b336b-e112-435b-8ee3-deee3484b8c6" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

JCB is a popular credit card brand in Japan that we already support. We should show it as a supported logo to users with the JPY currency.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch your currency to `JPY`
* Visit Checkout and proceed to the payment method step
* Verify that JCB is shown as one of the featured CC brand logos
* Make a purchase using the JCB test number `3566002020360505`
* Visit the purchase management screen and click "Change Payment Method"
* Verify that JCB is shown as one of the featured CC brand logos
