### PR TITLE
Hosting Dashboard: Record tracks when users change site list settings

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -17,12 +17,7 @@ import { getActions } from './actions';
 import AddNewSite from './add-new-site';
 import { getFields } from './fields';
 import { SitesNotices } from './notices';
-import {
-	getView,
-	mergeViews,
-	DEFAULT_LAYOUTS,
-	recordViewChanges,
-} from './views';
+import { getView, mergeViews, DEFAULT_LAYOUTS, recordViewChanges } from './views';
 import type { ViewPreferences, ViewSearchParams } from './views';
 import type { FetchSitesOptions, Site } from '../data/types';
 import type { View, Filter } from '@automattic/dataviews';

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -17,7 +17,12 @@ import { getActions } from './actions';
 import AddNewSite from './add-new-site';
 import { getFields } from './fields';
 import { SitesNotices } from './notices';
-import { getView, mergeViews, DEFAULT_LAYOUTS } from './views';
+import {
+	getView,
+	mergeViews,
+	DEFAULT_LAYOUTS,
+	recordViewChanges,
+} from './views';
 import type { ViewPreferences, ViewSearchParams } from './views';
 import type { FetchSitesOptions, Site } from '../data/types';
 import type { View, Filter } from '@automattic/dataviews';
@@ -138,64 +143,4 @@ export default function Sites() {
 			</PageLayout>
 		</>
 	);
-}
-
-function recordViewChanges(
-	oldView: View,
-	newView: View,
-	recordTracksEvent: ReturnType< typeof useAnalytics >[ 'recordTracksEvent' ]
-) {
-	if ( oldView.type !== newView.type ) {
-		recordTracksEvent( 'calypso_dashboard_sites_list_type_changed', { type: newView.type } );
-
-		// Changing view type can also change fields, but they weren't triggered by a user
-		// action, so we won't record those tracks events.
-		return;
-	}
-
-	if (
-		oldView.sort?.field !== newView.sort?.field ||
-		oldView.sort?.direction !== newView.sort?.direction
-	) {
-		recordTracksEvent( 'calypso_dashboard_sites_list_sort_changed', {
-			field: newView.sort?.field,
-			direction: newView.sort?.direction,
-		} );
-	}
-
-	const oldFilterFields = new Set( oldView.filters?.map( ( { field } ) => field ) || [] );
-	const newFilterFields = new Set( newView.filters?.map( ( { field } ) => field ) || [] );
-
-	// @ts-ignore Set.difference should be available in Hosting Dashboard environments
-	for ( const added of newFilterFields.difference( oldFilterFields ) ) {
-		recordTracksEvent( 'calypso_dashboard_sites_list_filter_changed', {
-			change: 'added',
-			field: added,
-		} );
-	}
-	// @ts-ignore Set.difference should be available in Hosting Dashboard environments
-	for ( const removed of oldFilterFields.difference( newFilterFields ) ) {
-		recordTracksEvent( 'calypso_dashboard_sites_list_filter_changed', {
-			change: 'removed',
-			field: removed,
-		} );
-	}
-
-	const oldShownFields = new Set( oldView.fields || [] );
-	const newShownFields = new Set( newView.fields || [] );
-
-	// @ts-ignore Set.difference should be available in Hosting Dashboard environments
-	for ( const added of newShownFields.difference( oldShownFields ) ) {
-		recordTracksEvent( 'calypso_dashboard_sites_list_field_visibility_changed', {
-			change: 'added',
-			field: added,
-		} );
-	}
-	// @ts-ignore Set.difference should be available in Hosting Dashboard environments
-	for ( const removed of oldShownFields.difference( newShownFields ) ) {
-		recordTracksEvent( 'calypso_dashboard_sites_list_field_visibility_changed', {
-			change: 'removed',
-			field: removed,
-		} );
-	}
 }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useRouter } from '@tanstack/react-router';
 import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
+import { useAnalytics } from '../app/analytics';
 import { useAuth } from '../app/auth';
 import { isAutomatticianQuery } from '../app/queries/me-a8c';
 import { userPreferencesQuery, userPreferencesMutation } from '../app/queries/me-preferences';
