### PR TITLE
Connect Refresh: Remove obsolete ".wp-login__links"

### DIFF
--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -304,69 +304,6 @@
 			display: none;
 		}
 
-		.wp-login__crowdsignal-footer {
-			background-color: var(--color-crowdsignal);
-			box-sizing: border-box;
-			color: var(--color-text-inverted);
-			display: flex;
-			flex-direction: row;
-			fill: var(--color-text-inverted);
-			height: 58px;
-			padding: 20px 40px;
-			position: absolute;
-			bottom: 0;
-			left: 0;
-			right: 0;
-		}
-
-		.wp-login__crowdsignal-footer-text {
-			display: none;
-			font-size: $font-body-extra-small;
-			flex: 1;
-			height: 18px;
-			letter-spacing: 0.8px;
-			line-height: 16px;
-			text-align: center;
-			text-transform: uppercase;
-
-			&:last-child {
-				display: inline;
-			}
-
-			@include breakpoint-deprecated(">660px") {
-				display: inline;
-				text-align: left;
-
-				&:last-child {
-					text-align: right;
-				}
-			}
-
-			.automattic-logo,
-			.gridicon {
-				margin: 0 5px;
-				vertical-align: bottom;
-			}
-		}
-
-		.wp-login__links {
-			padding: 20px 0 15px;
-
-			a,
-			button {
-				border: 0;
-				color: var(--color-text);
-				line-height: 21px;
-				padding: 10px 16px;
-				text-align: center;
-
-				&:hover,
-				&:active {
-					color: var(--color-text);
-				}
-			}
-		}
-
 		.wp-login__main.main {
 			max-width: 550px;
 			margin-bottom: 80px;
@@ -397,18 +334,12 @@
 		margin-top: 24px;
 	}
 
-	.wp-login__links,
 	.auth-form__social,
 	.login__form,
 	.two-factor-authentication__verification-code-form,
 	.two-factor-authentication__actions {
 		width: 100%;
 		max-width: 375px;
-	}
-
-	.wp-login__links {
-		font-size: $font-body;
-		font-weight: 400;
 	}
 
 	.login__form-action button {
@@ -545,15 +476,6 @@
 			color: var(--studio-white);
 			background: var(--studio-gray-10);
 			border-color: var(--studio-gray-10);
-		}
-	}
-
-	.wp-login__links button {
-		color: var(--studio-jetpack-green-40);
-
-		&:hover,
-		&:focus {
-			color: var(--studio-jetpack-green-60);
 		}
 	}
 }

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -156,8 +156,6 @@ $breakpoint-mobile: 660px;
 	}
 
 	a:not(.components-button),
-	.wp-login__links a,
-	.wp-login__links button,
 	.button,
 	.magic-login__footer a {
 		color: $gray-50;
@@ -484,7 +482,6 @@ $breakpoint-mobile: 660px;
 		}
 	}
 
-	.wp-login__links,
 	.login__social-connect-prompt,
 	.magic-login__request-link,
 	.signup-form,

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -110,53 +110,6 @@ $image-height: 47px;
 	}
 }
 
-.wp-login__links {
-
-	a,
-	a:visited,
-	button {
-		color: var(--color-neutral-50);
-
-		body.is-section-signup & {
-			color: var(--color-text-inverted);
-		}
-	}
-
-	a,
-	button,
-	.components-button {
-		border-bottom: 1px solid var(--color-neutral-10);
-		box-sizing: border-box;
-		cursor: pointer;
-		display: block;
-		font-size: $font-body-small;
-		font-weight: 600;
-		padding: 16px 24px;
-		text-align: center;
-		width: 100%;
-
-		&:hover,
-		&:active {
-			color: var(--color-accent);
-		}
-
-		&:last-child {
-			border-bottom: none;
-		}
-	}
-
-	.gridicon {
-		margin-right: 3px;
-		vertical-align: text-bottom;
-
-		&.gridicons-external {
-			top: 0;
-			margin-right: 0;
-			margin-left: 3px;
-		}
-	}
-}
-
 .wp-login__site-return-link {
 	overflow: hidden;
 	position: relative;
@@ -214,20 +167,6 @@ $image-height: 47px;
 
 .layout.is-wccom-oauth-flow {
 	background-color: var(--color-woocommerce-onboarding-background);
-
-	.wp-login__links {
-		margin-top: 1em;
-	}
-
-	.wp-login__links a {
-		border-bottom: none;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-		line-height: 3.4em;
-		color: var(--color-neutral-60);
-		font-size: $font-body-small;
-		text-decoration: underline;
-		font-weight: normal;
-	}
 
 	.wp-login__main.main {
 		max-width: 476px;
@@ -390,50 +329,6 @@ $image-height: 47px;
 				text-align: start;
 			}
 		}
-	}
-
-	.wp-login__links > .button,
-	.wp-login__links:not(.has-2fa-links) > a:first-of-type {
-		/* Note: Matches secondary button used in /start (signup). Should probably turn this into a button. */
-		background: transparent;
-		margin: 0;
-		outline: 0;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		text-decoration: none;
-		box-sizing: border-box;
-		font-size: $font-body-small;
-		-webkit-appearance: none;
-		-moz-appearance: none;
-		appearance: none;
-		background-color: var(--color-surface);
-		color: var(--color-neutral-70);
-		border: 1px solid var(--color-neutral-10);
-		border-radius: 4px;
-		letter-spacing: 0.32px;
-		line-height: 17px;
-		height: 44px;
-		box-shadow: 0 1px 2px rgb(0 0 0 / 5%);
-
-		&:hover,
-		&:focus {
-			border-color: var(--color-neutral-20);
-			color: var(--color-neutral-70);
-		}
-	}
-
-	.wp-login__links > button,
-	.wp-login__links > a {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-	}
-
-	.wp-login__links a:hover,
-	.wp-login__links a:active,
-	.wp-login__links button:hover,
-	.wp-login__links button:active {
-		color: #00a0d2;
 	}
 
 	.wp-login__main {
@@ -851,8 +746,7 @@ $image-height: 47px;
 		margin: 24px 0;
 	}
 
-	.grav-powered-login__footer,
-	.wp-login__links.has-2fa-links {
+	.grav-powered-login__footer {
 		display: flex;
 		flex-direction: column;
 		font-size: 16px;
@@ -867,20 +761,6 @@ $image-height: 47px;
 
 		button:focus {
 			outline: dotted;
-		}
-	}
-
-	.wp-login__links.has-2fa-links {
-		align-items: center;
-		margin-top: 24px;
-
-		a,
-		button {
-			color: var(--color-gravatar);
-			font-weight: normal;
-			text-decoration: underline;
-			padding: 0;
-			border: 0;
 		}
 	}
 
@@ -900,8 +780,7 @@ $image-height: 47px;
 			font-size: 40px;
 		}
 
-		.grav-powered-login__footer,
-		.wp-login__links.has-2fa-links {
+		.grav-powered-login__footer {
 			gap: 16px;
 		}
 	}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13627/login-and-signup-centralise-font-and-css-overrides

## Proposed Changes

Removes obsolete `.wp-login__links` styles. The consuming component was removed in https://github.com/Automattic/wp-calypso/pull/104583

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13627/login-and-signup-centralise-font-and-css-overrides

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Build passing

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
