### PR TITLE
Connect Refresh: Extract Login internal layout into a separate component

### DIFF
--- a/client/login/wp-login/components/one-login-layout.tsx
+++ b/client/login/wp-login/components/one-login-layout.tsx
@@ -1,0 +1,83 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Step } from '@automattic/onboarding';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import { getSignupUrl, pathWithLeadingSlash } from 'calypso/lib/login';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import { getCurrentQueryArguments } from 'calypso/state/selectors/get-current-query-arguments';
+import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
+import HeadingLogo from './heading-logo';
+
+interface OneLoginLayoutProps {
+	isJetpack: boolean;
+	isFromAkismet: boolean;
+	headingText: string;
+	headingSubText: React.ReactNode;
+	children: React.ReactNode;
+	signupUrl?: string;
+	shouldUseWideHeading?: number;
+}
+
+const OneLoginLayout = ( {
+	isJetpack,
+	isFromAkismet,
+	headingText,
+	headingSubText,
+	children,
+	signupUrl: signupUrlProp,
+	shouldUseWideHeading,
+}: OneLoginLayoutProps ) => {
+	const translate = useTranslate();
+	const locale = useSelector( getCurrentUserLocale );
+	const currentRoute = useSelector( getCurrentRoute );
+	const currentQuery = useSelector( getCurrentQueryArguments );
+	const oauth2Client = useSelector( getCurrentOAuth2Client );
+
+	const SignUpLink = () => {
+		// use '?signup_url' if explicitly passed as URL query param
+		const signupUrl = signupUrlProp
+			? window.location.origin + pathWithLeadingSlash( signupUrlProp )
+			: getSignupUrl( currentQuery, currentRoute, oauth2Client, locale );
+
+		return (
+			<Step.LinkButton
+				href={ signupUrl }
+				key="sign-up-link"
+				onClick={ () => {
+					recordTracksEvent( 'calypso_login_sign_up_link_click', { origin: 'login-layout' } );
+				} }
+				rel="external"
+			>
+				{ translate( 'Create an account' ) }
+			</Step.LinkButton>
+		);
+	};
+
+	return (
+		<Step.CenteredColumnLayout
+			columnWidth={ 6 }
+			{ ...( shouldUseWideHeading && { columnWidthHeading: 8 } ) }
+			topBar={ <Step.TopBar rightElement={ <SignUpLink /> } compactLogo="always" /> }
+			heading={
+				<Step.Heading
+					text={
+						<>
+							<HeadingLogo isFromAkismet={ isFromAkismet } isJetpack={ isJetpack } />
+							<div className="wp-login__heading-text">{ headingText }</div>
+						</>
+					}
+					subText={
+						// <span> here because the Step.Heading renders subtext as a <p> tag.
+						<span className="wp-login__heading-subtext">{ headingSubText }</span>
+					}
+				/>
+			}
+			verticalAlign="center"
+		>
+			{ children }
+		</Step.CenteredColumnLayout>
+	);
+};
+
+export default OneLoginLayout;

--- a/client/login/wp-login/hooks/get-heading-subtext.tsx
+++ b/client/login/wp-login/hooks/get-heading-subtext.tsx
@@ -1,15 +1,17 @@
 import { localizeUrl } from '@automattic/i18n-utils';
-import { fixMe, useTranslate } from 'i18n-calypso';
+import { type LocalizeProps, fixMe } from 'i18n-calypso';
 
 interface Props {
 	isSocialFirst: boolean;
 	twoFactorAuthType: string;
 	action?: string;
+	translate: LocalizeProps[ 'translate' ];
 }
 
-const HeadingSubText = ( { isSocialFirst, twoFactorAuthType, action }: Props ) => {
-	const translate = useTranslate();
-
+/**
+ * TODO This will be replaced by a hook in the future.
+ */
+const getHeadingSubText = ( { isSocialFirst, twoFactorAuthType, action, translate }: Props ) => {
 	if ( ! isSocialFirst || twoFactorAuthType ) {
 		return null;
 	}
@@ -60,18 +62,15 @@ const HeadingSubText = ( { isSocialFirst, twoFactorAuthType, action }: Props ) =
 		),
 	} );
 
