### PR TITLE
Stats: Update E2E test to use Jetpack > Stats

### DIFF
--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -78,7 +78,7 @@ export class SidebarComponent {
 
 		// Sub-level menu item selector.
 		if ( subitem ) {
-			const subitemSelector = `.is-toggle-open :text-is("${ subitem }"):visible`;
+			const subitemSelector = `.is-toggle-open :text-is("${ subitem }"):visible, .wp-menu-open .wp-submenu :text-is("${ subitem }"):visible`;
 			await Promise.all( [
 				this.page.waitForNavigation( { timeout: 30 * 1000 } ),
 				this.page.dispatchEvent( subitemSelector, 'click' ),

--- a/test/e2e/specs/stats/stats.ts
+++ b/test/e2e/specs/stats/stats.ts
@@ -54,7 +54,7 @@ describe( DataHelper.createSuiteTitle( 'Stats' ), function () {
 			);
 		}
 		const sidebarComponent = new SidebarComponent( page );
-		await sidebarComponent.navigate( 'Stats' );
+		await sidebarComponent.navigate( 'Jetpack', 'Stats' );
 	} );
 
 	describe( 'Traffic', function () {


### PR DESCRIPTION
Fixes DOTCOM-13777

## Proposed Changes

Update the Stats E2E test to access the feature via Jetpack > Stats rather than via the Stats top-level menu

## Why are these changes being made?

Because the Stats top-level menu is being removed soon 

## Testing Instructions

- Apply changes from 186964-ghe-Automattic/wpcom to your sandbox
- Sandbox the `e2eflowtesting8.wordpress.com` domain
- If your sandbox is in limited write mode, enable full access.
- Check out PR locally
- Set up the E2E test environment:
  - Grab the Calypso E2E config decode key from the Secret Store.
  - `export E2E_SECRETS_KEY='<CONFIG_DECODE_KEY>'`
  - `yarn workspace wp-e2e-tests decrypt-secrets`
  - `yarn workspace wp-e2e-tests build`
- Start Calypso locally: `yarn start`
- Run the Stats E2E test locally: `CALYPSO_BASE_URL=http://calypso.localhost:3000 yarn workspace wp-e2e-tests test -- test/e2e/specs/stats/stats.ts`
- Make sure the E2E test passes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?