### PR TITLE
Performance Profiler: Change loading messages while generating recommendations

### DIFF
--- a/client/performance-profiler/components/metrics-insight/index.tsx
+++ b/client/performance-profiler/components/metrics-insight/index.tsx
@@ -113,8 +113,6 @@ export const MetricsInsight: React.FC< MetricsInsightProps > = ( props ) => {
 		activeTab
 	);
 
-	const isLoadingLlmAnswer = isLoading || ! isFetched;
-
 	const { data } = useUrlPerformanceInsightsQuery( url, hash );
 	const wpscanErrors = data?.wpscan?.errors;
 	const hasWpscanErrors = wpscanErrors && Object.keys( wpscanErrors ).length > 0;
@@ -156,7 +154,8 @@ export const MetricsInsight: React.FC< MetricsInsightProps > = ( props ) => {
 						description: llmAnswer?.messages,
 					} }
 					secondaryArea={ tip && <Tip { ...tip } /> }
-					isLoading={ isLoadingLlmAnswer }
+					isLoading={ isLoading }
+					isFetched={ isFetched }
 					isWpscanLoading={ isWpscanLoading }
 					AIGenerated
 					hash={ hash }

--- a/client/performance-profiler/components/metrics-insight/insight-content.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-content.tsx
@@ -43,7 +43,7 @@ export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
 	const [ feedbackOpen, setFeedbackOpen ] = useState( false );
 	const [ userFeedback, setUserFeedback ] = useState( '' );
 	const [ messageIndex, setMessageIndex ] = useState( 0 );
