### PR TITLE
Connect Refresh: Update Login heading to adapt multiple subs

### DIFF
--- a/client/login/wp-login/components/one-login-layout.tsx
+++ b/client/login/wp-login/components/one-login-layout.tsx
@@ -54,23 +54,16 @@ const OneLoginLayout = ( {
 		<Step.CenteredColumnLayout
 			columnWidth={ 6 }
 			topBar={ <Step.TopBar rightElement={ <SignUpLink /> } compactLogo="always" /> }
-			heading={
-				<Step.Heading
-					text={
-						<>
-							<HeadingLogo isFromAkismet={ isFromAkismet } isJetpack={ isJetpack } />
-							{ headingText && <div className="wp-login__heading-text">{ headingText }</div> }
-						</>
-					}
-					subText={
-						// <span> here because the Step.Heading renders subtext as a <p> tag.
-						subHeadingText && <span className="wp-login__heading-subtext">{ subHeadingText }</span>
-					}
-				/>
-			}
 			verticalAlign="center"
 		>
-			{ children }
+			<div className="wp-login__one-login-layout-content-wrapper">
+				<div className="wp-login__header">
+					<HeadingLogo isFromAkismet={ isFromAkismet } isJetpack={ isJetpack } />
+					<Step.Heading text={ <div className="wp-login__heading-text">{ headingText }</div> } />
+					<h2 className="wp-login__heading-subtext">{ subHeadingText }</h2>
+				</div>
+				{ children }
+			</div>
 		</Step.CenteredColumnLayout>
 	);
 };

--- a/client/login/wp-login/components/one-login-layout.tsx
+++ b/client/login/wp-login/components/one-login-layout.tsx
@@ -15,7 +15,6 @@ interface OneLoginLayoutProps {
 	isFromAkismet: boolean;
 	children: React.ReactNode;
 	signupUrl?: string;
-	shouldUseWideHeading?: number;
 }
 
 const OneLoginLayout = ( {
@@ -23,7 +22,6 @@ const OneLoginLayout = ( {
 	isFromAkismet,
 	children,
 	signupUrl: signupUrlProp,
-	shouldUseWideHeading,
 }: OneLoginLayoutProps ) => {
 	const translate = useTranslate();
 	const locale = useSelector( getCurrentUserLocale );
@@ -55,7 +53,6 @@ const OneLoginLayout = ( {
 	return (
 		<Step.CenteredColumnLayout
 			columnWidth={ 6 }
-			{ ...( shouldUseWideHeading && { columnWidthHeading: 8 } ) }
 			topBar={ <Step.TopBar rightElement={ <SignUpLink /> } compactLogo="always" /> }
 			heading={
 				<Step.Heading

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -346,7 +346,6 @@ export class Login extends Component {
 			isWhiteLogin,
 			isJetpack,
 			isFromAkismet,
-			action,
 		} = this.props;
 
 		const canonicalUrl = localizeUrl( 'https://wordpress.com/log-in', locale );
@@ -389,7 +388,6 @@ export class Login extends Component {
 					<OneLoginLayout
 						isJetpack={ isJetpack }
 						isFromAkismet={ isFromAkismet }
-						shouldUseWideHeading={ 'lostpassword' !== action }
 						signupUrl={ this.props.signupUrl }
 					>
 						{ mainContent }

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -37,10 +37,6 @@ $image-height: 47px;
 		}
 	}
 
-	.step-container-v2__heading {
-		text-align: center;
-	}
-
 	/* Start: Blaze Pro OAuth client font styles for login page */
 	&.is-blaze-pro {
 		* {

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -81,7 +81,6 @@ $image-height: 47px;
 }
 
 .wp-login__heading-logo {
-	text-align: center;
 	margin-bottom: 16px;
 
 	> img {
@@ -91,7 +90,9 @@ $image-height: 47px;
 }
 
 .wp-login__heading-subtext {
+	text-wrap: balance;
 	color: var(--studio-gray-50, #646970);
+	margin-block: 0.5rem 0;
 
 	a {
 		color: var(--studio-gray-50, #646970);
@@ -100,7 +101,7 @@ $image-height: 47px;
 }
 
 .wp-login__header {
-	color: var(--color-neutral-40);
+	color: var( --color-neutral-100 );
 	font-size: $font-body;
 	margin-bottom: 16px;
 	text-align: center;
@@ -108,6 +109,10 @@ $image-height: 47px;
 	body.is-section-signup & {
 		color: var(--color-text-inverted);
 	}
+}
+
+.wp-login__main {
+	width: 100%;
 }
 
 .wp-login__site-return-link {
@@ -453,7 +458,13 @@ $image-height: 47px;
 	}
 }
 
-
+.wp-login__one-login-layout-content-wrapper {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 3em;
+}
 
 /* stylelint-disable scales/font-weights, scales/radii */
 .layout.is-section-login.is-grav-powered-client {

--- a/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/CenteredColumnLayout.tsx
+++ b/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/CenteredColumnLayout.tsx
@@ -13,13 +13,11 @@ interface CenteredColumnLayoutProps {
 	children?: ContentProp;
 	stickyBottomBar?: ContentProp;
 	columnWidth: 4 | 5 | 6 | 8 | 10;
-	columnWidthHeading?: 4 | 5 | 6 | 8 | 10;
 	verticalAlign?: 'center';
 }
 
 export const CenteredColumnLayout = ( {
 	columnWidth,
-	columnWidthHeading,
 	topBar,
 	heading,
 	className,
@@ -36,9 +34,7 @@ export const CenteredColumnLayout = ( {
 					<>
 						<TopBarRenderer topBar={ topBar } />
 						<ContentWrapper centerAligned={ context.isSmallViewport && verticalAlign === 'center' }>
-							{ heading && (
-								<ContentRow columns={ columnWidthHeading ?? 6 }>{ heading }</ContentRow>
-							) }
+							{ heading && <ContentRow columns={ 6 }>{ heading }</ContentRow> }
 							<ContentRow columns={ columnWidth } className={ className }>
 								{ content }
 							</ContentRow>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13220/login-make-the-two-columnwhite-layout-the-default-across-all-contexts

## Proposed Changes

We refactor the heading element to allow better extensibility, multiple sub-headers, and more control over enclosing tags. There are a few limitations with the current/initial approach:
- sub-headings are enclosed in a `p` tag which isn't desirable - it forces elements to be wrapped in `span` tags, also rather concerning from SEO perspective
- tthe heading is immediately followed with a large gap, which makes adding multiple sub-headings impossible - unless we want to include them in `span` tags and customise (not desirable)
- A logo rendered inside an `h1` tag is also not appropriate

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of Login refactors. Upcoming changes requiring multiple sub-headings.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to several [Login screens](https://linear.app/a8c/issue/DOTCOM-13220/login-make-the-two-columnwhite-layout-the-default-across-all-contexts) and confirm no changes from production. Currently, things should be identical.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
