### PR TITLE
E2E: Fix tests on eCommerce

### DIFF
--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -70,28 +70,15 @@ describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 		page = await browser.newPage();
 
 		testAccount = new TestAccount( accountName );
-		if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
-			// eCommerce plan sites attempt to load Calypso, but with
-			// third-party cookies disabled the fallback route to WP-Admin
-			// kicks in after some time.
-			await testAccount.authenticate( page, { url: /wp-admin/ } );
-		} else {
-			await testAccount.authenticate( page );
-		}
+		await testAccount.authenticate( page );
 	} );
 
 	it( 'Navigate to Full Site Editor', async function () {
 		fullSiteEditorPage = new FullSiteEditorPage( page );
 
-		// eCommerce plan loads WP-Admin for home dashboard,
-		// so instead navigate straight to the FSE page.
-		if ( envVariables.ATOMIC_VARIATION === 'ecomm-plan' ) {
-			await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: true } ) );
-		} else {
-			// Explicitly doing sidebar navigation to ensure Calypso navigation is intact.
-			const sidebarComponent = new SidebarComponent( page );
-			await sidebarComponent.navigate( 'Appearance', 'Editor' );
-		}
+		// Explicitly doing sidebar navigation to ensure Calypso navigation is intact.
+		const sidebarComponent = new SidebarComponent( page );
+		await sidebarComponent.navigate( 'Appearance', 'Editor' );
 	} );
 
 	it( 'Editor endpoint loads', async function () {

--- a/test/e2e/specs/jetpack/jetpack__dashboard-smoke.ts
+++ b/test/e2e/specs/jetpack/jetpack__dashboard-smoke.ts
@@ -36,15 +36,7 @@ skipDescribeIf( envVariables.TEST_ON_ATOMIC !== true )(
 
 		beforeAll( async function () {
 			page = await browser.newPage();
-
-			if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
-				// eCommerce plan sites attempt to load Calypso, but with
-				// third-party cookies disabled the fallback route to WP-Admin
-				// kicks in after some time.
-				await testAccount.authenticate( page, { url: /wp-admin/ } );
-			} else {
-				await testAccount.authenticate( page );
-			}
+			await testAccount.authenticate( page );
 
 			jetpackDashboardPage = new JetpackDashboardPage( page );
 

--- a/test/e2e/specs/published-content/forms__submissions.ts
+++ b/test/e2e/specs/published-content/forms__submissions.ts
@@ -107,14 +107,7 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 		let feedbackInboxPage: FeedbackInboxPage;
 
 		beforeAll( async function () {
-			if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
-				// eCommerce plan sites attempt to load Calypso, but with
-				// third-party cookies disabled the fallback route to WP-Admin
-				// kicks in after some time.
-				await testAccount.authenticate( page, { url: /wp-admin/ } );
-			} else {
-				await testAccount.authenticate( page );
-			}
+			await testAccount.authenticate( page );
 
 			// Atomic tests sites might have local users, so the Jetpack SSO login will
 			// show up when visiting the Jetpack dashboard directly. We can bypass it if

--- a/test/e2e/specs/settings/settings__database-phpmyadmin.ts
+++ b/test/e2e/specs/settings/settings__database-phpmyadmin.ts
@@ -37,15 +37,7 @@ skipDescribeIf( ! envVariables.TEST_ON_ATOMIC )(
 			page = await browser.newPage();
 
 			testAccount = new TestAccount( accountName );
-
-			if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
-				// Switching to or logging into eCommerce plan sites inevitably
-				// loads WP-Admin instead of Calypso, but the rediret occurs
-				// only after Calypso attempts to load.
-				await testAccount.authenticate( page, { url: /wp-admin/ } );
-			} else {
-				await testAccount.authenticate( page );
-			}
+			await testAccount.authenticate( page );
 		} );
 
 		it( 'Navigate to Settings > Hosting Configuration', async function () {

--- a/test/e2e/specs/stats/stats.ts
+++ b/test/e2e/specs/stats/stats.ts
@@ -35,14 +35,7 @@ describe( DataHelper.createSuiteTitle( 'Stats' ), function () {
 		page = await browser.newPage();
 
 		testAccount = new TestAccount( accountName );
-		if ( testAccount.accountName === 'jetpackAtomicEcommPlanUser' ) {
-			// eCommerce plan sites attempt to load Calypso, but with
-			// third-party cookies disabled the fallback route to WP-Admin
-			// kicks in after some time.
-			await testAccount.authenticate( page, { url: /wp-admin/ } );
-		} else {
-			await testAccount.authenticate( page );
-		}
+		await testAccount.authenticate( page );
 	} );
 
 	it( 'Navigate to Stats', async function () {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

This is largely a revert of #91018, but some files were since renamed and others removed (e.g. #99680). It seems many of the eCommerce exceptions are no longer needed.

I didn't see the reason for the change right off.

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

```
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION=ecomm-plan TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test -- test/e2e/specs/jetpack/jetpack__dashboard-smoke.ts
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION=ecomm-plan TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test -- test/e2e/specs/settings/settings__database-phpmyadmin.ts
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION=ecomm-plan TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test -- test/e2e/specs/published-content/forms__submissions.ts
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION=ecomm-plan TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test -- test/e2e/specs/stats/stats.ts
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION=ecomm-plan TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test -- test/e2e/specs/fse/fse__temp-smoke-test.ts
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?