### PR TITLE
Staging Sites Redesign: Add information component on staging site management move

### DIFF
--- a/client/sites/staging-site/components/staging-site-card/index.js
+++ b/client/sites/staging-site/components/staging-site-card/index.js
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useQueryClient } from '@tanstack/react-query';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
@@ -34,6 +35,7 @@ import { useGetLockQuery, USE_STAGING_SITE_LOCK_QUERY_KEY } from '../../hooks/us
 import { useHasValidQuotaQuery } from '../../hooks/use-has-valid-quota';
 import { useStagingSite } from '../../hooks/use-staging-site';
 import { usePullFromStagingMutation, usePushToStagingMutation } from '../../hooks/use-staging-sync';
+import StagingSiteManagementMoveInfo from '../staging-site-management-move-info';
 import { CardContentWrapper } from './card-content/card-content-wrapper';
 import { ManageStagingSiteCardContent } from './card-content/manage-staging-site-card-content';
 import { NewStagingSiteCardContent } from './card-content/new-staging-site-card-content';
@@ -517,6 +519,10 @@ export const StagingSiteCard = ( {
 			dispatch( requestJetpackConnectionHealthStatus( siteId ) );
 		}
 	}, [ dispatch, isJetpack, siteId ] );
+
+	if ( isEnabled( 'hosting/staging-sites-redesign' ) ) {
+		return <StagingSiteManagementMoveInfo />;
+	}
 
 	return (
 		<CardContentWrapper>

--- a/client/sites/staging-site/components/staging-site-card/staging-site-production-card.tsx
+++ b/client/sites/staging-site/components/staging-site-card/staging-site-production-card.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
@@ -16,6 +17,7 @@ import { getIsSyncingInProgress } from 'calypso/state/sync/selectors/get-is-sync
 import { IAppState } from 'calypso/state/types';
 import { useProductionSiteDetail, ProductionSite } from '../../hooks/use-production-site-detail';
 import { usePullFromStagingMutation, usePushToStagingMutation } from '../../hooks/use-staging-sync';
+import StagingSiteManagementMoveInfo from '../staging-site-management-move-info';
 import { CardContentWrapper } from './card-content/card-content-wrapper';
 import { SiteSyncCard } from './card-content/staging-sync-card';
 import { ConfirmationModal } from './confirmation-modal';
@@ -178,6 +180,10 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 				'Unable to load production site detail. Please contact support if you believe you are seeing this message in error.'
 			)
 		);
