### PR TITLE
Hosting Dashboard: Improve `userPreferencesQuery()` types and force all preferences to have a default

### DIFF
--- a/client/dashboard/app/queries/me-preferences.ts
+++ b/client/dashboard/app/queries/me-preferences.ts
@@ -7,14 +7,14 @@ const defaultValues: Required< UserPreferences > = {
 	'some-string': '',
 };
 
-export const userPreferencesQuery = () => ( {
+// Returns all user preferences, without applying any defaults.
+export const rawUserPreferencesQuery = () => ( {
 	queryKey: [ 'me', 'preferences' ],
 	queryFn: fetchPreferences,
-	select: ( data: UserPreferences ) => ( { ...defaultValues, ...data } ),
 } );
 
 export const userPreferenceQuery = < P extends keyof UserPreferences >( preferenceName: P ) => ( {
-	queryKey: userPreferencesQuery().queryKey,
+	queryKey: rawUserPreferencesQuery().queryKey,
 	queryFn: fetchPreferences,
 	select: ( data: UserPreferences ): Required< UserPreferences >[ P ] => {
 		const fetchedValue = data[ preferenceName ];
@@ -36,7 +36,7 @@ export const userPreferenceMutation = < P extends keyof UserPreferences >(
 		} ),
 	onSuccess: ( newData: UserPreferences ) => {
 		queryClient.setQueryData(
-			userPreferencesQuery().queryKey,
+			rawUserPreferencesQuery().queryKey,
 			( oldData: UserPreferences | undefined ) => ( oldData ? { ...oldData, ...newData } : newData )
 		);
 	},

--- a/client/dashboard/app/queries/me-preferences.ts
+++ b/client/dashboard/app/queries/me-preferences.ts
@@ -2,30 +2,39 @@ import { fetchPreferences, updatePreferences } from '../../data/me-preferences';
 import { queryClient } from '../query-client';
 import type { UserPreferences } from '../../data/me-preferences';
 
-export const userPreferencesQuery = (
-	preferenceName?: keyof UserPreferences,
-	defaultValue?: UserPreferences[ keyof UserPreferences ]
+const defaultValues: UserPreferences = {
+	'sites-view': {},
+	'some-string': '',
+};
+
+type HookDataType< P > = P extends keyof UserPreferences ? UserPreferences[ P ] : UserPreferences;
+
+export const userPreferencesQuery = < P extends keyof UserPreferences | undefined = undefined >(
+	preferenceName?: P
 ) => ( {
 	queryKey: [ 'me', 'preferences' ],
 	queryFn: fetchPreferences,
-	select: ( data: UserPreferences ) => {
-		if ( preferenceName ) {
-			return data[ preferenceName ] || defaultValue;
+	select( data: Partial< UserPreferences > ): HookDataType< P > {
+		if ( ! preferenceName ) {
+			return { ...defaultValues, ...data } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
 		}
-
-		return data;
+		const fetchedValue = data[ preferenceName ];
+		return fetchedValue === undefined
+			? ( defaultValues[ preferenceName ] as any ) // eslint-disable-line @typescript-eslint/no-explicit-any
+			: ( fetchedValue as any ); // eslint-disable-line @typescript-eslint/no-explicit-any
 	},
 } );
 
-export const userPreferencesMutation = ( preferenceName?: keyof UserPreferences ) => ( {
-	mutationFn: ( data: UserPreferences | UserPreferences[ keyof UserPreferences ] ) => {
-		if ( preferenceName ) {
-			return updatePreferences( {
-				[ preferenceName ]: data as Pick< UserPreferences, typeof preferenceName >,
-			} );
+export const userPreferencesMutation = < P extends keyof UserPreferences | undefined = undefined >(
+	preferenceName?: P
+) => ( {
+	mutationFn( data: HookDataType< P > ) {
+		if ( ! preferenceName ) {
+			return updatePreferences( data as any ); // eslint-disable-line @typescript-eslint/no-explicit-any
 		}
-
-		return updatePreferences( data as UserPreferences );
+		return updatePreferences( {
+			[ preferenceName ]: data,
+		} );
 	},
 	onSuccess: ( newData: Partial< UserPreferences > ) => {
 		queryClient.setQueryData(

--- a/client/dashboard/app/queries/me-preferences.ts
+++ b/client/dashboard/app/queries/me-preferences.ts
@@ -10,6 +10,7 @@ const defaultValues: UserPreferences = {
 export const userPreferencesQuery = () => ( {
 	queryKey: [ 'me', 'preferences' ],
 	queryFn: fetchPreferences,
+	select: ( data: Partial< UserPreferences > ) => ( { ...defaultValues, ...data } ),
 } );
 
 export const userPreferenceQuery = < P extends keyof UserPreferences >( preferenceName: P ) => ( {

--- a/client/dashboard/app/queries/me-preferences.ts
+++ b/client/dashboard/app/queries/me-preferences.ts
@@ -2,7 +2,7 @@ import { fetchPreferences, updatePreferences } from '../../data/me-preferences';
 import { queryClient } from '../query-client';
 import type { UserPreferences } from '../../data/me-preferences';
 
-const defaultValues: UserPreferences = {
+const defaultValues: Required< UserPreferences > = {
 	'sites-view': {},
 	'some-string': '',
 };
@@ -10,26 +10,31 @@ const defaultValues: UserPreferences = {
 export const userPreferencesQuery = () => ( {
 	queryKey: [ 'me', 'preferences' ],
 	queryFn: fetchPreferences,
-	select: ( data: Partial< UserPreferences > ) => ( { ...defaultValues, ...data } ),
+	select: ( data: UserPreferences ) => ( { ...defaultValues, ...data } ),
 } );
 
 export const userPreferenceQuery = < P extends keyof UserPreferences >( preferenceName: P ) => ( {
 	queryKey: userPreferencesQuery().queryKey,
 	queryFn: fetchPreferences,
-	select: ( data: Partial< UserPreferences > ) => {
+	select: ( data: UserPreferences ): Required< UserPreferences >[ P ] => {
 		const fetchedValue = data[ preferenceName ];
-		return fetchedValue === undefined ? defaultValues[ preferenceName ] : fetchedValue;
+		return fetchedValue === undefined
+			? defaultValues[ preferenceName ]
+			: // `fetchedValue` is a `NonNullable< UserPreferences[ P ] >`, which we know is the same
+			  // as `Required< UserPreferences >[ P ]`, but the later gives better type hints when
+			  // the query is used in the component.
+			  ( fetchedValue as Required< UserPreferences >[ P ] );
 	},
 } );
 
 export const userPreferenceMutation = < P extends keyof UserPreferences >(
 	preferenceName: P
 ) => ( {
-	mutationFn: ( data: UserPreferences[ P ] ) =>
+	mutationFn: ( data: Required< UserPreferences >[ P ] ) =>
 		updatePreferences( {
 			[ preferenceName ]: data,
 		} ),
-	onSuccess: ( newData: Partial< UserPreferences > ) => {
+	onSuccess: ( newData: UserPreferences ) => {
 		queryClient.setQueryData(
 			userPreferencesQuery().queryKey,
 			( oldData: UserPreferences | undefined ) => ( oldData ? { ...oldData, ...newData } : newData )

--- a/client/dashboard/app/queries/me-preferences.ts
+++ b/client/dashboard/app/queries/me-preferences.ts
@@ -7,37 +7,27 @@ const defaultValues: UserPreferences = {
 	'some-string': '',
 };
 
-type QueryGetSetData< P > = P extends keyof UserPreferences
-	? UserPreferences[ P ]
-	: UserPreferences;
-
-export const userPreferencesQuery = < P extends keyof UserPreferences | undefined = undefined >(
-	preferenceName?: P
-) => ( {
+export const userPreferencesQuery = () => ( {
 	queryKey: [ 'me', 'preferences' ],
 	queryFn: fetchPreferences,
-	select( data: Partial< UserPreferences > ): QueryGetSetData< P > {
-		if ( ! preferenceName ) {
-			return { ...defaultValues, ...data } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
-		}
+} );
+
+export const userPreferenceQuery = < P extends keyof UserPreferences >( preferenceName: P ) => ( {
+	queryKey: userPreferencesQuery().queryKey,
+	queryFn: fetchPreferences,
+	select: ( data: Partial< UserPreferences > ) => {
 		const fetchedValue = data[ preferenceName ];
-		return fetchedValue === undefined
-			? ( defaultValues[ preferenceName ] as any ) // eslint-disable-line @typescript-eslint/no-explicit-any
-			: ( fetchedValue as any ); // eslint-disable-line @typescript-eslint/no-explicit-any
+		return fetchedValue === undefined ? defaultValues[ preferenceName ] : fetchedValue;
 	},
 } );
 
-export const userPreferencesMutation = < P extends keyof UserPreferences | undefined = undefined >(
-	preferenceName?: P
+export const userPreferenceMutation = < P extends keyof UserPreferences >(
+	preferenceName: P
 ) => ( {
-	mutationFn( data: QueryGetSetData< P > ) {
-		if ( ! preferenceName ) {
-			return updatePreferences( data as any ); // eslint-disable-line @typescript-eslint/no-explicit-any
-		}
-		return updatePreferences( {
+	mutationFn: ( data: UserPreferences[ P ] ) =>
+		updatePreferences( {
 			[ preferenceName ]: data,
-		} );
-	},
+		} ),
 	onSuccess: ( newData: Partial< UserPreferences > ) => {
 		queryClient.setQueryData(
 			userPreferencesQuery().queryKey,

--- a/client/dashboard/app/queries/me-preferences.ts
+++ b/client/dashboard/app/queries/me-preferences.ts
@@ -7,14 +7,16 @@ const defaultValues: UserPreferences = {
 	'some-string': '',
 };
 
-type HookDataType< P > = P extends keyof UserPreferences ? UserPreferences[ P ] : UserPreferences;
+type QueryGetSetData< P > = P extends keyof UserPreferences
+	? UserPreferences[ P ]
+	: UserPreferences;
 
 export const userPreferencesQuery = < P extends keyof UserPreferences | undefined = undefined >(
 	preferenceName?: P
 ) => ( {
 	queryKey: [ 'me', 'preferences' ],
 	queryFn: fetchPreferences,
-	select( data: Partial< UserPreferences > ): HookDataType< P > {
+	select( data: Partial< UserPreferences > ): QueryGetSetData< P > {
 		if ( ! preferenceName ) {
 			return { ...defaultValues, ...data } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
 		}
@@ -28,7 +30,7 @@ export const userPreferencesQuery = < P extends keyof UserPreferences | undefine
 export const userPreferencesMutation = < P extends keyof UserPreferences | undefined = undefined >(
 	preferenceName?: P
 ) => ( {
-	mutationFn( data: HookDataType< P > ) {
+	mutationFn( data: QueryGetSetData< P > ) {
 		if ( ! preferenceName ) {
 			return updatePreferences( data as any ); // eslint-disable-line @typescript-eslint/no-explicit-any
 		}

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -23,7 +23,7 @@ import UnknownError from './500';
 import { domainsQuery } from './queries/domains';
 import { emailsQuery } from './queries/emails';
 import { isAutomatticianQuery } from './queries/me-a8c';
-import { userPreferencesQuery } from './queries/me-preferences';
+import { rawUserPreferencesQuery } from './queries/me-preferences';
 import { profileQuery } from './queries/me-profile';
 import { siteBySlugQuery } from './queries/site';
 import { siteAgencyBlogQuery } from './queries/site-agency';
@@ -80,7 +80,7 @@ const sitesRoute = createRoute( {
 
 		await Promise.all( [
 			queryClient.ensureQueryData( isAutomatticianQuery() ),
-			queryClient.ensureQueryData( userPreferencesQuery() ),
+			queryClient.ensureQueryData( rawUserPreferencesQuery() ),
 		] );
 	},
 	validateSearch: ( search ) => {

--- a/client/dashboard/data/me-preferences.ts
+++ b/client/dashboard/data/me-preferences.ts
@@ -5,13 +5,13 @@ export type SitesView = ViewTable | ViewGrid;
 
 // The view preferences are a subset of the view object.
 // It includes the merged layout object of all view types ever explicitly set by the user.
-export type ViewPreferences = Partial< Omit< SitesView, 'type' | 'layout' > > & {
+export type SitesViewPreferences = Partial< Omit< SitesView, 'type' | 'layout' > > & {
 	type?: ViewTable[ 'type' ] | ViewGrid[ 'type' ];
 	layout?: Partial< ViewTable[ 'layout' ] & ViewGrid[ 'layout' ] >;
 };
 
 export interface UserPreferences {
-	'sites-view': ViewPreferences;
+	'sites-view': SitesViewPreferences;
 	'some-string': string;
 }
 

--- a/client/dashboard/data/me-preferences.ts
+++ b/client/dashboard/data/me-preferences.ts
@@ -1,10 +1,21 @@
 import wpcom from 'calypso/lib/wp';
+import type { ViewTable, ViewGrid } from '@wordpress/dataviews';
+
+export type SitesView = ViewTable | ViewGrid;
+
+// The view preferences are a subset of the view object.
+// It includes the merged layout object of all view types ever explicitly set by the user.
+export type ViewPreferences = Partial< Omit< SitesView, 'type' | 'layout' > > & {
+	type?: ViewTable[ 'type' ] | ViewGrid[ 'type' ];
+	layout?: Partial< ViewTable[ 'layout' ] & ViewGrid[ 'layout' ] >;
+};
 
 export interface UserPreferences {
-	'sites-view'?: Record< string, unknown >;
+	'sites-view': ViewPreferences;
+	'some-string': string;
 }
 
-export async function fetchPreferences(): Promise< UserPreferences > {
+export async function fetchPreferences(): Promise< Partial< UserPreferences > > {
 	const { calypso_preferences } = await wpcom.req.get( '/me/preferences' );
 	return calypso_preferences;
 }

--- a/client/dashboard/data/me-preferences.ts
+++ b/client/dashboard/data/me-preferences.ts
@@ -11,18 +11,18 @@ export type SitesViewPreferences = Partial< Omit< SitesView, 'type' | 'layout' >
 };
 
 export interface UserPreferences {
-	'sites-view': SitesViewPreferences;
-	'some-string': string;
+	'sites-view'?: SitesViewPreferences;
+	'some-string'?: string;
 }
 
-export async function fetchPreferences(): Promise< Partial< UserPreferences > > {
+export async function fetchPreferences(): Promise< UserPreferences > {
 	const { calypso_preferences } = await wpcom.req.get( '/me/preferences' );
 	return calypso_preferences;
 }
 
 export async function updatePreferences(
 	data: Partial< UserPreferences >
-): Promise< Partial< UserPreferences > > {
+): Promise< UserPreferences > {
 	const { calypso_preferences } = await wpcom.req.post( '/me/preferences', {
 		calypso_preferences: data,
 	} );

--- a/client/dashboard/data/me-preferences.ts
+++ b/client/dashboard/data/me-preferences.ts
@@ -20,7 +20,9 @@ export async function fetchPreferences(): Promise< Partial< UserPreferences > > 
 	return calypso_preferences;
 }
 
-export async function updatePreferences( data: Partial< UserPreferences > ) {
+export async function updatePreferences(
+	data: Partial< UserPreferences >
+): Promise< Partial< UserPreferences > > {
 	const { calypso_preferences } = await wpcom.req.post( '/me/preferences', {
 		calypso_preferences: data,
 	} );

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -2,6 +2,7 @@ export type * from './agency';
 export type * from './domains';
 export type * from './emails';
 export type * from './me';
+export type * from './me-preferences';
 export type * from './me-profile';
 export type * from './me-sites';
 export type * from './me-ssh';

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -24,7 +24,7 @@ import {
 	recordViewChanges,
 	DEFAULT_PER_PAGE_SIZES,
 } from './views';
-import type { ViewPreferences, ViewSearchParams } from './views';
+import type { ViewSearchParams } from './views';
 import type { FetchSitesOptions, Site } from '../data/types';
 import type { View, Filter } from '@wordpress/dataviews';
 
@@ -58,8 +58,7 @@ export default function Sites() {
 
 	const { user } = useAuth();
 	const { data: isAutomattician } = useSuspenseQuery( isAutomatticianQuery() );
-	const viewPreferences = useSuspenseQuery( userPreferencesQuery( 'sites-view', {} ) )
-		.data as ViewPreferences;
+	const { data: viewPreferences } = useSuspenseQuery( userPreferencesQuery( 'sites-view' ) );
 	const { mutate: updateViewPreferences } = useMutation( userPreferencesMutation( 'sites-view' ) );
 
 	const { defaultView, view } = getView( {
@@ -101,7 +100,7 @@ export default function Sites() {
 			},
 		} );
 
-		updateViewPreferences( updatedViewPreferences as Record< string, unknown > );
+		updateViewPreferences( updatedViewPreferences );
 	};
 
 	return (

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -7,7 +7,7 @@ import { useState } from 'react';
 import { useAnalytics } from '../app/analytics';
 import { useAuth } from '../app/auth';
 import { isAutomatticianQuery } from '../app/queries/me-a8c';
-import { userPreferencesQuery, userPreferencesMutation } from '../app/queries/me-preferences';
+import { userPreferenceQuery, userPreferenceMutation } from '../app/queries/me-preferences';
 import { sitesQuery } from '../app/queries/sites';
 import { sitesRoute } from '../app/router';
 import DataViewsCard from '../components/dataviews-card';
@@ -58,8 +58,8 @@ export default function Sites() {
 
 	const { user } = useAuth();
 	const { data: isAutomattician } = useSuspenseQuery( isAutomatticianQuery() );
-	const { data: viewPreferences } = useSuspenseQuery( userPreferencesQuery( 'sites-view' ) );
-	const { mutate: updateViewPreferences } = useMutation( userPreferencesMutation( 'sites-view' ) );
+	const { data: viewPreferences } = useSuspenseQuery( userPreferenceQuery( 'sites-view' ) );
+	const { mutate: updateViewPreferences } = useMutation( userPreferenceMutation( 'sites-view' ) );
 
 	const { defaultView, view } = getView( {
 		user,

--- a/client/dashboard/sites/views.ts
+++ b/client/dashboard/sites/views.ts
@@ -1,13 +1,7 @@
 import fastDeepEqual from 'fast-deep-equal/es6';
 import type { AnalyticsClient } from '../app/analytics';
-import type { User } from '../data/types';
-import type {
-	Operator,
-	SortDirection,
-	ViewTable,
-	ViewGrid,
-	SupportedLayouts,
-} from '@wordpress/dataviews';
+import type { User, SitesView, ViewPreferences } from '../data/types';
+import type { Operator, SortDirection, SupportedLayouts } from '@wordpress/dataviews';
 
 export const DEFAULT_LAYOUTS: SupportedLayouts = {
 	table: {
@@ -33,14 +27,7 @@ const DEFAULT_LAYOUT_FIELDS: SupportedLayouts = {
 	},
 };
 
-export type SitesView = ViewTable | ViewGrid;
-
-// The view preferences are a subset of the view object.
-// It includes the merged layout object of all view types ever explicitly set by the user.
-export type ViewPreferences = Partial< Omit< SitesView, 'type' | 'layout' > > & {
-	type?: ViewTable[ 'type' ] | ViewGrid[ 'type' ];
-	layout?: Partial< ViewTable[ 'layout' ] & ViewGrid[ 'layout' ] >;
-};
+export type { SitesView, ViewPreferences };
 
 // All possible keys that can be stored as view preferences.
 const VIEW_PREFERENCES_KEYS = [

--- a/client/dashboard/sites/views.ts
+++ b/client/dashboard/sites/views.ts
@@ -1,6 +1,6 @@
 import fastDeepEqual from 'fast-deep-equal/es6';
 import type { AnalyticsClient } from '../app/analytics';
-import type { User, SitesView, ViewPreferences } from '../data/types';
+import type { User, SitesView, SitesViewPreferences } from '../data/types';
 import type { Operator, SortDirection, SupportedLayouts } from '@wordpress/dataviews';
 
 export const DEFAULT_LAYOUTS: SupportedLayouts = {
@@ -27,7 +27,7 @@ const DEFAULT_LAYOUT_FIELDS: SupportedLayouts = {
 	},
 };
 
-export type { SitesView, ViewPreferences };
+export type { SitesView, SitesViewPreferences };
 
 // All possible keys that can be stored as view preferences.
 const VIEW_PREFERENCES_KEYS = [
@@ -97,7 +97,7 @@ export function getView( {
 	user: User;
 	isAutomattician: boolean;
 	isRestoringAccount: boolean;
-	viewPreferences?: ViewPreferences;
+	viewPreferences?: SitesViewPreferences;
 	viewSearchParams: ViewSearchParams;
 } ): {
 	defaultView: SitesView;
@@ -137,10 +137,10 @@ export function mergeViews( {
 }: {
 	defaultView: SitesView;
 	view: SitesView;
-	viewPreferences?: ViewPreferences;
+	viewPreferences?: SitesViewPreferences;
 	nextView: SitesView;
 } ): {
-	updatedViewPreferences: ViewPreferences;
+	updatedViewPreferences: SitesViewPreferences;
 	updatedViewSearchParams: ViewSearchParams;
 } {
 	const nextType = nextView.type;
@@ -181,7 +181,7 @@ export function mergeViews( {
 			...viewPreferences?.layout,
 			...updatedView.layout,
 		},
-	} as ViewPreferences;
+	} as SitesViewPreferences;
 
 	const updatedViewSearchParams = {
 		// Show only params which have custom values.

--- a/client/sites/v2/sites-list/router.tsx
+++ b/client/sites/v2/sites-list/router.tsx
@@ -6,7 +6,7 @@ import {
 	redirect,
 } from '@tanstack/react-router';
 import { isAutomatticianQuery } from 'calypso/dashboard/app/queries/me-a8c';
-import { userPreferencesQuery } from 'calypso/dashboard/app/queries/me-preferences';
+import { rawUserPreferencesQuery } from 'calypso/dashboard/app/queries/me-preferences';
 import { sitesQuery } from 'calypso/dashboard/app/queries/sites';
 import { queryClient } from 'calypso/dashboard/app/query-client';
 import Root from '../components/root';
@@ -26,7 +26,7 @@ const sitesRoute = createRoute( {
 
 		await Promise.all( [
 			queryClient.ensureQueryData( isAutomatticianQuery() ),
-			queryClient.ensureQueryData( userPreferencesQuery() ),
+			queryClient.ensureQueryData( rawUserPreferencesQuery() ),
 		] );
 	},
 	validateSearch: ( search ) => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Follow up of #104651

## Proposed Changes

* `userPreferencesQuery()` return type is correctly determined by the preference key passed in
* The `sites-view` preference is now forced to be the correct `ViewPreferences` type, rather than a generic `Record`
* Moved default preference values to a shared place. v1 has a similar thing: https://github.com/Automattic/wp-calypso/blob/b28b1a8d2b7fccb5b125f4c1cab11efd2b268287/client/state/preferences/constants.js#L3

TODO: remove the phony `some-string` preference which is only there for testing to confirm the types work for any generic preference.

The data flow is:
1. The data layer returns partial set of preferences
2. The query layer mixes that partial set with the default preferences to make sure we have a complete `UserPreferences`
3. The `useQuery` hooks are sure to return a fully formed

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The `userPreferenceQuery()` typings weren't quite correct, we would have found that when we added one more preference type, the queries return type would have been `Preference1 | Preference 2`—not the price type represented by the preference name.

I moved the default preferences to a central place. When we have to views using the same query I am pretty sure we wouldn't want them to use different defaults. By being in a central place it means the `userPreferenceQuery()` _always_ returns a complete `UserPreferences` object, even if it is called without a specific preference key.

I kept your original interface @arthur791004, where the same query function can return either all the preferences or just one. But at what cost! :cry: The typings are much more complex. Claude recommended I just split the query function in two—`userPreferenceQuery` and `userPreferencesQuery` (plural). What do you think of that?

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Smoke test the sites list

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
