### PR TITLE
Site Overview v2: Implement Scan card

### DIFF
--- a/client/dashboard/app/queries/site-scan.ts
+++ b/client/dashboard/app/queries/site-scan.ts
@@ -1,0 +1,6 @@
+import { fetchSiteScan } from '../../data/site-scan';
+
+export const siteScanQuery = ( siteId: number ) => ( {
+	queryKey: [ 'site', siteId, 'scan' ],
+	queryFn: () => fetchSiteScan( siteId ),
+} );

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -33,6 +33,7 @@ import { siteDomainsQuery } from './queries/site-domains';
 import { sitePHPVersionQuery } from './queries/site-php-version';
 import { siteCurrentPlanQuery } from './queries/site-plans';
 import { sitePrimaryDataCenterQuery } from './queries/site-primary-data-center';
+import { siteScanQuery } from './queries/site-scan';
 import { siteSettingsQuery } from './queries/site-settings';
 import { siteSftpUsersQuery } from './queries/site-sftp';
 import { siteSshAccessStatusQuery } from './queries/site-ssh';
@@ -126,6 +127,7 @@ const siteOverviewRoute = createRoute( {
 			// The current plan is nice to have preloaded, but not blocking for
 			// navigation.
 			preload ? queryClient.ensureQueryData( siteCurrentPlanQuery( site.ID ) ) : undefined,
+			preload ? queryClient.ensureQueryData( siteScanQuery( site.ID ) ) : undefined,
 			queryClient.ensureQueryData( siteEngagementStatsQuery( site.ID ) ),
 		] );
 	},

--- a/client/dashboard/components/time-since/index.tsx
+++ b/client/dashboard/components/time-since/index.tsx
@@ -94,6 +94,13 @@ function formatDate( date: Date, format: string, locale: string ) {
 	return new Intl.DateTimeFormat( locale, formatOptions ).format( date );
 }
 
