### PR TITLE
Wire onInvalidAuth to return jwt

### DIFF
--- a/packages/help-center/src/components/help-center-smooch.tsx
+++ b/packages/help-center/src/components/help-center-smooch.tsx
@@ -9,6 +9,7 @@ import {
 	SMOOCH_INTEGRATION_ID,
 	SMOOCH_INTEGRATION_ID_STAGING,
 } from '@automattic/zendesk-client';
+import { useQueryClient, QueryClient } from '@tanstack/react-query';
 import { useSelect, useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { useCallback, useEffect, useRef } from '@wordpress/element';
 import Smooch from 'smooch';
@@ -21,22 +22,37 @@ const destroy = () => {
 	Smooch.destroy();
 };
 
-const initSmooch = ( {
-	jwt,
-	externalId,
-}: {
-	isLoggedIn: boolean;
-	jwt: string;
-	externalId: string | undefined;
-} ) => {
+const initSmooch = (
+	{
+		jwt,
+		externalId,
+	}: {
+		isLoggedIn: boolean;
+		jwt: string;
+		externalId: string | undefined;
+	},
+	queryClient: QueryClient
+) => {
 	const isTestMode = isTestModeEnvironment();
 
 	return Smooch.init( {
 		integrationId: isTestMode ? SMOOCH_INTEGRATION_ID_STAGING : SMOOCH_INTEGRATION_ID,
 		delegate: {
-			onInvalidAuth() {
+			async onInvalidAuth() {
 				recordTracksEvent( 'calypso_smooch_messenger_auth_error' );
-				return fetchMessagingAuth( 'zendesk' ).then( ( response ) => response.jwt );
+
+				const version = 'v2';
+				const staleTime = 7 * 24 * 60 * 60 * 1000; // 1 week
+
+				await queryClient.invalidateQueries( {
+					queryKey: [ 'getMessagingAuth', version, 'zendesk', isTestMode ],
+				} );
+				const authData = await queryClient.fetchQuery( {
+					queryKey: [ 'getMessagingAuth', version, 'zendesk', isTestMode ],
+					queryFn: () => fetchMessagingAuth( 'zendesk' ),
+					staleTime,
+				} );
+				return authData.jwt;
 			},
 		},
 		embedded: true,
@@ -71,6 +87,7 @@ const playNotificationSound = () => {
 
 const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } ) => {
 	const { isEligibleForChat } = useChatStatus();
+	const queryClient = useQueryClient();
 	const smoochRef = useRef< HTMLDivElement >( null );
 	const { isHelpCenterShown, isChatLoaded, areSoundNotificationsEnabled, allowPremiumSupport } =
 		useSelect( ( select ) => {
@@ -132,7 +149,7 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 		let retryTimeout: ReturnType< typeof setTimeout > | undefined;
 
 		const initializeSmooch = async () => {
-			initSmooch( authData )
+			initSmooch( authData, queryClient )
 				.then( () => {
 					setIsChatLoaded( true );
 					recordTracksEvent( 'calypso_smooch_messenger_init', {
@@ -160,7 +177,7 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 			clearTimeout( retryTimeout );
 			destroy();
 		};
-	}, [ isMessagingScriptLoaded, authData, setIsChatLoaded ] );
+	}, [ isMessagingScriptLoaded, authData, setIsChatLoaded, queryClient ] );
 
 	useEffect( () => {
 		if ( isChatLoaded && getZendeskConversations ) {

--- a/packages/help-center/src/components/help-center-smooch.tsx
+++ b/packages/help-center/src/components/help-center-smooch.tsx
@@ -41,17 +41,14 @@ const initSmooch = (
 			async onInvalidAuth() {
 				recordTracksEvent( 'calypso_smooch_messenger_auth_error' );
 
-				const version = 'v2';
-				const staleTime = 7 * 24 * 60 * 60 * 1000; // 1 week
-
 				await queryClient.invalidateQueries( {
-					queryKey: [ 'getMessagingAuth', version, 'zendesk', isTestMode ],
+					queryKey: [ 'getMessagingAuth', 'zendesk', isTestMode ],
 				} );
 				const authData = await queryClient.fetchQuery( {
-					queryKey: [ 'getMessagingAuth', version, 'zendesk', isTestMode ],
+					queryKey: [ 'getMessagingAuth', 'zendesk', isTestMode ],
 					queryFn: () => fetchMessagingAuth( 'zendesk' ),
-					staleTime,
 				} );
+
 				return authData.jwt;
 			},
 		},

--- a/packages/help-center/src/components/help-center-smooch.tsx
+++ b/packages/help-center/src/components/help-center-smooch.tsx
@@ -4,6 +4,7 @@ import { useGetUnreadConversations } from '@automattic/odie-client/src/data';
 import {
 	useLoadZendeskMessaging,
 	useAuthenticateZendeskMessaging,
+	fetchMessagingAuth,
 	isTestModeEnvironment,
 	SMOOCH_INTEGRATION_ID,
 	SMOOCH_INTEGRATION_ID_STAGING,
@@ -35,7 +36,7 @@ const initSmooch = ( {
 		delegate: {
 			onInvalidAuth() {
 				recordTracksEvent( 'calypso_smooch_messenger_auth_error' );
-				return Promise.resolve( '' );
+				return fetchMessagingAuth( 'zendesk' ).then( ( response ) => response.jwt );
 			},
 		},
 		embedded: true,

--- a/packages/zendesk-client/src/index.ts
+++ b/packages/zendesk-client/src/index.ts
@@ -1,7 +1,10 @@
 export { useZendeskMessagingBindings } from './use-zendesk-messaging-bindings';
 export { useLoadZendeskMessaging } from './use-load-zendesk-messaging';
 export { useCanConnectToZendeskMessaging } from './use-can-connect-to-zendesk-messaging';
-export { useAuthenticateZendeskMessaging } from './use-authenticate-zendesk-messaging';
+export {
+	useAuthenticateZendeskMessaging,
+	fetchMessagingAuth,
+} from './use-authenticate-zendesk-messaging';
 export { useZendeskMessagingAvailability } from './use-zendesk-messaging-availability';
 export { useRateChat } from './use-rate-chat';
 export { useUpdateZendeskUserFields } from './use-update-zendesk-user-fields';

--- a/packages/zendesk-client/src/use-authenticate-zendesk-messaging.ts
+++ b/packages/zendesk-client/src/use-authenticate-zendesk-messaging.ts
@@ -11,11 +11,6 @@ import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import { isTestModeEnvironment } from './util';
 import type { APIFetchOptions, MessagingAuth, ZendeskAuthType } from './types';
 
-/**
- * Bump me when the API response structure goes through a breaking change.
- */
-const VERSION = 'v2';
-
 export const fetchMessagingAuth = async ( type: string = 'zendesk' ) => {
 	const isTestMode = isTestModeEnvironment();
 	const params = { type, test_mode: String( isTestMode ) };
@@ -55,7 +50,7 @@ export function useAuthenticateZendeskMessaging(
 ) {
 	const isTestMode = isTestModeEnvironment();
 	return useQuery( {
-		queryKey: [ 'getMessagingAuth', VERSION, type, isTestMode ],
+		queryKey: [ 'getMessagingAuth', type, isTestMode ],
 		queryFn: async () => fetchMessagingAuth( type ),
 		staleTime: 7 * 24 * 60 * 60 * 1000, // 1 week (JWT is actually 2 weeks, but lets be on the safe side)
 		enabled,

--- a/packages/zendesk-client/src/use-authenticate-zendesk-messaging.ts
+++ b/packages/zendesk-client/src/use-authenticate-zendesk-messaging.ts
@@ -16,6 +16,39 @@ import type { APIFetchOptions, MessagingAuth, ZendeskAuthType } from './types';
  */
 const VERSION = 'v2';
 
+export const fetchMessagingAuth = async ( type: string = 'zendesk' ) => {
+	const isTestMode = isTestModeEnvironment();
+	const params = { type, test_mode: String( isTestMode ) };
+	const wpcomParams = new URLSearchParams( params );
+
+	const auth = await ( canAccessWpcomApis()
+		? wpcomRequest< MessagingAuth >( {
+				path: '/help/authenticate/chat',
+				apiNamespace: 'wpcom/v2',
+				query: wpcomParams.toString(),
+				method: 'POST',
+		  } )
+		: apiFetch< MessagingAuth >( {
+				path: addQueryArgs( '/help-center/authenticate/chat', params ),
+				method: 'POST',
+				global: true,
+		  } as APIFetchOptions ) );
+
+	const jwt = auth?.user?.jwt;
+
+	return new Promise< { isLoggedIn: boolean; jwt: string; externalId: string | undefined } >(
+		( resolve, reject ) => {
+			if ( ! jwt ) {
+				reject();
+			}
+			window?.zE?.( 'messenger', 'loginUser', function ( callback ) {
+				callback( jwt );
+				resolve( { isLoggedIn: true, jwt, externalId: auth?.user.external_id } );
+			} );
+		}
+	);
+};
+
 export function useAuthenticateZendeskMessaging(
 	enabled = false,
 	type: ZendeskAuthType = 'zendesk'
@@ -23,37 +56,7 @@ export function useAuthenticateZendeskMessaging(
 	const isTestMode = isTestModeEnvironment();
 	return useQuery( {
 		queryKey: [ 'getMessagingAuth', VERSION, type, isTestMode ],
-		queryFn: async () => {
-			const params = { type, test_mode: String( isTestMode ) };
-			const wpcomParams = new URLSearchParams( params );
-
-			const auth = await ( canAccessWpcomApis()
-				? wpcomRequest< MessagingAuth >( {
-						path: '/help/authenticate/chat',
-						apiNamespace: 'wpcom/v2',
-						query: wpcomParams.toString(),
-						method: 'POST',
-				  } )
-				: apiFetch< MessagingAuth >( {
-						path: addQueryArgs( '/help-center/authenticate/chat', params ),
-						method: 'POST',
-						global: true,
-				  } as APIFetchOptions ) );
-
-			const jwt = auth?.user?.jwt;
-
-			return new Promise< { isLoggedIn: boolean; jwt: string; externalId: string | undefined } >(
-				( resolve, reject ) => {
-					if ( ! jwt ) {
-						reject();
-					}
-					window?.zE?.( 'messenger', 'loginUser', function ( callback ) {
-						callback( jwt );
-						resolve( { isLoggedIn: true, jwt, externalId: auth?.user.external_id } );
-					} );
-				}
-			);
-		},
+		queryFn: async () => fetchMessagingAuth( type ),
 		staleTime: 7 * 24 * 60 * 60 * 1000, // 1 week (JWT is actually 2 weeks, but lets be on the safe side)
 		enabled,
 	} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

We weren't handling auth issues for users effectively.
We added logging for `onInvalidAuth` and noticed that customers are triggering the logging.
This PR wires it properly so that a new JWT token is generated.

| Before  | After |
| ------------- | ------------- |
|  <img width="605" alt="Screenshot 2025-07-07 at 10 29 52" src="https://github.com/user-attachments/assets/7ab51ea3-979e-4865-b89d-d9e366eceb99" /> |  <img width="674" alt="Screenshot 2025-07-07 at 10 15 35" src="https://github.com/user-attachments/assets/0ee39ca8-a4c4-4c36-8941-f2fa5ccdf17f" /> |

## Proposed Changes

* Wire onInvalidAuth to return jwt

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Solve zd auth issues for users

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR
* On your sandbox for `class-help-authentication` change the `exp` to `time() + 2 * MINUTE_IN_SECONDS` to force the token to expire quickly
* Open an incognito window and login with your testing user
* Open the help center
* Open an active chat with ZD or create a new one
* Leave the chat open for more than 2 minutes
* Write a message in the chat
* Notice that the first network request to send the message fails, a call to generate the token is made, and the message request is retried
* Open the chat in ZD and verify that the message was delivered

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
