### PR TITLE
[DO NOT MERGE] Sites list v2: add tooltip to Uptime, Visitors, Views, and Likes columns

### DIFF
--- a/client/dashboard/sites/fields.tsx
+++ b/client/dashboard/sites/fields.tsx
@@ -183,24 +183,28 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 	{
 		id: 'uptime',
 		label: __( 'Uptime' ),
+		description: __( 'Past 7 days' ),
 		render: ( { item } ) => <Uptime site={ item } />,
 		enableSorting: false,
 	},
 	{
 		id: 'visitors',
 		label: __( 'Visitors' ),
+		description: __( 'Past 7 days' ),
 		render: ( { item } ) => <EngagementStat site={ item } type="visitors" />,
 		enableSorting: false,
 	},
 	{
 		id: 'views',
 		label: __( 'Views' ),
+		description: __( 'Past 7 days' ),
 		render: ( { item } ) => <EngagementStat site={ item } type="views" />,
 		enableSorting: false,
 	},
 	{
 		id: 'likes',
 		label: __( 'Likes' ),
+		description: __( 'Past 7 days' ),
 		render: ( { item } ) => <EngagementStat site={ item } type="likes" />,
 		enableSorting: false,
 	},


### PR DESCRIPTION
Part of DOTDASH-75

## Proposed Changes

This PR adds a `Past 7 days` tooltip to the Uptime, Visitors, Views, and Likes columns.

<img width="534" alt="image" src="https://github.com/user-attachments/assets/ceaa93ab-73d0-48b9-825d-e3a5a1a9b61c" />


## Why are these changes being made?

To clarify the data range for the those columns.

## Testing Instructions

1. Check out this branch.
2. Apply this PR manually to wp-calypso's local dataviews 🙈 : https://github.com/WordPress/gutenberg/pull/70610
3. Go to `/v2/sites`
4. Show the Uptime, Visitors, Views, and Likes columns
5. Hover over the column header
6. Verify you see the tooltip

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
