### PR TITLE
Staging Sites Redesign: Update "Push/Pull" and "To" labels in the Sync modal to use site titles and new design

### DIFF
--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -6,15 +6,10 @@ import {
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
-	// eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
-	__experimentalInputControl as InputControl,
-	// eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
-	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, isRTL } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
-import { useSelector, useDispatch } from 'react-redux';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import InlineSupportLink from 'calypso/dashboard/components/inline-support-link';
 import { SectionHeader } from 'calypso/dashboard/components/section-header';
@@ -24,9 +19,10 @@ import SiteEnvironmentBadge, {
 import FileBrowser from 'calypso/my-sites/backup/backup-contents-page/file-browser';
 import { useFirstMatchingBackupAttempt } from 'calypso/my-sites/backup/hooks';
 import { usePullFromStagingMutation } from 'calypso/sites/staging-site/hooks/use-staging-sync';
+import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getBackupBrowserCheckList from 'calypso/state/rewind/selectors/get-backup-browser-check-list';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSiteSlug, getSiteTitle } from 'calypso/state/sites/selectors';
 import type { FileBrowserConfig } from 'calypso/my-sites/backup/backup-contents-page/file-browser';
 
 // TODO: Temporary style for the PoC
@@ -57,23 +53,28 @@ const DirectionArrow = () => {
 interface EnvironmentLabelProps {
 	label: string;
 	environmentType: EnvironmentType;
+	siteTitle?: string;
 }
 
-const EnvironmentLabel = ( { label, environmentType }: EnvironmentLabelProps ) => {
+const EnvironmentLabel = ( { label, environmentType, siteTitle }: EnvironmentLabelProps ) => {
 	return (
-		<VStack spacing={ 1 } style={ { flex: 1 } }>
+		<VStack spacing={ 1 }>
 			<SectionHeader level={ 3 } title={ label } />
-			<InputControl
-				readOnly
-				prefix={
-					<InputControlPrefixWrapper>
-						<SiteEnvironmentBadge environmentType={ environmentType } />
-					</InputControlPrefixWrapper>
-				}
-				__next40pxDefaultSize
-				tabIndex={ -1 }
-				aria-hidden="true"
-			/>
+			<HStack spacing={ 2 }>
+				<SiteEnvironmentBadge environmentType={ environmentType } />
+				{ siteTitle && (
+					<Text
+						style={ {
+							whiteSpace: 'nowrap',
+							overflow: 'hidden',
+							textOverflow: 'ellipsis',
+							maxWidth: '180px',
+						} }
+					>
+						{ siteTitle }
+					</Text>
+				) }
+			</HStack>
 		</VStack>
 	);
 };
@@ -172,7 +173,15 @@ export default function SyncModal( {
 		useSelector( ( state ) => getSiteSlug( state, productionSiteId ) ) ?? '';
 	const stagingSiteSlug = useSelector( ( state ) => getSiteSlug( state, stagingSiteId ) ) ?? '';
 
+	const productionSiteTitle =
+		useSelector( ( state ) => getSiteTitle( state, productionSiteId ) ) || '';
+	const stagingSiteTitle = useSelector( ( state ) => getSiteTitle( state, stagingSiteId ) ) || '';
+
 	const targetSiteSlug = targetEnvironment === 'production' ? productionSiteSlug : stagingSiteSlug;
+
+	const sourceSiteTitle = sourceEnvironment === 'staging' ? stagingSiteTitle : productionSiteTitle;
+	const targetSiteTitle =
+		targetEnvironment === 'production' ? productionSiteTitle : stagingSiteTitle;
 
 	const querySiteId = sourceEnvironment === 'staging' ? stagingSiteId : productionSiteId;
 
@@ -225,10 +234,18 @@ export default function SyncModal( {
 						a: <ExternalLink href={ `/backup/${ targetSiteSlug }` } children={ null } />,
 					} ) }
 				</Text>
-				<HStack spacing={ 2 } alignment="center">
-					<EnvironmentLabel label={ syncConfig.fromLabel } environmentType={ sourceEnvironment } />
+				<HStack spacing={ 4 } alignment="left">
+					<EnvironmentLabel
+						label={ syncConfig.fromLabel }
+						environmentType={ sourceEnvironment }
+						siteTitle={ sourceSiteTitle }
+					/>
 					<DirectionArrow />
-					<EnvironmentLabel label={ syncConfig.toLabel } environmentType={ targetEnvironment } />
+					<EnvironmentLabel
+						label={ syncConfig.toLabel }
+						environmentType={ targetEnvironment }
+						siteTitle={ targetSiteTitle }
+					/>
 				</HStack>
 				<SectionHeader level={ 3 } title={ syncConfig.syncSelectionHeading } />
 				{ querySiteId === stagingSiteId && (

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -170,8 +170,8 @@ export default function SyncModal( {
 	const sourceEnvironment = syncConfig[ environment ].syncFrom;
 
 	const productionSiteSlug =
-		useSelector( ( state ) => getSiteSlug( state, productionSiteId ) ) ?? '';
-	const stagingSiteSlug = useSelector( ( state ) => getSiteSlug( state, stagingSiteId ) ) ?? '';
+		useSelector( ( state ) => getSiteSlug( state, productionSiteId ) ) || '';
+	const stagingSiteSlug = useSelector( ( state ) => getSiteSlug( state, stagingSiteId ) ) || '';
 
 	const productionSiteTitle =
 		useSelector( ( state ) => getSiteTitle( state, productionSiteId ) ) || '';

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -68,7 +68,7 @@ const EnvironmentLabel = ( { label, environmentType, siteTitle }: EnvironmentLab
 							whiteSpace: 'nowrap',
 							overflow: 'hidden',
 							textOverflow: 'ellipsis',
-							maxWidth: '180px',
+							maxWidth: '190px',
 						} }
 					>
 						{ siteTitle }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTDEV-201

## Proposed Changes

* update "Push/Pull" and "To" labels in the Sync modal to use site titles and new design

| Before | After |
|--------|--------|
| ![Markup on 2025-07-09 at 17:34:50](https://github.com/user-attachments/assets/05322bdf-718a-4c81-aba7-7174d1468f02) | ![Markup on 2025-07-09 at 17:38:22](https://github.com/user-attachments/assets/0d9cc057-38ee-4794-b04a-6b7f46b4d97c) | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

DOTDEV-201

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start` (or use Calypso Live).
2. Ensure the `hosting/staging-sites-redesign` feature flag is enabled (by using `?flags=hosting/staging-sites-redesign` query parameter).
3. Head over to the `/sites` dashboard and select an Atomic test site that has a staging site created.
4. Click on the `Sync` dropdown button and observe the updated section (as can be seen in the _After_ screenshot above).
5. Try to update the site titles of the Production and Staging sites. Long site titles should be truncated and ending with ellipsis in a similar way as can be seen in the Studio app: https://github.com/Automattic/studio/pull/1545.
6. If a site does not have any title, site slug will be automatically used (this is already built-in behavior, not part of this PR).
7. RTL and mobile versions should look good as well: For mobile view we are truncating also the environment labels.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
