### PR TITLE
Help Center: Update help on Marketing > Connections

### DIFF
--- a/client/sites/marketing/connections/connections.jsx
+++ b/client/sites/marketing/connections/connections.jsx
@@ -3,7 +3,6 @@ import QueryKeyringConnections from 'calypso/components/data/query-keyring-conne
 import QueryKeyringServices from 'calypso/components/data/query-keyring-services';
 import QueryP2Connections from 'calypso/components/data/query-p2-connections';
 import QueryPublicizeConnections from 'calypso/components/data/query-publicize-connections';
-import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useRequestSiteChecklistTaskUpdate } from 'calypso/data/site-checklist';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import GoogleAnalyticsSettings from 'calypso/my-sites/site-settings/analytics/form-google-analytics';
@@ -29,17 +28,7 @@ const SharingConnections = ( { translate, isP2Hub, siteId } ) => {
 			{ ! isP2Hub && (
 				<SharingServicesGroup
 					type="publicize"
-					title={ translate( 'Share posts with Jetpack Social {{learnMoreLink/}}', {
-						components: {
-							learnMoreLink: (
-								<InlineSupportLink
-									linkTitle={ translate( 'Learn more about sharing posts with Jetpack Social' ) }
-									supportContext="publicize"
-									showText={ false }
-								/>
-							),
-						},
-					} ) }
+					title={ translate( 'Share posts with Jetpack Social' ) }
 				/>
 			) }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of
https://linear.app/a8c/issue/DOTCOM-875/update-help-on-marketing-connections

## Proposed Changes

* Removed the link to the support docs as requested in the main issue.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of our ongoing effort to improve the Help Center.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link
* Navigate to Marketing > Connections
* Make sure that `Share posts with Jetpack Social` does not include a link to the support docs

| Before | After |
|-----|-----|
|![Screenshot 2025-07-07 at 13 36 58](https://github.com/user-attachments/assets/2a9dac89-87a8-4f7e-b02a-93383155b19a)| ![Screenshot 2025-07-07 at 13 37 06](https://github.com/user-attachments/assets/5e9a089f-f93d-45a2-a64b-4d93fb5155bd) |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
