### PR TITLE
Site List v2: Update the design of the site icon and make it clickable

### DIFF
--- a/client/blocks/site-favicon/index.tsx
+++ b/client/blocks/site-favicon/index.tsx
@@ -1,7 +1,7 @@
 import { WordPressLogo } from '@automattic/components';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
-import SiteIcon from 'calypso/blocks/site-icon';
+import SiteIcon, { type SiteIconVariant } from 'calypso/blocks/site-icon';
 import { getFirstGrapheme } from 'calypso/lib/string';
 import { useSelector } from 'calypso/state';
 import { getSite } from 'calypso/state/sites/selectors';
@@ -18,6 +18,7 @@ interface SiteFaviconProps {
 	className?: string;
 	fallback?: SiteFaviconFallback;
 	lazy?: boolean;
+	variant?: SiteIconVariant;
 }
 
 const SiteFavicon = ( {
@@ -27,6 +28,7 @@ const SiteFavicon = ( {
 	className = '',
 	fallback = 'color',
 	lazy = false,
+	variant,
 }: SiteFaviconProps ) => {
 	const { __ } = useI18n();
 	const siteColor = color ?? 'linear-gradient(45deg, #ff0056, #ff8a78, #57b7ff, #9c00d4)';
@@ -61,7 +63,13 @@ const SiteFavicon = ( {
 
 	return (
 		<div className={ clsx( 'site-favicon', className, defaultFaviconClass ) }>
-			<SiteIcon siteId={ blogId } size={ size } defaultIcon={ defaultFavicon } lazy={ lazy } />
+			<SiteIcon
+				siteId={ blogId }
+				size={ size }
+				defaultIcon={ defaultFavicon }
+				lazy={ lazy }
+				variant={ variant }
+			/>
 		</div>
 	);
 };

--- a/client/blocks/site-favicon/style.scss
+++ b/client/blocks/site-favicon/style.scss
@@ -17,14 +17,23 @@
 	}
 
 	&.is-first-grapheme {
-		.is-blank {
+		.is-blank,
+		.is-primary {
 			font-size: xx-large !important;
 			text-transform: uppercase;
-			background-color: #f5f7f7;
-			border: 1px solid rgb(238, 238, 238);
 			border-radius: 4px;
 			box-sizing: border-box;
+		}
+
+		.is-blank {
+			background-color: #f5f7f7;
+			border: 1px solid rgb(238, 238, 238);
 			color: var(--color-link);
+		}
+
+		.is-primary {
+			background: linear-gradient(0deg, color-mix(in srgb, var(--color-surface) 32%, transparent) 0%, color-mix(in srgb, var(--color-surface) 32%, transparent) 100%), var(--color-primary);
+			color: var(--color-surface);
 		}
 	}
 }

--- a/client/blocks/site-icon/index.tsx
+++ b/client/blocks/site-icon/index.tsx
@@ -21,6 +21,8 @@ export type Site = {
 	};
 };
 
+export type SiteIconVariant = 'primary' | 'blank';
+
 type SiteIconProps = {
 	siteId?: number;
 	site?: object;
@@ -33,6 +35,7 @@ type SiteIconProps = {
 	href?: string;
 	title?: string;
 	lazy?: boolean;
+	variant?: SiteIconVariant;
 	onClick?: () => void;
 };
 
@@ -48,13 +51,14 @@ export function SiteIcon( {
 	href = '',
 	title = '',
 	lazy = false,
+	variant = 'blank',
 	onClick = () => {},
 }: SiteIconProps ) {
 	iconUrl = iconUrl?.replace( /\/$/, '' ); // Remove trailing slash from URL as it may lead to 404 errors when adding size parameters.
 	const iconSrc = resizeImageUrl( iconUrl, imgSize, null );
 
 	const classes = clsx( 'site-icon', {
-		'is-blank': ! iconSrc,
+		[ `is-${ variant }` ]: ! iconSrc,
 		'is-transient': isTransientIcon,
 	} );
 

--- a/client/blocks/site-icon/style.scss
+++ b/client/blocks/site-icon/style.scss
@@ -37,7 +37,7 @@
 }
 
 .site-icon__img {
-	background: #f0f0f0;
+	background: var(--color-surface);
 	border-radius: 4px;
 	outline: 1px solid rgba(0, 0, 0, 0.04);
 	outline-offset: -1px;

--- a/client/blocks/site-icon/style.scss
+++ b/client/blocks/site-icon/style.scss
@@ -6,15 +6,24 @@
 	text-align: center;
 
 	// Globe icon for sites without an icon
-	&.is-blank {
-		background: var(--color-neutral-10);
+	&.is-blank,
+	&.is-primary {
 		display: flex;
 		align-items: center;
 		justify-content: center;
+
 		.gridicon {
 			color: var(--color-surface);
 			z-index: z-index("root", ".site-icon.is-blank .gridicon");
 		}
+	}
+
+	&.is-blank {
+		background: var(--color-neutral-10);
+	}
+
+	&.is-primary {
+		background: var(--color-primary);
 	}
 }
 

--- a/client/blocks/site-icon/style.scss
+++ b/client/blocks/site-icon/style.scss
@@ -37,6 +37,9 @@
 }
 
 .site-icon__img {
-	background: color-mix(in srgb, var(--color-surface) 0%, transparent);
+	background: #f0f0f0;
+	border-radius: 4px;
+	outline: 1px solid rgba(0, 0, 0, 0.04);
+	outline-offset: -1px;
 	position: relative;
 }

--- a/client/dashboard/sites/fields.tsx
+++ b/client/dashboard/sites/fields.tsx
@@ -15,8 +15,8 @@ import {
 	Status,
 	URL,
 	Uptime,
+	SiteIconLink,
 } from './site-fields';
-import SiteIcon from './site-icon';
 import type { Site } from '../data/types';
 import type { Field, Operator } from '@wordpress/dataviews';
 
@@ -39,7 +39,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 	{
 		id: 'icon.ico',
 		label: __( 'Site icon' ),
-		render: ( { item } ) => <SiteIcon site={ item } />,
+		render: ( { item } ) => <SiteIconLink site={ item } />,
 		enableSorting: false,
 	},
 	{

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -93,6 +93,18 @@ export function URL( { site, value }: { site: Site; value: string } ) {
 	);
 }
 
+export function SiteIconLink( { site }: { site: Site } ) {
+	return (
+		<Link
+			to={ getSiteManagementUrl( site ) }
+			disabled={ site.is_deleted }
+			style={ { textDecoration: 'none' } }
+		>
+			<SiteIcon site={ site } />
+		</Link>
+	);
+}
+
 export function Preview( { site }: { site: Site } ) {
 	const [ resizeListener, { width } ] = useResizeObserver();
 	const { is_deleted, is_private, URL: url } = site;

--- a/client/dashboard/sites/site-icon/index.tsx
+++ b/client/dashboard/sites/site-icon/index.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { useMemo } from 'react';
 import { getSiteStatus } from '../../utils/site-status';
 import SiteMigrationIcon from './site-migration-icon';
@@ -20,10 +21,14 @@ export default function SiteIcon( { site, size = 48 }: { site: Site; size?: numb
 		return url.toString();
 	}, [ ico ] );
 
+	const className = clsx( {
+		'is-small': size <= 16,
+	} );
+
 	if ( ico ) {
 		return (
 			<img
-				className="site-icon"
+				className={ clsx( 'site-icon', className ) }
 				src={ src }
 				alt={ site.name }
 				{ ...dims }
@@ -35,11 +40,11 @@ export default function SiteIcon( { site, size = 48 }: { site: Site; size?: numb
 
 	const status = getSiteStatus( site );
 	if ( status === 'migration_pending' || status === 'migration_started' ) {
-		return <SiteMigrationIcon size={ size } />;
+		return <SiteMigrationIcon className={ clsx( 'site-icon', className ) } size={ size } />;
 	}
 
 	return (
-		<div className="site-letter" style={ { ...dims, fontSize: size * 0.5 } }>
+		<div className={ clsx( 'site-letter', className ) } style={ { ...dims, fontSize: size * 0.5 } }>
 			<span>{ site.name.charAt( 0 ) }</span>
 		</div>
 	);

--- a/client/dashboard/sites/site-icon/index.tsx
+++ b/client/dashboard/sites/site-icon/index.tsx
@@ -33,7 +33,7 @@ export default function SiteIcon( { site, size = 48 }: { site: Site; size?: numb
 				alt={ site.name }
 				{ ...dims }
 				loading="lazy"
-				style={ { width: size, height: size } }
+				style={ { width: size, height: size, minWidth: size } }
 			/>
 		);
 	}

--- a/client/dashboard/sites/site-icon/index.tsx
+++ b/client/dashboard/sites/site-icon/index.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import { useMemo } from 'react';
+import { getSiteDisplayName } from '../../utils/site-name';
 import { getSiteStatus } from '../../utils/site-status';
 import SiteMigrationIcon from './site-migration-icon';
 import type { Site } from '../../data/types';
@@ -45,7 +46,7 @@ export default function SiteIcon( { site, size = 48 }: { site: Site; size?: numb
 
 	return (
 		<div className={ clsx( 'site-letter', className ) } style={ { ...dims, fontSize: size * 0.5 } }>
-			<span>{ site.name.charAt( 0 ) }</span>
+			<span>{ getSiteDisplayName( site ).charAt( 0 ) }</span>
 		</div>
 	);
 }

--- a/client/dashboard/sites/site-icon/site-migration-icon.tsx
+++ b/client/dashboard/sites/site-icon/site-migration-icon.tsx
@@ -1,6 +1,12 @@
-export default function SiteMigrationIcon( { size = 56 }: { size?: number } ) {
+export default function SiteMigrationIcon( {
+	className,
+	size = 56,
+}: {
+	className?: string;
+	size?: number;
+} ) {
 	return (
-		<svg height={ size } width={ size } viewBox="0 0 56 56">
+		<svg className={ className } height={ size } width={ size } viewBox="0 0 56 56">
 			<g clipPath="url(#clip0_3923_15349)">
 				<path
 					d="M0 4C0 1.79086 1.79086 0 4 0H52C54.2091 0 56 1.79086 56 4V52C56 54.2091 54.2091 56 52 56H4C1.79086 56 0 54.2091 0 52V4Z"

--- a/client/dashboard/sites/site-icon/style.scss
+++ b/client/dashboard/sites/site-icon/style.scss
@@ -8,10 +8,9 @@
 
 .site-letter {
 	align-items: center;
-	background-color: linear-gradient(0deg, rgba($white, 0.32) 0%, rgba($white, 0.32) 100%), var(--wp-admin-theme-color);
+	background: linear-gradient(0deg, rgba($white, 0.32) 0%, rgba($white, 0.32) 100%), var(--wp-admin-theme-color);
 	border-radius: $radius-medium;
 	color: $white;
-	cursor: default;
 	display: flex;
 	flex-shrink: 0;
 	font-size: 24px;

--- a/client/dashboard/sites/site-icon/style.scss
+++ b/client/dashboard/sites/site-icon/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/colors';
+@import '@wordpress/base-styles/variables';
+
 .site-icon,
 .site-letter {
 	border-radius: 2px;
@@ -5,9 +8,9 @@
 
 .site-letter {
 	align-items: center;
-	background-color: #f5f7f7;
-	border: 1px solid #eee;
-	color: var(--wp-admin-theme-color);
+	background-color: linear-gradient(0deg, rgba($white, 0.32) 0%, rgba($white, 0.32) 100%), var(--wp-admin-theme-color);
+	border-radius: $radius-medium;
+	color: $white;
 	cursor: default;
 	display: flex;
 	flex-shrink: 0;

--- a/client/dashboard/sites/site-icon/style.scss
+++ b/client/dashboard/sites/site-icon/style.scss
@@ -11,7 +11,8 @@
 }
 
 .site-icon {
-	border: 1px solid rgba($black, 0.04);
+	outline: 1px solid rgba($black, 0.04);
+	outline-offset: -1px;
 	background: $gray-100;
 }
 

--- a/client/dashboard/sites/site-icon/style.scss
+++ b/client/dashboard/sites/site-icon/style.scss
@@ -3,13 +3,21 @@
 
 .site-icon,
 .site-letter {
-	border-radius: 2px;
+	border-radius: $radius-medium;
+
+	&.is-small {
+		border-radius: $radius-small;
+	}
+}
+
+.site-icon {
+	border: 1px solid rgba($black, 0.04);
+	background: $gray-100;
 }
 
 .site-letter {
 	align-items: center;
 	background: linear-gradient(0deg, rgba($white, 0.32) 0%, rgba($white, 0.32) 100%), var(--wp-admin-theme-color);
-	border-radius: $radius-medium;
 	color: $white;
 	display: flex;
 	flex-shrink: 0;
@@ -19,4 +27,5 @@
 	overflow: hidden;
 	width: 48px;
 	box-sizing: border-box;
+	text-transform: uppercase;
 }

--- a/client/dashboard/sites/site-icon/style.scss
+++ b/client/dashboard/sites/site-icon/style.scss
@@ -13,7 +13,7 @@
 .site-icon {
 	outline: 1px solid rgba($black, 0.04);
 	outline-offset: -1px;
-	background: $gray-100;
+	background: $white;
 }
 
 .site-letter {

--- a/client/layout/hosting-dashboard/item-view/item-view-header/index.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/index.tsx
@@ -90,6 +90,7 @@ export default function ItemViewHeader( {
 									color={ itemData.color }
 									className="hosting-dashboard-item-view__header-favicon"
 									size={ size }
+									variant="primary"
 								/>
 							) }
 							<div className="hosting-dashboard-item-view__header-info">

--- a/client/layout/hosting-dashboard/item-view/item-view-header/style.scss
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/style.scss
@@ -71,6 +71,11 @@ $blueberry-color: #3858e9;
 
 	.hosting-dashboard-item-view__header-favicon {
 		margin-inline-end: 12px;
+
+		.site-icon {
+			border: none;
+			background: none;
+		}
 	}
 
 	@media ( min-width: $break-large ) {

--- a/client/layout/hosting-dashboard/item-view/item-view-header/style.scss
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/style.scss
@@ -71,11 +71,6 @@ $blueberry-color: #3858e9;
 
 	.hosting-dashboard-item-view__header-favicon {
 		margin-inline-end: 12px;
-
-		.site-icon {
-			border: none;
-			background: none;
-		}
 	}
 
 	@media ( min-width: $break-large ) {

--- a/client/sites/components/sites-dataviews/dataview-style.scss
+++ b/client/sites/components/sites-dataviews/dataview-style.scss
@@ -20,6 +20,10 @@
 			}
 		}
 	}
+
+	.dataviews-view-list .dataviews-view-list__item-wrapper .dataviews-view-list__media-wrapper {
+		background: var(--color-surface);
+	}
 }
 
 .wpcom-site .main.hosting-dashboard-layout.sites-dashboard {

--- a/client/sites/components/sites-dataviews/site-icon.tsx
+++ b/client/sites/components/sites-dataviews/site-icon.tsx
@@ -68,6 +68,7 @@ export default function SiteIcon( {
 				fallback={ isInProgress ? 'migration' : 'first-grapheme' }
 				size={ size }
 				lazy
+				variant="primary"
 			/>
 		</ThumbnailLink>
 	);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-131

## Proposed Changes

* Update the design of the site icon
* Make the site icon clickable and link to site overview

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/c115367e-7fda-4534-84d7-350058e7a3fc) | ![image](https://github.com/user-attachments/assets/a95d9695-a289-4f91-9024-d7da9da9b077) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Ensure the new design of the site icon looks good
* Click the site icon
* Ensure it opens the site overview

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?