### PR TITLE
Theme Showcase: Show an unsupported message on third-party themes

### DIFF
--- a/client/my-sites/theme/theme-support-tab/index.jsx
+++ b/client/my-sites/theme/theme-support-tab/index.jsx
@@ -4,9 +4,11 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
+import useSupportDocData from 'calypso/components/inline-support-link/use-support-doc-data';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { useThemeTierForTheme } from 'calypso/state/themes/hooks/use-theme-tier-for-theme';
 
 import './style.scss';
 
@@ -17,6 +19,9 @@ export default function ThemeSupportTab( { themeId } ) {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const { setNavigateToOdie, setShowHelpCenter, setNavigateToRoute } =
 		useDataStoreDispatch( HELP_CENTER_STORE );
+
+	const themeTier = useThemeTierForTheme( themeId );
+	const { openSupportDoc } = useSupportDocData( { supportContext: 'themes-unsupported' } );
 
 	return (
 		<>
@@ -77,32 +82,59 @@ export default function ThemeSupportTab( { themeId } ) {
 						</Button>
 					</Card>
 
-					<Card className="theme__sheet-card-support">
-						<Gridicon icon="comment" size={ 48 } />
-						<div className="theme__sheet-card-support-details">
-							{ translate( 'Contact support' ) }
-							<small>
-								{ translate(
-									'Get answers from our AI assistant, with access to 24/7 expert human support on paid plans.'
-								) }
-							</small>
-						</div>
-						<Button
-							__next40pxDefaultSize
-							onClick={ () => {
-								setNavigateToOdie();
-								dispatch(
-									recordTracksEvent( 'calypso_theme_sheet_button_click', {
-										theme_name: themeId,
-										button_context: 'help-center-ai',
-									} )
-								);
-							} }
-							variant="secondary"
-						>
-							{ translate( 'Get in touch' ) }
-						</Button>
-					</Card>
+					{ themeTier?.slug === 'community' || themeTier?.slug === 'partner' ? (
+						<Card className="theme__sheet-card-support">
+							<Gridicon icon="notice-outline" size={ 48 } />
+							<div className="theme__sheet-card-support-details">
+								{ translate( 'Help and support for this theme is not offered by WordPress.com.' ) }
+								<small>
+									{ translate( 'Contact the theme developer directly for help with this theme.' ) }
+								</small>
+							</div>
+							<Button
+								__next40pxDefaultSize
+								onClick={ () => {
+									openSupportDoc();
+									dispatch(
+										recordTracksEvent( 'calypso_theme_sheet_button_click', {
+											theme_name: themeId,
+											button_context: 'themes-unsupported',
+										} )
+									);
+								} }
+								variant="secondary"
+							>
+								{ translate( 'Learn more' ) }
+							</Button>
+						</Card>
+					) : (
+						<Card className="theme__sheet-card-support">
+							<Gridicon icon="comment" size={ 48 } />
+							<div className="theme__sheet-card-support-details">
+								{ translate( 'Contact support' ) }
+								<small>
+									{ translate(
+										'Get answers from our AI assistant, with access to 24/7 expert human support on paid plans.'
+									) }
+								</small>
+							</div>
+							<Button
+								__next40pxDefaultSize
+								onClick={ () => {
+									setNavigateToOdie();
+									dispatch(
+										recordTracksEvent( 'calypso_theme_sheet_button_click', {
+											theme_name: themeId,
+											button_context: 'help-center-ai',
+										} )
+									);
+								} }
+								variant="secondary"
+							>
+								{ translate( 'Get in touch' ) }
+							</Button>
+						</Card>
+					) }
 				</>
 			) }
 		</>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTTHEM-41

## Proposed Changes

* Replace the "Get in touch" support action with an unsupported message on third party (Partner and Community) themes' details pages.
* The "Learn more" action opens the Help Center on the ["Get help with plugins and themes"](https://wordpress.com/support/plugins/get-help-with-plugins-and-themes/) support page.

| Before | After |
|--------|--------|
| ![Screenshot 2025-07-09 at 16 13 59](https://github.com/user-attachments/assets/b3d80ee1-5545-40f7-912c-891f4a80c1f9) | ![Screenshot 2025-07-09 at 16 14 12](https://github.com/user-attachments/assets/7ccd40aa-cd57-4fb7-8d4b-c151f4a7af91) | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We can't be expected to support third-party themes, so instead we inform the user on how to get support.

The "unsupported" card was displayed in the Showcase before I carelessly removed it in #104219.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the Theme Showcase (`/themes`).
* Click on a first-party theme (e.g. Patisserie, `/theme/patisserie`).
* Scroll to the bottom, and locate the support cards.
* Confirm that the last card's is "Get in touch", opening the AI assistant in the Help Center.
* Navigate back to the Theme Showcase.
* Click or search for a third-party theme (e.g. Solarone, `/theme/solarone`, or Astra, `/theme/astra`).
* Scroll to the bottom, and locate the support cards.
* Confirm that the last card's is "Learn More", opening the "Get help with plugins and themes" page in the Help Center.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
