### PR TITLE
Add tracking events to search card in /support

### DIFF
--- a/apps/happy-blocks/block-library/search-card/index.php
+++ b/apps/happy-blocks/block-library/search-card/index.php
@@ -38,7 +38,7 @@ if ( ! function_exists( 'get_support_search_link_for_query' ) ) {
 -->
 	<div class="content">
 			<h2><?php echo esc_html( __( 'How can we help you?', 'happy-blocks' ) ); ?></h2>
-			<form class="" role="search" method="get" action="">
+			<form id="support-search-form" class="" role="search" method="get" action="">
 				<div class="input-wrapper" dir="auto">
 					<input id="support-search-input" type="search" name="s" placeholder="<?php echo esc_html( __( 'Search questions, guides, courses', 'happy-blocks' ) ); ?>"/>
 

--- a/apps/happy-blocks/block-library/search-card/view.js
+++ b/apps/happy-blocks/block-library/search-card/view.js
@@ -1,8 +1,11 @@
 import './style.scss';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+
 document.addEventListener( 'DOMContentLoaded', function () {
 	const links = document.querySelectorAll( 'a[data-search-query]' );
 	const input = document.getElementById( 'support-search-input' );
 	const submitButton = document.querySelector( '.search-submit-button' );
+	const form = document.getElementById( 'support-search-form' );
 
 	links.forEach( ( link ) => {
 		link.addEventListener( 'click', function ( e ) {
@@ -10,6 +13,11 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			if ( ! input || ! query || ! submitButton ) {
 				return;
 			}
+
+			recordTracksEvent( 'calypso_happyblocks_support_suggested_search', {
+				query,
+				location: window.location.href,
+			} );
 
 			e.preventDefault();
 
@@ -19,6 +27,13 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			setTimeout( () => {
 				input.value = '';
 			}, 100 );
+		} );
+	} );
+
+	form.addEventListener( 'submit', function () {
+		recordTracksEvent( 'calypso_happyblocks_support_custom_search', {
+			query: input.value,
+			location: window.location.href,
 		} );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTSUP-246/adjust-support-events

## Proposed Changes

* Adds tracking event for the form:

<img width="882" alt="image" src="https://github.com/user-attachments/assets/b6635ef0-4ecd-4a9d-9aa4-50eeb3492649" />

- `calypso_happyblocks_support_suggested_search`: Whem the user clicks on a pill.
- `calypso_happyblocks_support_custom_search`: When the user searches something typing something in the input.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn dev --sync` from `apps/happy-blocks`
* Sandbox widgets
* Visit /support and check the events (use Tracks Vigilante)