### PR TITLE
A4A > Reports: CFT UI enhancements Part 2

### DIFF
--- a/client/a8c-for-agencies/sections/reports/primary/build-report/steps/step-1-details.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/steps/step-1-details.tsx
@@ -345,6 +345,11 @@ export default function Step1Details( { formData, state, handlers }: StepProps )
 					) }
 				</div>
 			) }
+			<p className="build-report__step-note">
+				{ translate(
+					"You'll be able to select your data, preview the report, and send during the next 2 steps."
+				) }
+			</p>
 		</>
 	);
 }

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/steps/step-3-send.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/steps/step-3-send.tsx
@@ -29,6 +29,10 @@ export default function Step3Send( { state }: StepProps ) {
 
 	const isSendingPreview = isSendPreview && sendReportEmailMutation.isPending;
 
+	const loadingText = translate(
+		'Please wait while we prepare your report. This may take a few minutes, depending on your data range and data selected. Do not navigate away from this screen.'
+	);
+
 	if ( reportId ) {
 		if ( isReportPending ) {
 			return (
@@ -40,12 +44,10 @@ export default function Step3Send( { state }: StepProps ) {
 						className="build-report__loading-state build-report__content-description"
 						role="status"
 						aria-live="polite"
-						aria-label={ translate( 'Please wait while we prepare your report…' ) }
+						aria-label={ loadingText }
 					>
 						<Spinner aria-hidden="true" />
-						<span aria-hidden="true">
-							{ translate( 'Please wait while we prepare your report…' ) }
-						</span>
+						<span aria-hidden="true">{ loadingText }</span>
 					</p>
 				</>
 			);

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/style.scss
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/style.scss
@@ -131,7 +131,7 @@
 	align-items: center;
 
 	svg {
-		margin: 5px 10px 5px 0;
+		margin: 5px 15px 5px 0;
 	}
 }
 

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
@@ -92,3 +92,52 @@ export const ReportTimeframeColumn = ( {
 
 	return timeframeText;
 };
+
+export const ReportClientEmailsColumn = ( { emails }: { emails: string[] } ) => {
+	const tooltipRef = useRef( null );
+	const [ showTooltip, setShowTooltip ] = useState( false );
+	const translate = useTranslate();
+
+	if ( ! emails || emails.length === 0 ) {
+		return <Gridicon icon="minus" />;
+	}
+
+	if ( emails.length === 1 ) {
+		return emails[ 0 ];
+	}
+
+	const firstEmail = emails[ 0 ];
+	const remainingCount = emails.length - 1;
+	const remainingEmails = emails.slice( 1 );
+
+	return (
+		<>
+			{ firstEmail }
+			{ remainingCount > 0 && (
+				<>
+					<span
+						onMouseEnter={ () => setShowTooltip( true ) }
+						onMouseLeave={ () => setShowTooltip( false ) }
+						onTouchStart={ () => setShowTooltip( true ) }
+						onTouchEnd={ () => setShowTooltip( false ) }
+						role="button"
+						tabIndex={ 0 }
+						ref={ tooltipRef }
+					>
+						{ translate( ' + %(count)d more', {
+							args: { count: remainingCount },
+						} ) }
+					</span>
+					<Tooltip
+						context={ tooltipRef.current }
+						showOnMobile
+						isVisible={ showTooltip }
+						position="top"
+					>
+						{ remainingEmails.join( ', ' ) }
+					</Tooltip>
+				</>
+			) }
+		</>
+	);
+};

--- a/client/a8c-for-agencies/sections/reports/reports-details/mobile-view.tsx
+++ b/client/a8c-for-agencies/sections/reports/reports-details/mobile-view.tsx
@@ -10,6 +10,7 @@ import {
 	ReportStatusColumn,
 	ReportDateColumn,
 	ReportTimeframeColumn,
+	ReportClientEmailsColumn,
 } from '../primary/dashboard/report-columns';
 import type { Report } from '../types';
 
@@ -40,6 +41,11 @@ export default function ReportsMobileView( {
 									startDate={ report.data.start_date }
 									endDate={ report.data.end_date }
 								/>
+							</div>
+						</ListItemCardContent>
+						<ListItemCardContent title={ translate( 'Client Emails' ) }>
+							<div className="reports-details-mobile-view__column">
+								<ReportClientEmailsColumn emails={ report.data.client_emails } />
 							</div>
 						</ListItemCardContent>
 						<ListItemCardContent title={ translate( 'Created' ) }>

--- a/client/a8c-for-agencies/sections/reports/reports-details/reports.tsx
+++ b/client/a8c-for-agencies/sections/reports/reports-details/reports.tsx
@@ -8,6 +8,7 @@ import {
 	ReportDateColumn,
 	ReportStatusColumn,
 	ReportTimeframeColumn,
+	ReportClientEmailsColumn,
 } from '../primary/dashboard/report-columns';
 import type { Report } from '../types';
 import type { Action } from 'calypso/a8c-for-agencies/components/list-item-cards';
@@ -17,7 +18,7 @@ export default function Reports( { reports, actions }: { reports: Report[]; acti
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
 		...initialDataViewsState,
-		fields: [ 'status', 'timeframe', 'createdAt' ],
+		fields: [ 'status', 'timeframe', 'createdAt', 'client-emails' ],
 	} );
 
 	const fields = useMemo(
@@ -49,6 +50,16 @@ export default function Reports( { reports, actions }: { reports: Report[]; acti
 				label: translate( 'Created' ),
 				getValue: () => '-',
 				render: ( { item }: { item: Report } ) => <ReportDateColumn date={ item.created_at } />,
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'client-emails',
+				label: translate( 'Client Emails' ),
+				getValue: () => '-',
+				render: ( { item }: { item: Report } ) => (
+					<ReportClientEmailsColumn emails={ item.data.client_emails } />
+				),
 				enableHiding: false,
 				enableSorting: false,
 			},

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -126,6 +126,10 @@
 		border-radius: 4px 0 0 4px;
 	}
 
+	.components-button.is-primary:disabled {
+		background-color: var(--color-primary-50);
+	}
+
 	.components-button.is-primary,
 	.button.is-primary {
 		&:not( :disabled ),


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1235/reports-cft-report-builder-enhancements
Resolves https://linear.app/a8c/issue/A4A-1239/reports-cft-show-client-emails-on-the-preview-panel
Resolves https://linear.app/a8c/issue/A4A-1238/reports-cft-fix-the-disabled-select-site-buttons-broken-hover-effect

## Proposed Changes

This PR

- Updates the texts on the Report Builder
- Shows the client emails on the reports dashboard
- Fix the disabled primary button color

## Why are these changes being made?

- UI enhancements and address CFT feedback

## Testing Instructions

* Open the A4A live link
* Go to Reports > Build a new report > Click the select site button > Verify that the "disabled" state of the button (default and hover) is updated


| Before | After |
|--------|--------|
| <img width="820" alt="Screenshot 2025-07-07 at 11 21 20 AM" src="https://github.com/user-attachments/assets/eb2fa867-609a-4bb6-89f5-620fd869925a" /> | <img width="820" alt="Screenshot 2025-07-07 at 11 21 35 AM" src="https://github.com/user-attachments/assets/32c7ff70-7f0d-4ecf-a37b-2bfbe6a43c7b" />| 


* Verify that the first step has a help text above the button

<img width="864" alt="Screenshot 2025-07-07 at 10 25 57 AM" src="https://github.com/user-attachments/assets/1e60ddbf-2810-4c7e-8712-4cad59cf3664" />

* Proceed to create a new report > Verify the text on the loading state on step 3 is updated as shown below

<img width="864" alt="Screenshot 2025-07-07 at 10 26 17 AM" src="https://github.com/user-attachments/assets/6a55c566-f04d-4673-974d-851f0560d925" />

* Go to Reports: Dashboard: open the detailed view of any site > Verify the client emails are displayed as shown below

| Desktop | Mobile |
|--------|--------|
| <img width="1174" alt="Screenshot 2025-07-07 at 10 52 54 AM" src="https://github.com/user-attachments/assets/6f6f1f91-e750-4e3a-b0da-f527bd2bf63a" /> | <img width="373" alt="Screenshot 2025-07-07 at 11 03 06 AM" src="https://github.com/user-attachments/assets/4b9d0eb3-18f6-4a5f-af56-26b1fe78815d" /> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
