### PR TITLE
Staging Sync: Add siteId prop to File Browser

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
@@ -14,22 +14,22 @@ import canRestoreSite from 'calypso/state/rewind/selectors/can-restore-site';
 import getBackupBrowserCheckList from 'calypso/state/rewind/selectors/get-backup-browser-check-list';
 import getBackupBrowserNode from 'calypso/state/rewind/selectors/get-backup-browser-node';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { backupGranularRestorePath } from '../../paths';
 import { FileBrowserCheckState } from './types';
 
 interface FileBrowserHeaderProps {
 	rewindId: number;
 	showHeaderButtons?: boolean;
+	siteId: number;
 }
 
 const FileBrowserHeader: FunctionComponent< FileBrowserHeaderProps > = ( {
 	rewindId,
 	showHeaderButtons = true,
+	siteId,
 } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
-	const siteId = useSelector( getSelectedSiteId ) as number;
 	const rootNode = useSelector( ( state ) => getBackupBrowserNode( state, siteId, '/' ) );
 	const browserCheckList = useSelector( ( state ) => getBackupBrowserCheckList( state, siteId ) );
 	const isRestoreDisabled = useSelector( ( state ) => ! canRestoreSite( state, siteId ) );

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -7,7 +7,6 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { addChildNodes, setNodeCheckState } from 'calypso/state/rewind/browser/actions';
 import getBackupBrowserNode from 'calypso/state/rewind/selectors/get-backup-browser-node';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import FileInfoCard from './file-info-card';
 import FileTypeIcon from './file-type-icon';
 import { useTruncatedFileName } from './hooks';
@@ -22,6 +21,7 @@ interface FileBrowserNodeProps {
 	setActiveNodePath: ( path: string ) => void;
 	activeNodePath: string;
 	parentItem?: FileBrowserItem; // This is used to pass the extension details to the child node
+	siteId: number;
 }
 
 const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
@@ -32,6 +32,7 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 	setActiveNodePath,
 	activeNodePath,
 	parentItem,
+	siteId,
 } ) => {
 	const isRoot = path === '/';
 	const dispatch = useDispatch();
@@ -39,7 +40,6 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 	const [ fetchContentsOnMount, setFetchContentsOnMount ] = useState< boolean >( isRoot );
 	const [ isOpen, setIsOpen ] = useState< boolean >( isRoot );
 	const [ addedAnyChildren, setAddedAnyChildren ] = useState< boolean >( false );
-	const siteId = useSelector( getSelectedSiteId ) as number;
 	const browserNodeItem = useSelector( ( state ) => getBackupBrowserNode( state, siteId, path ) );
 
 	const {
@@ -201,6 +201,7 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 						isAlternate={ childIsAlternate }
 						activeNodePath={ activeNodePath }
 						setActiveNodePath={ setActiveNodePath }
+						siteId={ siteId }
 						// Hacky way to pass extensions details to the child node
 						{ ...( childItem.type === 'archive' ? { parentItem: item } : {} ) }
 					/>

--- a/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
@@ -1,5 +1,7 @@
 import { useState } from '@wordpress/element';
 import { FunctionComponent } from 'react';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import FileBrowserHeader from './file-browser-header';
 import FileBrowserNode from './file-browser-node';
 import { FileBrowserItem } from './types';
@@ -7,14 +9,18 @@ import { FileBrowserItem } from './types';
 interface FileBrowserProps {
 	rewindId: number;
 	showHeaderButtons?: boolean;
+	siteId?: number;
 }
 
 const FileBrowser: FunctionComponent< FileBrowserProps > = ( {
 	rewindId,
 	showHeaderButtons = true,
+	siteId: propSiteId,
 } ) => {
 	// This is the path of the node that is clicked
 	const [ activeNodePath, setActiveNodePath ] = useState< string >( '' );
+	const selectedSiteId = useSelector( getSelectedSiteId ) as number;
+	const siteId = propSiteId ?? selectedSiteId;
 
 	const handleClick = ( path: string ) => {
 		setActiveNodePath( path );
@@ -28,7 +34,11 @@ const FileBrowser: FunctionComponent< FileBrowserProps > = ( {
 
 	return (
 		<div>
-			<FileBrowserHeader rewindId={ rewindId } showHeaderButtons={ showHeaderButtons } />
+			<FileBrowserHeader
+				rewindId={ rewindId }
+				showHeaderButtons={ showHeaderButtons }
+				siteId={ siteId }
+			/>
 			<FileBrowserNode
 				rewindId={ rewindId }
 				item={ rootItem }
@@ -36,6 +46,7 @@ const FileBrowser: FunctionComponent< FileBrowserProps > = ( {
 				isAlternate
 				setActiveNodePath={ handleClick }
 				activeNodePath={ activeNodePath }
+				siteId={ siteId }
 			/>
 		</div>
 	);

--- a/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
@@ -15,12 +15,12 @@ interface FileBrowserProps {
 const FileBrowser: FunctionComponent< FileBrowserProps > = ( {
 	rewindId,
 	showHeaderButtons = true,
-	siteId: propSiteId,
+	siteId,
 } ) => {
 	// This is the path of the node that is clicked
 	const [ activeNodePath, setActiveNodePath ] = useState< string >( '' );
 	const selectedSiteId = useSelector( getSelectedSiteId ) as number;
-	const siteId = propSiteId ?? selectedSiteId;
+	const effectiveSiteId = siteId ?? selectedSiteId;
 
 	const handleClick = ( path: string ) => {
 		setActiveNodePath( path );
@@ -37,7 +37,7 @@ const FileBrowser: FunctionComponent< FileBrowserProps > = ( {
 			<FileBrowserHeader
 				rewindId={ rewindId }
 				showHeaderButtons={ showHeaderButtons }
-				siteId={ siteId }
+				siteId={ effectiveSiteId }
 			/>
 			<FileBrowserNode
 				rewindId={ rewindId }
@@ -46,7 +46,7 @@ const FileBrowser: FunctionComponent< FileBrowserProps > = ( {
 				isAlternate
 				setActiveNodePath={ handleClick }
 				activeNodePath={ activeNodePath }
-				siteId={ siteId }
+				siteId={ effectiveSiteId }
 			/>
 		</div>
 	);

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -223,7 +223,7 @@ export default function SyncModal( {
 				<SectionHeader level={ 3 } title={ syncConfig.syncSelectionHeading } />
 				{ querySiteId === stagingSiteId && (
 					<div className="staging-site-card">
-						<FileBrowser rewindId={ rewindId } showHeaderButtons={ false } />
+						<FileBrowser rewindId={ rewindId } showHeaderButtons={ false } siteId={ querySiteId } />
 					</div>
 				) }
 				<Text>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes [DOTDEV-205 Staging Sites Redesign: Allow the File Browser to display a different Site than selected](https://linear.app/a8c/issue/DOTDEV-205/staging-sites-redesign-allow-the-file-browser-to-display-a-different)

## Proposed Changes

This PR modifies the File Browser component to accept an optional `siteId` prop, allowing it to display files from a specific site rather than always using the currently selected site.

- Added optional `siteId` prop to `FileBrowser` component
- Modified child components (`FileBrowserHeader` and `FileBrowserNode`) to accept and use the provided `siteId`
- Implemented fallback to `selectedSiteId` when no specific `siteId` is provided
- Removed redundant `getSelectedSiteId` calls from child components

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* [DOTDEV-205 Staging Sites Redesign: Allow the File Browser to display a different Site than selected](https://linear.app/a8c/issue/DOTDEV-205/staging-sites-redesign-allow-the-file-browser-to-display-a-different)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply these changes and start Calypso. That will enable the feature flag `hosting/staging-sites-redesign`
* Make sure you have a Production with a linked Staging site, [more info here](https://developer.wordpress.com/docs/developer-tools/staging-sites/) 
* Optionally, make some change on the staging site that's easy to recognize, eg. remove a plugin, then backup the staging site from the `/backup/:siteId` page manually
* Navigate to the staging site, and click on the Sync dropdown on the top-right corner
* Select `Push to Production`
* On the opened modal, note the folder structure, and identify any changes you've made
* Navigate to the production site, and click on the Sync dropdown on the top-right corner
* Select `Pull from staging`
* On the opened modal, check that the folder structure matches the one you've seen earlier, so this file browser also lists the files from the staging site

Eg. after removing the `give` plugin from only the staging site:
| Pull from Staging | Push to Prod |
|--------|--------|
| ![CleanShot 2025-07-08 at 15 19 09@2x](https://github.com/user-attachments/assets/356f8432-31ac-4269-9597-9cd821135dd3) | ![CleanShot 2025-07-08 at 15 19 25@2x](https://github.com/user-attachments/assets/1ee6e9e7-4a78-4138-ab43-30c92c4d4bd7) | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
