### PR TITLE
Connect Refresh: Woo Login - fix header alignment

### DIFF
--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1068,10 +1068,6 @@ $breakpoint-mobile: 660px;
 			font-weight: 700;
 			line-height: 39.6px;
 			letter-spacing: -0.72px;
-
-			@media (max-width: $break-mobile) {
-				text-align: left;
-			}
 		}
 
 		input[type="text"].form-text-input,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13220/login-make-the-two-columnwhite-layout-the-default-across-all-contexts

## Proposed Changes

Fixes what looks like a wrong left-alignment of the Login header text when on mobile with Woo OAuth client

| Before | After |
|--------|--------|
| <img width="359" alt="Screenshot 2025-07-08 at 12 46 04 PM" src="https://github.com/user-attachments/assets/54e1cffb-2e35-403e-907a-f66488baac6e" /> | <img width="366" alt="Screenshot 2025-07-08 at 12 45 32 PM" src="https://github.com/user-attachments/assets/22335f6e-d50f-4ed0-9265-2e1e34140e10" /> | 


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13220/login-make-the-two-columnwhite-layout-the-default-across-all-contexts

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [Woo](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Db30d4e6a81f72b803c873f517f4189601c46a1bc8b9bfdb9ed27cf3d17ad5601%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26from-calypso%3D1&client_id=50916&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D50916%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%252F%253Fresponse_type%253Dcode%2526client_id%253D50916%2526state%253Db30d4e6a81f72b803c873f517f4189601c46a1bc8b9bfdb9ed27cf3d17ad5601%2526redirect_uri%253Dhttps%25253A%25252F%25252Fwoocommerce.com%25252Fwc-api%25252Fwpcom-signin%25253Fnext%25253D%2525252F%2526blog_id%253D0%2526wpcom_connect%253D1%2526wccom-from%2526calypso_env%253Dproduction%2526from-calypso%253D1) and resize to mobile viewport. Confirm media

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
