### PR TITLE
Update professional email background screen

### DIFF
--- a/client/my-sites/email/email-providers-comparison/stacked/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/index.tsx
@@ -14,6 +14,7 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
 import Main from 'calypso/components/main';
+import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import {
 	getSelectedDomain,
@@ -263,6 +264,7 @@ const EmailProvidersStackedComparison = ( {
 			} ) }
 			wideLayout
 		>
+			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 			<QueryProductsList />
 
 			{ ! isDomainInCart && selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

follow-up of https://github.com/Automattic/wp-calypso/pull/104559

## Proposed Changes

* The professional email background screen was also in the incorrect color. Let's ensure we have a consistent experience.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want consistency during all Domain flows

## Testing Instructions

* Acess the Logged in domain search http://calypso.localhost:3000/domains/add/{siteDomain}
* Add one domain to the cart and click on advance
* Make sure the background is white

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/e5164f3b-dd07-4b32-b986-ce31127d9431) | ![image](https://github.com/user-attachments/assets/f24735a7-4cfb-47b8-9363-64d2ce42acd4) | 

 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
