### PR TITLE
A4A: Hide product line counter on referral checkout.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
@@ -145,7 +145,7 @@ export default function ProductInfo( {
 								},
 							} ) }
 					</label>
-					<span className="product-info__count">{ countInfo }</span>
+					{ ! isAutomatedReferrals && <span className="product-info__count">{ countInfo }</span> }
 				</div>
 				<p className="product-info__description">{ productDescription }</p>
 				{


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/A4A-1268/hide-the-plan-counter-in-the-referral-checkout

## Proposed Changes

During the referral checkout, the product line counter should not be shown since all items will have a quantity of 1.

| Before | After |
|--------|--------|
| <img width="1591" alt="Screenshot 2025-07-09 at 10 05 38 PM" src="https://github.com/user-attachments/assets/8d6f929c-161d-4ef1-8dad-6a15d0bea64d" /> | <img width="1221" alt="Screenshot 2025-07-10 at 12 01 54 AM" src="https://github.com/user-attachments/assets/3dce12c7-5228-4711-84d1-440fde530d55" /> | 

## Why are these changes being made?

* Make our referral checkout less confusing.

## Testing Instructions

* Use the A4A live link and navigate to `/marketplace`.
* Enable referral mode and purchase a few items.
* Proceed to checkout.
* Confirm that the product line counter is no longer visible.


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
