### PR TITLE
Domain Search Redesign: Set up UI changes foundation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -84,6 +84,12 @@
 /packages/data-stores/src/domain-suggestions @Automattic/nomado
 /packages/wpcom.js/src/lib/domain.dns.js @Automattic/nomado
 
+# Domains entrypoints and UI components
+/client/components/domains @Automattic/quake
+/client/signup/steps/domains @Automattic/quake
+/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains @Automattic/quake
+/client/landing/stepper/declarative-flow/internals/steps-repository/domains @Automattic/quake
+
 # Plans
 /client/my-sites/plans-grid @Automattic/martech
 /packages/plans-grid-next @Automattic/martech

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -86,6 +86,7 @@
 
 # Domains entrypoints and UI components
 /client/components/domains @Automattic/quake
+/client/components/domain-search-v2 @Automattic/quake
 /client/signup/steps/domains @Automattic/quake
 /client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains @Automattic/quake
 /client/landing/stepper/declarative-flow/internals/steps-repository/domains @Automattic/quake

--- a/client/components/domain-search-v2/domain-cart/index.tsx
+++ b/client/components/domain-search-v2/domain-cart/index.tsx
@@ -1,0 +1,5 @@
+const DomainCartV2 = () => {
+	return null;
+};
+
+export default DomainCartV2;

--- a/client/components/domain-search-v2/register-domain-step/already-own-a-domain.jsx
+++ b/client/components/domain-search-v2/register-domain-step/already-own-a-domain.jsx
@@ -1,0 +1,23 @@
+import { Button, MaterialIcon } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+
+function AlreadyOwnADomain( { onClick } ) {
+	const translate = useTranslate();
+	return (
+		<div className="already-own-a-domain">
+			<MaterialIcon icon="info" />
+			<span>
+				{ translate(
+					'Already own a domain? You can {{action}}use it as your site’s address{{/action}}',
+					{
+						components: {
+							action: <Button plain href="#" onClick={ onClick } />,
+						},
+					}
+				) }
+			</span>
+		</div>
+	);
+}
+
+export default AlreadyOwnADomain;

--- a/client/components/domain-search-v2/register-domain-step/analytics.js
+++ b/client/components/domain-search-v2/register-domain-step/analytics.js
@@ -1,0 +1,229 @@
+import { mapKeys, mapValues, snakeCase, startsWith } from 'lodash';
+import {
+	composeAnalytics,
+	recordGoogleEvent,
+	recordTracksEvent,
+} from 'calypso/state/analytics/actions';
+
+const noop = () => {};
+
+export const recordMapDomainButtonClick = ( section, flowName ) =>
+	composeAnalytics(
+		recordGoogleEvent( 'Domain Search', 'Clicked "Map it" Button' ),
+		recordTracksEvent( 'calypso_domain_search_results_mapping_button_click', {
+			section,
+			flow_name: flowName,
+		} )
+	);
+
+export const recordTransferDomainButtonClick = ( section, source, flowName ) =>
+	composeAnalytics(
+		recordGoogleEvent( 'Domain Search', 'Clicked "Use a Domain I own" Button' ),
+		recordTracksEvent( 'calypso_domain_search_results_transfer_button_click', {
+			section,
+			source,
+			flow_name: flowName,
+		} )
+	);
+
+export const recordUseYourDomainButtonClick = ( section, source, flowName ) =>
+	composeAnalytics(
+		recordGoogleEvent( 'Domain Search', 'Clicked "Use a Domain I own" Button' ),
+		recordTracksEvent( 'calypso_domain_search_results_use_my_domain_button_click', {
+			section,
+			source,
+			flow_name: flowName,
+		} )
+	);
+
+export const recordSearchFormSubmit = (
+	searchBoxValue,
+	section,
+	timeDiffFromLastSearch,
+	count,
+	vendor,
+	flowName
+) =>
+	composeAnalytics(
+		recordGoogleEvent(
+			'Domain Search',
+			'Submitted Search Form',
+			'Search Box Value',
+			searchBoxValue
+		),
+		recordTracksEvent( 'calypso_domain_search', {
+			search_box_value: searchBoxValue,
+			seconds_from_last_search: timeDiffFromLastSearch,
+			search_count: count,
+			search_vendor: vendor,
+			section,
+			flow_name: flowName,
+		} )
+	);
+
+export const recordSearchFormView = ( section, flowName ) =>
+	composeAnalytics(
+		recordGoogleEvent( 'Domain Search', 'Landed on Search' ),
+		recordTracksEvent( 'calypso_domain_search_pageview', { section, flow_name: flowName } )
+	);
+
+export const recordSearchResultsReceive = (
+	searchQuery,
+	searchResults,
+	responseTimeInMs,
+	resultCount,
+	section,
+	flowName
+) =>
+	composeAnalytics(
+		recordGoogleEvent( 'Domain Search', 'Receive Results', 'Response Time', responseTimeInMs ),
+		recordTracksEvent( 'calypso_domain_search_results_suggestions_receive', {
+			search_query: searchQuery,
+			results: searchResults.join( ';' ),
+			response_time_ms: responseTimeInMs,
+			result_count: resultCount,
+			section,
+			flow_name: flowName,
+		} )
+	);
+
+export const recordDomainAvailabilityReceive = (
+	searchQuery,
+	availableStatus,
+	responseTimeInMs,
+	section,
+	flowName
+) =>
+	composeAnalytics(
+		recordGoogleEvent(
+			'Domain Search',
+			'Domain Availability Result',
+			'Domain Available Status',
+			availableStatus
+		),
+		recordTracksEvent( 'calypso_domain_search_results_availability_receive', {
+			search_query: searchQuery,
+			available_status: availableStatus,
+			response_time: responseTimeInMs,
+			section,
+			flow_name: flowName,
+		} )
+	);
+
+export const recordDomainAddAvailabilityPreCheck = (
+	domain,
+	unavailableStatus,
+	section,
+	flowName,
+	rootVendor
+) =>
+	composeAnalytics(
+		recordGoogleEvent(
+			'Domain Search',
+			'Domain Add',
+			'Domain Precheck Unavailable',
+			unavailableStatus
+		),
+		recordTracksEvent( 'calypso_domain_add_availability_precheck', {
+			domain: domain,
+			unavailable_status: unavailableStatus,
+			section,
+			flow_name: flowName,
+			root_vendor: rootVendor,
+		} )
+	);
+
+export function recordShowMoreResults( searchQuery, pageNumber, section, flowName ) {
+	return composeAnalytics(
+		recordGoogleEvent( 'Domain Search', 'Show More Results' ),
+		recordTracksEvent( 'calypso_domain_search_show_more_results', {
+			search_query: searchQuery,
+			page_number: pageNumber,
+			section,
+			flow_name: flowName,
+		} )
+	);
+}
+
+function processFiltersForAnalytics( filters ) {
+	const convertArraysToCSV = ( input ) =>
+		mapValues( input, ( value ) => ( Array.isArray( value ) ? value.join( ',' ) : value ) );
+	const prepareKeys = ( input ) =>
+		mapKeys( input, ( value, key ) => `filters_${ snakeCase( key ) }` );
+	return convertArraysToCSV( prepareKeys( filters ) );
+}
+
+export function recordFiltersReset( filters, keysToReset, section, flowName ) {
+	return composeAnalytics(
+		recordGoogleEvent( 'Domain Search', 'Filters Reset' ),
+		recordTracksEvent( 'calypso_domain_search_filters_reset', {
+			keys_to_reset: keysToReset.join( ',' ),
+			section,
+			flow_name: flowName,
+			...processFiltersForAnalytics( filters ),
+		} )
+	);
+}
+
+export function recordFiltersSubmit( filters, section, flowName ) {
+	return composeAnalytics(
+		recordGoogleEvent( 'Domain Search', 'Filters Submit' ),
+		recordTracksEvent( 'calypso_domain_search_filters_submit', {
+			section,
+			flow_name: flowName,
+			...processFiltersForAnalytics( filters ),
+		} )
+	);
+}
+
+let searchQueue = [];
+let searchStackTimer = null;
+let lastSearchTimestamp = null;
+let searchCount = 0;
+let recordSearchFormSubmitWithDispatch = noop;
+
+export function resetSearchCount() {
+	searchCount = 0;
+}
+
+export function enqueueSearchStatReport( search, recordFunction ) {
+	recordSearchFormSubmitWithDispatch = recordFunction;
+	searchQueue.push( Object.assign( {}, search, { timestamp: Date.now() } ) );
+	if ( searchStackTimer ) {
+		window.clearTimeout( searchStackTimer );
+	}
+	searchStackTimer = window.setTimeout( processSearchStatQueue, 10000 );
+}
+
+function processSearchStatQueue() {
+	const queue = searchQueue.slice();
+	window.clearTimeout( searchStackTimer );
+	searchStackTimer = null;
+	searchQueue = [];
+
+	outerLoop: for ( let i = 0; i < queue.length; i++ ) {
+		for ( let k = i + 1; k < queue.length; k++ ) {
+			if ( startsWith( queue[ k ].query, queue[ i ].query ) ) {
+				continue outerLoop;
+			}
+		}
+		reportSearchStats( queue[ i ] );
+	}
+}
+
+function reportSearchStats( { query, section, timestamp, vendor, flowName } ) {
+	let timeDiffFromLastSearchInSeconds = 0;
+	if ( lastSearchTimestamp ) {
+		timeDiffFromLastSearchInSeconds = Math.floor( ( timestamp - lastSearchTimestamp ) / 1000 );
+	}
+	lastSearchTimestamp = timestamp;
+	searchCount++;
+	recordSearchFormSubmitWithDispatch(
+		query,
+		section,
+		timeDiffFromLastSearchInSeconds,
+		searchCount,
+		vendor,
+		flowName
+	);
+}

