### PR TITLE
Update tracks events for cancellations

### DIFF
--- a/client/components/marketing-survey/cancel-jetpack-form/index.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/index.tsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { isJetpackSearchFree } from '@automattic/calypso-products';
 import { Button, Dialog } from '@automattic/components';
 import { BaseButton } from '@automattic/components/dist/types/dialog/button-bar';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
@@ -94,6 +95,11 @@ const CancelJetpackForm: React.FC< Props > = ( {
 	// Record an event for Tracks
 	const recordEvent = useCallback(
 		( name: string, properties = {} ) => {
+			// Skip tracks events for Jetpack Search Free
+			if ( isJetpackSearchFree( purchase ) ) {
+				return;
+			}
+
 			dispatch(
 				recordTracksEvent( name, {
 					cancellation_flow: flowType,
@@ -104,7 +110,7 @@ const CancelJetpackForm: React.FC< Props > = ( {
 				} )
 			);
 		},
-		[ dispatch, flowType, isAtomicSite, purchase.productSlug ]
+		[ dispatch, flowType, isAtomicSite, purchase.productSlug, purchase ]
 	);
 
 	/**
@@ -226,9 +232,12 @@ const CancelJetpackForm: React.FC< Props > = ( {
 		answerText: TranslateResult | string
 	) => {
 		if ( answerId !== surveyAnswerId ) {
-			recordTracksEvent( 'calypso_purchases_cancel_jetpack_survey_answer_change', {
-				answer_id: answerId,
-			} );
+			// Skip tracks events for Jetpack Search Free
+			if ( ! isJetpackSearchFree( purchase ) ) {
+				recordTracksEvent( 'calypso_purchases_cancel_jetpack_survey_answer_change', {
+					answer_id: answerId,
+				} );
+			}
 		}
 
 		setSurveyAnswerId( answerId );

--- a/client/components/marketing-survey/cancel-jetpack-form/index.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/index.tsx
@@ -110,7 +110,7 @@ const CancelJetpackForm: React.FC< Props > = ( {
 				} )
 			);
 		},
-		[ dispatch, flowType, isAtomicSite, purchase.productSlug, purchase ]
+		[ dispatch, flowType, isAtomicSite, purchase ]
 	);
 
 	/**
@@ -232,12 +232,9 @@ const CancelJetpackForm: React.FC< Props > = ( {
 		answerText: TranslateResult | string
 	) => {
 		if ( answerId !== surveyAnswerId ) {
-			// Skip tracks events for Jetpack Search Free
-			if ( ! isJetpackSearchFree( purchase ) ) {
-				recordTracksEvent( 'calypso_purchases_cancel_jetpack_survey_answer_change', {
-					answer_id: answerId,
-				} );
-			}
+			recordTracksEvent( 'calypso_purchases_cancel_jetpack_survey_answer_change', {
+				answer_id: answerId,
+			} );
 		}
 
 		setSurveyAnswerId( answerId );

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -185,7 +185,7 @@ class CancelPurchaseForm extends Component {
 
 		// Only fire the tracking event if this is a dropdown selection (detailsValue is undefined)
 		if ( detailsValue === undefined && value && value !== '' ) {
-			this.recordClickRadioEvent( 'radio_1_details', value );
+			this.recordClickRadioEvent( 'radio_1_2', value );
 		}
 
 		const newState = {

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -510,7 +510,13 @@ class CancelPurchaseForm extends Component {
 
 		this.setState( { surveyStep: newStep } );
 
-		this.recordEvent( 'calypso_purchases_cancel_survey_step', { new_step: newStep } );
+		// Include upsell information when tracking the upsell step
+		const eventProperties = { new_step: newStep };
+		if ( newStep === UPSELL_STEP && this.state.upsell ) {
+			eventProperties.upsell_type = this.state.upsell;
+		}
+
+		this.recordEvent( 'calypso_purchases_cancel_survey_step', eventProperties );
 	};
 
 	clickNext = () => {

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -182,6 +182,12 @@ class CancelPurchaseForm extends Component {
 		const { downgradeClick, freeMonthOfferClick, purchase } = this.props;
 		const value = eventOrValue?.currentTarget?.value ?? eventOrValue;
 		const { purchaseIsAlreadyExtended, questionOneDetails } = this.state;
+
+		// Only fire the tracking event if this is a dropdown selection (detailsValue is undefined)
+		if ( detailsValue === undefined && value && value !== '' ) {
+			this.recordClickRadioEvent( 'radio_1_details', value );
+		}
+
 		const newState = {
 			...this.state,
 			questionOneText: value,

--- a/client/me/purchases/cancel-purchase/domain-options.jsx
+++ b/client/me/purchases/cancel-purchase/domain-options.jsx
@@ -8,9 +8,11 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { UPDATE_NAMESERVERS } from '@automattic/urls';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback } from 'react';
+import { useDispatch } from 'react-redux';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormRadio from 'calypso/components/forms/form-radio';
 import { getName, isRefundable, isSubscription } from 'calypso/lib/purchases';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 const NonRefundableDomainMappingMessage = ( { includedDomainPurchase } ) => {
 	const translate = useTranslate();
@@ -123,6 +125,7 @@ const CancelPurchaseDomainOptions = ( {
 } ) => {
 	const translate = useTranslate();
 	const [ confirmCancel, setConfirmCancel ] = useState( false );
+	const dispatch = useDispatch();
 
 	const onCancelBundledDomainChange = useCallback(
 		( event ) => {
@@ -143,8 +146,24 @@ const CancelPurchaseDomainOptions = ( {
 				cancelBundledDomain,
 				confirmCancelBundledDomain: checked,
 			} );
+
+			// Record tracks event for domain confirmation checkbox
+			dispatch(
+				recordTracksEvent( 'calypso_purchases_domain_confirm_checkbox', {
+					product_slug: purchase.productSlug,
+					purchase_id: purchase.id,
+					domain_name: includedDomainPurchase.meta,
+					checked: checked,
+				} )
+			);
 		},
-		[ cancelBundledDomain, onCancelConfirmationStateChange ]
+		[
+			cancelBundledDomain,
+			onCancelConfirmationStateChange,
+			purchase,
+			includedDomainPurchase,
+			dispatch,
+		]
 	);
 
 	if ( ! includedDomainPurchase || ! isSubscription( purchase ) ) {

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -160,12 +160,22 @@ class CancelPurchase extends Component {
 	};
 
 	onDomainConfirmationChange = () => {
-		this.setState( { domainConfirmationConfirmed: ! this.state.domainConfirmationConfirmed } );
+		const { purchase } = this.props;
+		const newValue = ! this.state.domainConfirmationConfirmed;
+
+		this.setState( { domainConfirmationConfirmed: newValue } );
+
+		// Record tracks event for domain confirmation checkbox
+		this.props.recordTracksEvent( 'calypso_purchases_domain_confirmation_checkbox', {
+			product_slug: purchase.productSlug,
+			purchase_id: purchase.id,
+			checked: newValue,
+		} );
 	};
 
 	onKeepSubscriptionClick = () => {
 		const { purchase } = this.props;
-		recordTracksEvent( 'calypso_purchases_keep_subscription', {
+		this.props.recordTracksEvent( 'calypso_purchases_keep_subscription', {
 			product_slug: purchase.productSlug,
 			purchase_id: purchase.id,
 		} );
@@ -512,28 +522,31 @@ class CancelPurchase extends Component {
 	}
 }
 
-export default connect( ( state, props ) => {
-	const purchase = getByPurchaseId( state, props.purchaseId );
-	const isJetpackPurchase =
-		purchase && ( isJetpackPlan( purchase ) || isJetpackProduct( purchase ) );
-	const purchases = purchase && getSitePurchases( state, purchase.siteId );
-	const productsList = getProductsList( state );
+export default connect(
+	( state, props ) => {
+		const purchase = getByPurchaseId( state, props.purchaseId );
+		const isJetpackPurchase =
+			purchase && ( isJetpackPlan( purchase ) || isJetpackProduct( purchase ) );
+		const purchases = purchase && getSitePurchases( state, purchase.siteId );
+		const productsList = getProductsList( state );
 
-	const domains = purchase && getDomainsBySiteId( state, purchase.siteId );
-	const selectedDomainName = purchase && getName( purchase );
-	const selectedDomain =
-		domains && selectedDomainName && getSelectedDomain( { domains, selectedDomainName } );
+		const domains = purchase && getDomainsBySiteId( state, purchase.siteId );
+		const selectedDomainName = purchase && getName( purchase );
+		const selectedDomain =
+			domains && selectedDomainName && getSelectedDomain( { domains, selectedDomainName } );
 
-	return {
-		hasLoadedSites: ! isRequestingSites( state ),
-		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
-		isJetpackPurchase,
-		purchase,
-		purchases,
-		productsList,
-		includedDomainPurchase: getIncludedDomainPurchase( state, purchase ),
-		site: getSite( state, purchase ? purchase.siteId : null ),
-		isHundredYearDomain: selectedDomain?.isHundredYearDomain,
-		atomicTransfer: getAtomicTransfer( state, purchase?.siteId ),
-	};
-} )( localize( withLocalizedMoment( CancelPurchase ) ) );
+		return {
+			hasLoadedSites: ! isRequestingSites( state ),
+			hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
+			isJetpackPurchase,
+			purchase,
+			purchases,
+			productsList,
+			includedDomainPurchase: getIncludedDomainPurchase( state, purchase ),
+			site: getSite( state, purchase ? purchase.siteId : null ),
+			isHundredYearDomain: selectedDomain?.isHundredYearDomain,
+			atomicTransfer: getAtomicTransfer( state, purchase?.siteId ),
+		};
+	},
+	{ recordTracksEvent }
+)( localize( withLocalizedMoment( CancelPurchase ) ) );

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -38,6 +38,7 @@ import ProductLink from 'calypso/me/purchases/product-link';
 import PurchaseSiteHeader from 'calypso/me/purchases/purchases-site/header';
 import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
 import { isDataLoading } from 'calypso/me/purchases/utils';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import {
 	getByPurchaseId,
@@ -160,6 +161,14 @@ class CancelPurchase extends Component {
 
 	onDomainConfirmationChange = () => {
 		this.setState( { domainConfirmationConfirmed: ! this.state.domainConfirmationConfirmed } );
+	};
+
+	onKeepSubscriptionClick = () => {
+		const { purchase } = this.props;
+		recordTracksEvent( 'calypso_purchases_keep_subscription', {
+			product_slug: purchase.productSlug,
+			purchase_id: purchase.id,
+		} );
 	};
 
 	getActiveMarketplaceSubscriptions() {
@@ -482,6 +491,7 @@ class CancelPurchase extends Component {
 											this.props.siteSlug,
 											this.props.purchaseId
 										) }
+										onClick={ this.onKeepSubscriptionClick }
 									>
 										{ this.props.translate( 'Keep subscription' ) }
 									</FormButton>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13781

## Proposed Changes

* Remove calypso_purchases_cancel_form_submit for Jetpack Free
* Add tracking for Keep subscription CTA
* Add tracking for the 2nd dropdown in the first survey page
* calypso_purchases_cancel_survey_step with upsell_step doesn't specify which step, so add the step
* Add event for the new domain checkbox confirmation
* Add event for the bundle domain confirmation checkbox

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

In order to view the events in a convenient way, open the console and 
```
localStorage.setItem( 'debug', 'calypso:analytics*' );
```
Also, use the Store Sandbox

Jetpack:
* Get Jetpack Search Free from a Jetpack site
* Cancel it from calypso.localhost:3000/me/purchases - no events should be triggered.
* Jetpack Search Free is not a real product, and should not be purchased or cancelled or managed in any way through the purchases UI. However, given that we can't remove it as a product, remove the events to not mess up the cancellation

WPCOM:
* With an already production atomic site, get the Business plan + domain with the sandbox
* go to /me/purchases 
* The atomic confirmation step has 2 new events that you can test - the domain checkbox sends an event, the keep subscription. Keep the domain, you'll need it a bit later
* Then when you proceed to the cancellation, the second dropdown from the top should send an event
* The final new event would need a standalone domain, so you can cancel the one you just created. The checkbox should also send an event
* 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
