### PR TITLE
Site list v2: fix Jetpack plan alignment in grid layout

### DIFF
--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -397,7 +397,7 @@ export function Plan( { site }: { site: Site } ) {
 			return <IneligibleIndicator />;
 		}
 		return (
-			<HStack spacing={ 1 } expanded={ false }>
+			<HStack spacing={ 1 } expanded={ false } justify="flex-start">
 				<JetpackLogo size={ 16 } />
 				<span>{ site.plan?.product_name_short }</span>
 			</HStack>


### PR DESCRIPTION

## Proposed Changes

|Before|After|
|-|-|
|<img width="365" alt="image" src="https://github.com/user-attachments/assets/fa38db3b-1433-4a7e-955d-07083b65c24e" />|<img width="365" alt="image" src="https://github.com/user-attachments/assets/088dedec-5a5d-4c9d-904b-36313de79c79" />|


## Testing Instructions

1. Create a Jurassic Ninja site
2. Go to `/v2/sites`
3. Switch to grid layout
4. Enable Plan column
5. Search for that site
6. Verify it shows the plan with the correct alignment

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
