### PR TITLE
A4A: Update WooPayments revenue share terms copy

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/woopayments-custom-description/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/woopayments-custom-description/index.tsx
@@ -55,7 +55,7 @@ export default function WooPaymentsCustomDescription() {
 				</p>
 				<p className="jetpack-product-info__description">
 					{ translate(
-						'You will receive a revenue share of 5 basis points on new Total Payments Volume (“TPV”) on client sites through June 30, 2025. {{a}}View full terms{{/a}}',
+						'You will receive a revenue share of 5 basis points on new Total Payments Volume (“TPV”) on client sites. {{a}}View full terms{{/a}}',
 						{
 							components: {
 								a: (

--- a/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
@@ -99,7 +99,7 @@ export default function CommissionOverview() {
 							summary={ false }
 						>
 							{ translate(
-								'You will receive a revenue share of 5 basis points (bps) on new WooPayments total payments volume (“TPV”) on client sites through June 30, 2025.' +
+								'You will receive a revenue share of 5 basis points (bps) on new WooPayments total payments volume (“TPV”) on client sites.' +
 									" For example, if your client's store generates %(maxAmount)s in TPV per year, your revenue share for that year would be %(amount)s.",
 								{
 									args: {

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-overview/index.tsx
@@ -306,7 +306,7 @@ const WooPaymentsOverview = () => {
 								</div>
 								<div>
 									{ translate(
-										'You will receive a revenue share of 5 basis points on new Total Payments Volume (“TPV”) on client sites through June 30, 2025. {{a}}View full terms{{/a}} ↗',
+										'You will receive a revenue share of 5 basis points on new Total Payments Volume (“TPV”) on client sites. {{a}}View full terms{{/a}} ↗',
 										{
 											components: {
 												a: (


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/A4A-1221/remove-through-june-30-2025-from-woopayments-page-and-modal

## Proposed Changes

This PR updates the WooPayments revenue share terms copy on several places:
•   On the [WooPayments page in A4A](https://agencies.automattic.com/woopayments/overview)
•   Within the [modal in the marketplace](https://agencies.automattic.com/overview?show_license_modal=woocommerce-woopayments)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

## Testing Instructions

- Open the A4A live link
- Verify the changes were reflected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
