### PR TITLE
Revert "Magic login: Hide Jetpack Mobile App promo on desktop / non-mobile UAs"

### DIFF
--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -28,7 +28,6 @@ import {
 } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
 import getToSAcceptancePayload from 'calypso/lib/tos-acceptance-tracking';
-import userAgent from 'calypso/lib/user-agent';
 import wpcom from 'calypso/lib/wp';
 import {
 	recordTracksEventWithClientId as recordTracksEvent,
@@ -276,17 +275,13 @@ class MagicLogin extends Component {
 		const { isJetpackLogin, locale, showCheckYourEmail, translate, isWCCOM, query } = this.props;
 
 		const isA4A = query?.redirect_to?.includes( 'agencies.automattic.com/client' ) ?? false;
-		const { isiPad, isiPod, isiPhone, isAndroid } = userAgent;
-		const isMobile = isiPad || isiPod || isiPhone || isAndroid;
-
-		const hideAppPromo = isA4A || ! isMobile;
 
 		if ( isWCCOM ) {
 			return null;
 		}
 
 		if ( showCheckYourEmail ) {
-			if ( hideAppPromo ) {
+			if ( isA4A ) {
 				return null;
 			}
 			return (
@@ -326,7 +321,7 @@ class MagicLogin extends Component {
 						{ linkBack }
 					</a>
 				</div>
-				{ ! hideAppPromo && (
+				{ ! isA4A && (
 					<AppPromo
 						title={ translate( 'Stay logged in with the Jetpack Mobile App' ) }
 						campaign="calypso-login-link"

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -370,7 +370,7 @@
 }
 .is-section-login .app-promo.magic-link-app-promo {
 	margin-top: 4px;
-	box-shadow: 0 0 0 1px var(--color-border-subtle);
+	box-shadow: 0 0 0 1px var(--color-border-subtle) inset;
 	border-radius: 16px; /* stylelint-disable-line scales/radii */
 	font-weight: 400;
 	letter-spacing: -0.4px;


### PR DESCRIPTION
Reverts Automattic/wp-calypso#101198

Based on discussion in pbArwn-7v7-p2#comment-8612, let's ensure the QR code for Jetpack Mobile appears on the magic login page.

To test, see the original steps in Automattic/wp-calypso#101198, but the TL;DR is to go to http://calypso.localhost:3000/log-in/link on a desktop and double check that the card to get the Jetpack Mobile app is present now.

| Before the revert | With the revert |
| --- | --- |
| <img width="1274" alt="image" src="https://github.com/user-attachments/assets/7f14750c-f625-4467-b52d-8166310222f0" /> | <img width="1273" alt="image" src="https://github.com/user-attachments/assets/4d6c7967-e395-4c39-ab5d-b8608dbc6805" /> |