### PR TITLE
A4A > Reports: Implement Build Report empty data UI & minor UI enhancements

### DIFF
--- a/client/a8c-for-agencies/sections/reports/hooks/use-report-error.ts
+++ b/client/a8c-for-agencies/sections/reports/hooks/use-report-error.ts
@@ -1,0 +1,35 @@
+import { useTranslate } from 'i18n-calypso';
+import type { Report } from '../types';
+
+export const useReportError = ( reportData?: Report ) => {
+	const translate = useTranslate();
+
+	// Get the latest error from the report data
+	const reportError = reportData?.data?.errors?.reduce(
+		( latest, error ) => {
+			if ( ! latest || error.timestamp > latest.timestamp ) {
+				return error;
+			}
+			return latest;
+		},
+		null as { code: string; message: string; timestamp: number } | null
+	);
+
+	const getErrorText = ( errorCode?: string ) => {
+		switch ( errorCode ) {
+			case 'report_empty_data':
+				return translate(
+					"We didn't find any data for the selected dates. The site may be new or inactive during this period. Try picking a different date range to see results."
+				);
+			default:
+				return translate( 'There was an error preparing your report.' );
+		}
+	};
+
+	const errorText = getErrorText( reportError?.code );
+
+	return {
+		errorText,
+		errorCode: reportError?.code,
+	};
+};

--- a/client/a8c-for-agencies/sections/reports/hooks/use-report-error.ts
+++ b/client/a8c-for-agencies/sections/reports/hooks/use-report-error.ts
@@ -19,7 +19,7 @@ export const useReportError = ( reportData?: Report ) => {
 		switch ( errorCode ) {
 			case 'report_empty_data':
 				return translate(
-					"We didn't find any data for the selected dates. The site may be new or inactive during this period. Try picking a different date range to see results."
+					'No data found for this timeframe. The site may be new, inactive, or missing Jetpack (required for reports). Try another date range or install Jetpack to see results.'
 				);
 			default:
 				return translate( 'There was an error preparing your report.' );

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/build-report-actions.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/build-report-actions.tsx
@@ -34,6 +34,7 @@ export default function BuildReportActions( {
 		reportId,
 		isProcessed,
 		isReportError,
+		reportErrorMetadata,
 	} = state;
 
 	const { setCurrentStep, handleNextStep, handlePrevStep } = handlers;
@@ -44,16 +45,28 @@ export default function BuildReportActions( {
 		setCurrentStep( 1 );
 	}, [ setCurrentStep, dispatch ] );
 
+	// We need to replace the reportId with the sourceId so that
+	// we can prefill the form with the previous data
+	const handleUpdateUrl = useCallback(
+		( step: number ) => {
+			const currentReportId = getQueryArg( window.location.href, 'reportId' );
+			const urlWithoutReportId = removeQueryArgs( window.location.pathname, 'reportId' );
+			const urlWithSourceId = addQueryArgs( urlWithoutReportId, { sourceId: currentReportId } );
+			page.redirect( urlWithSourceId );
+			setCurrentStep( step );
+		},
+		[ setCurrentStep ]
+	);
+
+	const changeTimeframe = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_reports_change_timeframe_click' ) );
+		handleUpdateUrl( 1 );
+	}, [ handleUpdateUrl, dispatch ] );
+
 	const handleBackToStep2 = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_reports_send_report_back_click' ) );
-		// We need to replace the reportId with the sourceId so that
-		// we can prefill the form with the previous data
-		const currentReportId = getQueryArg( window.location.href, 'reportId' );
-		const urlWithoutReportId = removeQueryArgs( window.location.pathname, 'reportId' );
-		const urlWithSourceId = addQueryArgs( urlWithoutReportId, { sourceId: currentReportId } );
-		page.redirect( urlWithSourceId );
-		setCurrentStep( 2 );
-	}, [ setCurrentStep, dispatch ] );
+		handleUpdateUrl( 2 );
+	}, [ handleUpdateUrl, dispatch ] );
 
 	const isCreatingReport = sendReportMutation.isPending;
 	const isSendingReport = sendReportEmailMutation.isPending;
@@ -150,6 +163,13 @@ export default function BuildReportActions( {
 						<div className="build-report__actions">
 							<Button variant="primary" onClick={ handleBuildNewReport }>
 								{ translate( 'Build a new report' ) }
+							</Button>
+						</div>
+					) }
+					{ reportErrorMetadata.errorCode === 'report_empty_data' && (
+						<div className="build-report__actions">
+							<Button variant="primary" onClick={ changeTimeframe }>
+								{ translate( 'Change date range' ) }
 							</Button>
 						</div>
 					) }

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/build-report-actions.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/build-report-actions.tsx
@@ -58,8 +58,8 @@ export default function BuildReportActions( {
 		[ setCurrentStep ]
 	);
 
-	const changeTimeframe = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_a4a_reports_change_timeframe_click' ) );
+	const changeReportDetails = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_reports_change_report_details_click' ) );
 		handleUpdateUrl( 1 );
 	}, [ handleUpdateUrl, dispatch ] );
 
