### PR TITLE
Notification settings: match endpoint expectations for day numbers

### DIFF
--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -136,7 +136,7 @@ class NotificationSubscriptions extends Component {
 			{ value: '4', label: translate( 'Thursday' ) },
 			{ value: '5', label: translate( 'Friday' ) },
 			{ value: '6', label: translate( 'Saturday' ) },
-			{ value: '7', label: translate( 'Sunday' ) },
+			{ value: '0', label: translate( 'Sunday' ) },
 		];
 
 		// Rotate the array based on startOfWeek


### PR DESCRIPTION
Fixes CML-645

## Proposed Changes, why are these changes being made?

The settings endpoint expects days of the week to go from 0 to 6, 0 being Sunday. Let's match that expectation in the settings screen, while still keeping the original item order to ensure Sunday gets re-ordered when Monday is set as the beginning of the week.

## Testing Instructions

* Go to http://calypso.localhost:3000/me/notifications/subscriptions
* Ensure the first day in the dropdown is Sunday.
* Change subscription settings to send emails on Sundays.
* Ensure the data is properly saved.
* Now go to http://calypso.localhost:3000/me/account
* Switch your language to French
* Go back to http://calypso.localhost:3000/me/notifications/subscriptions
* Ensure the first day in the dropdown is Monday (lundi).
* Ensure data is properly saved when changing values.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
