### PR TITLE
Staging Sites Redesign: Ensure the Activity log link in the Sync modal points to correct target site

### DIFF
--- a/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
@@ -7,15 +7,15 @@ import AsyncLoad from 'calypso/components/async-load';
 interface SyncDropdownProps {
 	className?: string;
 	environment: 'production' | 'staging';
-	productionSiteSlug: string;
-	stagingSiteSlug: string;
+	productionSiteId: number;
+	stagingSiteId: number;
 }
 
 export default function SyncDropdown( {
 	className,
 	environment,
-	productionSiteSlug,
-	stagingSiteSlug,
+	productionSiteId,
+	stagingSiteId,
 }: SyncDropdownProps ) {
 	const [ isModalOpen, setIsModalOpen ] = useState< boolean >( false );
 	const [ syncType, setSyncType ] = useState< 'pull' | 'push' >( 'pull' );
@@ -83,8 +83,8 @@ export default function SyncDropdown( {
 					onClose={ handleCloseModal }
 					syncType={ syncType }
 					environment={ environment }
-					productionSiteSlug={ productionSiteSlug }
-					stagingSiteSlug={ stagingSiteSlug }
+					productionSiteId={ productionSiteId }
+					stagingSiteId={ stagingSiteId }
 				/>
 			) }
 		</>

--- a/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
@@ -7,10 +7,16 @@ import AsyncLoad from 'calypso/components/async-load';
 interface SyncDropdownProps {
 	className?: string;
 	environment: 'production' | 'staging';
-	siteSlug: string;
+	productionSiteSlug: string;
+	stagingSiteSlug: string;
 }
 
-export default function SyncDropdown( { className, environment, siteSlug }: SyncDropdownProps ) {
+export default function SyncDropdown( {
+	className,
+	environment,
+	productionSiteSlug,
+	stagingSiteSlug,
+}: SyncDropdownProps ) {
 	const [ isModalOpen, setIsModalOpen ] = useState< boolean >( false );
 	const [ syncType, setSyncType ] = useState< 'pull' | 'push' >( 'pull' );
 
@@ -77,7 +83,8 @@ export default function SyncDropdown( { className, environment, siteSlug }: Sync
 					onClose={ handleCloseModal }
 					syncType={ syncType }
 					environment={ environment }
-					siteSlug={ siteSlug }
+					productionSiteSlug={ productionSiteSlug }
+					stagingSiteSlug={ stagingSiteSlug }
 				/>
 			) }
 		</>

--- a/client/sites/components/site-preview-pane/preview-pane-header-buttons.tsx
+++ b/client/sites/components/site-preview-pane/preview-pane-header-buttons.tsx
@@ -10,7 +10,6 @@ import SyncDropdown from 'calypso/dashboard/sites/staging-site-sync-dropdown';
 import hasWpcomStagingSite from 'calypso/state/selectors/has-wpcom-staging-site';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import { useSiteAdminInterfaceData } from 'calypso/state/sites/hooks';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
 import getSite from 'calypso/state/sites/selectors/get-site';
 import type { ItemData } from 'calypso/layout/hosting-dashboard/item-view/types';
 
@@ -41,15 +40,12 @@ const PreviewPaneHeaderButtons = ( { focusRef, itemData }: Props ) => {
 	);
 
 	const productionSiteId = isStagingSite
-		? site?.options?.wpcom_production_blog_id
-		: itemData.blogId;
-	const productionSiteSlug =
-		useSelector( ( state ) => getSiteSlug( state, productionSiteId ) ) ?? '';
+		? site?.options?.wpcom_production_blog_id ?? 0
+		: itemData.blogId ?? 0;
 
 	const stagingSiteId = hasStagingSite
-		? site?.options?.wpcom_staging_blog_ids?.[ 0 ]
-		: itemData.blogId;
-	const stagingSiteSlug = useSelector( ( state ) => getSiteSlug( state, stagingSiteId ) ) ?? '';
+		? site?.options?.wpcom_staging_blog_ids?.[ 0 ] ?? 0
+		: itemData.blogId ?? 0;
 
 	const environment = isStagingSite ? 'staging' : 'production';
 
@@ -59,8 +55,8 @@ const PreviewPaneHeaderButtons = ( { focusRef, itemData }: Props ) => {
 				<SyncDropdown
 					className="item-preview__sync-dropdown"
 					environment={ environment }
-					productionSiteSlug={ productionSiteSlug }
-					stagingSiteSlug={ stagingSiteSlug }
+					productionSiteId={ productionSiteId }
+					stagingSiteId={ stagingSiteId }
 				/>
 			) }
 			<Button

--- a/client/sites/components/site-preview-pane/preview-pane-header-buttons.tsx
+++ b/client/sites/components/site-preview-pane/preview-pane-header-buttons.tsx
@@ -11,6 +11,7 @@ import hasWpcomStagingSite from 'calypso/state/selectors/has-wpcom-staging-site'
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import { useSiteAdminInterfaceData } from 'calypso/state/sites/hooks';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
+import getSite from 'calypso/state/sites/selectors/get-site';
 import type { ItemData } from 'calypso/layout/hosting-dashboard/item-view/types';
 
 import './preview-pane-header-buttons.scss';
@@ -27,6 +28,8 @@ const PreviewPaneHeaderButtons = ( { focusRef, itemData }: Props ) => {
 
 	const stagingSitesRedesign = config.isEnabled( 'hosting/staging-sites-redesign' );
 
+	const site = useSelector( ( state ) => getSite( state, itemData.blogId ) );
+
 	const isStagingSite = useSelector( ( state ) =>
 		isSiteWpcomStaging( state, itemData.blogId ?? null )
 	);
@@ -37,15 +40,27 @@ const PreviewPaneHeaderButtons = ( { focusRef, itemData }: Props ) => {
 		stagingSitesRedesign && ( isStagingSite || hasStagingSite )
 	);
 
-	const siteSlug = useSelector( ( state ) => getSiteSlug( state, itemData.blogId ) ) ?? '';
+	const productionSiteId = isStagingSite
+		? site?.options?.wpcom_production_blog_id
+		: itemData.blogId;
+	const productionSiteSlug =
+		useSelector( ( state ) => getSiteSlug( state, productionSiteId ) ) ?? '';
+
+	const stagingSiteId = hasStagingSite
+		? site?.options?.wpcom_staging_blog_ids?.[ 0 ]
+		: itemData.blogId;
+	const stagingSiteSlug = useSelector( ( state ) => getSiteSlug( state, stagingSiteId ) ) ?? '';
+
+	const environment = isStagingSite ? 'staging' : 'production';
 
 	return (
 		<>
 			{ shouldShowSyncDropdown && (
 				<SyncDropdown
 					className="item-preview__sync-dropdown"
-					environment={ isStagingSite ? 'staging' : 'production' }
-					siteSlug={ siteSlug }
+					environment={ environment }
+					productionSiteSlug={ productionSiteSlug }
+					stagingSiteSlug={ stagingSiteSlug }
 				/>
 			) }
 			<Button

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -14,11 +14,13 @@ import {
 import { createInterpolateElement } from '@wordpress/element';
 import { __, isRTL } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
+import { useSelector } from 'react-redux';
 import InlineSupportLink from 'calypso/dashboard/components/inline-support-link';
 import { SectionHeader } from 'calypso/dashboard/components/section-header';
 import SiteEnvironmentBadge, {
 	EnvironmentType,
 } from 'calypso/dashboard/components/site-environment-badge';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 
 const DirectionArrow = () => {
 	return (
@@ -61,8 +63,8 @@ interface SyncModalProps {
 	onClose: () => void;
 	syncType: 'pull' | 'push';
 	environment: 'production' | 'staging';
-	productionSiteSlug: string;
-	stagingSiteSlug: string;
+	productionSiteId: number;
+	stagingSiteId: number;
 }
 
 interface EnvironmentConfig {
@@ -138,13 +140,17 @@ export default function SyncModal( {
 	onClose,
 	syncType,
 	environment,
-	productionSiteSlug,
-	stagingSiteSlug,
+	productionSiteId,
+	stagingSiteId,
 }: SyncModalProps ) {
 	const syncConfig = getSyncConfig( syncType );
 
 	const targetEnvironment = syncConfig[ environment ].syncTo;
 	const sourceEnvironment = syncConfig[ environment ].syncFrom;
+
+	const productionSiteSlug =
+		useSelector( ( state ) => getSiteSlug( state, productionSiteId ) ) ?? '';
+	const stagingSiteSlug = useSelector( ( state ) => getSiteSlug( state, stagingSiteId ) ) ?? '';
 
 	const targetSiteSlug = targetEnvironment === 'production' ? productionSiteSlug : stagingSiteSlug;
 

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -61,7 +61,8 @@ interface SyncModalProps {
 	onClose: () => void;
 	syncType: 'pull' | 'push';
 	environment: 'production' | 'staging';
-	siteSlug: string;
+	productionSiteSlug: string;
+	stagingSiteSlug: string;
 }
 
 interface EnvironmentConfig {
@@ -133,11 +134,19 @@ const getSyncConfig = ( type: 'pull' | 'push' ): SyncConfig => {
 	};
 };
 
-export default function SyncModal( { onClose, syncType, environment, siteSlug }: SyncModalProps ) {
+export default function SyncModal( {
+	onClose,
+	syncType,
+	environment,
+	productionSiteSlug,
+	stagingSiteSlug,
+}: SyncModalProps ) {
 	const syncConfig = getSyncConfig( syncType );
 
-	// TODO: Once we use the component in the Dashbaord V2, let's get siteSlug from Router instead of the passed prop
-	//const { siteSlug } = siteRoute.useParams();
+	const targetEnvironment = syncConfig[ environment ].syncTo;
+	const sourceEnvironment = syncConfig[ environment ].syncFrom;
+
+	const targetSiteSlug = targetEnvironment === 'production' ? productionSiteSlug : stagingSiteSlug;
 
 	return (
 		<Modal
@@ -149,19 +158,16 @@ export default function SyncModal( { onClose, syncType, environment, siteSlug }:
 				<VStack spacing={ 7 }>
 					<Text>
 						{ createInterpolateElement( syncConfig[ environment ].description, {
-							a: <ExternalLink href={ `/backup/${ siteSlug }` } children={ null } />,
+							a: <ExternalLink href={ `/backup/${ targetSiteSlug }` } children={ null } />,
 						} ) }
 					</Text>
 					<HStack spacing={ 2 } alignment="center">
 						<EnvironmentLabel
 							label={ syncConfig.fromLabel }
-							environmentType={ syncConfig[ environment ].syncFrom }
+							environmentType={ sourceEnvironment }
 						/>
 						<DirectionArrow />
-						<EnvironmentLabel
-							label={ syncConfig.toLabel }
-							environmentType={ syncConfig[ environment ].syncTo }
-						/>
+						<EnvironmentLabel label={ syncConfig.toLabel } environmentType={ targetEnvironment } />
 					</HStack>
 					<SectionHeader level={ 3 } title={ syncConfig.syncSelectionHeading } />
 					<Text>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTDEV-197

## Proposed Changes

* update Sync modal to use separate production and staging site slugs for correct Activity log link

![Markup on 2025-07-03 at 16:17:04](https://github.com/user-attachments/assets/61c36f02-92aa-46a4-b864-cec171802c84)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

DOTDEV-197

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start` (or use Calypso Live).
2. Ensure the `hosting/staging-sites-redesign` feature flag is enabled (by using `?flags=hosting/staging-sites-redesign` query parameter).
3. Head over to the `/sites` dashboard and select an Atomic test site that has a staging site created.
4. Open the Sync dropdown in the (`https://calypso.localhost:3000/overview/{site-slug}?flags=hosting/staging-sites-redesign`) and try both its options.
5. Modal should open with correct content, matching the action user wants to take. Try to click the `Activity log` link in the description. It should always lead to the **target site** of the sync operation.
6. Switch to related staging site and repeat the steps 4 to 5.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