@@ -168,8 +168,8 @@ export default function BuildReportActions( {
 					) }
 					{ reportErrorMetadata.errorCode === 'report_empty_data' && (
 						<div className="build-report__actions">
-							<Button variant="primary" onClick={ changeTimeframe }>
-								{ translate( 'Change date range' ) }
+							<Button variant="primary" onClick={ changeReportDetails }>
+								{ translate( 'Change report details' ) }
 							</Button>
 						</div>
 					) }

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/index.tsx
@@ -22,6 +22,7 @@ import {
 import { useFormValidation } from '../../hooks/use-build-report-form-validation';
 import { useDuplicateReportFormData } from '../../hooks/use-duplicate-report-form-data';
 import usePollReportStatus from '../../hooks/use-poll-report-status';
+import { useReportError } from '../../hooks/use-report-error';
 import useSendReportEmailMutation from '../../hooks/use-send-report-email-mutation';
 import useSendReportMutation from '../../hooks/use-send-report-mutation';
 import BuildReportActions from './build-report-actions';
@@ -91,11 +92,14 @@ const BuildReport = () => {
 
 	// Poll report status when reportId exists
 	const {
+		data: reportData,
 		isProcessed,
 		isError: isReportError,
 		isPending: isReportPending,
 		isErrorStatus: isReportErrorStatus,
 	} = usePollReportStatus( reportId );
+
+	const reportErrorMetadata = useReportError( reportData );
 
 	useEffect( () => {
 		if ( reportId ) {
@@ -150,6 +154,8 @@ const BuildReport = () => {
 		showValidationErrors,
 		validationErrors,
 		isReportError,
+		reportData,
+		reportErrorMetadata,
 	};
 
 	return (

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/steps/step-1-details.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/steps/step-1-details.tsx
@@ -94,6 +94,8 @@ export default function Step1Details( { formData, state, handlers }: StepProps )
 															)
 														)
 													}
+													target="_blank"
+													rel="noreferrer"
 												/>
 											),
 										},

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/steps/step-3-send.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/steps/step-3-send.tsx
@@ -60,7 +60,7 @@ export default function Step3Send( { state }: StepProps ) {
 						{ translate( 'Step 3 of 3: Report preparation failed' ) }
 					</h2>
 					<p className="build-report__step-description" role="alert" aria-live="assertive">
-						{ translate( 'There was an error preparing your report.' ) }
+						{ state.reportErrorMetadata.errorText }
 					</p>
 				</>
 			);

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
@@ -116,6 +116,7 @@ export const ReportClientEmailsColumn = ( { emails }: { emails: string[] } ) => 
 			{ remainingCount > 0 && (
 				<>
 					<span
+						className="a4a-reports-dashboard__more-emails"
 						onMouseEnter={ () => setShowTooltip( true ) }
 						onMouseLeave={ () => setShowTooltip( false ) }
 						onTouchStart={ () => setShowTooltip( true ) }

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/style.scss
@@ -131,3 +131,7 @@
 	@include body-medium;
 	color: var(--color-neutral-50);
 }
+
+.a4a-reports-dashboard__more-emails {
+	margin-inline-start: 4px;
+}

--- a/client/a8c-for-agencies/sections/reports/types.ts
+++ b/client/a8c-for-agencies/sections/reports/types.ts
@@ -24,6 +24,13 @@ export interface ReportFormData {
 export interface ReportFormAPIResponse extends ReportFormData {
 	managed_site_url: string;
 	blog_id: number;
+	errors:
+		| {
+				code: string;
+				message: string;
+				timestamp: number;
+		  }[]
+		| [];
 }
 
 export type ReportStatus = 'sent' | 'error' | 'pending' | 'processed';
@@ -122,7 +129,12 @@ export interface BuildReportState {
 	isReportPending: boolean;
 	isReportError: boolean;
 	isReportErrorStatus: boolean;
+	reportData?: Report;
 	isProcessed: boolean;
 	showValidationErrors: boolean;
 	validationErrors: Array< { field: string; message: string } >;
+	reportErrorMetadata: {
+		errorText: string;
+		errorCode?: string;
+	};
 }


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1209/report-builder-show-the-error-message-to-the-user-on-the-ui
Resolves https://linear.app/a8c/issue/A4A-1255/reports-minor-ui-enhancements-and-fixes

## Proposed Changes

This PR:

-  Implements Build Report empty data UI
- Fixes a minor spacing issue on the `CLIENT EMAILS` column
- Open the `Sites Dashboard` link in a new tab

## Why are these changes being made?

* To clearly indicate when there was no data found while generating the report

## Testing Instructions

* Open the A4A live link
* Go to Reports > Open the link for a report that has an error: /reports/build?reportId={id} > Verify that the below UI is shown

<img width="820" alt="Screenshot 2025-07-08 at 4 42 43 PM" src="https://github.com/user-attachments/assets/f50fba9e-d70b-4950-b2e3-7088032d3d62" />


* Build a report > Open the site selection modal > Click the link `Sites Dashboard` and verify it opens in a new tab

* Go to dashboard > Open a preview of any report > Verify that the `+` when there are multiple emails has clear spacing

<img width="1183" alt="Screenshot 2025-07-08 at 2 44 48 PM" src="https://github.com/user-attachments/assets/32d011ea-960e-420e-a785-71e531dde443" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
