### PR TITLE
Mobile apps: Clear noise on OAuth2 login page

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -31,6 +31,8 @@ import {
 	isPartnerPortalOAuth2Client,
 	isStudioAppOAuth2Client,
 	isVIPOAuth2Client,
+	isAndroidOAuth2Client,
+	isIosOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { createAccountUrl } from 'calypso/lib/paths';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
@@ -337,7 +339,9 @@ export default withCurrentRoute(
 			const isGravatar = isGravatarOAuth2Client( oauth2Client );
 			const isWPJobManager = isWPJobManagerOAuth2Client( oauth2Client );
 			const isBlazePro = getIsBlazePro( state );
+			const isAndroid = isAndroidOAuth2Client( oauth2Client );
 			const isGravPoweredClient = isGravPoweredOAuth2Client( oauth2Client );
+			const isIos = isIosOAuth2Client( oauth2Client );
 			const isPartnerPortal = isPartnerPortalOAuth2Client( oauth2Client );
 			const isWooJPC = isWooJPCFlow( state );
 			const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
@@ -359,7 +363,9 @@ export default withCurrentRoute(
 						isWoo ||
 						isJetpackCloudClient ||
 						isJetpackLogin ||
-						isVIPClient ) ) ||
+						isVIPClient ||
+						isAndroid ||
+						isIos ) ) ||
 				isPartnerPortal;
 
 			const noMasterbarForRoute =

--- a/client/lib/oauth2-clients.js
+++ b/client/lib/oauth2-clients.js
@@ -2,6 +2,10 @@ export const isAkismetOAuth2Client = ( oauth2Client ) => {
 	return oauth2Client?.id === 973;
 };
 
+export const isAndroidOAuth2Client = ( oauth2Client ) => {
+	return oauth2Client?.id === 2697;
+};
+
 export const isCrowdsignalOAuth2Client = ( oauth2Client ) => {
 	return oauth2Client?.id === 978;
 };
@@ -12,6 +16,10 @@ export const isGravatarFlowOAuth2Client = ( oauth2Client ) => {
 
 export const isGravatarOAuth2Client = ( oauth2Client ) => {
 	return oauth2Client?.id === 1854 || isGravatarFlowOAuth2Client( oauth2Client );
+};
+
+export const isIosOAuth2Client = ( oauth2Client ) => {
+	return oauth2Client?.id === 11;
 };
 
 export const isWPJobManagerOAuth2Client = ( oauth2Client ) => {


### PR DESCRIPTION
Fixes DOTOBRD-161

## Proposed Changes

* Remove the header on the mobile apps login page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As explained on issue, we want to remove potential distractions so the users focus on logging in.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to `/log-in?client_id=2697&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D2697%26redirect_uri%3Dwordpress%253A%252F%252Fwpcom-authorize%26response_type%3Dcode%26scope%3Dglobal%26from-calypso%3D1` (the link you would get if trying to log in on the wordpress mobile app for android)
* Check that the header and footer links, terms of service text, and the `Back` button have been removed.
* Repeat with `/log-in?client_id=11&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D11%26redirect_uri%3Dwordpress%253A%252F%252Fwpcom-authorize%26response_type%3Dcode%26scope%3Dglobal%26from-calypso%3D1` (the link you would get if trying to log in on the wordpress mobile app for iOs)

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/de123a0b-a90c-49b9-90c5-eea6f0cd01d3)|![image](https://github.com/user-attachments/assets/36ea31e4-c56e-486c-b97e-b4cb1f9fc3f6)|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
