### PR TITLE
Connect Refresh: Lost Password form - remove Blaze Pro & Woo layout customisations

### DIFF
--- a/client/layout/masterbar/blaze-pro.scss
+++ b/client/layout/masterbar/blaze-pro.scss
@@ -508,15 +508,6 @@ body.is-section-signup {
 		}
 	}
 
-	.login__lostpassword-form {
-		max-width: $login-form-max-width;
-		margin-bottom: 32px;
-
-		.login__form-userdata {
-			margin-bottom: 20px;
-		}
-	}
-
 	.wp-login__main.main:has(.login form.is-blaze-pro) {
 		max-width: unset;
 	}

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1228,8 +1228,7 @@ $breakpoint-mobile: 660px;
 		}
 
 		.signup-form,
-		.login__body--continue-as-user,
-		.login__lostpassword-form {
+		.login__body--continue-as-user {
 			width: 100%;
 			margin: 48px auto 0;
 			padding: 0;
@@ -1505,18 +1504,6 @@ $breakpoint-mobile: 660px;
 		.logged-out-form {
 			padding: 0;
 			margin: 0;
-		}
-
-		.login__lostpassword-form {
-			margin-bottom: 44px;
-
-			.login__form-userdata {
-				width: 100%;
-			}
-
-			input[type="email"].form-text-input {
-				margin-bottom: 0;
-			}
 		}
 
 		.two-factor-authentication__verification-code-form-wrapper {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13217/calypso-update-and-unify-the-lost-password-screen

## Proposed Changes

- Removes some of the customisations to the Lost Password form added for Woo and Blaze Pro screens.
- This should align things consistently with the rest

## Media

### Woo

| Woo Before | Woo After |
|--------|--------|
| <img width="1000" alt="Screenshot 2025-07-07 at 9 15 22 PM" src="https://github.com/user-attachments/assets/4ac1d78c-cfa1-461c-93bd-b30372289fb1" /> | <img width="999" alt="Screenshot 2025-07-07 at 9 14 28 PM" src="https://github.com/user-attachments/assets/1a84e65c-ef4c-478c-bdc2-accbefe90d72" /> |

### Blaze Pro

| Blaze Pro Before | Blaze Pro After |
|--------|--------|
| <img width="997" alt="Screenshot 2025-07-07 at 9 15 37 PM" src="https://github.com/user-attachments/assets/719ba7b0-51bd-4ee4-8da4-2120980a5bdf" /> | <img width="995" alt="Screenshot 2025-07-07 at 9 14 21 PM" src="https://github.com/user-attachments/assets/3728231d-68da-4646-9e34-71b85f8682cf" /> | 

### Studio

For reference, this is the Studio one (same with the rest OAuth and default Login variants):

<img width="600" alt="Screenshot 2025-07-07 at 9 14 13 PM" src="https://github.com/user-attachments/assets/241eab1b-1b50-4cd5-a43c-174a479a28c4" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13217/calypso-update-and-unify-the-lost-password-screen


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [Woo](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Db30d4e6a81f72b803c873f517f4189601c46a1bc8b9bfdb9ed27cf3d17ad5601%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26from-calypso%3D1&client_id=50916&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D50916%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%252F%253Fresponse_type%253Dcode%2526client_id%253D50916%2526state%253Db30d4e6a81f72b803c873f517f4189601c46a1bc8b9bfdb9ed27cf3d17ad5601%2526redirect_uri%253Dhttps%25253A%25252F%25252Fwoocommerce.com%25252Fwc-api%25252Fwpcom-signin%25253Fnext%25253D%2525252F%2526blog_id%253D0%2526wpcom_connect%253D1%2526wccom-from%2526calypso_env%253Dproduction%2526from-calypso%253D1) and confirm Lost Password screen
* Go to [Blaze Pro](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D99370%26state%3D0f0d1f16975b65cf8e9e924461b7c892f78eabeeb190dc03654cef0465786da0%26redirect_uri%3Dhttps%253A%252F%252Fblazepro.tumblr.com%252Fauth%252Fconnected%26blog_id%3D0%26wpcom_connect%3D1%26calypso_env%3Dproduction%26scope%3Dglobal%26from-calypso%3D1&client_id=99370&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D99370%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%253Fresponse_type%253Dcode%2526client_id%253D99370%2526state%253D0f0d1f16975b65cf8e9e924461b7c892f78eabeeb190dc03654cef0465786da0%2526redirect_uri%253Dhttps%25253A%25252F%25252Fblazepro.tumblr.com%25252Fauth%25252Fconnected%2526blog_id%253D0%2526wpcom_connect%253D1%2526calypso_env%253Dproduction%2526scope%253Dglobal%2526from-calypso%253D1) and confirm
* Go to [WordPress.com](http://calypso.localhost:3000/log-in) and confirm no changes
* Go to [other clients](https://linear.app/a8c/project/login-and-signup-unify-design-and-layout-16a857e58712/overview) and confirm.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
