### PR TITLE
Staging Sites Redesign: Ensure the Sync dropdown is rendered only when the staging site isn't being created or deleted

### DIFF
--- a/client/sites/components/site-preview-pane/preview-pane-header-buttons.tsx
+++ b/client/sites/components/site-preview-pane/preview-pane-header-buttons.tsx
@@ -11,6 +11,7 @@ import hasWpcomStagingSite from 'calypso/state/selectors/has-wpcom-staging-site'
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import { useSiteAdminInterfaceData } from 'calypso/state/sites/hooks';
 import { getSite } from 'calypso/state/sites/selectors';
+import { getIsStagingSiteInTransition } from 'calypso/state/staging-site/selectors';
 import type { ItemData } from 'calypso/layout/hosting-dashboard/item-view/types';
 
 import './preview-pane-header-buttons.scss';
@@ -35,18 +36,12 @@ const PreviewPaneHeaderButtons = ( { focusRef, itemData }: Props ) => {
 	const hasStagingSite = useSelector( ( state ) =>
 		hasWpcomStagingSite( state, itemData.blogId ?? null )
 	);
-	const stagingStatus = useSelector( ( state ) =>
-		getStagingSiteStatus( state, itemData.blogId ?? 0 )
+	const isStagingSiteInTransition = useSelector( ( state ) =>
+		getIsStagingSiteInTransition( state, itemData.blogId ?? 0 )
 	);
 
-	const isStagingSiteProgressing =
-		stagingStatus === StagingSiteStatus.INITIATE_TRANSFERRING ||
-		stagingStatus === StagingSiteStatus.TRANSFERRING ||
-		stagingStatus === StagingSiteStatus.INITIATE_REVERTING ||
-		stagingStatus === StagingSiteStatus.REVERTING;
-
 	const shouldShowSyncDropdown = Boolean(
-		stagingSitesRedesign && ( isStagingSite || hasStagingSite ) && ! isStagingSiteProgressing
+		stagingSitesRedesign && ( isStagingSite || hasStagingSite ) && ! isStagingSiteInTransition
 	);
 
 	const productionSiteId = isStagingSite

--- a/client/sites/components/site-preview-pane/preview-pane-header-buttons.tsx
+++ b/client/sites/components/site-preview-pane/preview-pane-header-buttons.tsx
@@ -35,8 +35,18 @@ const PreviewPaneHeaderButtons = ( { focusRef, itemData }: Props ) => {
 	const hasStagingSite = useSelector( ( state ) =>
 		hasWpcomStagingSite( state, itemData.blogId ?? null )
 	);
+	const stagingStatus = useSelector( ( state ) =>
+		getStagingSiteStatus( state, itemData.blogId ?? 0 )
+	);
+
+	const isStagingSiteProgressing =
+		stagingStatus === StagingSiteStatus.INITIATE_TRANSFERRING ||
+		stagingStatus === StagingSiteStatus.TRANSFERRING ||
+		stagingStatus === StagingSiteStatus.INITIATE_REVERTING ||
+		stagingStatus === StagingSiteStatus.REVERTING;
+
 	const shouldShowSyncDropdown = Boolean(
-		stagingSitesRedesign && ( isStagingSite || hasStagingSite )
+		stagingSitesRedesign && ( isStagingSite || hasStagingSite ) && ! isStagingSiteProgressing
 	);
 
 	const productionSiteId = isStagingSite

--- a/client/state/staging-site/selectors/get-is-staging-site-in-transition.ts
+++ b/client/state/staging-site/selectors/get-is-staging-site-in-transition.ts
@@ -1,0 +1,30 @@
+import { StagingSiteStatus } from 'calypso/state/staging-site/constants';
+import { getStagingSiteInfo } from 'calypso/state/staging-site/selectors/get-staging-site-info';
+import type { AppState } from 'calypso/types';
+
+import 'calypso/state/staging-site/init';
+
+/**
+ * Helper to determine if staging site is in a transition state
+ * @param {Object} state automated transfer state sub-tree for a site
+ * @returns {boolean} whether staging site is in a transition state
+ */
+export const getStagingSiteIsInTransition = ( state: AppState ): boolean => {
+	const status = state?.status ?? StagingSiteStatus.UNSET;
+	return (
+		status === StagingSiteStatus.INITIATE_TRANSFERRING ||
+		status === StagingSiteStatus.TRANSFERRING ||
+		status === StagingSiteStatus.INITIATE_REVERTING ||
+		status === StagingSiteStatus.REVERTING
+	);
+};
+
+/**
+ * Returns whether staging site is in a transition state
+ * @param {Object} state global app state
+ * @param {number} siteId requested site for transfer info
+ * @returns {boolean} true if staging site is in a transition state
+ */
+export function getIsStagingSiteInTransition( state: AppState, siteId: number | null ): boolean {
+	return getStagingSiteIsInTransition( getStagingSiteInfo( state, siteId ) );
+}

--- a/client/state/staging-site/selectors/get-is-staging-site-in-transition.ts
+++ b/client/state/staging-site/selectors/get-is-staging-site-in-transition.ts
@@ -5,8 +5,8 @@ import type { AppState } from 'calypso/types';
 import 'calypso/state/staging-site/init';
 
 /**
- * Helper to determine if staging site is in a transition state
- * @param {Object} state automated transfer state sub-tree for a site
+ * Helper to determine if staging site is in a transition state (transferring or reverting)
+ * @param {Object} state global app state
  * @returns {boolean} whether staging site is in a transition state
  */
 export const getStagingSiteIsInTransition = ( state: AppState ): boolean => {
@@ -20,9 +20,9 @@ export const getStagingSiteIsInTransition = ( state: AppState ): boolean => {
 };
 
 /**
- * Returns whether staging site is in a transition state
+ * Returns whether staging site is in a transition state (transferring or reverting)
  * @param {Object} state global app state
- * @param {number} siteId requested site for transfer info
+ * @param {number} siteId requested site for transition info
  * @returns {boolean} true if staging site is in a transition state
  */
 export function getIsStagingSiteInTransition( state: AppState, siteId: number | null ): boolean {

--- a/client/state/staging-site/selectors/index.ts
+++ b/client/state/staging-site/selectors/index.ts
@@ -6,3 +6,4 @@ import 'calypso/state/staging-site/init';
 export { getStagingSiteInfo } from 'calypso/state/staging-site/selectors/get-staging-site-info';
 export { getStagingSiteStatus } from 'calypso/state/staging-site/selectors/get-staging-site-status';
 export { getIsStagingSiteStatusComplete } from 'calypso/state/staging-site/selectors/get-is-staging-site-status-complete';
+export { getIsStagingSiteInTransition } from 'calypso/state/staging-site/selectors/get-is-staging-site-in-transition';


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTDEV-199
Fixes DOTDEV-203

## Proposed Changes

* add `isStagingSiteInTransition` check to the Sync dropdown
  * this ensures the dropdown will render only when the staging site isn't transferring or reverting 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* DOTDEV-199
* DOTDEV-203

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start` (or use Calypso Live).
2. Ensure the `hosting/staging-sites-redesign` feature flag is enabled (by using `?flags=hosting/staging-sites-redesign` query parameter).
3. Head over to the `/sites` dashboard and select an Atomic test site without a staging site.
4. Click the `+ Add staging site` button and wait until the staging site is created. **The Sync dropdown should render only after the staging site becomes available.**
5. Delete the staging site. **The Sync dropdown should hide itself right after the deletion is initiated.**

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
