### PR TITLE
ChatButton: Just use "Need help?"

### DIFF
--- a/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
+++ b/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
@@ -168,7 +168,6 @@ class CancelAutoRenewalForm extends Component {
 						purchase={ purchase }
 						onClick={ onClose }
 						className="cancel-auto-renewal-form__chat-button"
-						label={ translate( 'Need help?' ) }
 					/>
 					<Button onClick={ onClose } variant="tertiary">
 						{ translate( 'Skip' ) }

--- a/client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/index.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/index.tsx
@@ -16,7 +16,6 @@ type Props = {
 	surveyStep?: string;
 	onClick: () => void;
 	className?: string;
-	label?: string;
 };
 
 const PrecancellationChatButton: FC< Props > = ( {
@@ -24,7 +23,6 @@ const PrecancellationChatButton: FC< Props > = ( {
 	surveyStep = '',
 	onClick,
 	className,
-	label,
 } ) => {
 	const translate = useTranslate();
 	const siteUrl =
@@ -60,10 +58,7 @@ const PrecancellationChatButton: FC< Props > = ( {
 			onClick={ handleClick }
 			section="pre-cancellation"
 		>
-			{ label ||
-				translate( 'Need help? {{span}}Contact us{{/span}}', {
-					components: { span: <span /> },
-				} ) }
+			{ translate( 'Need help?' ) }
 		</ChatButton>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
@@ -1,5 +1,4 @@
 import { MaterialIcon } from '@automattic/components';
-import { useHasEnTranslation } from '@automattic/i18n-utils';
 import {
 	StepContainer,
 	GOOGLE_TRANSFER,
@@ -20,7 +19,6 @@ import './styles.scss';
 const Intro: Step = function Intro( { navigation, flow, variantSlug } ) {
 	const { submit, goBack } = navigation;
 	const { __ } = useI18n();
-	const hasEnTranslation = useHasEnTranslation();
 
 	const handleSubmit = () => {
 		submit?.();
@@ -85,9 +83,7 @@ const Intro: Step = function Intro( { navigation, flow, variantSlug } ) {
 					section="domains-transfer"
 				>
 					<MaterialIcon icon="chat_bubble" />
-					{ hasEnTranslation( 'Need help? Contact us' )
-						? __( 'Need help? Contact us' )
-						: __( 'Need help? Chat with us' ) }
+					{ __( 'Need help?' ) }
 				</ChatButton>
 			}
 		/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/index.tsx
@@ -1,5 +1,4 @@
 import { MaterialIcon } from '@automattic/components';
-import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { StepContainer, GOOGLE_TRANSFER } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import ChatButton from 'calypso/components/chat-button';
@@ -13,7 +12,6 @@ import './styles.scss';
 const Intro: Step = function Intro( { navigation, variantSlug } ) {
 	const { submit } = navigation;
 	const { __ } = useI18n();
-	const hasEnTranslation = useHasEnTranslation();
 
 	const handleSubmit = () => {
 		submit?.();
@@ -56,9 +54,7 @@ const Intro: Step = function Intro( { navigation, variantSlug } ) {
 					section="domains-transfer"
 				>
 					<MaterialIcon icon="chat_bubble" />
-					{ hasEnTranslation( 'Need help? Contact us' )
-						? __( 'Need help? Contact us' )
-						: __( 'Need help? Chat with us' ) }
+					{ __( 'Need help?' ) }
 				</ChatButton>
 			}
 		/>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTSUP-43/update-contact-link-in-delete-modal
More context: https://github.com/Automattic/wp-calypso/pull/104000#issuecomment-2949340013

## Proposed Changes

In domain (renewals, precancellations, ...) we show a modal to the user, with a link to contact support on bottom left.

![image](https://github.com/user-attachments/assets/5d94ec85-ef7a-4a38-b733-633a1a62fdbd)

This [issue](https://linear.app/a8c/issue/DOTSUP-43/update-contact-link-in-delete-modal) was about changing the colors, and to have it like this:

![image](https://github.com/user-attachments/assets/96933db1-0cd0-4f6f-9df8-e0947ff67ff3)

While deciding how to do it, I stumbled upon [this](https://github.com/Automattic/wp-calypso/pull/104000#issuecomment-2949340013) comment by @fditrapani:

`We've been cleaning up the "Need help?" link in other modals to not include "Contact us". Can we do the same here.`

So I ended up just using `Need help?` as a link.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to domains and try to delete one.
* A modal should open and the link on bottom left should be updated