### PR TITLE
Purchases: Use the purchase's domain meta for linking to purchase

### DIFF
--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -80,7 +80,7 @@ export function getPurchasesFieldDefinitions( {
 	);
 
 	const goToPurchase = ( item: Purchases.Purchase ) => {
-		const siteUrl = item.domain;
+		const siteUrl = item.meta || item.domain;
 		const subscriptionId = item.id;
 		if ( ! siteUrl ) {
 			// eslint-disable-next-line no-console

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -150,7 +150,7 @@ export function getPurchasesFieldDefinitions( {
 					' ' +
 					item.siteName +
 					' ' +
-					item.domain +
+					( item.meta || item.domain ) +
 					' ' +
 					site?.URL
 				);
@@ -183,7 +183,7 @@ export function getPurchasesFieldDefinitions( {
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
 				// Render a bunch of things to make this easily searchable.
 				const site = sites.find( ( site ) => site.ID === item.siteId );
-				return item.siteName + ' ' + item.domain + ' ' + site?.URL;
+				return item.siteName + ' ' + ( item.meta || item.domain ) + ' ' + site?.URL;
 			},
 			render: ( { item }: { item: Purchases.Purchase } ) => {
 				return (

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -250,7 +250,7 @@ export function PurchasesDataViews( {
 				label: translate( 'Manage purchase', { textOnly: true } ),
 				isEligible: ( item: Purchases.Purchase ) => Boolean( item.domain && item.id ),
 				callback: ( items: Purchases.Purchase[] ) => {
-					const siteUrl = items[ 0 ].domain;
+					const siteUrl = items[ 0 ].meta || items[ 0 ].domain;
 					const subscriptionId = items[ 0 ].id;
 					if ( ! siteUrl ) {
 						// eslint-disable-next-line no-console


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-220/site-level-purchases-clicking-to-view-a-purchase-when-site-has-custom

## Proposed Changes

This changes the purchases list so that when generating the link to an individual purchase (subscription), we use the `meta` value of the subscription data before falling back to the `domain` value. The `meta` value will contain the custom domain for that purchase, if one exists.

## Testing Instructions

- Use a site that has a custom domain set as its primary domain and has at least one purchased subscription.
- Visit the site-level (not the user-level) purchases list for that site, for example https://wordpress.com/purchases/subscriptions/example.com
- Click on a purchase to view it.
- Verify that you see the purchase.
