### PR TITLE
Checkout: Fix unit tests that are failing due to a missing Country field

### DIFF
--- a/client/my-sites/checkout/src/components/wp-contact-form.tsx
+++ b/client/my-sites/checkout/src/components/wp-contact-form.tsx
@@ -51,7 +51,8 @@ const BillingFormFields = styled.div< BillingFormFieldsProps >`
 	${ ( props ) =>
 		props.isLoading &&
 		css`
-			+ button {
+			&,
+			& + button {
 				display: none;
 			}
 		` }
@@ -87,8 +88,11 @@ export default function WPContactForm( {
 	} );
 
 	return (
-		<BillingFormFields isLoading={ ! hasCompleted }>
-			{ hasCompleted ? (
+		<>
+			{ ! hasCompleted && (
+				<LoadingText>{ translate( 'Retrieving contact details…' ) }</LoadingText>
+			) }
+			<BillingFormFields isLoading={ ! hasCompleted }>
 				<ContactDetailsContainer
 					contactDetailsType={ contactDetailsType }
 					contactInfo={ contactInfo }
@@ -97,9 +101,7 @@ export default function WPContactForm( {
 					isDisabled={ isDisabled }
 					isLoggedOutCart={ isLoggedOutCart }
 				/>
-			) : (
-				<LoadingText>{ translate( 'Retrieving contact details…' ) }</LoadingText>
-			) }
-		</BillingFormFields>
+			</BillingFormFields>
+		</>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://github.com/Automattic/wp-calypso/pull/104550#issuecomment-3028447797

## Proposed Changes

* Referring to https://github.com/Automattic/wp-calypso/pull/104550#issuecomment-3028447797, the problem started with https://github.com/Automattic/wp-calypso/pull/99149.
* As a result, this PR addresses the failing unit tests caused by a missing Country field by continuing to render `BillingFormFields` with `display: none`;

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The following unit tests should pass
  * client/my-sites/checkout/src/test/checkout-contact-autocomplete.tsx
  * client/my-sites/checkout/src/test/checkout-vat-form.tsx

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
