### PR TITLE
Help Center: Start new chat on My Home

### DIFF
--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -1,6 +1,7 @@
 import { Card, Button } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
 import { useStillNeedHelpURL } from '@automattic/help-center/src/hooks';
+import { useResetSupportInteraction } from '@automattic/help-center/src/hooks/use-reset-support-interaction';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
@@ -50,9 +51,11 @@ export default function HelpSearch() {
 	};
 	const { setShowHelpCenter, setNavigateToRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
 	const { url } = useStillNeedHelpURL();
+	const resetSupportInteraction = useResetSupportInteraction();
 
-	const onClick = () => {
+	const onClick = async () => {
 		setNavigateToRoute( url );
+		await resetSupportInteraction();
 		setShowHelpCenter( true );
 		dispatch( recordTracksEvent( 'calypso_inlinehelp_get_help_click' ) );
 	};


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
https://linear.app/a8c/issue/DOTCOM-867/start-new-chat-from-get-help-button

## Proposed Changes

* On My Home we now start a new chat instead of continuing with open chats.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of our ongoing efforts to improve the Help Center.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link
* Go to `My home`
* Scroll all the way down, you should see a secondary button with the text `Get help`
* Click on the button, and you should get a new Odie chat.

| Before | After |
|-----|-----|
|![Screenshot 2025-07-08 at 14 14 31](https://github.com/user-attachments/assets/5fb3df25-ed62-44ea-ac3b-984e77ead487)|![Screenshot 2025-07-08 at 14 14 41](https://github.com/user-attachments/assets/c5870f02-b085-4cae-a99c-9c72145627ac)|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
