### PR TITLE
HC CSAT: Minor improvements

### DIFF
--- a/packages/help-center/src/components/help-center-support-chat-message.scss
+++ b/packages/help-center/src/components/help-center-support-chat-message.scss
@@ -108,6 +108,7 @@
 				line-clamp: 1;
 				-webkit-line-clamp: 1;
 				-webkit-box-orient: vertical;
+				max-width: 70%;
 			}
 		}
 	}

--- a/packages/help-center/src/components/help-center-support-chat-message.scss
+++ b/packages/help-center/src/components/help-center-support-chat-message.scss
@@ -108,7 +108,10 @@
 				line-clamp: 1;
 				-webkit-line-clamp: 1;
 				-webkit-box-orient: vertical;
-				max-width: 70%;
+			}
+
+			.help-center-support-chat__conversation-information-time {
+				flex: 0 0 auto;
 			}
 		}
 	}

--- a/packages/help-center/src/components/help-center-support-chat-message.tsx
+++ b/packages/help-center/src/components/help-center-support-chat-message.tsx
@@ -41,7 +41,10 @@ export const HelpCenterSupportChatMessage = ( {
 	const { __ } = useI18n();
 	const { currentUser } = useHelpCenterContext();
 	const { displayName, received, role, text, altText } = message;
-
+	const messageText =
+		'metadata' in message && message.metadata?.type === 'csat'
+			? __( 'Please help us improve. How would you rate your support experience?' )
+			: text;
 	const helpCenterContext = useHelpCenterContext();
 	const helpCenterContextSectionName = helpCenterContext.sectionName;
 	const { supportInteractions } = useGetHistoryChats();
@@ -103,7 +106,7 @@ export const HelpCenterSupportChatMessage = ( {
 			</div>
 			<div className="help-center-support-chat__conversation-information">
 				<div className="help-center-support-chat__conversation-information-message">
-					{ text || altText }
+					{ messageText || altText }
 				</div>
 				<div className="help-center-support-chat__conversation-sub-information">
 					<span className="help-center-support-chat__conversation-information-name">

--- a/packages/help-center/src/components/help-center-support-chat-message.tsx
+++ b/packages/help-center/src/components/help-center-support-chat-message.tsx
@@ -43,7 +43,10 @@ export const HelpCenterSupportChatMessage = ( {
 	const { displayName, received, role, text, altText } = message;
 	const messageText =
 		'metadata' in message && message.metadata?.type === 'csat'
-			? __( 'Please help us improve. How would you rate your support experience?' )
+			? __(
+					'Please help us improve. How would you rate your support experience?',
+					__i18n_text_domain__
+			  )
 			: text;
 	const helpCenterContext = useHelpCenterContext();
 	const helpCenterContextSectionName = helpCenterContext.sectionName;

--- a/packages/help-center/src/components/help-center-support-chat-message.tsx
+++ b/packages/help-center/src/components/help-center-support-chat-message.tsx
@@ -126,7 +126,7 @@ export const HelpCenterSupportChatMessage = ( {
 							</svg>
 						}
 					/>
-					<span>
+					<span className="help-center-support-chat__conversation-information-time">
 						<TimeSince date={ receivedDateISO } dateFormat="lll" />
 					</span>
 				</div>

--- a/packages/odie-client/src/components/message/feedback-form.tsx
+++ b/packages/odie-client/src/components/message/feedback-form.tsx
@@ -88,9 +88,6 @@ export const FeedbackForm = ( { chatFeedbackOptions }: FeedbackFormProps ) => {
 	return (
 		<>
 			<div className={ clsx( 'odie-conversation__feedback', { has_message: score } ) }>
-				<div className="odie-conversation-feedback__text">
-					<p>{ __( 'Was this helpful?' ) }</p>
-				</div>
 				<div className="odie-conversation-feedback__thumbs">
 					<Button onClick={ () => postScore( 'good' ) }>
 						<ThumbsUpIcon />

--- a/packages/odie-client/src/components/message/feedback-form.tsx
+++ b/packages/odie-client/src/components/message/feedback-form.tsx
@@ -43,7 +43,10 @@ export const FeedbackForm = ( { chatFeedbackOptions }: FeedbackFormProps ) => {
 	const generateFeedbackMessage = useCallback(
 		( score: 'good' | 'bad' ): Message => {
 			return {
-				content: score === 'good' ? __( 'Good 👍' ) : __( 'Bad 👎' ),
+				content:
+					score === 'good'
+						? __( 'Good 👍', __i18n_text_domain__ )
+						: __( 'Bad 👎', __i18n_text_domain__ ),
 				payload: JSON.stringify( { csat_rating: score.toUpperCase() } ),
 				metadata: { rated: true },
 				role: 'user',
@@ -100,7 +103,11 @@ export const FeedbackForm = ( { chatFeedbackOptions }: FeedbackFormProps ) => {
 			{ score && (
 				<>
 					<div className="odie-rating-feedback-message">
-						<div>{ score === 'good' ? __( 'Good 👍' ) : __( 'Bad 👎' ) }</div>
+						<div>
+							{ score === 'good'
+								? __( 'Good 👍', __i18n_text_domain__ )
+								: __( 'Bad 👎', __i18n_text_domain__ ) }
+						</div>
 					</div>
 
 					{ isSubmitting && (
@@ -111,8 +118,13 @@ export const FeedbackForm = ( { chatFeedbackOptions }: FeedbackFormProps ) => {
 
 					{ ! isFormHidden && (
 						<div ref={ feedbackRef } className="odie-conversation-feedback__message">
-							<h3>{ __( 'Thank you for your input' ) }</h3>
-							<p>{ __( 'Please share any details that can help us understand your rating' ) }</p>
+							<h3>{ __( 'Thank you for your input', __i18n_text_domain__ ) }</h3>
+							<p>
+								{ __(
+									'Please share any details that can help us understand your rating',
+									__i18n_text_domain__
+								) }
+							</p>
 							{ score === 'bad' && (
 								<SelectControl
 									className="odie-conversation-feedback__reason"
@@ -125,7 +137,7 @@ export const FeedbackForm = ( { chatFeedbackOptions }: FeedbackFormProps ) => {
 							) }
 
 							<TextareaControl
-								label={ score === 'bad' ? __( 'Additional Comments' ) : '' }
+								label={ score === 'bad' ? __( 'Additional Comments', __i18n_text_domain__ ) : '' }
 								__nextHasNoMarginBottom
 								value={ comment }
 								onChange={ ( value ) => setComment( value ) }
@@ -133,7 +145,7 @@ export const FeedbackForm = ( { chatFeedbackOptions }: FeedbackFormProps ) => {
 
 							<div>
 								<Button variant="primary" onClick={ postCSAT } rel="noreferrer">
-									{ __( 'Send' ) }
+									{ __( 'Send', __i18n_text_domain__ ) }
 								</Button>
 
 								<Button
@@ -141,7 +153,7 @@ export const FeedbackForm = ( { chatFeedbackOptions }: FeedbackFormProps ) => {
 									onClick={ () => setIsFormHidden( true ) }
 									rel="noreferrer"
 								>
-									{ __( 'No thanks' ) }
+									{ __( 'No thanks', __i18n_text_domain__ ) }
 								</Button>
 							</div>
 						</div>

--- a/packages/odie-client/src/components/message/feedback-form.tsx
+++ b/packages/odie-client/src/components/message/feedback-form.tsx
@@ -112,9 +112,7 @@ export const FeedbackForm = ( { chatFeedbackOptions }: FeedbackFormProps ) => {
 					{ ! isFormHidden && (
 						<div ref={ feedbackRef } className="odie-conversation-feedback__message">
 							<h3>{ __( 'Thank you for your input' ) }</h3>
-							<p>
-								{ __( 'Please share any other details that can help understand your rating.' ) }
-							</p>
+							<p>{ __( 'Please share any details that can help us understand your rating' ) }</p>
 							{ score === 'bad' && (
 								<SelectControl
 									className="odie-conversation-feedback__reason"

--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -226,11 +226,14 @@ $blueberry-color: #3858e9;
 			}
 		}
 
+		.odie-chatbox-message__content {
+			flex-basis: calc(100% - 78px);
+		}
+
 		.odie-conversation__feedback {
 			width: 100%;
-			margin-left: 30px;
+			margin-left: 46px;
 			display: flex;
-			gap: 76px;
 			align-items: center;
 
 			&.has_message {
@@ -295,6 +298,11 @@ $blueberry-color: #3858e9;
 			button.is-primary {
 				margin-top: 10px;
     			margin-right: 8px;
+				background: var(--studio-wordpress-blue, #3858e9);
+			}
+
+			button.is-tertiary {
+				color: var(--studio-wordpress-blue, #3858e9);
 			}
 		}
 	}

--- a/packages/odie-client/src/utils/zendesk-message-converter.ts
+++ b/packages/odie-client/src/utils/zendesk-message-converter.ts
@@ -52,17 +52,20 @@ function getContentMessage( message: ZendeskMessage ): string {
 			if ( message.mediaUrl ) {
 				messageContent = createDownloadableMarkdownLink(
 					message.mediaUrl,
-					message.altText || __( 'Attachment' )
+					message.altText || __( 'Attachment', __i18n_text_domain__ )
 				);
 			}
 			break;
 		default:
 			// We don't support it yet return generic message.
-			messageContent = __( 'Message content not supported' );
+			messageContent = __( 'Message content not supported', __i18n_text_domain__ );
 	}
 
 	if ( message?.metadata?.type === 'csat' && message.actions?.length ) {
-		messageContent = __( 'Please help us improve. How would you rate your support experience?' );
+		messageContent = __(
+			'Please help us improve. How would you rate your support experience?',
+			__i18n_text_domain__
+		);
 	}
 
 	return messageContent;

--- a/packages/odie-client/src/utils/zendesk-message-converter.ts
+++ b/packages/odie-client/src/utils/zendesk-message-converter.ts
@@ -60,6 +60,11 @@ function getContentMessage( message: ZendeskMessage ): string {
 			// We don't support it yet return generic message.
 			messageContent = __( 'Message content not supported' );
 	}
+
+	if ( message?.metadata?.type === 'csat' && message.actions?.length ) {
+		messageContent = __( 'Please help us improve. How would you rate your support experience?' );
+	}
+
 	return messageContent;
 }
 

--- a/packages/zendesk-client/src/util.tsx
+++ b/packages/zendesk-client/src/util.tsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { isInSupportSession } from '@automattic/data-stores';
+import { __ } from '@wordpress/i18n';
 
 const IS_TEST_MODE_ENVIRONMENT = true;
 const IS_PRODUCTION_ENVIRONMENT = false;
@@ -31,19 +32,19 @@ export const isTestModeEnvironment = () => {
 export const getBadRatingReasons = () => {
 	if ( isTestModeEnvironment() ) {
 		return [
-			{ label: 'No reason provided', value: '' },
-			{ label: 'It took too long to get a reply.', value: '1001' },
-			{ label: 'The product cannot do what I want.', value: '1002' },
-			{ label: 'The issue was not resolved.', value: '1003' },
-			{ label: 'The Happiness Engineer was unhelpful.', value: '1004' },
+			{ label: __( 'No reason provided' ), value: '' },
+			{ label: __( 'It took too long to get a reply.' ), value: '1001' },
+			{ label: __( 'The product cannot do what I want.' ), value: '1002' },
+			{ label: __( 'The issue was not resolved.' ), value: '1003' },
+			{ label: __( 'The Happiness Engineer was unhelpful.' ), value: '1004' },
 		];
 	}
 
 	return [
-		{ label: 'No reason provided', value: '' },
-		{ label: 'It took too long to get a reply.', value: '1000' },
-		{ label: 'The product cannot do what I want.', value: '1001' },
-		{ label: 'The issue was not resolved.', value: '1002' },
-		{ label: 'The Happiness Engineer was unhelpful.', value: '1003' },
+		{ label: __( 'No reason provided' ), value: '' },
+		{ label: __( 'It took too long to get a reply.' ), value: '1000' },
+		{ label: __( 'The product cannot do what I want.' ), value: '1001' },
+		{ label: __( 'The issue was not resolved.' ), value: '1002' },
+		{ label: __( 'The Happiness Engineer was unhelpful.' ), value: '1003' },
 	];
 };

--- a/packages/zendesk-client/src/util.tsx
+++ b/packages/zendesk-client/src/util.tsx
@@ -32,19 +32,19 @@ export const isTestModeEnvironment = () => {
 export const getBadRatingReasons = () => {
 	if ( isTestModeEnvironment() ) {
 		return [
-			{ label: __( 'No reason provided' ), value: '' },
-			{ label: __( 'It took too long to get a reply.' ), value: '1001' },
-			{ label: __( 'The product cannot do what I want.' ), value: '1002' },
-			{ label: __( 'The issue was not resolved.' ), value: '1003' },
-			{ label: __( 'The Happiness Engineer was unhelpful.' ), value: '1004' },
+			{ label: __( 'No reason provided', __i18n_text_domain__ ), value: '' },
+			{ label: __( 'It took too long to get a reply.', __i18n_text_domain__ ), value: '1001' },
+			{ label: __( 'The product cannot do what I want.', __i18n_text_domain__ ), value: '1002' },
+			{ label: __( 'The issue was not resolved.', __i18n_text_domain__ ), value: '1003' },
+			{ label: __( 'The Happiness Engineer was unhelpful.', __i18n_text_domain__ ), value: '1004' },
 		];
 	}
 
 	return [
-		{ label: __( 'No reason provided' ), value: '' },
-		{ label: __( 'It took too long to get a reply.' ), value: '1000' },
-		{ label: __( 'The product cannot do what I want.' ), value: '1001' },
-		{ label: __( 'The issue was not resolved.' ), value: '1002' },
-		{ label: __( 'The Happiness Engineer was unhelpful.' ), value: '1003' },
+		{ label: __( 'No reason provided', __i18n_text_domain__ ), value: '' },
+		{ label: __( 'It took too long to get a reply.', __i18n_text_domain__ ), value: '1000' },
+		{ label: __( 'The product cannot do what I want.', __i18n_text_domain__ ), value: '1001' },
+		{ label: __( 'The issue was not resolved.', __i18n_text_domain__ ), value: '1002' },
+		{ label: __( 'The Happiness Engineer was unhelpful.', __i18n_text_domain__ ), value: '1003' },
 	];
 };

--- a/packages/zendesk-client/types.d.ts
+++ b/packages/zendesk-client/types.d.ts
@@ -1,3 +1,4 @@
+declare const __i18n_text_domain__: string;
 interface Window {
 	zE?: (
 		action: string,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13818

| Before  | After |
| ------------- | ------------- |
| <img width="418" alt="Screenshot 2025-07-08 at 15 52 26" src="https://github.com/user-attachments/assets/89b37b92-493b-4b77-a1f5-8ff481a97a8a" /> | <img width="414" alt="Screenshot 2025-07-08 at 15 51 57" src="https://github.com/user-attachments/assets/825312f8-8451-4bc6-85a0-70f383ddcf07" /> |
|<img width="416" alt="Screenshot 2025-07-08 at 15 54 52" src="https://github.com/user-attachments/assets/5853620c-0dd3-4544-8916-97186ff3e010" />| <img width="415" alt="Screenshot 2025-07-08 at 15 53 04" src="https://github.com/user-attachments/assets/ebdb463e-8633-415c-a311-eadf3c41a928" /> |
| <img width="413" alt="Screenshot 2025-07-08 at 16 11 12" src="https://github.com/user-attachments/assets/7c0785b5-4d83-46fe-902c-a4c489e3c057" />  | <img width="415" alt="Screenshot 2025-07-08 at 16 11 25" src="https://github.com/user-attachments/assets/ad681400-4083-44ac-9b9f-30943dc61a81" />  |
|<img width="412" alt="Screenshot 2025-07-08 at 16 11 01" src="https://github.com/user-attachments/assets/31f9990f-5ced-4b38-a0b8-21254d220f97" /> |<img width="406" alt="Screenshot 2025-07-08 at 16 10 43" src="https://github.com/user-attachments/assets/ac219d8a-ab34-42f8-961a-b95e78de46a9" /> |


## Proposed Changes

* Override default CSAT message from from `How did your chat go?` to `Please help us improve. How would you rate your support experience?`
* Change CSAT form message to `Please share any details that can help us understand your rating`
* Change CSAT form buttons to blueberry blue
* Adjust chat cell spacing. Noticed on Spanish locale this is way off.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improvements

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR or use PR link
* Open the help center and escalate to staging support
* Assign yourself the ticket and mark it as solved
* Test the customer satisfaction form and verify the changes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
