### PR TITLE
A4A > Reports: Implement survey and minor UI enhancement

### DIFF
--- a/client/a8c-for-agencies/sections/reports/constants.ts
+++ b/client/a8c-for-agencies/sections/reports/constants.ts
@@ -2,3 +2,5 @@ export const A4A_REPORTS_LINK = '/reports';
 export const A4A_REPORTS_OVERVIEW_LINK = '/reports/overview';
 export const A4A_REPORTS_DASHBOARD_LINK = '/reports/dashboard';
 export const A4A_REPORTS_BUILD_LINK = '/reports/build';
+
+export const A4A_REPORTS_SURVEY_PREFERENCE_KEY = 'a4a-reports-survey-shown';

--- a/client/a8c-for-agencies/sections/reports/primary/build-report/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/build-report/index.tsx
@@ -12,12 +12,14 @@ import LayoutHeader, {
 	LayoutHeaderBreadcrumb as Breadcrumb,
 	LayoutHeaderActions as Actions,
 } from 'calypso/layout/hosting-dashboard/header';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
 import {
 	A4A_REPORTS_LINK,
 	A4A_REPORTS_BUILD_LINK,
 	A4A_REPORTS_DASHBOARD_LINK,
+	A4A_REPORTS_SURVEY_PREFERENCE_KEY,
 } from '../../constants';
 import { useFormValidation } from '../../hooks/use-build-report-form-validation';
 import { useDuplicateReportFormData } from '../../hooks/use-duplicate-report-form-data';
@@ -34,6 +36,11 @@ import './style.scss';
 const BuildReport = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+
+	// Check if the survey has been shown to the user
+	const surveyShown = useSelector( ( state ) =>
+		getPreference( state, A4A_REPORTS_SURVEY_PREFERENCE_KEY )
+	);
 
 	const [ currentStep, setCurrentStep ] = useState( 1 );
 