@@ -42,6 +43,7 @@ const getFetchSitesOptions = ( view: View, isRestoringAccount: boolean ): FetchS
 };
 
 export default function Sites() {
+	const { recordTracksEvent } = useAnalytics();
 	const navigate = useNavigate( { from: sitesRoute.fullPath } );
 	const router = useRouter();
 	const currentSearchParams = sitesRoute.useSearch();
@@ -76,6 +78,8 @@ export default function Sites() {
 		if ( nextView.type === 'list' ) {
 			return;
 		}
+
+		recordViewChanges( view, nextView, recordTracksEvent );
 
 		const { updatedViewPreferences, updatedViewSearchParams } = mergeViews( {
 			defaultView,
@@ -134,4 +138,64 @@ export default function Sites() {
 			</PageLayout>
 		</>
 	);
+}
+
+function recordViewChanges(
+	oldView: View,
+	newView: View,
+	recordTracksEvent: ReturnType< typeof useAnalytics >[ 'recordTracksEvent' ]
+) {
+	if ( oldView.type !== newView.type ) {
+		recordTracksEvent( 'calypso_dashboard_sites_list_type_changed', { type: newView.type } );
+
+		// Changing view type can also change fields, but they weren't triggered by a user
+		// action, so we won't record those tracks events.
+		return;
+	}
+
+	if (
+		oldView.sort?.field !== newView.sort?.field ||
+		oldView.sort?.direction !== newView.sort?.direction
+	) {
+		recordTracksEvent( 'calypso_dashboard_sites_list_sort_changed', {
+			field: newView.sort?.field,
+			direction: newView.sort?.direction,
+		} );
+	}
+
+	const oldFilterFields = new Set( oldView.filters?.map( ( { field } ) => field ) || [] );
+	const newFilterFields = new Set( newView.filters?.map( ( { field } ) => field ) || [] );
+
+	// @ts-ignore Set.difference should be available in Hosting Dashboard environments
+	for ( const added of newFilterFields.difference( oldFilterFields ) ) {
+		recordTracksEvent( 'calypso_dashboard_sites_list_filter_changed', {
+			change: 'added',
+			field: added,
+		} );
+	}
+	// @ts-ignore Set.difference should be available in Hosting Dashboard environments
+	for ( const removed of oldFilterFields.difference( newFilterFields ) ) {
+		recordTracksEvent( 'calypso_dashboard_sites_list_filter_changed', {
+			change: 'removed',
+			field: removed,
+		} );
+	}
+
+	const oldShownFields = new Set( oldView.fields || [] );
+	const newShownFields = new Set( newView.fields || [] );
+
+	// @ts-ignore Set.difference should be available in Hosting Dashboard environments
+	for ( const added of newShownFields.difference( oldShownFields ) ) {
+		recordTracksEvent( 'calypso_dashboard_sites_list_field_visibility_changed', {
+			change: 'added',
+			field: added,
+		} );
+	}
+	// @ts-ignore Set.difference should be available in Hosting Dashboard environments
+	for ( const removed of oldShownFields.difference( newShownFields ) ) {
+		recordTracksEvent( 'calypso_dashboard_sites_list_field_visibility_changed', {
+			change: 'removed',
+			field: removed,
+		} );
+	}
 }

--- a/client/dashboard/sites/test/views.ts
+++ b/client/dashboard/sites/test/views.ts
@@ -1,0 +1,328 @@
+import { recordViewChanges } from '../views';
+import type { View } from '@automattic/dataviews';
+
+describe( 'recordViewChanges', () => {
+	test( 'nothing relevant changed', () => {
+		const tracks = jest.fn();
+		const oldView: View = {
+			type: 'grid',
+			page: 1,
+			fields: [ 'name', 'status' ],
+			filters: [ { field: 'name', value: 'hello', operator: 'is' } ],
+		};
+		const newView: View = {
+			type: 'grid',
+			page: 2,
+			fields: [ 'status', 'name' ],
+			filters: [ { field: 'name', value: 'new value', operator: 'isNot' } ],
+		};
+
+		recordViewChanges( oldView, newView, tracks );
+
+		expect( tracks ).not.toHaveBeenCalled();
+	} );
+
+	test( 'add new field', () => {
+		const tracks = jest.fn();
+		const oldView: View = { type: 'grid' };
+		const newView: View = {
+			type: 'grid',
+			fields: [ 'name' ],
+		};
+
+		recordViewChanges( oldView, newView, tracks );
+
+		expect( tracks ).toHaveBeenCalledTimes( 1 );
+		expect( tracks ).toHaveBeenCalledWith(
+			'calypso_dashboard_sites_view_field_visibility_changed',
+			{
+				change: 'added',
+				field: 'name',
+			}
+		);
+	} );
+
+	test( 'add multiple new fields', () => {
+		const tracks = jest.fn();
+		const oldView: View = { type: 'grid', fields: [ 'name' ] };
+		const newView: View = {
+			type: 'grid',
+			fields: [ 'name', 'url', 'status' ],
+		};
+
+		recordViewChanges( oldView, newView, tracks );
+
+		expect( tracks ).toHaveBeenCalledTimes( 2 );
+		expect( tracks ).toHaveBeenCalledWith(
+			'calypso_dashboard_sites_view_field_visibility_changed',
+			{
+				change: 'added',
+				field: 'url',
+			}
+		);
+		expect( tracks ).toHaveBeenCalledWith(
+			'calypso_dashboard_sites_view_field_visibility_changed',
+			{
+				change: 'added',
+				field: 'status',
+			}
+		);
+	} );
+
+	test( 'remove field', () => {
+		const tracks = jest.fn();
+		const oldView: View = {
+			type: 'grid',
+			fields: [ 'name' ],
+		};
+		const newView: View = { type: 'grid' };
+
+		recordViewChanges( oldView, newView, tracks );
+
+		expect( tracks ).toHaveBeenCalledTimes( 1 );
+		expect( tracks ).toHaveBeenCalledWith(
+			'calypso_dashboard_sites_view_field_visibility_changed',
+			{
+				change: 'removed',
+				field: 'name',
+			}
+		);
+	} );
+
+	test( 'remove multiple fields', () => {
+		const tracks = jest.fn();
+		const oldView: View = {
+			type: 'grid',
+			fields: [ 'name', 'url', 'status' ],
+		};
+		const newView: View = { type: 'grid', fields: [ 'name' ] };
+
+		recordViewChanges( oldView, newView, tracks );
+
+		expect( tracks ).toHaveBeenCalledTimes( 2 );
+		expect( tracks ).toHaveBeenCalledWith(
+			'calypso_dashboard_sites_view_field_visibility_changed',
+			{
+				change: 'removed',
+				field: 'url',
+			}
+		);
+		expect( tracks ).toHaveBeenCalledWith(
+			'calypso_dashboard_sites_view_field_visibility_changed',
+			{
+				change: 'removed',
+				field: 'status',
+			}
+		);
+	} );
+
+	test( 'add/remove fields', () => {
+		const tracks = jest.fn();
+		const oldView: View = {
+			type: 'grid',
+			fields: [ 'name', 'url' ],
+		};
+		const newView: View = {
+			type: 'grid',
+			fields: [ 'media', 'name' ],
+		};
+
+		recordViewChanges( oldView, newView, tracks );
+
+		expect( tracks ).toHaveBeenCalledTimes( 2 );
+		expect( tracks ).toHaveBeenCalledWith(
+			'calypso_dashboard_sites_view_field_visibility_changed',
+			{
+				change: 'added',
+				field: 'media',
+			}
+		);
+		expect( tracks ).toHaveBeenCalledWith(
+			'calypso_dashboard_sites_view_field_visibility_changed',
+			{
+				change: 'removed',
+				field: 'url',
+			}
+		);
+	} );
+
+	test( 'add new filters', () => {
+		const tracks = jest.fn();
+		const oldView: View = { type: 'grid' };
+		const newView: View = {
+			type: 'grid',
+			filters: [ { field: 'status', value: 'active', operator: 'is' } ],
+		};
+
+		recordViewChanges( oldView, newView, tracks );
+
+		expect( tracks ).toHaveBeenCalledTimes( 1 );
+		expect( tracks ).toHaveBeenCalledWith( 'calypso_dashboard_sites_view_filter_changed', {
+			change: 'added',
+			field: 'status',
+		} );
+	} );
+
+	test( 'add multiple new filters', () => {
+		const tracks = jest.fn();
+		const oldView: View = {
+			type: 'grid',
+			filters: [ { field: 'status', value: 'active', operator: 'is' } ],
+		};
+		const newView: View = {
+			type: 'grid',
+			filters: [
+				{ field: 'status', value: 'active', operator: 'is' },
+				{ field: 'url', value: 'active', operator: 'is' },
+				{ field: 'name', value: 'active', operator: 'is' },
+			],
+		};
+
+		recordViewChanges( oldView, newView, tracks );
+
+		expect( tracks ).toHaveBeenCalledTimes( 2 );
+		expect( tracks ).toHaveBeenCalledWith( 'calypso_dashboard_sites_view_filter_changed', {
+			change: 'added',
+			field: 'url',
+		} );
+		expect( tracks ).toHaveBeenCalledWith( 'calypso_dashboard_sites_view_filter_changed', {
+			change: 'added',
+			field: 'name',
+		} );
+	} );
+
+	test( 'remove filter', () => {
+		const tracks = jest.fn();
+		const oldView: View = {
+			type: 'grid',
+			filters: [ { field: 'status', value: 'active', operator: 'is' } ],
+		};
+		const newView: View = { type: 'grid' };
+
+		recordViewChanges( oldView, newView, tracks );
+
+		expect( tracks ).toHaveBeenCalledTimes( 1 );
+		expect( tracks ).toHaveBeenCalledWith( 'calypso_dashboard_sites_view_filter_changed', {
+			change: 'removed',
+			field: 'status',
+		} );
+	} );
+
+	test( 'remove multiple filters', () => {
+		const tracks = jest.fn();
+		const oldView: View = {
+			type: 'grid',
+			filters: [
+				{ field: 'status', value: 'active', operator: 'is' },
+				{ field: 'url', value: 'active', operator: 'is' },
+				{ field: 'name', value: 'active', operator: 'is' },
+			],
+		};
+		const newView: View = {
+			type: 'grid',
+			filters: [ { field: 'status', value: 'active', operator: 'is' } ],
+		};
+
+		recordViewChanges( oldView, newView, tracks );
+
+		expect( tracks ).toHaveBeenCalledTimes( 2 );
+		expect( tracks ).toHaveBeenCalledWith( 'calypso_dashboard_sites_view_filter_changed', {
+			change: 'removed',
+			field: 'url',
+		} );
+		expect( tracks ).toHaveBeenCalledWith( 'calypso_dashboard_sites_view_filter_changed', {
+			change: 'removed',
+			field: 'name',
+		} );
+	} );
+
+	test( 'add/remove filters', () => {
+		const tracks = jest.fn();
+		const oldView: View = {
+			type: 'grid',
+			filters: [
+				{ field: 'status', value: 'active', operator: 'is' },
+				{ field: 'name', value: 'active', operator: 'is' },
+			],
+		};
+		const newView: View = {
+			type: 'grid',
+			filters: [
+				{ field: 'media', value: 'active', operator: 'is' },
+				{ field: 'status', value: 'active', operator: 'is' },
+			],
+		};
+
+		recordViewChanges( oldView, newView, tracks );
+
+		expect( tracks ).toHaveBeenCalledTimes( 2 );
+		expect( tracks ).toHaveBeenCalledWith( 'calypso_dashboard_sites_view_filter_changed', {
+			change: 'added',
+			field: 'media',
+		} );
+		expect( tracks ).toHaveBeenCalledWith( 'calypso_dashboard_sites_view_filter_changed', {
+			change: 'removed',
+			field: 'name',
+		} );
+	} );
+
+	test( 'view type change', () => {
+		const tracks = jest.fn();
+		const oldView: View = {
+			type: 'grid',
+			fields: [ 'name', 'status' ],
+		};
+		const newView: View = {
+			type: 'table',
+			fields: [ 'name', 'visitors' ],
+		};
+
+		recordViewChanges( oldView, newView, tracks );
+
+		expect( tracks ).toHaveBeenCalledWith( 'calypso_dashboard_sites_view_type_changed', {
+			type: 'table',
+		} );
+		expect( tracks ).not.toHaveBeenCalledWith(
+			'calypso_dashboard_sites_view_field_visibility_changed',
+			expect.anything()
+		);
+	} );
+
+	test( 'sort direction change', () => {
+		const tracks = jest.fn();
+		const oldView: View = {
+			type: 'grid',
+			sort: { field: 'name', direction: 'asc' },
+		};
+		const newView: View = {
+			type: 'grid',
+			sort: { field: 'name', direction: 'desc' },
+		};
+
+		recordViewChanges( oldView, newView, tracks );
+
+		expect( tracks ).toHaveBeenCalledWith( 'calypso_dashboard_sites_view_sort_changed', {
+			field: 'name',
+			direction: 'desc',
+		} );
+	} );
+
+	test( 'sort field change change', () => {
+		const tracks = jest.fn();
+		const oldView: View = {
+			type: 'grid',
+			sort: { field: 'status', direction: 'asc' },
+		};
+		const newView: View = {
+			type: 'grid',
+			sort: { field: 'name', direction: 'desc' },
+		};
+
+		recordViewChanges( oldView, newView, tracks );
+
+		expect( tracks ).toHaveBeenCalledWith( 'calypso_dashboard_sites_view_sort_changed', {
+			field: 'name',
+			direction: 'desc',
+		} );
+	} );
+} );

--- a/client/dashboard/sites/test/views.ts
+++ b/client/dashboard/sites/test/views.ts
@@ -1,16 +1,15 @@
-import { recordViewChanges } from '../views';
-import type { View } from '@automattic/dataviews';
+import { recordViewChanges, type SitesView } from '../views';
 
 describe( 'recordViewChanges', () => {
 	test( 'nothing relevant changed', () => {
 		const tracks = jest.fn();
-		const oldView: View = {
+		const oldView: SitesView = {
 			type: 'grid',
 			page: 1,
 			fields: [ 'name', 'status' ],
 			filters: [ { field: 'name', value: 'hello', operator: 'is' } ],
 		};
-		const newView: View = {
+		const newView: SitesView = {
 			type: 'grid',
 			page: 2,
 			fields: [ 'status', 'name' ],
@@ -24,8 +23,8 @@ describe( 'recordViewChanges', () => {
 
 	test( 'add new field', () => {
 		const tracks = jest.fn();
-		const oldView: View = { type: 'grid' };
-		const newView: View = {
+		const oldView: SitesView = { type: 'grid' };
+		const newView: SitesView = {
 			type: 'grid',
 			fields: [ 'name' ],
 		};
@@ -44,8 +43,8 @@ describe( 'recordViewChanges', () => {
 
 	test( 'add multiple new fields', () => {
 		const tracks = jest.fn();
-		const oldView: View = { type: 'grid', fields: [ 'name' ] };
-		const newView: View = {
+		const oldView: SitesView = { type: 'grid', fields: [ 'name' ] };
+		const newView: SitesView = {
 			type: 'grid',
 			fields: [ 'name', 'url', 'status' ],
 		};
@@ -71,11 +70,11 @@ describe( 'recordViewChanges', () => {
 
 	test( 'remove field', () => {
 		const tracks = jest.fn();
-		const oldView: View = {
+		const oldView: SitesView = {
 			type: 'grid',
 			fields: [ 'name' ],
 		};
-		const newView: View = { type: 'grid' };
+		const newView: SitesView = { type: 'grid' };
 
 		recordViewChanges( oldView, newView, tracks );
 
@@ -91,11 +90,11 @@ describe( 'recordViewChanges', () => {
 
 	test( 'remove multiple fields', () => {
 		const tracks = jest.fn();
-		const oldView: View = {
+		const oldView: SitesView = {
 			type: 'grid',
 			fields: [ 'name', 'url', 'status' ],
 		};
-		const newView: View = { type: 'grid', fields: [ 'name' ] };
+		const newView: SitesView = { type: 'grid', fields: [ 'name' ] };
 
 		recordViewChanges( oldView, newView, tracks );
 
@@ -118,11 +117,11 @@ describe( 'recordViewChanges', () => {
 
 	test( 'add/remove fields', () => {
 		const tracks = jest.fn();
-		const oldView: View = {
+		const oldView: SitesView = {
 			type: 'grid',
 			fields: [ 'name', 'url' ],
 		};
-		const newView: View = {
+		const newView: SitesView = {
 			type: 'grid',
 			fields: [ 'media', 'name' ],
 		};
@@ -148,8 +147,8 @@ describe( 'recordViewChanges', () => {
 
 	test( 'add new filters', () => {
 		const tracks = jest.fn();
-		const oldView: View = { type: 'grid' };
-		const newView: View = {
+		const oldView: SitesView = { type: 'grid' };
+		const newView: SitesView = {
 			type: 'grid',
 			filters: [ { field: 'status', value: 'active', operator: 'is' } ],
 		};
@@ -165,11 +164,11 @@ describe( 'recordViewChanges', () => {
 
 	test( 'add multiple new filters', () => {
 		const tracks = jest.fn();
-		const oldView: View = {
+		const oldView: SitesView = {
 			type: 'grid',
 			filters: [ { field: 'status', value: 'active', operator: 'is' } ],
 		};
-		const newView: View = {
+		const newView: SitesView = {
 			type: 'grid',
 			filters: [
 				{ field: 'status', value: 'active', operator: 'is' },
@@ -193,11 +192,11 @@ describe( 'recordViewChanges', () => {
 
 	test( 'remove filter', () => {
 		const tracks = jest.fn();
-		const oldView: View = {
+		const oldView: SitesView = {
 			type: 'grid',
 			filters: [ { field: 'status', value: 'active', operator: 'is' } ],
 		};
-		const newView: View = { type: 'grid' };
+		const newView: SitesView = { type: 'grid' };
 
 		recordViewChanges( oldView, newView, tracks );
 
@@ -210,7 +209,7 @@ describe( 'recordViewChanges', () => {
 
 	test( 'remove multiple filters', () => {
 		const tracks = jest.fn();
-		const oldView: View = {
+		const oldView: SitesView = {
 			type: 'grid',
 			filters: [
 				{ field: 'status', value: 'active', operator: 'is' },
@@ -218,7 +217,7 @@ describe( 'recordViewChanges', () => {
 				{ field: 'name', value: 'active', operator: 'is' },
 			],
 		};
-		const newView: View = {
+		const newView: SitesView = {
 			type: 'grid',
 			filters: [ { field: 'status', value: 'active', operator: 'is' } ],
 		};
@@ -238,14 +237,14 @@ describe( 'recordViewChanges', () => {
 
 	test( 'add/remove filters', () => {
 		const tracks = jest.fn();
-		const oldView: View = {
+		const oldView: SitesView = {
 			type: 'grid',
 			filters: [
 				{ field: 'status', value: 'active', operator: 'is' },
 				{ field: 'name', value: 'active', operator: 'is' },
 			],
 		};
-		const newView: View = {
+		const newView: SitesView = {
 			type: 'grid',
 			filters: [
 				{ field: 'media', value: 'active', operator: 'is' },
@@ -268,11 +267,11 @@ describe( 'recordViewChanges', () => {
 
 	test( 'view type change', () => {
 		const tracks = jest.fn();
-		const oldView: View = {
+		const oldView: SitesView = {
 			type: 'grid',
 			fields: [ 'name', 'status' ],
 		};
-		const newView: View = {
+		const newView: SitesView = {
 			type: 'table',
 			fields: [ 'name', 'visitors' ],
 		};
@@ -290,11 +289,11 @@ describe( 'recordViewChanges', () => {
 
 	test( 'sort direction change', () => {
 		const tracks = jest.fn();
-		const oldView: View = {
+		const oldView: SitesView = {
 			type: 'grid',
 			sort: { field: 'name', direction: 'asc' },
 		};
-		const newView: View = {
+		const newView: SitesView = {
 			type: 'grid',
 			sort: { field: 'name', direction: 'desc' },
 		};
@@ -309,11 +308,11 @@ describe( 'recordViewChanges', () => {
 
 	test( 'sort field change change', () => {
 		const tracks = jest.fn();
-		const oldView: View = {
+		const oldView: SitesView = {
 			type: 'grid',
 			sort: { field: 'status', direction: 'asc' },
 		};
-		const newView: View = {
+		const newView: SitesView = {
 			type: 'grid',
 			sort: { field: 'name', direction: 'desc' },
 		};

--- a/client/dashboard/sites/test/views.ts
+++ b/client/dashboard/sites/test/views.ts
@@ -306,7 +306,7 @@ describe( 'recordViewChanges', () => {
 		} );
 	} );
 
-	test( 'sort field change change', () => {
+	test( 'sort field change', () => {
 		const tracks = jest.fn();
 		const oldView: SitesView = {
 			type: 'grid',

--- a/client/dashboard/sites/views.ts
+++ b/client/dashboard/sites/views.ts
@@ -1,4 +1,5 @@
 import fastDeepEqual from 'fast-deep-equal/es6';
+import type { AnalyticsClient } from '../app/analytics';
 import type { User } from '../data/types';
 import type {
 	Operator,
@@ -219,4 +220,64 @@ function pickNonDefaultFields(
 				! fastDeepEqual( value, defaultValues[ key as keyof typeof defaultValues ] )
 		)
 	);
+}
+
+export function recordViewChanges(
+	oldView: View,
+	newView: View,
+	recordTracksEvent: AnalyticsClient[ 'recordTracksEvent' ]
+) {
+	if ( oldView.type !== newView.type ) {
+		recordTracksEvent( 'calypso_dashboard_sites_list_type_changed', { type: newView.type } );
+
+		// Changing view type can also change fields, but they weren't triggered by a user
+		// action, so we won't record those tracks events.
+		return;
+	}
+
+	if (
+		oldView.sort?.field !== newView.sort?.field ||
+		oldView.sort?.direction !== newView.sort?.direction
+	) {
+		recordTracksEvent( 'calypso_dashboard_sites_list_sort_changed', {
+			field: newView.sort?.field,
+			direction: newView.sort?.direction,
+		} );
+	}
+
+	const oldFilterFields = new Set( oldView.filters?.map( ( { field } ) => field ) || [] );
+	const newFilterFields = new Set( newView.filters?.map( ( { field } ) => field ) || [] );
+
+	// @ts-ignore Set.difference should be available in Hosting Dashboard environments
+	for ( const added of newFilterFields.difference( oldFilterFields ) ) {
+		recordTracksEvent( 'calypso_dashboard_sites_list_filter_changed', {
+			change: 'added',
+			field: added,
+		} );
+	}
+	// @ts-ignore Set.difference should be available in Hosting Dashboard environments
+	for ( const removed of oldFilterFields.difference( newFilterFields ) ) {
+		recordTracksEvent( 'calypso_dashboard_sites_list_filter_changed', {
+			change: 'removed',
+			field: removed,
+		} );
+	}
+
+	const oldShownFields = new Set( oldView.fields || [] );
+	const newShownFields = new Set( newView.fields || [] );
+
+	// @ts-ignore Set.difference should be available in Hosting Dashboard environments
+	for ( const added of newShownFields.difference( oldShownFields ) ) {
+		recordTracksEvent( 'calypso_dashboard_sites_list_field_visibility_changed', {
+			change: 'added',
+			field: added,
+		} );
+	}
+	// @ts-ignore Set.difference should be available in Hosting Dashboard environments
+	for ( const removed of oldShownFields.difference( newShownFields ) ) {
+		recordTracksEvent( 'calypso_dashboard_sites_list_field_visibility_changed', {
+			change: 'removed',
+			field: removed,
+		} );
+	}
 }

--- a/client/dashboard/sites/views.ts
+++ b/client/dashboard/sites/views.ts
@@ -228,7 +228,7 @@ export function recordViewChanges(
 	recordTracksEvent: AnalyticsClient[ 'recordTracksEvent' ]
 ) {
 	if ( oldView.type !== newView.type ) {
-		recordTracksEvent( 'calypso_dashboard_sites_list_type_changed', { type: newView.type } );
+		recordTracksEvent( 'calypso_dashboard_sites_view_type_changed', { type: newView.type } );
 
 		// Changing view type can also change fields, but they weren't triggered by a user
 		// action, so we won't record those tracks events.
@@ -239,7 +239,7 @@ export function recordViewChanges(
 		oldView.sort?.field !== newView.sort?.field ||
 		oldView.sort?.direction !== newView.sort?.direction
 	) {
-		recordTracksEvent( 'calypso_dashboard_sites_list_sort_changed', {
+		recordTracksEvent( 'calypso_dashboard_sites_view_sort_changed', {
 			field: newView.sort?.field,
 			direction: newView.sort?.direction,
 		} );
@@ -249,13 +249,13 @@ export function recordViewChanges(
 	const newFilterFields = new Set( newView.filters?.map( ( { field } ) => field ) || [] );
 
 	for ( const added of setDifference( newFilterFields, oldFilterFields ) ) {
-		recordTracksEvent( 'calypso_dashboard_sites_list_filter_changed', {
+		recordTracksEvent( 'calypso_dashboard_sites_view_filter_changed', {
 			change: 'added',
 			field: added,
 		} );
 	}
 	for ( const removed of setDifference( oldFilterFields, newFilterFields ) ) {
-		recordTracksEvent( 'calypso_dashboard_sites_list_filter_changed', {
+		recordTracksEvent( 'calypso_dashboard_sites_view_filter_changed', {
 			change: 'removed',
 			field: removed,
 		} );
@@ -265,13 +265,13 @@ export function recordViewChanges(
 	const newShownFields = new Set( newView.fields || [] );
 
 	for ( const added of setDifference( newShownFields, oldShownFields ) ) {
-		recordTracksEvent( 'calypso_dashboard_sites_list_field_visibility_changed', {
+		recordTracksEvent( 'calypso_dashboard_sites_view_field_visibility_changed', {
 			change: 'added',
 			field: added,
 		} );
 	}
 	for ( const removed of setDifference( oldShownFields, newShownFields ) ) {
-		recordTracksEvent( 'calypso_dashboard_sites_list_field_visibility_changed', {
+		recordTracksEvent( 'calypso_dashboard_sites_view_field_visibility_changed', {
 			change: 'removed',
 			field: removed,
 		} );

--- a/client/dashboard/sites/views.ts
+++ b/client/dashboard/sites/views.ts
@@ -223,8 +223,8 @@ function pickNonDefaultFields(
 }
 
 export function recordViewChanges(
-	oldView: View,
-	newView: View,
+	oldView: SitesView,
+	newView: SitesView,
 	recordTracksEvent: AnalyticsClient[ 'recordTracksEvent' ]
 ) {
 	if ( oldView.type !== newView.type ) {

--- a/client/dashboard/sites/views.ts
+++ b/client/dashboard/sites/views.ts
@@ -248,15 +248,13 @@ export function recordViewChanges(
 	const oldFilterFields = new Set( oldView.filters?.map( ( { field } ) => field ) || [] );
 	const newFilterFields = new Set( newView.filters?.map( ( { field } ) => field ) || [] );
 
-	// @ts-ignore Set.difference should be available in Hosting Dashboard environments
-	for ( const added of newFilterFields.difference( oldFilterFields ) ) {
+	for ( const added of setDifference( newFilterFields, oldFilterFields ) ) {
 		recordTracksEvent( 'calypso_dashboard_sites_list_filter_changed', {
 			change: 'added',
 			field: added,
 		} );
 	}
-	// @ts-ignore Set.difference should be available in Hosting Dashboard environments
-	for ( const removed of oldFilterFields.difference( newFilterFields ) ) {
+	for ( const removed of setDifference( oldFilterFields, newFilterFields ) ) {
 		recordTracksEvent( 'calypso_dashboard_sites_list_filter_changed', {
 			change: 'removed',
 			field: removed,
@@ -266,18 +264,25 @@ export function recordViewChanges(
 	const oldShownFields = new Set( oldView.fields || [] );
 	const newShownFields = new Set( newView.fields || [] );
 
-	// @ts-ignore Set.difference should be available in Hosting Dashboard environments
-	for ( const added of newShownFields.difference( oldShownFields ) ) {
+	for ( const added of setDifference( newShownFields, oldShownFields ) ) {
 		recordTracksEvent( 'calypso_dashboard_sites_list_field_visibility_changed', {
 			change: 'added',
 			field: added,
 		} );
 	}
-	// @ts-ignore Set.difference should be available in Hosting Dashboard environments
-	for ( const removed of oldShownFields.difference( newShownFields ) ) {
+	for ( const removed of setDifference( oldShownFields, newShownFields ) ) {
 		recordTracksEvent( 'calypso_dashboard_sites_list_field_visibility_changed', {
 			change: 'removed',
 			field: removed,
 		} );
 	}
+}
+
+// Ponyfill for Set.prototype.difference, which is not available in all target environments.
+function setDifference< T >( a: Set< T >, b: Set< T > ): Set< T > {
+	const difference = new Set( a );
+	for ( const item of b ) {
+		difference.delete( item );
+	}
+	return difference;
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-13780

## Proposed Changes

* Create new events to represent site list filter/sort changes
  * `calypso_dashboard_sites_view_type_changed`
  * `calypso_dashboard_sites_view_sort_changed`
  * `calypso_dashboard_sites_view_filter_changed`
  * `calypso_dashboard_sites_view_field_visibility_changed`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Help us to understand how often these functions are being used and whether we should make changes to the defaults.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Note**: during testing you will notice there are repeated `calypso_page_view` events sent. That is fixed by https://github.com/Automattic/wp-calypso/pull/104661

* Load v2
* Mess with the site list settings
* Watch the tracks events and confirm the correct events with the correct props are sent

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
