### PR TITLE
Reader - improve empty list state, prompt owners to add items.

### DIFF
--- a/client/reader/list-stream/empty.tsx
+++ b/client/reader/list-stream/empty.tsx
@@ -1,24 +1,69 @@
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import EmptyContent from 'calypso/components/empty-content';
+import { getListItems } from 'calypso/state/reader/lists/selectors';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 
-export default function ListEmptyContent(): JSX.Element {
+interface ListEmptyContentProps {
+	list?: {
+		title: string;
+		owner: string;
+		slug: string;
+		is_owner: boolean;
+		ID: number;
+	};
+}
+
+export default function ListEmptyContent( { list }: ListEmptyContentProps ): JSX.Element {
 	const translate = useTranslate();
 	const previousRoute: string = useSelector( getPreviousRoute );
+	const listItems = useSelector( ( state ) =>
+		list ? getListItems( state, list.ID ) : undefined
+	);
+	const isEmptyList = listItems?.length === 0;
+	const shouldPromptManagement = isEmptyList && list?.is_owner;
+	const isRecommendedBlogsList = list?.slug === 'recommended-blogs';
 
 	function previousRouteIsUserProfileLists(): boolean {
 		return /^\/reader\/users\/[a-z0-9]+\/lists\??$/.test( previousRoute );
 	}
 
 	function getActionBtnLink(): string {
+		if ( shouldPromptManagement ) {
+			return `/reader/list/${ list?.owner }/${ list?.slug }/edit/items`;
+		}
+
 		return previousRouteIsUserProfileLists() ? previousRoute : '/reader';
 	}
 
 	function getActionBtnText(): string {
+		if ( shouldPromptManagement ) {
+			return isRecommendedBlogsList ? translate( 'Add recommendations' ) : translate( 'Add items' );
+		}
+
 		return previousRouteIsUserProfileLists()
 			? translate( 'Back to User Profile' )
 			: translate( 'Back to Following' );
+	}
+
+	function getTitle(): string {
+		if ( shouldPromptManagement ) {
+			return isRecommendedBlogsList
+				? translate( 'No recommendations' )
+				: translate( 'This list is empty' );
+		}
+
+		return translate( 'No recent posts' );
+	}
+
+	function getLine(): string {
+		if ( shouldPromptManagement ) {
+			return isRecommendedBlogsList
+				? translate( 'You have not recommended any blogs yet.' )
+				: translate( 'You have not added any items to this list.' );
+		}
+
+		return translate( 'The sites in this list have not posted anything recently.' );
 	}
 
 	const action = (
@@ -27,11 +72,5 @@ export default function ListEmptyContent(): JSX.Element {
 		</a>
 	);
 
-	return (
-		<EmptyContent
-			title={ translate( 'No recent posts' ) }
-			line={ translate( 'The sites in this list have not posted anything recently.' ) }
-			action={ action }
-		/>
-	);
+	return <EmptyContent title={ getTitle() } line={ getLine() } action={ action } />;
 }

--- a/client/reader/list-stream/empty.tsx
+++ b/client/reader/list-stream/empty.tsx
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import QueryReaderListItems from 'calypso/components/data/query-reader-list-items';
 import EmptyContent from 'calypso/components/empty-content';
 import { getListItems } from 'calypso/state/reader/lists/selectors';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
@@ -20,7 +21,7 @@ export default function ListEmptyContent( { list }: ListEmptyContentProps ): JSX
 	const listItems = useSelector( ( state ) =>
 		list ? getListItems( state, list.ID ) : undefined
 	);
-	const isEmptyList = listItems?.length === 0;
+	const isEmptyList = ! listItems?.length;
 	const shouldPromptManagement = isEmptyList && list?.is_owner;
 	const isRecommendedBlogsList = list?.slug === 'recommended-blogs';
 
@@ -72,5 +73,10 @@ export default function ListEmptyContent( { list }: ListEmptyContentProps ): JSX
 		</a>
 	);
 
-	return <EmptyContent title={ getTitle() } line={ getLine() } action={ action } />;
+	return (
+		<>
+			<QueryReaderListItems owner={ list?.owner } slug={ list?.slug } />
+			<EmptyContent title={ getTitle() } line={ getLine() } action={ action } />
+		</>
+	);
 }

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -18,7 +18,11 @@ import ListStreamHeader from './header';
 import ListMissing from './missing';
 import './style.scss';
 
