### PR TITLE
Lists management - improve empty state.

### DIFF
--- a/client/reader/list-manage/feed-item.tsx
+++ b/client/reader/list-manage/feed-item.tsx
@@ -65,6 +65,7 @@ export default function FeedItem( props: {
 	item: Item;
 	list: List;
 	owner: string;
+	hideFollowButton?: boolean;
 } ) {
 	const { list, owner, item } = props;
 	const feed = useSelector( ( state ) => {
@@ -106,7 +107,7 @@ export default function FeedItem( props: {
 		<Card className="list-manage__site-card">
 			{ isFeedError( feed ) ? renderFeedError( feed ) : renderFeed( feed ) }
 
-			{ props.isFollowed && (
+			{ props.isFollowed && ! props.hideFollowButton && (
 				<FollowButton followLabel={ translate( 'Following site' ) } following />
 			) }
 

--- a/client/reader/list-manage/feed-item.tsx
+++ b/client/reader/list-manage/feed-item.tsx
@@ -75,6 +75,7 @@ export default function FeedItem( props: {
 		}
 		return feed;
 	} );
+	const isRecommendedBlogsList = list.slug === 'recommended-blogs';
 
 	const isInList = !! useSelector( ( state ) =>
 		getMatchingItem( state, { feedId: item.feed_ID, listId: list.ID } )
@@ -113,7 +114,7 @@ export default function FeedItem( props: {
 
 			{ ! isInList ? (
 				<Button primary onClick={ addItem }>
-					{ translate( 'Add' ) }
+					{ isRecommendedBlogsList ? translate( 'Recommend' ) : translate( 'Add' ) }
 				</Button>
 			) : (
 				<Button primary onClick={ () => setShowDeleteConfirmation( true ) }>

--- a/client/reader/list-manage/index.jsx
+++ b/client/reader/list-manage/index.jsx
@@ -25,6 +25,7 @@ import ItemAdder from './item-adder';
 import ListDelete from './list-delete';
 import ListForm from './list-form';
 import ListItem from './list-item';
+import SubscriptionItemAdder from './subscription-item-adder';
 
 import './style.scss';
 
@@ -62,6 +63,7 @@ function Items( { list, listItems, owner } ) {
 					) ) }
 				</>
 			) }
+			<SubscriptionItemAdder list={ list } listItems={ listItems } owner={ owner } />
 		</>
 	);
 }

--- a/client/reader/list-manage/item-adder.jsx
+++ b/client/reader/list-manage/item-adder.jsx
@@ -1,6 +1,6 @@
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import QueryReaderFeedsSearch from 'calypso/components/data/query-reader-feeds-search';
 import SyncReaderFollows from 'calypso/components/data/sync-reader-follows';
@@ -15,26 +15,16 @@ import ListItem from './list-item';
 
 export default function ItemAdder( props ) {
 	const translate = useTranslate();
-	const [ renderAllFollows, setRenderAllFollows ] = useState( false );
 
 	const [ query, updateQuery ] = useState( '' );
 	const queryIsUrl = resemblesUrl( query );
 	const followResults = useSelector( ( state ) =>
 		filterFollowsByQuery( query, getReaderFollows( state ) ).slice( 0, 7 )
 	);
-	const allFollows = useSelector( ( state ) => getReaderFollows( state ) );
+
 	const feedResults = useSelector( ( state ) =>
 		getReaderFeedsForQuery( state, { query, excludeFollowed: false, sort: SORT_BY_RELEVANCE } )
 	);
-
-	// Continue showing the all follows list when there is no query, if we have been in the empty
-	// state and exposed it once in this session.
-	useEffect( () => {
-		if ( props.listItems?.length === 0 ) {
-			setRenderAllFollows( true );
-		}
-	}, [ props.listItems ] );
-	const showAllFollows = renderAllFollows && ! query;
 
 	return (
 		<div className="list-manage__item-adder" id="reader-list-item-adder">
@@ -81,24 +71,6 @@ export default function ItemAdder( props ) {
 						owner={ props.owner }
 					/>
 				) ) }
-			{ showAllFollows && (
-				<>
-					<h2 className="list-manage-item-adder__all-subscriptions">
-						{ translate( 'Your subscriptions' ) }
-					</h2>
-					{ allFollows.map( ( item ) => (
-						<ListItem
-							hideIfInList
-							isFollowed
-							hideFollowButton
-							item={ item }
-							key={ item.feed_ID || item.site_ID || item.tag_ID || item.feed_URL }
-							list={ props.list }
-							owner={ props.owner }
-						/>
-					) ) }
-				</>
-			) }
 		</div>
 	);
 }

--- a/client/reader/list-manage/item-adder.jsx
+++ b/client/reader/list-manage/item-adder.jsx
@@ -83,6 +83,7 @@ export default function ItemAdder( props ) {
 						<ListItem
 							hideIfInList
 							isFollowed
+							hideFollowButton
 							item={ item }
 							key={ item.feed_ID || item.site_ID || item.tag_ID || item.feed_URL }
 							list={ props.list }

--- a/client/reader/list-manage/item-adder.jsx
+++ b/client/reader/list-manage/item-adder.jsx
@@ -1,6 +1,6 @@
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import QueryReaderFeedsSearch from 'calypso/components/data/query-reader-feeds-search';
 import SyncReaderFollows from 'calypso/components/data/sync-reader-follows';
@@ -15,6 +15,7 @@ import ListItem from './list-item';
 
 export default function ItemAdder( props ) {
 	const translate = useTranslate();
+	const [ renderAllFollows, setRenderAllFollows ] = useState( false );
 
 	const [ query, updateQuery ] = useState( '' );
 	const queryIsUrl = resemblesUrl( query );
@@ -26,8 +27,14 @@ export default function ItemAdder( props ) {
 		getReaderFeedsForQuery( state, { query, excludeFollowed: false, sort: SORT_BY_RELEVANCE } )
 	);
 
-	const isEmptyList = props.listItems?.length === 0;
-	const showAllFollows = isEmptyList && ! query;
+	// Continue showing the all follows list when there is no query, if we have been in the empty
+	// state and exposed it once in this session.
+	useEffect( () => {
+		if ( props.listItems?.length === 0 ) {
+			setRenderAllFollows( true );
+		}
+	}, [ props.listItems ] );
+	const showAllFollows = renderAllFollows && ! query;
 
 	return (
 		<div className="list-manage__item-adder" id="reader-list-item-adder">

--- a/client/reader/list-manage/item-adder.jsx
+++ b/client/reader/list-manage/item-adder.jsx
@@ -21,9 +21,13 @@ export default function ItemAdder( props ) {
 	const followResults = useSelector( ( state ) =>
 		filterFollowsByQuery( query, getReaderFollows( state ) ).slice( 0, 7 )
 	);
+	const allFollows = useSelector( ( state ) => getReaderFollows( state ) );
 	const feedResults = useSelector( ( state ) =>
 		getReaderFeedsForQuery( state, { query, excludeFollowed: false, sort: SORT_BY_RELEVANCE } )
 	);
+
+	const isEmptyList = props.listItems?.length === 0;
+	const showAllFollows = isEmptyList && ! query;
 
 	return (
 		<div className="list-manage__item-adder" id="reader-list-item-adder">
@@ -70,6 +74,23 @@ export default function ItemAdder( props ) {
 						owner={ props.owner }
 					/>
 				) ) }
+			{ showAllFollows && (
+				<>
+					<h2 className="list-manage-item-adder__all-subscriptions">
+						{ translate( 'Your subscriptions' ) }
+					</h2>
+					{ allFollows.map( ( item ) => (
+						<ListItem
+							hideIfInList
+							isFollowed
+							item={ item }
+							key={ item.feed_ID || item.site_ID || item.tag_ID || item.feed_URL }
+							list={ props.list }
+							owner={ props.owner }
+						/>
+					) ) }
+				</>
+			) }
 		</div>
 	);
 }

--- a/client/reader/list-manage/site-item.tsx
+++ b/client/reader/list-manage/site-item.tsx
@@ -77,6 +77,7 @@ export default function SiteItem( props: {
 	const isInList = !! useSelector( ( state ) =>
 		getMatchingItem( state, { siteId: props.item.site_ID, listId: props.list.ID } )
 	);
+	const isRecommendedBlogsList = list.slug === 'recommended-blogs';
 
 	const [ showDeleteConfirmation, setShowDeleteConfirmation ] = useState( false );
 	const addItem = () =>
@@ -111,7 +112,7 @@ export default function SiteItem( props: {
 
 			{ ! isInList ? (
 				<Button primary onClick={ addItem }>
-					{ translate( 'Add' ) }
+					{ isRecommendedBlogsList ? translate( 'Recommend' ) : translate( 'Add' ) }
 				</Button>
 			) : (
 				<Button primary onClick={ () => setShowDeleteConfirmation( true ) }>

--- a/client/reader/list-manage/site-item.tsx
+++ b/client/reader/list-manage/site-item.tsx
@@ -67,6 +67,7 @@ export default function SiteItem( props: {
 	item: Item;
 	list: List;
 	owner: string;
+	hideFollowButton?: boolean;
 } ) {
 	const { item, list, owner } = props;
 	const site = props.item.meta?.data?.site as Site | SiteError | undefined;
@@ -104,7 +105,7 @@ export default function SiteItem( props: {
 		<Card className="list-manage__site-card">
 			{ isSiteError( site ) ? renderSiteError( site ) : renderSite( site ) }
 
-			{ props.isFollowed && (
+			{ props.isFollowed && ! props.hideFollowButton && (
 				<FollowButton followLabel={ translate( 'Following site' ) } following />
 			) }
 

--- a/client/reader/list-manage/style.scss
+++ b/client/reader/list-manage/style.scss
@@ -130,4 +130,10 @@
 		position: relative;
 		z-index: 1;
 	}
+
+	.list-manage-item-adder__all-subscriptions {
+		font-size: 1.25rem;
+		font-weight: 500;
+		margin-bottom: 10px;
+	}
 }

--- a/client/reader/list-manage/style.scss
+++ b/client/reader/list-manage/style.scss
@@ -130,10 +130,10 @@
 		position: relative;
 		z-index: 1;
 	}
+}
 
-	.list-manage-item-adder__all-subscriptions {
-		font-size: 1.25rem;
-		font-weight: 500;
-		margin-bottom: 10px;
-	}
+.list-manage-subscription-item-adder__title {
+	font-size: 1.25rem;
+	font-weight: 500;
+	margin-bottom: 10px;
 }

--- a/client/reader/list-manage/style.scss
+++ b/client/reader/list-manage/style.scss
@@ -104,7 +104,9 @@
 }
 
 .list-manage__subscriptions-header {
-	margin: 1em 0;
+	margin: 1em 0.5em;
+	font-weight: 500;
+	font-size: 1.25rem;
 
 	.button {
 		margin-left: 1em;
@@ -130,10 +132,4 @@
 		position: relative;
 		z-index: 1;
 	}
-}
-
-.list-manage-subscription-item-adder__title {
-	font-size: 1.25rem;
-	font-weight: 500;
-	margin-bottom: 10px;
 }

--- a/client/reader/list-manage/subscription-item-adder.jsx
+++ b/client/reader/list-manage/subscription-item-adder.jsx
@@ -21,15 +21,13 @@ export default function SubscriptionItemAdder( { list, listItems, owner } ) {
 		}
 	}, [ listItems ] );
 
-	if ( ! renderAllFollows ) {
+	if ( ! renderAllFollows || ! allFollows?.length ) {
 		return null;
 	}
 
 	return (
 		<>
-			<h2 className="list-manage-subscription-item-adder__title">
-				{ translate( 'Your subscriptions' ) }
-			</h2>
+			<h2 className="list-manage__subscriptions-header">{ translate( 'Your subscriptions' ) }</h2>
 			{ allFollows.map( ( item ) => (
 				<ListItem
 					hideIfInList

--- a/client/reader/list-manage/subscription-item-adder.jsx
+++ b/client/reader/list-manage/subscription-item-adder.jsx
@@ -1,0 +1,46 @@
+import { useTranslate } from 'i18n-calypso';
+import { useState, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { getReaderFollows } from 'calypso/state/reader/follows/selectors';
+import ListItem from './list-item';
+
+// This is different than the item adder as this simply shows followed subscriptions to recommended
+// adding, and only appears if the list has been empty. This is also intended to show beneath the
+// list items (where the item adder shows items above), so items it adds are not hidden beneath the
+// long list of subs.
+export default function SubscriptionItemAdder( { list, listItems, owner } ) {
+	const translate = useTranslate();
+	const [ renderAllFollows, setRenderAllFollows ] = useState( false );
+
+	const allFollows = useSelector( ( state ) => getReaderFollows( state ) );
+
+	// Continue showing the subscriptions list if we have showed it once in this session.
+	useEffect( () => {
+		if ( listItems?.length === 0 ) {
+			setRenderAllFollows( true );
+		}
+	}, [ listItems ] );
+
+	if ( ! renderAllFollows ) {
+		return null;
+	}
+
+	return (
+		<>
+			<h2 className="list-manage-subscription-item-adder__title">
+				{ translate( 'Your subscriptions' ) }
+			</h2>
+			{ allFollows.map( ( item ) => (
+				<ListItem
+					hideIfInList
+					isFollowed
+					hideFollowButton
+					item={ item }
+					key={ item.feed_ID || item.site_ID || item.tag_ID || item.feed_URL }
+					list={ list }
+					owner={ owner }
+				/>
+			) ) }
+		</>
+	);
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/CML-595/improve-recommended-blogs-list-blank-slate

## Proposed Changes

Improves empty list management interface by adding a list of the users subscriptions to easily add to the list.
* This list appears only if the list has had 0 items in the management session. After adding an item, this should still be visible. Loading this interface with a list that has items should not render this section.
* These items appear beneath list items / at the bottom of this interface. This ensures list items added by this section are clearly visible in the interface as part of the list.
* Removes the following label for these items from the card, since it is already clear as part of "Your subscriptions" that it is followed and the labels are extra clutter.
* Changes the label from "Add" to "Recommend" when the list slug is `recommended-blogs`.


BEFORE

![Screenshot 2025-07-08 at 10 45 48 AM](https://github.com/user-attachments/assets/5eabc176-caef-4b1d-93de-364bd0bc54f4)

AFTER

![Screenshot 2025-07-08 at 10 46 04 AM](https://github.com/user-attachments/assets/295299b0-e97f-4af2-a7d7-a28c31d96e10)
![Screenshot 2025-07-08 at 10 46 15 AM](https://github.com/user-attachments/assets/460784d7-f8f1-4ff4-a30c-04ecfdf9c59b)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve empty state for recommended blogs and lists management.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to add a new list or manage an empty list.
* Under 'sites' when none are followed, verify there is a new "Your subscriptions" section.
* Verify you can add a site from this section.
* Verify the section is still available.
* Verify prior functionality for searching and adding items continues to work as expected.
* When on the recommended blogs list, verify items are CTA'd with "Recommend" instead of "Add", and that Add is still the copy on other lists.
* Reload the page or visit a list that has items, verify this does not appear.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
