### PR TITLE
One question poll for Reader users

### DIFF
--- a/client/reader/components/reader-main/index.jsx
+++ b/client/reader/components/reader-main/index.jsx
@@ -1,6 +1,8 @@
 import { Component } from 'react';
+import { connect } from 'react-redux';
 import SyncReaderFollows from 'calypso/components/data/sync-reader-follows';
 import Main from 'calypso/components/main';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { ReaderPendingActionHandler } from './pending-action-handler';
 import './style.scss';
 
@@ -17,11 +19,44 @@ import './style.scss';
  * 3. dismount old ReaderMain from the first step (dismount, 1 ref)
  */
 let activeReaderMainRefCount = 0;
+let survicateScriptLoaded = false;
+
 const setIsReaderPage = ( add ) => {
 	if ( add ) {
 		document.querySelector( 'body' ).classList.add( 'is-reader-page' );
 	} else if ( activeReaderMainRefCount === 0 ) {
 		document.querySelector( 'body' ).classList.remove( 'is-reader-page' );
+	}
+};
+
+const loadSurvicateScript = ( userId ) => {
+	if ( survicateScriptLoaded || typeof window === 'undefined' ) {
+		return;
+	}
+
+	try {
+		// Define user IDs before the init of the tracking code
+		if ( userId ) {
+			( function ( opts ) {
+				opts.traits = {
+					user_id: userId.toString(),
+				};
+			} )( ( window._sva = window._sva || {} ) );
+		}
+
+		const script = document.createElement( 'script' );
+		script.src =
+			'https://survey.survicate.com/workspaces/e4794374cce15378101b63de24117572/web_surveys.js';
+		script.async = true;
+
+		const firstScript = document.getElementsByTagName( 'script' )[ 0 ];
+		if ( firstScript && firstScript.parentNode ) {
+			firstScript.parentNode.insertBefore( script, firstScript );
+			survicateScriptLoaded = true;
+		}
+	} catch ( error ) {
+		// eslint-disable-next-line no-console
+		console.warn( 'Failed to load Survicate script:', error );
 	}
 };
 
@@ -31,10 +66,11 @@ const setIsReaderPage = ( add ) => {
  * This class is used by pieces of the Reader to indicate they want "editorial" styles.
  * Notably, this overrides the background color of the document and is used as a hook by other parts to override styles.
  */
-export default class ReaderMain extends Component {
+class ReaderMain extends Component {
 	componentDidMount() {
 		activeReaderMainRefCount++;
 		setIsReaderPage( true );
+		loadSurvicateScript( this.props.userId );
 	}
 
 	componentWillUnmount() {
@@ -55,3 +91,7 @@ export default class ReaderMain extends Component {
 		);
 	}
 }
+
+export default connect( ( state ) => ( {
+	userId: getCurrentUserId( state ),
+} ) )( ReaderMain );

--- a/client/reader/components/reader-main/index.jsx
+++ b/client/reader/components/reader-main/index.jsx
@@ -3,6 +3,9 @@ import { connect } from 'react-redux';
 import SyncReaderFollows from 'calypso/components/data/sync-reader-follows';
 import Main from 'calypso/components/main';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import getUserSetting from 'calypso/state/selectors/get-user-setting';
+import { saveUserSettings } from 'calypso/state/user-settings/actions';
+import setUserSetting from 'calypso/state/user-settings/thunks/set-user-setting';
 import { ReaderPendingActionHandler } from './pending-action-handler';
 import './style.scss';
 
@@ -29,8 +32,13 @@ const setIsReaderPage = ( add ) => {
 	}
 };
 
-const loadSurvicateScript = ( userId ) => {
+const loadSurvicateScript = ( userId, hasCompletedSurvey, onSurveyCompleted ) => {
 	if ( survicateScriptLoaded || typeof window === 'undefined' ) {
+		return;
+	}
+
+	// Don't load script if user has already completed a survey
+	if ( hasCompletedSurvey ) {
 		return;
 	}
 
@@ -48,6 +56,17 @@ const loadSurvicateScript = ( userId ) => {
 		script.src =
 			'https://survey.survicate.com/workspaces/e4794374cce15378101b63de24117572/web_surveys.js';
 		script.async = true;
+
+		// Set up event listener once script loads
+		script.onload = () => {
+			if ( window._sva && typeof window._sva.addEventListener === 'function' ) {
+				// Listen for survey completion
+				window._sva.addEventListener( 'survey_completed', ( surveyId ) => {
+					// Call the callback to save user preference
+					onSurveyCompleted( surveyId );
+				} );
+			}
+		};
 
 		const firstScript = document.getElementsByTagName( 'script' )[ 0 ];
 		if ( firstScript && firstScript.parentNode ) {
@@ -67,10 +86,25 @@ const loadSurvicateScript = ( userId ) => {
  * Notably, this overrides the background color of the document and is used as a hook by other parts to override styles.
  */
 class ReaderMain extends Component {
+	// eslint-disable-next-line no-unused-vars
+	handleSurveyCompleted = ( surveyId ) => {
+		const { dispatch } = this.props;
+
+		// Set user preference to indicate they've completed a poll
+		dispatch( setUserSetting( 'reader_poll_completed', true ) );
+
+		// Save the settings immediately
+		dispatch( saveUserSettings() );
+	};
+
 	componentDidMount() {
 		activeReaderMainRefCount++;
 		setIsReaderPage( true );
-		loadSurvicateScript( this.props.userId );
+		loadSurvicateScript(
+			this.props.userId,
+			this.props.hasCompletedSurvey,
+			this.handleSurveyCompleted
+		);
 	}
 
 	componentWillUnmount() {
@@ -92,6 +126,10 @@ class ReaderMain extends Component {
 	}
 }
 
-export default connect( ( state ) => ( {
-	userId: getCurrentUserId( state ),
-} ) )( ReaderMain );
+export default connect(
+	( state ) => ( {
+		userId: getCurrentUserId( state ),
+		hasCompletedSurvey: getUserSetting( state, 'reader_poll_completed' ) === true,
+	} ),
+	{ setUserSetting, saveUserSettings }
+)( ReaderMain );


### PR DESCRIPTION
## Description

We'd like to experiment with asking visitors to the web Reader one question: "How can we improve WordPress.com for you?"

This poll will show up once per user in the bottom right corner of the page:

![CleanShot 2025-07-07 at 09 58 09](https://github.com/user-attachments/assets/7e533c91-33c2-4205-b0e1-b40336b5ee16)

A couple of additional notes:

- I'm passing the userID of the user when submissions are made so we can follow up with users if need be. We intentionally used userID here instead of email to prevent having to share email addresses with a third party service.
- This is a single question poll, followed by a thank you message.
- It should show up instantly.
- Users should only see this once. It's currently scoped to just reader pages (though I've excluded /reader/subscriptions). Once you submit, or dismiss, or ignore this poll and move to another page, you should not see it again.
- I've limited the poll to 150 responses.

## Testing
- Load this PR
- Visit the reader
- Submit the poll (ping me about verifying whether your submission was received)
- Try to get the poll to show up again