### PR TITLE
A4A > Reports: Minor UI enhancements & copy changes

### DIFF
--- a/client/a8c-for-agencies/components/a4a-select-site/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-select-site/index.tsx
@@ -36,6 +36,7 @@ const A4ASelectSite = ( {
 				variant="secondary"
 				onClick={ handleOpenModal }
 				className={ className }
+				data-field="selectedSite"
 			>
 				{ buttonLabel || translate( 'Select a site' ) }
 			</Button>

--- a/client/a8c-for-agencies/components/list-item-cards/index.tsx
+++ b/client/a8c-for-agencies/components/list-item-cards/index.tsx
@@ -43,7 +43,11 @@ export function ListItemCardActions( { actions, item }: { actions: Action[]; ite
 		setIsOpen( false );
 	}, [] );
 
-	const hasEligibleActions = actions.some( ( action ) => action.isEligible?.( item ) );
+	const isEligible = ( action: Action ) => {
+		return action.isEligible?.( item ) ?? true;
+	};
+
+	const hasEligibleActions = actions.some( isEligible );
 
 	if ( ! hasEligibleActions ) {
 		return null;
@@ -61,7 +65,7 @@ export function ListItemCardActions( { actions, item }: { actions: Action[]; ite
 				position="bottom left"
 			>
 				{ actions.map( ( action ) =>
-					action.isEligible?.( item ) ? (
+					isEligible( action ) ? (
 						<PopoverMenuItem
 							key={ action.id }
 							onClick={ () => {

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/steps/step-1-details.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/steps/step-1-details.tsx
@@ -102,7 +102,7 @@ export default function Step1Details( { formData, state, handlers }: StepProps )
 							</span>
 							<span>
 								{ translate(
-									'Only live WordPress.com or Pressable sites using Jetpack or the Automattic for Agencies plugin are supported.'
+									'Only live WordPress.com or Pressable sites using Jetpack are supported.'
 								) }
 							</span>
 						</div>
@@ -115,7 +115,6 @@ export default function Step1Details( { formData, state, handlers }: StepProps )
 					} }
 					buttonLabel={ selectedSite?.domain || translate( 'Choose a site to report on' ) }
 					trackingEvent="calypso_a4a_reports_select_site_button_click"
-					data-field="selectedSite"
 					aria-required="true"
 					aria-describedby="selected-site-error"
 				/>

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/empty-state.tsx
@@ -59,9 +59,7 @@ const ReportsDashboardEmptyState = () => {
 				</StepSection>
 			</div>
 			<div className="reports-dashboard-empty-state__footnote">
-				{ translate(
-					'*Only live WordPress.com or Pressable sites using Jetpack or the Automattic for Agencies plugin are supported.'
-				) }
+				{ translate( '*Only live WordPress.com or Pressable sites using Jetpack are supported.' ) }
 			</div>
 			<ExampleReportModal
 				isVisible={ showExampleModal }

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/index.tsx
@@ -101,7 +101,7 @@ export default function ReportsDashboard() {
 			title={ title }
 			wide
 		>
-			<LayoutColumn wide className="reports-dashboard__column">
+			<LayoutColumn wide className="reports-dashboard__column" scrollable>
 				<LayoutTop isFullWidth={ isFullWidth }>
 					<LayoutHeader>
 						<Title>{ title }</Title>

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/style.scss
@@ -106,7 +106,6 @@
 	flex-direction: column;
 	gap: 8px;
 	margin-block-start: 16px;
-	align-items: center;
 
 	@include break-large {
 		margin-block-start: 0;
@@ -115,6 +114,7 @@
 	@include break-xlarge {
 		flex-direction: row;
 		gap: 12px;
+		align-items: center;
 	}
 
 	button {

--- a/client/layout/hosting-dashboard/column.tsx
+++ b/client/layout/hosting-dashboard/column.tsx
@@ -10,14 +10,23 @@ type Props = {
 	wide?: boolean;
 	withBorder?: boolean;
 	compact?: boolean;
+	scrollable?: boolean;
 };
 
-export default function LayoutColumn( { children, className, wide, withBorder, compact }: Props ) {
+export default function LayoutColumn( {
+	children,
+	className,
+	wide,
+	withBorder,
+	compact,
+	scrollable,
+}: Props ) {
 	return (
 		<Main
 			className={ clsx( 'hosting-dashboard-layout-column', className, {
 				'is-with-border': withBorder,
 				'is-compact': compact,
+				'is-scrollable': scrollable,
 			} ) }
 			fullWidthLayout={ wide }
 			wideLayout={ ! wide } // When we set to full width, we want to set this to false.

--- a/client/layout/hosting-dashboard/style.scss
+++ b/client/layout/hosting-dashboard/style.scss
@@ -117,6 +117,11 @@
 	}
 }
 
+.main.hosting-dashboard-layout-column.is-scrollable {
+	height: auto;
+	overflow-y: scroll;
+}
+
 .hosting-dashboard-layout__header {
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1211/cft-empty-state-mobile-view-enhancements

## Proposed Changes

This PR:

- Fixes an issue with accessibility on the report builder
- Copy changes to the site selection criteria
- Fixes the scroll issue on the dashboard 
- Fixes empty state alignment issues on mobile view
- Fixes an issue on the **ListItemCardActions** component with eligible actions not showing up on the mobile view

## Why are these changes being made?

* To make the user experience better and set clear expectations

## Testing Instructions

* Open the A4A live link
* Build a new report > Click the `Next` button on the form > Verify the `Choose a site to report` button is focused for accessibility.

<img width="727" alt="Screenshot 2025-07-03 at 11 59 53 AM" src="https://github.com/user-attachments/assets/a7b201a5-8342-4394-a91b-3c4660728861" />
 
* Click the  `Choose a site to report` button > Verify that the copy changes are made to the subtitle as shown below

<img width="837" alt="Screenshot 2025-07-03 at 11 37 41 AM" src="https://github.com/user-attachments/assets/2d067942-81d0-4a2f-8908-f905efd3b010" />

* Go to the Dashboard >  Verify that the site selection criteria on the empty state view are updated

<img width="1548" alt="Screenshot 2025-07-03 at 11 34 56 AM" src="https://github.com/user-attachments/assets/39881d90-c103-44b2-84d1-c398ed273e62" />

* Switch to mobile view > Verify the buttons are aligned well > Also, verify that you can scroll to the end. You can use the iPhone SE at 100% from the device toolbar on the dev tool. 

| Before | After |
|--------|--------|
| <img width="402" alt="Screenshot 2025-07-03 at 12 07 24 PM" src="https://github.com/user-attachments/assets/738863db-5913-4960-9763-296bd3a6fddd" /> | <img width="402" alt="Screenshot 2025-07-03 at 11 44 34 AM" src="https://github.com/user-attachments/assets/d88cb968-4ea2-4c4e-9ce8-fdd523db3871" /> | 

* Build a report and send to client > On the dashboard > Open the detailed view > Switch to mobile view > Verify all the actions, including the `Delete report` are displayed as shown below:

| Before | After |
|--------|--------|
| <img width="375" alt="Screenshot 2025-07-03 at 1 20 17 PM" src="https://github.com/user-attachments/assets/ab9e7666-8a1d-4743-b577-f0649bdcf1e4" /> | <img width="375" alt="Screenshot 2025-07-03 at 1 11 34 PM" src="https://github.com/user-attachments/assets/a6a13a05-fde3-4b1a-9481-b8a540fe640e" /> | 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
