### PR TITLE
Sites List v2: Add action Jetpack Cloud

### DIFF
--- a/client/dashboard/sites/actions.tsx
+++ b/client/dashboard/sites/actions.tsx
@@ -50,6 +50,15 @@ export function getActions( router: AnyRouter ): Action< Site >[] {
 			isEligible: ( item: Site ) => canManageSite( item ),
 		},
 		{
+			id: 'jetpack-cloud',
+			label: __( 'Jetpack Cloud ↗' ),
+			callback: ( sites: Site[] ) => {
+				const site = sites[ 0 ];
+				window.open( `https://cloud.jetpack.com/landing/${ site.slug }` );
+			},
+			isEligible: ( item: Site ) => isSelfHostedJetpackConnected( item ),
+		},
+		{
 			id: 'prepare-for-launch',
 			label: __( 'Prepare for launch' ),
 			callback: ( sites ) => {


### PR DESCRIPTION
Fixes DOTDASH-134

## Proposed Changes

As discussed in pdtkmj-3Nc-p2#comment-7251, we'll bring back the Jetpack Cloud action until all their features are available in the Hosting Dashboard. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Enhancement.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Check that non Atomic Jetpack-connected sites have this action 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?