### PR TITLE
Help Center: Open Odie links in the Help Center

### DIFF
--- a/packages/help-center/src/hooks/use-content-filter.ts
+++ b/packages/help-center/src/hooks/use-content-filter.ts
@@ -1,10 +1,8 @@
+import { isThisASupportArticleLink } from '@automattic/urls';
 import { useEffect, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
-
-const isThisASupportArticleLink = ( href: string ) =>
-	/wordpress\.com(\/\w\w)?(?=\/support\/)|support\.wordpress\.com/.test( href );
 
 export const useContentFilter = ( node: HTMLDivElement | null ) => {
 	const navigate = useNavigate();

--- a/packages/odie-client/src/components/message/custom-a-link.tsx
+++ b/packages/odie-client/src/components/message/custom-a-link.tsx
@@ -1,5 +1,7 @@
+import { isThisASupportArticleLink } from '@automattic/urls';
 import clsx from 'clsx';
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useOdieAssistantContext } from '../../context';
 import { uriTransformer } from './uri-transformer';
 
@@ -22,6 +24,7 @@ const CustomALink = ( {
 } ) => {
 	const { trackEvent } = useOdieAssistantContext();
 	const [ transformedHref, setTransformedHref ] = useState( '' );
+	const navigate = useNavigate();
 
 	useEffect( () => {
 		let urlHref = uriTransformer( href ?? '' );
@@ -45,7 +48,12 @@ const CustomALink = ( {
 				href={ transformedHref }
 				target={ target }
 				rel="noopener noreferrer"
-				onClick={ () => {
+				onClick={ ( e ) => {
+					// Open support article links in the Help Center.
+					if ( isThisASupportArticleLink( transformedHref ) ) {
+						navigate( `/post?link=${ transformedHref }` );
+						e.preventDefault();
+					}
 					trackEvent( 'chat_message_action_click', {
 						action: 'link',
 						in_chat_view: false,

--- a/packages/urls/src/index.ts
+++ b/packages/urls/src/index.ts
@@ -75,3 +75,6 @@ export const TRANSFER_DOMAIN_REGISTRATION = `${ root }/transfer-domain-registrat
 export const UPDATE_CONTACT_INFORMATION_EMAIL_OR_NAME_CHANGES = `${ root }/update-contact-information/#email-or-name-changes`;
 export const UPDATE_NAMESERVERS = `${ root }/domains/change-name-servers/`;
 export const WPCC = `${ root }/wpcc-faq/`;
+
+export const isThisASupportArticleLink = ( href: string ) =>
+	/wordpress\.com(\/\w\w)?(?=\/support\/)|support\.wordpress\.com/.test( href );


### PR DESCRIPTION
Fixes DOTSUP-50

## Proposed Changes

When Odie links to an article from wordpress.com/support, it should be opened in the Help Center like the rest of the link.

## Why are these changes being made?
To keep the session coherent, when the article is opened in the HC:

1. The user can move around, refresh the page, or navigate, without losing track of it.
2. They click back and go back to the chat for the next steps.
3. It's less distracting. 

## Testing Instructions

1. Ask Odie how to connect a domain and ask it to give you article links.
2. Click this links, they should open in the HC.
3. Click back, you should be taken back to the chat you were at.
