### PR TITLE
Site list v2: use browser native tooltip for table layout header (alternative)

### DIFF
--- a/client/dashboard/sites/fields.tsx
+++ b/client/dashboard/sites/fields.tsx
@@ -102,24 +102,28 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 	{
 		id: 'uptime',
 		label: __( 'Uptime' ),
+		header: <span title={ __( 'Past 7 days' ) }>{ __( 'Uptime' ) }</span>,
 		render: ( { item } ) => <Uptime site={ item } />,
 		enableSorting: false,
 	},
 	{
 		id: 'visitors',
 		label: __( 'Visitors' ),
+		header: <span title={ __( 'Past 7 days' ) }>{ __( 'Visitors' ) }</span>,
 		render: ( { item } ) => <EngagementStat site={ item } type="visitors" />,
 		enableSorting: false,
 	},
 	{
 		id: 'views',
 		label: __( 'Views' ),
+		header: <span title={ __( 'Past 7 days' ) }>{ __( 'Views' ) }</span>,
 		render: ( { item } ) => <EngagementStat site={ item } type="views" />,
 		enableSorting: false,
 	},
 	{
 		id: 'likes',
 		label: __( 'Likes' ),
+		header: <span title={ __( 'Past 7 days' ) }>{ __( 'Likes' ) }</span>,
 		render: ( { item } ) => <EngagementStat site={ item } type="likes" />,
 		enableSorting: false,
 	},


### PR DESCRIPTION
Part of DOTDASH-75

## Proposed Changes

This is an alternative / stopgap solution to:

- https://github.com/WordPress/gutenberg/pull/70610

where we want to show a tooltip in statistic columns that explain the date range ("past 7 days"):

<img width="294" alt="image" src="https://github.com/user-attachments/assets/540c5238-6dfb-4c32-8350-6c8377a234a9" />

## Testing Instructions

1. Go to `/sites`
2. Use the Table layout
3. Show the Uptime, Visitors, Views, and Likes columns
4. Hover over the column header
5. Verify you see the tooltip
    - Note that the tooltip can be slow to show up -- it's the inherent feature of the browser and we can't control it (easily).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
