### PR TITLE
Domain Search Retrofitting: Apply new designs to the list and list items

### DIFF
--- a/client/components/domain-search-v2/domain-cart/index.tsx
+++ b/client/components/domain-search-v2/domain-cart/index.tsx
@@ -62,8 +62,11 @@ const DomainCartV2 = ( { onContinue }: { onContinue: () => void } ) => {
 			} ),
 			total,
 			onAddItem: () => {},
-			onRemoveItem: ( domain ) => {
-				removeProductFromCart( domain.uuid );
+			onRemoveItem: ( uuid ) => {
+				removeProductFromCart( uuid );
+			},
+			hasItem: ( uuid ) => {
+				return responseCart.products.some( ( item ) => item.uuid === uuid );
 			},
 		} satisfies DomainSearchCart;
 	}, [ responseCart, removeProductFromCart ] );

--- a/packages/domain-search/src/components/DomainSuggestions/List.tsx
+++ b/packages/domain-search/src/components/DomainSuggestions/List.tsx
@@ -1,3 +1,0 @@
-export const List = () => {
-	return <div>List</div>;
-};

--- a/packages/domain-search/src/components/DomainSuggestions/Recommendations.tsx
+++ b/packages/domain-search/src/components/DomainSuggestions/Recommendations.tsx
@@ -1,3 +1,0 @@
-export const Recommendations = () => {
-	return <div>Recommendations</div>;
-};

--- a/packages/domain-search/src/components/DomainSuggestions/index.ts
+++ b/packages/domain-search/src/components/DomainSuggestions/index.ts
@@ -1,2 +1,0 @@
-export { Recommendations } from './Recommendations';
-export { List } from './List';

--- a/packages/domain-search/src/components/domain-search/index.tsx
+++ b/packages/domain-search/src/components/domain-search/index.tsx
@@ -1,30 +1,7 @@
 import { createContext, useCallback, useContext, useLayoutEffect, useMemo, useState } from 'react';
+import type { DomainSearchCart, DomainSearchContextType } from './types';
+
 import './style.scss';
