### PR TITLE
Email Stats: Fix Email Clicks chart tooltip data for display

### DIFF
--- a/client/my-sites/stats/stats-email-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-email-chart-tabs/utility.js
@@ -1,6 +1,5 @@
-import { eye } from '@automattic/components/src/icons';
 import { formatNumber } from '@automattic/number-formatters';
-import { Icon, people, starEmpty, chevronRight, postContent } from '@wordpress/icons';
+import { Icon, starEmpty } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
 import { capitalize } from 'lodash';
 import moment from 'moment';
@@ -90,55 +89,15 @@ function addTooltipData( chartTab, item, period ) {
 				icon: <Icon className="gridicon" icon={ starEmpty } />,
 			} );
 			break;
-		default:
+		case 'clicks_count':
 			tooltipData.push( {
-				label: translate( 'Views' ),
-				value: formatNumber( item.data.views ),
-				className: 'is-views',
-				icon: <Icon className="gridicon" icon={ eye } />,
+				label: translate( 'Clicks' ),
+				value: formatNumber( item.value ),
+				className: 'is-clicks',
+				icon: <Icon className="gridicon" icon={ starEmpty } />,
 			} );
-			tooltipData.push( {
-				label: translate( 'Visitors' ),
-				value: formatNumber( item.data.visitors ),
-				className: 'is-visitors',
-				icon: <Icon className="gridicon" icon={ people } />,
-			} );
-			tooltipData.push( {
-				label: translate( 'Views Per Visitor' ),
-				value: formatNumber( item.data.views / item.data.visitors, { decimals: 2 } ),
-				className: 'is-views-per-visitor',
-				icon: <Icon className="gridicon" icon={ chevronRight } />,
-			} );
-
-			if ( item.data.post_titles && item.data.post_titles.length ) {
-				// only show two post titles
-				if ( item.data.post_titles.length > 2 ) {
-					tooltipData.push( {
-						label: translate( 'Posts Published' ),
-						value: formatNumber( item.data.post_titles.length ),
-						className: 'is-published-nolist',
-						icon: <Icon className="gridicon" icon={ postContent } />,
-					} );
-				} else {
-					tooltipData.push( {
-						label:
-							translate( 'Post Published', 'Posts Published', {
-								textOnly: true,
-								count: item.data.post_titles.length,
-							} ) + ':',
-						className: 'is-published',
-						icon: <Icon className="gridicon" icon={ postContent } />,
-						value: '',
-					} );
-					item.data.post_titles.forEach( ( post_title ) => {
-						tooltipData.push( {
-							className: 'is-published-item',
-							label: post_title,
-						} );
-					} );
-				}
-			}
 			break;
+		default:
 	}
 
 	return { ...item, tooltipData };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of STATS-81.

## Proposed Changes

* Fix the chart tooltip data for display with the correct chartTab `clicks_count`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Subscribers page.
* Click on any item of the `Emails` module card.
* Click on the `Email clicks` tab of the `StatsEmailDetail` page.
* Hover on the chart bars.
* Ensure the chart tooltip shows the correct `Clicks` number.

|Before|After|
|-|-|
|<img width="410" alt="截圖 2025-07-02 晚上11 24 03" src="https://github.com/user-attachments/assets/9291337e-0801-4941-b7e1-bf4a49492714" />|<img width="430" alt="截圖 2025-07-02 晚上11 24 13" src="https://github.com/user-attachments/assets/558acdda-5f8e-42f2-a191-2eb14c97964e" />|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
