### PR TITLE
Site settings v2: implement edge cache rate limiting

### DIFF
--- a/client/dashboard/app/queries/site-cache.ts
+++ b/client/dashboard/app/queries/site-cache.ts
@@ -6,12 +6,36 @@ import {
 } from '../../data/site-hosting-edge-cache';
 import { queryClient } from '../query-client';
 
+export const siteObjectCacheLastClearedTimestampQuery = ( siteId: number ) => ( {
+	queryKey: [ 'site', siteId, 'object-cache', 'last-cleared-timestamp' ],
+	queryFn: () => Promise.resolve( 0 ),
+	staleTime: Infinity,
+} );
+
 export const siteObjectCacheClearMutation = ( siteId: number ) => ( {
 	mutationFn: ( reason: string ) => clearObjectCache( siteId, reason ),
+	onSuccess: () => {
+		queryClient.setQueryData(
+			siteObjectCacheLastClearedTimestampQuery( siteId ).queryKey,
+			new Date().valueOf()
+		);
+	},
+} );
+
+export const siteEdgeCacheLastClearedTimestampQuery = ( siteId: number ) => ( {
+	queryKey: [ 'site', siteId, 'edge-cache', 'last-cleared-timestamp' ],
+	queryFn: () => Promise.resolve( 0 ),
+	staleTime: Infinity,
 } );
 
 export const siteEdgeCacheClearMutation = ( siteId: number ) => ( {
 	mutationFn: () => clearEdgeCache( siteId ),
+	onSuccess: () => {
+		queryClient.setQueryData(
+			siteEdgeCacheLastClearedTimestampQuery( siteId ).queryKey,
+			new Date().valueOf()
+		);
+	},
 } );
 
 export const siteEdgeCacheStatusQuery = ( siteId: number ) => ( {


### PR DESCRIPTION
Fixes DOTCOM-13374

## Proposed Changes

This PR implements the original v1 rate limiting (one minute) for edge cache, object cache, and (consequently) all caches.

<img width="516" alt="image" src="https://github.com/user-attachments/assets/0024ab00-faa7-4e21-90a5-bd6c197468d1" />

<img width="518" alt="image" src="https://github.com/user-attachments/assets/da1d8af8-050c-4671-a1b4-643eea687948" />

<img width="522" alt="image" src="https://github.com/user-attachments/assets/41e378e5-8574-4c04-8d43-de4a74decb6c" />


## Testing Instructions

1. Go to `/v2/sites`
2. Click a public Atomic site
3. Go to Settings -> Caching
4. Try clearing each cache
     - Verify that it's disabled after clearing
     - Verify you can see the tooltip when hovered
     - Verify that it persists upon page refresh
     - Wait until > 1 minute, refresh the page, verify you can clear the cache again


Note that similar to v1, you might need to refresh the page after one minute in order to be able to click the button again. It does not implement live-reload of the button status (v1 does not either).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