+export function useTimeSince( date: string, format = 'll' ) {
+	const { user } = useAuth();
+	const locale = user.locale_variant || user.language || 'en';
+
+	return useRelativeTime( date, format, locale );
+}
+
 export default function TimeSince( { date, format = 'll' }: { date: string; format?: string } ) {
 	const { user } = useAuth();
 	const locale = user.locale_variant || user.language || 'en';

--- a/client/dashboard/data/site-scan.ts
+++ b/client/dashboard/data/site-scan.ts
@@ -1,0 +1,17 @@
+import wpcom from 'calypso/lib/wp';
+
+export interface SiteScan {
+	most_recent: {
+		timestamp: string;
+	};
+	reason: string;
+	state: 'unavailable' | 'idle';
+	threats: Record< string, unknown >[];
+}
+
+export async function fetchSiteScan( siteId: number ): Promise< SiteScan > {
+	return wpcom.req.get( {
+		path: `/sites/${ siteId }/scan`,
+		apiNamespace: 'wpcom/v2',
+	} );
+}

--- a/client/dashboard/sites/features.ts
+++ b/client/dashboard/sites/features.ts
@@ -35,7 +35,8 @@ export function canManageSite( site: Site ) {
 	}
 
 	// Self-hosted Jetpack-connected sites are not supported, yet.
-	if ( isSelfHostedJetpackConnected( site ) ) {
+	// Only enable for the development environment, for now.
+	if ( isSelfHostedJetpackConnected( site ) && config( 'env_id' ) !== 'development' ) {
 		return false;
 	}
 

--- a/client/dashboard/sites/overview-card/card.stories.tsx
+++ b/client/dashboard/sites/overview-card/card.stories.tsx
@@ -54,6 +54,6 @@ export const WithLink: Story = {
 		heading: '24',
 		metaText: 'Past 7 days',
 		icon: comment,
-		isLink: true,
+		externalLink: 'https://wordpress.com',
 	},
 };

--- a/client/dashboard/sites/overview-card/index.tsx
+++ b/client/dashboard/sites/overview-card/index.tsx
@@ -43,7 +43,16 @@ export default function OverviewCard( {
 	const isDisabled = variant === 'disabled';
 
 	const content = (
-		<Card className={ `dashboard-overview-card${ variant ? ` dashboard-overview-card--${ variant }` : '' }` }>
+		<Card
+			className={
+				variant
+					? `dashboard-overview-card dashboard-overview-card--${ variant }`
+					: 'dashboard-overview-card'
+			}
+			style={ {
+				opacity: isDisabled ? 0.5 : 1,
+			} }
+		>
 			<CardBody>
 				{ trackId && (
 					<ComponentViewTracker

--- a/client/dashboard/sites/overview-card/index.tsx
+++ b/client/dashboard/sites/overview-card/index.tsx
@@ -9,68 +9,128 @@ import {
 	ProgressBar,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useAnalytics } from '../../app/analytics';
+import ComponentViewTracker from '../../components/component-view-tracker';
 import type { ReactElement, ReactNode } from 'react';
 import './style.scss';
 
 interface OverviewCardProps {
 	title: string;
-	heading?: ReactNode;
 	customHeading?: ReactNode;
+	description?: string;
+	externalLink?: string;
+	heading?: ReactNode;
 	icon?: ReactElement;
 	metaText?: string;
-	isLink?: boolean;
+	trackId?: string;
+	variant?: 'disabled' | 'loading' | 'success' | 'error';
 	children?: ReactNode;
 }
 
 export default function OverviewCard( {
-	title,
-	heading,
 	customHeading,
+	description,
+	externalLink,
+	heading,
 	icon,
 	metaText,
-	isLink,
+	title,
+	trackId,
+	variant,
 	children,
 }: OverviewCardProps ) {
-	// TODO: handle `isLink`..
-	return (
-		<Card className="dashboard-overview-card">
+	const { recordTracksEvent } = useAnalytics();
+	const isDisabled = variant === 'disabled';
+
+	const content = (
+		<Card className={ `dashboard-overview-card${ variant ? ` dashboard-overview-card--${ variant }` : '' }` }>
 			<CardBody>
+				{ trackId && (
+					<ComponentViewTracker
+						eventName="calypso_dashboard_overview_card_impression"
+						properties={ { type: trackId, variant } }
+					/>
+				) }
 				<VStack spacing={ 4 }>
 					<HStack justify="space-between">
-						<Text variant="muted">
-							{ title }
-							{ isLink && (
-								<span
-									className="components-external-link__icon"
-									aria-label={
-										/* translators: accessibility text */
-										__( '(opens in a new tab)' )
-									}
-								>
-									&#8599;
-								</span>
-							) }
-						</Text>
-
-						{ icon && <Icon className="dashboard-overview-card__icon" icon={ icon } /> }
+						<HStack spacing={ 2 } alignment="center" expanded={ false }>
+							{ icon && <Icon className="dashboard-overview-card__icon" icon={ icon } /> }
+							<Text variant="muted" lineHeight="16px" size={ 11 } weight={ 500 } upperCase>
+								{ title }
+							</Text>
+						</HStack>
+						{ externalLink && (
+							<span
+								className="components-external-link__icon"
+								aria-label={
+									/* translators: accessibility text */
+									__( '(opens in a new tab)' )
+								}
+							>
+								&#8599;
+							</span>
+						) }
 					</HStack>
 					<HStack justify="flex-start" alignment="baseline">
 						{ customHeading ? (
 							customHeading
 						) : (
-							<>
-								<Heading level={ 2 }>{ heading }</Heading>
+							<VStack spacing={ 2 }>
+								<Heading
+									level={ 2 }
+									size={ 20 }
+									variant={ isDisabled ? 'muted' : undefined }
+									weight={ 500 }
+								>
+									{ heading }
+								</Heading>
 								{ metaText && <Text variant="muted">{ metaText }</Text> }
-							</>
+								{ description && (
+									<Text
+										className="dashboard-overview-card__description"
+										variant="muted"
+										lineHeight="16px"
+										size={ 12 }
+									>
+										{ description }
+									</Text>
+								) }
+							</VStack>
 						) }
 					</HStack>
+					{ variant === 'loading' && <OverviewCardProgressBar /> }
 					{ children }
 				</VStack>
 			</CardBody>
 		</Card>
 	);
+
+	if ( externalLink ) {
+		return (
+			<a
+				href={ externalLink }
+				className="dashboard-overview-card__link"
+				target="_blank"
+				rel="noreferrer"
+				onClick={ () => {
+					if ( ! trackId ) {
+						return;
+					}
+
+					recordTracksEvent( 'calypso_dashboard_overview_card_click', {
+						type: trackId,
+						variant,
+					} );
+				} }
+			>
+				{ content }
+			</a>
+		);
+	}
+
+	return content;
 }
 
-export function OverviewCardProgressBar( { value }: { value: number | undefined } ) {
+export function OverviewCardProgressBar( { value }: { value?: number } ) {
 	return <ProgressBar className="dashboard-overview-card__progress-bar" value={ value } />;
 }

--- a/client/dashboard/sites/overview-card/style.scss
+++ b/client/dashboard/sites/overview-card/style.scss
@@ -1,11 +1,58 @@
+@import "@wordpress/base-styles/colors";
+
 .dashboard-overview-card {
+	&--disabled {
+		background-color: transparent !important;
+		box-shadow: 0 0 0 1px $gray-100 !important;
+	}
+
 	.components-card__body {
+		border-radius: 8px !important; /* stylelint-disable-line scales/radii */
 		padding: 24px;
 	}
 }
 
 .dashboard-overview-card__icon {
-	fill: #757575;
+	fill: $gray-700;
+
+	.dashboard-overview-card--success & {
+		fill: $alert-green;
+	}
+
+	.dashboard-overview-card--error & {
+		fill: $alert-red;
+		background-color: color-mix(in srgb, $alert-red 8%, transparent);
+	}
+}
+
+.dashboard-overview-card__link {
+	border-radius: 8px; /* stylelint-disable-line scales/radii */
+	display: flex;
+	text-decoration: none;
+
+	.dashboard-overview-card {
+		flex: 1;
+
+		&:hover {
+			background-color: color-mix(in srgb, var( --wp-admin-theme-color ) 2%, transparent);
+			box-shadow: 0 0 0 1px color-mix(in srgb, var( --wp-admin-theme-color ) 12%, transparent);
+
+			span, h2 {
+				color: var( --wp-admin-theme-color );
+			}
+
+			.dashboard-overview-card__icon {
+				fill: var( --wp-admin-theme-color );
+				background-color: transparent;
+			}	
+		}
+	}
+}
+
+.dashboard-overview-card__description {
+	.dashboard-overview-card--error & {
+		color: $alert-red;
+	}
 }
 
 .dashboard-overview-card__progress-bar {

--- a/client/dashboard/sites/overview/comments-card.tsx
+++ b/client/dashboard/sites/overview/comments-card.tsx
@@ -12,7 +12,6 @@ export default function CommentsCard( { engagementStats }: { engagementStats: En
 			icon={ comment }
 			heading={ `${ currentData.comments }` }
 			metaText={ __( 'Past 7 days' ) }
-			isLink
 		>
 			<TrendComparisonBadge
 				count={ currentData.comments }

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -17,6 +17,7 @@ import { getSiteDisplayName } from '../../utils/site-name';
 import CommentsCard from './comments-card';
 import LikesCard from './likes-card';
 import PerformanceCards from './performance-cards';
+import ScanCard from './scan-card';
 import SiteOverviewFields from './site-overview-fields';
 import SitePreviewCard from './site-preview-card';
 import StorageCard from './storage-card';
@@ -74,6 +75,7 @@ function SiteOverview() {
 						<PerformanceCards site={ site } />
 					</VStack>
 					<VStack spacing={ 6 } justify="start">
+						<ScanCard site={ site } />
 						<StorageCard site={ site } />
 						<UptimeCard site={ site } />
 					</VStack>

--- a/client/dashboard/sites/overview/likes-card.tsx
+++ b/client/dashboard/sites/overview/likes-card.tsx
@@ -12,7 +12,6 @@ export default function LikesCard( { engagementStats }: { engagementStats: Engag
 			icon={ starEmpty }
 			heading={ `${ currentData.likes }` }
 			metaText={ __( 'Past 7 days' ) }
-			isLink
 		>
 			<TrendComparisonBadge count={ currentData.likes } previousCount={ previousData.likes } />
 		</OverviewCard>

--- a/client/dashboard/sites/overview/scan-card.tsx
+++ b/client/dashboard/sites/overview/scan-card.tsx
@@ -1,0 +1,91 @@
+import { useQuery } from '@tanstack/react-query';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { shield } from '@wordpress/icons';
+import { siteScanQuery } from '../../app/queries/site-scan';
+import { useTimeSince } from '../../components/time-since';
+import { isSelfHostedJetpackConnected } from '../../utils/site-types';
+import OverviewCard from '../overview-card';
+import type { SiteScan } from '../../data/site-scan';
+import type { Site } from '../../data/types';
+
+const CARD_PROPS = {
+	icon: shield,
+	title: __( 'Last scan' ),
+	trackId: 'scan',
+};
+
+function getScanURL( site: Site ) {
+	const domain = isSelfHostedJetpackConnected( site ) ? 'cloud.jetpack.com' : 'wordpress.com';
+	return `https://${ domain }/scan/${ site.slug }`;
+}
+
+function ScanCardUnavailable() {
+	return (
+		<OverviewCard
+			{ ...CARD_PROPS }
+			heading={ __( 'Unavailable' ) }
+			description={ __( 'Requires the Jetpack module' ) }
+			variant="disabled"
+		/>
+	);
+}
+
+function ScanCardWithThreats( { site, scan }: { site: Site; scan: SiteScan } ) {
+	const threatCount = scan.threats.length;
+	const description = sprintf(
+		/* translators: %d: number of threats */
+		_n( '%d threat found', '%d threats found', threatCount ),
+		threatCount
+	);
+
+	return (
+		<OverviewCard
+			{ ...CARD_PROPS }
+			heading={ description }
+			description={ __( 'Auto fixes are available' ) }
+			externalLink={ getScanURL( site ) }
+			variant="error"
+		/>
+	);
+}
+
+function ScanCardNoThreats( { site, scan }: { site: Site; scan: SiteScan } ) {
+	const lastScanDate = useTimeSince( scan.most_recent?.timestamp );
+	let description = '\u00A0';
+
+	if ( lastScanDate ) {
+		description = sprintf(
+			/* translators: %s: time since last scan */
+			__( 'Scanned %s' ),
+			lastScanDate
+		);
+	}
+
+	return (
+		<OverviewCard
+			{ ...CARD_PROPS }
+			heading={ __( 'No threats found' ) }
+			description={ description }
+			externalLink={ getScanURL( site ) }
+			variant="success"
+		/>
+	);
+}
+
+export default function ScanCard( { site }: { site: Site } ) {
+	const { data: scan, isLoading } = useQuery( siteScanQuery( site.ID ) );
+
+	if ( ! scan || isLoading ) {
+		return <OverviewCard { ...CARD_PROPS } variant="loading" />;
+	}
+
+	if ( scan.state === 'unavailable' ) {
+		return <ScanCardUnavailable />;
+	}
+
+	if ( scan.threats.length > 0 ) {
+		return <ScanCardWithThreats site={ site } scan={ scan } />;
+	}
+
+	return <ScanCardNoThreats site={ site } scan={ scan } />;
+}

--- a/client/dashboard/sites/overview/subscribers-card.tsx
+++ b/client/dashboard/sites/overview/subscribers-card.tsx
@@ -4,11 +4,6 @@ import OverviewCard from '../overview-card';
 
 export default function SubscribersCard( { subscribers }: { subscribers: number } ) {
 	return (
-		<OverviewCard
-			title={ __( 'Subscribers' ) }
-			icon={ envelope }
-			heading={ `${ subscribers }` }
-			isLink
-		/>
+		<OverviewCard title={ __( 'Subscribers' ) } icon={ envelope } heading={ `${ subscribers }` } />
 	);
 }

--- a/client/dashboard/sites/overview/views-card.tsx
+++ b/client/dashboard/sites/overview/views-card.tsx
@@ -12,7 +12,6 @@ export default function ViewsCard( { engagementStats }: { engagementStats: Engag
 			icon={ seen }
 			heading={ `${ currentData.views }` }
 			metaText={ __( 'Past 7 days' ) }
-			isLink
 		>
 			<TrendComparisonBadge count={ currentData.views } previousCount={ previousData.views } />
 		</OverviewCard>

--- a/client/dashboard/sites/overview/visitors-card.tsx
+++ b/client/dashboard/sites/overview/visitors-card.tsx
@@ -12,7 +12,6 @@ export default function VisitorsCard( { engagementStats }: { engagementStats: En
 			icon={ people }
 			heading={ `${ currentData.visitors }` }
 			metaText={ __( 'Past 7 days' ) }
-			isLink
 		>
 			<TrendComparisonBadge
 				count={ currentData.visitors }


### PR DESCRIPTION
Ref DOTDASH-116
Ref DOTDASH-124

## Proposed Changes

This PR implements the site overview Scan card. As a note, while this PR updates the OverviewCard component, its goal is not to complete its implementation as per the design spec. Also note that the Scan upsell card will be handled separated to keep this PR small.

>[!NOTE]
> This PR also enables Jetpack-connected sites to have access to the Site Overview in the development environment.

In short, this PR implements the following Scan card states:

| Success | Warning | Disabled |
| --- | --- | --- |
| <img width="338" height="158" alt="SCR-20250711-lmcx" src="https://github.com/user-attachments/assets/5154fb20-99dc-4fb3-8998-86ea2529684d" /> | <img width="335" height="192" alt="SCR-20250711-llxs" src="https://github.com/user-attachments/assets/98a3276e-10ec-4eab-a172-fc986a27e3a7" /> | <img width="347" height="162" alt="SCR-20250711-lmso" src="https://github.com/user-attachments/assets/ffe94ec2-1c7e-48c7-a972-19b0e52f8f6f" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Sites Overview v2 development.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Select a WoA, go to the Site Overview and ensure that the Scan card success state is as shown above
* Now using the same site or a separate site, enable Jetpack Debug Helper from Jetpack Beta Tester, add Jetpack Scan Helper and update the site with some threats. IMPORTANT: Remember to undo the threats after testing as they are monitored and might trigger false positive alerts.
* Go to this site's Overview and ensure that the Scan card error state is as shown above
* Now create a site Jetpack-connect site but without the scan module enabled
* Go to this site's Overview and ensure that the Scan card disabled state is as shown above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
