### PR TITLE
Reader profile - register Id route before username and view routes.

### DIFF
--- a/client/reader/index.ts
+++ b/client/reader/index.ts
@@ -84,7 +84,7 @@ export default async function (): Promise< void > {
 
 		// User profile
 		page(
-			[ '/reader/users/:user_login', '/reader/users/:user_login/:view' ],
+			'/reader/users/id/:user_id',
 			blogDiscoveryByFeedId,
 			redirectLoggedOutToSignup,
 			sidebar,
@@ -94,7 +94,7 @@ export default async function (): Promise< void > {
 		);
 
 		page(
-			'/reader/users/id/:user_id',
+			[ '/reader/users/:user_login', '/reader/users/:user_login/:view' ],
 			blogDiscoveryByFeedId,
 			redirectLoggedOutToSignup,
 			sidebar,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/CML-644/user-not-found-message-shown-when-clicking-on-the-user-name-in-the

regression from https://github.com/Automattic/wp-calypso/pull/104524/files 

## Proposed Changes

Reorders how we define the user profile routes, defining the id route first.
* Last week I refactored the routing for the user profile as part of adding a new tab, the refactor being necessary to fix this a11y issue - https://linear.app/a8c/issue/CML-440/reader-user-profile-does-not-preserve-focus-when-selecting-tabs-for
* In the refactor, we enabled routes for `/reader/users/:user_login/:view`.
* The above was defined before the ID route (`/reader/users/id/:user_id` ), thus the ID route would never trigger when expected and instead would be the userlogin route with "id" as the user_login and the id number as the view, resulting in unexpected results like "user not found".
* Defining the more specific route first makes sense to resolve the issue.


BEFORE
![Screenshot 2025-07-08 at 12 00 46 PM](https://github.com/user-attachments/assets/3a3aaa43-03e8-467a-9771-5a42ab1d45ee)


AFTER
![Screenshot 2025-07-08 at 12 00 54 PM](https://github.com/user-attachments/assets/b49c21e7-ae16-43fb-b14b-e5737fc31893)



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Unexpected "user not found" pages.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `*/reader/users/id/5`, and verify it loads as expected and directs to the `/reader/users/{username}` route.
* Smoke test the reader profile pages.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
