### PR TITLE
Site list v2: correctly deserialize view search params on first page load

### DIFF
--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -86,11 +86,13 @@ const sitesRoute = createRoute( {
 	validateSearch: ( search ) => {
 		// Deserialize the view search param if it exists on the first page load.
 		if ( typeof search.view === 'string' ) {
+			let parsedView;
 			try {
-				return { ...search, view: JSON.parse( search.view ) };
+				parsedView = JSON.parse( search.view );
 			} catch ( e ) {
 				// pass
 			}
+			return { ...search, view: parsedView };
 		}
 		return search;
 	},

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -83,6 +83,17 @@ const sitesRoute = createRoute( {
 			queryClient.ensureQueryData( userPreferencesQuery() ),
 		] );
 	},
+	validateSearch: ( search ) => {
+		// Deserialize the view search param if it exists on the first page load.
+		if ( typeof search.view === 'string' ) {
+			try {
+				return { ...search, view: JSON.parse( search.view ) };
+			} catch ( e ) {
+				// pass
+			}
+		}
+		return search;
+	},
 } ).lazy( () =>
 	import( '../sites' ).then( ( d ) =>
 		createLazyRoute( 'sites' )( {

--- a/client/sites/v2/sites-list/router.tsx
+++ b/client/sites/v2/sites-list/router.tsx
@@ -32,11 +32,13 @@ const sitesRoute = createRoute( {
 	validateSearch: ( search ) => {
 		// Deserialize the view search param if it exists on the first page load.
 		if ( typeof search.view === 'string' ) {
+			let parsedView;
 			try {
-				return { ...search, view: JSON.parse( search.view ) };
+				parsedView = JSON.parse( search.view );
 			} catch ( e ) {
 				// pass
 			}
+			return { ...search, view: parsedView };
 		}
 		return search;
 	},

--- a/client/sites/v2/sites-list/router.tsx
+++ b/client/sites/v2/sites-list/router.tsx
@@ -6,6 +6,7 @@ import {
 	redirect,
 } from '@tanstack/react-router';
 import { isAutomatticianQuery } from 'calypso/dashboard/app/queries/me-a8c';
+import { userPreferencesQuery } from 'calypso/dashboard/app/queries/me-preferences';
 import { sitesQuery } from 'calypso/dashboard/app/queries/sites';
 import { queryClient } from 'calypso/dashboard/app/query-client';
 import Root from '../components/root';
@@ -23,7 +24,21 @@ const sitesRoute = createRoute( {
 		// Preload the default sites list response without blocking.
 		queryClient.ensureQueryData( sitesQuery() );
 
-		await queryClient.ensureQueryData( isAutomatticianQuery() );
+		await Promise.all( [
+			queryClient.ensureQueryData( isAutomatticianQuery() ),
+			queryClient.ensureQueryData( userPreferencesQuery() ),
+		] );
+	},
+	validateSearch: ( search ) => {
+		// Deserialize the view search param if it exists on the first page load.
+		if ( typeof search.view === 'string' ) {
+			try {
+				return { ...search, view: JSON.parse( search.view ) };
+			} catch ( e ) {
+				// pass
+			}
+		}
+		return search;
 	},
 } ).lazy( () =>
 	import( 'calypso/dashboard/sites' ).then( ( d ) =>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/pull/104651#issuecomment-3051594405

## Proposed Changes

In v2 site list, the `view` query param is in the form of a JSON object. When navigating through the app, the object is built in the memory by TanStack. However, it's not the case on the first page load (where the query params already exist). We need to parse it first then give it to TanStack.

(Props to Google Gemini that helped me find this solution 🫡)

## Testing Instructions

- Follow instructions on https://github.com/Automattic/wp-calypso/pull/104651.
- While doing that, try to occasionally refresh the page; verify the view stays intact.
- Also try to manually modify the param in the URL. For example, modify the `perPage` in the URL then hit Enter. Verify that the view is updated correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
