### PR TITLE
Help Center: Update article ToC background color

### DIFF
--- a/packages/help-center/src/components/help-center-article.scss
+++ b/packages/help-center/src/components/help-center-article.scss
@@ -68,7 +68,7 @@
 			}
 
 			.wp-block-a8c-support-table-of-contents {
-				background-color: var(--studio-blue-0);
+				background-color: var(--studio-blue-5);
 				padding: 16px;
 
 				ol {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of
https://linear.app/a8c/issue/DOTCOM-872/update-help-center-article-background

## Proposed Changes

* Updated the ToC background color from studio blue 0 to studio blue 5

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of our ongoing effort for improving the Help Center.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link
* Deploy the Help Center app using the command in this PR
* Open an article in the help center
* The ToC background should be darker than the one in production

| Before | After |
|-----|-----|
|![Screenshot 2025-07-07 at 14 14 37](https://github.com/user-attachments/assets/56930582-7bc1-4c73-b4f8-e9d5cda015ef) | ![Screenshot 2025-07-07 at 14 15 02](https://github.com/user-attachments/assets/b6eadddc-0bd7-425a-b0a6-1018ed6c44df) |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
