### PR TITLE
Dashboard v2: fix styles of title fields

### DIFF
--- a/client/dashboard/sites/fields.tsx
+++ b/client/dashboard/sites/fields.tsx
@@ -1,52 +1,24 @@
-import { Badge } from '@automattic/ui';
-import { Link } from '@tanstack/react-router';
-import { __experimentalHStack as HStack, __experimentalText as Text } from '@wordpress/components';
-import { useResizeObserver } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import TimeSince from '../components/time-since';
 import { getSiteDisplayName } from '../utils/site-name';
 import { STATUS_LABELS, getSiteStatus } from '../utils/site-status';
-import { isP2 } from '../utils/site-types';
 import { getSiteDisplayUrl } from '../utils/site-url';
 import { getFormattedWordPressVersion } from '../utils/wp-version';
-import { canManageSite } from './features';
-import { isSitePlanTrial } from './plans';
 import {
 	EngagementStat,
 	LastBackup,
 	MediaStorage,
+	Name,
 	PHPVersion,
 	Plan,
+	Preview,
 	Status,
+	URL,
 	Uptime,
 } from './site-fields';
 import SiteIcon from './site-icon';
-import SitePreview from './site-preview';
 import type { Site } from '../data/types';
 import type { Field, Operator } from '@automattic/dataviews';
