### PR TITLE
Dashboard v2: Try to add slide-in & slide-out animation on settings page

### DIFF
--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -610,7 +610,7 @@ const createRouteTree = ( config: AppConfig ) => {
 
 export const getRouter = ( config: AppConfig ) => {
 	const routeTree = createRouteTree( config );
-	return new Router( {
+	const router = new Router( {
 		routeTree,
 		basepath: config.basePath,
 		defaultErrorComponent: UnknownError,
@@ -621,8 +621,27 @@ export const getRouter = ( config: AppConfig ) => {
 		// Tanstack Router knows how to do it best. Even though it says
 		// "default", we can still customize it in CSS and add more transition
 		// areas.
-		defaultViewTransition: true,
+		defaultViewTransition: {
+			types: ( { fromLocation, toLocation } ) => {
+				const fromMatch = fromLocation ? router.matchRoutes( fromLocation )?.at( -1 ) : false;
+				const toMatch = router.matchRoutes( toLocation )?.at( -1 );
+				if (
+					fromMatch &&
+					fromMatch.routeId.startsWith( siteSettingsRoute.id ) &&
+					toMatch &&
+					toMatch.routeId.startsWith( siteSettingsRoute.id ) &&
+					fromMatch.routeId !== toMatch.routeId
+				) {
+					const direction = toMatch.routeId.length > fromMatch.routeId.length ? 'left' : 'right';
+					return [ `slide-${ direction }` ];
+				}
+
+				return [ 'default' ];
+			},
+		},
 	} );
+
+	return router;
 };
 
 export {

--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -4,6 +4,7 @@
 // Should be implemented differently once v2 is not loaded via the v1 stack
 // I'm tempted to even just replace all this with a display:none on the logo
 @import './loading-screen';
+@import './view-transitions/style.scss';
 
 // Hacks that shouldn't be necessary.
 .environment-badge {

--- a/client/dashboard/app/view-transitions/animations.scss
+++ b/client/dashboard/app/view-transitions/animations.scss
@@ -1,0 +1,77 @@
+/**
+ * Variables
+ */
+$animation-duration: 0.25s;
+
+/**
+ * Mixins
+ */
+@mixin disable-default-animation {
+	// Prevent the default animation, so both views remain opacity:1 throughout the transition.
+	animation: none;
+}
+
+/**
+ * Keyframes
+ */
+@keyframes fade-out {
+	from {
+		opacity: 1;
+	}
+	to {
+		opacity: 0;
+	}
+}
+
+@keyframes fade-in {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
+@keyframes slide-out-left {
+	from {
+		transform: translateX( 0 );
+		opacity: 1;
+	}
+	to {
+		transform: translateX( -50px );
+		opacity: 0;
+	}
+}
+
+@keyframes slide-in-left {
+	from {
+		transform: translateX( 50px );
+		opacity: 0;
+	}
+	to {
+		transform: translateX( 0 );
+		opacity: 1;
+	}
+}
+
+@keyframes slide-out-right {
+	from {
+		transform: translateX( 0 );
+		opacity: 1;
+	}
+	to {
+		transform: translateX( 50px );
+		opacity: 0;
+	}
+}
+
+@keyframes slide-in-right {
+	from {
+		transform: translateX( -50px );
+		opacity: 0;
+	}
+	to {
+		transform: translateX( 0 );
+		opacity: 1;
+	}
+}

--- a/client/dashboard/app/view-transitions/header.scss
+++ b/client/dashboard/app/view-transitions/header.scss
@@ -1,3 +1,5 @@
+@import './animations.scss';
+
 // The main and sub headers must be separate view transitions, otherwise the sub
 // header won't slide in!
 header.dashboard-header-bar {
@@ -8,20 +10,12 @@ main div.dashboard-header-bar {
 	view-transition-name: sub-header;
 }
 
-::view-transition-group(main-header),
-::view-transition-group(sub-header) {
-	/** Prevent the default animation, so both views remain opacity:1 throughout the transition */
-	animation: none;
-	/** Headers should show on top of any view transition elements (important for sticky) */
+::view-transition-group( main-header ),
+::view-transition-group( sub-header ) {
+	// Headers should show on top of any view transition elements (important for sticky).
 	z-index: 1;
 }
 
-::view-transition-group(sub-header) {
-	/** Prevent the sub-header from overlapping any view transition elements when it's removed */
-	height: fit-content;
-}
-
-::view-transition-old(sub-header) {
-	/** Don't show the frozen old view */
-	display: none;
+::view-transition-group( main-header ) {
+	@include disable-default-animation;
 }

--- a/client/dashboard/app/view-transitions/header.scss
+++ b/client/dashboard/app/view-transitions/header.scss
@@ -1,0 +1,27 @@
+// The main and sub headers must be separate view transitions, otherwise the sub
+// header won't slide in!
+header.dashboard-header-bar {
+	view-transition-name: main-header;
+}
+
+main div.dashboard-header-bar {
+	view-transition-name: sub-header;
+}
+
+::view-transition-group(main-header),
+::view-transition-group(sub-header) {
+	/** Prevent the default animation, so both views remain opacity:1 throughout the transition */
+	animation: none;
+	/** Headers should show on top of any view transition elements (important for sticky) */
+	z-index: 1;
+}
+
+::view-transition-group(sub-header) {
+	/** Prevent the sub-header from overlapping any view transition elements when it's removed */
+	height: fit-content;
+}
+
+::view-transition-old(sub-header) {
+	/** Don't show the frozen old view */
+	display: none;
+}

--- a/client/dashboard/app/view-transitions/page-header.scss
+++ b/client/dashboard/app/view-transitions/page-header.scss
@@ -1,33 +1,43 @@
-html:active-view-transition-type(default) {
+html:active-view-transition-type( default ) {
 	.dashboard-page-layout.is-large {
-		.dashboard-page-header .dashboard-section-header__prefix {
-			view-transition-name: page-layout-header-prefix-large;
-		}
-
 		.dashboard-page-header .dashboard-section-header__heading-row {
-			view-transition-name: page-layout-header-heading-row-large;
+			view-transition-name: page-layout-header-large-heading-row;
 		}
 
-		.dashboard-page-header .dashboard-section-header__description {
-			view-transition-name: page-layout-header-description-large;
+		.dashboard-page-header .dashboard-section-header__heading {
+			view-transition-name: page-layout-header-large-heading;
 		}
 
 		.dashboard-page-header .components-button.is-primary {
-			view-transition-name: page-layout-header-large--button;
+			view-transition-name: page-layout-header-large-primary-button;
 		}
 	}
 
 	.dashboard-page-layout.is-small {
-		.dashboard-page-header .dashboard-section-header__prefix {
-			view-transition-name: page-layout-header-prefix-small;
-		}
-
 		.dashboard-page-header .dashboard-section-header__heading-row {
-			view-transition-name: page-layout-header-heading-row-small;
+			view-transition-name: page-layout-header-small-heading-row;
 		}
 
-		.dashboard-page-header .dashboard-section-header__description {
-			view-transition-name: page-layout-header-description-small;
+		.dashboard-page-header .dashboard-section-header__heading {
+			view-transition-name: page-layout-header-small-heading;
+		}
+
+		.dashboard-page-header .components-button.is-primary {
+			view-transition-name: page-layout-header-small-primary-button;
 		}
 	}
+}
+
+::view-transition-old( page-layout-header-small-heading ),
+::view-transition-new( page-layout-header-small-heading ),
+::view-transition-old( page-layout-header-large-heading ),
+::view-transition-new( page-layout-header-large-heading ) {
+	height: 100%;
+}
+
+::view-transition-old( page-layout-header-small-primary-button ),
+::view-transition-new( page-layout-header-small-primary-button ),
+::view-transition-old( page-layout-header-large-primary-button ),
+::view-transition-new( page-layout-header-large-primary-button ) {
+	height: 100%;
 }

--- a/client/dashboard/app/view-transitions/page-header.scss
+++ b/client/dashboard/app/view-transitions/page-header.scss
@@ -1,0 +1,33 @@
+html:active-view-transition-type(default) {
+	.dashboard-page-layout.is-large {
+		.dashboard-page-header .dashboard-section-header__prefix {
+			view-transition-name: page-layout-header-prefix-large;
+		}
+
+		.dashboard-page-header .dashboard-section-header__heading-row {
+			view-transition-name: page-layout-header-heading-row-large;
+		}
+
+		.dashboard-page-header .dashboard-section-header__description {
+			view-transition-name: page-layout-header-description-large;
+		}
+
+		.dashboard-page-header .components-button.is-primary {
+			view-transition-name: page-layout-header-large--button;
+		}
+	}
+
+	.dashboard-page-layout.is-small {
+		.dashboard-page-header .dashboard-section-header__prefix {
+			view-transition-name: page-layout-header-prefix-small;
+		}
+
+		.dashboard-page-header .dashboard-section-header__heading-row {
+			view-transition-name: page-layout-header-heading-row-small;
+		}
+
+		.dashboard-page-header .dashboard-section-header__description {
+			view-transition-name: page-layout-header-description-small;
+		}
+	}
+}

--- a/client/dashboard/app/view-transitions/page-layout.scss
+++ b/client/dashboard/app/view-transitions/page-layout.scss
@@ -1,8 +1,9 @@
+@import './animations.scss';
 
-// Large and small must be separate so they don't cross-animate.
 .dashboard-page-layout.is-small {
 	view-transition-name: page-layout-small;
 }
+
 .dashboard-page-layout.is-large {
 	view-transition-name: page-layout-large;
 }
@@ -13,30 +14,21 @@
 html:active-view-transition-type( default ) {
 	&::view-transition-old( page-layout-small ),
 	&::view-transition-old( page-layout-large ) {
-		animation: 0.25s ease-in-out both default-out;
+		animation: $animation-duration ease-in-out both fade-out;
 	}
 
 	&::view-transition-new( page-layout-small ),
 	&::view-transition-new( page-layout-large ) {
-		animation: 0.25s ease-in-out both default-in;
+		animation: $animation-duration ease-in-out both fade-in;
 	}
 }
 
-@keyframes default-out {
-	from {
-		opacity: 1;
-	}
-	to {
-		opacity: 0;
-	}
-}
-
-@keyframes default-in {
-	from {
-		opacity: 0;
-	}
-	to {
-		opacity: 1;
+html:active-view-transition-type( slide-left ),
+html:active-view-transition-type( slide-right ) {
+	// Disable animation due to the scroll position.
+	&::view-transition-group( page-layout-small ),
+	&::view-transition-group( page-layout-large ) {
+		@include disable-default-animation;
 	}
 }
 
@@ -44,44 +36,16 @@ html:active-view-transition-type( default ) {
  * Slide Left Transition
  */
 html:active-view-transition-type( slide-left ) {
-	// Disable animation due to the scroll position.
-	&::view-transition-group( page-layout-small ),
-	&::view-transition-group( page-layout-large ) {
-		animation: none;
-	}
-
 	&::view-transition-old( page-layout-small ),
 	&::view-transition-old( page-layout-large ) {
-		animation: 0.25s ease-in-out both slide-out-left;
+		animation: $animation-duration ease-in-out both slide-out-left;
 		will-change: transform, opacity;
 	}
 
 	&::view-transition-new( page-layout-small ),
 	&::view-transition-new( page-layout-large ) {
-		animation: 0.25s ease-in-out both slide-in-left;
+		animation: $animation-duration ease-in-out both slide-in-left;
 		will-change: transform, opacity;
-	}
-}
-
-@keyframes slide-out-left {
-	from {
-		transform: translateX( 0 );
-		opacity: 1;
-	}
-	to {
-		transform: translateX( -50px );
-		opacity: 0;
-	}
-}
-
-@keyframes slide-in-left {
-	from {
-		transform: translateX( 50px );
-		opacity: 0;
-	}
-	to {
-		transform: translateX( 0 );
-		opacity: 1;
 	}
 }
 
@@ -89,43 +53,15 @@ html:active-view-transition-type( slide-left ) {
  * Slide Right Transition
  */
 html:active-view-transition-type( slide-right ) {
-	// Disable animation due to the scroll position.
-	&::view-transition-group( page-layout-small ),
-	&::view-transition-group( page-layout-large ) {
-		animation: none;
-	}
-
 	&::view-transition-old( page-layout-small ),
 	&::view-transition-old( page-layout-large ) {
-		animation: 0.25s ease-in-out both slide-out-right;
+		animation: $animation-duration ease-in-out both slide-out-right;
 		will-change: transform, opacity;
 	}
 
 	&::view-transition-new( page-layout-small ),
 	&::view-transition-new( page-layout-large ) {
-		animation: 0.25s ease-in-out both slide-in-right;
+		animation: $animation-duration ease-in-out both slide-in-right;
 		will-change: transform, opacity;
-	}
-}
-
-@keyframes slide-out-right {
-	from {
-		transform: translateX( 0 );
-		opacity: 1;
-	}
-	to {
-		transform: translateX( 50px );
-		opacity: 0;
-	}
-}
-
-@keyframes slide-in-right {
-	from {
-		transform: translateX( -50px );
-		opacity: 0;
-	}
-	to {
-		transform: translateX( 0 );
-		opacity: 1;
 	}
 }

--- a/client/dashboard/app/view-transitions/page-layout.scss
+++ b/client/dashboard/app/view-transitions/page-layout.scss
@@ -1,0 +1,131 @@
+
+// Large and small must be separate so they don't cross-animate.
+.dashboard-page-layout.is-small {
+	view-transition-name: page-layout-small;
+}
+.dashboard-page-layout.is-large {
+	view-transition-name: page-layout-large;
+}
+
+/**
+ * Default Transition
+ */
+html:active-view-transition-type( default ) {
+	&::view-transition-old( page-layout-small ),
+	&::view-transition-old( page-layout-large ) {
+		animation: 0.25s ease-in-out both default-out;
+	}
+
+	&::view-transition-new( page-layout-small ),
+	&::view-transition-new( page-layout-large ) {
+		animation: 0.25s ease-in-out both default-in;
+	}
+}
+
+@keyframes default-out {
+	from {
+		opacity: 1;
+	}
+	to {
+		opacity: 0;
+	}
+}
+
+@keyframes default-in {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
+/**
+ * Slide Left Transition
+ */
+html:active-view-transition-type( slide-left ) {
+	// Disable animation due to the scroll position.
+	&::view-transition-group( page-layout-small ),
+	&::view-transition-group( page-layout-large ) {
+		animation: none;
+	}
+
+	&::view-transition-old( page-layout-small ),
+	&::view-transition-old( page-layout-large ) {
+		animation: 0.25s ease-in-out both slide-out-left;
+		will-change: transform, opacity;
+	}
+
+	&::view-transition-new( page-layout-small ),
+	&::view-transition-new( page-layout-large ) {
+		animation: 0.25s ease-in-out both slide-in-left;
+		will-change: transform, opacity;
+	}
+}
+
+@keyframes slide-out-left {
+	from {
+		transform: translateX( 0 );
+		opacity: 1;
+	}
+	to {
+		transform: translateX( -50px );
+		opacity: 0;
+	}
+}
+
+@keyframes slide-in-left {
+	from {
+		transform: translateX( 50px );
+		opacity: 0;
+	}
+	to {
+		transform: translateX( 0 );
+		opacity: 1;
+	}
+}
+
+/**
+ * Slide Right Transition
+ */
+html:active-view-transition-type( slide-right ) {
+	// Disable animation due to the scroll position.
+	&::view-transition-group( page-layout-small ),
+	&::view-transition-group( page-layout-large ) {
+		animation: none;
+	}
+
+	&::view-transition-old( page-layout-small ),
+	&::view-transition-old( page-layout-large ) {
+		animation: 0.25s ease-in-out both slide-out-right;
+		will-change: transform, opacity;
+	}
+
+	&::view-transition-new( page-layout-small ),
+	&::view-transition-new( page-layout-large ) {
+		animation: 0.25s ease-in-out both slide-in-right;
+		will-change: transform, opacity;
+	}
+}
+
+@keyframes slide-out-right {
+	from {
+		transform: translateX( 0 );
+		opacity: 1;
+	}
+	to {
+		transform: translateX( 50px );
+		opacity: 0;
+	}
+}
+
+@keyframes slide-in-right {
+	from {
+		transform: translateX( -50px );
+		opacity: 0;
+	}
+	to {
+		transform: translateX( 0 );
+		opacity: 1;
+	}
+}

--- a/client/dashboard/app/view-transitions/style.scss
+++ b/client/dashboard/app/view-transitions/style.scss
@@ -1,0 +1,12 @@
+@import './header.scss';
+@import './page-header.scss';
+@import './page-layout.scss';
+
+@media ( prefers-reduced-motion: reduce ) {
+	::view-transition-group( * ),
+	::view-transition-old( * ),
+	::view-transition-new( * ) {
+		animation: none;
+		transition: none;
+	}
+}

--- a/client/package.json
+++ b/client/package.json
@@ -91,7 +91,7 @@
 		"@tanstack/react-query": "^5.15.5",
 		"@tanstack/react-query-devtools": "^5.15.5",
 		"@tanstack/react-query-persist-client": "^5.15.5",
-		"@tanstack/react-router": "^1.114.34",
+		"@tanstack/react-router": "^1.125.4",
 		"@wordpress/a11y": "^4.23.0",
 		"@wordpress/api-fetch": "^7.23.0",
 		"@wordpress/base-styles": "^5.23.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9249,10 +9249,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/history@npm:1.114.29":
-  version: 1.114.29
-  resolution: "@tanstack/history@npm:1.114.29"
-  checksum: b9f2bc9cee4747ffd9870885b48ded156ed5d208059b3608f6d7767bda764b0a40987d62b9ad9b9b6ba946139c528d7ef31b52db06be882aafda759db4ba94bb
+"@tanstack/history@npm:1.121.34":
+  version: 1.121.34
+  resolution: "@tanstack/history@npm:1.121.34"
+  checksum: f29ee1f8a15cf588a77d9749623149265476f31c6aa90e48bdc4dcdb60269f55d1a679173d9178c4955394eaa41846cc38b289cfa2624d6beb28139fa532ac56
   languageName: node
   linkType: hard
 
@@ -9324,20 +9324,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/react-router@npm:^1.114.34":
-  version: 1.114.34
-  resolution: "@tanstack/react-router@npm:1.114.34"
+"@tanstack/react-router@npm:^1.125.4":
+  version: 1.125.4
+  resolution: "@tanstack/react-router@npm:1.125.4"
   dependencies:
-    "@tanstack/history": "npm:1.114.29"
+    "@tanstack/history": "npm:1.121.34"
     "@tanstack/react-store": "npm:^0.7.0"
-    "@tanstack/router-core": "npm:1.114.33"
+    "@tanstack/router-core": "npm:1.125.4"
+    isbot: "npm:^5.1.22"
     jsesc: "npm:^3.1.0"
     tiny-invariant: "npm:^1.3.3"
     tiny-warning: "npm:^1.0.3"
   peerDependencies:
     react: ">=18.0.0 || >=19.0.0"
     react-dom: ">=18.0.0 || >=19.0.0"
-  checksum: 2e8a9bafbd5ce29bf854f0c32c693ea6a6277944fa05ef4077aaa7cfb9a58954cbb6ed31e6a74dec34aefda3370dfe6e2f5b482e95e7bf414d802792df4a5621
+  checksum: 347ffa0ebdc24a7ef73e7b9a0e25f6d169926d3a0b463ef1792be818e3da08e120d538589e8d0369f6b56ac3aeea49ad7386b2f93f2858240031d6ef04463c73
   languageName: node
   linkType: hard
 
@@ -9354,14 +9355,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/router-core@npm:1.114.33":
-  version: 1.114.33
-  resolution: "@tanstack/router-core@npm:1.114.33"
+"@tanstack/router-core@npm:1.125.4":
+  version: 1.125.4
+  resolution: "@tanstack/router-core@npm:1.125.4"
   dependencies:
-    "@tanstack/history": "npm:1.114.29"
+    "@tanstack/history": "npm:1.121.34"
     "@tanstack/store": "npm:^0.7.0"
+    cookie-es: "npm:^1.2.2"
+    jsesc: "npm:^3.1.0"
     tiny-invariant: "npm:^1.3.3"
-  checksum: fd4ecf8e62d5999b5066ad658cc31678359563c9bbe5c945eea44feeb81787e437c8dfa7e64e17e55ae6eb57253848246da05af2ac10e62f93c8ad94aeaf2197
+    tiny-warning: "npm:^1.0.3"
+  checksum: 470356dd1d07fcb14aeb032f384f52c20f330c43a9211e66ceb438553fa732655aa0d43a8dd1c9f8024675108bfa1df7248b7dcbdd9fffd3c906924c9edb2781
   languageName: node
   linkType: hard
 
@@ -14972,7 +14976,7 @@ __metadata:
     "@tanstack/react-query": "npm:^5.15.5"
     "@tanstack/react-query-devtools": "npm:^5.15.5"
     "@tanstack/react-query-persist-client": "npm:^5.15.5"
-    "@tanstack/react-router": "npm:^1.114.34"
+    "@tanstack/react-router": "npm:^1.125.4"
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^16.3.0"
@@ -16339,6 +16343,13 @@ __metadata:
   version: 2.0.0
   resolution: "convert-source-map@npm:2.0.0"
   checksum: 8f2f7a27a1a011cc6cc88cc4da2d7d0cfa5ee0369508baae3d98c260bb3ac520691464e5bbe4ae7cdf09860c1d69ecc6f70c63c6e7c7f7e3f18ec08484dc7d9b
+  languageName: node
+  linkType: hard
+
+"cookie-es@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "cookie-es@npm:1.2.2"
+  checksum: 210eb67cd40a53986fda99d6f47118cfc45a69c4abc03490d15ab1b83ac978d5518356aecdd7a7a4969292445e3063c2302deda4c73706a67edc008127608638
   languageName: node
   linkType: hard
 
@@ -23529,6 +23540,13 @@ __metadata:
   version: 4.0.8
   resolution: "isbinaryfile@npm:4.0.8"
   checksum: 4bffeff291023d2693216cc5d678783c5c1ac11af73eb6c2b6e230f01588a8966812a85fb43b4aee79ec7ff64c8689e5e45ac07bde57409344478831a3a18702
+  languageName: node
+  linkType: hard
+
+"isbot@npm:^5.1.22":
+  version: 5.1.28
+  resolution: "isbot@npm:5.1.28"
+  checksum: 1e9417986613e4b493e57e20b813d7e0130c845657ff14a11d39e4bf326056065850bf52773767f2681c0b7b146ba833d4686db16017dfbadd85a206c8396d90
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Now the default transition between pages is fade-in & fade-out
* Implement side-in & slide-out animations on the Settings page by the types function of the defaultViewTransition. It's a new feature of the `@tanstack/react-router` but the new version generates a warning, "Could not find match for from: /sites/$siteSlug/settings Error Component Stack" duration the navigation. See https://x.com/tannerlinsley/status/1939757633793401102.

   https://github.com/user-attachments/assets/65ff1a9e-b38b-4eef-8abc-4e1b6f9adfa2

* Restructure the view-transitions folder by the view-transition-name group
* Disable the default animation on the main header and page-layout (slide-in & slide-out only) to prevent new view transition elements from animating in from the top of the page during scroll.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Navigate between pages to see whether it looks good
* Navigate to any site > Settings > * to see whether the slide-in & slide-out animation looks good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
