### PR TITLE
Connect Refresh: Remove need for wider heading from Login

### DIFF
--- a/client/login/wp-login/components/one-login-layout.tsx
+++ b/client/login/wp-login/components/one-login-layout.tsx
@@ -15,7 +15,6 @@ interface OneLoginLayoutProps {
 	isFromAkismet: boolean;
 	children: React.ReactNode;
 	signupUrl?: string;
-	shouldUseWideHeading?: number;
 }
 
 const OneLoginLayout = ( {
@@ -23,7 +22,6 @@ const OneLoginLayout = ( {
 	isFromAkismet,
 	children,
 	signupUrl: signupUrlProp,
-	shouldUseWideHeading,
 }: OneLoginLayoutProps ) => {
 	const translate = useTranslate();
 	const locale = useSelector( getCurrentUserLocale );
@@ -55,7 +53,6 @@ const OneLoginLayout = ( {
 	return (
 		<Step.CenteredColumnLayout
 			columnWidth={ 6 }
-			{ ...( shouldUseWideHeading && { columnWidthHeading: 8 } ) }
 			topBar={ <Step.TopBar rightElement={ <SignUpLink /> } compactLogo="always" /> }
 			heading={
 				<Step.Heading

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -346,7 +346,6 @@ export class Login extends Component {
 			isWhiteLogin,
 			isJetpack,
 			isFromAkismet,
-			action,
 		} = this.props;
 
 		const canonicalUrl = localizeUrl( 'https://wordpress.com/log-in', locale );
@@ -389,7 +388,6 @@ export class Login extends Component {
 					<OneLoginLayout
 						isJetpack={ isJetpack }
 						isFromAkismet={ isFromAkismet }
-						shouldUseWideHeading={ 'lostpassword' !== action }
 						signupUrl={ this.props.signupUrl }
 					>
 						{ mainContent }

--- a/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/CenteredColumnLayout.tsx
+++ b/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/CenteredColumnLayout.tsx
@@ -13,13 +13,11 @@ interface CenteredColumnLayoutProps {
 	children?: ContentProp;
 	stickyBottomBar?: ContentProp;
 	columnWidth: 4 | 5 | 6 | 8 | 10;
-	columnWidthHeading?: 4 | 5 | 6 | 8 | 10;
 	verticalAlign?: 'center';
 }
 
 export const CenteredColumnLayout = ( {
 	columnWidth,
-	columnWidthHeading,
 	topBar,
 	heading,
 	className,
@@ -36,9 +34,7 @@ export const CenteredColumnLayout = ( {
 					<>
 						<TopBarRenderer topBar={ topBar } />
 						<ContentWrapper centerAligned={ context.isSmallViewport && verticalAlign === 'center' }>
-							{ heading && (
-								<ContentRow columns={ columnWidthHeading ?? 6 }>{ heading }</ContentRow>
-							) }
+							{ heading && <ContentRow columns={ 6 }>{ heading }</ContentRow> }
 							<ContentRow columns={ columnWidth } className={ className }>
 								{ content }
 							</ContentRow>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13220/login-make-the-two-columnwhite-layout-the-default-across-all-contexts

## Proposed Changes

Remove the need to adjust the Login page heading depending on client/default use. We had introduced this earlier to piece-meal the migration. It should now be a static `false` (despite being a static `true` in the code - wrongly).

## Media

### Studio

<img width="500" alt="Screenshot 2025-07-09 at 12 54 49 PM" src="https://github.com/user-attachments/assets/2a32ca3c-396d-490f-bab5-3dc971a9a4d7" />


### Default
<img width="500" alt="Screenshot 2025-07-09 at 12 55 00 PM" src="https://github.com/user-attachments/assets/eb735021-da24-4615-bbad-2d05c57710c7" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13220/login-make-the-two-columnwhite-layout-the-default-across-all-contexts

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Got to a few [Login variants](https://linear.app/a8c/issue/DOTCOM-13220/login-make-the-two-columnwhite-layout-the-default-across-all-contexts) and confirm heading/sub-heading render properly (compare to production - mostly two lines for OAuth clients)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
