### PR TITLE
Dashboard v2: reapply the font antialiasing styles

### DIFF
--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -32,6 +32,13 @@ body {
 	background: var( --dashboard__background-color );
 	color: var( --dashboard__text-color );
 	line-height: $font-line-height-small;
+
+	/* stylelint-disable-next-line unit-allowed-list */
+	@media (-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi) {
+		text-rendering: optimizeLegibility;
+		-moz-osx-font-smoothing: grayscale;
+		-webkit-font-smoothing: antialiased;
+	}
 }
 
 a {


### PR DESCRIPTION
## Proposed Changes

This PR reapplies the font anti-aliasing styles that was done for Calypso. See:

- https://github.com/Automattic/wp-calypso/pull/54196
- p58i-aHm-p2

The backported sites list already has the anti-aliasing styles applied. This PR reapplies it to v2 sites list.

Screenshots (taken on a 16" MBP):

|Before|After|
|-|-|
|<img width="373" alt="image" src="https://github.com/user-attachments/assets/0d34baa3-6b38-44aa-bb70-5bdbb02c818c" />|<img width="363" alt="image" src="https://github.com/user-attachments/assets/8c83de2d-b7a2-4887-a9f7-7b7a69ab74b5" />


## Testing Instructions

1. Go to `/v2/sites` (v2 sites list)
2. Go to `/sites?flags=dashboard/v2/backport/sites-list` (backported sites list)
3. Verify sites lists look the same.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?