-const emptyContent = () => <EmptyContent />;
+const createEmptyContent = ( list ) => {
+	const EmptyContentWithList = () => <EmptyContent list={ list } />;
+	EmptyContentWithList.displayName = 'EmptyContentWithList';
+	return EmptyContentWithList;
+};
 
 class ListStream extends Component {
 	constructor( props ) {
@@ -72,7 +76,7 @@ class ListStream extends Component {
 			<Stream
 				{ ...this.props }
 				listName={ this.title }
-				emptyContent={ emptyContent }
+				emptyContent={ createEmptyContent( list ) }
 				showFollowInHeader={ shouldShowFollow }
 			>
 				<DocumentHead

--- a/client/reader/user-profile/views/recommended-blogs.tsx
+++ b/client/reader/user-profile/views/recommended-blogs.tsx
@@ -7,6 +7,7 @@ import EmptyContent from 'calypso/components/empty-content';
 import RecommendedBlogItem from 'calypso/components/gravatar-with-hovercards/recommended-blogs/item';
 import { UserData } from 'calypso/lib/user/user';
 import { useSelector, useDispatch } from 'calypso/state';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { requestUserRecommendedBlogs } from 'calypso/state/reader/lists/actions';
 import {
 	isRequestingUserRecommendedBlogs,
@@ -32,6 +33,7 @@ const UserRecommendedBlogs = ( { user }: UserRecommendedBlogsProps ): JSX.Elemen
 	const recommendedBlogs = useSelector( ( state ) =>
 		getUserRecommendedBlogs( state, userLogin || '' )
 	);
+	const currentUser = useSelector( getCurrentUser );
 
 	useEffect( () => {
 		if ( ! recommendedBlogs && userLogin && ! hasRequested ) {
@@ -48,12 +50,21 @@ const UserRecommendedBlogs = ( { user }: UserRecommendedBlogsProps ): JSX.Elemen
 	}
 
 	if ( ! recommendedBlogs?.length ) {
+		const action = currentUser?.username === userLogin && (
+			<a
+				className="empty-content__action button is-primary"
+				href={ `/reader/list/${ userLogin }/recommended-blogs/edit/items` }
+			>
+				{ translate( 'Add recommendations' ) }
+			</a>
+		);
 		return (
 			<EmptyContent
 				illustration={ null }
 				icon={ <Icon icon={ siteLogo } size={ 48 } /> }
 				title={ null }
 				line={ translate( 'No blogs have been recommended yet.' ) }
+				action={ action }
 			/>
 		);
 	}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/CML-595/improve-recommended-blogs-list-blank-slate

## Proposed Changes

Updates the empty content state for lists and recommended blogs on:
* On the lists stream - `*/reader/list/{ownerName}/{listName}` - if the list has no items and the user is the owner of the list, we show a new message (depending on if the list is generic or the recommended blog list) and link the CTA to the list management add section. Previously this showed a generic "no recent posts" regardless of whether or not there were any items followed by the list.
* On the user profile recommended blogs tab - if the list has no items and the user is the owner (viewing their own user profile), we add a CTA button to link to the lists management add section.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* improve empty states of lists and recommended blogs, make it easier for owners to add items.

BEFORE

Empty list stream:
![Screenshot 2025-07-09 at 9 45 51 AM](https://github.com/user-attachments/assets/8cd7be7f-3f72-486b-ad66-33bbf5a9c28f)


Empty profile tab:
![Screenshot 2025-07-09 at 9 46 21 AM](https://github.com/user-attachments/assets/938959a6-7d70-4a5e-90c0-101a80bd52c3)


AFTER

Lists stream for empty list and owner viewing:
![Screenshot 2025-07-09 at 9 42 56 AM](https://github.com/user-attachments/assets/6a5637b1-c454-49ae-87e9-deb796293768)
Recommended blog list stream for empty list and owner viewing:
![Screenshot 2025-07-09 at 9 42 49 AM](https://github.com/user-attachments/assets/fbc1e16a-a2e0-4102-b13b-88c23ad753d8)
User profile tab for empty list and owner viewing:
![Screenshot 2025-07-09 at 9 32 58 AM](https://github.com/user-attachments/assets/d6b1892a-8f3b-4f41-946e-e96c014e4f12)



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the reader.
* Create a new list, do not add any items.
* View the stream for the list by clicking the new lists name in the sidebar.
* Verify the new copies shown above are visible and that the CTA directs you to the management page for adding items to the list.
* Do the same for the recommended blogs list. Since list streams are cached and you likely currently have items in this list, it may be easiest to test by creating a new user account in another browser.
* Now view your user profile recommended blogs tab. Verify there is a similar CTA to add items.
* Add items and verify the CTAs go away.
* Visit another users profile tab for and empty recommended blogs list, verify there is no CTA to add items.
* Visit another users list page for an empty list. If you created a new user for the recommended blogs step, you can try visiting their list stream page from your main account. Verify there is no updated copy and the generic 'no recent posts' message is shown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
