### PR TITLE
Cleanup unnecessary code

### DIFF
--- a/packages/odie-client/src/hooks/use-zendesk-message-listener.ts
+++ b/packages/odie-client/src/hooks/use-zendesk-message-listener.ts
@@ -4,7 +4,7 @@ import { useSelect } from '@wordpress/data';
 import { useCallback, useEffect } from '@wordpress/element';
 import Smooch from 'smooch';
 import { useOdieAssistantContext } from '../context';
-import { getConversationIdFromInteraction, zendeskMessageConverter } from '../utils';
+import { zendeskMessageConverter } from '../utils';
 import type { ZendeskMessage } from '../types';
 
 /**
@@ -13,16 +13,12 @@ import type { ZendeskMessage } from '../types';
 export const useZendeskMessageListener = () => {
 	const { setChat, chat } = useOdieAssistantContext();
 
-	const { isChatLoaded, currentSupportInteraction } = useSelect( ( select ) => {
+	const { isChatLoaded } = useSelect( ( select ) => {
 		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
 		return {
-			currentSupportInteraction: helpCenterSelect.getCurrentSupportInteraction(),
 			isChatLoaded: helpCenterSelect.getIsChatLoaded(),
 		};
 	}, [] );
-
-	const currentZendeskConversationId =
-		getConversationIdFromInteraction( currentSupportInteraction );
 
 	const messageListener = useCallback(
 		( message: unknown, data: { conversation: { id: string } } ) => {
@@ -52,12 +48,5 @@ export const useZendeskMessageListener = () => {
 			// @ts-expect-error -- 'off' is not part of the def.
 			Smooch?.off?.( 'message:received', messageListener );
 		};
-	}, [
-		isChatLoaded,
-		currentZendeskConversationId,
-		chat,
-		setChat,
-		currentSupportInteraction,
-		messageListener,
-	] );
+	}, [ isChatLoaded, messageListener ] );
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Cleanup unnecessary code leftovers

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Simplify and improve code readability

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the help center
* Escalate to chat support
* Send messages back from ZD
* Ensure that they are delivered in the chat
* Send messages from ZD to a chat other than the active one
* Navigate back to history and ensure that the message is delivered

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