-
-export interface SelectedDomain {
-	uuid: string;
-	domain: string;
-	tld: string;
-	originalPrice?: string;
-	price: string;
-}
-
-export interface DomainSearchCart {
-	items: SelectedDomain[];
-	total: string;
-	onAddItem: ( item: SelectedDomain ) => void;
-	onRemoveItem: ( item: SelectedDomain ) => void;
-}
-
-export interface DomainSearchContextType {
-	query: string;
-	setQuery: ( query: string ) => void;
-	onContinue: () => void;
-	cart: DomainSearchCart;
-	isFullCartOpen: boolean;
-	closeFullCart: () => void;
-	openFullCart: () => void;
-}
 
 export const DomainSearchContext = createContext< DomainSearchContextType >( {
 	query: '',
@@ -33,6 +10,7 @@ export const DomainSearchContext = createContext< DomainSearchContextType >( {
 	cart: {
 		items: [],
 		total: '',
+		hasItem: () => false,
 		onAddItem: () => {},
 		onRemoveItem: () => {},
 	},

--- a/packages/domain-search/src/components/domain-search/types.ts
+++ b/packages/domain-search/src/components/domain-search/types.ts
@@ -1,0 +1,25 @@
+export interface SelectedDomain {
+	uuid: string;
+	domain: string;
+	tld: string;
+	originalPrice?: string;
+	price: string;
+}
+
+export interface DomainSearchCart {
+	items: SelectedDomain[];
+	total: string;
+	onAddItem: ( item: SelectedDomain[ 'uuid' ] ) => void;
+	onRemoveItem: ( item: SelectedDomain[ 'uuid' ] ) => void;
+	hasItem: ( uuid: SelectedDomain[ 'uuid' ] ) => boolean;
+}
+
+export interface DomainSearchContextType {
+	query: string;
+	setQuery: ( query: string ) => void;
+	onContinue: () => void;
+	cart: DomainSearchCart;
+	isFullCartOpen: boolean;
+	closeFullCart: () => void;
+	openFullCart: () => void;
+}

--- a/packages/domain-search/src/components/domain-suggestion-badge/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-badge/index.tsx
@@ -1,0 +1,23 @@
+import { __experimentalText as Text } from '@wordpress/components';
+import clsx from 'clsx';
+
+import './style.scss';
+
+interface DomainSuggestionBadgeProps {
+	children: React.ReactNode;
+	variation?: 'warning';
+}
+
+export const DomainSuggestionBadge = ( { children, variation }: DomainSuggestionBadgeProps ) => {
+	return (
+		<Text
+			size={ 12 }
+			className={ clsx(
+				'domain-suggestion-badge',
+				variation && `domain-suggestion-badge--${ variation }`
+			) }
+		>
+			{ children }
+		</Text>
+	);
+};

--- a/packages/domain-search/src/components/domain-suggestion-badge/style.scss
+++ b/packages/domain-search/src/components/domain-suggestion-badge/style.scss
@@ -1,0 +1,10 @@
+.domain-suggestion-badge {
+	padding: 4px 8px;
+	border-radius: 2px;
+	box-shadow: 0 0 0 1px rgba( 0, 0, 0, 0.1 );
+}
+
+.domain-suggestion-badge--warning {
+	box-shadow: 0 0 0 1px #f4df7b;
+	background-color: #f9edb4;
+}

--- a/packages/domain-search/src/components/domain-suggestion-cta/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-cta/index.tsx
@@ -3,17 +3,15 @@ import { arrowRight } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useDomainSearch } from '../domain-search';
 import { shoppingCartIcon } from './shopping-cart-icon';
-import type { SelectedDomain } from '../domain-search/types';
 
 import './style.scss';
 
-export const DomainSuggestionCTA = ( {
-	compact,
-	domainUuid,
-}: {
+interface DomainSuggestionCTAProps {
 	compact?: boolean;
-	domainUuid: SelectedDomain[ 'uuid' ];
-} ) => {
+	domainUuid: string;
+}
+
+export const DomainSuggestionCTA = ( { compact, domainUuid }: DomainSuggestionCTAProps ) => {
 	const { __ } = useI18n();
 	const { cart, onContinue } = useDomainSearch();
 

--- a/packages/domain-search/src/components/domain-suggestion-cta/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-cta/index.tsx
@@ -1,0 +1,47 @@
+import { Button } from '@wordpress/components';
+import { arrowRight } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import { useDomainSearch } from '../domain-search';
+import { shoppingCartIcon } from './shopping-cart-icon';
+import type { SelectedDomain } from '../domain-search/types';
+
+import './style.scss';
+
+export const DomainSuggestionCTA = ( {
+	compact,
+	domainUuid,
+}: {
+	compact?: boolean;
+	domainUuid: SelectedDomain[ 'uuid' ];
+} ) => {
+	const { __ } = useI18n();
+	const { cart, onContinue } = useDomainSearch();
+
+	const isDomainOnCart = cart.hasItem( domainUuid );
+
+	if ( isDomainOnCart ) {
+		return (
+			<Button
+				variant="primary"
+				__next40pxDefaultSize
+				icon={ arrowRight }
+				className="domain-suggestion-cta domain-suggestion-cta--continue"
+				onClick={ onContinue }
+			>
+				{ compact ? undefined : __( 'Continue' ) }
+			</Button>
+		);
+	}
+
+	return (
+		<Button
+			className="domain-suggestion-cta"
+			variant="primary"
+			__next40pxDefaultSize
+			icon={ shoppingCartIcon }
+			onClick={ () => cart.onAddItem( domainUuid ) }
+		>
+			{ compact ? undefined : __( 'Add to Cart' ) }
+		</Button>
+	);
+};

--- a/packages/domain-search/src/components/domain-suggestion-cta/shopping-cart-icon.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-cta/shopping-cart-icon.tsx
@@ -1,0 +1,35 @@
+import { Path, SVG } from '@wordpress/primitives';
+
+export const shoppingCartIcon = (
+	<SVG width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<Path
+			d="M8.4165 20.1665C8.83072 20.1665 9.1665 19.8307 9.1665 19.4165C9.1665 19.0023 8.83072 18.6665 8.4165 18.6665C8.00229 18.6665 7.6665 19.0023 7.6665 19.4165C7.6665 19.8307 8.00229 20.1665 8.4165 20.1665Z"
+			stroke="currentColor"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		/>
+		<Path
+			d="M17.5835 20.1665C17.9977 20.1665 18.3335 19.8307 18.3335 19.4165C18.3335 19.0023 17.9977 18.6665 17.5835 18.6665C17.1693 18.6665 16.8335 19.0023 16.8335 19.4165C16.8335 19.8307 17.1693 20.1665 17.5835 20.1665Z"
+			stroke="currentColor"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		/>
+		<Path
+			d="M2.8335 3.8335H5.16683L7.40016 13.9918C7.47637 14.3755 7.68509 14.7201 7.98978 14.9654C8.29448 15.2107 8.67574 15.341 9.06683 15.3335H17.1668C17.5579 15.341 17.9392 15.2107 18.2439 14.9654C18.5486 14.7201 18.7573 14.3755 18.8335 13.9918L20.1668 7.00016"
+			stroke="currentColor"
+			fill="none"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		/>
+		<Path
+			d="M10.5 8H15.5M13 10.5V5.5"
+			stroke="currentColor"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		/>
+	</SVG>
+);

--- a/packages/domain-search/src/components/domain-suggestion-cta/style.scss
+++ b/packages/domain-search/src/components/domain-suggestion-cta/style.scss
@@ -1,0 +1,9 @@
+.domain-suggestion-cta {
+	justify-content: center !important;
+}
+
+.domain-suggestion-cta--continue {
+	--wp-components-color-accent: var( --domain-search-secondary-action-color );
+	--wp-components-color-accent-darker-10: var( --domain-search-secondary-action-color-darker-10 );
+	--wp-components-color-accent-darker-20: var( --domain-search-secondary-action-color-darker-10 );
+}

--- a/packages/domain-search/src/components/domain-suggestion-price/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-price/index.tsx
@@ -37,7 +37,7 @@ export const DomainSuggestionPrice = ( {
 				) }
 			</HStack>
 			{ originalPrice && (
-				<Text size="body">
+				<Text size="body" align={ alignment }>
 					{ sprintf(
 						// translators: %(price)s is the price of the domain.
 						__( 'For first year. %(price)s/year renewal.' ),

--- a/packages/domain-search/src/components/domain-suggestion-price/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-price/index.tsx
@@ -24,16 +24,16 @@ export const DomainSuggestionPrice = ( {
 			<HStack spacing={ 2 } justify={ alignment === 'left' ? 'start' : 'end' }>
 				{ originalPrice ? (
 					<>
-						<Text size="title" variant="muted" style={ { textDecoration: 'line-through' } }>
+						<Text size={ 18 } variant="muted" style={ { textDecoration: 'line-through' } }>
 							{ originalPrice }
 						</Text>
-						<Text size="title" color="green">
+						<Text size={ 18 } color="green">
 							{ price }
 						</Text>
 					</>
 				) : (
 					<HStack spacing={ 1 } alignment="baseline">
-						<Text size="title">{ price }</Text>
+						<Text size={ 18 }>{ price }</Text>
 						<Text>{ __( '/year' ) }</Text>
 					</HStack>
 				) }

--- a/packages/domain-search/src/components/domain-suggestion-price/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-price/index.tsx
@@ -6,15 +6,17 @@ import {
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 
+interface DomainSuggestionPriceProps {
+	originalPrice?: string;
+	price: string;
+	alignment?: 'left' | 'right';
+}
+
 export const DomainSuggestionPrice = ( {
 	originalPrice,
 	price,
 	alignment = 'left',
-}: {
-	originalPrice?: string;
-	price: string;
-	alignment?: 'left' | 'right';
-} ) => {
+}: DomainSuggestionPriceProps ) => {
 	const { __ } = useI18n();
 
 	return (

--- a/packages/domain-search/src/components/domain-suggestion-price/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-price/index.tsx
@@ -1,0 +1,50 @@
+import {
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
+
+export const DomainSuggestionPrice = ( {
+	originalPrice,
+	price,
+	alignment = 'left',
+}: {
+	originalPrice?: string;
+	price: string;
+	alignment?: 'left' | 'right';
+} ) => {
+	const { __ } = useI18n();
+
+	return (
+		<VStack spacing={ 0 }>
+			<HStack spacing={ 2 } justify={ alignment === 'left' ? 'start' : 'end' }>
+				{ originalPrice ? (
+					<>
+						<Text size="title" variant="muted" style={ { textDecoration: 'line-through' } }>
+							{ originalPrice }
+						</Text>
+						<Text size="title" color="green">
+							{ price }
+						</Text>
+					</>
+				) : (
+					<HStack spacing={ 1 } alignment="baseline">
+						<Text size="title">{ price }</Text>
+						<Text>{ __( '/year' ) }</Text>
+					</HStack>
+				) }
+			</HStack>
+			{ originalPrice && (
+				<Text size="body">
+					{ sprintf(
+						// translators: %(price)s is the price of the domain.
+						__( 'For first year. %(price)s/year renewal.' ),
+						{ price: originalPrice }
+					) }
+				</Text>
+			) }
+		</VStack>
+	);
+};

--- a/packages/domain-search/src/components/domain-suggestions-list-item/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestions-list-item/index.tsx
@@ -29,9 +29,11 @@ export const DomainSuggestionsListItem = ( {
 	const { activeQuery } = useDomainSuggestionsListContext();
 
 	const domainName = (
-		<Text>
+		<Text size={ activeQuery === 'large' ? 18 : 16 }>
 			{ domain }
-			<Text weight={ 500 }>.{ tld }</Text>
+			<Text size="inherit" weight={ 500 }>
+				.{ tld }
+			</Text>
 		</Text>
 	);
 
@@ -41,8 +43,8 @@ export const DomainSuggestionsListItem = ( {
 		if ( activeQuery === 'large' ) {
 			return (
 				<HStack spacing={ 3 }>
-					<HStack alignment="left">
-						<Icon icon={ globe } size={ 24 } />
+					<HStack alignment="left" spacing={ 3 }>
+						<Icon icon={ globe } size={ 24 } style={ { flexShrink: 0 } } />
 						{ domainName }
 					</HStack>
 

--- a/packages/domain-search/src/components/domain-suggestions-list-item/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestions-list-item/index.tsx
@@ -1,5 +1,79 @@
+import {
+	Card,
+	CardBody,
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { globe, Icon } from '@wordpress/icons';
+import { DomainSuggestionCTA } from '../domain-suggestion-cta';
+import { DomainSuggestionPrice } from '../domain-suggestion-price';
+import { useDomainSuggestionsListContext } from '../domain-suggestions-list';
 import { Unavailable } from './unavailable';
 
-export const DomainSuggestionsListItem = {
-	Unavailable,
+interface DomainSuggestionsListItemProps {
+	domainUuid: string;
+	domain: string;
+	tld: string;
+	originalPrice?: string;
+	price: string;
+}
+
+export const DomainSuggestionsListItem = ( {
+	domainUuid,
+	domain,
+	tld,
+	originalPrice,
+	price,
+}: DomainSuggestionsListItemProps ) => {
+	const { activeQuery } = useDomainSuggestionsListContext();
+
+	const domainName = (
+		<Text>
+			{ domain }
+			<Text weight={ 500 }>.{ tld }</Text>
+		</Text>
+	);
+
+	const cta = <DomainSuggestionCTA compact domainUuid={ domainUuid } />;
+
+	const getContent = () => {
+		if ( activeQuery === 'large' ) {
+			return (
+				<HStack spacing={ 3 }>
+					<HStack alignment="left">
+						<Icon icon={ globe } size={ 24 } />
+						{ domainName }
+					</HStack>
+
+					<HStack alignment="right" spacing={ 4 }>
+						<DomainSuggestionPrice
+							alignment="right"
+							originalPrice={ originalPrice }
+							price={ price }
+						/>
+						{ cta }
+					</HStack>
+				</HStack>
+			);
+		}
+
+		return (
+			<HStack spacing={ 4 }>
+				<VStack spacing={ 2 }>
+					{ domainName }
+					<DomainSuggestionPrice originalPrice={ originalPrice } price={ price } />
+				</VStack>
+				{ cta }
+			</HStack>
+		);
+	};
+
+	return (
+		<Card>
+			<CardBody>{ getContent() }</CardBody>
+		</Card>
+	);
 };
+
+DomainSuggestionsListItem.Unavailable = Unavailable;

--- a/packages/domain-search/src/components/domain-suggestions-list-item/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestions-list-item/index.tsx
@@ -11,12 +11,15 @@ import { DomainSuggestionPrice } from '../domain-suggestion-price';
 import { useDomainSuggestionsListContext } from '../domain-suggestions-list';
 import { Unavailable } from './unavailable';
 
+import './style.scss';
+
 interface DomainSuggestionsListItemProps {
 	domainUuid: string;
 	domain: string;
 	tld: string;
 	originalPrice?: string;
 	price: string;
+	badges?: React.ReactNode[];
 }
 
 export const DomainSuggestionsListItem = ( {
@@ -25,15 +28,21 @@ export const DomainSuggestionsListItem = ( {
 	tld,
 	originalPrice,
 	price,
+	badges,
 }: DomainSuggestionsListItemProps ) => {
 	const { activeQuery } = useDomainSuggestionsListContext();
 
 	const domainName = (
 		<Text size={ activeQuery === 'large' ? 18 : 16 }>
 			{ domain }
-			<Text size="inherit" weight={ 500 }>
+			<Text
+				size="inherit"
+				weight={ 500 }
+				style={ { marginRight: badges?.length ? '12px' : undefined } }
+			>
 				.{ tld }
 			</Text>
+			{ badges?.length && <span className="domain-suggestions-list-item__badges">{ badges }</span> }
 		</Text>
 	);
 

--- a/packages/domain-search/src/components/domain-suggestions-list-item/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestions-list-item/index.tsx
@@ -70,7 +70,7 @@ export const DomainSuggestionsListItem = ( {
 	};
 
 	return (
-		<Card>
+		<Card isBorderless size={ activeQuery === 'large' ? 'medium' : 'small' }>
 			<CardBody>{ getContent() }</CardBody>
 		</Card>
 	);

--- a/packages/domain-search/src/components/domain-suggestions-list-item/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestions-list-item/index.tsx
@@ -1,0 +1,5 @@
+import { Unavailable } from './unavailable';
+
+export const DomainSuggestionsListItem = {
+	Unavailable,
+};

--- a/packages/domain-search/src/components/domain-suggestions-list-item/style.scss
+++ b/packages/domain-search/src/components/domain-suggestions-list-item/style.scss
@@ -1,0 +1,5 @@
+.domain-suggestions-list-item__badges {
+	display: inline-flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}

--- a/packages/domain-search/src/components/domain-suggestions-list-item/test/unavailable.tsx
+++ b/packages/domain-search/src/components/domain-suggestions-list-item/test/unavailable.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DomainSuggestionsListItem } from '..';
+
+describe( 'DomainSuggestionsListItem.Unavailable', () => {
+	it( 'shows already registered message', () => {
+		const { container } = render(
+			<DomainSuggestionsListItem.Unavailable
+				domain="example"
+				tld="com"
+				unavailableReason="already-registered"
+			/>
+		);
+
+		expect( container ).toHaveTextContent( 'example.com is already registered.' );
+	} );
+
+	it( 'calls onTransferClick when transfer button is clicked', async () => {
+		const user = userEvent.setup();
+		const onTransferClick = jest.fn();
+
+		const { container } = render(
+			<DomainSuggestionsListItem.Unavailable
+				domain="example"
+				tld="com"
+				unavailableReason="already-registered"
+				onTransferClick={ onTransferClick }
+			/>
+		);
+
+		expect( container ).toHaveTextContent( 'Already yours? Bring it over' );
+
+		const transferButton = screen.getByRole( 'button', { name: 'Bring it over' } );
+		await user.click( transferButton );
+
+		expect( onTransferClick ).toHaveBeenCalled();
+	} );
+} );

--- a/packages/domain-search/src/components/domain-suggestions-list-item/unavailable.scss
+++ b/packages/domain-search/src/components/domain-suggestions-list-item/unavailable.scss
@@ -1,0 +1,4 @@
+.domain-suggestions-list-item-unavailable__transfer-button {
+	// We need to use !important here because WPCOM adds overrides to the button with a very high specificity.
+	--wp-components-color-accent: var( --domain-search-secondary-action-color ) !important;
+}

--- a/packages/domain-search/src/components/domain-suggestions-list-item/unavailable.tsx
+++ b/packages/domain-search/src/components/domain-suggestions-list-item/unavailable.tsx
@@ -1,0 +1,88 @@
+import {
+	Card,
+	CardBody,
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Button,
+} from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { Icon, notAllowed } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import { useMemo } from 'react';
+import { useDomainSuggestionsListContext } from '../domain-suggestions-list';
+
+import './unavailable.scss';
+
+export interface UnavailableProps {
+	domain: string;
+	tld: string;
+	unavailableReason: 'already-registered';
+	onTransferClick?(): void;
+}
+
+export const Unavailable = ( {
+	domain,
+	tld,
+	unavailableReason,
+	onTransferClick,
+}: UnavailableProps ) => {
+	const { activeQuery } = useDomainSuggestionsListContext();
+	const { __ } = useI18n();
+
+	const reasonText = useMemo( () => {
+		if ( unavailableReason === 'already-registered' ) {
+			return createInterpolateElement( __( '<domainName /> is already registered.' ), {
+				domainName: (
+					<Text>
+						{ domain }
+						<Text weight={ 500 }>.{ tld }</Text>
+					</Text>
+				),
+			} );
+		}
+	}, [ __, unavailableReason, domain, tld ] );
+
+	const reason = <Text size="body">{ reasonText }</Text>;
+
+	const onTransfer = onTransferClick && (
+		<div style={ { marginLeft: activeQuery === 'large' ? 'auto' : undefined } }>
+			<Text>
+				{ createInterpolateElement( __( 'Already yours? <button>Bring it over</button>' ), {
+					button: (
+						<Button
+							className="domain-suggestions-list-item-unavailable__transfer-button"
+							variant="link"
+							onClick={ onTransferClick }
+						/>
+					),
+				} ) }
+			</Text>
+		</div>
+	);
+
+	const getContent = () => {
+		if ( activeQuery === 'large' ) {
+			return (
+				<HStack alignment="left" spacing={ 3 }>
+					<Icon icon={ notAllowed } size={ 24 } />
+					{ reason }
+					{ onTransfer }
+				</HStack>
+			);
+		}
+
+		return (
+			<VStack spacing={ 3 }>
+				{ reason }
+				{ onTransfer }
+			</VStack>
+		);
+	};
+
+	return (
+		<Card>
+			<CardBody>{ getContent() }</CardBody>
+		</Card>
+	);
+};

--- a/packages/domain-search/src/components/domain-suggestions-list-item/unavailable.tsx
+++ b/packages/domain-search/src/components/domain-suggestions-list-item/unavailable.tsx
@@ -81,7 +81,7 @@ export const Unavailable = ( {
 	};
 
 	return (
-		<Card>
+		<Card isBorderless size={ activeQuery === 'large' ? 'medium' : 'small' }>
 			<CardBody>{ getContent() }</CardBody>
 		</Card>
 	);

--- a/packages/domain-search/src/components/domain-suggestions-list-item/unavailable.tsx
+++ b/packages/domain-search/src/components/domain-suggestions-list-item/unavailable.tsx
@@ -34,19 +34,26 @@ export const Unavailable = ( {
 		if ( unavailableReason === 'already-registered' ) {
 			return createInterpolateElement( __( '<domainName /> is already registered.' ), {
 				domainName: (
-					<Text>
+					<Text size="inherit">
 						{ domain }
-						<Text weight={ 500 }>.{ tld }</Text>
+						<Text size="inherit" weight={ 500 }>
+							.{ tld }
+						</Text>
 					</Text>
 				),
 			} );
 		}
 	}, [ __, unavailableReason, domain, tld ] );
 
-	const reason = <Text size="body">{ reasonText }</Text>;
+	const reason = <Text size={ activeQuery === 'large' ? 18 : 16 }>{ reasonText }</Text>;
 
 	const onTransfer = onTransferClick && (
-		<div style={ { marginLeft: activeQuery === 'large' ? 'auto' : undefined } }>
+		<div
+			style={ {
+				marginLeft: activeQuery === 'large' ? 'auto' : undefined,
+				textAlign: activeQuery === 'large' ? 'right' : 'left',
+			} }
+		>
 			<Text>
 				{ createInterpolateElement( __( 'Already yours? <button>Bring it over</button>' ), {
 					button: (
@@ -65,7 +72,7 @@ export const Unavailable = ( {
 		if ( activeQuery === 'large' ) {
 			return (
 				<HStack alignment="left" spacing={ 3 }>
-					<Icon icon={ notAllowed } size={ 24 } />
+					<Icon icon={ notAllowed } size={ 24 } style={ { flexShrink: 0 } } />
 					{ reason }
 					{ onTransfer }
 				</HStack>

--- a/packages/domain-search/src/components/domain-suggestions-list/index.stories.tsx
+++ b/packages/domain-search/src/components/domain-suggestions-list/index.stories.tsx
@@ -1,0 +1,52 @@
+import { buildDomainSearchCart } from '../../test-helpers/factories';
+import { DomainSearch } from '../domain-search';
+import { DomainsSuggestionsList } from '.';
+import type { Meta } from '@storybook/react';
+
+const cart = buildDomainSearchCart();
+
+export const Default = () => {
+	return (
+		<div
+			style={ {
+				margin: '0 auto',
+				padding: '1rem',
+				boxSizing: 'border-box',
+				width: '100%',
+				maxWidth: '1040px',
+			} }
+		>
+			<DomainSearch
+				onContinue={ () => {
+					alert( 'Continue' );
+				} }
+				cart={ cart }
+			>
+				<DomainsSuggestionsList>hello</DomainsSuggestionsList>
+			</DomainSearch>
+		</div>
+	);
+};
+
+Default.parameters = {
+	viewport: {
+		defaultViewport: 'desktop',
+	},
+};
+
+const meta: Meta< typeof Default > = {
+	title: 'DomainsSuggestionsList',
+	component: Default,
+};
+
+export default meta;
+
+export const Mobile = () => {
+	return <Default />;
+};
+
+Mobile.parameters = {
+	viewport: {
+		defaultViewport: 'mobile1',
+	},
+};

--- a/packages/domain-search/src/components/domain-suggestions-list/index.stories.tsx
+++ b/packages/domain-search/src/components/domain-suggestions-list/index.stories.tsx
@@ -1,12 +1,29 @@
+import { useState } from 'react';
 import { buildDomainSearchCart } from '../../test-helpers/factories';
 import { DomainSearch } from '../domain-search';
+import { SelectedDomain } from '../domain-search/types';
 import { DomainSuggestionsListItem } from '../domain-suggestions-list-item';
 import { DomainsSuggestionsList } from '.';
 import type { Meta } from '@storybook/react';
 
-const cart = buildDomainSearchCart();
+const SUGGESTIONS: SelectedDomain[] = [];
 
 export const Default = () => {
+	const [ cartItems, setCartItems ] = useState< string[] >( [] );
+
+	const cart = buildDomainSearchCart( {
+		items: cartItems
+			.map( ( uuid ) => SUGGESTIONS.find( ( s ) => s.uuid === uuid ) )
+			.filter( ( domain ) => !! domain ),
+		onAddItem: ( uuid ) => {
+			setCartItems( [ ...cartItems, uuid ] );
+		},
+		onRemoveItem: ( item ) => {
+			setCartItems( cartItems.filter( ( i ) => i !== item ) );
+		},
+		hasItem: ( item ) => cartItems.some( ( i ) => i === item ),
+	} );
+
 	return (
 		<div
 			style={ {
@@ -29,6 +46,13 @@ export const Default = () => {
 						tld="com"
 						unavailableReason="already-registered"
 						onTransferClick={ () => alert( 'Your wish is an order!' ) }
+					/>
+					<DomainSuggestionsListItem
+						domainUuid="1"
+						domain="example"
+						tld="com"
+						originalPrice="$10"
+						price="$0"
 					/>
 				</DomainsSuggestionsList>
 			</DomainSearch>

--- a/packages/domain-search/src/components/domain-suggestions-list/index.stories.tsx
+++ b/packages/domain-search/src/components/domain-suggestions-list/index.stories.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { buildDomainSearchCart } from '../../test-helpers/factories';
 import { DomainSearch } from '../domain-search';
 import { SelectedDomain } from '../domain-search/types';
+import { DomainSuggestionBadge } from '../domain-suggestion-badge';
 import { DomainSuggestionsListItem } from '../domain-suggestions-list-item';
 import { DomainsSuggestionsList } from '.';
 import type { Meta } from '@storybook/react';
@@ -53,6 +54,12 @@ export const Default = () => {
 						tld="com"
 						originalPrice="$10"
 						price="$0"
+						badges={ [
+							<DomainSuggestionBadge key="recommended">Recommended</DomainSuggestionBadge>,
+							<DomainSuggestionBadge variation="warning" key="sale">
+								Sale
+							</DomainSuggestionBadge>,
+						] }
 					/>
 				</DomainsSuggestionsList>
 			</DomainSearch>

--- a/packages/domain-search/src/components/domain-suggestions-list/index.stories.tsx
+++ b/packages/domain-search/src/components/domain-suggestions-list/index.stories.tsx
@@ -1,5 +1,6 @@
 import { buildDomainSearchCart } from '../../test-helpers/factories';
 import { DomainSearch } from '../domain-search';
+import { DomainSuggestionsListItem } from '../domain-suggestions-list-item';
 import { DomainsSuggestionsList } from '.';
 import type { Meta } from '@storybook/react';
 
@@ -22,7 +23,14 @@ export const Default = () => {
 				} }
 				cart={ cart }
 			>
-				<DomainsSuggestionsList>hello</DomainsSuggestionsList>
+				<DomainsSuggestionsList>
+					<DomainSuggestionsListItem.Unavailable
+						domain="example"
+						tld="com"
+						unavailableReason="already-registered"
+						onTransferClick={ () => alert( 'Your wish is an order!' ) }
+					/>
+				</DomainsSuggestionsList>
 			</DomainSearch>
 		</div>
 	);

--- a/packages/domain-search/src/components/domain-suggestions-list/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestions-list/index.tsx
@@ -1,0 +1,26 @@
+import { Card } from '@wordpress/components';
+import { createContext, useContext, useMemo } from 'react';
+import { useContainerQuery } from '../../hooks/use-container-query';
+
+const DomainSuggestionListContext = createContext( {
+	activeQuery: 'small' as 'small' | 'large',
+} );
+
+export const DomainsSuggestionsList = ( { children }: { children: React.ReactNode } ) => {
+	const { ref: containerRef, activeQuery } = useContainerQuery( {
+		small: 480,
+		large: 1024,
+	} );
+
+	const contextValue = useMemo( () => ( { activeQuery } ), [ activeQuery ] );
+
+	return (
+		<Card ref={ containerRef }>
+			<DomainSuggestionListContext.Provider value={ contextValue }>
+				{ children }
+			</DomainSuggestionListContext.Provider>
+		</Card>
+	);
+};
+
+export const useDomainSuggestionsListContext = () => useContext( DomainSuggestionListContext );

--- a/packages/domain-search/src/components/domain-suggestions-list/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestions-list/index.tsx
@@ -1,5 +1,5 @@
-import { Card } from '@wordpress/components';
-import { createContext, useContext, useMemo } from 'react';
+import { Card, CardDivider } from '@wordpress/components';
+import { createContext, useContext, useMemo, Children, isValidElement, Fragment } from 'react';
 import { useContainerQuery } from '../../hooks/use-container-query';
 
 const DomainSuggestionListContext = createContext( {
@@ -14,10 +14,27 @@ export const DomainsSuggestionsList = ( { children }: { children: React.ReactNod
 
 	const contextValue = useMemo( () => ( { activeQuery } ), [ activeQuery ] );
 
+	const childrenWithSeparators = useMemo( () => {
+		const totalChildren = Children.count( children );
+
+		return Children.toArray( children ).map( ( child, index ) => {
+			if ( ! isValidElement( child ) ) {
+				return <Fragment key={ `child-${ index }` }>{ child }</Fragment>;
+			}
+
+			return (
+				<Fragment key={ `child-${ index }` }>
+					{ child }
+					{ index < totalChildren - 1 && <CardDivider /> }
+				</Fragment>
+			);
+		} );
+	}, [ children ] );
+
 	return (
 		<Card ref={ containerRef }>
 			<DomainSuggestionListContext.Provider value={ contextValue }>
-				{ children }
+				{ childrenWithSeparators }
 			</DomainSuggestionListContext.Provider>
 		</Card>
 	);

--- a/packages/domain-search/src/components/domain-suggestions-list/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestions-list/index.tsx
@@ -2,11 +2,15 @@ import { Card, CardDivider } from '@wordpress/components';
 import { createContext, useContext, useMemo, Children, isValidElement, Fragment } from 'react';
 import { useContainerQuery } from '../../hooks/use-container-query';
 
+interface DomainsSuggestionsListProps {
+	children: React.ReactNode;
+}
+
 const DomainSuggestionListContext = createContext( {
 	activeQuery: 'small' as 'small' | 'large',
 } );
 
-export const DomainsSuggestionsList = ( { children }: { children: React.ReactNode } ) => {
+export const DomainsSuggestionsList = ( { children }: DomainsSuggestionsListProps ) => {
 	const { ref: containerRef, activeQuery } = useContainerQuery( {
 		small: 480,
 		large: 1024,

--- a/packages/domain-search/src/components/domains-full-cart-items/index.tsx
+++ b/packages/domain-search/src/components/domains-full-cart-items/index.tsx
@@ -31,7 +31,7 @@ export const DomainsFullCartItems = () => {
 								<Button
 									variant="link"
 									className="domains-full-cart-items__remove"
-									onClick={ () => cart.onRemoveItem( domain ) }
+									onClick={ () => cart.onRemoveItem( domain.uuid ) }
 								>
 									{ __( 'Remove' ) }
 								</Button>

--- a/packages/domain-search/src/components/domains-full-cart-items/test/index.test.tsx
+++ b/packages/domain-search/src/components/domains-full-cart-items/test/index.test.tsx
@@ -48,12 +48,7 @@ describe( 'DomainsFullCartItems', () => {
 
 		await user.click( screen.getByRole( 'button', { name: 'Remove' } ) );
 
-		expect( onRemoveItem ).toHaveBeenCalledWith( {
-			uuid: '1',
-			domain: 'example',
-			tld: 'com',
-			price: '$10',
-		} );
+		expect( onRemoveItem ).toHaveBeenCalledWith( '1' );
 	} );
 
 	test( 'renders the original price if included', () => {

--- a/packages/domain-search/src/components/domains-full-cart/index.stories.tsx
+++ b/packages/domain-search/src/components/domains-full-cart/index.stories.tsx
@@ -51,8 +51,9 @@ export const Default = () => {
 				],
 				total: '$74',
 				onAddItem: () => {},
+				hasItem: () => false,
 				onRemoveItem: ( domain ) => {
-					alert( `Remove ${ domain.domain }.${ domain.tld }` );
+					alert( `Remove ${ domain }` );
 				},
 			} }
 		>

--- a/packages/domain-search/src/hooks/use-container-query.ts
+++ b/packages/domain-search/src/hooks/use-container-query.ts
@@ -1,0 +1,40 @@
+import { useEvent, useResizeObserver } from '@wordpress/compose';
+import { useLayoutEffect, useRef, useState } from 'react';
+
+export const useContainerQuery = < T extends string >(
+	queries: Record< T, number >
+): {
+	ref: ( element: Element | null | undefined ) => void;
+	activeQuery: T;
+} => {
+	const [ activeQuery, setActiveQuery ] = useState< T >( Object.keys( queries )[ 0 ] as T );
+
+	const initialMountRef = useRef< Element | null | undefined >( null );
+
+	const callback = useEvent( ( width: number ) => {
+		const query = Object.entries< number >( queries ).find( ( [ , value ] ) => width <= value );
+		if ( query ) {
+			setActiveQuery( query[ 0 ] as T );
+		}
+	} );
+
+	useLayoutEffect( () => {
+		if ( ! initialMountRef.current ) {
+			return;
+		}
+
+		callback( initialMountRef.current.getBoundingClientRect().width );
+	}, [ callback ] );
+
+	const resizableContainerRef = useResizeObserver( ( [ element ] ) => {
+		callback( element.contentRect.width );
+	} );
+
+	return {
+		ref: ( element ) => {
+			initialMountRef.current = element;
+			resizableContainerRef( element );
+		},
+		activeQuery,
+	};
+};

--- a/packages/domain-search/src/index.stories.tsx
+++ b/packages/domain-search/src/index.stories.tsx
@@ -10,7 +10,7 @@ import {
 	DomainSearchControls,
 	DomainsFullCart,
 	DomainsMiniCart,
-	DomainSuggestions,
+	DomainsSuggestionsList,
 } from '.';
 import type { Meta } from '@storybook/react';
 
@@ -95,10 +95,8 @@ function DomainSearchResults( { initialQuery }: { initialQuery: string } ) {
 			>
 				<VStack spacing={ 8 }>
 					<DomainSearchControls />
-					<HStack spacing={ 4 }>
-						<DomainSuggestions.Recommendations />
-					</HStack>
-					<DomainSuggestions.List />
+					<HStack spacing={ 4 }>TODO Recommendations</HStack>
+					<DomainsSuggestionsList>TODO</DomainsSuggestionsList>
 				</VStack>
 			</Step.CenteredColumnLayout>
 			<DomainsFullCart />

--- a/packages/domain-search/src/index.stories.tsx
+++ b/packages/domain-search/src/index.stories.tsx
@@ -70,6 +70,7 @@ function DomainSearchResults( { initialQuery }: { initialQuery: string } ) {
 				total: '',
 				onAddItem: () => {},
 				onRemoveItem: () => {},
+				hasItem: () => false,
 			} }
 			initialQuery={ initialQuery }
 			onContinue={ () => {

--- a/packages/domain-search/src/index.ts
+++ b/packages/domain-search/src/index.ts
@@ -1,4 +1,5 @@
-export { DomainSearch, type DomainSearchCart } from './components/domain-search';
+export { DomainSearch } from './components/domain-search';
+export type { DomainSearchCart } from './components/domain-search/types';
 export { DomainSearchControls } from './components/DomainSearchControls/DomainSearchControls';
 export { DomainsMiniCart } from './components/domains-mini-cart';
 export { DomainsFullCart } from './components/domains-full-cart';

--- a/packages/domain-search/src/index.ts
+++ b/packages/domain-search/src/index.ts
@@ -4,3 +4,4 @@ export { DomainSearchControls } from './components/DomainSearchControls/DomainSe
 export { DomainsMiniCart } from './components/domains-mini-cart';
 export { DomainsFullCart } from './components/domains-full-cart';
 export { DomainsSuggestionsList } from './components/domain-suggestions-list';
+export { DomainSuggestionBadge } from './components/domain-suggestion-badge';

--- a/packages/domain-search/src/index.ts
+++ b/packages/domain-search/src/index.ts
@@ -2,4 +2,4 @@ export { DomainSearch, type DomainSearchCart } from './components/domain-search'
 export { DomainSearchControls } from './components/DomainSearchControls/DomainSearchControls';
 export { DomainsMiniCart } from './components/domains-mini-cart';
 export { DomainsFullCart } from './components/domains-full-cart';
-export * as DomainSuggestions from './components/DomainSuggestions';
+export { DomainsSuggestionsList } from './components/domain-suggestions-list';

--- a/packages/domain-search/src/test-helpers/factories.ts
+++ b/packages/domain-search/src/test-helpers/factories.ts
@@ -2,7 +2,7 @@ import {
 	DomainSearchContextType,
 	DomainSearchCart,
 	SelectedDomain,
-} from '../components/domain-search';
+} from '../components/domain-search/types';
 
 export const buildDomainSearchCart = (
 	overrides: Partial< DomainSearchCart > = {}
@@ -11,6 +11,7 @@ export const buildDomainSearchCart = (
 	total: '$0',
 	onAddItem: () => {},
 	onRemoveItem: () => {},
+	hasItem: () => false,
 	...overrides,
 } );
 


### PR DESCRIPTION
Closes DOMAINS-1408. Closes DOMAINS-1424.

## Proposed Changes


## Screenshots

### Small viewports

<img width="467" alt="image" src="https://github.com/user-attachments/assets/53aea088-3ae9-4588-8727-bfd41019332f" />

### Large viewports

<img width="848" alt="image" src="https://github.com/user-attachments/assets/e0679fc7-e67e-4c19-a694-fda7187878c6" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
