### PR TITLE
Bring back 2 cancellation events in Jetpack Search Free Cancellation

### DIFF
--- a/client/components/marketing-survey/cancel-jetpack-form/index.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/index.tsx
@@ -1,5 +1,4 @@
 import config from '@automattic/calypso-config';
-import { isJetpackSearchFree } from '@automattic/calypso-products';
 import { Button, Dialog } from '@automattic/components';
 import { BaseButton } from '@automattic/components/dist/types/dialog/button-bar';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
@@ -95,11 +94,6 @@ const CancelJetpackForm: React.FC< Props > = ( {
 	// Record an event for Tracks
 	const recordEvent = useCallback(
 		( name: string, properties = {} ) => {
-			// Skip tracks events for Jetpack Search Free
-			if ( isJetpackSearchFree( purchase ) ) {
-				return;
-			}
-
 			dispatch(
 				recordTracksEvent( name, {
 					cancellation_flow: flowType,
@@ -110,7 +104,7 @@ const CancelJetpackForm: React.FC< Props > = ( {
 				} )
 			);
 		},
-		[ dispatch, flowType, isAtomicSite, purchase ]
+		[ dispatch, flowType, isAtomicSite, purchase.productSlug ]
 	);
 
 	/**


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

Remove the check per Bohdan's request

## Proposed Changes

* Given that we refactored the cancellation form, this restriction is actually not needed.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

* With a Jetpack site, get search free
* Go to /me/purchases and proceed to cancel JP Search Free
* Verify the events during look like this

<img width="1389" alt="Screenshot 2025-07-04 at 16 34 59" src="https://github.com/user-attachments/assets/628fabe4-6bac-4fe4-8845-39720a905ae7" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
