### PR TITLE
Help Center: Show launchpad only if site owner

### DIFF
--- a/packages/data-stores/src/help-center/types.ts
+++ b/packages/data-stores/src/help-center/types.ts
@@ -32,6 +32,7 @@ export interface HelpCenterSite {
 	is_wpcom_atomic: boolean;
 	jetpack: boolean;
 	logo: SiteLogo;
+	site_owner: number;
 	options: {
 		launchpad_screen: string;
 		site_intent: string;

--- a/packages/help-center/src/components/help-center-search.tsx
+++ b/packages/help-center/src/components/help-center-search.tsx
@@ -26,7 +26,7 @@ export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSe
 	const navigate = useNavigate();
 	const { search } = useLocation();
 	const params = new URLSearchParams( search );
-	const { sectionName, site } = useHelpCenterContext();
+	const { sectionName, site, currentUser } = useHelpCenterContext();
 	const query = params.get( 'query' );
 	const [ searchQuery, setSearchQuery ] = useState( query || '' );
 	const { setSubject, setMessage } = useDispatch( HELP_CENTER_STORE );
@@ -45,7 +45,8 @@ export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSe
 		[ setSubject, setMessage, onSearchChange ]
 	);
 
-	const launchpadEnabled = site?.options?.launchpad_screen === 'full';
+	const isSiteOwner = site?.site_owner === currentUser?.ID;
+	const launchpadEnabled = site?.options?.launchpad_screen === 'full' && isSiteOwner;
 
 	// Search query can be a query param, if the user searches or clears the search field
 	// we need to keep the query param up-to-date with that


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTSUP-240/help-center-showing-misleading-prompt-for-non-admins

## Proposed Changes

Show the Launchpad in the Help Center only to site owners.

<img width="449" alt="image" src="https://github.com/user-attachments/assets/3721fa0f-1726-41ee-8632-0aac7547d32e" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

If you're accessing the Help Center as an Editor (or other non-admin role) and the original site is not yet onboarding-complete (e.g., launched but still showing the Launchpad steps), the Help Center displays a dialogue saying:
“Continue setting up your site with these next steps.”

However, clicking this as a non-admin doesn't actually do anything 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a website that shows the launchpad, such as from `/setup/start-writing`.
* On the website, you should see the Launchpad.
* Invite another user as an editor.
* Enter the website as the other user (editor) and open the Help Center.
* No Launchpad should be shown.
