### PR TITLE
Sites List v2: Update label from Coming Soon to Prepare for Launch when linking to Launchpad

### DIFF
--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -268,7 +268,7 @@ function SiteLaunchNag( { site }: { site: Site } ) {
 					recordTracksEvent( 'calypso_dashboard_sites_site_launch_nag_click' );
 				} }
 			>
-				{ getSiteStatusLabel( site ) }
+				{ __( 'Prepare for launch' ) }
 			</ExternalLink>
 		</>
 	);

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -268,7 +268,7 @@ function SiteLaunchNag( { site }: { site: Site } ) {
 					recordTracksEvent( 'calypso_dashboard_sites_site_launch_nag_click' );
 				} }
 			>
-				{ __( 'Prepare for launch' ) }
+				{ __( 'Finish setup' ) }
 			</ExternalLink>
 		</>
 	);

--- a/client/dashboard/sites/site-fields/test/status.tsx
+++ b/client/dashboard/sites/site-fields/test/status.tsx
@@ -47,7 +47,7 @@ describe( '<Status>', () => {
 		expect( container.textContent ).toBe( 'Migration started' );
 	} );
 
-	test( 'for unlaunched sites, it renders a "Coming soon" link', () => {
+	test( 'for unlaunched sites, it renders a "Finish setup" link', () => {
 		const site = {
 			slug: 'test.wordpress.com',
 			site_migration: {},
@@ -55,8 +55,8 @@ describe( '<Status>', () => {
 			is_private: true,
 		} as Site;
 		const { container, getByRole } = render( <Status site={ site } /> );
-		expect( container.textContent ).toBe( 'Coming soon↗' );
-		expect( getByRole( 'link', { name: /Coming soon/ } ) ).toHaveAttribute(
+		expect( container.textContent ).toBe( 'Finish setup↗' );
+		expect( getByRole( 'link', { name: /Finish setup/ } ) ).toHaveAttribute(
 			'href',
 			'/home/test.wordpress.com'
 		);


### PR DESCRIPTION
Fixes DOTDASH-136

## Proposed Changes

As discussed in pdtkmj-3Nc-p2#comment-7252, changing the label from "Coming soon" to "Prepare for launch" when linking to Launchpad is clearer.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Enhancement.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Ensure that "Coming soon" is updated to "Prepare for launch" as described above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?