### PR TITLE
wpcom-block-editor: Remove the coblocks/applyFontSettings filter when dom is ready

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/fix-coblocks-fonts.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/fix-coblocks-fonts.js
@@ -1,3 +1,4 @@
+import domReady from '@wordpress/dom-ready';
 import { removeFilter } from '@wordpress/hooks';
 import { isEditorReadyWithBlocks } from '../../utils';
 
@@ -14,10 +15,17 @@ import { isEditorReadyWithBlocks } from '../../utils';
  * so we can't remove the filter for just the font styles.
  * @see https://github.com/godaddy-wordpress/coblocks/issues/2475
  */
-async function removeCoBlocksFontStyles() {
-	await isEditorReadyWithBlocks();
-
+function removeCoBlocksFontStyles() {
 	removeFilter( 'blocks.getSaveContent.extraProps', 'coblocks/applyFontSettings' );
 }
 
-removeCoBlocksFontStyles();
+domReady( () => {
+	// Remove the filter immediately when the dom is ready.
+	removeCoBlocksFontStyles();
+
+	// For backward compatibility, this ensures that the filter can be removed
+	// even if it was registered between the DOM ready and editor ready events.
+	isEditorReadyWithBlocks().then( () => {
+		removeCoBlocksFontStyles();
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes THEME-36

## Proposed Changes

* The filter, `coblocks/applyFontSettings`, might be registered before the editor is fully ready, which can lead to a block validation error. To address this, we also attempt to remove the `coblocks/applyFontSettings` filter when the DOM is ready.

Note that the coblocks loads only for the old blog.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* [Apply changes to your sandbox](https://github.com/Automattic/wp-calypso/pull/104598#issuecomment-3034947033) or run the following command to sync changes to your sandbox manually
  ```
  cd apps/wpcom-block-editor
  yarn dev --sync
  ```
* Sandbox widgets.wp.com
* Go to the editor
* Edit a block to set a custom the font
* Reload
* Ensure you won't see the block validation error

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