-
-function getSiteManagementUrl( site: Site ) {
-	if ( canManageSite( site ) ) {
-		return `/sites/${ site.slug }`;
-	}
-	return site.options?.admin_url;
-}
-
-function SiteBadge( { site }: { site: Site } ) {
-	if ( site.is_wpcom_staging_site ) {
-		return <Badge>{ __( 'Staging' ) }</Badge>;
-	}
-
-	if ( isSitePlanTrial( site ) ) {
-		return <Badge>{ __( 'Trial' ) }</Badge>;
-	}
-
-	if ( isP2( site ) ) {
-		return <Badge>{ __( 'P2' ) }</Badge>;
-	}
-
-	return null;
-}
 
 const DEFAULT_FIELDS: Field< Site >[] = [
 	{
@@ -54,37 +26,14 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		label: __( 'Site' ),
 		enableGlobalSearch: true,
 		getValue: ( { item } ) => getSiteDisplayName( item ),
-		render: ( { field, item } ) => (
-			<Link to={ getSiteManagementUrl( item ) } disabled={ item.is_deleted }>
-				<HStack alignment="center" spacing={ 1 }>
-					<Text
-						as="span"
-						style={ { overflowX: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }
-						{ ...( item.is_deleted ? { variant: 'muted' } : {} ) }
-					>
-						{ field.getValue( { item } ) }
-					</Text>
-					<Text as="span" style={ { flexShrink: 0 } }>
-						<SiteBadge site={ item } />
-					</Text>
-				</HStack>
-			</Link>
-		),
+		render: ( { field, item } ) => <Name site={ item } value={ field.getValue( { item } ) } />,
 	},
 	{
 		id: 'URL',
 		label: __( 'URL' ),
 		enableGlobalSearch: true,
 		getValue: ( { item } ) => getSiteDisplayUrl( item ),
-		render: ( { field, item } ) => (
-			<Text
-				as="span"
-				variant="muted"
-				style={ { overflowX: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }
-			>
-				{ field.getValue( { item } ) }
-			</Text>
-		),
+		render: ( { field, item } ) => <URL site={ item } value={ field.getValue( { item } ) } />,
 	},
 	{
 		id: 'icon.ico',
@@ -139,38 +88,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 	{
 		id: 'preview',
 		label: __( 'Preview' ),
-		render: function PreviewRender( { item } ) {
-			const [ resizeListener, { width } ] = useResizeObserver();
-			const { is_deleted, is_private, URL: url } = item;
-			// If the site is a private A8C site, X-Frame-Options is set to same
-			// origin.
-			const iframeDisabled = is_deleted || ( item.is_a8c && is_private );
-			return (
-				<Link
-					to={ getSiteManagementUrl( item ) }
-					disabled={ item.is_deleted }
-					style={ { display: 'block', height: '100%', width: '100%' } }
-				>
-					{ resizeListener }
-					{ iframeDisabled && (
-						<div
-							style={ {
-								fontSize: '24px',
-								display: 'flex',
-								alignItems: 'center',
-								justifyContent: 'center',
-								height: '100%',
-							} }
-						>
-							<SiteIcon site={ item } />
-						</div>
-					) }
-					{ width && ! iframeDisabled && (
-						<SitePreview url={ url } scale={ width / 1200 } height={ 1200 } />
-					) }
-				</Link>
-			);
-		},
+		render: ( { item } ) => <Preview site={ item } />,
 		enableSorting: false,
 	},
 	{

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -1,11 +1,13 @@
 import { Badge } from '@automattic/ui';
 import { useQuery } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
 import {
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	ExternalLink,
 } from '@wordpress/components';
+import { useResizeObserver } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
 import { useInView } from 'react-intersection-observer';
 import { useAnalytics } from '../../app/analytics';
@@ -21,9 +23,11 @@ import TimeSince from '../../components/time-since';
 import { JetpackModules } from '../../data/constants';
 import { hasAtomicFeature, hasJetpackModule } from '../../utils/site-features';
 import { getSiteStatus, getSiteStatusLabel } from '../../utils/site-status';
-import { isSelfHostedJetpackConnected } from '../../utils/site-types';
-import { HostingFeatures } from '../features';
+import { isSelfHostedJetpackConnected, isP2 } from '../../utils/site-types';
+import { HostingFeatures, canManageSite } from '../features';
 import { isSitePlanTrial } from '../plans';
+import SiteIcon from '../site-icon';
+import SitePreview from '../site-preview';
 import { JetpackLogo } from './jetpack-logo';
 import type { Site } from '../../data/types';
 
@@ -33,6 +37,91 @@ function IneligibleIndicator() {
 
 function LoadingIndicator( { label }: { label: string } ) {
 	return <TextBlur>{ label }</TextBlur>;
+}
+
+function getSiteManagementUrl( site: Site ) {
+	if ( canManageSite( site ) ) {
+		return `/sites/${ site.slug }`;
+	}
+	return site.options?.admin_url;
+}
+
+const titleFieldStyle = {
+	overflowX: 'hidden',
+	textOverflow: 'ellipsis',
+	whiteSpace: 'nowrap',
+} as const;
+
+export function Name( { site, value }: { site: Site; value: string } ) {
+	const renderBadge = () => {
+		if ( site.is_wpcom_staging_site ) {
+			return <Badge>{ __( 'Staging' ) }</Badge>;
+		}
+
+		if ( isSitePlanTrial( site ) ) {
+			return <Badge>{ __( 'Trial' ) }</Badge>;
+		}
+
+		if ( isP2( site ) ) {
+			return <Badge>{ __( 'P2' ) }</Badge>;
+		}
+
+		return null;
+	};
+
+	return (
+		<Link to={ getSiteManagementUrl( site ) } disabled={ site.is_deleted }>
+			<HStack alignment="center" spacing={ 1 }>
+				{ site.is_deleted ? (
+					<Text variant="muted">{ value }</Text>
+				) : (
+					<span style={ titleFieldStyle }>{ value }</span>
+				) }
+				<span style={ { flexShrink: 0 } }>{ renderBadge() }</span>
+			</HStack>
+		</Link>
+	);
+}
+
+export function URL( { site, value }: { site: Site; value: string } ) {
+	return site.is_deleted ? (
+		<Text variant="muted">{ value }</Text>
+	) : (
+		<span style={ titleFieldStyle }>{ value }</span>
+	);
+}
+
+export function Preview( { site }: { site: Site } ) {
+	const [ resizeListener, { width } ] = useResizeObserver();
+	const { is_deleted, is_private, URL: url } = site;
+	// If the site is a private A8C site, X-Frame-Options is set to same
+	// origin.
+	const iframeDisabled = is_deleted || ( site.is_a8c && is_private );
+	return (
+		<Link
+			to={ getSiteManagementUrl( site ) }
+			disabled={ site.is_deleted }
+			style={ { display: 'block', height: '100%', width: '100%' } }
+		>
+			{ resizeListener }
+			{ iframeDisabled && (
+				<div
+					style={ {
+						fontSize: '24px',
+						display: 'flex',
+						alignItems: 'center',
+						justifyContent: 'center',
+						height: '100%',
+					} }
+				>
+					<SiteIcon site={ site } />
+				</div>
+			) }
+			{ width && ! iframeDisabled && (
+				<SitePreview url={ url } scale={ width / 1200 } height={ 1200 } />
+			) }
+		</Link>
+	);
 }
 
 export function EngagementStat( {

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -46,7 +46,7 @@ function getSiteManagementUrl( site: Site ) {
 	return site.options?.admin_url;
 }
 
-const titleFieldStyle = {
+const titleFieldTextOverflowStyles = {
 	overflowX: 'hidden',
 	textOverflow: 'ellipsis',
 	whiteSpace: 'nowrap',
@@ -75,7 +75,7 @@ export function Name( { site, value }: { site: Site; value: string } ) {
 				{ site.is_deleted ? (
 					<Text variant="muted">{ value }</Text>
 				) : (
-					<span style={ titleFieldStyle }>{ value }</span>
+					<span style={ titleFieldTextOverflowStyles }>{ value }</span>
 				) }
 				<span style={ { flexShrink: 0 } }>{ renderBadge() }</span>
 			</HStack>
@@ -87,7 +87,7 @@ export function URL( { site, value }: { site: Site; value: string } ) {
 	return site.is_deleted ? (
 		<Text variant="muted">{ value }</Text>
 	) : (
-		<span style={ titleFieldStyle }>{ value }</span>
+		<span style={ titleFieldTextOverflowStyles }>{ value }</span>
 	);
 }
 


### PR DESCRIPTION
## Proposed Changes

This PR fixes a regression from https://github.com/Automattic/wp-calypso/pull/104316, where we use `<Text>` in the name field. It mistakenly overrode the default DataViews' style, particularly the font weight, making it lighter that it should be (400 vs 500). 500 is the correct weight from Figma.

Additionally, this PR also removes the `<Text>` component from the URL field so that the correct DataViews styles will be used. However, it will make the font weight a bit stronger in the grid view (see the screenshots). But this is the default DataViews behavior, so I'd suggest we keep this. cc: @matt-west 

Note that the screenshots below also show deleted sites' styles, which were ported from v1.

### Table view

|Before|After|
|-|-|
|<img width="521" alt="image" src="https://github.com/user-attachments/assets/bce381ee-8482-40b3-8ef5-e63ad8bcb0a0" />|<img width="524" alt="image" src="https://github.com/user-attachments/assets/8d4988f4-7799-4ff3-a7a9-e12de82d72fb" />

### Grid view

|Before|After|
|-|-|
|<img width="692" alt="image" src="https://github.com/user-attachments/assets/5c526b7e-e8e6-47d6-b094-93f1daee7aa5" />|<img width="688" alt="image" src="https://github.com/user-attachments/assets/669482f2-5482-4f1e-95a8-2474119ab293" />

Notice that the URL is stronger than before. But this is DataViews behavior, see the following as example:

<img width="309" alt="image" src="https://github.com/user-attachments/assets/4b4c8be0-de46-4a1b-a476-5473abc1c62d" />


## Testing Instructions

1. Go to `/sites?flags=dashboard/v2/backport/sites-list`
2. Verify the above screenshots.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
