### PR TITLE
Help Center: don't translate before translations are loaded

### DIFF
--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -7,12 +7,12 @@ import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import Markdown from 'react-markdown';
 import {
-	ODIE_FORWARD_TO_FORUMS_MESSAGE,
-	ODIE_FORWARD_TO_ZENDESK_MESSAGE,
-	ODIE_THIRD_PARTY_MESSAGE_CONTENT,
-	ODIE_EMAIL_FALLBACK_MESSAGE_CONTENT,
-	ODIE_ERROR_MESSAGE,
-	ODIE_ERROR_MESSAGE_NON_ELIGIBLE,
+	getOdieForwardToForumsMessage,
+	getOdieForwardToZendeskMessage,
+	getOdieThirdPartyMessageContent,
+	getOdieEmailFallbackMessageContent,
+	getOdieErrorMessage,
+	getOdieErrorMessageNonEligible,
 } from '../../constants';
 import { useOdieAssistantContext } from '../../context';
 import {
@@ -38,7 +38,7 @@ const getDisplayMessage = (
 	isErrorMessage?: boolean
 ) => {
 	if ( isUserEligibleForPaidSupport && ! canConnectToZendesk && isRequestingHumanSupport ) {
-		return ODIE_THIRD_PARTY_MESSAGE_CONTENT;
+		return getOdieThirdPartyMessageContent();
 	}
 
 	if ( isUserEligibleForPaidSupport && hasCannedResponse ) {
@@ -46,18 +46,18 @@ const getDisplayMessage = (
 	}
 
 	if ( isUserEligibleForPaidSupport && forceEmailSupport && isRequestingHumanSupport ) {
-		return ODIE_EMAIL_FALLBACK_MESSAGE_CONTENT;
+		return getOdieEmailFallbackMessageContent();
 	}
 
 	if ( isErrorMessage && ! isUserEligibleForPaidSupport ) {
-		return ODIE_ERROR_MESSAGE_NON_ELIGIBLE;
+		return getOdieErrorMessageNonEligible();
 	}
 
 	const forwardMessage = isUserEligibleForPaidSupport
-		? ODIE_FORWARD_TO_ZENDESK_MESSAGE
-		: ODIE_FORWARD_TO_FORUMS_MESSAGE;
+		? getOdieForwardToZendeskMessage()
+		: getOdieForwardToForumsMessage();
 
-	return isErrorMessage ? ODIE_ERROR_MESSAGE : forwardMessage;
+	return isErrorMessage ? getOdieErrorMessage() : forwardMessage;
 };
 
 export const UserMessage = ( {

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -11,7 +11,7 @@ import { useCallback, useRef, useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { SendMessageIcon } from '../../assets/send-message-icon';
-import { ODIE_WRONG_FILE_TYPE_MESSAGE } from '../../constants';
+import { getOdieWrongFileTypeMessage } from '../../constants';
 import { useOdieAssistantContext } from '../../context';
 import { useSendChatMessage } from '../../hooks';
 import { Message } from '../../types';
@@ -115,7 +115,7 @@ export const OdieSendMessageButton = () => {
 					} );
 				}
 			} else {
-				addMessage( ODIE_WRONG_FILE_TYPE_MESSAGE );
+				addMessage( getOdieWrongFileTypeMessage() );
 			}
 		},
 		[

--- a/packages/odie-client/src/constants.ts
+++ b/packages/odie-client/src/constants.ts
@@ -2,38 +2,44 @@ import { __ } from '@wordpress/i18n';
 import type { Context, Message, OdieAllowedBots } from './types';
 declare const __i18n_text_domain__: string;
 
-export const ODIE_ERROR_MESSAGE = __(
-	"Sorry, I'm offline right now. Leave our Support team a note and they'll get back to you as soon as possible.",
-	__i18n_text_domain__
-);
+export const getOdieErrorMessage = (): string =>
+	__(
+		"Sorry, I'm offline right now. Leave our Support team a note and they'll get back to you as soon as possible.",
+		__i18n_text_domain__
+	);
 
-export const ODIE_ERROR_MESSAGE_NON_ELIGIBLE = __(
-	'Sorry, I am offline right now. Come back later or ask for help in our forums:',
-	__i18n_text_domain__
-);
+export const getOdieErrorMessageNonEligible = (): string =>
+	__(
+		'Sorry, I am offline right now. Come back later or ask for help in our forums:',
+		__i18n_text_domain__
+	);
 
-export const ODIE_RATE_LIMIT_MESSAGE_CONTENT = __(
-	"Hi there! You've hit your AI usage limit. Upgrade your plan for unlimited Wapuu support! You can still get user support using the buttons below.",
-	__i18n_text_domain__
-);
+export const getOdieRateLimitMessageContent = (): string =>
+	__(
+		"Hi there! You've hit your AI usage limit. Upgrade your plan for unlimited Wapuu support! You can still get user support using the buttons below.",
+		__i18n_text_domain__
+	);
 
-export const ODIE_RATE_LIMIT_MESSAGE: Message = {
-	content: ODIE_RATE_LIMIT_MESSAGE_CONTENT,
+export const getOdieRateLimitMessage = (): Message => ( {
+	content: getOdieRateLimitMessageContent(),
 	role: 'bot',
 	type: 'message',
-};
+} );
 
-export const ODIE_FORWARD_TO_FORUMS_MESSAGE = __(
-	'It sounds like you want to talk to a human. Human support is only available for our [paid plans](https://wordpress.com/pricing/). For community support, visit our forums:',
-	__i18n_text_domain__
-);
+export const getOdieForwardToForumsMessage = (): string =>
+	__(
+		'It sounds like you want to talk to a human. Human support is only available for our [paid plans](https://wordpress.com/pricing/). For community support, visit our forums:',
+		__i18n_text_domain__
+	);
 
-export const ODIE_FORWARD_TO_ZENDESK_MESSAGE = __(
-	'It sounds like you want to talk to a human. We’re here to help! Use the option below to message our Happiness Engineers.',
-	__i18n_text_domain__
-);
+export const getOdieForwardToZendeskMessage = (): string =>
+	// eslint-disable-next-line quotes
+	__(
+		'It sounds like you want to talk to a human. We’re here to help! Use the option below to message our Happiness Engineers.',
+		__i18n_text_domain__
+	);
 
-export const ODIE_TRANSFER_MESSAGE: Message[] = [
+export const getOdieTransferMessage = (): Message[] => [
 	{
 		content: __( 'No problem. Help is on the way!', __i18n_text_domain__ ),
 		role: 'bot',
@@ -49,9 +55,9 @@ export const ODIE_TRANSFER_MESSAGE: Message[] = [
 	},
 ];
 
-export const ODIE_ON_ERROR_TRANSFER_MESSAGE: Message[] = [
+export const getOdieOnErrorTransferMessage = (): Message[] => [
 	{
-		content: ODIE_ERROR_MESSAGE,
+		content: getOdieErrorMessage(),
 		role: 'bot',
 		type: 'message',
 		context: {
@@ -65,15 +71,16 @@ export const ODIE_ON_ERROR_TRANSFER_MESSAGE: Message[] = [
 	},
 ];
 
-export const ODIE_THIRD_PARTY_MESSAGE_CONTENT = `${ __(
-	'I’m happy to connect you to a human! However, it looks like 3rd party cookies are disabled in your browser. Please turn them on for our live chat to work properly. [Use our guide](https://wordpress.com/support/third-party-cookies/)',
-	__i18n_text_domain__
-) } \n\n ${ __(
-	'Once you’re done, you can come back here to start talking with someone by clicking on the following button.',
-	__i18n_text_domain__
-) }`;
+export const getOdieThirdPartyMessageContent = (): string =>
+	`${ __(
+		'I’m happy to connect you to a human! However, it looks like 3rd party cookies are disabled in your browser. Please turn them on for our live chat to work properly. [Use our guide](https://wordpress.com/support/third-party-cookies/)',
+		__i18n_text_domain__
+	) } \n\n ${ __(
+		'Once you’re done, you can come back here to start talking with someone by clicking on the following button.',
+		__i18n_text_domain__
+	) }`;
 
-export const ODIE_WRONG_FILE_TYPE_MESSAGE: Message = {
+export const getOdieWrongFileTypeMessage = (): Message => ( {
 	content: __(
 		'Sorry! The file you are trying to upload is not supported. Please upload a .jpg, .png, or .gif file.',
 		__i18n_text_domain__
@@ -87,15 +94,16 @@ export const ODIE_WRONG_FILE_TYPE_MESSAGE: Message = {
 		},
 		site_id: null,
 	},
-};
+} );
 
-export const ODIE_EMAIL_FALLBACK_MESSAGE_CONTENT = __(
-	'We’re sorry, but live chat is temporarily unavailable for scheduled maintenance. Please feel free to reach out via email or check our Support Guides in the meantime.',
-	__i18n_text_domain__
-);
+export const getOdieEmailFallbackMessageContent = (): string =>
+	__(
+		'We’re sorry, but live chat is temporarily unavailable for scheduled maintenance. Please feel free to reach out via email or check our Support Guides in the meantime.',
+		__i18n_text_domain__
+	);
 
-export const ODIE_EMAIL_FALLBACK_MESSAGE: Message = {
-	content: ODIE_EMAIL_FALLBACK_MESSAGE_CONTENT,
+export const getOdieEmailFallbackMessage = (): Message => ( {
+	content: getOdieEmailFallbackMessageContent(),
 	role: 'bot',
 	type: 'message',
 	context: {
@@ -108,7 +116,7 @@ export const ODIE_EMAIL_FALLBACK_MESSAGE: Message = {
 		},
 		site_id: null,
 	},
-};
+} );
 
 const getOdieInitialPromptContext = ( botNameSlug: OdieAllowedBots ): Context | undefined => {
 	switch ( botNameSlug ) {

--- a/packages/odie-client/src/constants.ts
+++ b/packages/odie-client/src/constants.ts
@@ -33,7 +33,6 @@ export const getOdieForwardToForumsMessage = (): string =>
 	);
 
 export const getOdieForwardToZendeskMessage = (): string =>
-	// eslint-disable-next-line quotes
 	__(
 		'It sounds like you want to talk to a human. We’re here to help! Use the option below to message our Happiness Engineers.',
 		__i18n_text_domain__

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -6,9 +6,9 @@ import { useSelect } from '@wordpress/data';
 import { useEffect, useState } from 'react';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import {
-	ODIE_RATE_LIMIT_MESSAGE,
-	ODIE_EMAIL_FALLBACK_MESSAGE,
-	ODIE_ERROR_MESSAGE_NON_ELIGIBLE,
+	getOdieRateLimitMessage,
+	getOdieEmailFallbackMessage,
+	getOdieErrorMessageNonEligible,
 } from '../constants';
 import { useOdieAssistantContext } from '../context';
 import { useCreateZendeskConversation } from '../hooks';
@@ -21,7 +21,7 @@ const getErrorMessageForSiteIdAndInternalMessageId = (
 	internal_message_id: string
 ): Message => {
 	return {
-		content: ODIE_ERROR_MESSAGE_NON_ELIGIBLE,
+		content: getOdieErrorMessageNonEligible(),
 		internal_message_id,
 		role: 'bot',
 		type: 'message',
@@ -109,7 +109,7 @@ export const useSendOdieMessage = () => {
 					setChat( ( prevChat ) => ( {
 						...prevChat,
 						...props,
-						messages: [ ...prevChat.messages, ...[ ODIE_EMAIL_FALLBACK_MESSAGE ] ],
+						messages: [ ...prevChat.messages, getOdieEmailFallbackMessage() ],
 						status: 'loaded',
 					} ) );
 					broadcastOdieMessage( message, odieBroadcastClientId );
@@ -227,7 +227,7 @@ export const useSendOdieMessage = () => {
 
 			if ( isRateLimitError ) {
 				// Handle rate limit error with standard rate limit message
-				const message: Message = { ...ODIE_RATE_LIMIT_MESSAGE, internal_message_id };
+				const message: Message = { ...getOdieRateLimitMessage(), internal_message_id };
 				addMessage( { message, props: {}, isFromError: true } );
 			} else if ( isUserEligibleForPaidSupport && canConnectToZendesk ) {
 				// User is eligible for premium support - transfer to Zendesk

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -4,7 +4,7 @@ import { useUpdateZendeskUserFields } from '@automattic/zendesk-client';
 import { useSelect } from '@wordpress/data';
 import Smooch from 'smooch';
 import { logToLogstash } from 'calypso/lib/logstash'; // eslint-disable-line no-restricted-imports -- this import is safe, not introudcing any circular deps; also, it should be removed shortly after investigating the chats with missing zd ids issue
-import { ODIE_ON_ERROR_TRANSFER_MESSAGE, ODIE_TRANSFER_MESSAGE } from '../constants';
+import { getOdieOnErrorTransferMessage, getOdieTransferMessage } from '../constants';
 import { useOdieAssistantContext } from '../context';
 import { useManageSupportInteraction } from '../data';
 
@@ -107,7 +107,7 @@ export const useCreateZendeskConversation = (): ( ( {
 				? prevChat.messages
 				: [
 						...prevChat.messages,
-						...( isFromError ? ODIE_ON_ERROR_TRANSFER_MESSAGE : ODIE_TRANSFER_MESSAGE ),
+						...( isFromError ? getOdieOnErrorTransferMessage() : getOdieTransferMessage() ),
 				  ],
 			status: 'transfer',
 		} ) );

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -3,7 +3,7 @@ import { HelpCenterSelect } from '@automattic/data-stores';
 import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { useSelect } from '@wordpress/data';
 import { useState, useEffect, useRef } from '@wordpress/element';
-import { ODIE_TRANSFER_MESSAGE } from '../constants';
+import { getOdieTransferMessage } from '../constants';
 import { emptyChat } from '../context';
 import { useGetZendeskConversation, useManageSupportInteraction, useOdieChat } from '../data';
 import {
@@ -98,7 +98,7 @@ export const useGetCombinedChat = (
 							conversationId: conversation.id,
 							messages: [
 								...( odieChat ? filteredOdieMessages : [] ),
-								...( odieChat ? ODIE_TRANSFER_MESSAGE : [] ),
+								...( odieChat ? getOdieTransferMessage() : [] ),
 								...( conversation.messages as Message[] ),
 							],
 							provider: 'zendesk',

--- a/packages/odie-client/src/utils/is-odie-allowed-bot.ts
+++ b/packages/odie-client/src/utils/is-odie-allowed-bot.ts
@@ -1,11 +1,8 @@
 import { ODIE_ALLOWED_BOTS } from '../constants';
 import type { OdieAllowedBots } from '../types';
 
-/**
- * Checks if a bot is allowed based on its name slug.
- * @param {string | undefined} botNameSlug - The slug of the bot to check.
- * @returns {boolean} - True if the bot is allowed, false otherwise.
- */
-export const isOdieAllowedBot = ( botNameSlug: string | undefined ): boolean => {
+export function isOdieAllowedBot(
+	botNameSlug: string | undefined
+): botNameSlug is OdieAllowedBots {
 	return !! ( botNameSlug && ODIE_ALLOWED_BOTS.includes( botNameSlug as OdieAllowedBots ) );
-};
+}

--- a/packages/odie-client/src/utils/is-odie-allowed-bot.ts
+++ b/packages/odie-client/src/utils/is-odie-allowed-bot.ts
@@ -1,8 +1,11 @@
 import { ODIE_ALLOWED_BOTS } from '../constants';
 import type { OdieAllowedBots } from '../types';
 
-export function isOdieAllowedBot(
-	botNameSlug: string | undefined
-): botNameSlug is OdieAllowedBots {
+/**
+ * Checks if a bot is allowed based on its name slug.
+ * @param {string | undefined} botNameSlug - The slug of the bot to check.
+ * @returns {boolean} - True if the bot is allowed, false otherwise.
+ */
+export const isOdieAllowedBot = ( botNameSlug: string | undefined ): boolean => {
 	return !! ( botNameSlug && ODIE_ALLOWED_BOTS.includes( botNameSlug as OdieAllowedBots ) );
-}
+};


### PR DESCRIPTION
Fixes DOTCOM-12648

## Proposed Changes

This translates the phrases when they're needed, not on module initialization. Modules can be initiated before translations are downloaded and the phrases are cached untranslated.

## Why are these changes being made?
-

## Testing Instructions
1. Change your UI language to anything non-English.
2. Go to Odie.
3. Ask for a Human.
4. The transfer message should be in the new language, not "No problem. Help is on the way!"

### Screenshots

#### Before
![image](https://github.com/user-attachments/assets/4ce26fa6-9a16-4ee7-9fd9-46ebcbd03898)

#### After
![image](https://github.com/user-attachments/assets/d407fb3d-91de-49fc-847b-d49ded414653)
