### PR TITLE
Dashboard v2: fix SummaryButton's line-height when there is no badge

### DIFF
--- a/packages/components/src/summary-button/style.scss
+++ b/packages/components/src/summary-button/style.scss
@@ -77,6 +77,7 @@
 
 		.summary-button-title {
 			@include body-medium;
+			line-height: $font-line-height-medium;
 		}
 	}
 


### PR DESCRIPTION

## Proposed Changes

This PR fixes a vertical text misalignment in SummaryButton when there is no badge. It was not vertically centered. The reason is that the line height is 20px but the badge is 24px.

The PR fixes this by forcing the line height to be 24px to match with the badges' height.

NOTE: It only affect SummaryButton with `density="medium"`. I've tested that the low and high densities are not affected.

|Before|After|
|-|-|
|<img width="493" alt="image" src="https://github.com/user-attachments/assets/fb370a90-22b6-47b6-950e-8d36e2b8337d" />|<img width="496" alt="image" src="https://github.com/user-attachments/assets/c738be3a-e1cc-4305-97b4-5ba06d53710b" />|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fixes a visual bug.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to `/v2/sites/:slug/settings` of a Simple site.
2. Verify that the rows without badges are now vertically centered.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