-	const messageTimer = useRef< number | null >( null );
+	const messageTimer = useRef< ReturnType< typeof setTimeout > | null >( null );
 
 	const messages = useMemo(
 		() => [

--- a/client/performance-profiler/components/metrics-insight/insight-content.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-content.tsx
@@ -48,12 +48,12 @@ export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
 	const messages = useMemo(
 		() => [
 			{
-				message: translate( 'Generating a personalized solution for your site using AI' ),
+				message: translate( 'Generating a personalized solution for your site using AI…' ),
 				nextTimer: 3000,
 			},
-			{ message: translate( 'Writing instructions' ), nextTimer: 3000 },
-			{ message: translate( 'This is taking a little longer than I thought' ), nextTimer: 4000 },
-			{ message: translate( 'Stick with me' ), nextTimer: null },
+			{ message: translate( 'Writing instructions…' ), nextTimer: 3000 },
+			{ message: translate( 'This is taking a little longer than I thought…' ), nextTimer: 4000 },
+			{ message: translate( 'Stick with me…' ), nextTimer: null },
 		],
 		[ translate ]
 	);

--- a/client/performance-profiler/components/metrics-insight/insight-content.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-content.tsx
@@ -58,6 +58,11 @@ export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
 		[ translate ]
 	);
 
+	/**
+	 * Updates the current message index and schedules the next message in the sequence.
+	 * Only schedules the next timer if loading is still active and there are more messages.
+	 * @param currentIndex - The index of the message to display
+	 */
 	const updateMessageIndex = useCallback(
 		( currentIndex: number ) => {
 			setMessageIndex( currentIndex );

--- a/client/performance-profiler/components/metrics-insight/insight-content.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-content.tsx
@@ -78,7 +78,6 @@ export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
 
 	useEffect( () => {
 		if ( isLoading && ! messageTimer.current ) {
-			setMessageIndex( 0 );
 			updateMessageIndex( 0 );
 		}
 		return () => {

--- a/client/performance-profiler/components/metrics-insight/insight-content.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-content.tsx
@@ -1,6 +1,6 @@
 import { Button, TextareaControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import Markdown from 'react-markdown';
 import {
 	FullPageScreenshot,
@@ -17,6 +17,7 @@ interface InsightContentProps {
 	data: PerformanceMetricsItemQueryResponse;
 	secondaryArea?: React.ReactNode;
 	isLoading?: boolean;
+	isFetched?: boolean;
 	isWpscanLoading?: boolean;
 	AIGenerated: boolean;
 	hash: string;
@@ -26,12 +27,63 @@ interface InsightContentProps {
 
 export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
 	const translate = useTranslate();
-	const { data, fullPageScreenshot, isLoading, isWpscanLoading, AIGenerated, hash, url, chatId } =
-		props;
+	const {
+		data,
+		fullPageScreenshot,
+		isLoading,
+		isFetched,
+		isWpscanLoading,
+		AIGenerated,
+		hash,
+		url,
+		chatId,
+	} = props;
 	const { description = '' } = data ?? {};
 	const [ feedbackSent, setFeedbackSent ] = useState( false );
 	const [ feedbackOpen, setFeedbackOpen ] = useState( false );
 	const [ userFeedback, setUserFeedback ] = useState( '' );
+	const [ messageIndex, setMessageIndex ] = useState( 0 );
+	const messageTimer = useRef< NodeJS.Timeout | null >( null );
+
+	const messages = useMemo(
+		() => [
+			{
+				message: translate( 'Generating a personalized solution for your site using AI' ),
+				nextTimer: 3000,
+			},
+			{ message: translate( 'Writing instructions' ), nextTimer: 3000 },
+			{ message: translate( 'This is taking a little longer than I thought' ), nextTimer: 4000 },
+			{ message: translate( 'Stick with me' ), nextTimer: null },
+		],
+		[ translate ]
+	);
+
+	const updateMessageIndex = useCallback(
+		( currentIndex: number ) => {
+			setMessageIndex( currentIndex );
+			const currentMessage = messages[ currentIndex ];
+			if ( currentMessage.nextTimer && currentIndex < messages.length - 1 && isLoading ) {
+				messageTimer.current = setTimeout( () => {
+					updateMessageIndex( currentIndex + 1 );
+				}, currentMessage.nextTimer );
+			}
+		},
+		[ isLoading, messages ]
+	);
+
+	useEffect( () => {
+		if ( isLoading && ! messageTimer.current ) {
+			setMessageIndex( 0 );
+			updateMessageIndex( 0 );
+		}
+		return () => {
+			if ( messageTimer.current ) {
+				clearTimeout( messageTimer.current );
+				messageTimer.current = null;
+			}
+		};
+	}, [ isLoading, updateMessageIndex ] );
+
 	const onSurveyClick = ( rating: string ) => {
 		recordTracksEvent( 'calypso_performance_profiler_llm_survey_click', {
 			hash,
@@ -111,12 +163,12 @@ export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
 				/>
 			);
 		}
-		return <LLMMessage message={ translate( 'Finding the best solution for your page' ) } rotate />;
+		return <LLMMessage message={ messages[ messageIndex ].message } rotate />;
 	};
 
 	return (
 		<div className="metrics-insight-content">
-			{ isLoading || isWpscanLoading ? (
+			{ isLoading || isWpscanLoading || ! isFetched ? (
 				renderLoadingMessage()
 			) : (
 				<>

--- a/client/performance-profiler/components/metrics-insight/insight-content.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-content.tsx
@@ -60,6 +60,7 @@ export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
 
 	/**
 	 * Updates the current message index and schedules the next message in the sequence.
+	 * It is used for rotating display message, while insights are fetched from the API.
 	 * Only schedules the next timer if loading is still active and there are more messages.
 	 * @param currentIndex - The index of the message to display
 	 */

--- a/client/performance-profiler/components/metrics-insight/insight-content.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-content.tsx
@@ -31,7 +31,7 @@ export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
 		data,
 		fullPageScreenshot,
 		isLoading,
-		isFetched,
+		isFetched = false,
 		isWpscanLoading,
 		AIGenerated,
 		hash,
@@ -43,7 +43,7 @@ export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
 	const [ feedbackOpen, setFeedbackOpen ] = useState( false );
 	const [ userFeedback, setUserFeedback ] = useState( '' );
 	const [ messageIndex, setMessageIndex ] = useState( 0 );
-	const messageTimer = useRef< NodeJS.Timeout | null >( null );
+	const messageTimer = useRef< number | null >( null );
 
 	const messages = useMemo(
 		() => [


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTDEV-47

## Proposed Changes

* Add progressive messages while generating recommendations

| 1st | 2nd | 3rd | 4th |
|--------|--------|--------|--------|
| ![image](https://github.com/user-attachments/assets/a819f9d6-c606-4e4b-bb2b-fbd9cbb5cb37) | ![image](https://github.com/user-attachments/assets/f6b65b72-9d43-4fe9-ab5b-6082a8fc8f8a) | ![image](https://github.com/user-attachments/assets/b4b76deb-12b9-4aab-8cb3-9604d33ddb5b) | ![image](https://github.com/user-attachments/assets/22a523c0-f857-4c9e-b450-fc09bd4381f6) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We should update the loading message shown while generating recommendation content to reassure the user that something is happening.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch
* Navigate to the Performance Profiler and run a report, or open an existing report, e.g. /speed-test-tool?url=https%3A%2F%2Fwordpress.com%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6Nzc3Mn0.048zsfIxmJ0M_YpPGRg0QSsTmtMglyBAlPMJhrGB1vg
* Open recommendations and see if messages are displayed as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
