### PR TITLE
Site list v2: retain `fields` and type-specific `layout` when changing view type

### DIFF
--- a/client/dashboard/app/queries/me-preferences.ts
+++ b/client/dashboard/app/queries/me-preferences.ts
@@ -2,12 +2,15 @@ import { fetchPreferences, updatePreferences } from '../../data/me-preferences';
 import { queryClient } from '../query-client';
 import type { UserPreferences } from '../../data/me-preferences';
 
-export const userPreferencesQuery = ( preferenceName?: keyof UserPreferences ) => ( {
+export const userPreferencesQuery = (
+	preferenceName?: keyof UserPreferences,
+	defaultValue?: UserPreferences[ keyof UserPreferences ]
+) => ( {
 	queryKey: [ 'me', 'preferences' ],
 	queryFn: fetchPreferences,
 	select: ( data: UserPreferences ) => {
 		if ( preferenceName ) {
-			return data[ preferenceName ] || {};
+			return data[ preferenceName ] || defaultValue;
 		}
 
 		return data;

--- a/client/dashboard/app/queries/me-preferences.ts
+++ b/client/dashboard/app/queries/me-preferences.ts
@@ -7,7 +7,7 @@ export const userPreferencesQuery = ( preferenceName?: keyof UserPreferences ) =
 	queryFn: fetchPreferences,
 	select: ( data: UserPreferences ) => {
 		if ( preferenceName ) {
-			return data[ preferenceName ];
+			return data[ preferenceName ] || {};
 		}
 
 		return data;
@@ -22,7 +22,7 @@ export const userPreferencesMutation = ( preferenceName?: keyof UserPreferences 
 			} );
 		}
 
-		return updatePreferences( data );
+		return updatePreferences( data as UserPreferences );
 	},
 	onSuccess: ( newData: Partial< UserPreferences > ) => {
 		queryClient.setQueryData(

--- a/client/dashboard/data/me-preferences.ts
+++ b/client/dashboard/data/me-preferences.ts
@@ -1,7 +1,7 @@
 import wpcom from 'calypso/lib/wp';
 
 export interface UserPreferences {
-	'sites-view': Record< string, unknown >;
+	'dashboard-sites-view'?: Record< string, unknown >;
 }
 
 export async function fetchPreferences(): Promise< UserPreferences > {

--- a/client/dashboard/data/me-preferences.ts
+++ b/client/dashboard/data/me-preferences.ts
@@ -1,7 +1,7 @@
 import wpcom from 'calypso/lib/wp';
 
 export interface UserPreferences {
-	'dashboard-sites-view'?: Record< string, unknown >;
+	'sites-view'?: Record< string, unknown >;
 }
 
 export async function fetchPreferences(): Promise< UserPreferences > {

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -50,7 +50,7 @@ export default function Sites() {
 
 	const { user } = useAuth();
 	const { data: isAutomattician } = useSuspenseQuery( isAutomatticianQuery() );
-	const viewPreferences = useSuspenseQuery( userPreferencesQuery( 'sites-view' ) )
+	const viewPreferences = useSuspenseQuery( userPreferencesQuery( 'sites-view', {} ) )
 		.data as ViewPreferences;
 	const { mutate: updateViewPreferences } = useMutation( userPreferencesMutation( 'sites-view' ) );
 

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -16,7 +16,7 @@ import { getActions } from './actions';
 import AddNewSite from './add-new-site';
 import { getFields } from './fields';
 import { SitesNotices } from './notices';
-import { getView, getUpdatedView, DEFAULT_LAYOUTS } from './views';
+import { getView, mergeViews, DEFAULT_LAYOUTS } from './views';
 import type { ViewPreferences, ViewSearchParams } from './views';
 import type { FetchSitesOptions, Site } from '../data/types';
 import type { View, Filter } from '@automattic/dataviews';
@@ -77,7 +77,7 @@ export default function Sites() {
 			return;
 		}
 
-		const { updatedViewPreferences, updatedViewSearchParams } = getUpdatedView( {
+		const { updatedViewPreferences, updatedViewSearchParams } = mergeViews( {
 			defaultView,
 			view,
 			viewPreferences,

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -3,7 +3,6 @@ import { useQuery, useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { useNavigate, useRouter } from '@tanstack/react-router';
 import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import fastDeepEqual from 'fast-deep-equal/es6';
 import { useState } from 'react';
 import { useAuth } from '../app/auth';
 import { isAutomatticianQuery } from '../app/queries/me-a8c';
@@ -17,9 +16,10 @@ import { getActions } from './actions';
 import AddNewSite from './add-new-site';
 import { getFields } from './fields';
 import { SitesNotices } from './notices';
-import { getView, DEFAULT_LAYOUTS, CONFIGURABLE_VIEW_KEYS, PERSISTABLE_VIEW_KEYS } from './views';
+import { getView, getUpdatedView, DEFAULT_LAYOUTS } from './views';
+import type { ViewPreferences, ViewSearchParams } from './views';
 import type { FetchSitesOptions, Site } from '../data/types';
-import type { View, ViewTable, ViewGrid, Filter } from '@automattic/dataviews';
+import type { View, Filter } from '@automattic/dataviews';
 
 const getFetchSitesOptions = ( view: View, isRestoringAccount: boolean ): FetchSitesOptions => {
 	const filters = view.filters ?? [];
@@ -45,20 +45,23 @@ export default function Sites() {
 	const navigate = useNavigate( { from: sitesRoute.fullPath } );
 	const router = useRouter();
 	const currentSearchParams = sitesRoute.useSearch();
-	const viewOptions: Partial< ViewTable | ViewGrid > = currentSearchParams.view ?? {};
+	const viewSearchParams: ViewSearchParams = currentSearchParams.view ?? {};
 	const isRestoringAccount = !! currentSearchParams.restored;
 
 	const { user } = useAuth();
 	const { data: isAutomattician } = useSuspenseQuery( isAutomatticianQuery() );
-	const { data: viewPreferences } = useSuspenseQuery( userPreferencesQuery( 'sites-view' ) );
-	const { mutate: updateViewPreferences } = useMutation( userPreferencesMutation( 'sites-view' ) );
+	const viewPreferences = useSuspenseQuery( userPreferencesQuery( 'dashboard-sites-view' ) )
+		.data as ViewPreferences;
+	const { mutate: updateViewPreferences } = useMutation(
+		userPreferencesMutation( 'dashboard-sites-view' )
+	);
 
 	const { defaultView, view } = getView( {
 		user,
 		isAutomattician,
 		isRestoringAccount,
-		viewPreferences: viewPreferences as Partial< View >,
-		viewOptions,
+		viewPreferences,
+		viewSearchParams,
 	} );
 
 	const { data: sites, isLoading: isLoadingSites } = useQuery(
@@ -76,44 +79,21 @@ export default function Sites() {
 			return;
 		}
 
-		if ( nextView.type !== view.type ) {
-			navigate( {
-				search: {
-					...currentSearchParams,
-					view: { type: nextView.type },
-				},
-			} );
-			updateViewPreferences( { type: nextView.type } );
-			return;
-		}
-
-		const _defaultView = {
-			...defaultView,
-			...DEFAULT_LAYOUTS[ nextView.type as keyof typeof DEFAULT_LAYOUTS ],
-		};
+		const { updatedViewPreferences, updatedViewSearchParams } = getUpdatedView( {
+			defaultView,
+			view,
+			viewPreferences,
+			nextView,
+		} );
 
 		navigate( {
 			search: {
 				...currentSearchParams,
-				view: Object.fromEntries(
-					Object.entries( nextView ).filter(
-						( [ key, value ] ) =>
-							CONFIGURABLE_VIEW_KEYS.includes( key ) &&
-							! fastDeepEqual( value, _defaultView[ key as keyof typeof _defaultView ] )
-					)
-				),
+				view: updatedViewSearchParams,
 			},
 		} );
 
-		updateViewPreferences(
-			Object.fromEntries(
-				Object.entries( nextView ).filter(
-					( [ key, value ] ) =>
-						PERSISTABLE_VIEW_KEYS.includes( key ) &&
-						! fastDeepEqual( value, _defaultView[ key as keyof typeof _defaultView ] )
-				)
-			)
-		);
+		updateViewPreferences( updatedViewPreferences as Record< string, unknown > );
 	};
 
 	return (

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -76,6 +76,17 @@ export default function Sites() {
 			return;
 		}
 
+		if ( nextView.type !== view.type ) {
+			navigate( {
+				search: {
+					...currentSearchParams,
+					view: { type: nextView.type },
+				},
+			} );
+			updateViewPreferences( { type: nextView.type } );
+			return;
+		}
+
 		const _defaultView = {
 			...defaultView,
 			...DEFAULT_LAYOUTS[ nextView.type as keyof typeof DEFAULT_LAYOUTS ],

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -50,11 +50,9 @@ export default function Sites() {
 
 	const { user } = useAuth();
 	const { data: isAutomattician } = useSuspenseQuery( isAutomatticianQuery() );
-	const viewPreferences = useSuspenseQuery( userPreferencesQuery( 'dashboard-sites-view' ) )
+	const viewPreferences = useSuspenseQuery( userPreferencesQuery( 'sites-view' ) )
 		.data as ViewPreferences;
-	const { mutate: updateViewPreferences } = useMutation(
-		userPreferencesMutation( 'dashboard-sites-view' )
-	);
+	const { mutate: updateViewPreferences } = useMutation( userPreferencesMutation( 'sites-view' ) );
 
 	const { defaultView, view } = getView( {
 		user,

--- a/client/dashboard/sites/views.ts
+++ b/client/dashboard/sites/views.ts
@@ -34,21 +34,27 @@ const DEFAULT_LAYOUT_FIELDS: SupportedLayouts = {
 
 export type SitesView = ViewTable | ViewGrid;
 
-export interface ViewPreferences {
-	base?: Partial< SitesView >;
-	table?: Partial< ViewTable >;
-	grid?: Partial< ViewGrid >;
-}
+// The view preferences are a subset of the view object.
+// It includes the merged layout object of all view types ever explicitly set by the user.
+export type ViewPreferences = Partial< Omit< SitesView, 'type' | 'layout' > > & {
+	type?: ViewTable[ 'type' ] | ViewGrid[ 'type' ];
+	layout?: Partial< ViewTable[ 'layout' ] & ViewGrid[ 'layout' ] >;
+};
 
-export type ViewSearchParams = Partial< ViewTable | ViewGrid >;
+// All possible keys that can be stored as view preferences.
+const VIEW_PREFERENCES_KEYS = [
+	'fields',
+	'layout',
+	'perPage',
+	'showDescription',
+	'showMedia',
+	'sort',
+	'type',
+];
 
-// Preferences that are shared for all view types.
-const BASE_VIEW_PREFERENCES_KEYS = [ 'fields', 'perPage', 'showDescription', 'sort', 'type' ];
+export type ViewSearchParams = Partial< SitesView >;
 
-// Preferences that are specific to a view type.
-const TYPE_VIEW_PREFERENCES_KEYS = [ 'layout', 'showMedia' ];
-
-const VIEW_PREFERENCES_KEYS = [ ...BASE_VIEW_PREFERENCES_KEYS, ...TYPE_VIEW_PREFERENCES_KEYS ];
+// All possible keys that can be shown in the query params.
 const VIEW_SEARCH_PARAM_KEYS = [ ...VIEW_PREFERENCES_KEYS, 'filters', 'page', 'search' ];
 
 const DEFAULT_PER_PAGE = 10;
@@ -113,14 +119,13 @@ export function getView( {
 		isRestoringAccount,
 	} );
 
-	const type = viewSearchParams.type || viewPreferences?.base?.type || defaultView.type;
+	const type = viewSearchParams.type || viewPreferences?.type || defaultView.type;
 
 	const view = {
 		...defaultView,
 		...DEFAULT_LAYOUTS[ type ],
 		...DEFAULT_LAYOUT_FIELDS[ type ],
-		...viewPreferences?.base,
-		...viewPreferences?.[ type ],
+		...viewPreferences,
 		...viewSearchParams,
 	} as SitesView;
 
@@ -146,43 +151,46 @@ export function getUpdatedView( {
 } {
 	const nextType = nextView.type;
 
+	let updatedView = nextView;
+
+	if ( nextType !== view.type ) {
+		updatedView = {
+			...updatedView,
+
+			// If the type is changed, we restore the default layout for that type.
+			...DEFAULT_LAYOUTS[ nextType ],
+		} as SitesView;
+
+		if ( ! viewPreferences?.fields ) {
+			updatedView = {
+				...updatedView,
+
+				// If the type is changed, and the user has never explicitly set custom fields,
+				// we restore the default fields for that type.
+				...DEFAULT_LAYOUT_FIELDS[ nextType ],
+			} as SitesView;
+		}
+	}
+
 	const defaultNextView = {
 		...defaultView,
 		...DEFAULT_LAYOUTS[ nextType ],
 		...DEFAULT_LAYOUT_FIELDS[ nextType ],
 	} as SitesView;
 
-	let updatedView = nextView;
-	if ( nextType !== view.type ) {
-		updatedView = {
-			...updatedView,
-
-			// Merge with the previously-stored type-specific preferences.
-			...pickFields( viewPreferences?.[ nextType ] || {}, TYPE_VIEW_PREFERENCES_KEYS ),
-		} as SitesView;
-
-		if ( ! viewPreferences?.base?.fields ) {
-			updatedView = {
-				...updatedView,
-
-				// Reset the fields to the type's default fields.
-				...DEFAULT_LAYOUT_FIELDS[ nextType ],
-			} as SitesView;
-		}
-	}
-
 	const updatedViewPreferences = {
-		...viewPreferences,
+		// Store only fields which have custom values.
+		...pickNonDefaultFields( updatedView, VIEW_PREFERENCES_KEYS, defaultNextView ),
 
-		// Store only fields which have different values than the default ones.
-		base: pickNonDefaultFields( updatedView, BASE_VIEW_PREFERENCES_KEYS, defaultNextView ),
-
-		// Store only fields which have different values than the default ones.
-		[ nextType ]: pickNonDefaultFields( updatedView, TYPE_VIEW_PREFERENCES_KEYS, defaultNextView ),
+		// Store the merged layouts from all possible view types.
+		layout: {
+			...viewPreferences?.layout,
+			...updatedView.layout,
+		},
 	} as ViewPreferences;
 
 	const updatedViewSearchParams = {
-		// Show only params which have different values than the default ones.
+		// Show only params which have custom values.
 		...pickNonDefaultFields( updatedView, VIEW_SEARCH_PARAM_KEYS, defaultNextView ),
 
 		// Show the type param explicitly to ensure the view type is updated immediately.
@@ -193,12 +201,6 @@ export function getUpdatedView( {
 		updatedViewPreferences,
 		updatedViewSearchParams,
 	};
-}
-
-function pickFields( object: Partial< SitesView >, keys: string[] ) {
-	return Object.fromEntries(
-		Object.entries( object ).filter( ( [ key ] ) => keys.includes( key ) )
-	);
 }
 
 function pickNonDefaultFields(

--- a/client/dashboard/sites/views.ts
+++ b/client/dashboard/sites/views.ts
@@ -135,7 +135,11 @@ export function getView( {
 	};
 }
 
-export function getUpdatedView( {
+// Returns the updated view preferences and search params, after `view` has changed to `nextView`.
+// The updated view preferences are produced by merging `nextView` into `viewPreferences`.
+// Finally, the updated view preferences and search params are filtered to remove any default values,
+// so that the remaining values reflect the user's explicit intent.
+export function mergeViews( {
 	defaultView,
 	view,
 	viewPreferences,

--- a/client/dashboard/sites/views.ts
+++ b/client/dashboard/sites/views.ts
@@ -1,8 +1,8 @@
+import fastDeepEqual from 'fast-deep-equal/es6';
 import type { User } from '../data/types';
 import type {
 	Operator,
 	SortDirection,
-	View,
 	ViewTable,
 	ViewGrid,
 	SupportedLayouts,
@@ -10,41 +10,55 @@ import type {
 
 export const DEFAULT_LAYOUTS: SupportedLayouts = {
 	table: {
+		showMedia: true,
 		mediaField: 'icon.ico',
-		fields: [ 'status', 'visitors', 'subscribers_count' ],
 		titleField: 'name',
 		descriptionField: 'URL',
 	},
 	grid: {
+		showMedia: true,
 		mediaField: 'preview',
-		fields: [ 'status' ],
 		titleField: 'name',
 		descriptionField: 'URL',
 	},
 };
 
-export const PERSISTABLE_VIEW_KEYS = [
-	'density',
-	'fields',
-	'layout',
-	'perPage',
-	'previewSize',
-	'showDescription',
-	'showMedia',
-	'sort',
-	'type',
-];
+const DEFAULT_LAYOUT_FIELDS: SupportedLayouts = {
+	table: {
+		fields: [ 'status', 'visitors', 'subscribers_count' ],
+	},
+	grid: {
+		fields: [ 'status' ],
+	},
+};
 
-export const CONFIGURABLE_VIEW_KEYS = [ ...PERSISTABLE_VIEW_KEYS, 'filters', 'page', 'search' ];
+export type SitesView = ViewTable | ViewGrid;
+
+export interface ViewPreferences {
+	base?: Partial< SitesView >;
+	table?: Partial< ViewTable >;
+	grid?: Partial< ViewGrid >;
+}
+
+export type ViewSearchParams = Partial< ViewTable | ViewGrid >;
+
+// Preferences that are shared for all view types.
+const BASE_VIEW_PREFERENCES_KEYS = [ 'fields', 'perPage', 'showDescription', 'sort', 'type' ];
+
+// Preferences that are specific to a view type.
+const TYPE_VIEW_PREFERENCES_KEYS = [ 'layout', 'showMedia' ];
+
+const VIEW_PREFERENCES_KEYS = [ ...BASE_VIEW_PREFERENCES_KEYS, ...TYPE_VIEW_PREFERENCES_KEYS ];
+const VIEW_SEARCH_PARAM_KEYS = [ ...VIEW_PREFERENCES_KEYS, 'filters', 'page', 'search' ];
 
 const DEFAULT_PER_PAGE = 10;
 
-const DEFAULT_VIEW = {
+const DEFAULT_VIEW: Partial< SitesView > = {
 	page: 1,
 	perPage: DEFAULT_PER_PAGE,
 	sort: { field: 'name', direction: 'asc' as SortDirection },
 	search: '',
-} as Partial< View >;
+};
 
 function getDefaultView( {
 	user,
@@ -54,14 +68,15 @@ function getDefaultView( {
 	user: User;
 	isAutomattician: boolean;
 	isRestoringAccount: boolean;
-} ): View {
+} ): SitesView {
 	const type = isRestoringAccount || user.site_count > DEFAULT_PER_PAGE ? 'table' : 'grid';
 
 	const defaultView = {
 		type,
 		...DEFAULT_VIEW,
 		...DEFAULT_LAYOUTS[ type ],
-	} as View;
+		...DEFAULT_LAYOUT_FIELDS[ type ],
+	} as SitesView;
 
 	if ( isAutomattician ) {
 		defaultView.filters = [
@@ -80,17 +95,17 @@ export function getView( {
 	user,
 	isAutomattician,
 	isRestoringAccount,
-	viewOptions,
 	viewPreferences,
+	viewSearchParams,
 }: {
 	user: User;
 	isAutomattician: boolean;
 	isRestoringAccount: boolean;
-	viewOptions: Partial< ViewTable | ViewGrid >;
-	viewPreferences?: Partial< View >;
+	viewPreferences?: ViewPreferences;
+	viewSearchParams: ViewSearchParams;
 } ): {
-	defaultView: View;
-	view: View;
+	defaultView: SitesView;
+	view: SitesView;
 } {
 	const defaultView = getDefaultView( {
 		user,
@@ -98,13 +113,104 @@ export function getView( {
 		isRestoringAccount,
 	} );
 
-	const type = viewOptions.type || viewPreferences?.type || defaultView.type;
+	const type = viewSearchParams.type || viewPreferences?.base?.type || defaultView.type;
+
 	const view = {
 		...defaultView,
 		...DEFAULT_LAYOUTS[ type ],
-		...viewPreferences,
-		...Object.fromEntries( Object.entries( viewOptions ).filter( ( [ , v ] ) => v !== undefined ) ),
-	} as View;
+		...DEFAULT_LAYOUT_FIELDS[ type ],
+		...viewPreferences?.base,
+		...viewPreferences?.[ type ],
+		...viewSearchParams,
+	} as SitesView;
 
-	return { defaultView, view };
+	return {
+		defaultView,
+		view,
+	};
+}
+
+export function getUpdatedView( {
+	defaultView,
+	view,
+	viewPreferences,
+	nextView,
+}: {
+	defaultView: SitesView;
+	view: SitesView;
+	viewPreferences?: ViewPreferences;
+	nextView: SitesView;
+} ): {
+	updatedViewPreferences: ViewPreferences;
+	updatedViewSearchParams: ViewSearchParams;
+} {
+	const nextType = nextView.type;
+
+	const defaultNextView = {
+		...defaultView,
+		...DEFAULT_LAYOUTS[ nextType ],
+		...DEFAULT_LAYOUT_FIELDS[ nextType ],
+	} as SitesView;
+
+	let updatedView = nextView;
+	if ( nextType !== view.type ) {
+		updatedView = {
+			...updatedView,
+
+			// Merge with the previously-stored type-specific preferences.
+			...pickFields( viewPreferences?.[ nextType ] || {}, TYPE_VIEW_PREFERENCES_KEYS ),
+		} as SitesView;
+
+		if ( ! viewPreferences?.base?.fields ) {
+			updatedView = {
+				...updatedView,
+
+				// Reset the fields to the type's default fields.
+				...DEFAULT_LAYOUT_FIELDS[ nextType ],
+			} as SitesView;
+		}
+	}
+
+	const updatedViewPreferences = {
+		...viewPreferences,
+
+		// Store only fields which have different values than the default ones.
+		base: pickNonDefaultFields( updatedView, BASE_VIEW_PREFERENCES_KEYS, defaultNextView ),
+
+		// Store only fields which have different values than the default ones.
+		[ nextType ]: pickNonDefaultFields( updatedView, TYPE_VIEW_PREFERENCES_KEYS, defaultNextView ),
+	} as ViewPreferences;
+
+	const updatedViewSearchParams = {
+		// Show only params which have different values than the default ones.
+		...pickNonDefaultFields( updatedView, VIEW_SEARCH_PARAM_KEYS, defaultNextView ),
+
+		// Show the type param explicitly to ensure the view type is updated immediately.
+		type: nextType,
+	} as ViewSearchParams;
+
+	return {
+		updatedViewPreferences,
+		updatedViewSearchParams,
+	};
+}
+
+function pickFields( object: Partial< SitesView >, keys: string[] ) {
+	return Object.fromEntries(
+		Object.entries( object ).filter( ( [ key ] ) => keys.includes( key ) )
+	);
+}
+
+function pickNonDefaultFields(
+	object: Partial< SitesView >,
+	keys: string[],
+	defaultValues: Partial< SitesView >
+) {
+	return Object.fromEntries(
+		Object.entries( object ).filter(
+			( [ key, value ] ) =>
+				keys.includes( key ) &&
+				! fastDeepEqual( value, defaultValues[ key as keyof typeof defaultValues ] )
+		)
+	);
 }


### PR DESCRIPTION
Fixes DOTDASH-122
Fixes DOTDASH-127

## Proposed Changes

When changing v2 site list view to another type, before this PR:

- We could "pollute" the preferences with invalid fields from the previous type. For example, when we hide site icon from `table` view, `showMedia: false` will be persisted, but then when we change the type to `grid`, we lose the preview but we cannot get it back because that field is unmodifiable via https://github.com/Automattic/wp-calypso/pull/104628.
- We lose type-specific layout appearance options, such as density (table view) or preview size (grid view).

With this PR, we:

- Restore the type's default `showMedia` and type-specific `layout`.
- If the user has not explicitly modified the default fields, we will retain the fields, otherwise we restore the type's default fields.

## Why are these changes being made?

Fixes CfT bugs.

## Testing Instructions

1. It's best to first clear the `sites-view` Calypso preferences first via dev console's `POST /me/preferences`.
1. Go to /sites.
2. Verify you see the table view by default (if you have more than 10 sites... obviously you do)
3. Change to to grid view.
    - Verify the transition is smooth
    - Verify you see the default grid view fields.
4. Change back to table view.
    - Verify the transition is smooth
    - Verify you see the default table view fields.
5. Verify the logic in the PR's description.
6. Try playing around with appearance settings; verify they are persisted as you would expect from the UI.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?