### PR TITLE
Add /me/chat redirect

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -1020,7 +1020,7 @@ export default function pages() {
 
 	// Redirect legacy `/help` routes to `sites?help-center=home` if logged in, otherwise `/support`
 	// Note: isLoggedIn will only work under *.wordpress.com domains (wpcalypso, horizon, and prod)
-	app.get( [ '/help', '/help/*' ], ( req, res ) => {
+	app.get( [ '/me/chat', '/help', '/help/*' ], ( req, res ) => {
 		if ( req.context.isLoggedIn ) {
 			return res.redirect( 301, '/sites?help-center=home' );
 		}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

When I removed the /help page, I forgot to include the existent redirect for /me/chat, [here](https://github.com/Automattic/wp-calypso/pull/104586/files#diff-ce6303d38937490a14885e2e2144cad41b1d39327066d8d8ef366c7de91310cdL26).

This PR adds it.