--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -1,0 +1,1884 @@
+import { isBlogger, isFreeWordPressComDomain } from '@automattic/calypso-products';
+import page from '@automattic/calypso-router';
+import { Button, CompactCard, ResponsiveToolbarGroup } from '@automattic/components';
+import {
+	AI_SITE_BUILDER_FLOW,
+	HUNDRED_YEAR_DOMAIN_FLOW,
+	HUNDRED_YEAR_PLAN_FLOW,
+	isHundredYearDomainFlow,
+	isDomainForGravatarFlow,
+} from '@automattic/onboarding';
+import Search from '@automattic/search';
+import { withShoppingCart } from '@automattic/shopping-cart';
+import clsx from 'clsx';
+import debugFactory from 'debug';
+import { localize } from 'i18n-calypso';
+import {
+	compact,
+	find,
+	flatten,
+	get,
+	includes,
+	isEmpty,
+	isEqual,
+	mapKeys,
+	pick,
+	pickBy,
+	reject,
+	snakeCase,
+} from 'lodash';
+import PropTypes from 'prop-types';
+import { stringify, parse } from 'qs';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+import DomainSearchResults from 'calypso/components/domains/domain-search-results';
+import ExampleDomainSuggestions from 'calypso/components/domains/example-domain-suggestions';
+import FreeDomainExplainer from 'calypso/components/domains/free-domain-explainer';
+import {
+	recordDomainAvailabilityReceive,
+	recordDomainAddAvailabilityPreCheck,
+	recordFiltersReset,
+	recordFiltersSubmit,
+	recordMapDomainButtonClick,
+	recordSearchFormSubmit,
+	recordSearchFormView,
+	recordSearchResultsReceive,
+	recordShowMoreResults,
+	recordTransferDomainButtonClick,
+	recordUseYourDomainButtonClick,
+	resetSearchCount,
+	enqueueSearchStatReport,
+} from 'calypso/components/domains/register-domain-step/analytics';
+import {
+	getStrippedDomainBase,
+	getTldWeightOverrides,
+	isNumberString,
+	isUnknownSuggestion,
+	isUnsupportedPremiumSuggestion,
+	isMissingVendor,
+	markFeaturedSuggestions,
+} from 'calypso/components/domains/register-domain-step/utility';
+import { DropdownFilters, FilterResetNotice } from 'calypso/components/domains/search-filters';
+import TrademarkClaimsNotice from 'calypso/components/domains/trademark-claims-notice';
+import EmptyContent from 'calypso/components/empty-content';
+import Notice from 'calypso/components/notice';
+import { hasDomainInCart } from 'calypso/lib/cart-values/cart-items';
+import {
+	checkDomainAvailability,
+	getAvailableTlds,
+	getDomainSuggestionSearch,
+	getTld,
+} from 'calypso/lib/domains';
+import { domainAvailability } from 'calypso/lib/domains/constants';
+import { getAvailabilityNotice } from 'calypso/lib/domains/registration/availability-messages';
+import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
+import wpcom from 'calypso/lib/wp';
+import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
+import { domainUseMyDomain } from 'calypso/my-sites/domains/paths';
+import { shouldUseMultipleDomainsInCart } from 'calypso/signup/steps/domains/utils';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import { getCurrentFlowName } from 'calypso/state/signup/flow/selectors';
+import AlreadyOwnADomain from './already-own-a-domain';
+
+import './style.scss';
+
+const debug = debugFactory( 'calypso:domains:register-domain-step' );
+
+const noop = () => {};
+const domains = wpcom.domains();
+
+// max amount of domain suggestions we should fetch/display
+const PAGE_SIZE = 10;
+const EXACT_MATCH_PAGE_SIZE = 4;
+const MAX_PAGES = 3;
+const SUGGESTION_QUANTITY = PAGE_SIZE * MAX_PAGES;
+const MIN_QUERY_LENGTH = 2;
+
+// session storage key for query cache
+const SESSION_STORAGE_QUERY_KEY = 'domain_step_query';
+
+class RegisterDomainStep extends Component {
+	static propTypes = {
+		cart: PropTypes.object,
+		isCartPendingUpdate: PropTypes.bool,
+		isCartPendingUpdateDomain: PropTypes.object,
+		isDomainOnly: PropTypes.bool,
+		onDomainsAvailabilityChange: PropTypes.func,
+		products: PropTypes.object,
+		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
+		basePath: PropTypes.string.isRequired,
+		suggestion: PropTypes.string,
+		domainsWithPlansOnly: PropTypes.bool,
+		isSignupStep: PropTypes.bool,
+		includeWordPressDotCom: PropTypes.bool,
+		includeOwnedDomainInSuggestions: PropTypes.bool,
+		includeDotBlogSubdomain: PropTypes.bool,
+		showExampleSuggestions: PropTypes.bool,
+		onSave: PropTypes.func,
+		onAddMapping: PropTypes.func,
+		onAddDomain: PropTypes.func,
+		onMappingError: PropTypes.func,
+		onAddTransfer: PropTypes.func,
+		designType: PropTypes.string,
+		deemphasiseTlds: PropTypes.array,
+		recordFiltersSubmit: PropTypes.func.isRequired,
+		recordFiltersReset: PropTypes.func.isRequired,
+		/**
+		 * A flag signalling if the step is being used in the onboarding flow
+		 */
+		isOnboarding: PropTypes.bool,
+		showSkipButton: PropTypes.bool,
+		onSkip: PropTypes.func,
+		promoTlds: PropTypes.array,
+		showAlreadyOwnADomain: PropTypes.bool,
+		domainAndPlanUpsellFlow: PropTypes.bool,
+		useProvidedProductsList: PropTypes.bool,
+		otherManagedSubdomains: PropTypes.array,
+		forceExactSuggestion: PropTypes.bool,
+		checkDomainAvailabilityPromises: PropTypes.array,
+
+		/**
+		 * If an override is not provided we generate 1 suggestion per 1 other subdomain
+		 * Multiple subdomains of .wordpress.com have not been tested
+		 */
+		otherManagedSubdomainsCountOverride: PropTypes.number,
+		handleClickUseYourDomain: PropTypes.func,
+		wpcomSubdomainSelected: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
+
+		/**
+		 * Force the loading placeholder to show even if the search request has been completed, since there is other unresolved requests.
+		 * Although it is a general functionality, but it's only needed by the hiding free subdomain test for now.
+		 * It will be removed if there is still no need of it once the test concludes.
+		 */
+		hasPendingRequests: PropTypes.bool,
+
+		// Whether subdomains (.wordpress.com, .blog subdomains) should be queried - used for hiding free subdomains in specific cases
+		shouldQuerySubdomains: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		analyticsSection: 'domains',
+		deemphasiseTlds: [],
+		includeDotBlogSubdomain: false,
+		includeWordPressDotCom: false,
+		includeOwnedDomainInSuggestions: false,
+		isDomainOnly: false,
+		onAddDomain: noop,
+		onAddMapping: noop,
+		onMappingError: noop,
+		onDomainsAvailabilityChange: noop,
+		onSave: noop,
+		vendor: getSuggestionsVendor(),
+		showExampleSuggestions: false,
+		onSkip: noop,
+		showSkipButton: false,
+		useProvidedProductsList: false,
+		otherManagedSubdomains: null,
+		hasPendingRequests: false,
+		forceExactSuggestion: false,
+		shouldQuerySubdomains: true,
+	};
+
+	constructor( props ) {
+		super( props );
+
+		resetSearchCount();
+
+		this._isMounted = false;
+		this.state = this.getState( props );
+		this.state.filters = this.getInitialFiltersState();
+		this.state.lastFilters = this.getInitialFiltersState();
+
+		if ( props.initialState ) {
+			this.state = { ...this.state, ...props.initialState };
+
+			if ( props.initialState.searchResults ) {
+				this.state.loadingResults = false;
+				this.state.searchResults = props.initialState.searchResults;
+			}
+
+			if ( props.initialState.subdomainSearchResults ) {
+				this.state.loadingSubdomainResults = false;
+				this.state.subdomainSearchResults = props.initialState.subdomainSearchResults;
+			}
+
+			if (
+				this.state.searchResults ||
+				this.state.subdomainSearchResults ||
+				! props.initialState.isInitialQueryActive
+			) {
+				this.state.lastQuery = props.initialState.lastQuery;
+			} else {
+				this.state.railcarId = this.getNewRailcarId();
+			}
+
+			// If there's a domain name as a query parameter suggestion, we always search for it first when the page loads
+			if ( props.suggestion ) {
+				this.state.lastQuery = getDomainSuggestionSearch( props.suggestion, MIN_QUERY_LENGTH );
+
+				// If we're coming from the general settings page, we want to use the exact site title as the initial query
+				if ( props.forceExactSuggestion ) {
+					this.state.lastQuery = props.suggestion;
+				}
+			}
+		}
+	}
+
+	isSubdomainResultsVisible() {
+		if ( ! this.props.shouldQuerySubdomains ) {
+			return false;
+		}
+
+		return (
+			this.props.includeWordPressDotCom ||
+			this.props.includeDotBlogSubdomain ||
+			this.props.otherManagedSubdomains?.length > 0
+		);
+	}
+
+	getState( props ) {
+		const suggestion = getDomainSuggestionSearch( props.suggestion, MIN_QUERY_LENGTH );
+		const loadingResults = Boolean( suggestion );
+
+		return {
+			availabilityError: null,
+			availabilityErrorData: null,
+			availabilityErrorDomain: null,
+			availableTlds: [],
+			bloggerFilterAdded: false,
+			clickedExampleSuggestion: false,
+			filters: this.getInitialFiltersState(),
+			lastDomainIsTransferrable: false,
+			lastDomainSearched: null,
+			lastDomainStatus: null,
+			lastFilters: this.getInitialFiltersState(),
+			lastQuery: suggestion,
+			loadingResults,
+			loadingSubdomainResults: this.isSubdomainResultsVisible() && loadingResults,
+			pageNumber: 1,
+			pageSize: PAGE_SIZE,
+			premiumDomains: {},
+			promoTldsAdded: false,
+			searchResults: null,
+			showAvailabilityNotice: false,
+			showSuggestionNotice: false,
+			subdomainSearchResults: null,
+			suggestionError: null,
+			suggestionErrorData: null,
+			suggestionErrorDomain: null,
+			pendingCheckSuggestion: null,
+			unavailableDomains: [],
+			trademarkClaimsNoticeInfo: null,
+			selectedSuggestion: null,
+			isInitialQueryActive: !! props.suggestion,
+			checkAvailabilityTimeout: null,
+		};
+	}
+
+	getInitialFiltersState() {
+		return {
+			exactSldMatchesOnly: false,
+			tlds: [],
+		};
+	}
+
+	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
+	UNSAFE_componentWillReceiveProps( nextProps ) {
+		// Reset state on site change
+		if (
+			nextProps.selectedSite &&
+			nextProps.selectedSite.slug !== ( this.props.selectedSite || {} ).slug
+		) {
+			this.setState( this.getState( nextProps ) );
+			nextProps.suggestion && this.onSearch( nextProps.suggestion );
+		}
+	}
+
+	checkForBloggerPlan() {
+		const plan = get( this.props, 'selectedSite.plan', {} );
+		const products = get( this.props, 'cart.products', [] );
+		const isBloggerPlan = isBlogger( plan ) || products.some( isBlogger );
+
+		if (
+			! this.state.bloggerFilterAdded &&
+			isBloggerPlan &&
+			isEqual( this.getInitialFiltersState(), this.state.filters )
+		) {
+			this.setState( { bloggerFilterAdded: true } );
+			this.onFiltersChange( { tlds: [ 'blog' ] } );
+		}
+	}
+
+	componentWillUnmount() {
+		this._isMounted = false;
+	}
+
+	// In the launch flow, the initial query could sometimes be missing if the user had
+	// created a site by skipping the domain step. In these cases, fire the initial search
+	// with the subdomain name.
+	getInitialQueryInLaunchFlow() {
+		if ( ! this.props.isInLaunchFlow || this.props.selectedSite === null ) {
+			return;
+		}
+
+		if (
+			typeof this.props.selectedSite !== 'object' ||
+			typeof this.props.selectedSite.domain !== 'string'
+		) {
+			return;
+		}
+
+		const hostname = this.props.selectedSite.domain.split( '.' )[ 0 ];
+		const regexHostnameWithRandomNumberSuffix = /^(.+?)([0-9]{5,})/i;
+		const [ , strippedHostname ] = hostname.match( regexHostnameWithRandomNumberSuffix ) || [];
+		return strippedHostname ?? hostname;
+	}
+
+	getInitialQueryFromSiteName() {
+		// fallback to siteTitle in query string if there is no selected site in the props
+		// This usually happens the first time this step is loaded for a free trial site
+		const queryParams = parse( window.location.search.substring( 1 ) );
+		const siteTitle = queryParams.siteTitle;
+		return this.props.selectedSite?.name || siteTitle;
+	}
+
+	componentDidMount() {
+		const storedQuery = globalThis?.sessionStorage?.getItem( SESSION_STORAGE_QUERY_KEY );
+		let query = this.state.lastQuery || storedQuery;
+
+		// Flow specific query fallbacks.
+		if ( ! query && this.props.flowName === AI_SITE_BUILDER_FLOW ) {
+			query = this.getInitialQueryFromSiteName();
+		}
+
+		if ( ! query && this.props.isInLaunchFlow ) {
+			query = this.getInitialQueryInLaunchFlow();
+		}
+
+		if ( query && ! this.state.searchResults && ! this.state.subdomainSearchResults ) {
+			this.onSearch( query );
+
+			// Delete the stored query once it is consumed.
+			globalThis?.sessionStorage?.removeItem( SESSION_STORAGE_QUERY_KEY );
+		} else {
+			this.getAvailableTlds();
+			this.save();
+		}
+		this._isMounted = true;
+		this.props.recordSearchFormView( this.props.analyticsSection, this.props.flowName );
+	}
+
+	componentDidUpdate( prevProps ) {
+		this.checkForBloggerPlan();
+
+		if (
+			this.props.selectedSite &&
+			prevProps.selectedSite &&
+			this.props.selectedSite.domain !== prevProps.selectedSite.domain
+		) {
+			this.focusSearchCard();
+		}
+
+		// Filter out the free wp.com subdomains to avoid doing another API request.
+		// Please note that it's intentional to be incomplete -- the complete version of this
+		// should be able to handle flag transition the other way around, i.e.
+		// when `includeWordPressDotCom` is first `false` and then transit to `true`. The
+		// same should also be ported to the dotblog subdomain flag. However, this code is likely
+		// temporary specific for the hiding free subdomain test, so it's not practical to implement
+		// the complete version for now.
+		if (
+			prevProps.includeWordPressDotCom &&
+			! this.props.includeWordPressDotCom &&
+			this.state.subdomainSearchResults
+		) {
+			// this is fine since we've covered the condition to prevent infinite loop
+			// eslint-disable-next-line react/no-did-update-set-state
+			this.setState( {
+				subdomainSearchResults: this.state.subdomainSearchResults.filter(
+					( subdomain ) => ! isFreeWordPressComDomain( subdomain )
+				),
+			} );
+		}
+	}
+
+	getOtherManagedSubdomainsQuantity() {
+		let otherManagedSubdomainsCount = 0;
+		// In order to generate "other" (Not blog or wpcom) subdomains an Array of those subdomains need to be provided
+		if ( Array.isArray( this.props.otherManagedSubdomains ) ) {
+			// If an override is not provided we generate 1 suggestion per 1 other subdomain
+			otherManagedSubdomainsCount = this.props.otherManagedSubdomains.length;
+			if ( typeof this.props.otherManagedSubdomainsCountOverride === 'number' ) {
+				otherManagedSubdomainsCount = this.props.otherManagedSubdomainsCountOverride;
+			}
+		}
+		return otherManagedSubdomainsCount;
+	}
+
+	getFreeSubdomainSuggestionsQuantity() {
+		return (
+			this.props.includeWordPressDotCom +
+			this.props.includeDotBlogSubdomain +
+			this.getOtherManagedSubdomainsQuantity()
+		);
+	}
+
+	getNewRailcarId() {
+		return `${ crypto.randomUUID().replace( /-/g, '' ) }-domain-suggestion`;
+	}
+
+	focusSearchCard = () => {
+		this.searchCard.focus();
+	};
+
+	bindSearchCardReference = ( searchCard ) => {
+		this.searchCard = searchCard;
+	};
+
+	getSuggestionsFromProps() {
+		const { pageNumber, pageSize } = this.state;
+		const searchResults = this.state.searchResults || [];
+
+		const suggestions = searchResults.slice( 0, pageNumber * pageSize );
+
+		if ( this.isSubdomainResultsVisible() ) {
+			if ( this.state.loadingSubdomainResults && ! this.state.loadingResults ) {
+				const freeSubdomainPlaceholders = Array( this.getFreeSubdomainSuggestionsQuantity() ).fill(
+					{ is_placeholder: true }
+				);
+				suggestions.unshift( ...freeSubdomainPlaceholders );
+			} else if ( ! isEmpty( this.state.subdomainSearchResults ) ) {
+				suggestions.unshift( ...this.state.subdomainSearchResults );
+			}
+		}
+		return suggestions;
+	}
+
+	render() {
+		const {
+			isSignupStep,
+			showAlreadyOwnADomain,
+			isDomainAndPlanPackageFlow,
+			replaceDomainFailedMessage,
+			dismissReplaceDomainFailed,
+		} = this.props;
+
+		const {
+			availabilityError,
+			availabilityErrorData,
+			availabilityErrorDomain,
+			showAvailabilityNotice,
+			showSuggestionNotice,
+			suggestionError,
+			suggestionErrorData,
+			suggestionErrorDomain,
+			trademarkClaimsNoticeInfo,
+			isQueryInvalid,
+		} = this.state;
+
+		if ( trademarkClaimsNoticeInfo ) {
+			return this.renderTrademarkClaimsNotice();
+		}
+
+		const { message: suggestionMessage, severity: suggestionSeverity } = showSuggestionNotice
+			? getAvailabilityNotice( suggestionErrorDomain, suggestionError, suggestionErrorData )
+			: {};
+		const { message: availabilityMessage, severity: availabilitySeverity } = showAvailabilityNotice
+			? getAvailabilityNotice( availabilityErrorDomain, availabilityError, availabilityErrorData )
+			: {};
+
+		const containerDivClassName = clsx( 'register-domain-step', {
+			'register-domain-step__signup': this.props.isSignupStep,
+		} );
+
+		const searchBoxClassName = clsx( 'register-domain-step__search', {
+			'register-domain-step__search-domain-step': this.props.isSignupStep,
+		} );
+
+		return (
+			<>
+				<div className={ containerDivClassName }>
+					<div className={ searchBoxClassName }>
+						<CompactCard className="register-domain-step__search-card">
+							{ this.renderSearchBar() }
+						</CompactCard>
+					</div>
+					{ isDomainAndPlanPackageFlow && this.renderQuickFilters() }
+
+					{ ! isSignupStep && isQueryInvalid && (
+						<Notice
+							className="register-domain-step__notice"
+							text={ `Please search for domains with more than ${ MIN_QUERY_LENGTH } characters length.` }
+							status="is-info"
+							showDismiss={ false }
+						/>
+					) }
+					{ availabilityMessage && (
+						<Notice
+							className="register-domain-step__notice"
+							text={ availabilityMessage }
+							status={ `is-${ availabilitySeverity }` }
+							showDismiss={ false }
+						/>
+					) }
+					{ suggestionMessage && availabilityError !== suggestionError && (
+						<Notice
+							className="register-domain-step__notice"
+							text={ suggestionMessage }
+							status={ `is-${ suggestionSeverity }` }
+							showDismiss={ false }
+						/>
+					) }
+					{ replaceDomainFailedMessage && (
+						<Notice
+							status="is-error"
+							text={ replaceDomainFailedMessage }
+							showDismiss
+							onDismissClick={ dismissReplaceDomainFailed }
+						/>
+					) }
+					{ this.renderFilterContent() }
+					{ this.renderSideContent() }
+				</div>
+				{ showAlreadyOwnADomain && (
+					<AlreadyOwnADomain
+						onClick={ this.props.handleClickUseYourDomain ?? this.useYourDomainFunction() }
+					/>
+				) }
+			</>
+		);
+	}
+
+	renderSearchFilters() {
+		const isRenderingInitialSuggestions =
+			! Array.isArray( this.state.searchResults ) &&
+			! this.state.loadingResults &&
+			! this.props.showExampleSuggestions;
+		const showFilters = ! isRenderingInitialSuggestions || this.props.isOnboarding;
+
+		const showTldFilter =
+			( Array.isArray( this.state.availableTlds ) && this.state.availableTlds.length > 0 ) ||
+			this.state.loadingResults;
+
+		if ( [ HUNDRED_YEAR_PLAN_FLOW, HUNDRED_YEAR_DOMAIN_FLOW ].includes( this.props.flowName ) ) {
+			return null;
+		}
+
+		return (
+			showFilters && (
+				<DropdownFilters
+					availableTlds={ this.state.availableTlds }
+					filters={ this.state.filters }
+					lastFilters={ this.state.lastFilters }
+					onChange={ this.onFiltersChange }
+					onReset={ this.onFiltersReset }
+					onSubmit={ this.onFiltersSubmit }
+					showPlaceholder={ this.state.loadingResults || ! this.getSuggestionsFromProps() }
+					showTldFilter={ showTldFilter }
+				/>
+			)
+		);
+	}
+
+	getActiveIndexByKey( items, tlds ) {
+		if ( undefined === tlds[ 0 ] ) {
+			return 0;
+		}
+
+		return items.findIndex( ( item ) => item.key === tlds[ 0 ] );
+	}
+
+	renderQuickFilters() {
+		if ( this.state.availableTlds.length === 0 ) {
+			return;
+		}
+
+		const items = this.state.availableTlds.slice( 0, 10 ).map( ( tld ) => {
+			return { key: `${ tld }`, text: `.${ tld }` };
+		} );
+
+		// translators: filter label displayed when all TLDs are enabled
+		items.unshift( { key: 'all', text: this.props.translate( 'All' ) } );
+
+		const handleClick = ( index ) => {
+			const option = items[ index ].key;
+			if ( 'all' === option ) {
+				this.onFiltersReset();
+			} else {
+				this.onFiltersChange( { tlds: [ option ] }, { shouldSubmit: true } );
+			}
+		};
+
+		return (
+			<ResponsiveToolbarGroup
+				className="register-domain-step__domains-quickfilter-group"
+				initialActiveIndex={ this.getActiveIndexByKey( items, this.state.filters.tlds ) }
+				forceSwipe={ 'undefined' === typeof window }
+				onClick={ handleClick }
+			>
+				{ items.map( ( item ) => (
+					<span key={ `domains-quickfilter-group-item-${ item.key }` }>{ item.text }</span>
+				) ) }
+			</ResponsiveToolbarGroup>
+		);
+	}
+
+	renderSearchBar() {
+		const componentProps = {
+			className: this.state.clickedExampleSuggestion ? 'is-refocused' : undefined,
+			autoFocus: true,
+			delaySearch: true,
+			delayTimeout: 1000,
+			describedBy: 'step-header',
+			dir: 'ltr',
+			defaultValue: this.state.hideInitialQuery ? '' : this.state.lastQuery,
+			value: this.state.hideInitialQuery ? '' : this.state.lastQuery,
+			inputLabel: this.props.translate( 'What would you like your domain name to be?' ),
+			minLength: MIN_QUERY_LENGTH,
+			maxLength: 60,
+			onBlur: this.save,
+			onSearch: this.onSearch,
+			onSearchChange: this.onSearchChange,
+			ref: this.bindSearchCardReference,
+			isOnboarding: this.props.isOnboarding,
+			childrenBeforeCloseButton:
+				this.props.isDomainAndPlanPackageFlow && this.renderSearchFilters(),
+		};
+
+		return (
+			<>
+				<Search { ...componentProps }></Search>
+				{ false === this.props.isDomainAndPlanPackageFlow && this.renderSearchFilters() }
+			</>
+		);
+	}
+
+	rejectTrademarkClaim = () => {
+		this.setState( {
+			selectedSuggestion: null,
+			selectedSuggestionPosition: null,
+			trademarkClaimsNoticeInfo: null,
+		} );
+	};
+
+	acceptTrademarkClaim = () => {
+		this.props.onAddDomain( this.state.selectedSuggestion, this.state.selectedSuggestionPosition );
+	};
+
+	renderTrademarkClaimsNotice() {
+		const { isSignupStep } = this.props;
+		const { selectedSuggestion, trademarkClaimsNoticeInfo, isLoading } = this.state;
+		const domain = get( selectedSuggestion, 'domain_name' );
+
+		return (
+			<TrademarkClaimsNotice
+				domain={ domain }
+				isLoading={ isLoading }
+				isSignupStep={ isSignupStep }
+				onAccept={ this.acceptTrademarkClaim }
+				onGoBack={ this.rejectTrademarkClaim }
+				onReject={ this.rejectTrademarkClaim }
+				suggestion={ selectedSuggestion }
+				trademarkClaimsNoticeInfo={ trademarkClaimsNoticeInfo }
+			/>
+		);
+	}
+
+	renderFilterResetNotice() {
+		return (
+			<FilterResetNotice
+				className="register-domain-step__filter-reset-notice"
+				isLoading={ this.state.loadingResults }
+				lastFilters={ this.state.lastFilters }
+				onReset={ this.onFiltersReset }
+				suggestions={ this.state.searchResults }
+			/>
+		);
+	}
+
+	renderPaginationControls() {
+		const { searchResults, pageNumber, pageSize, loadingResults: isLoading } = this.state;
+
+		if ( searchResults === null ) {
+			return null;
+		}
+
+		if ( pageNumber >= MAX_PAGES ) {
+			return null;
+		}
+
+		if ( searchResults.length <= pageNumber * pageSize ) {
+			return null;
+		}
+
+		const className = clsx( 'register-domain-step__next-page', {
+			'register-domain-step__next-page--is-loading': isLoading,
+		} );
+		return (
+			<CompactCard className={ className }>
+				<Button
+					className="register-domain-step__next-page-button"
+					disabled={ isLoading }
+					busy={ isLoading }
+					onClick={ this.showNextPage }
+				>
+					{ this.props.translate( 'Show more results' ) }
+				</Button>
+			</CompactCard>
+		);
+	}
+
+	handleClickExampleSuggestion = () => {
+		this.focusSearchCard();
+
+		this.setState( { clickedExampleSuggestion: true } );
+	};
+
+	renderFilterContent() {
+		const { isSignupStep } = this.props;
+		const isSearching = this.state.lastQuery !== '' || this.state.loadingResults;
+
+		if ( isSignupStep || isSearching ) {
+			return (
+				<>
+					{ this.renderContent() }
+					{ this.renderFilterResetNotice() }
+					{ this.renderPaginationControls() }
+				</>
+			);
+		}
+
+		return (
+			<>
+				{ this.renderBestNamesPrompt() }
+				<EmptyContent title="" className="register-domain-step__placeholder" />
+			</>
+		);
+	}
+
+	renderContent() {
+		if ( Array.isArray( this.state.searchResults ) || this.state.loadingResults ) {
+			return this.renderSearchResults();
+		}
+
+		if ( this.props.showExampleSuggestions ) {
+			return this.renderExampleSuggestions();
+		}
+
+		return null;
+	}
+
+	save = () => {
+		this.props.onSave( this.state );
+	};
+
+	removeUnavailablePremiumDomain = ( domainName ) => {
+		this.setState( ( state ) => {
+			const premiumDomains = Object.fromEntries(
+				Object.entries( state.premiumDomains ).filter( ( [ key ] ) => key !== domainName )
+			);
+			const { searchResults } = state;
+			if ( Array.isArray( searchResults ) ) {
+				const newSearchResults = searchResults.filter(
+					( suggestion ) => suggestion.domain_name !== domainName
+				);
+				return {
+					premiumDomains,
+					searchResults: newSearchResults,
+				};
+			}
+			return {
+				premiumDomains,
+				searchResults,
+			};
+		} );
+	};
+
+	saveAndGetPremiumPrices = () => {
+		this.save();
+
+		const premiumDomainsFetched = [];
+
+		Object.keys( this.state.premiumDomains ).forEach( ( domainName ) => {
+			premiumDomainsFetched.push(
+				new Promise( ( resolve ) => {
+					checkDomainAvailability(
+						{
+							domainName,
+							blogId: get( this.props, 'selectedSite.ID', null ),
+							vendor: this.props.vendor,
+						},
+						( err, availabilityResult ) => {
+							if ( err ) {
+								// if any error occurs, removes the domain from both premium domains and
+								// search results state.
+								this.removeUnavailablePremiumDomain( domainName );
+								return resolve( null );
+							}
+
+							const status = availabilityResult?.status ?? err;
+
+							const isAvailablePremiumDomain = domainAvailability.AVAILABLE_PREMIUM === status;
+							const isAvailableSupportedPremiumDomain =
+								domainAvailability.AVAILABLE_PREMIUM === status &&
+								availabilityResult?.is_supported_premium_domain;
+
+							if ( ! isAvailablePremiumDomain || ! isAvailableSupportedPremiumDomain ) {
+								this.removeUnavailablePremiumDomain( domainName );
+								return resolve( null );
+							}
+
+							this.setState(
+								( state ) => {
+									const newPremiumDomains = { ...state.premiumDomains };
+									newPremiumDomains[ domainName ] = availabilityResult;
+									return {
+										premiumDomains: newPremiumDomains,
+									};
+								},
+								() => resolve( domainName )
+							);
+						}
+					);
+				} )
+			);
+		} );
+
+		Promise.all( premiumDomainsFetched ).then( () => {
+			this.setState( {
+				loadingResults: false,
+			} );
+		} );
+	};
+
+	repeatSearch = ( stateOverride = {} ) => {
+		this.save();
+
+		const { lastQuery } = this.state;
+		const loadingResults = Boolean( getDomainSuggestionSearch( lastQuery, MIN_QUERY_LENGTH ) );
+
+		const nextState = {
+			availabilityError: null,
+			availabilityErrorData: null,
+			availabilityErrorDomain: null,
+			exactMatchDomain: null,
+			lastDomainSearched: null,
+			lastFilters: this.state.filters,
+			loadingResults,
+			loadingSubdomainResults: loadingResults,
+			showAvailabilityNotice: false,
+			showSuggestionNotice: false,
+			suggestionError: null,
+			suggestionErrorData: null,
+			suggestionErrorDomain: null,
+			...stateOverride,
+		};
+		debug( 'Repeating a search with the following input for setState', nextState );
+		this.setState( nextState, () => {
+			loadingResults && this.onSearch( lastQuery );
+		} );
+	};
+
+	getActiveFiltersForAPI() {
+		const { filters } = this.state;
+		const { promoTlds } = this.props;
+		const filtersForAPI = mapKeys(
+			pickBy(
+				filters,
+				( value ) => isNumberString( value ) || value === true || Array.isArray( value )
+			),
+			( value, key ) => snakeCase( key )
+		);
+
+		/**
+		 * If promoTlds is set we want to make sure only those TLDs will be suggested
+		 * so we set the filter to those or filter the existing tld filter just in case
+		 */
+		if ( promoTlds ) {
+			if ( filtersForAPI?.tlds?.length > 0 ) {
+				filtersForAPI.tlds = filtersForAPI.tlds.filter( ( tld ) => promoTlds.includes( tld ) );
+			} else {
+				filtersForAPI.tlds = promoTlds;
+			}
+		}
+		return filtersForAPI;
+	}
+
+	toggleTldInFilter = ( event ) => {
+		const isCurrentlySelected = event.currentTarget.dataset.selected === 'true';
+		const newTld = event.currentTarget.value;
+
+		const tlds = new Set( [ ...this.state.filters.tlds, newTld ] );
+		if ( isCurrentlySelected ) {
+			tlds.delete( newTld );
+		}
+
+		this.repeatSearch( {
+			filters: {
+				...this.state.filters,
+				tlds: [ ...tlds ],
+			},
+			pageNumber: 1,
+		} );
+	};
+
+	onFiltersChange = ( newFilters, { shouldSubmit = false } = {} ) => {
+		this.setState(
+			{
+				filters: { ...this.state.filters, ...newFilters },
+			},
+			() => {
+				shouldSubmit && this.onFiltersSubmit();
+			}
+		);
+	};
+
+	onFiltersReset = ( ...keysToReset ) => {
+		this.props.recordFiltersReset(
+			this.state.filters,
+			keysToReset,
+			this.props.analyticsSection,
+			this.props.flowName
+		);
+		const filters = {
+			...this.state.filters,
+			...( Array.isArray( keysToReset ) && keysToReset.length > 0
+				? pick( this.getInitialFiltersState(), keysToReset )
+				: this.getInitialFiltersState() ),
+		};
+		this.repeatSearch( {
+			filters,
+			lastFilters: filters,
+			pageNumber: 1,
+		} );
+	};
+
+	onFiltersSubmit = () => {
+		this.props.recordFiltersSubmit(
+			this.state.filters,
+			this.props.analyticsSection,
+			this.props.flowName
+		);
+		this.repeatSearch( { pageNumber: 1 } );
+	};
+
+	onSearchChange = ( searchQuery, callback = noop ) => {
+		if ( ! this._isMounted ) {
+			return;
+		}
+
+		const cleanedQuery = getDomainSuggestionSearch( searchQuery, MIN_QUERY_LENGTH );
+		const loadingResults = Boolean( cleanedQuery );
+		const isInitialQueryActive = ! searchQuery || searchQuery === this.props.suggestion;
+
+		this.setState(
+			{
+				isInitialQueryActive,
+				availabilityError: null,
+				availabilityErrorData: null,
+				availabilityErrorDomain: null,
+				exactMatchDomain: null,
+				lastDomainSearched: null,
+				isQueryInvalid: false,
+				lastQuery: cleanedQuery,
+				hideInitialQuery: false,
+				loadingResults,
+				loadingSubdomainResults: loadingResults,
+				pageNumber: 1,
+				showAvailabilityNotice: false,
+				showSuggestionNotice: false,
+				suggestionError: null,
+				suggestionErrorData: null,
+				suggestionErrorDomain: null,
+			},
+			callback
+		);
+	};
+
+	getAvailableTlds = ( domain = undefined, vendor = undefined ) => {
+		const { promoTlds } = this.props;
+		return getAvailableTlds( { vendor, search: domain } )
+			.then( ( availableTlds ) => {
+				let filteredAvailableTlds = availableTlds;
+				if ( promoTlds ) {
+					filteredAvailableTlds = availableTlds.filter( ( tld ) => promoTlds.includes( tld ) );
+				}
+				this.setState( {
+					availableTlds: filteredAvailableTlds,
+				} );
+			} )
+			.catch( noop );
+	};
+
+	fetchDomainPrice = ( domain ) => {
+		return wpcom.req
+			.get( `/domains/${ encodeURIComponent( domain ) }/price` )
+			.then( ( data ) => ( {
+				pending: false,
+				is_premium: data.is_premium,
+				cost: data.cost,
+				sale_cost: data.sale_cost,
+				renew_cost: data.renew_cost,
+				is_price_limit_exceeded: data.is_price_limit_exceeded,
+			} ) )
+			.catch( ( error ) => ( {
+				pending: true,
+				error,
+			} ) );
+	};
+
+	preCheckDomainAvailability = ( domain ) => {
+		return new Promise( ( resolve ) => {
+			checkDomainAvailability(
+				{
+					domainName: domain,
+					blogId: get( this.props, 'selectedSite.ID', null ),
+					isCartPreCheck: true,
+					vendor: this.props.vendor,
+				},
+				( error, result ) => {
+					const status = get( result, 'status', error );
+					const isAvailable = domainAvailability.AVAILABLE === status;
+					const isAvailableSupportedPremiumDomain =
+						domainAvailability.AVAILABLE_PREMIUM === status && result?.is_supported_premium_domain;
+					resolve( {
+						status: ! isAvailable && ! isAvailableSupportedPremiumDomain ? status : null,
+						trademarkClaimsNoticeInfo: get( result, 'trademark_claims_notice_info', null ),
+					} );
+				}
+			);
+		} );
+	};
+
+	checkDomainAvailability = ( domain, timestamp ) => {
+		if (
+			! domain.match(
+				/^([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)*[a-z0-9]([a-z0-9-]*[a-z0-9])?\.[a-z]{2,63}$/i
+			)
+		) {
+			this.setState( { lastDomainStatus: null, lastDomainIsTransferrable: false } );
+			return;
+		}
+		if ( this.props.isSignupStep && domain.match( /\.wordpress\.com$/ ) ) {
+			this.setState( { lastDomainStatus: null, lastDomainIsTransferrable: false } );
+			return;
+		}
+
+		if ( this.props.promoTlds && ! this.props.promoTlds.includes( getTld( domain ) ) ) {
+			// We don't want to run an availability check if promoTlds are set
+			// and the searched domain is not one of those TLDs
+			return;
+		}
+
+		// Skips availability check for the Gravatar flow - so TLDs that are
+		// available but not eligible for Gravatar won't be displayed
+		if ( isDomainForGravatarFlow( this.props.flowName ) ) {
+			this.clearSuggestionErrorMessage();
+			const gravatarTlds = [
+				'link',
+				'bio',
+				'contact',
+				'cool',
+				'fyi',
+				'guru',
+				'info',
+				'life',
+				'live',
+				'ninja',
+				'place',
+				'pro',
+				'rocks',
+				'social',
+				'world',
+			];
+			// Also, we want to error messages for unavailable TLDs in Gravatar.
+			// Since only a limited number of tlds is enabled for now, we show the message for all other TLDs.
+			if ( ! gravatarTlds.includes( getTld( domain ) ) ) {
+				this.showSuggestionErrorMessage( domain, 'gravatar_tld_restriction', {} );
+			}
+			return;
+		}
+
+		// Skip availability check for the 100-year domain flow if the domain is not com/net/org
+		if (
+			isHundredYearDomainFlow( this.props.flowName ) &&
+			! [ 'com', 'net', 'org', 'blog' ].includes( getTld( domain ) )
+		) {
+			this.showSuggestionErrorMessage( domain, 'hundred_year_domain_tld_restriction', {} );
+			return;
+		}
+
+		return new Promise( ( resolve ) => {
+			checkDomainAvailability(
+				{
+					domainName: domain,
+					blogId: get( this.props, 'selectedSite.ID', null ),
+					vendor: this.props.vendor,
+				},
+				( error, result ) => {
+					const timeDiff = Date.now() - timestamp;
+					const status = get( result, 'status', error );
+					const mappable = get( result, 'mappable' );
+					const domainChecked = get( result, 'domain_name', domain );
+
+					const {
+						AVAILABLE,
+						AVAILABLE_PREMIUM,
+						MAPPED,
+						MAPPED_SAME_SITE_TRANSFERRABLE,
+						MAPPED_OTHER_SITE_SAME_USER_REGISTRABLE,
+						MAPPED_SAME_SITE_REGISTRABLE,
+						TRANSFERRABLE,
+						TRANSFERRABLE_PREMIUM,
+						UNKNOWN,
+						REGISTERED_OTHER_SITE_SAME_USER,
+					} = domainAvailability;
+
+					const availableDomainStatuses = [ AVAILABLE, UNKNOWN, MAPPED_SAME_SITE_REGISTRABLE ];
+
+					if ( error ) {
+						resolve( null );
+						return;
+					}
+
+					if ( this.props.includeOwnedDomainInSuggestions ) {
+						availableDomainStatuses.push( REGISTERED_OTHER_SITE_SAME_USER );
+					}
+
+					const isDomainAvailable = availableDomainStatuses.includes( status );
+					const isDomainTransferrable = TRANSFERRABLE === status;
+					const isDomainMapped = MAPPED === mappable;
+					const isAvailablePremiumDomain = AVAILABLE_PREMIUM === status;
+					const isAvailableSupportedPremiumDomain =
+						AVAILABLE_PREMIUM === status && result?.is_supported_premium_domain;
+
+					/**
+					 * In rare cases we don't get the FQDN as suggestion from the suggestion engine but only
+					 * from the availability endpoint. Let's make sure the `is_premium` flag is set.
+					 */
+					if ( result?.is_supported_premium_domain ) {
+						result.is_premium = true;
+					}
+
+					let availabilityStatus = status;
+
+					// Mapped status always overrides other statuses, unless the domain is owned by the current user.
+					if (
+						isDomainMapped &&
+						status !== REGISTERED_OTHER_SITE_SAME_USER &&
+						status !== MAPPED_OTHER_SITE_SAME_USER_REGISTRABLE &&
+						status !== MAPPED_SAME_SITE_REGISTRABLE
+					) {
+						availabilityStatus = mappable;
+					}
+
+					if (
+						[ HUNDRED_YEAR_PLAN_FLOW, HUNDRED_YEAR_DOMAIN_FLOW ].includes( this.props.flowName ) &&
+						isAvailablePremiumDomain
+					) {
+						this.removeUnavailablePremiumDomain( domain );
+						this.showSuggestionErrorMessage(
+							domain,
+							'hundred_year_domain_premium_name_restriction',
+							{}
+						);
+						resolve( null );
+					}
+
+					this.setState( {
+						exactMatchDomain: domainChecked,
+						lastDomainTld: result.tld,
+						lastDomainStatus: availabilityStatus,
+						lastDomainIsTransferrable: isDomainTransferrable,
+					} );
+					if ( isDomainAvailable || isAvailableSupportedPremiumDomain ) {
+						this.setState( {
+							showAvailabilityNotice: false,
+							availabilityError: null,
+							availabilityErrorData: null,
+						} );
+					} else {
+						let site = get( result, 'other_site_domain', null );
+						if (
+							includes(
+								[ MAPPED_SAME_SITE_TRANSFERRABLE, AVAILABLE_PREMIUM, TRANSFERRABLE_PREMIUM ],
+								status
+							)
+						) {
+							site = get( this.props, 'selectedSite.slug', null );
+						}
+						this.showAvailabilityErrorMessage( domain, availabilityStatus, {
+							site,
+							maintenanceEndTime: get( result, 'maintenance_end_time', null ),
+						} );
+					}
+
+					this.props.recordDomainAvailabilityReceive(
+						domain,
+						status,
+						timeDiff,
+						this.props.analyticsSection,
+						this.props.flowName
+					);
+
+					this.props.onDomainsAvailabilityChange( true );
+					resolve(
+						isDomainAvailable || isAvailableSupportedPremiumDomain || isAvailablePremiumDomain
+							? result
+							: null
+					);
+				}
+			);
+		} );
+	};
+
+	getDomainsSuggestions = ( domain, timestamp ) => {
+		const suggestionQuantity = SUGGESTION_QUANTITY - this.getFreeSubdomainSuggestionsQuantity();
+
+		const query = {
+			query: domain,
+			quantity: suggestionQuantity,
+			include_wordpressdotcom: false,
+			include_dotblogsubdomain: false,
+			tld_weight_overrides: getTldWeightOverrides( this.props.designType ),
+			vendor: this.props.vendor,
+			site_slug: this.props?.selectedSite?.slug,
+			recommendation_context: get( this.props, 'selectedSite.name', '' )
+				.replace( ' ', ',' )
+				.toLocaleLowerCase(),
+			...this.getActiveFiltersForAPI(),
+			include_internal_move_eligible: this.props.includeOwnedDomainInSuggestions,
+		};
+
+		debug( 'Fetching domains suggestions with the following query', query );
+
+		return domains
+			.suggestions( query )
+			.then( ( domainSuggestions ) => {
+				this.props.onDomainsAvailabilityChange( true );
+				const timeDiff = Date.now() - timestamp;
+				const analyticsResults = domainSuggestions.map( ( suggestion ) => suggestion.domain_name );
+
+				this.props.recordSearchResultsReceive(
+					domain,
+					analyticsResults,
+					timeDiff,
+					domainSuggestions.length,
+					this.props.analyticsSection,
+					this.props.flowName
+				);
+
+				return domainSuggestions;
+			} )
+			.catch( ( error ) => {
+				const timeDiff = Date.now() - timestamp;
+				if ( error && error.statusCode === 503 && ! this.props.isSignupStep ) {
+					const maintenanceEndTime = get( error, 'data.maintenance_end_time', null );
+					this.props.onDomainsAvailabilityChange( false, maintenanceEndTime );
+				} else if ( error && error.error ) {
+					this.showSuggestionErrorMessage( domain, error.error, {
+						maintenanceEndTime: get( error, 'data.maintenance_end_time', null ),
+						site: this.props?.selectedSite,
+					} );
+				}
+
+				const analyticsResults = [
+					error.code || error.error || 'ERROR' + ( error.statusCode || '' ),
+				];
+				this.props.recordSearchResultsReceive(
+					domain,
+					analyticsResults,
+					timeDiff,
+					-1,
+					this.props.analyticsSection,
+					this.props.flowName
+				);
+				throw error;
+			} );
+	};
+
+	handleDomainSuggestions = ( domain ) => ( results ) => {
+		if (
+			! this.state.loadingResults ||
+			domain !== this.state.lastDomainSearched ||
+			! this._isMounted
+		) {
+			// this callback is irrelevant now, a newer search has been made or the results were cleared OR
+			// domain registration was not available and component is unmounted
+			return;
+		}
+
+		const suggestionMap = new Map();
+
+		flatten( compact( results ) ).forEach( ( result ) => {
+			const { domain_name: domainName } = result;
+			suggestionMap.has( domainName )
+				? suggestionMap.set( domainName, { ...suggestionMap.get( domainName ), ...result } )
+				: suggestionMap.set( domainName, result );
+		} );
+
+		const suggestions = reject(
+			reject( reject( [ ...suggestionMap.values() ], isUnknownSuggestion ), isMissingVendor ),
+			isUnsupportedPremiumSuggestion
+		);
+
+		const hasAvailableFQDNSearch = [
+			domainAvailability.AVAILABLE,
+			domainAvailability.AVAILABLE_PREMIUM,
+		].includes( suggestions?.[ 0 ]?.status );
+
+		const markedSuggestions = markFeaturedSuggestions(
+			suggestions,
+			this.state.exactMatchDomain,
+			getStrippedDomainBase( domain ),
+			true,
+			this.props.deemphasiseTlds,
+			hasAvailableFQDNSearch
+		);
+
+		const premiumDomains = {};
+		markedSuggestions
+			.filter( ( suggestion ) => suggestion?.is_premium )
+			.map( ( suggestion ) => {
+				premiumDomains[ suggestion.domain_name ] = {
+					pending: true,
+				};
+			} );
+
+		this.setState(
+			{
+				premiumDomains,
+				pageSize: hasAvailableFQDNSearch ? EXACT_MATCH_PAGE_SIZE : PAGE_SIZE,
+				searchResults: markedSuggestions,
+			},
+			this.saveAndGetPremiumPrices
+		);
+	};
+
+	getSubdomainSuggestions = ( domain, timestamp ) => {
+		const subdomainQuery = {
+			query: domain,
+			quantity: this.getFreeSubdomainSuggestionsQuantity(),
+			include_wordpressdotcom: this.props.includeWordPressDotCom,
+			include_dotblogsubdomain: this.props.includeDotBlogSubdomain,
+			only_wordpressdotcom: this.props.includeDotBlogSubdomain,
+			tld_weight_overrides: null,
+			vendor: 'dot',
+			managed_subdomains: this.props.otherManagedSubdomains?.join(),
+			managed_subdomain_quantity: this.getOtherManagedSubdomainsQuantity(),
+			...this.getActiveFiltersForAPI(),
+		};
+
+		domains
+			.suggestions( subdomainQuery )
+			.then( this.handleSubdomainSuggestions( domain, subdomainQuery.vendor, timestamp ) )
+			.catch( this.handleSubdomainSuggestionsFailure( domain, timestamp ) );
+	};
+
+	handleSubdomainSuggestions = ( domain, vendor, timestamp ) => ( subdomainSuggestions ) => {
+		subdomainSuggestions = subdomainSuggestions.map( ( suggestion ) => {
+			suggestion.fetch_algo = suggestion.domain_name.endsWith( '.wordpress.com' )
+				? '/domains/search/wpcom'
+				: '/domains/search/dotblogsub';
+			suggestion.vendor = vendor;
+			suggestion.isSubDomainSuggestion = true;
+
+			return suggestion;
+		} );
+
+		this.props.onDomainsAvailabilityChange( true );
+		const timeDiff = Date.now() - timestamp;
+		const analyticsResults = subdomainSuggestions.map( ( suggestion ) => suggestion.domain_name );
+
+		this.props.recordSearchResultsReceive(
+			domain,
+			analyticsResults,
+			timeDiff,
+			subdomainSuggestions.length,
+			this.props.analyticsSection,
+			this.props.flowName
+		);
+
+		// This part handles the other end of the condition handled by the line 282:
+		// 1. The query request is sent.
+		// 2. `includeWordPressDotCom` is changed by the loaded result of the experiment. (this is where the line 282 won't handle)
+		// 3. The domain query result is returned and will be set here.
+		// The drawback is that it'd add unnecessary computation if `includeWordPressDotCom ` never changes.
+		if ( ! this.props.includeWordPressDotCom ) {
+			subdomainSuggestions = subdomainSuggestions.filter(
+				( subdomain ) => ! isFreeWordPressComDomain( subdomain )
+			);
+		}
+
+		this.setState(
+			{
+				subdomainSearchResults: subdomainSuggestions,
+				loadingSubdomainResults: false,
+			},
+			this.save
+		);
+	};
+
+	handleSubdomainSuggestionsFailure = ( domain, timestamp ) => ( error ) => {
+		const timeDiff = Date.now() - timestamp;
+
+		if ( error && error.statusCode === 503 ) {
+			this.props.onDomainsAvailabilityChange( false );
+		} else if ( error && error.error ) {
+			this.showSuggestionErrorMessage( domain, error.error );
+		}
+
+		const analyticsResults = [ error.code || error.error || 'ERROR' + ( error.statusCode || '' ) ];
+		this.props.recordSearchResultsReceive(
+			domain,
+			analyticsResults,
+			timeDiff,
+			-1,
+			this.props.analyticsSection,
+			this.props.flowName
+		);
+
+		this.setState( {
+			subdomainSearchResults: [],
+			loadingSubdomainResults: false,
+		} );
+	};
+
+	onSearch = async ( searchQuery ) => {
+		debug( 'onSearch handler was triggered with query', searchQuery );
+
+		const domain = getDomainSuggestionSearch( searchQuery, MIN_QUERY_LENGTH );
+
+		this.setState(
+			{
+				lastQuery: domain,
+				lastFilters: this.state.filters,
+				hideInitialQuery: false,
+				showAvailabilityNotice: false,
+				showSuggestionNotice: false,
+				availabilityError: null,
+				availabilityErrorData: null,
+				availabilityErrorDomain: null,
+				suggestionError: null,
+				suggestionErrorData: null,
+				suggestionErrorDomain: null,
+				lastDomainStatus: null,
+			},
+			this.save
+		);
+
+		if ( domain === '' ) {
+			this.setState( { isQueryInvalid: searchQuery !== domain } );
+			debug( 'onSearch handler was terminated by an empty domain input' );
+			return;
+		}
+
+		enqueueSearchStatReport(
+			{
+				query: searchQuery,
+				section: this.props.analyticsSection,
+				vendor: this.props.vendor,
+				flowName: this.props.flowName,
+			},
+			this.props.recordSearchFormSubmit
+		);
+
+		this.setState(
+			{
+				isQueryInvalid: false,
+				lastDomainSearched: domain,
+				railcarId: this.getNewRailcarId(),
+				loadingResults: true,
+			},
+			() => {
+				const timestamp = Date.now();
+
+				this.getAvailableTlds( domain, this.props.vendor );
+				const domainSuggestions = Promise.all( [
+					this.checkDomainAvailability( domain, timestamp ),
+					this.getDomainsSuggestions( domain, timestamp ),
+				] );
+
+				domainSuggestions
+					.catch( () => [] ) // handle the error and return an empty list
+					.then( this.handleDomainSuggestions( domain ) );
+
+				if ( this.isSubdomainResultsVisible() ) {
+					this.getSubdomainSuggestions( domain, timestamp );
+				}
+			}
+		);
+	};
+
+	showNextPage = () => {
+		const pageNumber = this.state.pageNumber + 1;
+
+		debug(
+			`Showing page ${ pageNumber } with query "${ this.state.lastQuery }" in section "${ this.props.analyticsSection }"`
+		);
+
+		this.props.recordShowMoreResults(
+			this.state.lastQuery,
+			pageNumber,
+			this.props.analyticsSection,
+			this.props.flowName
+		);
+
+		this.setState( { pageNumber, pageSize: PAGE_SIZE }, this.save );
+	};
+
+	renderBestNamesPrompt() {
+		const { translate, promptText } = this.props;
+		return (
+			<div className="register-domain-step__example-prompt">
+				{ promptText ?? translate( 'The best names are short and memorable' ) }
+			</div>
+		);
+	}
+
+	renderExampleSuggestions() {
+		const { isOnboarding, domainsWithPlansOnly, offerUnavailableOption, products } = this.props;
+
+		if ( isOnboarding ) {
+			return this.renderBestNamesPrompt();
+		}
+
+		return (
+			<ExampleDomainSuggestions
+				domainsWithPlansOnly={ domainsWithPlansOnly }
+				offerUnavailableOption={ offerUnavailableOption }
+				onClickExampleSuggestion={ this.handleClickExampleSuggestion }
+				products={ products }
+				url={ this.getUseYourDomainUrl() }
+			/>
+		);
+	}
+
+	renderFreeDomainExplainer() {
+		return <FreeDomainExplainer onSkip={ this.props.hideFreePlan } />;
+	}
+
+	onAddDomain = async ( suggestion, position, previousState ) => {
+		const domain = get( suggestion, 'domain_name' );
+		const rootVendor = get( suggestion, 'vendor' );
+		const { premiumDomains } = this.state;
+		const { includeOwnedDomainInSuggestions } = this.props;
+		const {
+			DOMAIN_AVAILABILITY_THROTTLED,
+			REGISTERED_OTHER_SITE_SAME_USER,
+			MAPPED_SAME_SITE_REGISTRABLE,
+		} = domainAvailability;
+
+		// disable adding a domain to the cart while the premium price is still fetching
+		if ( premiumDomains?.[ domain ]?.pending ) {
+			return;
+		}
+
+		// also don't allow premium domain purchases over certain price point
+		if ( premiumDomains?.[ domain ]?.is_price_limit_exceeded ) {
+			return;
+		}
+
+		globalThis?.sessionStorage.setItem( SESSION_STORAGE_QUERY_KEY, this.state.lastQuery || '' );
+
+		const isSubDomainSuggestion = get( suggestion, 'isSubDomainSuggestion' );
+		if ( ! hasDomainInCart( this.props.cart, domain ) && ! isSubDomainSuggestion ) {
+			// For Multi-domain flows, add the domain first, than check availability
+			if ( shouldUseMultipleDomainsInCart( this.props.flowName ) ) {
+				this.props.onAddDomain( suggestion, position, previousState );
+			}
+
+			this.setState( { pendingCheckSuggestion: suggestion } );
+			const promise = this.preCheckDomainAvailability( domain )
+				.catch( () => [] )
+				.then( ( { status, trademarkClaimsNoticeInfo } ) => {
+					this.setState( { pendingCheckSuggestion: null } );
+					this.props.recordDomainAddAvailabilityPreCheck(
+						domain,
+						status,
+						this.props.analyticsSection,
+						this.props.flowName,
+						rootVendor
+					);
+
+					const skipAvailabilityErrors =
+						! status ||
+						( status === REGISTERED_OTHER_SITE_SAME_USER && includeOwnedDomainInSuggestions ) ||
+						status === DOMAIN_AVAILABILITY_THROTTLED ||
+						status === MAPPED_SAME_SITE_REGISTRABLE;
+
+					if ( ! skipAvailabilityErrors ) {
+						this.setState( { unavailableDomains: [ ...this.state.unavailableDomains, domain ] } );
+						this.showAvailabilityErrorMessage( domain, status, {
+							availabilityPreCheck: true,
+						} );
+						this.props.onMappingError( domain, status );
+					} else if ( trademarkClaimsNoticeInfo ) {
+						this.setState( {
+							trademarkClaimsNoticeInfo: trademarkClaimsNoticeInfo,
+							selectedSuggestion: suggestion,
+							selectedSuggestionPosition: position,
+						} );
+						this.props.onMappingError( domain, status );
+					} else if ( ! shouldUseMultipleDomainsInCart( this.props.flowName ) ) {
+						this.props.onAddDomain( suggestion, position, previousState );
+					}
+				} );
+			this.props.checkDomainAvailabilityPromises?.push( promise );
+		} else {
+			this.props.onAddDomain( suggestion, position, previousState );
+		}
+	};
+
+	useYourDomainFunction = () => {
+		return this.goToUseYourDomainStep;
+	};
+
+	renderSearchResults() {
+		const {
+			exactMatchDomain,
+			lastDomainIsTransferrable,
+			lastDomainSearched,
+			lastDomainStatus,
+			lastDomainTld,
+			premiumDomains,
+		} = this.state;
+
+		const matchesSearchedDomain = ( suggestion ) => suggestion.domain_name === exactMatchDomain;
+		const availableDomain =
+			[ domainAvailability.AVAILABLE, domainAvailability.REGISTERED_OTHER_SITE_SAME_USER ].includes(
+				lastDomainStatus
+			) && find( this.state.searchResults, matchesSearchedDomain );
+		const onAddMapping = ( domain ) => this.props.onAddMapping( domain, this.state );
+
+		const suggestions = this.getSuggestionsFromProps();
+
+		// the search returned no results
+		if (
+			suggestions.length === 0 &&
+			! this.state.loadingResults &&
+			this.props.showExampleSuggestions
+		) {
+			return this.renderExampleSuggestions();
+		}
+
+		const hasResults =
+			( Array.isArray( this.state.searchResults ) && this.state.searchResults.length ) > 0 &&
+			! this.state.loadingResults;
+
+		const isFreeDomainExplainerVisible =
+			! this.props.forceHideFreeDomainExplainerAndStrikeoutUi &&
+			this.props.isPlanSelectionAvailableInFlow;
+
+		return (
+			<DomainSearchResults
+				key="domain-search-results" // key is required for CSS transition of content/
+				availableDomain={ availableDomain }
+				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+				isDomainOnly={ this.props.isDomainOnly }
+				lastDomainSearched={ lastDomainSearched }
+				lastDomainStatus={ lastDomainStatus }
+				lastDomainTld={ lastDomainTld }
+				lastDomainIsTransferrable={ lastDomainIsTransferrable }
+				onAddMapping={ onAddMapping }
+				onClickResult={ this.onAddDomain }
+				onClickMapping={ this.goToMapDomainStep }
+				onAddTransfer={ this.props.onAddTransfer }
+				onClickUseYourDomain={ this.props.handleClickUseYourDomain ?? this.useYourDomainFunction() }
+				tracksButtonClickSource="exact-match-top"
+				suggestions={ suggestions }
+				premiumDomains={ premiumDomains }
+				isLoadingSuggestions={ this.state.loadingResults || this.props.hasPendingRequests }
+				products={ this.props.products }
+				selectedSite={ this.props.selectedSite }
+				offerUnavailableOption={ this.props.offerUnavailableOption }
+				showAlreadyOwnADomain={ this.props.showAlreadyOwnADomain }
+				placeholderQuantity={ PAGE_SIZE }
+				isSignupStep={ this.props.isSignupStep }
+				showStrikedOutPrice={
+					this.props.isSignupStep && ! this.props.forceHideFreeDomainExplainerAndStrikeoutUi
+				}
+				railcarId={ this.state.railcarId }
+				fetchAlgo={ this.getFetchAlgo() }
+				cart={ this.props.cart }
+				isCartPendingUpdate={ this.props.isCartPendingUpdate }
+				pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
+				unavailableDomains={ this.state.unavailableDomains }
+				onSkip={ this.props.onSkip }
+				showSkipButton={ this.props.showSkipButton }
+				hideMatchReasons={ this.props.hideMatchReasons ?? this.props.isOnboarding }
+				domainAndPlanUpsellFlow={ this.props.domainAndPlanUpsellFlow }
+				useProvidedProductsList={ this.props.useProvidedProductsList }
+				isCartPendingUpdateDomain={ this.props.isCartPendingUpdateDomain }
+				wpcomSubdomainSelected={ this.props.wpcomSubdomainSelected }
+				temporaryCart={ this.props.temporaryCart }
+				domainRemovalQueue={ this.props.domainRemovalQueue }
+			>
+				{ ! this.props.isOnboarding &&
+					hasResults &&
+					isFreeDomainExplainerVisible &&
+					this.renderFreeDomainExplainer() }
+			</DomainSearchResults>
+		);
+	}
+
+	renderSideContent() {
+		return this.props.isOnboarding && ! this.state.loadingResults && this.props.sideContent;
+	}
+
+	getFetchAlgo() {
+		const fetchAlgoPrefix = '/domains/search/' + this.props.vendor;
+
+		if ( this.props.isDomainOnly ) {
+			return fetchAlgoPrefix + '/domain-only';
+		}
+		if ( this.props.isSignupStep ) {
+			return fetchAlgoPrefix + '/signup';
+		}
+		return fetchAlgoPrefix + '/domains';
+	}
+
+	getMapDomainUrl() {
+		let mapDomainUrl;
+
+		if ( this.props.mapDomainUrl ) {
+			mapDomainUrl = this.props.mapDomainUrl;
+		} else {
+			const query = stringify( { initialQuery: this.state.lastQuery.trim() } );
+			mapDomainUrl = `${ this.props.basePath }/mapping`;
+			if ( this.props.selectedSite ) {
+				mapDomainUrl += `/${ this.props.selectedSite.slug }?${ query }`;
+			}
+		}
+
+		return mapDomainUrl;
+	}
+
+	getUseYourDomainUrl() {
+		let useYourDomainUrl;
+
+		if ( this.props.useYourDomainUrl ) {
+			useYourDomainUrl = this.props.useYourDomainUrl;
+		} else {
+			useYourDomainUrl = `${ this.props.basePath }/use-your-domain`;
+			if ( this.props.selectedSite ) {
+				useYourDomainUrl = domainUseMyDomain( this.props.selectedSite.slug, {
+					domain: this.state.lastQuery.trim(),
+				} );
+			}
+		}
+
+		return useYourDomainUrl;
+	}
+
+	goToMapDomainStep = ( event ) => {
+		event.preventDefault();
+
+		this.props.recordMapDomainButtonClick( this.props.analyticsSection, this.props.flowName );
+
+		page( this.getMapDomainUrl() );
+	};
+
+	goToUseYourDomainStep = ( event ) => {
+		event.preventDefault();
+
+		this.props.recordUseYourDomainButtonClick(
+			this.props.analyticsSection,
+			null,
+			this.props.flowName
+		);
+
+		page( this.getUseYourDomainUrl() );
+	};
+
+	showAvailabilityErrorMessage( domain, error, errorData ) {
+		const {
+			DOTBLOG_SUBDOMAIN,
+			TRANSFERRABLE,
+			RECENT_REGISTRATION_LOCK_NOT_TRANSFERRABLE,
+			SERVER_TRANSFER_PROHIBITED_NOT_TRANSFERRABLE,
+			REGISTERED_OTHER_SITE_SAME_USER,
+			REGISTERED_SAME_SITE,
+		} = domainAvailability;
+
+		const { isSignupStep, includeOwnedDomainInSuggestions } = this.props;
+		const isGravatarDomain = isDomainForGravatarFlow( this.props.flowName );
+
+		if (
+			( TRANSFERRABLE === error && this.state.lastDomainIsTransferrable ) ||
+			RECENT_REGISTRATION_LOCK_NOT_TRANSFERRABLE === error ||
+			SERVER_TRANSFER_PROHIBITED_NOT_TRANSFERRABLE === error ||
+			( isSignupStep && DOTBLOG_SUBDOMAIN === error ) ||
+			( includeOwnedDomainInSuggestions && REGISTERED_OTHER_SITE_SAME_USER === error ) ||
+			( isGravatarDomain &&
+				[ REGISTERED_OTHER_SITE_SAME_USER, REGISTERED_SAME_SITE ].includes( error ) )
+		) {
+			return;
+		}
+		this.setState( {
+			showAvailabilityNotice: true,
+			availabilityError: error,
+			availabilityErrorData: errorData,
+			availabilityErrorDomain: domain,
+		} );
+	}
+
+	clearSuggestionErrorMessage() {
+		this.setState( {
+			showSuggestionNotice: false,
+			suggestionError: null,
+			suggestionErrorData: null,
+			suggestionErrorDomain: null,
+			showAvailabilityNotice: false,
+			availabilityError: null,
+			availabilityErrorData: null,
+			availabilityErrorDomain: null,
+		} );
+	}
+
+	showSuggestionErrorMessage( domain, error, errorData ) {
+		const {
+			DOTBLOG_SUBDOMAIN,
+			TRANSFERRABLE,
+			RECENT_REGISTRATION_LOCK_NOT_TRANSFERRABLE,
+			SERVER_TRANSFER_PROHIBITED_NOT_TRANSFERRABLE,
+		} = domainAvailability;
+		if (
+			( TRANSFERRABLE === error && this.state.lastDomainIsTransferrable ) ||
+			RECENT_REGISTRATION_LOCK_NOT_TRANSFERRABLE === error ||
+			SERVER_TRANSFER_PROHIBITED_NOT_TRANSFERRABLE === error ||
+			( this.props.isSignupStep && DOTBLOG_SUBDOMAIN === error )
+		) {
+			return;
+		}
+		this.setState( {
+			showSuggestionNotice: true,
+			suggestionError: error,
+			suggestionErrorData: errorData,
+			suggestionErrorDomain: domain,
+		} );
+	}
+}
+
+export default connect(
+	( state ) => {
+		return {
+			currentUser: getCurrentUser( state ),
+			isDomainAndPlanPackageFlow: !! getCurrentQueryArguments( state )?.domainAndPlanPackage,
+			flowName: getCurrentFlowName( state ),
+		};
+	},
+	{
+		recordDomainAvailabilityReceive,
+		recordDomainAddAvailabilityPreCheck,
+		recordFiltersReset,
+		recordFiltersSubmit,
+		recordMapDomainButtonClick,
+		recordSearchFormSubmit,
+		recordSearchFormView,
+		recordSearchResultsReceive,
+		recordShowMoreResults,
+		recordTransferDomainButtonClick,
+		recordUseYourDomainButtonClick,
+	}
+)( withCartKey( withShoppingCart( localize( RegisterDomainStep ) ) ) );

--- a/client/components/domain-search-v2/register-domain-step/style.scss
+++ b/client/components/domain-search-v2/register-domain-step/style.scss
@@ -1,0 +1,316 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.register-domain-step:not(.register-domain-step__signup) {
+	display: block;
+	position: relative;
+	margin: 0 auto 10px;
+	padding: 16px;
+	box-sizing: border-box;
+	background: var(--color-surface);
+	box-shadow: 0 0 0 1px var(--color-border-subtle);
+
+	@include break-mobile {
+		padding: 24px;
+	}
+
+	.search-filters__dropdown-filters {
+		height: 40px;
+
+		@include break-mobile {
+			height: 48px;
+		}
+	}
+
+	.button.domain-suggestion__action {
+		padding: 0;
+		@include break-mobile {
+			min-width: 120px;
+		}
+	}
+
+	.card {
+		background: none;
+		box-shadow: none;
+		border-bottom: 1px solid var(--color-border-subtle);
+		padding-left: 0;
+		padding-right: 0;
+	}
+
+	.domain-search-results__domain-available-notice,
+	.search-component {
+		border-bottom: none;
+	}
+
+	.register-domain-step__next-page {
+		border-bottom: none;
+		padding-bottom: 0;
+		.register-domain-step__next-page-button {
+			padding-bottom: 0;
+			padding-top: 0;
+			@include break-mobile {
+				padding-top: 8px;
+				padding-bottom: 8px;
+			}
+		}
+	}
+
+	.domain-search-results__domain-available-notice {
+		padding-top: 0;
+		padding-bottom: 0;
+	}
+
+	.search-component {
+		overflow: hidden;
+		border: 1px solid var(--color-border-subtle);
+		border-radius: 4px;
+	}
+
+	.search-component.is-open {
+		border: 1px solid #a7aaad;
+		border-radius: 4px;
+		box-sizing: border-box;
+		height: 40px;
+
+		@include break-mobile {
+			height: 48px;
+		}
+	}
+
+	.search-component.is-open.has-focus {
+		border-color: #646970;
+		background: var(--color-surface);
+		box-shadow: none;
+
+		.search-component__input {
+			background: var(--color-surface);
+		}
+	}
+
+	.card.register-domain-step__search-card {
+		background-color: var(--color-surface);
+	}
+}
+
+.register-domain-step__search {
+	padding-bottom: 12px;
+
+	.card.register-domain-step__search-card {
+		padding: 0;
+		display: flex;
+		align-items: center;
+		border-bottom: none;
+	}
+
+	.search {
+		margin-bottom: 0;
+
+		&.is-refocused {
+			animation: shake 0.5s both;
+			box-shadow: 0 0 0 1px var(--color-neutral-light), 0 2px 4px var(--color-neutral-10);
+		}
+	}
+
+	&.disabled {
+		border-bottom: none; // so that bottom border is not there during google app dialog animation
+		opacity: 0.7;
+		transition: opacity, 0.3s, ease-in-out;
+	}
+
+	.search-card {
+		margin-bottom: 0;
+	}
+}
+
+.register-domain-step > .calypso-notice.register-domain-step__notice {
+	margin-bottom: 12px;
+}
+
+.register-domain-step__example-prompt {
+	font-size: 0.875rem;
+	line-height: 20px;
+	color: var(--studio-gray-50);
+	display: flex;
+	align-items: center;
+	margin: 0;
+
+	@include break-small {
+		margin: 0 20px;
+	}
+
+	@include break-large {
+		margin: 0;
+	}
+}
+
+.register-domain-step__placeholder.empty-content {
+	padding-bottom: 30px;
+}
+
+@keyframes shake {
+	0%,
+	100% {
+		transform: translate3d(0, 0, 0);
+	}
+
+	10%,
+	60% {
+		transform: translate3d(-5px, 0, 0);
+	}
+
+	30% {
+		transform: translate3d(5px, 0, 0);
+	}
+}
+
+.register-domain-step__filter-reset-notice {
+	color: var(--color-primary);
+	font-weight: 600;
+	width: 100%;
+	position: relative;
+	margin-bottom: 0;
+
+	border: 0;
+	border-radius: 0;
+
+	// from components/card/style.scss
+	box-shadow:
+		0 0 0 1px color-mix(in srgb, var(--color-neutral-10) 50%, transparent),
+		0 1px 2px var(--color-neutral-0);
+
+	// from components/domains/domain-suggestion/style
+	// NOTE: easeOutExpo easing function from http://easings.net/#easeOutExpo
+	transition: box-shadow 0.25s cubic-bezier(0.19, 1, 0.22, 1);
+
+	&:hover {
+		color: var(--color-primary);
+
+		// from components/domains/domain-suggestion/style
+		box-shadow: 0 0 0 1px var(--color-neutral-light);
+	}
+}
+
+.register-domain-step__next-page {
+	color: var(--color-link);
+	display: flex;
+	justify-content: center;
+}
+
+.register-domain-step {
+	.button.is-active {
+		background: var(--color-neutral-0);
+	}
+}
+
+button.register-domain-step__next-page-button {
+	font-size: 0.875rem;
+}
+
+body.is-section-domains {
+	.register-domain-step {
+		button.register-domain-step__next-page-button {
+			color: var(--color-link);
+			border: none;
+			box-shadow: none;
+		}
+	}
+}
+
+body.is-section-stepper,
+body.is-section-signup {
+	.domain-search-results__domain-availability .card {
+		box-shadow: none;
+		padding: 0;
+		margin-bottom: 24px;
+		margin-left: 20px;
+
+		@include break-mobile {
+			margin-left: 0;
+		}
+	}
+	.domain-search-results__domain-availability svg,
+	.register-domain-step__notice svg {
+		margin: 0;
+		padding: 0;
+	}
+	.register-domain-step__next-page {
+		background: none;
+		box-shadow: none;
+
+		button.register-domain-step__next-page-button {
+			padding: 0.57em 1.17em;
+			border-radius: 4px;
+
+			letter-spacing: 0.32px;
+			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+			line-height: 1.25rem;
+
+			@include break-mobile {
+				padding: 0.65em 2.8em;
+			}
+		}
+	}
+}
+
+.already-own-a-domain {
+	font-size: $font-body-small;
+	color: var(--color-text-subtle);
+	display: flex;
+	align-items: center;
+	margin-top: 26px;
+	svg {
+		align-self: flex-start;
+		width: 16px;
+		height: 16px;
+		fill: var(--color-text-subtle);
+		margin: 3px 8px 0;
+		@include break-mobile {
+			margin-left: 0;
+		}
+	}
+	.button-plain {
+		color: var(--color-link);
+	}
+}
+.register-domain-step__placeholder {
+	display: none;
+
+	@include break-large {
+		display: block;
+	}
+}
+
+.is-domain-plan-package-flow {
+
+	.register-domain-step {
+		box-shadow: none;
+		background: var(--color-body-background);
+	}
+
+	.search-filters__dropdown-filters {
+		border-color: transparent;
+	}
+
+	.register-domain-step__domains-quickfilter-group {
+
+		@include break-large {
+			display: flex;
+		}
+
+		.components-button {
+			&.is-pressed {
+				&::before {
+					border-radius: 4px;
+				}
+			}
+		}
+	}
+}
+
+.search-component .search-filters__dropdown-filters button {
+	background-color: transparent;
+	border-color: transparent;
+	border-radius: 0;
+	border-right: none;
+	border-left: none;
+}

--- a/client/components/domain-search-v2/register-domain-step/test/utility.js
+++ b/client/components/domain-search-v2/register-domain-step/test/utility.js
@@ -1,0 +1,132 @@
+import { markFeaturedSuggestions } from '../utility';
+
+describe( 'markFeaturedSuggestions', () => {
+	describe( 'featuredSuggestionsAtTop = false', () => {
+		test( 'when strippedDomainBase does not match any domain, it should assume the recomendation is the top result, also it should identify best alternative and move it to second position', () => {
+			const input = [
+				{ domain_name: 'test.com' },
+				{ domain_name: 'test.press' },
+				{ domain_name: 'test.live' },
+			];
+
+			const output = markFeaturedSuggestions( input, '', 'abc', false, [] );
+
+			expect( output ).toEqual( [
+				{ domain_name: 'test.com', isRecommended: true },
+				{ domain_name: 'test.press', isBestAlternative: true },
+				{ domain_name: 'test.live' },
+			] );
+		} );
+
+		test(
+			'when strippedDomainBase matches every domain, it should identify recommendation as the first domain and move it to top of the list,' +
+				'and it should assume the best alternative',
+			() => {
+				const input = [
+					{ domain_name: 'test.com' },
+					{ domain_name: 'test.press' },
+					{ domain_name: 'test.live' },
+				];
+
+				const output = markFeaturedSuggestions( input, '', 'test', false, [] );
+
+				expect( output ).toEqual( [
+					{ domain_name: 'test.com', isRecommended: true },
+					{ domain_name: 'test.press', isBestAlternative: true },
+					{ domain_name: 'test.live' },
+				] );
+			}
+		);
+
+		test(
+			'when exactMatchDomain matches some domain, it should identify recommendation as that domain and move it to top of the list,' +
+				'and it should assume the best alternative',
+			() => {
+				const input = [
+					{ domain_name: 'test.com' },
+					{ domain_name: 'test.press' },
+					{ domain_name: 'test.live' },
+				];
+
+				const output = markFeaturedSuggestions( input, 'test.live', 'unrelated', false, [] );
+
+				expect( output ).toEqual( [
+					{ domain_name: 'test.live', isRecommended: true },
+					{ domain_name: 'test.com', isBestAlternative: true },
+					{ domain_name: 'test.press' },
+				] );
+			}
+		);
+
+		test( 'when exactMatchDomain matches some domain and strippedDomainBase matches other domain, it should identify recommendation as whichever one matches first (1)', () => {
+			const input = [
+				{ domain_name: 'test.com' },
+				{ domain_name: 'test.press' },
+				{ domain_name: 'test.live' },
+				{ domain_name: 'domainbase.live' },
+			];
+
+			const output = markFeaturedSuggestions( input, 'test.live', 'domainbase', false, [] );
+
+			expect( output ).toEqual( [
+				{ domain_name: 'test.live', isRecommended: true },
+				{ domain_name: 'test.com', isBestAlternative: true },
+				{ domain_name: 'test.press' },
+				{ domain_name: 'domainbase.live' },
+			] );
+		} );
+
+		test( 'when exactMatchDomain matches some domain and strippedDomainBase matches other domain, it should identify recommendation as whichever one matches first (2)', () => {
+			const input = [
+				{ domain_name: 'test.com' },
+				{ domain_name: 'test.press' },
+				{ domain_name: 'domainbase.live' },
+				{ domain_name: 'test.live' },
+			];
+
+			const output = markFeaturedSuggestions( input, 'test.live', 'domainbase', false, [] );
+
+			expect( output ).toEqual( [
+				{ domain_name: 'domainbase.live', isRecommended: true },
+				{ domain_name: 'test.com', isBestAlternative: true },
+				{ domain_name: 'test.press' },
+				{ domain_name: 'test.live' },
+			] );
+		} );
+
+		test( 'when strippedDomainBase matches some domains, it should identify recommendation as the first matching domain, and the best alternative as first non-matching domain', () => {
+			const input = [
+				{ domain_name: 'alternative.com' },
+				{ domain_name: 'test.press' },
+				{ domain_name: 'test.live' },
+				{ domain_name: 'alternative2.com' },
+			];
+
+			const output = markFeaturedSuggestions( input, '', 'test', false, [] );
+
+			expect( output ).toEqual( [
+				{ domain_name: 'test.press', isRecommended: true },
+				{ domain_name: 'alternative.com', isBestAlternative: true },
+				{ domain_name: 'test.live' },
+				{ domain_name: 'alternative2.com' },
+			] );
+		} );
+	} );
+	describe( 'featuredSuggestionsAtTop = true', () => {
+		test( 'it should always mark first domain as recommendation and second as best alternative', () => {
+			const input = [
+				{ domain_name: 'unrelated.com' },
+				{ domain_name: 'test.press' },
+				{ domain_name: 'test.live' },
+			];
+
+			const output = markFeaturedSuggestions( input, '', 'test', true, [] );
+
+			expect( output ).toEqual( [
+				{ domain_name: 'unrelated.com', isRecommended: true },
+				{ domain_name: 'test.press', isBestAlternative: true },
+				{ domain_name: 'test.live' },
+			] );
+		} );
+	} );
+} );

--- a/client/components/domain-search-v2/register-domain-step/utility.js
+++ b/client/components/domain-search-v2/register-domain-step/utility.js
@@ -1,0 +1,97 @@
+import { domainAvailability } from 'calypso/lib/domains/constants';
+
+function moveArrayElement( array, from, to ) {
+	if ( from !== to && from < array.length && to < array.length ) {
+		array.splice( to, 0, array.splice( from, 1 )[ 0 ] );
+	}
+}
+
+export function markFeaturedSuggestions(
+	suggestions,
+	exactMatchDomain,
+	strippedDomainBase,
+	featuredSuggestionsAtTop = false,
+	avoidTlds = [],
+	markOnlyRecommended = false
+) {
+	function isExactMatchBeforeTld( suggestion ) {
+		return (
+			suggestion.domain_name === exactMatchDomain ||
+			suggestion.domain_name?.startsWith( `${ strippedDomainBase }.` )
+		);
+	}
+
+	function isBestAlternative( suggestion ) {
+		return ! isExactMatchBeforeTld( suggestion ) && suggestion.isRecommended !== true;
+	}
+
+	const output = [ ...suggestions ];
+	let outputWithoutTlds = filterOutDomainsWithTlds( output, avoidTlds );
+
+	const recommendedSuggestion =
+		( featuredSuggestionsAtTop ? null : outputWithoutTlds.find( isExactMatchBeforeTld ) ) ||
+		outputWithoutTlds[ 0 ];
+
+	if ( recommendedSuggestion ) {
+		recommendedSuggestion.isRecommended = true;
+		moveArrayElement( output, output.indexOf( recommendedSuggestion ), 0 );
+		outputWithoutTlds = filterOutDomainsWithTlds( output, avoidTlds );
+	}
+
+	const bestAlternativeSuggestion =
+		! markOnlyRecommended &&
+		( ( featuredSuggestionsAtTop ? null : outputWithoutTlds.find( isBestAlternative ) ) ||
+			outputWithoutTlds[ 1 ] );
+
+	if ( bestAlternativeSuggestion ) {
+		bestAlternativeSuggestion.isBestAlternative = true;
+		moveArrayElement( output, output.indexOf( bestAlternativeSuggestion ), 1 );
+	}
+
+	return output;
+}
+
+export function filterOutDomainsWithTlds( suggestions, disallowedTlds ) {
+	return suggestions.filter( ( suggestion ) => {
+		const tld = suggestion.domain_name.split( '.' ).pop();
+		return disallowedTlds.indexOf( tld ) === -1;
+	} );
+}
+
+export function isUnknownSuggestion( suggestion ) {
+	return suggestion.status === domainAvailability.UNKNOWN;
+}
+
+export function isUnsupportedPremiumSuggestion( suggestion ) {
+	return (
+		domainAvailability.AVAILABLE_PREMIUM === suggestion.status &&
+		suggestion.hasOwnProperty( 'is_supported_premium_domain' ) &&
+		suggestion?.is_supported_premium_domain === false
+	);
+}
+
+export function isMissingVendor( suggestion ) {
+	return ! ( 'vendor' in suggestion );
+}
+
+export function isFreeSuggestion( suggestion ) {
+	return suggestion.is_free === true;
+}
+
+export function getStrippedDomainBase( domain ) {
+	let strippedDomainBase = domain;
+	const lastIndexOfDot = strippedDomainBase.lastIndexOf( '.' );
+
+	if ( lastIndexOfDot !== -1 ) {
+		strippedDomainBase = strippedDomainBase.substring( 0, lastIndexOfDot );
+	}
+	return strippedDomainBase.replace( /[ .]/g, '' );
+}
+
+export function isNumberString( string ) {
+	return /^[0-9_]+$/.test( string );
+}
+
+export function getTldWeightOverrides( designType ) {
+	return designType && designType === 'blog' ? 'design_type_blog' : null;
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -8,6 +8,8 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { isEmpty } from 'lodash';
 import { useState } from 'react';
 import QueryProductsList from 'calypso/components/data/query-products-list';
+import DomainCartV2 from 'calypso/components/domain-search-v2/domain-cart';
+import RegisterDomainStepV2 from 'calypso/components/domain-search-v2/register-domain-step';
 import { useMyDomainInputMode as inputMode } from 'calypso/components/domains/connect-domain-step/constants';
 import RegisterDomainStep from 'calypso/components/domains/register-domain-step';
 import { recordUseYourDomainButtonClick } from 'calypso/components/domains/register-domain-step/analytics';
@@ -15,6 +17,7 @@ import SideExplainer from 'calypso/components/domains/side-explainer';
 import UseMyDomain from 'calypso/components/domains/use-my-domain';
 import { getDomainSuggestionSearch, getFixedDomainSearch } from 'calypso/lib/domains';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
+import { useDomainSearchV2 } from 'calypso/lib/domains/use-domain-search-v2';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import {
 	retrieveSignupDestination,
@@ -176,6 +179,8 @@ export function DomainFormControl( {
 		);
 	};
 
+	const [ , isDomainSearchV2Enabled ] = useDomainSearchV2( flow ?? '' );
+
 	const renderDomainForm = () => {
 		let initialState: DomainForm = {};
 		if ( domainForm ) {
@@ -203,9 +208,14 @@ export function DomainFormControl( {
 			showExampleSuggestions = true;
 		}
 
+		const RegisterDomainStepComponent = isDomainSearchV2Enabled
+			? RegisterDomainStepV2
+			: RegisterDomainStep;
+
 		return (
 			<CalypsoShoppingCartProvider>
-				<RegisterDomainStep
+				{ isDomainSearchV2Enabled && <DomainCartV2 /> }
+				<RegisterDomainStepComponent
 					isCartPendingUpdate={ isCartPendingUpdate }
 					isCartPendingUpdateDomain={ isCartPendingUpdateDomain }
 					analyticsSection={ analyticsSection }
@@ -253,7 +263,7 @@ export function DomainFormControl( {
 		content = renderDomainForm();
 	}
 
-	if ( isDomainUpsellFlow( flow ) && ! showUseYourDomain ) {
+	if ( isDomainUpsellFlow( flow ) && ! showUseYourDomain && ! isDomainSearchV2Enabled ) {
 		sideContent = getSideContent();
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -15,11 +15,13 @@ import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
+import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import {
 	domainRegistration,
 	domainMapping,
 	domainTransfer,
 } from 'calypso/lib/cart-values/cart-items';
+import { useDomainSearchV2 } from 'calypso/lib/domains/use-domain-search-v2';
 import { useDispatch as useReduxDispatch } from 'calypso/state';
 import {
 	composeAnalytics,
@@ -356,4 +358,22 @@ const DomainsStep: Step< {
 	);
 };
 
-export default DomainsStep;
+const StyleWrappedDomainsStep: typeof DomainsStep = ( props ) => {
+	const [ isLoading, shouldUseDomainSearchV2 ] = useDomainSearchV2( props.flow );
+
+	if ( isLoading ) {
+		// TODO: Add a loading state to indicate that the experiment is loading.
+		return null;
+	}
+
+	return (
+		<>
+			<DomainsStep { ...props } />
+			{ ! shouldUseDomainSearchV2 && (
+				<BodySectionCssClass bodyClass={ [ 'domain-search-legacy--stepper' ] } />
+			) }
+		</>
+	);
+};
+
+export default StyleWrappedDomainsStep;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -2,618 +2,620 @@
 @import '@automattic/onboarding/styles/mixins';
 @import '../hundred-year-plan-step-wrapper/mixins';
 
-.domains {
-	.step-container {
-		max-width: 1040px;
-		padding: 0 20px;
-		margin: 0;
-
-		@include break-small {
-			margin: 0 0 0 20px;
-		}
-
-		@include break-wide {
-			margin: 0 auto;
-		}
-
-		.step-container__header {
-			margin: 20px 24px 40px 20px;
+.domain-search-legacy--stepper {
+	.domains {
+		.step-container {
+			max-width: 1040px;
+			padding: 0 20px;
+			margin: 0;
 
 			@include break-small {
-				margin: 36px 0 58px 0;
-			}
-
-			.formatted-header__title {
-				font-size: 2.25rem;
-				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-				line-height: 2.5rem;
-				@include break-mobile {
-					font-size: 2.75rem;
-					line-height: 48px;
-				}
-			}
-		}
-
-		.domains__domain-side-content-container {
-			flex-direction: column;
-			margin-top: 40px;
-			margin-bottom: 40px;
-			display: none;
-
-			@include break-large {
-				width: 30vw;
-				margin-top: 0;
-				flex-direction: column;
-				display: flex;
+				margin: 0 0 0 20px;
 			}
 
 			@include break-wide {
-				width: 350px;
+				margin: 0 auto;
 			}
 
-			.domains__domain-side-content {
-				border-bottom: 1px solid var( --studio-gray-5 );
-				margin: 0;
-				padding: 20px 0 20px 0;
-				&:not( .domains__free-domain ) {
-					border-bottom: none;
+			.step-container__header {
+				margin: 20px 24px 40px 20px;
+
+				@include break-small {
+					margin: 36px 0 58px 0;
+				}
+
+				.formatted-header__title {
+					font-size: 2.25rem;
+					/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+					line-height: 2.5rem;
+					@include break-mobile {
+						font-size: 2.75rem;
+						line-height: 48px;
+					}
 				}
 			}
-		}
 
-		.register-domain-step .domains__domain-side-content-container {
-			display: flex;
+			.domains__domain-side-content-container {
+				flex-direction: column;
+				margin-top: 40px;
+				margin-bottom: 40px;
+				display: none;
 
-			@include break-small {
-				flex-direction: row;
+				@include break-large {
+					width: 30vw;
+					margin-top: 0;
+					flex-direction: column;
+					display: flex;
+				}
+
+				@include break-wide {
+					width: 350px;
+				}
 
 				.domains__domain-side-content {
-					padding-top: 0;
-					border-bottom: none;
+					border-bottom: 1px solid var( --studio-gray-5 );
+					margin: 0;
+					padding: 20px 0 20px 0;
+					&:not( .domains__free-domain ) {
+						border-bottom: none;
+					}
 				}
 			}
 
-			@include break-large {
-				display: none;
-			}
-		}
+			.register-domain-step .domains__domain-side-content-container {
+				display: flex;
 
-		.domains__step-section-wrapper {
-			.use-my-domain__page-heading {
-				padding-left: 24px;
-				padding-right: 24px;
-				text-align: center;
-			}
+				@include break-small {
+					flex-direction: row;
 
-			.use-my-domain,
-			.connect-domain-step,
-			.domain-transfer-or-connect__content {
-				background: transparent;
-				box-shadow: none;
-
-				.form-text-input {
-					height: 100%;
+					.domains__domain-side-content {
+						padding-top: 0;
+						border-bottom: none;
+					}
 				}
 
-				@include break-mobile {
-					padding-left: 0;
-					padding-right: 0;
+				@include break-large {
+					display: none;
 				}
 			}
-		}
 
-		.register-domain-step__search {
-			padding-top: 0;
-			padding-bottom: 16px;
-		}
-
-		.search-component {
-			border: 1px solid var( --color-border-subtle );
-			border-radius: 4px;
-			overflow: hidden;
-		}
-
-		.search-component.is-open {
-			border: 1px solid #a7aaad;
-			border-radius: 4px;
-			box-sizing: border-box;
-			height: 40px;
-
-			@include break-mobile {
-				height: 48px;
-			}
-		}
-
-		.search-component.is-open.has-focus {
-			border-color: #646970;
-			background: var( --color-surface );
-			box-shadow: none;
-
-			.search-component__input {
-				background: var( --color-surface );
-			}
-		}
-
-		.domain-suggestion__action {
-			border-radius: 4px;
-			margin: 0;
-		}
-
-		.register-domain-step__search-card {
-			background: var( --color-surface );
-			box-shadow: none;
-			display: flex;
-			padding: 0;
-		}
-
-		.search-component__icon-search {
-			fill: var( --studio-gray-20 );
-			margin: 8px 6px 8px 8px;
-		}
-
-		.domain-search-results__domain-suggestions {
-			margin: 0;
-			@include break-mobile {
-				margin: 0 20px;
-			}
-			@include break-small {
-				margin: 0;
-			}
-		}
-
-		.featured-domain-suggestions {
-			border-top: 1px solid var( --studio-gray-5 );
-			@include break-mobile {
-				border-top: none;
-			}
-
-			.featured-domain-suggestion {
-				border-bottom: 1px solid var( --studio-gray-5 );
-				box-shadow: none;
-				@include break-mobile {
-					border-bottom: none;
-					box-shadow: 0 0 0 1px var( --color-border-subtle );
+			.domains__step-section-wrapper {
+				.use-my-domain__page-heading {
+					padding-left: 24px;
+					padding-right: 24px;
+					text-align: center;
 				}
-				background: var( --color-surface );
+
+				.use-my-domain,
+				.connect-domain-step,
+				.domain-transfer-or-connect__content {
+					background: transparent;
+					box-shadow: none;
+
+					.form-text-input {
+						height: 100%;
+					}
+
+					@include break-mobile {
+						padding-left: 0;
+						padding-right: 0;
+					}
+				}
+			}
+
+			.register-domain-step__search {
+				padding-top: 0;
+				padding-bottom: 16px;
+			}
+
+			.search-component {
+				border: 1px solid var( --color-border-subtle );
+				border-radius: 4px;
+				overflow: hidden;
+			}
+
+			.search-component.is-open {
+				border: 1px solid #a7aaad;
 				border-radius: 4px;
 				box-sizing: border-box;
-				margin-bottom: 12px;
-				padding: 16px 24px;
+				height: 40px;
+
+				@include break-mobile {
+					height: 48px;
+				}
 			}
 
-			.domain-registration-suggestion__title-wrapper {
+			.search-component.is-open.has-focus {
+				border-color: #646970;
+				background: var( --color-surface );
+				box-shadow: none;
+
+				.search-component__input {
+					background: var( --color-surface );
+				}
+			}
+
+			.domain-suggestion__action {
+				border-radius: 4px;
+				margin: 0;
+			}
+
+			.register-domain-step__search-card {
+				background: var( --color-surface );
+				box-shadow: none;
+				display: flex;
+				padding: 0;
+			}
+
+			.search-component__icon-search {
+				fill: var( --studio-gray-20 );
+				margin: 8px 6px 8px 8px;
+			}
+
+			.domain-search-results__domain-suggestions {
+				margin: 0;
+				@include break-mobile {
+					margin: 0 20px;
+				}
+				@include break-small {
+					margin: 0;
+				}
+			}
+
+			.featured-domain-suggestions {
+				border-top: 1px solid var( --studio-gray-5 );
+				@include break-mobile {
+					border-top: none;
+				}
+
+				.featured-domain-suggestion {
+					border-bottom: 1px solid var( --studio-gray-5 );
+					box-shadow: none;
+					@include break-mobile {
+						border-bottom: none;
+						box-shadow: 0 0 0 1px var( --color-border-subtle );
+					}
+					background: var( --color-surface );
+					border-radius: 4px;
+					box-sizing: border-box;
+					margin-bottom: 12px;
+					padding: 16px 24px;
+				}
+
+				.domain-registration-suggestion__title-wrapper {
+					flex-wrap: nowrap;
+					flex-direction: column-reverse;
+					margin-bottom: initial;
+					.domain-registration-suggestion__badges {
+						margin-left: 0;
+						margin-top: 0;
+						margin-bottom: 10px;
+					}
+				}
+
+				.domain-product-price {
+					align-items: flex-start;
+					margin-top: 12px;
+				}
+			}
+
+			.domain-suggestion:not( .featured-domain-suggestion ) {
+				box-shadow: unset;
+				background: none;
+				border-bottom: 1px solid var( --studio-gray-5 );
+				border-top: 1px solid #fff;
+				margin-bottom: 0;
+			}
+
+			.domain-product-price__free-price {
+				font-weight: 500;
+				color: var( --studio-green-60 );
+				font-size: 0.875rem;
+				letter-spacing: 0.2px;
+				line-height: 20px;
+			}
+
+			.is-borderless {
+				border: 0;
+			}
+
+			.domain-search-results__domain-not-available {
+				.domain-search-results__domain-available-notice {
+					box-shadow: none;
+					border: 0;
+					margin-bottom: 24px;
+					padding: 0;
+				}
+			}
+			.register-domain-step__next-page {
+				background: none;
+				box-shadow: none;
+
+				.register-domain-step__next-page-button {
+					padding: 0.57em 1.17em;
+					border-radius: 4px;
+					@include break-mobile {
+						padding: 0.65em 2.8em;
+					}
+				}
+			}
+			.side-explainer__subtitle-2 {
+				display: none;
+				@include break-small {
+					display: block;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Layout for the following flows
+	 * - domain-upsell
+	 */
+	.domain-upsell.domains {
+		$domain-stepper-component-width: 1040px;
+
+		padding: 60px 20px;
+		.signup-header h1 {
+			display: none;
+		}
+
+		.step-container.domains {
+			max-width: $domain-stepper-component-width;
+			padding: 0;
+			margin: 0 auto;
+			@media ( max-width: break-large ) {
+				margin: 0 40px;
+			}
+
+			.step-container__header .formatted-header__title {
+				@media ( max-width: $break-large ) {
+					font-size: 2.25rem;
+				}
+			}
+
+			.domains__domain-side-content-container {
+				flex-direction: column;
+				margin-top: 40px;
+				margin-bottom: 0;
+
+				@include break-large {
+					width: 30vw;
+					margin-top: 0;
+					flex-direction: column;
+					display: flex;
+				}
+
+				@include break-wide {
+					width: 350px;
+				}
+			}
+
+			// Content only visible below the search results on mobile view port
+			.register-domain-step .domains__domain-side-content-container {
+				display: flex;
+
+				@include break-small {
+					flex-direction: row;
+
+					.domains__domain-side-content {
+						padding-top: 0;
+						border-bottom: none;
+						padding-bottom: 20px;
+						margin: 0 20px;
+					}
+				}
+
+				@include break-large {
+					display: none;
+				}
+			}
+
+			// Side content only visible on desktop viewport
+			.domains__domain-side-content-container .domains__domain-side-content {
+				padding: 40px 0;
+				margin: 0 0 0 80px;
+
+				@media ( max-width: $domain-stepper-component-width ) {
+					margin: 0 20px 0 40px;
+				}
+			}
+
+			.featured-domain-suggestions .featured-domain-suggestion:hover {
+				border: 1px solid #646970;
+			}
+
+			.featured-domain-suggestions .featured-domain-suggestion {
+				border-radius: 4px;
+				margin-bottom: 12px;
+				box-sizing: border-box;
+				border: 1px solid #e2e4e7;
+				background: var( --color-surface );
+				padding: 16px 24px;
+				box-shadow: none;
+			}
+
+			.domains__domain-side-content-container .domains__domain-side-content:first-of-type {
+				padding-top: 0;
+			}
+
+			.featured-domain-suggestions .domain-registration-suggestion__title-wrapper {
 				flex-wrap: nowrap;
 				flex-direction: column-reverse;
 				margin-bottom: initial;
-				.domain-registration-suggestion__badges {
-					margin-left: 0;
-					margin-top: 0;
-					margin-bottom: 10px;
-				}
-			}
 
-			.domain-product-price {
-				align-items: flex-start;
-				margin-top: 12px;
-			}
-		}
-
-		.domain-suggestion:not( .featured-domain-suggestion ) {
-			box-shadow: unset;
-			background: none;
-			border-bottom: 1px solid var( --studio-gray-5 );
-			border-top: 1px solid #fff;
-			margin-bottom: 0;
-		}
-
-		.domain-product-price__free-price {
-			font-weight: 500;
-			color: var( --studio-green-60 );
-			font-size: 0.875rem;
-			letter-spacing: 0.2px;
-			line-height: 20px;
-		}
-
-		.is-borderless {
-			border: 0;
-		}
-
-		.domain-search-results__domain-not-available {
-			.domain-search-results__domain-available-notice {
-				box-shadow: none;
-				border: 0;
-				margin-bottom: 24px;
-				padding: 0;
-			}
-		}
-		.register-domain-step__next-page {
-			background: none;
-			box-shadow: none;
-
-			.register-domain-step__next-page-button {
-				padding: 0.57em 1.17em;
-				border-radius: 4px;
-				@include break-mobile {
-					padding: 0.65em 2.8em;
-				}
-			}
-		}
-		.side-explainer__subtitle-2 {
-			display: none;
-			@include break-small {
-				display: block;
-			}
-		}
-	}
-}
-
-/**
- * Layout for the following flows
- * - domain-upsell
- */
-.domain-upsell.domains {
-	$domain-stepper-component-width: 1040px;
-
-	padding: 60px 20px;
-	.signup-header h1 {
-		display: none;
-	}
-
-	.step-container.domains {
-		max-width: $domain-stepper-component-width;
-		padding: 0;
-		margin: 0 auto;
-		@media ( max-width: break-large ) {
-			margin: 0 40px;
-		}
-
-		.step-container__header .formatted-header__title {
-			@media ( max-width: $break-large ) {
-				font-size: 2.25rem;
-			}
-		}
-
-		.domains__domain-side-content-container {
-			flex-direction: column;
-			margin-top: 40px;
-			margin-bottom: 0;
-
-			@include break-large {
-				width: 30vw;
-				margin-top: 0;
-				flex-direction: column;
-				display: flex;
-			}
-
-			@include break-wide {
-				width: 350px;
-			}
-		}
-
-		// Content only visible below the search results on mobile view port
-		.register-domain-step .domains__domain-side-content-container {
-			display: flex;
-
-			@include break-small {
-				flex-direction: row;
-
-				.domains__domain-side-content {
-					padding-top: 0;
-					border-bottom: none;
-					padding-bottom: 20px;
-					margin: 0 20px;
-				}
-			}
-
-			@include break-large {
-				display: none;
-			}
-		}
-
-		// Side content only visible on desktop viewport
-		.domains__domain-side-content-container .domains__domain-side-content {
-			padding: 40px 0;
-			margin: 0 0 0 80px;
-
-			@media ( max-width: $domain-stepper-component-width ) {
-				margin: 0 20px 0 40px;
-			}
-		}
-
-		.featured-domain-suggestions .featured-domain-suggestion:hover {
-			border: 1px solid #646970;
-		}
-
-		.featured-domain-suggestions .featured-domain-suggestion {
-			border-radius: 4px;
-			margin-bottom: 12px;
-			box-sizing: border-box;
-			border: 1px solid #e2e4e7;
-			background: var( --color-surface );
-			padding: 16px 24px;
-			box-shadow: none;
-		}
-
-		.domains__domain-side-content-container .domains__domain-side-content:first-of-type {
-			padding-top: 0;
-		}
-
-		.featured-domain-suggestions .domain-registration-suggestion__title-wrapper {
-			flex-wrap: nowrap;
-			flex-direction: column-reverse;
-			margin-bottom: initial;
-
-			@media ( min-width: $break-wide ) {
-				flex-direction: row;
-			}
-		}
-
-		.step-container__header {
-			@media ( max-width: $break-large ) {
-				margin: 34px 20px 40px;
-			}
-		}
-
-		.featured-domain-suggestions
-			.domain-registration-suggestion__title-wrapper
-			.domain-registration-suggestion__badges {
-			align-self: baseline;
-			margin-left: 0;
-			margin-bottom: 10px;
-			flex: 1;
-
-			@media ( min-width: $break-wide ) {
-				margin-left: 12px;
-				margin-bottom: 0;
-			}
-		}
-
-		.featured-domain-suggestion .domain-registration-suggestion__title {
-			font-size: 1.5rem;
-			padding-right: 0;
-			margin-bottom: 0;
-			flex: 0 1 auto;
-			align-self: baseline;
-		}
-	}
-
-	.domains__step-content.domains__step-content-domain-step {
-		display: flex;
-
-		.domains__step-section-wrapper {
-			margin: 0 auto;
-			width: 100%;
-
-			.use-my-domain__page-heading {
-				margin: 0;
-			}
-		}
-
-		h1.formatted-header__title.wp-brand-font {
-			font-family: Recoleta, 'Noto Serif', Georgia, 'Times New Roman', Times, serif;
-			font-weight: 400;
-			color: #101517;
-			letter-spacing: 0.2px;
-			font-size: 2.25rem;
-			margin-bottom: 0;
-			margin-top: 35px;
-
-			@media ( min-width: $break-xlarge ) {
-				font-size: 2.75rem;
-			}
-		}
-
-		.use-my-domain .use-my-domain__domain-input .form-text-input {
-			padding: 13px 14px 9px 68px;
-		}
-	}
-
-	.register-domain-step.register-domain-step__signup {
-		flex: 1;
-	}
-
-	.register-domain-step__search.register-domain-step__search-domain-step,
-	.domain-search-results,
-	.domain-search-results__domain-suggestions {
-		@media ( max-width: $break-large ) {
-			margin: 0 20px;
-		}
-	}
-
-	.side-explainer .side-explainer__cta .side-explainer__cta-text {
-		padding-left: 0;
-	}
-}
-
-// Hundred year plan flow
-.hundred-year-plan.domains,
-.hundred-year-domain.domains {
-	.step-container {
-		margin: 0;
-	}
-
-	.step-container__header {
-		margin-bottom: 0;
-
-		@include break-small {
-			margin-bottom: 40px;
-		}
-
-		.formatted-header {
-			margin: 32px 16px;
-
-			@include break-small {
-				margin-top: 60px;
-				margin-bottom: 0;
-			}
-
-			.formatted-header__title {
-				font-size: rem( 32px );
-				@include break-small {
-					font-size: rem( 44px );
-				}
-			}
-
-			.formatted-header__subtitle {
-				margin-top: 0;
-			}
-		}
-	}
-
-	.hundred-year-plan-step-wrapper__step-container {
-		width: 100%;
-	}
-
-	.register-domain-step__search-card {
-		background: none;
-	}
-
-	.search-component {
-		overflow: hidden;
-	}
-
-	.token-field__suggestion.is-selected {
-		background: var( --studio-gray-100 );
-	}
-
-	.domains__content {
-		width: 100%;
-
-		@include break-small {
-			max-width: 780px;
-			margin: 0 auto;
-		}
-
-		.domains__step-content {
-			padding: 0 16px;
-
-			@include break-small {
-				padding: 0 32px;	
-			}
-		}
-
-		// Hide domain prices
-		.domain-product-price {
-			display: none;
-		}
-		// Hide the "Sale" tag
-		.badge.badge--warning {
-			display: none;
-		}
-		// Change button styles
-		.button.is-primary {
-			@include primary-button-black-theme;
-		}
-
-		.domain-search-results__domain-suggestions {
-			margin: 0;
-		}
-
-		.domain-transfer-suggestion {
-			display: none;
-		}
-
-		// Reset styles for the featured domain suggestion
-		.domain-suggestion.card.featured-domain-suggestion {
-			box-shadow: none;
-			border-top: 1px solid transparent;
-			border-bottom: 1px solid var( --studio-gray-5 );
-			border-radius: 0;
-			margin-bottom: 0;
-			background: transparent;
-			border-left: 0 !important;
-			border-right: 0 !important;
-
-			.domain-registration-suggestion__title-wrapper {
-				gap: 4px;
-				@include break-mobile {
+				@media ( min-width: $break-wide ) {
 					flex-direction: row;
-					align-items: center;
-					gap: 12px;
 				}
+			}
+
+			.step-container__header {
+				@media ( max-width: $break-large ) {
+					margin: 34px 20px 40px;
+				}
+			}
+
+			.featured-domain-suggestions
+				.domain-registration-suggestion__title-wrapper
 				.domain-registration-suggestion__badges {
+				align-self: baseline;
+				margin-left: 0;
+				margin-bottom: 10px;
+				flex: 1;
+
+				@media ( min-width: $break-wide ) {
+					margin-left: 12px;
 					margin-bottom: 0;
 				}
 			}
 
-			.domain-registration-suggestion__domain-title {
-				font-size: 1rem;
-				.domain-registration-suggestion__domain-title-tld {
-					font-weight: 500;
+			.featured-domain-suggestion .domain-registration-suggestion__title {
+				font-size: 1.5rem;
+				padding-right: 0;
+				margin-bottom: 0;
+				flex: 0 1 auto;
+				align-self: baseline;
+			}
+		}
+
+		.domains__step-content.domains__step-content-domain-step {
+			display: flex;
+
+			.domains__step-section-wrapper {
+				margin: 0 auto;
+				width: 100%;
+
+				.use-my-domain__page-heading {
+					margin: 0;
+				}
+			}
+
+			h1.formatted-header__title.wp-brand-font {
+				font-family: Recoleta, 'Noto Serif', Georgia, 'Times New Roman', Times, serif;
+				font-weight: 400;
+				color: #101517;
+				letter-spacing: 0.2px;
+				font-size: 2.25rem;
+				margin-bottom: 0;
+				margin-top: 35px;
+
+				@media ( min-width: $break-xlarge ) {
+					font-size: 2.75rem;
+				}
+			}
+
+			.use-my-domain .use-my-domain__domain-input .form-text-input {
+				padding: 13px 14px 9px 68px;
+			}
+		}
+
+		.register-domain-step.register-domain-step__signup {
+			flex: 1;
+		}
+
+		.register-domain-step__search.register-domain-step__search-domain-step,
+		.domain-search-results,
+		.domain-search-results__domain-suggestions {
+			@media ( max-width: $break-large ) {
+				margin: 0 20px;
+			}
+		}
+
+		.side-explainer .side-explainer__cta .side-explainer__cta-text {
+			padding-left: 0;
+		}
+	}
+
+	// Hundred year plan flow
+	.hundred-year-plan.domains,
+	.hundred-year-domain.domains {
+		.step-container {
+			margin: 0;
+		}
+
+		.step-container__header {
+			margin-bottom: 0;
+
+			@include break-small {
+				margin-bottom: 40px;
+			}
+
+			.formatted-header {
+				margin: 32px 16px;
+
+				@include break-small {
+					margin-top: 60px;
+					margin-bottom: 0;
+				}
+
+				.formatted-header__title {
+					font-size: rem( 32px );
+					@include break-small {
+						font-size: rem( 44px );
+					}
+				}
+
+				.formatted-header__subtitle {
+					margin-top: 0;
 				}
 			}
 		}
 
-		.featured-domain-suggestion--is-placeholder {
-			background: transparent !important;
-			margin-bottom: 0 !important;
-			box-shadow: none;
-			min-height: unset;
-			border-bottom: 1px solid var( --studio-gray-5 ) !important;
-			border-radius: 0 !important;
-			padding: 20px !important;
-			align-items: unset !important;
+		.hundred-year-plan-step-wrapper__step-container {
+			width: 100%;
+		}
 
-			.domain-suggestion__content {
+		.register-domain-step__search-card {
+			background: none;
+		}
+
+		.search-component {
+			overflow: hidden;
+		}
+
+		.token-field__suggestion.is-selected {
+			background: var( --studio-gray-100 );
+		}
+
+		.domains__content {
+			width: 100%;
+
+			@include break-small {
+				max-width: 780px;
+				margin: 0 auto;
+			}
+
+			.domains__step-content {
+				padding: 0 16px;
+
+				@include break-small {
+					padding: 0 32px;
+				}
+			}
+
+			// Hide domain prices
+			.domain-product-price {
+				display: none;
+			}
+			// Hide the "Sale" tag
+			.badge.badge--warning {
+				display: none;
+			}
+			// Change button styles
+			.button.is-primary {
+				@include primary-button-black-theme;
+			}
+
+			.domain-search-results__domain-suggestions {
+				margin: 0;
+			}
+
+			.domain-transfer-suggestion {
 				display: none;
 			}
 
-			.domain-suggestion__action-container {
+			// Reset styles for the featured domain suggestion
+			.domain-suggestion.card.featured-domain-suggestion {
+				box-shadow: none;
+				border-top: 1px solid transparent;
+				border-bottom: 1px solid var( --studio-gray-5 );
+				border-radius: 0;
 				margin-bottom: 0;
+				background: transparent;
+				border-left: 0 !important;
+				border-right: 0 !important;
+
+				.domain-registration-suggestion__title-wrapper {
+					gap: 4px;
+					@include break-mobile {
+						flex-direction: row;
+						align-items: center;
+						gap: 12px;
+					}
+					.domain-registration-suggestion__badges {
+						margin-bottom: 0;
+					}
+				}
+
+				.domain-registration-suggestion__domain-title {
+					font-size: 1rem;
+					.domain-registration-suggestion__domain-title-tld {
+						font-weight: 500;
+					}
+				}
+			}
+
+			.featured-domain-suggestion--is-placeholder {
+				background: transparent !important;
+				margin-bottom: 0 !important;
+				box-shadow: none;
+				min-height: unset;
+				border-bottom: 1px solid var( --studio-gray-5 ) !important;
+				border-radius: 0 !important;
+				padding: 20px !important;
+				align-items: unset !important;
+
+				.domain-suggestion__content {
+					display: none;
+				}
+
+				.domain-suggestion__action-container {
+					margin-bottom: 0;
+				}
+			}
+
+			.domain-registration-suggestion__title-info {
+				width: auto;
+			}
+
+			.domain-suggestion__content {
+				min-height: unset;
+				gap: 0;
+			}
+
+			.domain-suggestion__action-container {
+				margin-top: 16px;
+
+				@include break-small {
+					margin-top: 0;
+				}
+			}
+
+			.domain-search-results__domain-available-notice {
+				background: transparent;
+				display: flex;
+				margin-left: 0;
+
+				.domain-search-results__domain-available-notice-icon {
+					margin-right: 4px;
+				}
+			}
+
+			// Hide the domain explanation image
+			.domains__domain-side-content-container {
+				display: none;
 			}
 		}
+	}
 
-		.domain-registration-suggestion__title-info {
-			width: auto;
-		}
-
-		.domain-suggestion__content {
-			min-height: unset;
-			gap: 0;
-		}
-
-		.domain-suggestion__action-container {
-			margin-top: 16px;
-
-			@include break-small {
+	.hundred-year-domain.domains {
+		.domains__content {
+			.domain-product-price {
+				display: block;
 				margin-top: 0;
-			}
-		}
 
-		.domain-search-results__domain-available-notice {
-			background: transparent;
-			display: flex;
-			margin-left: 0;
-
-			.domain-search-results__domain-available-notice-icon {
-				margin-right: 4px;
-			}
-		}
-
-		// Hide the domain explanation image
-		.domains__domain-side-content-container {
-			display: none;
-		}
-	}
-}
-
-.hundred-year-domain.domains {
-	.domains__content {
-		.domain-product-price {
-			display: block;
-			margin-top: 0;
-
-			@include break-small {
-				align-items: flex-end;
-				align-self: center;
-				margin-right: 16px;
+				@include break-small {
+					align-items: flex-end;
+					align-self: center;
+					margin-right: 16px;
+				}
 			}
 		}
 	}
-}
 
-.copy-site.domains {
-	.step-wrapper.is-wide-layout {
-		max-width: 1040px;
+	.copy-site.domains {
+		.step-wrapper.is-wide-layout {
+			max-width: 1040px;
+		}
 	}
 }

--- a/client/lib/domains/use-domain-search-v2.ts
+++ b/client/lib/domains/use-domain-search-v2.ts
@@ -1,0 +1,28 @@
+import config from '@automattic/calypso-config';
+import { useEffect, useState } from 'react';
+
+/**
+ * This hook is used to determine if the domain search redesign is enabled for a given flow.
+ * It should NOT be used within components, only at top level pages.
+ */
+export const useDomainSearchV2 = ( flowName: string ) => {
+	const isDomainSearchV2Enabled = config.isEnabled( 'domains/ui-redesign' );
+	const [ isLoading, setIsLoading ] = useState( true );
+
+	/**
+	 * Introduce an artificial delay to simulate the loading state of the experiment.
+	 */
+	useEffect( () => {
+		const interval = setInterval( () => {
+			setIsLoading( false );
+		}, 750 );
+
+		return () => clearInterval( interval );
+	}, [] );
+
+	if ( flowName === 'onboarding' && isDomainSearchV2Enabled ) {
+		return [ isLoading, isDomainSearchV2Enabled ];
+	}
+
+	return [ false, isDomainSearchV2Enabled ];
+};

--- a/client/my-sites/domains/domain-search/index.tsx
+++ b/client/my-sites/domains/domain-search/index.tsx
@@ -22,6 +22,7 @@ import {
 	domainRegistration,
 	ObjectWithProducts,
 } from 'calypso/lib/cart-values/cart-items';
+import { useDomainSearchV2 } from 'calypso/lib/domains/use-domain-search-v2';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import DomainAndPlanPackageNavigation from 'calypso/my-sites/domains/components/domain-and-plan-package/navigation';
 import NewDomainsRedirectionNoticeUpsell from 'calypso/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell';
@@ -484,6 +485,23 @@ class DomainSearch extends Component< DomainSearchProps > {
 	}
 }
 
+const StyleWrappedDomainSearch = ( props: DomainSearchProps ) => {
+	const [ isLoading, shouldUseDomainSearchV2 ] = useDomainSearchV2( 'domains/add' );
+
+	if ( isLoading ) {
+		return null;
+	}
+
+	return (
+		<>
+			<DomainSearch { ...props } />
+			{ ! shouldUseDomainSearchV2 && (
+				<BodySectionCssClass bodyClass={ [ 'domain-search-legacy--my-sites' ] } />
+			) }
+		</>
+	);
+};
+
 export default connect(
 	( state: IAppState ) => {
 		const site = getSelectedSite( state );
@@ -528,4 +546,4 @@ export default connect(
 		setDesignType,
 		fetchUsernameSuggestion,
 	}
-)( withCartKey( withShoppingCart( localize( DomainSearch ) ) ) );
+)( withCartKey( withShoppingCart( localize( StyleWrappedDomainSearch ) ) ) );

--- a/client/my-sites/domains/domain-search/style.scss
+++ b/client/my-sites/domains/domain-search/style.scss
@@ -1,435 +1,441 @@
-@import "@automattic/onboarding/styles/mixins";
+@import '@automattic/onboarding/styles/mixins';
 // domain search
 
-.site-domains-add-page {
-	.already-own-a-domain {
-		display: none;
-	}
-
-	$light-white: #f3f4f5;
-
-	.register-domain-step__example-prompt {
-		margin: 0;
-	}
-
-	.featured-domain-suggestions {
-		@include break-mobile {
-			border-top: none;
+.domain-search-legacy--my-sites {
+	.site-domains-add-page {
+		.already-own-a-domain {
+			display: none;
 		}
-	}
 
-	.domains__step-content {
-		display: flex;
+		$light-white: #f3f4f5;
 
-		.search-component.is-open {
-			border: 1px solid #a7aaad;
-			border-radius: 4px;
-			box-sizing: border-box;
+		.register-domain-step__example-prompt {
+			margin: 0;
+		}
+
+		.featured-domain-suggestions {
+			@include break-mobile {
+				border-top: none;
+			}
+		}
+
+		.domains__step-content {
+			display: flex;
+
+			.search-component.is-open {
+				border: 1px solid #a7aaad;
+				border-radius: 4px;
+				box-sizing: border-box;
+				height: 40px;
+				overflow: hidden;
+
+				@include break-mobile {
+					height: 48px;
+				}
+			}
+
+			.search-component.is-open.has-focus {
+				border-color: #646970;
+				background: var( --color-surface );
+				box-shadow: none;
+
+				.search-component__input {
+					background: var( --color-surface );
+				}
+			}
+
+			.domains__domain-side-content-container {
+				flex-direction: column;
+				margin-top: 40px;
+				display: none;
+
+				@include break-large {
+					margin-top: 0;
+					flex-direction: column;
+					display: flex;
+				}
+
+				&.is-sticky {
+					position: sticky;
+					top: 0;
+					align-self: flex-start;
+				}
+			}
+
+			.register-domain-step.register-domain-step__signup {
+				max-width: 100%;
+			}
+
+			.register-domain-step .domains__domain-side-content-container {
+				display: flex;
+				margin-bottom: 80px;
+
+				@include break-medium {
+					flex-direction: row;
+					justify-content: center;
+
+					.domains__domain-side-content {
+						padding-top: 0;
+						border-bottom: none;
+					}
+				}
+
+				@include break-large {
+					display: none;
+				}
+			}
+
+			.domains__free-domain .side-explainer__subtitle-2 {
+				display: none;
+
+				@include break-small {
+					display: block;
+				}
+			}
+
+			.domains__domain-side-content {
+				border-bottom: 1px solid;
+				border-bottom-color: var( --studio-gray-5 );
+				padding: 20px 0;
+				margin: 0;
+
+				@include break-large {
+					max-width: 290px;
+					margin: 0 0 0 40px;
+					padding: 40px 0;
+				}
+
+				@include break-huge {
+					margin: 0 0 0 60px;
+				}
+
+				&.fade-out {
+					opacity: 0;
+					visibility: hidden;
+					transition: all 0.4s ease-out;
+				}
+			}
+
+			.domains__domain-side-content:first-of-type {
+				padding-top: 0;
+			}
+
+			.domains__domain-side-content:last-of-type {
+				border-bottom: none;
+			}
+
+			.domains__domain-cart-foldable-card .domains__domain-side-content {
+				padding: 0;
+			}
+
+			.register-domain-step {
+				flex: 1;
+			}
+
+			.register-domain-step__search-card {
+				background: transparent;
+				box-shadow: none;
+				margin: 0;
+			}
+			.search-component__input {
+				border-radius: 4px;
+
+				&::placeholder {
+					color: var( --color-neutral-50 );
+				}
+			}
+			.search-component.is-open .search-component__input-fade.ltr::before {
+				display: none;
+			}
+			.search-component__open-icon {
+				transform: scaleX( -1 );
+			}
+
+			.search-component__icon-search {
+				fill: #a7aaad;
+				margin: 8px 6px 8px 8px;
+			}
+
+			.search-component .search-component__icon-navigation {
+				padding: 0 7px;
+			}
+
+			.use-my-domain__page-heading {
+				text-align: center;
+			}
+		}
+
+		.search-filters__dropdown-filters {
 			height: 40px;
-			overflow: hidden;
 
 			@include break-mobile {
 				height: 48px;
 			}
-		}
 
-		.search-component.is-open.has-focus {
-			border-color: #646970;
-			background: var(--color-surface);
-			box-shadow: none;
-
-			.search-component__input {
-				background: var(--color-surface);
-			}
-		}
-
-		.domains__domain-side-content-container {
-			flex-direction: column;
-			margin-top: 40px;
-			display: none;
-
-			@include break-large {
-				margin-top: 0;
-				flex-direction: column;
-				display: flex;
-			}
-
-			&.is-sticky {
-				position: sticky;
-				top: 0;
-				align-self: flex-start;
-			}
-		}
-
-		.register-domain-step.register-domain-step__signup {
-			max-width: 100%;
-		}
-
-		.register-domain-step .domains__domain-side-content-container {
-			display: flex;
-			margin-bottom: 80px;
-
-			@include break-medium {
-				flex-direction: row;
-				justify-content: center;
-
-				.domains__domain-side-content {
-					padding-top: 0;
-					border-bottom: none;
-				}
-			}
-
-			@include break-large {
-				display: none;
-			}
-		}
-
-		.domains__free-domain .side-explainer__subtitle-2 {
-			display: none;
-
-			@include break-small {
-				display: block;
-			}
-		}
-
-		.domains__domain-side-content {
-			border-bottom: 1px solid;
-			border-bottom-color: var(--studio-gray-5);
-			padding: 20px 0;
-			margin: 0;
-
-			@include break-large {
-				max-width: 290px;
-				margin: 0 0 0 40px;
-				padding: 40px 0;
-			}
-
-			@include break-huge {
-				margin: 0 0 0 60px;
-			}
-
-			&.fade-out {
-				opacity: 0;
-				visibility: hidden;
-				transition: all 0.4s ease-out;
-			}
-		}
-
-		.domains__domain-side-content:first-of-type {
-			padding-top: 0;
-		}
-
-		.domains__domain-side-content:last-of-type {
-			border-bottom: none;
-		}
-
-		.domains__domain-cart-foldable-card .domains__domain-side-content {
-			padding: 0;
-		}
-
-		.register-domain-step {
-			flex: 1;
-		}
-
-		.register-domain-step__search-card {
-			background: transparent;
-			box-shadow: none;
-			margin: 0;
-		}
-		.search-component__input {
-			border-radius: 4px;
-
-			&::placeholder {
-				color: var(--color-neutral-50);
-			}
-		}
-		.search-component.is-open .search-component__input-fade.ltr::before {
-			display: none;
-		}
-		.search-component__open-icon {
-			transform: scaleX(-1);
-		}
-
-		.search-component__icon-search {
-			fill: #a7aaad;
-			margin: 8px 6px 8px 8px;
-		}
-
-		.search-component .search-component__icon-navigation {
-			padding: 0 7px;
-		}
-
-		.use-my-domain__page-heading {
-			text-align: center;
-		}
-	}
-
-	.search-filters__dropdown-filters {
-		height: 40px;
-
-		@include break-mobile {
-			height: 48px;
-		}
-
-		&.search-filters__dropdown-filters--is-open {
-			box-shadow: none;
-		}
-
-		.button {
-			&:hover {
+			&.search-filters__dropdown-filters--is-open {
 				box-shadow: none;
 			}
 
-			.search-filters__dropdown-filters-button-text {
-				color: var(--color-neutral-60);
+			.button {
+				&:hover {
+					box-shadow: none;
+				}
+
+				.search-filters__dropdown-filters-button-text {
+					color: var( --color-neutral-60 );
+				}
 			}
 		}
-	}
-	
-	.domains__domain-cart-foldable-card {
-		position: fixed;
-		width: 100%;
-		bottom: 0;
-		left: 0;
-		z-index: 99;
-		padding-bottom: 0 !important;
-		box-shadow: 0 -3px 10px 0 rgba(0, 0, 0, 0.12);
 
-		@include break-medium {
-			width: calc(100% - var(--sidebar-width-min));
-			left: var(--sidebar-width-min);
-		}
-
-		.foldable-card__main {
-			max-width: 100%;
-			display: block;
+		.domains__domain-cart-foldable-card {
+			position: fixed;
 			width: 100%;
-			margin: 0;
+			bottom: 0;
+			left: 0;
+			z-index: 99;
+			padding-bottom: 0 !important;
+			box-shadow: 0 -3px 10px 0 rgba( 0, 0, 0, 0.12 );
 
-			.foldable-card__action {
-				right: auto;
-				left: 0;
+			@include break-medium {
+				width: calc( 100% - var( --sidebar-width-min ) );
+				left: var( --sidebar-width-min );
 			}
+
+			.foldable-card__main {
+				max-width: 100%;
+				display: block;
+				width: 100%;
+				margin: 0;
+
+				.foldable-card__action {
+					right: auto;
+					left: 0;
+				}
+				.domains__domain-cart-title {
+					margin-left: 24px;
+					display: flex;
+					align-items: center;
+					justify-content: space-between;
+				}
+
+				.domains__domain-cart-total {
+					display: flex;
+					gap: 8px;
+					align-items: center;
+
+					.domains__domain-cart-total-items {
+						font-family: 'SF Pro Display', $sans;
+						font-size: $font-body-extra-small;
+						font-weight: 400;
+						line-height: 20px;
+						letter-spacing: 0;
+						text-align: left;
+					}
+					.domains__domain-cart-total-price {
+						font-family: 'SF Pro Display', $sans;
+						font-size: $font-body;
+						font-weight: 500;
+						line-height: 24px;
+						letter-spacing: -0.32px;
+						text-align: left;
+					}
+				}
+			}
+			.foldable-card__content {
+				max-height: 70vh;
+				border-top: 0;
+				padding: 0 16px;
+				overflow-x: auto;
+				.domains__domain-cart {
+					border-top: 1px solid var( --color-neutral-5 );
+				}
+				.domains__domain-cart-rows {
+					padding-top: 6px;
+				}
+			}
+		}
+
+		.domains__domain-cart {
+			border-bottom: 0 !important;
+
 			.domains__domain-cart-title {
-				margin-left: 24px;
-				display: flex;
-				align-items: center;
-				justify-content: space-between;
+				font-size: $font-body;
+				color: var( --studio-gray-90 );
+				margin-bottom: 10px;
+			}
+
+			.domains__domain-cart-rows {
+				.domains__domain-cart-row > div {
+					display: flex;
+					justify-content: space-between;
+					padding-top: 6px;
+					column-gap: 10px;
+				}
+				.domains__domain-cart-row > div:nth-child( 2 ) {
+					display: block;
+					padding-bottom: 6px;
+					padding-top: 0;
+				}
+
+				.savings-message {
+					color: var( --studio-green-60 );
+					display: flex;
+					align-items: center;
+					font-size: 0.75rem;
+					margin-top: 10px;
+				}
+
+				.domains__domain-cart-domain {
+					color: var( --studio-gray-50 );
+					font-size: $font-body-small;
+					overflow: auto;
+					span {
+						overflow-wrap: anywhere;
+					}
+				}
+
+				.domains__domain-cart-remove {
+					color: var( --studio-gray-100 );
+					font-size: $font-body-extra-small;
+					min-width: 50px;
+					margin-right: 10px;
+					text-align: left;
+					text-decoration: underline;
+				}
+
+				.domain-product-price__price {
+					display: flex;
+					align-items: center;
+					font-size: 0.875rem;
+
+					del {
+						font-size: 0.75rem;
+						margin-right: 10px;
+					}
+				}
+
+				.domains__price-free {
+					color: var( --studio-green-60 );
+				}
 			}
 
 			.domains__domain-cart-total {
-				display: flex;
-				gap: 8px;
-				align-items: center;
-
-				.domains__domain-cart-total-items {
-					font-family: "SF Pro Display", $sans;
-					font-size: $font-body-extra-small;
-					font-weight: 400;
-					line-height: 20px;
-					letter-spacing: 0;
-					text-align: left;
-				}
-				.domains__domain-cart-total-price {
-					font-family: "SF Pro Display", $sans;
-					font-size: $font-body;
-					font-weight: 500;
-					line-height: 24px;
-					letter-spacing: -0.32px;
-					text-align: left;
-
-				}
-			}
-		}
-		.foldable-card__content {
-			max-height: 70vh;
-			border-top: 0;
-			padding: 0 16px;
-			overflow-x: auto;
-			.domains__domain-cart {
-				border-top: 1px solid var(--color-neutral-5);
-			}
-			.domains__domain-cart-rows {
-				padding-top: 6px;
-			}
-		}
-	}
-
-	.domains__domain-cart {
-		border-bottom: 0 !important;
-
-		.domains__domain-cart-title {
-			font-size: $font-body;
-			color: var(--studio-gray-90);
-			margin-bottom: 10px;
-		}
-
-		.domains__domain-cart-rows {
-			.domains__domain-cart-row > div {
+				border-top: 1px solid;
+				border-top-color: var( --studio-gray-5 );
+				padding-top: 28px;
+				margin-bottom: 28px;
+				margin-top: 12px;
+				color: var( --studio-gray-60 );
+				font-size: $font-body-small;
 				display: flex;
 				justify-content: space-between;
-				padding-top: 6px;
-				column-gap: 10px;
-			}
-			.domains__domain-cart-row > div:nth-child(2) {
-				display: block;
-				padding-bottom: 6px;
-				padding-top: 0;
 			}
 
-			.savings-message {
-				color: var(--studio-green-60);
-				display: flex;
-				align-items: center;
-				font-size: 0.75rem;
-				margin-top: 10px;
-			}
+			.domains__domain-cart-continue {
+				width: 100%;
+				height: 40px;
+				padding-left: 24px;
+				padding-right: 24px;
+				border-radius: 4px;
+				background-color: var( --studio-wordpress-blue-50 );
+				border-color: var( --studio-wordpress-blue-50 );
 
-			.domains__domain-cart-domain {
-				color: var(--studio-gray-50);
-				font-size: $font-body-small;
-				overflow: auto;
-				span {
-					overflow-wrap: anywhere;
+				&:hover {
+					background-color: var( --studio-wordpress-blue-60 );
+					border-color: var( --studio-wordpress-blue-60 );
+				}
+
+				&.is-busy {
+					background-image: linear-gradient(
+						-45deg,
+						var( --studio-wordpress-blue-50 ) 28%,
+						var( --studio-wordpress-blue-60 ) 28%,
+						var( --studio-wordpress-blue-60 ) 72%,
+						var( --studio-wordpress-blue-50 ) 72%
+					);
 				}
 			}
 
-			.domains__domain-cart-remove {
-				color: var(--studio-gray-100);
-				font-size: $font-body-extra-small;
-				min-width: 50px;
-				margin-right: 10px;
-				text-align: left;
+			.domains__domain-cart-choose-later {
+				width: 100%;
+				height: 40px;
+				color: var( --studio-gray-100 );
 				text-decoration: underline;
+				text-align: left;
+				margin-top: 5px;
 			}
+		}
+	}
 
-			.domain-product-price__price {
-				display: flex;
-				align-items: center;
-				font-size: 0.875rem;
-
-				del {
-					font-size: 0.75rem;
-					margin-right: 10px;
+	.domain-search__content {
+		overflow: visible;
+		padding: 0 0 20px;
+		position: static;
+		.domain-search__go-back {
+			margin-bottom: 18px;
+			&.is-link {
+				@include onboarding-medium-text;
+				text-decoration: none;
+				color: var( --studio-gray-50 );
+			}
+		}
+		.domain-search-results {
+			.domain-suggestion__content {
+				gap: 8px;
+			}
+			.featured-domain-suggestion {
+				flex-direction: column-reverse;
+				.domain-registration-suggestion__match-reasons {
+					order: 1;
+					flex-grow: 1;
+				}
+				.domain-suggestion__price-container {
+					order: 2;
+				}
+				.domain-suggestion__action-container {
+					order: 3;
+				}
+				.domain-product-price {
+					align-self: stretch;
+					align-items: flex-end;
 				}
 			}
-
-			.domains__price-free {
-				color: var(--studio-green-60);
-			}
-
-		}
-
-		.domains__domain-cart-total {
-			border-top: 1px solid;
-			border-top-color: var(--studio-gray-5);
-			padding-top: 28px;
-			margin-bottom: 28px;
-			margin-top: 12px;
-			color: var(--studio-gray-60);
-			font-size: $font-body-small;
-			display: flex;
-			justify-content: space-between;
-		}
-
-		.domains__domain-cart-continue {
-			width: 100%;
-			height: 40px;
-			padding-left: 24px;
-			padding-right: 24px;
-			border-radius: 4px;
-			background-color: var(--studio-wordpress-blue-50);
-			border-color: var(--studio-wordpress-blue-50);
-
-			&:hover {
-				background-color: var(--studio-wordpress-blue-60);
-				border-color: var(--studio-wordpress-blue-60);
-			}
-
-			&.is-busy{
-				background-image: linear-gradient(-45deg, var(--studio-wordpress-blue-50) 28%, var(--studio-wordpress-blue-60) 28%, var(--studio-wordpress-blue-60) 72%, var(--studio-wordpress-blue-50) 72%);
-			}
-		}
-
-		.domains__domain-cart-choose-later {
-			width: 100%;
-			height: 40px;
-			color: var(--studio-gray-100);
-			text-decoration: underline;
-			text-align: left;
-			margin-top: 5px;
-		}
-	}
-}
-
-.domain-search__content {
-	overflow: visible;
-	padding: 0 0 20px;
-	position: static;
-	.domain-search__go-back {
-		margin-bottom: 18px;
-		&.is-link {
-			@include onboarding-medium-text;
-			text-decoration: none;
-			color: var(--studio-gray-50);
-		}
-	}
-	.domain-search-results {
-		.domain-suggestion__content {
-			gap: 8px;
-		}
-		.featured-domain-suggestion {
-			flex-direction: column-reverse;
-			.domain-registration-suggestion__match-reasons {
-				order: 1;
-				flex-grow: 1;
-			}
-			.domain-suggestion__price-container {
-				order: 2;
-			}
-			.domain-suggestion__action-container {
-				order: 3;
+			.domain-suggestion:not( .featured-domain-suggestion ) {
+				flex-direction: column;
 			}
 			.domain-product-price {
-				align-self: stretch;
-				align-items: flex-end;
+				flex-grow: 1;
 			}
-		}
-		.domain-suggestion:not(.featured-domain-suggestion) {
-			flex-direction: column;
-		}
-		.domain-product-price {
-			flex-grow: 1;
-		}
-		.domain-registration-suggestion__badges {
-			margin-left: 0;
-			margin-bottom: 4px;
+			.domain-registration-suggestion__badges {
+				margin-left: 0;
+				margin-bottom: 4px;
 
-			.badge {
-				border-radius: 4px;
-				font-size: 0.75rem;
-				font-weight: 500;
-				white-space: nowrap;
-			}
+				.badge {
+					border-radius: 4px;
+					font-size: 0.75rem;
+					font-weight: 500;
+					white-space: nowrap;
+				}
 
-			@include break-wide {
-				flex: 1;
+				@include break-wide {
+					flex: 1;
+				}
 			}
 		}
 	}
-}
 
-.domain-search-page-wrapper h2 {
-	@include heading;
-	margin: 0 0 10px;
-}
+	.domain-search-page-wrapper h2 {
+		@include heading;
+		margin: 0 0 10px;
+	}
 
-.domain-search-page-wrapper h3 {
-	color: var(--color-neutral-70);
-	font-size: $font-body;
-	word-wrap: break-word;
+	.domain-search-page-wrapper h3 {
+		color: var( --color-neutral-70 );
+		font-size: $font-body;
+		word-wrap: break-word;
 
-	@include breakpoint-deprecated( ">660px" ) {
-		font-size: 17px;
+		@include breakpoint-deprecated( '>660px' ) {
+			font-size: 17px;
+		}
 	}
 }

--- a/client/my-sites/domains/style.scss
+++ b/client/my-sites/domains/style.scss
@@ -1,51 +1,53 @@
-@import "@wordpress/base-styles/breakpoints";
-@import "@wordpress/base-styles/mixins";
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
-.domains__header {
-	display: flex;
-	justify-content: space-between;
-	align-items: flex-start;
-
-	@include breakpoint-deprecated( "<660px" ) {
-		align-items: center;
-	}
-}
-
-body.is-section-domains.is-domain-plan-package-flow {
-	background: var(--color-body-background);
-
+.domain-search-legacy--my-sites {
 	.domains__header {
-		display: block;
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
 
-		h1 {
-			font-family: $brand-serif;
-			font-size: $font-headline-small;
-		}
-
-		p {
-			font-size: $font-body;
-			color: var(--color-text-subtle);
-			text-align: center;
-			padding: 0 10px;
-			max-width: $break-small;
-			margin-inline: auto;
-		}
-
-		.domains__header-decide-later {
-			color: var(--studio-gray-90);
-			font-weight: 500;
-			padding-left: 5px;
-			text-decoration: underline;
+		@include breakpoint-deprecated( '<660px' ) {
+			align-items: center;
 		}
 	}
 
-	@include break-small {
+	&.is-section-domains.is-domain-plan-package-flow {
+		background: var( --color-body-background );
+
 		.domains__header {
+			display: block;
+
 			h1 {
-				font-size: $font-headline-medium;
+				font-family: $brand-serif;
+				font-size: $font-headline-small;
 			}
+
 			p {
-				padding: 0 80px;
+				font-size: $font-body;
+				color: var( --color-text-subtle );
+				text-align: center;
+				padding: 0 10px;
+				max-width: $break-small;
+				margin-inline: auto;
+			}
+
+			.domains__header-decide-later {
+				color: var( --studio-gray-90 );
+				font-weight: 500;
+				padding-left: 5px;
+				text-decoration: underline;
+			}
+		}
+
+		@include break-small {
+			.domains__header {
+				h1 {
+					font-size: $font-headline-medium;
+				}
+				p {
+					padding: 0 80px;
+				}
 			}
 		}
 	}

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -26,6 +26,8 @@ import { Children, Component, isValidElement } from 'react';
 import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import QueryProductsList from 'calypso/components/data/query-products-list';
+import DomainCartV2 from 'calypso/components/domain-search-v2/domain-cart';
+import RegisterDomainStepV2 from 'calypso/components/domain-search-v2/register-domain-step';
 import { useMyDomainInputMode as inputMode } from 'calypso/components/domains/connect-domain-step/constants';
 import RegisterDomainStep from 'calypso/components/domains/register-domain-step';
 import { recordUseYourDomainButtonClick } from 'calypso/components/domains/register-domain-step/analytics';
@@ -1119,8 +1121,12 @@ class RenderDomainsStepComponent extends Component {
 		const includeWordPressDotCom = this.props.includeWordPressDotCom ?? ! this.props.isDomainOnly;
 		const promoTlds = this.props?.queryObject?.tld?.split( ',' ) ?? null;
 
+		const RegisterDomainStepComponent = this.props.shouldUseDomainSearchV2
+			? RegisterDomainStepV2
+			: RegisterDomainStep;
+
 		return (
-			<RegisterDomainStep
+			<RegisterDomainStepComponent
 				key="domainForm"
 				path={ this.props.path }
 				domainAndPlanUpsellFlow={ this.props.domainAndPlanUpsellFlow }
@@ -1325,10 +1331,15 @@ class RenderDomainsStepComponent extends Component {
 		}
 
 		if ( ! this.props.stepSectionName || this.props.isDomainOnly ) {
-			content = this.domainForm();
+			content = (
+				<>
+					{ this.domainForm() }
+					{ this.props.shouldUseDomainSearchV2 && <DomainCartV2 /> }
+				</>
+			);
 		}
 
-		if ( ! this.props.stepSectionName ) {
+		if ( ! this.props.stepSectionName && ! this.props.shouldUseDomainSearchV2 ) {
 			sideContent = this.getSideContent();
 		}
 
@@ -1627,7 +1638,10 @@ const StyleWrappedDomainsStepComponent = ( props ) => {
 
 	return (
 		<>
-			<RenderDomainsStepComponent { ...props } />
+			<RenderDomainsStepComponent
+				{ ...props }
+				shouldUseDomainSearchV2={ shouldUseDomainSearchV2 }
+			/>
 			{ ! shouldUseDomainSearchV2 && (
 				<BodySectionCssClass bodyClass={ [ 'domain-search-legacy--unified' ] } />
 			) }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -39,6 +39,7 @@ import {
 	LOCAL_STORAGE_KEY_FOR_PG_ID_TS as PG_TS,
 	LOCAL_STORAGE_KEY_FOR_PG_VALIDITY as PG_ID_VALIDITY,
 } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground';
+import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import {
 	domainRegistration,
@@ -57,6 +58,7 @@ import {
 	getFixedDomainSearch,
 } from 'calypso/lib/domains';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
+import { useDomainSearchV2 } from 'calypso/lib/domains/use-domain-search-v2';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
@@ -1615,8 +1617,26 @@ class RenderDomainsStepComponent extends Component {
 	}
 }
 
+const StyleWrappedDomainsStepComponent = ( props ) => {
+	const [ isLoading, shouldUseDomainSearchV2 ] = useDomainSearchV2( props.flowName );
+
+	if ( isLoading ) {
+		// TODO: Add a loading state to indicate that the experiment is loading.
+		return null;
+	}
+
+	return (
+		<>
+			<RenderDomainsStepComponent { ...props } />
+			{ ! shouldUseDomainSearchV2 && (
+				<BodySectionCssClass bodyClass={ [ 'domain-search-legacy--unified' ] } />
+			) }
+		</>
+	);
+};
+
 export const RenderDomainsStep = withViewportMatch( { isDesktop: '>= large' } )(
-	RenderDomainsStepComponent
+	StyleWrappedDomainsStepComponent
 );
 
 export const submitDomainStepSelection = ( suggestion, section ) => {

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -1,524 +1,530 @@
-@import "@wordpress/base-styles/breakpoints";
-@import "@wordpress/base-styles/mixins";
-@import "@wordpress/base-styles/variables";
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
 
-.domains__step-section-wrapper {
-	margin: 0 auto;
-	width: 100%;
-}
-
-.signup__step.is-domains {
-	.action-buttons.step-wrapper__navigation {
-		@media (max-width: $break-mobile) {
-			display: none;
-		}
-	}
-
-	.async-load__placeholder {
-		margin: 12px;
-	}
-}
-
-body.is-section-stepper .domains__step-content,
-.is-section-signup .domains__step-content {
-	margin-bottom: 50px;
-
-	& .use-my-domain__page-heading {
-		padding-left: 24px;
-		padding-right: 24px;
-		text-align: center;
-	}
-
-	& .use-my-domain,
-	& .connect-domain-step,
-	& .domain-transfer-or-connect__content {
-		background: transparent;
-		box-shadow: none;
-
-		@include break-mobile {
-			padding-left: 0;
-			padding-right: 0;
-		}
-	}
-
-	&.domains__step-content-domain-step {
-		margin-bottom: 20px;
-		.spinner {
-			width: 100%;
-		}
-	}
-
-	.search-component .search-component__icon-navigation {
-		background: none;
-	}
-
-	.search-filters__dropdown-filters {
-		border-radius: 0 2px 2px 0;
-	}
-
-	.domains__domain-cart-foldable-card {
-		position: fixed;
+body.domain-search-legacy--unified {
+	.domains__step-section-wrapper {
+		margin: 0 auto;
 		width: 100%;
-		bottom: 0;
-		left: 0;
-		z-index: 99;
-		padding-bottom: 0 !important;
-		box-shadow: 0 -3px 10px 0 rgba(0, 0, 0, 0.12);
-
-		.foldable-card__main {
-			max-width: 100%;
-			display: block;
-			width: 100%;
-			margin: 0;
-
-			.foldable-card__action {
-				right: auto;
-				left: 0;
-			}
-			.domains__domain-cart-title {
-				margin-left: 24px;
-				display: flex;
-				align-items: center;
-				justify-content: space-between;
-			}
-
-			.domains__domain-cart-total {
-				display: flex;
-				gap: 8px;
-				align-items: center;
-
-				.domains__domain-cart-total-items {
-					font-family: "SF Pro Display", $sans;
-					font-size: $font-body-extra-small;
-					font-weight: 400;
-					line-height: 20px;
-					letter-spacing: 0;
-					text-align: left;
-				}
-				.domains__domain-cart-total-price {
-					font-family: "SF Pro Display", $sans;
-					font-size: $font-body;
-					font-weight: 500;
-					line-height: 24px;
-					letter-spacing: -0.32px;
-					text-align: left;
-
-				}
-			}
-		}
-		.foldable-card__content {
-			max-height: 70vh;
-			border-top: 0;
-			padding: 0 16px;
-			overflow-x: auto;
-			.domains__domain-cart {
-				border-top: 1px solid var(--color-neutral-5);
-			}
-			.domains__domain-cart-rows {
-				padding-top: 6px;
-			}
-		}
 	}
 
-	.domains__domain-cart {
-		border-bottom: 0 !important;
-
-		.domains__domain-cart-title {
-			font-size: $font-body;
-			color: var(--studio-gray-90);
-			margin-bottom: 10px;
-		}
-
-		.domains__domain-cart-rows {
-			.domains__domain-cart-row > div {
-				display: flex;
-				justify-content: space-between;
-				padding-top: 6px;
-				column-gap: 10px;
-			}
-			.domains__domain-cart-row > div:nth-child(2) {
-				display: block;
-				padding-bottom: 6px;
-				padding-top: 0;
-			}
-
-			.savings-message {
-				color: var(--studio-green-60);
-				display: flex;
-				align-items: center;
-				font-size: 0.75rem;
-				margin-top: 10px;
-			}
-
-			.domains__domain-cart-domain {
-				color: var(--studio-gray-50);
-				font-size: $font-body-small;
-				overflow: auto;
-				span {
-					overflow-wrap: anywhere;
-				}
-			}
-
-			.domains__domain-cart-remove {
-				color: var(--studio-gray-100);
-				font-size: $font-body-extra-small;
-				min-width: 50px;
-				margin-right: 10px;
-				text-align: left;
-				text-decoration: underline;
-			}
-
-			.domain-product-price__price {
-				display: flex;
-				align-items: center;
-				font-size: 0.875rem;
-
-				del {
-					font-size: 0.75rem;
-					margin-right: 10px;
-				}
-			}
-
-			.domains__price-free {
-				color: var(--studio-green-60);
-			}
-
-		}
-
-		.domains__domain-cart-total {
-			border-top: 1px solid;
-			border-top-color: var(--studio-gray-5);
-			padding-top: 28px;
-			margin-bottom: 28px;
-			margin-top: 12px;
-			color: var(--studio-gray-60);
-			font-size: $font-body-small;
-			display: flex;
-			justify-content: space-between;
-		}
-
-		.domains__domain-cart-continue {
-			width: 100%;
-			height: 40px;
-			padding-left: 24px;
-			padding-right: 24px;
-			border-radius: 4px;
-			background-color: var(--studio-wordpress-blue-50);
-			border-color: var(--studio-wordpress-blue-50);
-
-			&:hover {
-				background-color: var(--studio-wordpress-blue-60);
-				border-color: var(--studio-wordpress-blue-60);
-			}
-
-			&.is-busy{
-				background-image: linear-gradient(-45deg, var(--studio-wordpress-blue-50) 28%, var(--studio-wordpress-blue-60) 28%, var(--studio-wordpress-blue-60) 72%, var(--studio-wordpress-blue-50) 72%);
-			}
-		}
-
-		.domains__domain-cart-choose-later {
-			width: 100%;
-			height: 40px;
-			color: var(--studio-gray-100);
-			text-decoration: underline;
-			text-align: left;
-			margin-top: 5px;
-		}
-	}
-}
-
-.onboarding {
-	&.domains {
-		&.step-route {
-			padding: 60px 12px 0 12px;
-
-			.step-container {
-				.step-container__header {
-					margin: 36px 0 24px 0;
-					@include break-mobile {
-						margin: 24px 20px;
-					}
-					@include break-large {
-						margin: 48px 0 40px;
-					}
-				}
-			}
-			.formatted-header__title {
-				font-size: 2rem;
-				@include break-mobile {
-					font-size: 2.25rem;
-				}
-				@include break-xlarge {
-					font-size: 2.75rem;
-				}
-			}
-			.formatted-header__subtitle {
-				margin-top: 8px;
-			}
-			.register-domain-step__search-domain-step {
-				padding-bottom: 16px;
-			}
-		}
-	}
-}
-
-body.is-section-stepper.is-group-stepper,
-body.is-section-signup {
-	$light-white: #f3f4f5;
-
-	#primary {
-		.signup__step.is-domains,
-		.signup__step.is-domain-only,
-		.signup__step.is-mailbox-domain {
-			@media (max-width: $break-mobile) {
-				.step-wrapper__header {
-					margin-left: 0;
-					margin-right: 0;
-					margin-top: 36px;
-				}
-
-				.formatted-header__title {
-					padding-left: 0;
-					padding-right: 0;
-					font-size: rem(32px);
-				}
-
-				.formatted-header__subtitle {
-					padding-left: 0;
-					padding-right: 0;
-					margin-top: 8px;
-					font-size: rem(16px);
-				}
-			}
-		}
-	}
-
-	.featured-domain-suggestions {
-		@include break-mobile {
-			border-top: none;
-		}
-	}
-
-	.domains__step-content {
-		display: flex;
-
-		.search-component.is-open {
-			border: 1px solid #a7aaad;
-			border-radius: 4px;
-			box-sizing: border-box;
-			height: 40px;
-			overflow: hidden;
-
-			@include break-mobile {
-				height: 48px;
-			}
-		}
-
-		.search-component.is-open.has-focus {
-			border-color: #646970;
-			background: var(--color-surface);
-			box-shadow: none;
-
-			.search-component__input {
-				background: var(--color-surface);
-			}
-		}
-
-		.domains__domain-side-content-container {
-			flex-direction: column;
-			margin-top: 40px;
-			display: none;
-
-			@include break-large {
-				margin-top: 0;
-				flex-direction: column;
-				display: flex;
-			}
-
-			&.is-sticky {
-				position: sticky;
-				top: 0;
-				align-self: flex-start;
-			}
-		}
-
-		.register-domain-step .domains__domain-side-content-container {
-			display: flex;
-			margin-bottom: 80px;
-
-			@include break-small {
-				margin-inline: 20px;
-			}
-
-			@include break-medium {
-				flex-direction: row;
-				justify-content: center;
-
-				.domains__domain-side-content {
-					padding-top: 0;
-					border-bottom: none;
-				}
-			}
-
-			@include break-large {
+	.signup__step.is-domains {
+		.action-buttons.step-wrapper__navigation {
+			@media ( max-width: $break-mobile ) {
 				display: none;
 			}
 		}
 
-		.domains__free-domain .side-explainer__subtitle-2 {
-			display: none;
+		.async-load__placeholder {
+			margin: 12px;
+		}
+	}
 
-			@include break-small {
-				display: block;
-			}
+	&.is-section-stepper .domains__step-content,
+	.is-section-signup .domains__step-content {
+		margin-bottom: 50px;
+
+		& .use-my-domain__page-heading {
+			padding-left: 24px;
+			padding-right: 24px;
+			text-align: center;
 		}
 
-		.domains__domain-side-content {
-			border-bottom: 1px solid;
-			border-bottom-color: var(--studio-gray-5);
-			padding: 20px 0;
-			margin: 0;
-
-			@include break-large {
-				width: 290px;
-				margin: 0 0 0 40px;
-				padding: 40px 0;
-			}
-
-			@include break-huge {
-				margin: 0 0 0 60px;
-			}
-
-			&.fade-out {
-				opacity: 0;
-				visibility: hidden;
-				transition: all 0.4s ease-out;
-			}
-		}
-
-		.domains__domain-side-content:first-of-type {
-			padding-top: 0;
-		}
-
-		.domains__domain-side-content:last-of-type {
-			border-bottom: none;
-		}
-
-		.domains__domain-cart-foldable-card .domains__domain-side-content {
-			padding: 0;
-		}
-
-		.register-domain-step {
-			flex: 1;
-		}
-
-		.register-domain-step__search-card {
+		& .use-my-domain,
+		& .connect-domain-step,
+		& .domain-transfer-or-connect__content {
 			background: transparent;
 			box-shadow: none;
-			margin: 20px 0 0;
 
-			@include break-small {
-				margin: 20px 20px 0;
-			}
-
-			@include break-large {
-				margin: 0;
-			}
-
-			@include break-wide {
-				margin: initial;
+			@include break-mobile {
+				padding-left: 0;
+				padding-right: 0;
 			}
 		}
-		.search-component__input {
-			border-radius: 4px;
 
-			&::placeholder {
-				color: var(--color-neutral-50);
+		&.domains__step-content-domain-step {
+			margin-bottom: 20px;
+			.spinner {
+				width: 100%;
 			}
-		}
-		.search-component.is-open .search-component__input-fade.ltr::before {
-			display: none;
-		}
-		.search-component__open-icon {
-			transform: scaleX(-1);
-		}
-
-		.search-component__icon-search {
-			fill: #a7aaad;
-			margin: 8px 6px 8px 8px;
 		}
 
 		.search-component .search-component__icon-navigation {
-			padding: 0 7px;
+			background: none;
 		}
 
-		.use-my-domain__page-heading {
-			text-align: center;
+		.search-filters__dropdown-filters {
+			border-radius: 0 2px 2px 0;
+		}
+
+		.domains__domain-cart-foldable-card {
+			position: fixed;
+			width: 100%;
+			bottom: 0;
+			left: 0;
+			z-index: 99;
+			padding-bottom: 0 !important;
+			box-shadow: 0 -3px 10px 0 rgba( 0, 0, 0, 0.12 );
+
+			.foldable-card__main {
+				max-width: 100%;
+				display: block;
+				width: 100%;
+				margin: 0;
+
+				.foldable-card__action {
+					right: auto;
+					left: 0;
+				}
+				.domains__domain-cart-title {
+					margin-left: 24px;
+					display: flex;
+					align-items: center;
+					justify-content: space-between;
+				}
+
+				.domains__domain-cart-total {
+					display: flex;
+					gap: 8px;
+					align-items: center;
+
+					.domains__domain-cart-total-items {
+						font-family: 'SF Pro Display', $sans;
+						font-size: $font-body-extra-small;
+						font-weight: 400;
+						line-height: 20px;
+						letter-spacing: 0;
+						text-align: left;
+					}
+					.domains__domain-cart-total-price {
+						font-family: 'SF Pro Display', $sans;
+						font-size: $font-body;
+						font-weight: 500;
+						line-height: 24px;
+						letter-spacing: -0.32px;
+						text-align: left;
+					}
+				}
+			}
+			.foldable-card__content {
+				max-height: 70vh;
+				border-top: 0;
+				padding: 0 16px;
+				overflow-x: auto;
+				.domains__domain-cart {
+					border-top: 1px solid var( --color-neutral-5 );
+				}
+				.domains__domain-cart-rows {
+					padding-top: 6px;
+				}
+			}
+		}
+
+		.domains__domain-cart {
+			border-bottom: 0 !important;
+
+			.domains__domain-cart-title {
+				font-size: $font-body;
+				color: var( --studio-gray-90 );
+				margin-bottom: 10px;
+			}
+
+			.domains__domain-cart-rows {
+				.domains__domain-cart-row > div {
+					display: flex;
+					justify-content: space-between;
+					padding-top: 6px;
+					column-gap: 10px;
+				}
+				.domains__domain-cart-row > div:nth-child( 2 ) {
+					display: block;
+					padding-bottom: 6px;
+					padding-top: 0;
+				}
+
+				.savings-message {
+					color: var( --studio-green-60 );
+					display: flex;
+					align-items: center;
+					font-size: 0.75rem;
+					margin-top: 10px;
+				}
+
+				.domains__domain-cart-domain {
+					color: var( --studio-gray-50 );
+					font-size: $font-body-small;
+					overflow: auto;
+					span {
+						overflow-wrap: anywhere;
+					}
+				}
+
+				.domains__domain-cart-remove {
+					color: var( --studio-gray-100 );
+					font-size: $font-body-extra-small;
+					min-width: 50px;
+					margin-right: 10px;
+					text-align: left;
+					text-decoration: underline;
+				}
+
+				.domain-product-price__price {
+					display: flex;
+					align-items: center;
+					font-size: 0.875rem;
+
+					del {
+						font-size: 0.75rem;
+						margin-right: 10px;
+					}
+				}
+
+				.domains__price-free {
+					color: var( --studio-green-60 );
+				}
+			}
+
+			.domains__domain-cart-total {
+				border-top: 1px solid;
+				border-top-color: var( --studio-gray-5 );
+				padding-top: 28px;
+				margin-bottom: 28px;
+				margin-top: 12px;
+				color: var( --studio-gray-60 );
+				font-size: $font-body-small;
+				display: flex;
+				justify-content: space-between;
+			}
+
+			.domains__domain-cart-continue {
+				width: 100%;
+				height: 40px;
+				padding-left: 24px;
+				padding-right: 24px;
+				border-radius: 4px;
+				background-color: var( --studio-wordpress-blue-50 );
+				border-color: var( --studio-wordpress-blue-50 );
+
+				&:hover {
+					background-color: var( --studio-wordpress-blue-60 );
+					border-color: var( --studio-wordpress-blue-60 );
+				}
+
+				&.is-busy {
+					background-image: linear-gradient(
+						-45deg,
+						var( --studio-wordpress-blue-50 ) 28%,
+						var( --studio-wordpress-blue-60 ) 28%,
+						var( --studio-wordpress-blue-60 ) 72%,
+						var( --studio-wordpress-blue-50 ) 72%
+					);
+				}
+			}
+
+			.domains__domain-cart-choose-later {
+				width: 100%;
+				height: 40px;
+				color: var( --studio-gray-100 );
+				text-decoration: underline;
+				text-align: left;
+				margin-top: 5px;
+			}
 		}
 	}
 
-	.search-filters__dropdown-filters {
-		height: 40px;
+	.onboarding {
+		&.domains {
+			&.step-route {
+				padding: 60px 12px 0 12px;
 
-		@include break-mobile {
-			height: 48px;
+				.step-container {
+					.step-container__header {
+						margin: 36px 0 24px 0;
+						@include break-mobile {
+							margin: 24px 20px;
+						}
+						@include break-large {
+							margin: 48px 0 40px;
+						}
+					}
+				}
+				.formatted-header__title {
+					font-size: 2rem;
+					@include break-mobile {
+						font-size: 2.25rem;
+					}
+					@include break-xlarge {
+						font-size: 2.75rem;
+					}
+				}
+				.formatted-header__subtitle {
+					margin-top: 8px;
+				}
+				.register-domain-step__search-domain-step {
+					padding-bottom: 16px;
+				}
+			}
+		}
+	}
+
+	&.is-section-stepper.is-group-stepper,
+	&.is-section-signup {
+		$light-white: #f3f4f5;
+
+		#primary {
+			.signup__step.is-domains,
+			.signup__step.is-domain-only,
+			.signup__step.is-mailbox-domain {
+				@media ( max-width: $break-mobile ) {
+					.step-wrapper__header {
+						margin-left: 0;
+						margin-right: 0;
+						margin-top: 36px;
+					}
+
+					.formatted-header__title {
+						padding-left: 0;
+						padding-right: 0;
+						font-size: rem( 32px );
+					}
+
+					.formatted-header__subtitle {
+						padding-left: 0;
+						padding-right: 0;
+						margin-top: 8px;
+						font-size: rem( 16px );
+					}
+				}
+			}
 		}
 
-		&.search-filters__dropdown-filters--is-open {
-			box-shadow: none;
+		.featured-domain-suggestions {
+			@include break-mobile {
+				border-top: none;
+			}
 		}
 
-		.button {
-			&:hover {
+		.domains__step-content {
+			display: flex;
+
+			.search-component.is-open {
+				border: 1px solid #a7aaad;
+				border-radius: 4px;
+				box-sizing: border-box;
+				height: 40px;
+				overflow: hidden;
+
+				@include break-mobile {
+					height: 48px;
+				}
+			}
+
+			.search-component.is-open.has-focus {
+				border-color: #646970;
+				background: var( --color-surface );
+				box-shadow: none;
+
+				.search-component__input {
+					background: var( --color-surface );
+				}
+			}
+
+			.domains__domain-side-content-container {
+				flex-direction: column;
+				margin-top: 40px;
+				display: none;
+
+				@include break-large {
+					margin-top: 0;
+					flex-direction: column;
+					display: flex;
+				}
+
+				&.is-sticky {
+					position: sticky;
+					top: 0;
+					align-self: flex-start;
+				}
+			}
+
+			.register-domain-step .domains__domain-side-content-container {
+				display: flex;
+				margin-bottom: 80px;
+
+				@include break-small {
+					margin-inline: 20px;
+				}
+
+				@include break-medium {
+					flex-direction: row;
+					justify-content: center;
+
+					.domains__domain-side-content {
+						padding-top: 0;
+						border-bottom: none;
+					}
+				}
+
+				@include break-large {
+					display: none;
+				}
+			}
+
+			.domains__free-domain .side-explainer__subtitle-2 {
+				display: none;
+
+				@include break-small {
+					display: block;
+				}
+			}
+
+			.domains__domain-side-content {
+				border-bottom: 1px solid;
+				border-bottom-color: var( --studio-gray-5 );
+				padding: 20px 0;
+				margin: 0;
+
+				@include break-large {
+					width: 290px;
+					margin: 0 0 0 40px;
+					padding: 40px 0;
+				}
+
+				@include break-huge {
+					margin: 0 0 0 60px;
+				}
+
+				&.fade-out {
+					opacity: 0;
+					visibility: hidden;
+					transition: all 0.4s ease-out;
+				}
+			}
+
+			.domains__domain-side-content:first-of-type {
+				padding-top: 0;
+			}
+
+			.domains__domain-side-content:last-of-type {
+				border-bottom: none;
+			}
+
+			.domains__domain-cart-foldable-card .domains__domain-side-content {
+				padding: 0;
+			}
+
+			.register-domain-step {
+				flex: 1;
+			}
+
+			.register-domain-step__search-card {
+				background: transparent;
+				box-shadow: none;
+				margin: 20px 0 0;
+
+				@include break-small {
+					margin: 20px 20px 0;
+				}
+
+				@include break-large {
+					margin: 0;
+				}
+
+				@include break-wide {
+					margin: initial;
+				}
+			}
+			.search-component__input {
+				border-radius: 4px;
+
+				&::placeholder {
+					color: var( --color-neutral-50 );
+				}
+			}
+			.search-component.is-open .search-component__input-fade.ltr::before {
+				display: none;
+			}
+			.search-component__open-icon {
+				transform: scaleX( -1 );
+			}
+
+			.search-component__icon-search {
+				fill: #a7aaad;
+				margin: 8px 6px 8px 8px;
+			}
+
+			.search-component .search-component__icon-navigation {
+				padding: 0 7px;
+			}
+
+			.use-my-domain__page-heading {
+				text-align: center;
+			}
+		}
+
+		.search-filters__dropdown-filters {
+			height: 40px;
+
+			@include break-mobile {
+				height: 48px;
+			}
+
+			&.search-filters__dropdown-filters--is-open {
 				box-shadow: none;
 			}
 
-			.search-filters__dropdown-filters-button-text {
-				color: var(--color-neutral-60);
+			.button {
+				&:hover {
+					box-shadow: none;
+				}
+
+				.search-filters__dropdown-filters-button-text {
+					color: var( --color-neutral-60 );
+				}
+			}
+		}
+		.signup__step.is-domain-only,
+		.signup__step.is-domains,
+		.signup__step.is-mailbox-domain {
+			padding: 0 12px;
+		}
+		.step-container__content .domains__step-content-domain-step {
+			padding: 0 12px;
+			@include break-mobile {
+				padding: 0;
 			}
 		}
 	}
-	.signup__step.is-domain-only,
-	.signup__step.is-domains,
-	.signup__step.is-mailbox-domain {
-		padding: 0 12px;
-	}
-	.step-container__content .domains__step-content-domain-step {
-		padding: 0 12px;
-		@include break-mobile {
-			padding: 0;
+
+	&.is-section-stepper .step-route.domains:has( .step-container-v2 ) {
+		padding: 0;
+
+		.register-domain-step__search-card {
+			margin: 0;
 		}
-	}
-}
 
-body.is-section-stepper .step-route.domains:has(.step-container-v2) {
-	padding: 0;
+		.featured-domain-suggestions,
+		.domain-suggestion {
+			margin-inline: 0;
+		}
 
-	.register-domain-step__search-card {
-		margin: 0;
-	}
+		.register-domain-step__example-prompt {
+			margin: 0;
+		}
 
-	.featured-domain-suggestions,
-	.domain-suggestion {
-		margin-inline: 0;
-	}
+		.domains__domain-side-content-container {
+			display: flex;
+			margin-top: 0;
+		}
 
-	.register-domain-step__example-prompt {
-		margin: 0;
-	}
+		.domains__domain-side-content {
+			margin: 0;
+			flex: 1;
+			width: 100%;
+		}
 
-	.domains__domain-side-content-container {
-		display: flex;
-		margin-top: 0;
-	}
-
-	.domains__domain-side-content {
-		margin: 0;
-		flex: 1;
-		width: 100%;
-	}
-
-	.domains__domain-side-content.fade-out {
-		display: none;
+		.domains__domain-side-content.fade-out {
+			display: none;
+		}
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -60,6 +60,7 @@
 		"dev/store-sandbox-helper": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
+		"domains/ui-redesign": false,
 		"email-accounts/enabled": true,
 		"global-styles/on-personal-plan": false,
 		"google-drive": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -30,6 +30,7 @@
 		"dashboard/v2/backport/sites-list": true,
 		"design-picker/use-assembler-styles": true,
 		"devdocs": false,
+		"domains/ui-redesign": false,
 		"global-styles/on-personal-plan": false,
 		"google-my-business": false,
 		"gravatar/hovercards": true,

--- a/config/production.json
+++ b/config/production.json
@@ -40,6 +40,7 @@
 		"current-site/notice": true,
 		"dashboard/v2/backport/site-settings": true,
 		"dashboard/v2/backport/sites-list": false,
+		"domains/ui-redesign": false,
 		"global-styles/on-personal-plan": false,
 		"google-my-business": true,
 		"help": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -44,6 +44,7 @@
 		"dev/store-sandbox-helper": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
+		"domains/ui-redesign": false,
 		"email-accounts/enabled": true,
 		"cookie-banner": true,
 		"google-my-business": true,


### PR DESCRIPTION
Closes DOTOBRD-219.

## Proposed Changes

This is the foundation work for the UI redesign project on Linear.

Here's what this PR does:

1. Introduces a feature flag and consumes it in the three domain search entry points:
a. In-Calypso domain search (`/domains/add/%s`), by changing `client/my-sites/domains/domain-search/index.tsx`.
b. Start and most Stepper flows by changing `client/signup/steps/domains/index.jsx`.
c. Stepper's domain step by changing `client/landing/stepper/declarative-flow/internals/steps-repository/domains`.
2. Scopes all style modifications coming from these three entry points depending on the state of the feature flag.
3. Duplicate one `client/components/domains` component so we can kick off the work.
4. Adds Quake as the code owner for most domains folders so we are aware of changes made by other teams.

The idea behind component duplication is to avoid endless and risky ternaries deep within code, and allow for code removal/restructuring without the fear of affecting the production version.

## Review instructions

This PR looks big by absolute numbers, but two big operations happen because of CSS scoping (which shifts the file indentation), and a copy of a big component (which adds new files.) If we remove that, the PR becomes really small, but I couldn't split it any further.

I recommend reviewing the PR by looking at the individual commits.

## Testing Instructions

You should still be able to search for domains and transfer them to WPCOM. The mobile and desktop version should work just like production.

Enter these entry points and verify that nothing changes compared to production:
- `/start/domain` and other Start flows
- `/setup/onboarding` and other Stepper flows
- `/domains/add/%s`

Turn the feature flag on `?flags=+domains/ui-redesign` and this time verify everything is visually broken. **That's expected because we're not rendering the entry points styling anymore.**