### PR TITLE
Sites List v2: Update Preview field behavior depending on the selected view type

### DIFF
--- a/client/dashboard/sites/fields.tsx
+++ b/client/dashboard/sites/fields.tsx
@@ -90,6 +90,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		id: 'preview',
 		label: __( 'Preview' ),
 		render: ( { item } ) => <Preview site={ item } />,
+		enableHiding: false,
 		enableSorting: false,
 	},
 	{
@@ -169,6 +170,10 @@ export function getFields( {
 		}
 
 		if ( field.id === 'icon.ico' && viewType === 'grid' ) {
+			return false;
+		}
+
+		if ( field.id === 'preview' && viewType === 'table' ) {
 			return false;
 		}
 


### PR DESCRIPTION
Ref DOTDASH-96

## Proposed Changes

This PR updates the Preview field in the Sites List so that:
* Grid view: the Preview field is now unselectable. This is because the preview is essential in the grid view.
* Table view: the Preview field is now unavailable. This is because the preview is not needed in the table view, we show site icon instead.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Enhancement.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Ensure that the Preview field is updated as described above 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
