### PR TITLE
Fix login form not having padding on mobile

### DIFF
--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -336,6 +336,12 @@ $breakpoint-mobile: 782px; //Mobile size.
 			display: none;
 		}
 	}
+
+	&.is-mobile {
+		.login__lostpassword-form  {
+			padding: 16px 16px 0;
+		}
+	}
 }
 
 .is-gravatar {

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -68,6 +68,7 @@ const LayoutLoggedOut = ( {
 	isGravatar,
 	isWPJobManager,
 	isGravPoweredClient,
+	isMobile,
 	masterbarIsHidden,
 	oauth2Client,
 	primary,
@@ -139,6 +140,7 @@ const LayoutLoggedOut = ( {
 		'is-popup': isPopup,
 		'is-jetpack-woo-dna-flow': isJetpackWooDnaFlow,
 		'is-gravatar': isGravatar,
+		'is-mobile': isMobile,
 		'is-wp-job-manager': isWPJobManager,
 		'is-grav-powered-client': hasGravPoweredClientClass,
 		'is-woocommerce-core-profiler-flow': isWooJPC,
@@ -339,9 +341,8 @@ export default withCurrentRoute(
 			const isGravatar = isGravatarOAuth2Client( oauth2Client );
 			const isWPJobManager = isWPJobManagerOAuth2Client( oauth2Client );
 			const isBlazePro = getIsBlazePro( state );
-			const isAndroid = isAndroidOAuth2Client( oauth2Client );
 			const isGravPoweredClient = isGravPoweredOAuth2Client( oauth2Client );
-			const isIos = isIosOAuth2Client( oauth2Client );
+			const isMobile = isAndroidOAuth2Client( oauth2Client ) || isIosOAuth2Client( oauth2Client );
 			const isPartnerPortal = isPartnerPortalOAuth2Client( oauth2Client );
 			const isWooJPC = isWooJPCFlow( state );
 			const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
@@ -364,8 +365,7 @@ export default withCurrentRoute(
 						isJetpackCloudClient ||
 						isJetpackLogin ||
 						isVIPClient ||
-						isAndroid ||
-						isIos ) ) ||
+						isMobile ) ) ||
 				isPartnerPortal;
 
 			const noMasterbarForRoute =
@@ -398,6 +398,7 @@ export default withCurrentRoute(
 				isPopup,
 				isJetpackWooDnaFlow,
 				isGravatar,
+				isMobile,
 				isWPJobManager,
 				isGravPoweredClient,
 				wccomFrom,

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -499,7 +499,7 @@ $image-height: 47px;
 		}
 	}
 
-	.layout__primary {
+	&:not(.is-mobile) .layout__primary {
 		margin-top: 0;
 
 		/* START - Note: Patches below needed to continue using the current Divider.


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-13807

## Proposed Changes

* Bring back the side padding to the login form for mobile apps.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The changes on https://github.com/Automattic/wp-calypso/pull/104582 unexpectedly removed the padding  

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Open dev tools, enable responsive view
* Go to `/log-in?client_id=2697&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D2697%26redirect_uri%3Dwordpress%253A%252F%252Fwpcom-authorize%26response_type%3Dcode%26scope%3Dglobal%26from-calypso%3D1` (the link you would get if trying to log in on the wordpress mobile app for android)
* Check that the header and footer links, terms of service text, and the `Back` button have been removed.
* Repeat with `/log-in?client_id=11&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D11%26redirect_uri%3Dwordpress%253A%252F%252Fwpcom-authorize%26response_type%3Dcode%26scope%3Dglobal%26from-calypso%3D1` (the link you would get if trying to log in on the wordpress mobile app for iOs)

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/151104d8-fb8d-47f5-b380-1b8ce70f128c)|![image](https://github.com/user-attachments/assets/39a8032f-de97-4df6-8d79-85ae6d23fb22)|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
