### PR TITLE
Connect Refresh: Introduce a Login context provider

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -17,6 +17,7 @@ import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
 import { getOAuth2Client } from 'calypso/state/oauth2-clients/selectors';
 import getIsBlazePro from 'calypso/state/selectors/get-is-blaze-pro';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
+import LoginContextProvider from './login-context';
 import MagicLogin from './magic-login';
 import HandleEmailedLinkForm from './magic-login/handle-emailed-link-form';
 import HandleEmailedLinkFormJetpackConnect from './magic-login/handle-emailed-link-form-jetpack-connect';
@@ -86,20 +87,22 @@ const enhanceContextWithLogin = ( context ) => {
 		isVIPClient;
 
 	context.primary = (
-		<WPLogin
-			action={ action }
-			isJetpack={ isJetpackLogin }
-			isWhiteLogin={ isWhiteLogin }
-			isGravPoweredClient={ isGravPoweredClient }
-			path={ path }
-			twoFactorAuthType={ twoFactorAuthType }
-			socialService={ socialService }
-			socialServiceResponse={ socialServiceResponse }
-			socialConnect={ flow === 'social-connect' }
-			domain={ ( query && query.domain ) || null }
-			fromSite={ ( query && query.site ) || null }
-			signupUrl={ ( query && query.signup_url ) || null }
-		/>
+		<LoginContextProvider>
+			<WPLogin
+				action={ action }
+				isJetpack={ isJetpackLogin }
+				isWhiteLogin={ isWhiteLogin }
+				isGravPoweredClient={ isGravPoweredClient }
+				path={ path }
+				twoFactorAuthType={ twoFactorAuthType }
+				socialService={ socialService }
+				socialServiceResponse={ socialServiceResponse }
+				socialConnect={ flow === 'social-connect' }
+				domain={ ( query && query.domain ) || null }
+				fromSite={ ( query && query.site ) || null }
+				signupUrl={ ( query && query.signup_url ) || null }
+			/>
+		</LoginContextProvider>
 	);
 };
 

--- a/client/login/login-context.tsx
+++ b/client/login/login-context.tsx
@@ -1,0 +1,37 @@
+import { createContext, useContext, useState } from '@wordpress/element';
+import { type TranslateResult } from 'i18n-calypso';
+
+export interface LoginContextType {
+	headingText?: TranslateResult | null;
+	headingSubText?: TranslateResult | null;
+	setHeadingText: ( headingText: TranslateResult | null ) => void;
+	setHeadingSubText: ( headingSubText: TranslateResult | null ) => void;
+}
+
+export const LoginContext = createContext< LoginContextType >( {} as LoginContextType );
+
+const LoginContextProvider = ( { children }: { children: React.ReactNode } ) => {
+	const [ headingText, setHeadingText ] = useState< TranslateResult | undefined | null >(
+		undefined
+	);
+	const [ headingSubText, setHeadingSubText ] = useState< TranslateResult | undefined | null >(
+		undefined
+	);
+
+	return (
+		<LoginContext.Provider
+			value={ {
+				headingText,
+				headingSubText,
+				setHeadingText,
+				setHeadingSubText,
+			} }
+		>
+			{ children }
+		</LoginContext.Provider>
+	);
+};
+
+export const useLoginContext = (): LoginContextType => useContext( LoginContext );
+
+export default LoginContextProvider;