@@ -75,7 +82,10 @@ const BuildReport = () => {
 				)
 			);
 			if ( ! isPreview ) {
-				page.redirect( A4A_REPORTS_DASHBOARD_LINK );
+				const dashboardUrl = ! surveyShown
+					? addQueryArgs( A4A_REPORTS_DASHBOARD_LINK, { 'show-survey': 'true' } )
+					: A4A_REPORTS_DASHBOARD_LINK;
+				page.redirect( dashboardUrl );
 			}
 		},
 		onError: ( error ) => {

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/index.tsx
@@ -24,6 +24,7 @@ import { A4A_REPORTS_BUILD_LINK } from '../../constants';
 import useFetchReports from '../../hooks/use-fetch-reports';
 import { getSiteReports } from '../../lib/get-site-reports';
 import ReportsDetails from '../../reports-details';
+import ReportsSurvey from '../../reports-survey';
 import ReportsDashboardEmptyState from './empty-state';
 import ReportsList from './reports-list';
 import type { SiteReports } from '../../types';
@@ -81,11 +82,14 @@ export default function ReportsDashboard() {
 		}
 
 		return (
-			<ReportsList
-				siteReports={ siteReports }
-				dataViewsState={ updatedDataViewsState }
-				setDataViewsState={ setDataViewsState }
-			/>
+			<>
+				<ReportsList
+					siteReports={ siteReports }
+					dataViewsState={ updatedDataViewsState }
+					setDataViewsState={ setDataViewsState }
+				/>
+				<ReportsSurvey />
+			</>
 		);
 	}, [ isLoading, showEmptyState, siteReports, updatedDataViewsState, setDataViewsState ] );
 

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
@@ -13,7 +13,7 @@ export const ReportSiteColumn = ( { site }: { site: string } ) => urlToSlug( sit
 export const ReportCountColumn = ( { count, onClick }: { count: number; onClick: () => void } ) => {
 	const translate = useTranslate();
 	return (
-		<Button variant="tertiary" onClick={ onClick }>
+		<Button variant="link" onClick={ onClick }>
 			{ translate( '%(count)d report', '%(count)d reports', {
 				count,
 				args: { count },

--- a/client/a8c-for-agencies/sections/reports/reports-survey/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/reports-survey/index.tsx
@@ -1,0 +1,84 @@
+import page from '@automattic/calypso-router';
+import { Button, Modal } from '@wordpress/components';
+import { Icon, external } from '@wordpress/icons';
+import { getQueryArgs, removeQueryArgs } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
+import { A4A_REPORTS_SURVEY_PREFERENCE_KEY } from '../constants';
+
+import './style.scss';
+
+const SURVEY_URL = 'https://automattic.survey.fm/automattic-for-agencies-client-reports-beta';
+
+export default function ReportsSurvey() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const surveyShown = useSelector( ( state ) =>
+		getPreference( state, A4A_REPORTS_SURVEY_PREFERENCE_KEY )
+	);
+
+	const [ showSurvey, setShowSurvey ] = useState( false );
+
+	// Handle URL parameter for showing survey modal
+	useEffect( () => {
+		const queryArgs = getQueryArgs( window.location.href );
+		const showSurveyParam = queryArgs[ 'show-survey' ];
+
+		if ( showSurveyParam === 'true' && ! surveyShown ) {
+			setShowSurvey( true );
+		}
+	}, [ dispatch, surveyShown ] );
+
+	const closeModal = () => {
+		page.redirect(
+			removeQueryArgs( window.location.pathname + window.location.search, 'show-survey' )
+		);
+		dispatch( savePreference( A4A_REPORTS_SURVEY_PREFERENCE_KEY, true ) );
+		setShowSurvey( false );
+	};
+
+	const handleClose = () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_reports_survey_modal_close' ) );
+		closeModal();
+	};
+
+	const handleSurveyClick = () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_reports_survey_modal_survey_click' ) );
+		closeModal();
+	};
+
+	if ( ! showSurvey ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			title={ translate( 'Congrats on your first Client Report!' ) }
+			onRequestClose={ handleClose }
+			className="reports-survey-modal"
+		>
+			<p className="reports-survey-modal__text">
+				{ translate(
+					'Do you have 2 minutes? Share your thoughts on our Client Reports BETA. Your feedback shapes our roadmap and helps us build the right tools for you and your clients.'
+				) }
+			</p>
+			<div className="reports-survey-modal__buttons">
+				<Button
+					variant="primary"
+					href={ SURVEY_URL }
+					target="_blank"
+					onClick={ handleSurveyClick }
+					icon={ <Icon icon={ external } /> }
+					iconPosition="right"
+				>
+					{ translate( 'Take 2 minute survey' ) }
+				</Button>
+			</div>
+		</Modal>
+	);
+}

--- a/client/a8c-for-agencies/sections/reports/reports-survey/style.scss
+++ b/client/a8c-for-agencies/sections/reports/reports-survey/style.scss
@@ -1,0 +1,15 @@
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
+
+.reports-survey-modal {
+	width: 30%;
+}
+
+.reports-survey-modal__text {
+	@include body-medium;
+}
+
+.reports-survey-modal__buttons {
+	display: flex;
+	justify-content: flex-end;
+}

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -130,6 +130,16 @@
 		background-color: var(--color-primary-50);
 	}
 
+	.components-button.is-link {
+		&:hover {
+			background-color: transparent;
+		}
+		&:focus-visible,
+		&:focus {
+			color: inherit;
+		}
+	}
+
 	.components-button.is-primary,
 	.button.is-primary {
 		&:not( :disabled ),


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1259/client-reports-add-modal-to-survey

## Proposed Changes

This PR:

- Adds a survey when the first report is sent
- Changes the button on the `Reports` column from "tertiary" to "link"

## Why are these changes being made?

* To show a survey after the user sends their first report. 

## Testing Instructions

* Open the A4A live link
* Go to Reports > Build a report > Verify you are redirected to the Dashboard, and a survey is shown as displayed below. 
* Click the `Take 2 minute survey` button and verify that you are navigated to an external survey link and the modal is closed 
* Verify the survey is not shown again when you build a new report.
* Verify the survey is not shown when you manually append the URL with `?show-survey=true`

<img width="764" alt="Screenshot 2025-07-09 at 1 57 24 PM" src="https://github.com/user-attachments/assets/666ca004-69b1-450f-8de3-54cc6d7a505b" />

* Verify the button is changed to "link"

<img width="195" alt="Screenshot 2025-07-08 at 5 52 04 PM" src="https://github.com/user-attachments/assets/644e479a-9903-47d0-828b-284f5ffd0d5b" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
