### PR TITLE
Checkout: Remove duplicate "Need help?" text during DIFM checkout

### DIFF
--- a/packages/help-center/src/hooks/use-products-with-premium-support.ts
+++ b/packages/help-center/src/hooks/use-products-with-premium-support.ts
@@ -43,7 +43,7 @@ export function useProductsWithPremiumSupport(
 				hasPremiumSupport: hasPremiumSupport || false,
 				helpCenterButtonCopy: hasPremiumSupport
 					? __( 'Questions?', __i18n_text_domain__ )
-					: defaultButtonLink,
+					: undefined,
 				helpCenterButtonLink: hasPremiumSupport
 					? __( 'Contact our site-building team', __i18n_text_domain__ )
 					: defaultButtonLink,


### PR DESCRIPTION
Fixes DOTCOM-13736

## Proposed Changes

Removes a duplicate "Need help?" text during the DIFM checkout, that was inadvertently added in https://github.com/Automattic/wp-calypso/pull/104254.

Before | After
--- | ---
<img width="1277" alt="Screenshot 2025-07-02 at 17 53 09" src="https://github.com/user-attachments/assets/2ed771f1-e431-4e58-8ef2-36859d38b5b1" /> | <img width="1279" alt="Screenshot 2025-07-02 at 17 52 18" src="https://github.com/user-attachments/assets/a83e5ca9-a21e-42ea-9f29-3dcc3734f470" />
 

## Why are these changes being made?

Because there is a visual issue

## Testing Instructions

- Use the Calypso live link below
- Go to `/start/do-it-for-me/new-or-existing-site`
- Proceed to checkout
- Make sure the text on the top right does not have a duplicate "Need help?" text

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
