### PR TITLE
Remove the trailing period at the end of the sentence

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
@@ -84,31 +84,31 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 			{
 				value: 'lackOfCustomization',
 				get label() {
-					return translate( 'Lack of customization features (e.g., colors, fonts, themes).' );
+					return translate( 'Lack of customization features (e.g., colors, fonts, themes)' );
 				},
 			},
 			{
 				value: 'freeIsGoodEnough',
 				get label() {
-					return translate( 'The free plan is sufficient for my current needs.' );
+					return translate( 'The free plan is sufficient for my current needs' );
 				},
 			},
 			{
 				value: 'foundBetterValue',
 				get label() {
-					return translate( 'I found a competitor with better pricing/value.' );
+					return translate( 'I found a competitor with better pricing/value' );
 				},
 			},
 			{
 				value: 'budgetConstraints',
 				get label() {
-					return translate( 'Budget constraints / Can no longer afford it.' );
+					return translate( 'Budget constraints / Can no longer afford it' );
 				},
 			},
 			{
 				value: 'otherPriceValue',
 				get label() {
-					return translate( 'Something else related to price/value.' );
+					return translate( 'Something else related to price/value' );
 				},
 				get textPlaceholder() {
 					return translate( 'Please tell us more about your price/value concern' );
@@ -126,31 +126,31 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 			{
 				value: 'complicatedDashboard',
 				get label() {
-					return translate( 'The platform/dashboard is too complicated or confusing to navigate.' );
+					return translate( 'The platform/dashboard is too complicated or confusing to navigate' );
 				},
 			},
 			{
 				value: 'difficultEditor',
 				get label() {
-					return translate( 'The website editor is difficult or unintuitive to use.' );
+					return translate( 'The website editor is difficult or unintuitive to use' );
 				},
 			},
 			{
 				value: 'tooMuchTimeToLearn',
 				get label() {
-					return translate( 'It takes too much time to learn how to use the platform.' );
+					return translate( 'It takes too much time to learn how to use the platform' );
 				},
 			},
 			{
 				value: 'inadequateOnboarding',
 				get label() {
-					return translate( 'Onboarding or tutorials were not helpful enough.' );
+					return translate( 'Onboarding or tutorials were not helpful enough' );
 				},
 			},
 			{
 				value: 'otherTooHardToUse',
 				get label() {
-					return translate( 'Something else related to too hard to use.' );
+					return translate( 'Something else related to too hard to use' );
 				},
 				get textPlaceholder() {
 					return translate( 'Please tell us more' );
@@ -169,21 +169,21 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 				value: 'cannotInstallPlugins',
 				get label() {
 					return translate(
-						'Cannot install desired plugins (e.g., from WordPress.org or third-party).'
+						'Cannot install desired plugins (e.g., from WordPress.org or third-party)'
 					);
 				},
 			},
 			{
 				value: 'cannotUploadThemes',
 				get label() {
-					return translate( 'Cannot upload custom themes.' );
+					return translate( 'Cannot upload custom themes' );
 				},
 			},
 			{
 				value: 'limitedCustomization',
 				get label() {
 					return translate(
-						'Limited design or customization options (e.g., layout, specific elements).'
+						'Limited design or customization options (e.g., layout, specific elements)'
 					);
 				},
 			},
@@ -191,20 +191,20 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 				value: 'missingFunctionality',
 				get label() {
 					return translate(
-						'Lacking specific functionality I need (e.g., e-commerce, specific integrations, advanced SEO tools).'
+						'Lacking specific functionality I need (e.g., e-commerce, specific integrations, advanced SEO tools)'
 					);
 				},
 			},
 			{
 				value: 'coreFeaturesMissing',
 				get label() {
-					return translate( 'Core features I expected are only available on a much higher plan.' );
+					return translate( 'Core features I expected are only available on a much higher plan' );
 				},
 			},
 			{
 				value: 'otherMissingFeatures',
 				get label() {
-					return translate( 'Something else related to features/flexibility.' );
+					return translate( 'Something else related to features/flexibility' );
 				},
 				get textPlaceholder() {
 					return translate( 'Please tell us more' );
@@ -222,31 +222,31 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 			{
 				value: 'tooSlow',
 				get label() {
-					return translate( 'Site is slow or experiences performance issues.' );
+					return translate( 'Site is slow or experiences performance issues' );
 				},
 			},
 			{
 				value: 'bugsOrGlitches',
 				get label() {
-					return translate( 'Encountered bugs, errors, or glitches.' );
+					return translate( 'Encountered bugs, errors, or glitches' );
 				},
 			},
 			{
 				value: 'migrationProblems',
 				get label() {
-					return translate( 'Problems migrating my existing site or content.' );
+					return translate( 'Problems migrating my existing site or content' );
 				},
 			},
 			{
 				value: 'downtime',
 				get label() {
-					return translate( 'Site was down or inaccessible.' );
+					return translate( 'Site was down or inaccessible' );
 				},
 			},
 			{
 				value: 'otherTechnicalIssues',
 				get label() {
-					return translate( 'Something else related to technical problems.' );
+					return translate( 'Something else related to technical problems' );
 				},
 				get textPlaceholder() {
 					return translate( 'Please tell us more' );
@@ -264,25 +264,25 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 			{
 				value: 'troubleConnectingOrTransferring',
 				get label() {
-					return translate( 'Trouble connecting or transferring my existing domain.' );
+					return translate( 'Trouble connecting or transferring my existing domain' );
 				},
 			},
 			{
 				value: 'confusedAboutDomains',
 				get label() {
-					return translate( 'Confused about how domains work with the WordPress.com plan.' );
+					return translate( 'Confused about how domains work with the WordPress.com plan' );
 				},
 			},
 			{
 				value: 'domainIncorrect',
 				get label() {
-					return translate( 'Didn’t get the domain name I expected / My domain is incorrect.' );
+					return translate( 'Didn’t get the domain name I expected / My domain is incorrect' );
 				},
 			},
 			{
 				value: 'otherDomain',
 				get label() {
-					return translate( 'Something else related to domains.' );
+					return translate( 'Something else related to domains' );
 				},
 				get textPlaceholder() {
 					return translate( 'Please tell us more' );
@@ -300,25 +300,25 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 			{
 				value: 'wrongPlan',
 				get label() {
-					return translate( 'I purchased this plan by mistake.' );
+					return translate( 'I purchased this plan by mistake' );
 				},
 			},
 			{
 				value: 'wrongSite',
 				get label() {
-					return translate( 'I meant to upgrade a different website or account.' );
+					return translate( 'I meant to upgrade a different website or account' );
 				},
 			},
 			{
 				value: 'noMatch',
 				get label() {
-					return translate( 'The plan I chose didn’t match what I thought I was buying.' );
+					return translate( 'The plan I chose didn’t match what I thought I was buying' );
 				},
 			},
 			{
 				value: 'otherWrongPlanOrSite',
 				get label() {
-					return translate( 'Something else related to an accidental purchase.' );
+					return translate( 'Something else related to an accidental purchase' );
 				},
 				get textPlaceholder() {
 					return translate( 'Please tell us more' );
@@ -336,25 +336,25 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 			{
 				value: 'slowOrUnhelpful',
 				get label() {
-					return translate( 'Support was unhelpful or slow to respond.' );
+					return translate( 'Support was unhelpful or slow to respond' );
 				},
 			},
 			{
 				value: 'noHumanSupport',
 				get label() {
-					return translate( 'Could not easily reach a human support agent.' );
+					return translate( 'Could not easily reach a human support agent' );
 				},
 			},
 			{
 				value: 'AIInsufficient',
 				get label() {
-					return translate( 'AI/automated support was not sufficient for my issue.' );
+					return translate( 'AI/automated support was not sufficient for my issue' );
 				},
 			},
 			{
 				value: 'otherBadSupport',
 				get label() {
-					return translate( 'Something else related to support.' );
+					return translate( 'Something else related to support' );
 				},
 				get textPlaceholder() {
 					return translate( 'Please tell us more' );
@@ -372,31 +372,31 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 			{
 				value: 'projectChanged',
 				get label() {
-					return translate( 'My project/business plans have changed.' );
+					return translate( 'My project/business plans have changed' );
 				},
 			},
 			{
 				value: 'justExploring',
 				get label() {
-					return translate( 'I was just exploring/testing the platform.' );
+					return translate( 'I was just exploring/testing the platform' );
 				},
 			},
 			{
 				value: 'noLongerNeedSite',
 				get label() {
-					return translate( 'I no longer need this website/service.' );
+					return translate( 'I no longer need this website/service' );
 				},
 			},
 			{
 				value: 'mayReturn',
 				get label() {
-					return translate( 'Temporary cancellation, I might return.' );
+					return translate( 'Temporary cancellation, I might return' );
 				},
 			},
 			{
 				value: 'otherNoLongerNeedSite',
 				get label() {
-					return translate( 'Something else related to changed needs.' );
+					return translate( 'Something else related to changed needs' );
 				},
 				get textPlaceholder() {
 					return translate( 'Please tell us more' );
@@ -410,7 +410,7 @@ export const JETPACK_CANCELLATION_REASONS: CancellationReason[] = [
 	{
 		value: 'didNotInclude',
 		get label() {
-			return translate( "This upgrade didn't include what I needed." );
+			return translate( "This upgrade didn't include what I needed" );
 		},
 		get textPlaceholder() {
 			return translate( 'What are we missing that you need?' );
@@ -419,7 +419,7 @@ export const JETPACK_CANCELLATION_REASONS: CancellationReason[] = [
 	{
 		value: 'onlyNeedFree',
 		get label() {
-			return translate( 'The plan was too expensive.' );
+			return translate( 'The plan was too expensive' );
 		},
 		get textPlaceholder() {
 			return translate( 'How can we improve our upgrades?' );
@@ -428,7 +428,7 @@ export const JETPACK_CANCELLATION_REASONS: CancellationReason[] = [
 	{
 		value: 'couldNotActivate',
 		get label() {
-			return translate( 'I was unable to activate or use the product.' );
+			return translate( 'I was unable to activate or use the product' );
 		},
 		get textPlaceholder() {
 			return translate( 'Where did you run into problems?' );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Remove the trailing periods in the wpcom marketing cancellation survey per request by @fditrapani 

## Why are these changes being made?

* Visual inconsistence - some of the questions are with dots, and some without

## Testing Instructions

* With the store sandbox
* Get a plan
* Then cancel it and fill in the cancellation survey
* You should see questions without periods

<img width="566" alt="Screenshot 2025-07-07 at 9 24 41" src="https://github.com/user-attachments/assets/677962a7-561a-4c48-816f-e9ec176c40b2" />
<img width="831" alt="Screenshot 2025-07-07 at 9 24 34" src="https://github.com/user-attachments/assets/f56f2a43-ce92-4da1-ab2c-86af01031c31" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