--- a/client/login/login-context.tsx
+++ b/client/login/login-context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState } from '@wordpress/element';
+import { createContext, useContext, useState, useCallback } from '@wordpress/element';
 import { type TranslateResult } from 'i18n-calypso';
 
 export interface LoginContextType {
@@ -22,16 +22,19 @@ const LoginContextProvider = ( { children }: { children: React.ReactNode } ) => 
 	const [ subHeadingText, setSubHeadingText ] = useState< TranslateResult | undefined | null >(
 		undefined
 	);
-	const setHeaders = ( {
-		heading,
-		subHeading,
-	}: {
-		heading?: TranslateResult | null;
-		subHeading?: TranslateResult | null;
-	} ) => {
-		setHeadingText( heading );
-		setSubHeadingText( subHeading );
-	};
+	const setHeaders = useCallback(
+		( {
+			heading,
+			subHeading,
+		}: {
+			heading?: TranslateResult | null;
+			subHeading?: TranslateResult | null;
+		} ) => {
+			setHeadingText( heading );
+			setSubHeadingText( subHeading );
+		},
+		[]
+	);
 
 	return (
 		<LoginContext.Provider

--- a/client/login/login-context.tsx
+++ b/client/login/login-context.tsx
@@ -3,9 +3,14 @@ import { type TranslateResult } from 'i18n-calypso';
 
 export interface LoginContextType {
 	headingText?: TranslateResult | null;
-	headingSubText?: TranslateResult | null;
-	setHeadingText: ( headingText: TranslateResult | null ) => void;
-	setHeadingSubText: ( headingSubText: TranslateResult | null ) => void;
+	subHeadingText?: TranslateResult | null;
+	setHeaders: ( {
+		heading,
+		subHeading,
+	}: {
+		heading?: TranslateResult | null;
+		subHeading?: TranslateResult | null;
+	} ) => void;
 }
 
 export const LoginContext = createContext< LoginContextType >( {} as LoginContextType );
@@ -14,17 +19,26 @@ const LoginContextProvider = ( { children }: { children: React.ReactNode } ) => 
 	const [ headingText, setHeadingText ] = useState< TranslateResult | undefined | null >(
 		undefined
 	);
-	const [ headingSubText, setHeadingSubText ] = useState< TranslateResult | undefined | null >(
+	const [ subHeadingText, setSubHeadingText ] = useState< TranslateResult | undefined | null >(
 		undefined
 	);
+	const setHeaders = ( {
+		heading,
+		subHeading,
+	}: {
+		heading?: TranslateResult | null;
+		subHeading?: TranslateResult | null;
+	} ) => {
+		setHeadingText( heading );
+		setSubHeadingText( subHeading );
+	};
 
 	return (
 		<LoginContext.Provider
 			value={ {
 				headingText,
-				headingSubText,
-				setHeadingText,
-				setHeadingSubText,
+				subHeadingText,
+				setHeaders,
 			} }
 		>
 			{ children }

--- a/client/login/wp-login/components/one-login-layout.tsx
+++ b/client/login/wp-login/components/one-login-layout.tsx
@@ -3,6 +3,7 @@ import { Step } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { getSignupUrl, pathWithLeadingSlash } from 'calypso/lib/login';
+import { useLoginContext } from 'calypso/login/login-context';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import { getCurrentQueryArguments } from 'calypso/state/selectors/get-current-query-arguments';
@@ -12,8 +13,6 @@ import HeadingLogo from './heading-logo';
 interface OneLoginLayoutProps {
 	isJetpack: boolean;
 	isFromAkismet: boolean;
-	headingText: string;
-	headingSubText: React.ReactNode;
 	children: React.ReactNode;
 	signupUrl?: string;
 	shouldUseWideHeading?: number;
@@ -22,8 +21,6 @@ interface OneLoginLayoutProps {
 const OneLoginLayout = ( {
 	isJetpack,
 	isFromAkismet,
-	headingText,
-	headingSubText,
 	children,
 	signupUrl: signupUrlProp,
 	shouldUseWideHeading,
@@ -33,6 +30,7 @@ const OneLoginLayout = ( {
 	const currentRoute = useSelector( getCurrentRoute );
 	const currentQuery = useSelector( getCurrentQueryArguments );
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
+	const { headingText, subHeadingText } = useLoginContext();
 
 	const SignUpLink = () => {
 		// use '?signup_url' if explicitly passed as URL query param
@@ -64,12 +62,12 @@ const OneLoginLayout = ( {
 					text={
 						<>
 							<HeadingLogo isFromAkismet={ isFromAkismet } isJetpack={ isJetpack } />
-							<div className="wp-login__heading-text">{ headingText }</div>
+							{ headingText && <div className="wp-login__heading-text">{ headingText }</div> }
 						</>
 					}
 					subText={
 						// <span> here because the Step.Heading renders subtext as a <p> tag.
-						<span className="wp-login__heading-subtext">{ headingSubText }</span>
+						subHeadingText && <span className="wp-login__heading-subtext">{ subHeadingText }</span>
 					}
 				/>
 			}

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -331,8 +331,10 @@ export class Login extends Component {
 			translate,
 		} );
 
-		this.context.setHeadingText( headingText );
-		this.context.setHeadingSubText( headingSubText );
+		this.context.setHeaders( {
+			heading: headingText,
+			subHeading: headingSubText,
+		} );
 	}
 
 	render() {
@@ -387,8 +389,6 @@ export class Login extends Component {
 					<OneLoginLayout
 						isJetpack={ isJetpack }
 						isFromAkismet={ isFromAkismet }
-						headingText={ this.context.headingText }
-						headingSubText={ this.context.headingSubText }
 						shouldUseWideHeading={ 'lostpassword' !== action }
 						signupUrl={ this.props.signupUrl }
 					>

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -40,6 +40,7 @@ import getIsWCCOM from 'calypso/state/selectors/get-is-wccom';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
 import isWooJPCFlow from 'calypso/state/selectors/is-woo-jpc-flow';
 import { withEnhancers } from 'calypso/state/utils';
+import { LoginContext } from '../login-context';
 import OneLoginLayout from './components/one-login-layout';
 import GravPoweredLoginBlockFooter from './gravatar/grav-powered-login-block-footer';
 import getHeadingSubText from './hooks/get-heading-subtext';
@@ -67,6 +68,7 @@ export class Login extends Component {
 	};
 
 	static defaultProps = { isJetpack: false, isWhiteLogin: false, isLoginView: true };
+	static contextType = LoginContext;
 
 	state = {
 		usernameOrEmail: '',
@@ -80,15 +82,42 @@ export class Login extends Component {
 
 	componentDidMount() {
 		this.recordPageView();
+		this.updateHeadingText();
 	}
 
 	componentDidUpdate( prevProps ) {
+		// Record page view if relevant props changed
 		if ( this.props.twoFactorAuthType !== prevProps.twoFactorAuthType ) {
 			this.recordPageView();
 		}
-
 		if ( this.props.socialConnect !== prevProps.socialConnect ) {
 			this.recordPageView();
+		}
+
+		// List all props that affect the heading text
+		const headingProps = [
+			'isWhiteLogin',
+			'twoFactorAuthType',
+			'isManualRenewalImmediateLoginAttempt',
+			'socialConnect',
+			'linkingSocialService',
+			'action',
+			'oauth2Client',
+			'isWooJPC',
+			'isJetpack',
+			'isWCCOM',
+			'isFromAkismet',
+			'isFromAutomatticForAgenciesPlugin',
+			'isGravPoweredClient',
+			'twoFactorEnabled',
+			'currentQuery',
+			'translate',
+		];
+
+		const headingChanged = headingProps.some( ( key ) => this.props[ key ] !== prevProps[ key ] );
+
+		if ( headingChanged ) {
+			this.updateHeadingText();
 		}
 	}
 
@@ -253,6 +282,59 @@ export class Login extends Component {
 		);
 	}
 
+	updateHeadingText() {
+		const {
+			isWhiteLogin,
+			twoFactorAuthType,
+			isManualRenewalImmediateLoginAttempt,
+			socialConnect,
+			linkingSocialService,
+			action,
+			oauth2Client,
+			isWooJPC,
+			isJetpack,
+			isWCCOM,
+			isFromAkismet,
+			isFromAutomatticForAgenciesPlugin,
+			isGravPoweredClient,
+			twoFactorEnabled,
+			currentQuery,
+			translate,
+		} = this.props;
+
+		// TODO: remove isGravPoweredClient when login pages are unified.
+		const isSocialFirst = isWhiteLogin && ! isGravPoweredClient;
+
+		const headingText = getHeaderText( {
+			isSocialFirst,
+			twoFactorAuthType,
+			isManualRenewalImmediateLoginAttempt,
+			socialConnect,
+			linkingSocialService,
+			action,
+			oauth2Client,
+			isWooJPC,
+			isJetpack,
+			isWCCOM,
+			isFromAkismet,
+			isFromAutomatticForAgenciesPlugin,
+			isGravPoweredClient,
+			twoFactorEnabled,
+			currentQuery,
+			translate,
+		} );
+
+		const headingSubText = getHeadingSubText( {
+			isSocialFirst,
+			twoFactorAuthType,
+			action,
+			translate,
+		} );
+
+		this.context.setHeadingText( headingText );
+		this.context.setHeadingSubText( headingSubText );
+	}
+
 	render() {
 		const {
 			locale,
@@ -262,17 +344,7 @@ export class Login extends Component {
 			isWhiteLogin,
 			isJetpack,
 			isFromAkismet,
-			twoFactorAuthType,
-			isManualRenewalImmediateLoginAttempt,
-			socialConnect,
-			linkingSocialService,
 			action,
-			oauth2Client,
-			isWooJPC,
-			isWCCOM,
-			isFromAutomatticForAgenciesPlugin,
-			currentQuery,
-			twoFactorEnabled,
 		} = this.props;
 
 		const canonicalUrl = localizeUrl( 'https://wordpress.com/log-in', locale );
@@ -309,40 +381,14 @@ export class Login extends Component {
 			</Main>
 		);
 
-		const headingText = getHeaderText( {
-			isSocialFirst,
-			twoFactorAuthType,
-			isManualRenewalImmediateLoginAttempt,
-			socialConnect,
-			linkingSocialService,
-			action,
-			oauth2Client,
-			isWooJPC,
-			isJetpack,
-			isWCCOM,
-			isFromAkismet,
-			isFromAutomatticForAgenciesPlugin,
-			isGravPoweredClient,
-			twoFactorEnabled,
-			currentQuery,
-			translate,
-		} );
-
-		const headingSubText = getHeadingSubText( {
-			isSocialFirst,
-			twoFactorAuthType,
-			action,
-			translate,
-		} );
-
 		return (
 			<>
 				{ isWhiteLogin && (
 					<OneLoginLayout
 						isJetpack={ isJetpack }
 						isFromAkismet={ isFromAkismet }
-						headingText={ headingText }
-						headingSubText={ headingSubText }
+						headingText={ this.context.headingText }
+						headingSubText={ this.context.headingSubText }
 						shouldUseWideHeading={ 'lostpassword' !== action }
 						signupUrl={ this.props.signupUrl }
 					>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13220/login-make-the-two-columnwhite-layout-the-default-across-all-contexts
Part of https://linear.app/a8c/issue/DOTCOM-13219/login-magic-login-update-and-unify-magic-login-screens

## Proposed Changes

- Introduces a Login context provider so we can assist in unifying the Login top-bar and main layout. It will be needed especially in Magic Login screens, where nested components need to communicate a header and sub-header text.
- It's not the cleanest solution, but it's the quickest to continue with unification. We may rework/abstract things differently later.

### Media

<img width="700" alt="Screenshot 2025-07-04 at 8 36 22 PM" src="https://github.com/user-attachments/assets/7e8ff4bf-3daf-4596-bec9-ad4c0bde81e3" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13220/login-make-the-two-columnwhite-layout-the-default-across-all-contexts
Part of https://linear.app/a8c/issue/DOTCOM-13219/login-magic-login-update-and-unify-magic-login-screens

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to several of the [Login screens](https://linear.app/a8c/project/login-and-signup-unify-design-and-layout-16a857e58712/overview) (default and OAuth client ones) and confirm things render correctly (highlights in media above).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
