### PR TITLE
Restore Jetpack promo offer for users not eligible for refund

### DIFF
--- a/client/components/marketing-survey/cancel-jetpack-form/index.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/index.tsx
@@ -391,9 +391,9 @@ const CancelJetpackForm: React.FC< Props > = ( {
 			return firstButtons.concat( [ cancel ] );
 		}
 
-		// on the last step
+		// on the last step or the offer step
 		// show the cancel button here
-		if ( lastStep === cancellationStep ) {
+		if ( lastStep === cancellationStep || steps.CANCELLATION_OFFER_STEP === cancellationStep ) {
 			// If loading offers, show a "loading" button in place of the remove button.
 			// The steps may change if an offer is available and this may no longer be the last step.
 			if ( loadingOffers ) {

--- a/client/components/marketing-survey/cancel-jetpack-form/index.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/index.tsx
@@ -393,13 +393,35 @@ const CancelJetpackForm: React.FC< Props > = ( {
 
 		// on the last step or the offer step
 		// show the cancel button here
-		if ( lastStep === cancellationStep || steps.CANCELLATION_OFFER_STEP === cancellationStep ) {
+		if ( lastStep === cancellationStep ) {
 			// If loading offers, show a "loading" button in place of the remove button.
 			// The steps may change if an offer is available and this may no longer be the last step.
 			if ( loadingOffers ) {
 				return firstButtons.concat( [ loading ] );
 			}
 			return firstButtons.concat( [ cancel ] );
+		}
+
+		// For the offer step, show a single "No, thanks" button instead of close + cancel
+		if ( steps.CANCELLATION_OFFER_STEP === cancellationStep ) {
+			// If loading offers, show a "loading" button
+			if ( loadingOffers ) {
+				return [ loading ];
+			}
+
+			const noThanksButton = (
+				<Button
+					disabled={ disabled || disableContinuation || applyingOffer }
+					busy={ cancellationInProgress }
+					onClick={ onSubmit }
+					primary
+					scary={ ! cancellationCompleted }
+				>
+					{ translate( 'No, thanks' ) }
+				</Button>
+			);
+
+			return [ noThanksButton ];
 		}
 
 		return firstButtons.concat( [ next ] );

--- a/client/components/marketing-survey/cancel-jetpack-form/index.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/index.tsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import page from '@automattic/calypso-router';
 import { Button, Dialog } from '@automattic/components';
 import { BaseButton } from '@automattic/components/dist/types/dialog/button-bar';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
@@ -7,15 +8,22 @@ import * as React from 'react';
 import QueryPurchaseCancellationOffers from 'calypso/components/data/query-purchase-cancellation-offers';
 import FormattedHeader from 'calypso/components/formatted-header';
 import JetpackBenefitsStep from 'calypso/components/marketing-survey/cancel-jetpack-form/jetpack-benefits-step';
+import JetpackCancellationOfferStep from 'calypso/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-offer';
+import JetpackCancellationOfferAccepted from 'calypso/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-offer-accepted';
 import JetpackCancellationSurvey from 'calypso/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-survey';
 import { CANCEL_FLOW_TYPE } from 'calypso/components/marketing-survey/cancel-purchase-form/constants';
 import enrichedSurveyData from 'calypso/components/marketing-survey/cancel-purchase-form/enriched-survey-data';
 import Notice from 'calypso/components/notice';
 import { getName, isExpired } from 'calypso/lib/purchases';
 import { submitSurvey } from 'calypso/lib/purchases/actions';
+import { isOutsideCalypso } from 'calypso/lib/url';
 import { isJetpackTemporarySitePurchase } from 'calypso/me/purchases/utils';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getCancellationOfferApplySuccess from 'calypso/state/cancellation-offers/selectors/get-cancellation-offer-apply-success';
+import getCancellationOffers from 'calypso/state/cancellation-offers/selectors/get-cancellation-offers';
+import isApplyingCancellationOffer from 'calypso/state/cancellation-offers/selectors/is-applying-cancellation-offer';
+import isFetchingCancellationOffers from 'calypso/state/cancellation-offers/selectors/is-fetching-cancellation-offers';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import nextStep from '../cancel-purchase-form/next-step';
 import * as steps from './steps';
@@ -81,6 +89,41 @@ const CancelJetpackForm: React.FC< Props > = ( {
 		isSiteAutomatedTransfer( state, purchase.siteId )
 	);
 
+	const cancellationOffer = useSelector( ( state ) => {
+		const offers = getCancellationOffers( state, purchase.id );
+		if ( 1 === offers.length ) {
+			return offers[ 0 ];
+		}
+
+		return null;
+	} );
+
+	const fetchingCancellationOffers = useSelector( ( state ) =>
+		isFetchingCancellationOffers( state, purchase.id )
+	);
+
+	const applyingCancellationOffer = useSelector( ( state ) =>
+		isApplyingCancellationOffer( state, purchase.id )
+	);
+
+	const cancellationOfferApplySuccess = useSelector( ( state ) =>
+		getCancellationOfferApplySuccess( state, purchase.id )
+	);
+
+	const isOfferPriceSameOrLowerThanPurchasePrice = useMemo( () => {
+		return cancellationOffer ? purchase.amount >= cancellationOffer.originalPrice : false;
+	}, [ cancellationOffer, purchase.amount ] );
+
+	const offerDiscountBasedFromPurchasePrice = useMemo( () => {
+		if ( cancellationOffer ) {
+			const offerDiscountPercentage = ( 1 - cancellationOffer.rawPrice / purchase.amount ) * 100;
+
+			// Round the cancellation offer discount percentage to the nearest whole number
+			return Math.round( offerDiscountPercentage );
+		}
+		return 0;
+	}, [ cancellationOffer, purchase ] );
+
 	/**
 	 * Set the cancellation flow back to the beginning
 	 * Clear out stored state for the flow
@@ -136,8 +179,28 @@ const CancelJetpackForm: React.FC< Props > = ( {
 		) {
 			availableSteps.push( steps.CANCELLATION_REASON_STEP );
 		}
+
+		if (
+			CANCEL_FLOW_TYPE.REMOVE === flowType &&
+			shouldProvideCancellationOffer &&
+			cancellationOffer &&
+			isOfferPriceSameOrLowerThanPurchasePrice &&
+			offerDiscountBasedFromPurchasePrice >= 10
+		) {
+			availableSteps.push( steps.CANCELLATION_OFFER_STEP );
+			availableSteps.push( steps.OFFER_ACCEPTED_STEP );
+		}
+
 		return availableSteps;
-	}, [ flowType, purchase, props.cancellationCompleted ] );
+	}, [
+		purchase,
+		props.cancellationCompleted,
+		flowType,
+		shouldProvideCancellationOffer,
+		cancellationOffer,
+		isOfferPriceSameOrLowerThanPurchasePrice,
+		offerDiscountBasedFromPurchasePrice,
+	] );
 
 	const { firstStep, lastStep } = useMemo( () => {
 		return {
@@ -163,7 +226,16 @@ const CancelJetpackForm: React.FC< Props > = ( {
 		// record tracks event
 		// sends the same event name as the main product cancellation form
 		recordEvent( 'calypso_purchases_cancel_form_close' );
-		resetSurveyState();
+
+		// When an offer has been accepted, redirect back to the purchases page.
+		if (
+			( cancellationOfferApplySuccess || steps.OFFER_ACCEPTED_STEP === cancellationStep ) &&
+			! isOutsideCalypso( props.purchaseListUrl )
+		) {
+			page.redirect( props.purchaseListUrl );
+		} else {
+			resetSurveyState();
+		}
 	};
 
 	const setSurveyStep = useCallback(
@@ -192,7 +264,19 @@ const CancelJetpackForm: React.FC< Props > = ( {
 		setSurveyStep( nextStep );
 	};
 
+	useEffect( () => {
+		if ( true === cancellationOfferApplySuccess ) {
+			setSurveyStep( () => {
+				return steps.OFFER_ACCEPTED_STEP;
+			} );
+		}
+	}, [ cancellationOfferApplySuccess, setSurveyStep ] );
+
 	const onSubmit = () => {
+		if ( applyingCancellationOffer ) {
+			return;
+		}
+
 		if ( surveyAnswerId ) {
 			const surveyData = {
 				'why-cancel': {
@@ -235,6 +319,10 @@ const CancelJetpackForm: React.FC< Props > = ( {
 		setSurveyAnswerText( answerText );
 	};
 
+	const onGetCancellationOffer = () => {
+		recordEvent( 'calypso_purchases_cancel_get_discount' );
+	};
+
 	/**
 	 * Render the dialog buttons for the current step
 	 */
@@ -252,10 +340,11 @@ const CancelJetpackForm: React.FC< Props > = ( {
 			}
 			return translate( 'Cancel subscription' );
 		};
-
+		const loadingOffers = shouldProvideCancellationOffer && fetchingCancellationOffers;
+		const applyingOffer = shouldProvideCancellationOffer && applyingCancellationOffer;
 		const close = {
 			action: 'close',
-			disabled: disabled,
+			disabled: disabled || applyingOffer,
 			isPrimary: cancellationCompleted ? false : lastStep !== cancellationStep,
 			label: translate( 'Close' ),
 		};
@@ -269,7 +358,7 @@ const CancelJetpackForm: React.FC< Props > = ( {
 
 		const cancel = (
 			<Button
-				disabled={ disabled || disableContinuation }
+				disabled={ disabled || disableContinuation || applyingOffer }
 				busy={ cancellationInProgress }
 				onClick={ onSubmit }
 				primary
@@ -278,8 +367,24 @@ const CancelJetpackForm: React.FC< Props > = ( {
 				{ getButtonText() }
 			</Button>
 		);
-
+		const loading = (
+			<Button disabled busy primary>
+				{ translate( 'Loading' ) }
+			</Button>
+		);
 		const firstButtons: ( BaseButton | React.ReactElement )[] = [ close ];
+
+		const backToPurchases = {
+			action: 'close',
+			isPrimary: true,
+			disabled: disabled,
+			label: translate( 'Back to my purchases' ),
+		};
+
+		// Offer accepted screen only provides back to site button.
+		if ( steps.OFFER_ACCEPTED_STEP === cancellationStep ) {
+			return [ backToPurchases ];
+		}
 
 		// Cancel confirm step only shows the remove button
 		if ( steps.CANCEL_CONFIRM_STEP === cancellationStep ) {
@@ -289,6 +394,11 @@ const CancelJetpackForm: React.FC< Props > = ( {
 		// on the last step
 		// show the cancel button here
 		if ( lastStep === cancellationStep ) {
+			// If loading offers, show a "loading" button in place of the remove button.
+			// The steps may change if an offer is available and this may no longer be the last step.
+			if ( loadingOffers ) {
+				return firstButtons.concat( [ loading ] );
+			}
 			return firstButtons.concat( [ cancel ] );
 		}
 
@@ -365,6 +475,35 @@ const CancelJetpackForm: React.FC< Props > = ( {
 						isAkismet={ !! props?.isAkismet }
 					/>
 				</>
+			);
+		}
+
+		// Step 3: Offer
+		// This step is only made available after offers are checked for/ loaded.
+		if ( steps.CANCELLATION_OFFER_STEP === cancellationStep ) {
+			// Show an offer, the user can accept it or go ahead with the cancellation.
+			return (
+				<JetpackCancellationOfferStep
+					siteId={ purchase.siteId }
+					purchase={ purchase }
+					offer={ cancellationOffer }
+					percentDiscount={ offerDiscountBasedFromPurchasePrice }
+					onGetDiscount={ onGetCancellationOffer }
+					isAkismet={ !! props?.isAkismet }
+				/>
+			);
+		}
+
+		// Step 4: Offer Accepted
+		if ( steps.OFFER_ACCEPTED_STEP === cancellationStep ) {
+			// Show after an offer discount has been accepted
+			return (
+				<JetpackCancellationOfferAccepted
+					siteId={ purchase.siteId }
+					percentDiscount={ offerDiscountBasedFromPurchasePrice }
+					productName={ productName }
+					isAkismet={ !! props?.isAkismet }
+				/>
 			);
 		}
 


### PR DESCRIPTION
Part of #

## Proposed Changes

The recent cancellation flow changes removed the Jetpack promo offer. However, as @DavidRothstein pointed out, it can still be used outside of refund period when the flow doesn't remove the purchase but only turns off the auto-renew.

## Why are these changes being made?

* Restore some of the previous features

## Testing Instructions

* With your own Jetpack site (I use one on Hostinger because wpcom plans don't let me buy Jetpack)
* With the Store Sandbox on
* Add yourself a lot of credits
* Get Jetpack Boost
* Go to /me/purchases
* Cancel it. It's not refundable because credits are not refundable, so the offer will become available

<img width="1386" alt="Screenshot 2025-07-03 at 13 51 40" src="https://github.com/user-attachments/assets/c7a35abe-023c-45a7-ad5f-540e77afc668" />

Canceling closes the window, submit - submits the cancellation survey. Get discount produces this:

<img width="1390" alt="Screenshot 2025-07-03 at 13 57 15" src="https://github.com/user-attachments/assets/431d346d-a4cb-48a3-93ef-9b2adc35dacd" />

The offer is applied:
<img width="1089" alt="Screenshot 2025-07-03 at 13 57 57" src="https://github.com/user-attachments/assets/b6be15e9-c4a4-4f2e-9c2c-1f8622f2a50c" />

However, the auto-renew is off.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
