### PR TITLE
A4A: Show error message to the user if add managed site request fails

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/index.tsx
@@ -5,7 +5,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import useImportWPCOMSitesMutation from 'calypso/a8c-for-agencies/data/sites/use-import-wpcom-sites';
 import { useDispatch } from 'calypso/state';
-import { successNotice } from 'calypso/state/notices/actions';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import WPCOMSitesTable from './wpcom-sites-table';
 
 import './style.scss';
@@ -48,6 +48,12 @@ export default function ImportFromWPCOMModal( { onImport, onClose }: Props ) {
 							)
 						);
 					}, 1000 );
+				},
+				onError: ( error ) => {
+					setIsPendingImport( false );
+					dispatch(
+						errorNotice( error?.message || translate( 'Something went wrong. Please try again.' ) )
+					);
 				},
 			} );
 		}

--- a/client/a8c-for-agencies/data/sites/use-import-wpcom-sites.ts
+++ b/client/a8c-for-agencies/data/sites/use-import-wpcom-sites.ts
@@ -3,7 +3,9 @@ import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 
-interface APIError {}
+interface APIError {
+	message?: string;
+}
 
 interface APIResponse {
 	success: boolean;


### PR DESCRIPTION
## Proposed Changes

When a user attempts to add a new managed site and the endpoint returns an error, the UI currently fails to display any feedback.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch locally or visit the A4A Live link
* Visit https://agencies.automattic.com/sites and click "Add Sites" -> Via WordPress.com connection
* Force the endpoint for adding new site to return an error by applying 384d0-pb/#diff (using `git apply` or manually) to your sandbox
* Verify the error message is displayed correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?