### PR TITLE
Enable Sites List v2 on wpcalypso and horizon envs

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -27,7 +27,7 @@
 		"current-site/notice": true,
 		"dashboard/v2": false,
 		"dashboard/v2/backport/site-settings": true,
-		"dashboard/v2/backport/sites-list": false,
+		"dashboard/v2/backport/sites-list": true,
 		"design-picker/use-assembler-styles": true,
 		"devdocs": false,
 		"global-styles/on-personal-plan": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -36,7 +36,7 @@
 		"current-site/notice": true,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-settings": true,
-		"dashboard/v2/backport/sites-list": false,
+		"dashboard/v2/backport/sites-list": true,
 		"design-picker/use-assembler-styles": true,
 		"dev/auth-helper": true,
 		"dev/account-settings-helper": true,


### PR DESCRIPTION
## Proposed Changes

Enables the `dashboard/v2/backport/sites-list` flag on `wpcalypso` and `horizon`.

## Why are these changes being made?

CfT preparation.

## Testing Instructions

1. Go to /sites
2. Verify you see the new sites list.
