### PR TITLE
Stats: Avoid showing a detail page for the Homepage set as latest posts

### DIFF
--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -391,7 +391,8 @@ export const normalizers = {
 		const viewData = get( data, dataPath, [] );
 
 		return map( viewData, ( item ) => {
-			const detailPage = site ? `/stats/post/${ item.id }/${ site.slug }` : null;
+			// To avoid showing a detail page for the Homepage set as latest posts.
+			const detailPage = site && item.href ? `/stats/post/${ item.id }/${ site.slug }` : null;
 			let inPeriod = false;
 
 			// Archive and home pages do not have dates


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of STATS-124.

## Proposed Changes

* To avoid showing a detail page for the `Homepage` set as the latest posts, which has a `null` href.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Since the `Homepage (Latest posts)` does not have a detailed page, we should also make the item unclickable on the `Posts & pages` list.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change with the Calypso Live branch.
* Navigate to Stats > Trafic page.
* Ensure the `Home page / Archives` on the `Posts & pages` list works as previously, as it has a detailed post page.

<img width="633" alt="截圖 2025-07-09 晚上9 17 23" src="https://github.com/user-attachments/assets/7f667ac5-3aa2-4126-8fc4-9960259c5465" />

* Ensure the `Homepage (Latest posts)` on the `Posts & pages` list is not clickable since it does not have a detailed post page.

<img width="645" alt="截圖 2025-07-09 晚上9 17 32" src="https://github.com/user-attachments/assets/4190ff69-508a-4ae1-bf0c-6d33c0282f4f" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