-	/**
-	 * Return a span here because the Step.Heading renders subtext as a p tag.
-	 */
 	return (
-		<span className="wp-login__heading-subtext">
+		<>
 			{ 'lostpassword' === action
 				? translate(
 						"Please enter your username or email address. You'll receive a link to create a new password via email."
 				  )
 				: tos }
-		</span>
+		</>
 	);
 };
 
-export default HeadingSubText;
+export default getHeadingSubText;

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -1,7 +1,6 @@
 import page from '@automattic/calypso-router';
 import { Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { Step } from '@automattic/onboarding';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
@@ -13,11 +12,9 @@ import DocumentHead from 'calypso/components/data/document-head';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import Main from 'calypso/components/main';
 import isAkismetRedirect from 'calypso/lib/akismet/is-akismet-redirect';
-import { getSignupUrl, pathWithLeadingSlash } from 'calypso/lib/login';
 import {
 	isJetpackCloudOAuth2Client,
 	isA4AOAuth2Client,
-	isGravPoweredOAuth2Client,
 	isBlazeProOAuth2Client,
 	isWooOAuth2Client,
 	isStudioAppOAuth2Client,
@@ -25,7 +22,6 @@ import {
 	isVIPOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
-import { addQueryArgs } from 'calypso/lib/url';
 import { getHeaderText } from 'calypso/login/wp-login/hooks/get-header-text';
 import {
 	recordPageViewWithClientId as recordPageView,
@@ -192,48 +188,6 @@ export class Login extends Component {
 				{ this.props.translate( 'Back to Login' ) }
 			</a>
 		);
-	}
-
-	renderSignUpLink( signupLinkText ) {
-		// Taken from client/layout/masterbar/logged-out.jsx
-		const {
-			currentRoute,
-			locale,
-			oauth2Client,
-			pathname,
-			currentQuery,
-			translate,
-			usernameOrEmail,
-		} = this.props;
-
-		if ( isGravPoweredOAuth2Client( oauth2Client ) ) {
-			return null;
-		}
-
-		// use '?signup_url' if explicitly passed as URL query param
-		const signupUrl = this.props.signupUrl
-			? window.location.origin + pathWithLeadingSlash( this.props.signupUrl )
-			: getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, pathname );
-
-		return (
-			<Step.LinkButton
-				href={ addQueryArgs(
-					{
-						user_email: usernameOrEmail,
-					},
-					signupUrl
-				) }
-				key="sign-up-link"
-				onClick={ this.recordSignUpLinkClick }
-				rel="external"
-			>
-				{ signupLinkText ?? translate( 'Create a new account' ) }
-			</Step.LinkButton>
-		);
-	}
-
-	renderLoginHeaderNavigation() {
-		return this.renderSignUpLink( this.props.translate( 'Create an account' ) );
 	}
 
 	renderContent( isSocialFirst ) {

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -20,7 +20,6 @@ import {
 	isGravPoweredOAuth2Client,
 	isBlazeProOAuth2Client,
 	isWooOAuth2Client,
-	isPartnerPortalOAuth2Client,
 	isStudioAppOAuth2Client,
 	isCrowdsignalOAuth2Client,
 	isVIPOAuth2Client,
@@ -45,9 +44,9 @@ import getIsWCCOM from 'calypso/state/selectors/get-is-wccom';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
 import isWooJPCFlow from 'calypso/state/selectors/is-woo-jpc-flow';
 import { withEnhancers } from 'calypso/state/utils';
-import HeadingLogo from './components/heading-logo';
-import HeadingSubText from './components/heading-subtext';
+import OneLoginLayout from './components/one-login-layout';
 import GravPoweredLoginBlockFooter from './gravatar/grav-powered-login-block-footer';
+import getHeadingSubText from './hooks/get-heading-subtext';
 import LoginBlockFooter from './login-block-footer';
 
 import './style.scss';
@@ -306,7 +305,6 @@ export class Login extends Component {
 			translate,
 			isGenericOauth,
 			isGravPoweredClient,
-			isBlazePro,
 			isWhiteLogin,
 			isJetpack,
 			isFromAkismet,
@@ -318,7 +316,6 @@ export class Login extends Component {
 			oauth2Client,
 			isWooJPC,
 			isWCCOM,
-			isWoo,
 			isFromAutomatticForAgenciesPlugin,
 			currentQuery,
 			twoFactorEnabled,
@@ -358,7 +355,7 @@ export class Login extends Component {
 			</Main>
 		);
 
-		const headerText = getHeaderText( {
+		const headingText = getHeaderText( {
 			isSocialFirst,
 			twoFactorAuthType,
 			isManualRenewalImmediateLoginAttempt,
@@ -377,51 +374,26 @@ export class Login extends Component {
 			translate,
 		} );
 
-		const shouldUseWideHeading =
-			'lostpassword' !== action &&
-			( isStudioAppOAuth2Client( oauth2Client ) ||
-				isFromAkismet ||
-				isCrowdsignalOAuth2Client( oauth2Client ) ||
-				isBlazePro ||
-				isJetpack ||
-				isJetpackCloudOAuth2Client( oauth2Client ) ||
-				isWoo ||
-				isVIPOAuth2Client( oauth2Client ) ||
-				isPartnerPortalOAuth2Client( oauth2Client ) );
+		const headingSubText = getHeadingSubText( {
+			isSocialFirst,
+			twoFactorAuthType,
+			action,
+			translate,
+		} );
 
 		return (
 			<>
 				{ isWhiteLogin && (
-					<Step.CenteredColumnLayout
-						columnWidth={ 6 }
-						{ ...( shouldUseWideHeading && { columnWidthHeading: 8 } ) }
-						topBar={
-							<Step.TopBar
-								rightElement={ this.renderLoginHeaderNavigation() }
-								compactLogo="always"
-							/>
-						}
-						heading={
-							<Step.Heading
-								text={
-									<>
-										<HeadingLogo isFromAkismet={ isFromAkismet } isJetpack={ isJetpack } />
-										<div className="wp-login__heading-text">{ headerText }</div>
-									</>
-								}
-								subText={
-									<HeadingSubText
-										isSocialFirst={ isSocialFirst }
-										twoFactorAuthType={ twoFactorAuthType }
-										action={ action }
-									/>
-								}
-							/>
-						}
-						verticalAlign="center"
+					<OneLoginLayout
+						isJetpack={ isJetpack }
+						isFromAkismet={ isFromAkismet }
+						headingText={ headingText }
+						headingSubText={ headingSubText }
+						shouldUseWideHeading={ 'lostpassword' !== action }
+						signupUrl={ this.props.signupUrl }
 					>
 						{ mainContent }
-					</Step.CenteredColumnLayout>
+					</OneLoginLayout>
 				) }
 				{ ! isWhiteLogin && mainContent }
 			</>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13220/login-make-the-two-columnwhite-layout-the-default-across-all-contexts
Part of https://linear.app/a8c/issue/DOTCOM-13334/clean-up-loginheader-and-top-barmasterbar-components-and-styles

## Proposed Changes

* Extracts a `OneLoginLayout` component that includes the top-bar, logo, heading and sub-heading placeholders.
* This can now be extended and used in other parts of Login that are separated (magic-login, magic-code, etc.)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of general refactors

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test several [Login screens](https://linear.app/a8c/issue/DOTCOM-13220/login-make-the-two-columnwhite-layout-the-default-across-all-contexts) (OAuth clients and default) and confirm the structure renders as expected (with client logos and headings in respective font)
* Test [Gravatar Login](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D4a5153e30a28e2ef24ca7e599abd80f3969340cd1f88327c1f5d2fbc88593fa1%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1&client_id=1854) and confirm no changes
* Click on the "lost your password" link at the bottom. Confirm no changes from production (narrower heading/subheading)
* Click on "create an account" at the top-left and confirm the redirection is to the correct URL (confirm with a OAuth client Login screen)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
