### PR TITLE
Sites List v2: Adjust the number of the items per page

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -17,7 +17,13 @@ import { getActions } from './actions';
 import AddNewSite from './add-new-site';
 import { getFields } from './fields';
 import { SitesNotices } from './notices';
-import { getView, mergeViews, DEFAULT_LAYOUTS, recordViewChanges } from './views';
+import {
+	getView,
+	mergeViews,
+	DEFAULT_LAYOUTS,
+	recordViewChanges,
+	DEFAULT_PER_PAGE_SIZES,
+} from './views';
 import type { ViewPreferences, ViewSearchParams } from './views';
 import type { FetchSitesOptions, Site } from '../data/types';
 import type { View, Filter } from '@wordpress/dataviews';
@@ -133,6 +139,7 @@ export default function Sites() {
 						onChangeView={ handleViewChange }
 						defaultLayouts={ DEFAULT_LAYOUTS }
 						paginationInfo={ paginationInfo }
+						perPageSizes={ DEFAULT_PER_PAGE_SIZES }
 					/>
 				</DataViewsCard>
 			</PageLayout>

--- a/client/dashboard/sites/views.ts
+++ b/client/dashboard/sites/views.ts
@@ -58,7 +58,9 @@ export type ViewSearchParams = Partial< SitesView >;
 // All possible keys that can be shown in the query params.
 const VIEW_SEARCH_PARAM_KEYS = [ ...VIEW_PREFERENCES_KEYS, 'filters', 'page', 'search' ];
 
-const DEFAULT_PER_PAGE = 10;
+export const DEFAULT_PER_PAGE_SIZES = [ 12, 24, 48, 96 ];
+
+const DEFAULT_PER_PAGE = 12;
 
 const DEFAULT_VIEW: Partial< SitesView > = {
 	page: 1,

--- a/client/dashboard/sites/views.ts
+++ b/client/dashboard/sites/views.ts
@@ -58,7 +58,7 @@ export type ViewSearchParams = Partial< SitesView >;
 // All possible keys that can be shown in the query params.
 const VIEW_SEARCH_PARAM_KEYS = [ ...VIEW_PREFERENCES_KEYS, 'filters', 'page', 'search' ];
 
-export const DEFAULT_PER_PAGE_SIZES = [ 12, 24, 48, 96 ];
+export const DEFAULT_PER_PAGE_SIZES: [ number, number, number, number ] = [ 12, 24, 48, 96 ];
 
 const DEFAULT_PER_PAGE = 12;
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-24

## Proposed Changes

* Follow-up of https://github.com/WordPress/gutenberg/pull/70604 to adjust the number of the items per page on Dashboard v2

![image](https://github.com/user-attachments/assets/cd8756df-9137-4e3d-b13e-2239360f7f3f)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The new set of numbers fits our layout better

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Ensure the initial number of the sites are 12
* Open the Appearance setting
* Ensure the ITEMS PER PAGE is 12, 24, 48 and 96

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
