### PR TITLE
Purchases: Default to primary domain when linking to purchase

### DIFF
--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -80,7 +80,7 @@ export function getPurchasesFieldDefinitions( {
 	);
 
 	const goToPurchase = ( item: Purchases.Purchase ) => {
-		const siteUrl = item.domain;
+		const siteUrl = item.siteSlug || item.domain;
 		const subscriptionId = item.id;
 		if ( ! siteUrl ) {
 			// eslint-disable-next-line no-console
@@ -150,7 +150,7 @@ export function getPurchasesFieldDefinitions( {
 					' ' +
 					item.siteName +
 					' ' +
-					item.domain +
+					( item.siteSlug || item.domain ) +
 					' ' +
 					site?.URL
 				);

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -250,7 +250,7 @@ export function PurchasesDataViews( {
 				label: translate( 'Manage purchase', { textOnly: true } ),
 				isEligible: ( item: Purchases.Purchase ) => Boolean( item.domain && item.id ),
 				callback: ( items: Purchases.Purchase[] ) => {
-					const siteUrl = items[ 0 ].domain;
+					const siteUrl = items[ 0 ].siteSlug || items[ 0 ].domain;
 					const subscriptionId = items[ 0 ].id;
 					if ( ! siteUrl ) {
 						// eslint-disable-next-line no-console

--- a/packages/data-stores/src/purchases/lib/assembler.ts
+++ b/packages/data-stores/src/purchases/lib/assembler.ts
@@ -114,6 +114,7 @@ export function createPurchaseObject( purchase: RawPurchase | RawPurchaseCreditC
 		saleAmountInteger: purchase.sale_amount_integer,
 		siteId: Number( purchase.blog_id ),
 		siteName: purchase.blogname,
+		siteSlug: purchase.site_slug,
 		subscribedDate: purchase.subscribed_date,
 		subscriptionStatus: purchase.subscription_status,
 		tagLine: purchase.tag_line,

--- a/packages/data-stores/src/purchases/types.ts
+++ b/packages/data-stores/src/purchases/types.ts
@@ -16,7 +16,18 @@ export interface Purchase {
 	currencyCode: string;
 	currencySymbol: string;
 	description: string;
+
+	/**
+	 * The domain name of the site associated with the purchase.
+	 *
+	 * IMPORTANT: this is not necessarily the primary domain of the site. This
+	 * can cause issues for Atomic sites if you try to use it for things that
+	 * expect the primary domain, like routing.
+	 *
+	 * To get the primary domain instead, use `siteSlug`.
+	 */
 	domain: string;
+
 	domainRegistrationAgreementUrl: string | null;
 	error: null;
 	expiryDate: string;
@@ -106,6 +117,12 @@ export interface Purchase {
 	saleAmountInteger?: number;
 	siteId: number;
 	siteName: string;
+
+	/**
+	 * The primary domain for the site that owns this purchase.
+	 */
+	siteSlug?: string;
+
 	subscribedDate: string;
 	subscriptionStatus: 'active' | 'inactive';
 
@@ -256,6 +273,7 @@ export interface RawPurchase {
 	sale_amount_integer: number | undefined;
 	blog_id: number | string;
 	blogname: string;
+	site_slug?: string;
 	subscribed_date: string;
 	subscription_status: 'active' | 'inactive';
 	tag_line: string;


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-220/site-level-purchases-clicking-to-view-a-purchase-when-site-has-custom

## Proposed Changes

This changes the purchases list so that when generating the link to an individual purchase (subscription), we use the `siteSlug` value of the subscription data before falling back to the `domain` value. The `siteSlug` value will contain the primary domain for that purchase.

Depends on 186978-ghe-Automattic/wpcom

This fixes an issue where relying on the `domain` property broke the links from the site-level purchases page to subscriptions for Atomic sites with a custom domain. Prior to this PR, the links would look something like https://wordpress.com/purchases/subscriptions/example.wordpress.com/12345 but the site is now at `example.wpcomstaging.com`. After this PR, the links should look something like https://wordpress.com/purchases/subscriptions/example.com/12345

## Testing Instructions

First, apply 186978-ghe-Automattic/wpcom to your sandbox and point `public-api.wordpress.com` there.

- Use a site that has a custom domain set as its primary domain and has at least one purchased subscription.
- Visit the site-level (not the user-level) purchases list for that site, for example https://wordpress.com/purchases/subscriptions/example.com
- Click on a purchase to view it.
- Verify that you see the purchase.