+	}
+
+	if ( isEnabled( 'hosting/staging-sites-redesign' ) ) {
+		return <StagingSiteManagementMoveInfo />;
 	}
 
 	return (

--- a/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
+++ b/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
@@ -23,7 +23,7 @@ interface IconConfig {
 interface InfoCardItem {
 	title: string;
 	description: string;
-	icon: IconConfig;
+	mainIcon: IconConfig;
 	locationIcon: Parameters< typeof Icon >[ 0 ][ 'icon' ];
 	location: string;
 }
@@ -34,7 +34,7 @@ const infoCardItems: InfoCardItem[] = [
 		description: __(
 			'Create and manage staging environments using the button in the top navigation bar.'
 		),
-		icon: {
+		mainIcon: {
 			icon: plus,
 			fill: '#3858E9',
 			backgroundColor: '#3858E914',
@@ -47,7 +47,7 @@ const infoCardItems: InfoCardItem[] = [
 		description: __(
 			'Switch between production and staging environments using the environment switcher.'
 		),
-		icon: {
+		mainIcon: {
 			icon: chevronUpDown,
 			fill: '#008A20',
 			backgroundColor: '#008A2014',
@@ -58,7 +58,7 @@ const infoCardItems: InfoCardItem[] = [
 	{
 		title: __( 'Delete staging site' ),
 		description: __( 'Remove staging sites and manage advanced configurations in the Settings.' ),
-		icon: {
+		mainIcon: {
 			icon: trash,
 			fill: '#CC1818',
 			backgroundColor: '#CC181814',
@@ -69,7 +69,7 @@ const infoCardItems: InfoCardItem[] = [
 	{
 		title: __( 'Try selective sync' ),
 		description: __( 'Sync specific files and folders, as well as database tables.' ),
-		icon: {
+		mainIcon: {
 			icon: reusableBlock,
 			fill: '#B26200',
 			backgroundColor: '#B2620014',
@@ -93,15 +93,15 @@ const InfoCard: FunctionComponent< InfoCardProps > = ( { item } ) => {
 							width: '32px',
 							height: '32px',
 							minWidth: '32px',
-							fill: item.icon.fill,
-							backgroundColor: item.icon.backgroundColor,
+							fill: item.mainIcon.fill,
+							backgroundColor: item.mainIcon.backgroundColor,
 							borderRadius: '4px',
 							display: 'flex',
 							alignItems: 'center',
 							justifyContent: 'center',
 						} }
 					>
-						<Icon icon={ item.icon.icon } size={ 20 } />
+						<Icon icon={ item.mainIcon.icon } size={ 20 } />
 					</div>
 					<VStack>
 						<Text weight={ 500 } size={ 16 }>

--- a/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
+++ b/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
@@ -1,7 +1,6 @@
 import {
 	Card,
 	CardBody,
-	Icon,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	__experimentalGrid as Grid,
@@ -9,80 +8,76 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { arrowUp, cog } from '@wordpress/icons';
+import { Icon, arrowUp, cog } from '@wordpress/icons';
 import { FunctionComponent } from 'react';
+
+interface InfoCardItem {
+	title: string;
+	description: string;
+	icon: Parameters< typeof Icon >[ 0 ][ 'icon' ];
+	location: string;
+}
+
+const infoCardItems: InfoCardItem[] = [
+	{
+		title: __( 'Create new staging site' ),
+		description: __(
+			'Create and manage staging environments using the button in the top navigation bar.'
+		),
+		icon: arrowUp,
+		location: __( 'Located in top navigation' ),
+	},
+	{
+		title: __( 'Switch environment' ),
+		description: __(
+			'Switch between production and staging environments using the environment switcher.'
+		),
+		icon: arrowUp,
+		location: __( 'Located in top navigation' ),
+	},
+	{
+		title: __( 'Delete staging site' ),
+		description: __( 'Remove staging sites and manage advanced configurations in the Settings.' ),
+		icon: cog,
+		location: __( 'Available in settings' ),
+	},
+	{
+		title: __( 'Try selective sync' ),
+		description: __( 'Sync specific files and folders, as well as database tables.' ),
+		icon: arrowUp,
+		location: __( 'Located in top navigation' ),
+	},
+];
+
+interface InfoCardProps {
+	item: InfoCardItem;
+}
+
+const InfoCard: FunctionComponent< InfoCardProps > = ( { item } ) => {
+	return (
+		<Card>
+			<CardBody>
+				<VStack>
+					<Text weight={ 500 }>{ item.title }</Text>
+					<Text>{ item.description }</Text>
+					<HStack alignment="left" spacing={ 1 }>
+						<Icon icon={ item.icon } size={ 16 } style={ { fill: '#757575' } } />
+						<Text variant="muted">{ item.location }</Text>
+					</HStack>
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+};
 
 const StagingSiteManagementMoveInfo: FunctionComponent = () => {
 	return (
 		<Grid alignment="topLeft" columns={ 2 } gap={ 2 } style={ { maxWidth: '748px' } }>
-			<Item>
-				<Card>
-					<CardBody>
-						<VStack>
-							<Text weight={ 500 }>{ __( 'Create new staging site' ) }</Text>
-							<Text>
-								{ __(
-									'Create and manage staging environments using the button in the top navigation bar.'
-								) }
-							</Text>
-							<HStack alignment="left" spacing={ 1 }>
-								<Icon icon={ arrowUp } size={ 16 } style={ { fill: '#757575' } } />
-								<Text variant="muted">{ __( 'Located in top navigation' ) }</Text>
-							</HStack>
-						</VStack>
-					</CardBody>
-				</Card>
-			</Item>
-			<Item>
-				<Card>
-					<CardBody>
-						<VStack>
-							<Text weight={ 500 }>{ __( 'Switch environment' ) }</Text>
-							<Text>
-								{ __(
-									'Switch between production and staging environments using the environment switcher.'
-								) }
-							</Text>
-							<HStack alignment="left" spacing={ 1 }>
-								<Icon icon={ arrowUp } size={ 16 } style={ { fill: '#757575' } } />
-								<Text variant="muted">{ __( 'Located in top navigation' ) }</Text>
-							</HStack>
-						</VStack>
-					</CardBody>
-				</Card>
-			</Item>
-			<Item>
-				<Card>
-					<CardBody>
-						<VStack>
-							<Text weight={ 500 }>{ __( 'Delete staging site' ) }</Text>
-							<Text>
-								{ __( 'Remove staging sites and manage advanced configurations in the Settings.' ) }
-							</Text>
-							<HStack alignment="left" spacing={ 1 }>
-								<Icon icon={ cog } size={ 16 } style={ { fill: '#757575' } } />
-								<Text variant="muted">{ __( 'Available in settings' ) }</Text>
-							</HStack>
-						</VStack>
-					</CardBody>
-				</Card>
-			</Item>
-			<Item>
-				<Card>
-					<CardBody>
-						<VStack>
-							<Text weight={ 500 }>{ __( 'Try selective sync' ) }</Text>
-							<Text>
-								{ __( 'Sync specific files and folders, as well as well as database tables.' ) }
-							</Text>
-							<HStack alignment="left" spacing={ 1 }>
-								<Icon icon={ arrowUp } size={ 16 } style={ { fill: '#757575' } } />
-								<Text variant="muted">{ __( 'Located in top navigation' ) }</Text>
-							</HStack>
-						</VStack>
-					</CardBody>
-				</Card>
-			</Item>
+			{ infoCardItems.map( ( item, index ) => (
+				<Item key={ index }>
+					<InfoCard item={ item } />
+				</Item>
+			) ) }
 		</Grid>
 	);
 };

--- a/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
+++ b/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
@@ -8,6 +8,7 @@ import {
 	__experimentalItem as Item,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { arrowUp, cog } from '@wordpress/icons';
 import { FunctionComponent } from 'react';
 
@@ -18,13 +19,15 @@ const StagingSiteManagementMoveInfo: FunctionComponent = () => {
 				<Card>
 					<CardBody>
 						<VStack>
-							<Text weight={ 500 }>Create new staging site</Text>
+							<Text weight={ 500 }>{ __( 'Create new staging site' ) }</Text>
 							<Text>
-								Create and manage staging environments using the button in the top navigation bar.
+								{ __(
+									'Create and manage staging environments using the button in the top navigation bar.'
+								) }
 							</Text>
 							<HStack alignment="left" spacing={ 1 }>
 								<Icon icon={ arrowUp } size={ 16 } style={ { fill: '#757575' } } />
-								<Text variant="muted">Located in top navigation</Text>
+								<Text variant="muted">{ __( 'Located in top navigation' ) }</Text>
 							</HStack>
 						</VStack>
 					</CardBody>
@@ -34,13 +37,15 @@ const StagingSiteManagementMoveInfo: FunctionComponent = () => {
 				<Card>
 					<CardBody>
 						<VStack>
-							<Text weight={ 500 }>Switch environment</Text>
+							<Text weight={ 500 }>{ __( 'Switch environment' ) }</Text>
 							<Text>
-								Switch between production and staging environments using the environment switcher.
+								{ __(
+									'Switch between production and staging environments using the environment switcher.'
+								) }
 							</Text>
 							<HStack alignment="left" spacing={ 1 }>
 								<Icon icon={ arrowUp } size={ 16 } style={ { fill: '#757575' } } />
-								<Text variant="muted">Located in top navigation</Text>
+								<Text variant="muted">{ __( 'Located in top navigation' ) }</Text>
 							</HStack>
 						</VStack>
 					</CardBody>
@@ -50,11 +55,13 @@ const StagingSiteManagementMoveInfo: FunctionComponent = () => {
 				<Card>
 					<CardBody>
 						<VStack>
-							<Text weight={ 500 }>Delete staging site</Text>
-							<Text>Remove staging sites and manage advanced configurations in the Settings.</Text>
+							<Text weight={ 500 }>{ __( 'Delete staging site' ) }</Text>
+							<Text>
+								{ __( 'Remove staging sites and manage advanced configurations in the Settings.' ) }
+							</Text>
 							<HStack alignment="left" spacing={ 1 }>
 								<Icon icon={ cog } size={ 16 } style={ { fill: '#757575' } } />
-								<Text variant="muted">Available in settings</Text>
+								<Text variant="muted">{ __( 'Available in settings' ) }</Text>
 							</HStack>
 						</VStack>
 					</CardBody>
@@ -64,11 +71,13 @@ const StagingSiteManagementMoveInfo: FunctionComponent = () => {
 				<Card>
 					<CardBody>
 						<VStack>
-							<Text weight={ 500 }>Try selective sync</Text>
-							<Text>Sync specific files and folders, as well as well as database tables.</Text>
+							<Text weight={ 500 }>{ __( 'Try selective sync' ) }</Text>
+							<Text>
+								{ __( 'Sync specific files and folders, as well as well as database tables.' ) }
+							</Text>
 							<HStack alignment="left" spacing={ 1 }>
 								<Icon icon={ arrowUp } size={ 16 } style={ { fill: '#757575' } } />
-								<Text variant="muted">Located in top navigation</Text>
+								<Text variant="muted">{ __( 'Located in top navigation' ) }</Text>
 							</HStack>
 						</VStack>
 					</CardBody>

--- a/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
+++ b/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
@@ -4,6 +4,7 @@ import {
 	CardBody,
 	Icon,
 	__experimentalText as Text,
+	__experimentalHeading as Heading,
 	__experimentalVStack as VStack,
 	__experimentalGrid as Grid,
 	__experimentalItem as Item,
@@ -120,18 +121,32 @@ const StagingSiteManagementMoveInfo: FunctionComponent = () => {
 	const isMobile = useBreakpoint( '<660px' );
 
 	return (
-		<Grid
-			alignment="topLeft"
-			columns={ isMobile ? 1 : 2 }
-			gap={ 6 }
-			style={ { maxWidth: '748px' } }
-		>
-			{ infoCardItems.map( ( item, index ) => (
-				<Item key={ index } style={ { padding: '0' } }>
-					<InfoCard item={ item } />
-				</Item>
-			) ) }
-		</Grid>
+		<VStack spacing={ 10 }>
+			<div>
+				<Heading level={ 2 } weight={ 500 } size={ 24 }>
+					{ __( 'Staging site management has moved' ) }
+				</Heading>
+				<Text>
+					{ __(
+						"We've reorganized staging site controls to make them more accessible and intuitive."
+					) }
+					<br />
+					{ __( 'Find everything you need in the new locations highlighted below.' ) }
+				</Text>
+			</div>
+			<Grid
+				alignment="topLeft"
+				columns={ isMobile ? 1 : 2 }
+				gap={ 6 }
+				style={ { maxWidth: '748px' } }
+			>
+				{ infoCardItems.map( ( item, index ) => (
+					<Item key={ index } style={ { padding: '0' } }>
+						<InfoCard item={ item } />
+					</Item>
+				) ) }
+			</Grid>
+		</VStack>
 	);
 };
 

--- a/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
+++ b/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
@@ -1,6 +1,7 @@
 import {
 	Card,
 	CardBody,
+	Icon,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	__experimentalGrid as Grid,
@@ -8,7 +9,7 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Icon, arrowUp, cog } from '@wordpress/icons';
+import { arrowUp, cog } from '@wordpress/icons';
 import { FunctionComponent } from 'react';
 
 interface InfoCardItem {

--- a/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
+++ b/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
@@ -1,7 +1,81 @@
+import {
+	Card,
+	CardBody,
+	Icon,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	__experimentalGrid as Grid,
+	__experimentalItem as Item,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { arrowUp, cog } from '@wordpress/icons';
 import { FunctionComponent } from 'react';
 
 const StagingSiteManagementMoveInfo: FunctionComponent = () => {
-	return <div>content will go here</div>;
+	return (
+		<Grid alignment="topLeft" columns={ 2 } gap={ 2 } style={ { maxWidth: '748px' } }>
+			<Item>
+				<Card>
+					<CardBody>
+						<VStack>
+							<Text weight={ 500 }>Create new staging site</Text>
+							<Text>
+								Create and manage staging environments using the button in the top navigation bar.
+							</Text>
+							<HStack alignment="left" spacing={ 1 }>
+								<Icon icon={ arrowUp } size={ 16 } style={ { fill: '#757575' } } />
+								<Text variant="muted">Located in top navigation</Text>
+							</HStack>
+						</VStack>
+					</CardBody>
+				</Card>
+			</Item>
+			<Item>
+				<Card>
+					<CardBody>
+						<VStack>
+							<Text weight={ 500 }>Switch environment</Text>
+							<Text>
+								Switch between production and staging environments using the environment switcher.
+							</Text>
+							<HStack alignment="left" spacing={ 1 }>
+								<Icon icon={ arrowUp } size={ 16 } style={ { fill: '#757575' } } />
+								<Text variant="muted">Located in top navigation</Text>
+							</HStack>
+						</VStack>
+					</CardBody>
+				</Card>
+			</Item>
+			<Item>
+				<Card>
+					<CardBody>
+						<VStack>
+							<Text weight={ 500 }>Delete staging site</Text>
+							<Text>Remove staging sites and manage advanced configurations in the Settings.</Text>
+							<HStack alignment="left" spacing={ 1 }>
+								<Icon icon={ cog } size={ 16 } style={ { fill: '#757575' } } />
+								<Text variant="muted">Available in settings</Text>
+							</HStack>
+						</VStack>
+					</CardBody>
+				</Card>
+			</Item>
+			<Item>
+				<Card>
+					<CardBody>
+						<VStack>
+							<Text weight={ 500 }>Try selective sync</Text>
+							<Text>Sync specific files and folders, as well as well as database tables.</Text>
+							<HStack alignment="left" spacing={ 1 }>
+								<Icon icon={ arrowUp } size={ 16 } style={ { fill: '#757575' } } />
+								<Text variant="muted">Located in top navigation</Text>
+							</HStack>
+						</VStack>
+					</CardBody>
+				</Card>
+			</Item>
+		</Grid>
+	);
 };
 
 export default StagingSiteManagementMoveInfo;

--- a/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
+++ b/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
@@ -84,7 +84,7 @@ interface InfoCardProps {
 const InfoCard: FunctionComponent< InfoCardProps > = ( { item } ) => {
 	return (
 		<Card>
-			<CardBody>
+			<CardBody style={ { padding: '16px' } }>
 				<HStack spacing={ 4 } alignment="topLeft">
 					<div
 						style={ {
@@ -117,9 +117,9 @@ const InfoCard: FunctionComponent< InfoCardProps > = ( { item } ) => {
 
 const StagingSiteManagementMoveInfo: FunctionComponent = () => {
 	return (
-		<Grid alignment="topLeft" columns={ 2 } gap={ 2 } style={ { maxWidth: '748px' } }>
+		<Grid alignment="topLeft" columns={ 2 } gap={ 6 } style={ { maxWidth: '748px' } }>
 			{ infoCardItems.map( ( item, index ) => (
-				<Item key={ index }>
+				<Item key={ index } style={ { padding: '0' } }>
 					<InfoCard item={ item } />
 				</Item>
 			) ) }

--- a/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
+++ b/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
@@ -1,3 +1,4 @@
+import { useBreakpoint } from '@automattic/viewport-react';
 import {
 	Card,
 	CardBody,
@@ -116,8 +117,15 @@ const InfoCard: FunctionComponent< InfoCardProps > = ( { item } ) => {
 };
 
 const StagingSiteManagementMoveInfo: FunctionComponent = () => {
+	const isMobile = useBreakpoint( '<660px' );
+
 	return (
-		<Grid alignment="topLeft" columns={ 2 } gap={ 6 } style={ { maxWidth: '748px' } }>
+		<Grid
+			alignment="topLeft"
+			columns={ isMobile ? 1 : 2 }
+			gap={ 6 }
+			style={ { maxWidth: '748px' } }
+		>
 			{ infoCardItems.map( ( item, index ) => (
 				<Item key={ index } style={ { padding: '0' } }>
 					<InfoCard item={ item } />

--- a/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
+++ b/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
@@ -1,0 +1,7 @@
+import { FunctionComponent } from 'react';
+
+const StagingSiteManagementMoveInfo: FunctionComponent = () => {
+	return <div>content will go here</div>;
+};
+
+export default StagingSiteManagementMoveInfo;

--- a/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
+++ b/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
@@ -9,13 +9,20 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { arrowUp, cog } from '@wordpress/icons';
+import { arrowUp, cog, plus, chevronUpDown, trash, reusableBlock } from '@wordpress/icons';
 import { FunctionComponent } from 'react';
+
+interface IconConfig {
+	icon: Parameters< typeof Icon >[ 0 ][ 'icon' ];
+	fill: string;
+	backgroundColor: string;
+}
 
 interface InfoCardItem {
 	title: string;
 	description: string;
-	icon: Parameters< typeof Icon >[ 0 ][ 'icon' ];
+	icon: IconConfig;
+	locationIcon: Parameters< typeof Icon >[ 0 ][ 'icon' ];
 	location: string;
 }
 
@@ -25,7 +32,12 @@ const infoCardItems: InfoCardItem[] = [
 		description: __(
 			'Create and manage staging environments using the button in the top navigation bar.'
 		),
-		icon: arrowUp,
+		icon: {
+			icon: plus,
+			fill: '#3858E9',
+			backgroundColor: '#3858E914',
+		},
+		locationIcon: arrowUp,
 		location: __( 'Located in top navigation' ),
 	},
 	{
@@ -33,19 +45,34 @@ const infoCardItems: InfoCardItem[] = [
 		description: __(
 			'Switch between production and staging environments using the environment switcher.'
 		),
-		icon: arrowUp,
+		icon: {
+			icon: chevronUpDown,
+			fill: '#008A20',
+			backgroundColor: '#008A2014',
+		},
+		locationIcon: arrowUp,
 		location: __( 'Located in top navigation' ),
 	},
 	{
 		title: __( 'Delete staging site' ),
 		description: __( 'Remove staging sites and manage advanced configurations in the Settings.' ),
-		icon: cog,
+		icon: {
+			icon: trash,
+			fill: '#CC1818',
+			backgroundColor: '#CC181814',
+		},
+		locationIcon: cog,
 		location: __( 'Available in settings' ),
 	},
 	{
 		title: __( 'Try selective sync' ),
 		description: __( 'Sync specific files and folders, as well as database tables.' ),
-		icon: arrowUp,
+		icon: {
+			icon: reusableBlock,
+			fill: '#B26200',
+			backgroundColor: '#B2620014',
+		},
+		locationIcon: arrowUp,
 		location: __( 'Located in top navigation' ),
 	},
 ];
@@ -58,14 +85,31 @@ const InfoCard: FunctionComponent< InfoCardProps > = ( { item } ) => {
 	return (
 		<Card>
 			<CardBody>
-				<VStack>
-					<Text weight={ 500 }>{ item.title }</Text>
-					<Text>{ item.description }</Text>
-					<HStack alignment="left" spacing={ 1 }>
-						<Icon icon={ item.icon } size={ 16 } style={ { fill: '#757575' } } />
-						<Text variant="muted">{ item.location }</Text>
-					</HStack>
-				</VStack>
+				<HStack spacing={ 4 } alignment="topLeft">
+					<div
+						style={ {
+							width: '32px',
+							height: '32px',
+							minWidth: '32px',
+							fill: item.icon.fill,
+							backgroundColor: item.icon.backgroundColor,
+							borderRadius: '4px',
+							display: 'flex',
+							alignItems: 'center',
+							justifyContent: 'center',
+						} }
+					>
+						<Icon icon={ item.icon.icon } size={ 20 } />
+					</div>
+					<VStack>
+						<Text weight={ 500 }>{ item.title }</Text>
+						<Text>{ item.description }</Text>
+						<HStack alignment="left" spacing={ 1 }>
+							<Icon icon={ item.locationIcon } size={ 16 } style={ { fill: '#757575' } } />
+							<Text variant="muted">{ item.location }</Text>
+						</HStack>
+					</VStack>
+				</HStack>
 			</CardBody>
 		</Card>
 	);

--- a/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
+++ b/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
@@ -104,7 +104,9 @@ const InfoCard: FunctionComponent< InfoCardProps > = ( { item } ) => {
 						<Icon icon={ item.icon.icon } size={ 20 } />
 					</div>
 					<VStack>
-						<Text weight={ 500 }>{ item.title }</Text>
+						<Text weight={ 500 } size={ 16 }>
+							{ item.title }
+						</Text>
 						<Text>{ item.description }</Text>
 						<HStack alignment="left" spacing={ 1 }>
 							<Icon icon={ item.locationIcon } size={ 16 } style={ { fill: '#757575' } } />
@@ -123,7 +125,7 @@ const StagingSiteManagementMoveInfo: FunctionComponent = () => {
 	return (
 		<VStack spacing={ 10 }>
 			<div>
-				<Heading level={ 2 } weight={ 500 } size={ 24 }>
+				<Heading level={ 1 } weight={ 500 } size={ 20 }>
 					{ __( 'Staging site management has moved' ) }
 				</Heading>
 				<Text>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTDEV-182

## Proposed Changes

* add temporary information component describing staging site management move

![Markup on 2025-07-08 at 20:07:32](https://github.com/user-attachments/assets/d5cc41d7-2d8f-40af-95c9-9b5463ea7633)

design in Figma: ASqz3fW9Go9m5bHL2XiuUR-fi-724_136351

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

DOTDEV-182

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start` (or use Calypso Live).
2. Ensure the `hosting/staging-sites-redesign` feature flag is enabled (by using `?flags=hosting/staging-sites-redesign` query parameter).
3. Head over to the `/sites` dashboard and select an Atomic test site with a staging site.
4. Click on the `Staging site` tab. Instead of staging site management buttons a new information tab content should be rendered (as can be seen in the screenshot above). The content should be clear and make sense.
5. The same content should be rendered for staging and production site.
6. Content should render correctly on mobile and RTL as well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?