### PR TITLE
A4A: Add the new Pressable Signature plans

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/common/hosting-features.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/common/hosting-features.tsx
@@ -12,6 +12,13 @@ type Props = {
 export default function HostingFeatures( { heading, isPressable, useSignaturePlans }: Props ) {
 	const translate = useTranslate();
 
+	const phpWorkers = translate( '%(workers)d PHP workers w/ auto-scaling', {
+		args: {
+			workers: useSignaturePlans ? 5 : 10,
+		},
+		comment: '%(workers)s is the number of PHP workers.',
+	} ).toString();
+
 	return (
 		<HostingFeaturesSectionV2
 			heading={ heading }
@@ -28,12 +35,7 @@ export default function HostingFeatures( { heading, isPressable, useSignaturePla
 						translate( 'High-burst capacity' ),
 						translate( 'Automated datacenter failover' ),
 						translate( 'Extremely fast DNS with SSL' ),
-						translate( '%(workers)d PHP workers w/ auto-scaling', {
-							args: {
-								workers: useSignaturePlans ? 5 : 10,
-							},
-							comment: '%(workers)s is the number of PHP workers.',
-						} ),
+						phpWorkers,
 						translate( 'Uptime monitoring' ),
 					],
 				},

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/common/hosting-features.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/common/hosting-features.tsx
@@ -6,9 +6,10 @@ import HostingFeaturesSectionV2 from '../../../common/hosting-features-section-v
 type Props = {
 	heading: string;
 	isPressable?: boolean;
+	useSignaturePlans?: boolean;
 };
 
-export default function HostingFeatures( { heading, isPressable }: Props ) {
+export default function HostingFeatures( { heading, isPressable, useSignaturePlans }: Props ) {
 	const translate = useTranslate();
 
 	return (
@@ -27,8 +28,12 @@ export default function HostingFeatures( { heading, isPressable }: Props ) {
 						translate( 'High-burst capacity' ),
 						translate( 'Automated datacenter failover' ),
 						translate( 'Extremely fast DNS with SSL' ),
-						// todo: update this for new plans. If new plan: 5 PHP workers
-						translate( '10 PHP workers w/ auto-scaling' ),
+						translate( '%(workers)d PHP workers w/ auto-scaling', {
+							args: {
+								workers: useSignaturePlans ? 5 : 10,
+							},
+							comment: '%(workers)s is the number of PHP workers.',
+						} ),
 						translate( 'Uptime monitoring' ),
 					],
 				},

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/common/hosting-features.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/common/hosting-features.tsx
@@ -1,23 +1,19 @@
+import { sprintf } from '@wordpress/i18n';
 import { code, copy, key, plus } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
 import { BackgroundType9 } from 'calypso/a8c-for-agencies/components/page-section/backgrounds';
 import HostingFeaturesSectionV2 from '../../../common/hosting-features-section-v2';
 
 type Props = {
 	heading: string;
 	isPressable?: boolean;
-	useSignaturePlans?: boolean;
+	areSignaturePlans?: boolean;
 };
 
-export default function HostingFeatures( { heading, isPressable, useSignaturePlans }: Props ) {
+export default function HostingFeatures( { heading, isPressable, areSignaturePlans }: Props ) {
 	const translate = useTranslate();
-
-	const phpWorkers = useMemo( () => {
-		return useSignaturePlans
-			? translate( '5 PHP workers w/ auto-scaling' )
-			: translate( '10 PHP workers w/ auto-scaling' );
-	}, [ useSignaturePlans, translate ] );
+	const { __ } = useI18n();
 
 	return (
 		<HostingFeaturesSectionV2
@@ -35,7 +31,11 @@ export default function HostingFeatures( { heading, isPressable, useSignaturePla
 						translate( 'High-burst capacity' ),
 						translate( 'Automated datacenter failover' ),
 						translate( 'Extremely fast DNS with SSL' ),
-						phpWorkers,
+						sprintf(
+							/* translators: %s is the number of PHP workers */
+							__( '%s PHP workers w/ auto-scaling' ),
+							areSignaturePlans ? '5' : '10'
+						),
 						translate( 'Uptime monitoring' ),
 					],
 				},

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/common/hosting-features.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/common/hosting-features.tsx
@@ -27,6 +27,7 @@ export default function HostingFeatures( { heading, isPressable }: Props ) {
 						translate( 'High-burst capacity' ),
 						translate( 'Automated datacenter failover' ),
 						translate( 'Extremely fast DNS with SSL' ),
+						// todo: update this for new plans. If new plan: 5 PHP workers
 						translate( '10 PHP workers w/ auto-scaling' ),
 						translate( 'Uptime monitoring' ),
 					],

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/common/hosting-features.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/common/hosting-features.tsx
@@ -1,5 +1,6 @@
 import { code, copy, key, plus } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
 import { BackgroundType9 } from 'calypso/a8c-for-agencies/components/page-section/backgrounds';
 import HostingFeaturesSectionV2 from '../../../common/hosting-features-section-v2';
 
@@ -12,12 +13,11 @@ type Props = {
 export default function HostingFeatures( { heading, isPressable, useSignaturePlans }: Props ) {
 	const translate = useTranslate();
 
-	const phpWorkers = translate( '%(workers)d PHP workers w/ auto-scaling', {
-		args: {
-			workers: useSignaturePlans ? 5 : 10,
-		},
-		comment: '%(workers)s is the number of PHP workers.',
-	} ).toString();
+	const phpWorkers = useMemo( () => {
+		return useSignaturePlans
+			? translate( '5 PHP workers w/ auto-scaling' )
+			: translate( '10 PHP workers w/ auto-scaling' );
+	}, [ useSignaturePlans, translate ] );
 
 	return (
 		<HostingFeaturesSectionV2

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/index.tsx
@@ -73,7 +73,7 @@ export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 	const useSignaturePlans = useMemo( () => {
 		return (
 			isReferralMode ||
-			existingPlanInfo === null ||
+			! existingPlanInfo ||
 			existingPlanInfo?.category === PLAN_CATEGORY_SIGNATURE ||
 			existingPlanInfo?.category === PLAN_CATEGORY_SIGNATURE_HIGH
 		);

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/index.tsx
@@ -74,8 +74,8 @@ export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 		return (
 			isReferralMode ||
 			existingPlanInfo === null ||
-			existingPlanInfo.category === PLAN_CATEGORY_SIGNATURE ||
-			existingPlanInfo.category === PLAN_CATEGORY_SIGNATURE_HIGH
+			existingPlanInfo?.category === PLAN_CATEGORY_SIGNATURE ||
+			existingPlanInfo?.category === PLAN_CATEGORY_SIGNATURE_HIGH
 		);
 	}, [ existingPlanInfo, isReferralMode ] );
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/index.tsx
@@ -1,9 +1,13 @@
 import { JetpackLogo } from '@automattic/components';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useTranslate } from 'i18n-calypso';
-import { useContext } from 'react';
+import { useContext, useMemo } from 'react';
 import { BackgroundType10 } from 'calypso/a8c-for-agencies/components/page-section/backgrounds';
 import useFetchLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-licenses';
+import {
+	PLAN_CATEGORY_SIGNATURE,
+	PLAN_CATEGORY_SIGNATURE_HIGH,
+} from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/constants';
 import ProfileAvatar1 from 'calypso/assets/images/a8c-for-agencies/hosting/premier-testimonial-1.png';
 import ProfileAvatar2 from 'calypso/assets/images/a8c-for-agencies/hosting/premier-testimonial-2.png';
 import {
@@ -66,6 +70,15 @@ export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 
 	const existingPlanInfo = getPressablePlan( agencyPressablePlan?.slug ?? '' );
 
+	const useSignaturePlans = useMemo( () => {
+		return (
+			isReferralMode ||
+			existingPlanInfo === null ||
+			existingPlanInfo.category === PLAN_CATEGORY_SIGNATURE ||
+			existingPlanInfo.category === PLAN_CATEGORY_SIGNATURE_HIGH
+		);
+	}, [ existingPlanInfo, isReferralMode ] );
+
 	return (
 		<div className="premier-agency-hosting">
 			{ agencyPressablePlan && ! isReferralMode && (
@@ -80,7 +93,11 @@ export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 				isFetching={ isExistingPlanFetched }
 			/>
 
-			<HostingFeatures heading={ translate( 'Included with every Pressable site' ) } isPressable />
+			<HostingFeatures
+				heading={ translate( 'Included with every Pressable site' ) }
+				isPressable
+				useSignaturePlans={ useSignaturePlans }
+			/>
 
 			<HostingAdditionalFeaturesSection
 				icon={ <JetpackLogo size={ 16 } /> }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/index.tsx
@@ -70,7 +70,7 @@ export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 
 	const existingPlanInfo = getPressablePlan( agencyPressablePlan?.slug ?? '' );
 
-	const useSignaturePlans = useMemo( () => {
+	const areSignaturePlans = useMemo( () => {
 		return (
 			isReferralMode ||
 			! existingPlanInfo ||
@@ -96,7 +96,7 @@ export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 			<HostingFeatures
 				heading={ translate( 'Included with every Pressable site' ) }
 				isPressable
-				useSignaturePlans={ useSignaturePlans }
+				areSignaturePlans={ areSignaturePlans }
 			/>
 
 			<HostingAdditionalFeaturesSection

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
@@ -52,7 +52,7 @@ export default function PressablePlanSection( {
 
 	const selectedPlanInfo = selectedPlan ? getPressablePlan( selectedPlan.slug ) : null;
 
-	const useSignaturePlans = useMemo( () => {
+	const areSignaturePlans = useMemo( () => {
 		return (
 			isReferralMode ||
 			! existingPlanInfo ||
@@ -66,23 +66,23 @@ export default function PressablePlanSection( {
 			return [];
 		}
 
-		if ( useSignaturePlans ) {
+		if ( areSignaturePlans ) {
 			return pressablePlans.filter( ( plan ) => plan.slug.startsWith( 'pressable-signature-' ) );
 		}
 
 		return pressablePlans.filter( ( plan ) => ! plan.slug.startsWith( 'pressable-signature-' ) );
-	}, [ pressablePlans, useSignaturePlans ] );
+	}, [ pressablePlans, areSignaturePlans ] );
 
 	useEffect( () => {
 		if ( pressablePlans?.length ) {
-			const defaultSlug = useSignaturePlans ? 'pressable-signature-1' : 'pressable-build';
+			const defaultSlug = areSignaturePlans ? 'pressable-signature-1' : 'pressable-build';
 			setSelectedPlan(
 				isReferralMode
 					? pressablePlans.find( ( plan ) => plan.slug === defaultSlug ) ?? null
 					: pressablePlans.find( ( plan ) => plan.slug === defaultSlug ) ?? pressablePlans[ 0 ]
 			);
 		}
-	}, [ isReferralMode, pressablePlans, setSelectedPlan, useSignaturePlans ] );
+	}, [ isReferralMode, pressablePlans, setSelectedPlan, areSignaturePlans ] );
 
 	useEffect( () => {
 		if ( ! isReferralMode && existingPlan ) {
@@ -114,7 +114,7 @@ export default function PressablePlanSection( {
 					onSelectPlan={ setSelectedPlan }
 					pressablePlan={ isReferralMode ? null : existingPlanInfo }
 					isLoading={ ! isFetching }
-					useSignaturePlans={ useSignaturePlans }
+					areSignaturePlans={ areSignaturePlans }
 				/>
 			</HostingPlanSection.Banner>
 		);
@@ -125,7 +125,7 @@ export default function PressablePlanSection( {
 		isReferralMode,
 		existingPlanInfo,
 		isFetching,
-		useSignaturePlans,
+		areSignaturePlans,
 	] );
 
 	const heading = useMemo( () => {
@@ -141,7 +141,7 @@ export default function PressablePlanSection( {
 	}, [ existingPlan, isReferralMode, pressableOwnership, translate ] );
 
 	const isStandardPlan =
-		! useSignaturePlans && selectedPlanInfo?.category === PLAN_CATEGORY_STANDARD;
+		! areSignaturePlans && selectedPlanInfo?.category === PLAN_CATEGORY_STANDARD;
 
 	const onScheduleDemo = useCallback( () => {
 		dispatch(
@@ -181,7 +181,7 @@ export default function PressablePlanSection( {
 					</p>
 				) : (
 					<p>
-						{ useSignaturePlans || isStandardPlan
+						{ areSignaturePlans || isStandardPlan
 							? translate(
 									'With Signature Plans, your traffic & storage limits are shared amongst your total sites.'
 							  )

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
@@ -4,7 +4,11 @@ import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback, useEffect, useMemo } from 'react';
 import SimpleList from 'calypso/a8c-for-agencies/components/simple-list';
 import useProductAndPlans from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans';
-import { PLAN_CATEGORY_STANDARD } from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/constants';
+import {
+	PLAN_CATEGORY_SIGNATURE,
+	PLAN_CATEGORY_SIGNATURE_HIGH,
+	PLAN_CATEGORY_STANDARD,
+} from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/constants';
 import getPressablePlan, {
 	PressablePlan,
 } from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan';
@@ -48,15 +52,37 @@ export default function PressablePlanSection( {
 
 	const selectedPlanInfo = selectedPlan ? getPressablePlan( selectedPlan.slug ) : null;
 
+	const useSignaturePlans = useMemo( () => {
+		return (
+			isReferralMode ||
+			existingPlanInfo === null ||
+			existingPlanInfo.category === PLAN_CATEGORY_SIGNATURE ||
+			existingPlanInfo.category === PLAN_CATEGORY_SIGNATURE_HIGH
+		);
+	}, [ existingPlanInfo, isReferralMode ] );
+
+	const filteredPressablePlans = useMemo( () => {
+		if ( ! pressablePlans ) {
+			return [];
+		}
+
+		if ( useSignaturePlans ) {
+			return pressablePlans.filter( ( plan ) => plan.slug.startsWith( 'pressable-signature-' ) );
+		}
+
+		return pressablePlans.filter( ( plan ) => ! plan.slug.startsWith( 'pressable-signature-' ) );
+	}, [ pressablePlans, useSignaturePlans ] );
+
 	useEffect( () => {
 		if ( pressablePlans?.length ) {
+			const defaultSlug = useSignaturePlans ? 'pressable-signature-1' : 'pressable-build';
 			setSelectedPlan(
 				isReferralMode
-					? pressablePlans.find( ( plan ) => plan.slug === 'pressable-build' ) ?? null
-					: pressablePlans[ 0 ]
+					? pressablePlans.find( ( plan ) => plan.slug === defaultSlug ) ?? null
+					: pressablePlans.find( ( plan ) => plan.slug === defaultSlug ) ?? pressablePlans[ 0 ]
 			);
 		}
-	}, [ isReferralMode, pressablePlans, setSelectedPlan ] );
+	}, [ isReferralMode, pressablePlans, setSelectedPlan, useSignaturePlans ] );
 
 	useEffect( () => {
 		if ( ! isReferralMode && existingPlan ) {
@@ -84,20 +110,22 @@ export default function PressablePlanSection( {
 			<HostingPlanSection.Banner>
 				<PlanSelectionFilter
 					selectedPlan={ selectedPlan }
-					plans={ pressablePlans }
+					plans={ filteredPressablePlans }
 					onSelectPlan={ setSelectedPlan }
 					pressablePlan={ isReferralMode ? null : existingPlanInfo }
 					isLoading={ ! isFetching }
+					useSignaturePlans={ useSignaturePlans }
 				/>
 			</HostingPlanSection.Banner>
 		);
 	}, [
 		pressableOwnership,
 		selectedPlan,
-		pressablePlans,
+		filteredPressablePlans,
 		isReferralMode,
 		existingPlanInfo,
 		isFetching,
+		useSignaturePlans,
 	] );
 
 	const heading = useMemo( () => {
@@ -112,7 +140,8 @@ export default function PressablePlanSection( {
 		return translate( 'Choose from a variety of high performance hosting plans' );
 	}, [ existingPlan, isReferralMode, pressableOwnership, translate ] );
 
-	const isStandardPlan = selectedPlanInfo?.category === PLAN_CATEGORY_STANDARD;
+	const isStandardPlan =
+		! useSignaturePlans && selectedPlanInfo?.category === PLAN_CATEGORY_STANDARD;
 
 	const onScheduleDemo = useCallback( () => {
 		dispatch(
@@ -152,7 +181,7 @@ export default function PressablePlanSection( {
 					</p>
 				) : (
 					<p>
-						{ isStandardPlan
+						{ useSignaturePlans || isStandardPlan
 							? translate(
 									'With Signature Plans, your traffic & storage limits are shared amongst your total sites.'
 							  )

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
@@ -56,8 +56,8 @@ export default function PressablePlanSection( {
 		return (
 			isReferralMode ||
 			existingPlanInfo === null ||
-			existingPlanInfo.category === PLAN_CATEGORY_SIGNATURE ||
-			existingPlanInfo.category === PLAN_CATEGORY_SIGNATURE_HIGH
+			existingPlanInfo?.category === PLAN_CATEGORY_SIGNATURE ||
+			existingPlanInfo?.category === PLAN_CATEGORY_SIGNATURE_HIGH
 		);
 	}, [ existingPlanInfo, isReferralMode ] );
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
@@ -55,7 +55,7 @@ export default function PressablePlanSection( {
 	const useSignaturePlans = useMemo( () => {
 		return (
 			isReferralMode ||
-			existingPlanInfo === null ||
+			! existingPlanInfo ||
 			existingPlanInfo?.category === PLAN_CATEGORY_SIGNATURE ||
 			existingPlanInfo?.category === PLAN_CATEGORY_SIGNATURE_HIGH
 		);

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/regular-plan-card-content.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/regular-plan-card-content.tsx
@@ -35,7 +35,7 @@ export default function PressablePlanSelectorCard( {
 		if ( isReferralMode ) {
 			return translate( 'Add %(planName)s to referral', {
 				args: {
-					planName: plan.name,
+					planName: plan.name.replace( /Pressable/g, '' ),
 				},
 				comment: '%(planName)s is the name of the plan.',
 			} );
@@ -43,7 +43,7 @@ export default function PressablePlanSelectorCard( {
 
 		return translate( 'Add %(planName)s to cart', {
 			args: {
-				planName: plan.name,
+				planName: plan.name.replace( /Pressable/g, '' ),
 			},
 			comment: '%(planName)s is the name of the plan.',
 		} );

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/constants.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/constants.ts
@@ -4,3 +4,5 @@ export const FILTER_TYPE_STORAGE = 'storage';
 export const PLAN_CATEGORY_STANDARD = 'standard';
 export const PLAN_CATEGORY_ENTERPRISE = 'enterprise';
 export const PLAN_CATEGORY_HIGH_RESOURCE = 'high-resource';
+export const PLAN_CATEGORY_SIGNATURE = 'signature';
+export const PLAN_CATEGORY_SIGNATURE_HIGH = 'signature-high';

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
@@ -1,4 +1,9 @@
-import { PLAN_CATEGORY_STANDARD, PLAN_CATEGORY_ENTERPRISE } from '../constants';
+import {
+	PLAN_CATEGORY_STANDARD,
+	PLAN_CATEGORY_ENTERPRISE,
+	PLAN_CATEGORY_SIGNATURE,
+	PLAN_CATEGORY_SIGNATURE_HIGH,
+} from '../constants';
 
 export type PressablePlan = {
 	slug: string;
@@ -9,6 +14,7 @@ export type PressablePlan = {
 };
 
 const PLAN_DATA: Record< string, PressablePlan > = {
+	// [Legacy] Old Pressable plans
 	'pressable-wp-1': {
 		slug: 'pressable-wp-1',
 		install: 1,
@@ -59,7 +65,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		category: PLAN_CATEGORY_STANDARD,
 	},
 
-	// New pressable plans
+	// [Legacy] Pressable Plans 2024-08
 	'pressable-build': {
 		slug: 'pressable-build',
 		install: 1,
@@ -131,7 +137,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		category: PLAN_CATEGORY_STANDARD,
 	},
 
-	// Pressable Enterprise plans
+	// [Legacy] Pressable Enterprise plans 2024-08
 	'pressable-enterprise-4': {
 		slug: 'pressable-enterprise-4',
 		install: 200,
@@ -180,6 +186,126 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		visits: 10000000,
 		storage: 1000,
 		category: PLAN_CATEGORY_ENTERPRISE,
+	},
+	// [New] Pressable Signature Plans 2025-06
+	'pressable-signature-1': {
+		slug: 'pressable-signature-1',
+		install: 1,
+		visits: 30000,
+		storage: 20,
+		category: PLAN_CATEGORY_SIGNATURE,
+	},
+	'pressable-signature-2': {
+		slug: 'pressable-signature-2',
+		install: 3,
+		visits: 50000,
+		storage: 30,
+		category: PLAN_CATEGORY_SIGNATURE,
+	},
+	'pressable-signature-3': {
+		slug: 'pressable-signature-3',
+		install: 5,
+		visits: 75000,
+		storage: 35,
+		category: PLAN_CATEGORY_SIGNATURE,
+	},
+	'pressable-signature-4': {
+		slug: 'pressable-signature-4',
+		install: 10,
+		visits: 150000,
+		storage: 50,
+		category: PLAN_CATEGORY_SIGNATURE,
+	},
+	'pressable-signature-5': {
+		slug: 'pressable-signature-5',
+		install: 20,
+		visits: 400000,
+		storage: 80,
+		category: PLAN_CATEGORY_SIGNATURE,
+	},
+	'pressable-signature-6': {
+		slug: 'pressable-signature-6',
+		install: 50,
+		visits: 1000000,
+		storage: 200,
+		category: PLAN_CATEGORY_SIGNATURE,
+	},
+	'pressable-signature-7': {
+		slug: 'pressable-signature-7',
+		install: 80,
+		visits: 1600000,
+		storage: 275,
+		category: PLAN_CATEGORY_SIGNATURE,
+	},
+	'pressable-signature-8': {
+		slug: 'pressable-signature-8',
+		install: 100,
+		visits: 2000000,
+		storage: 325,
+		category: PLAN_CATEGORY_SIGNATURE,
+	},
+	'pressable-signature-9': {
+		slug: 'pressable-signature-9',
+		install: 120,
+		visits: 2400000,
+		storage: 375,
+		category: PLAN_CATEGORY_SIGNATURE,
+	},
+	'pressable-signature-10': {
+		slug: 'pressable-signature-10',
+		install: 150,
+		visits: 3000000,
+		storage: 450,
+		category: PLAN_CATEGORY_SIGNATURE,
+	},
+	'pressable-signature-11': {
+		slug: 'pressable-signature-11',
+		install: 200,
+		visits: 4000000,
+		storage: 500,
+		category: PLAN_CATEGORY_SIGNATURE_HIGH,
+	},
+	'pressable-signature-12': {
+		slug: 'pressable-signature-12',
+		install: 250,
+		visits: 5000000,
+		storage: 550,
+		category: PLAN_CATEGORY_SIGNATURE_HIGH,
+	},
+	'pressable-signature-13': {
+		slug: 'pressable-signature-13',
+		install: 300,
+		visits: 6000000,
+		storage: 600,
+		category: PLAN_CATEGORY_SIGNATURE_HIGH,
+	},
+	'pressable-signature-14': {
+		slug: 'pressable-signature-14',
+		install: 350,
+		visits: 7000000,
+		storage: 700,
+		category: PLAN_CATEGORY_SIGNATURE_HIGH,
+	},
+	'pressable-signature-15': {
+		slug: 'pressable-signature-15',
+		install: 400,
+		visits: 8000000,
+		storage: 800,
+		category: PLAN_CATEGORY_SIGNATURE_HIGH,
+	},
+	'pressable-signature-16': {
+		slug: 'pressable-signature-16',
+		install: 450,
+		visits: 9000000,
+		storage: 900,
+		category: PLAN_CATEGORY_SIGNATURE_HIGH,
+	},
+	'pressable-signature-17': {
+		slug: 'pressable-signature-17',
+		install: 500,
+		visits: 10000000,
+		storage: 1000,
+		category: PLAN_CATEGORY_SIGNATURE_HIGH,
 	},
 };
 

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -14,6 +14,8 @@ import {
 	PLAN_CATEGORY_ENTERPRISE,
 	PLAN_CATEGORY_HIGH_RESOURCE,
 	FILTER_TYPE_STORAGE,
+	PLAN_CATEGORY_SIGNATURE,
+	PLAN_CATEGORY_SIGNATURE_HIGH,
 } from '../constants';
 import getPressablePlan, { PressablePlan } from '../lib/get-pressable-plan';
 import getSliderOptions from '../lib/get-slider-options';
@@ -31,6 +33,7 @@ type Props = {
 	// Whether the existing plan is still being loaded
 	isLoading?: boolean;
 	showHighResourceTab?: boolean;
+	useSignaturePlans?: boolean;
 };
 
 export default function PlanSelectionFilter( {
@@ -40,33 +43,36 @@ export default function PlanSelectionFilter( {
 	pressablePlan,
 	isLoading,
 	showHighResourceTab = false,
+	useSignaturePlans = false,
 }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
 	const [ filterType, setFilterType ] = useState< FilterType >( FILTER_TYPE_INSTALL );
-	const [ selectedTab, setSelectedTab ] = useState( PLAN_CATEGORY_STANDARD );
+	const [ selectedTab, setSelectedTab ] = useState(
+		useSignaturePlans ? PLAN_CATEGORY_SIGNATURE : PLAN_CATEGORY_STANDARD
+	);
 	const [ disableStandardTab, setDisableStandardTab ] = useState( false );
 
 	const isMobile = useMobileBreakpoint();
 
-	const standardOptions = useMemo(
+	const lowPlanOptions = useMemo(
 		() =>
 			getSliderOptions(
 				filterType,
 				plans.map( ( plan ) => getPressablePlan( plan.slug ) ),
-				PLAN_CATEGORY_STANDARD,
+				useSignaturePlans ? PLAN_CATEGORY_SIGNATURE : PLAN_CATEGORY_STANDARD,
 				isMobile
 			),
-		[ filterType, isMobile, plans ]
+		[ filterType, isMobile, plans, useSignaturePlans ]
 	);
 
-	const enterpriseOptions = useMemo(
+	const highPlanOptions = useMemo(
 		() => [
 			...getSliderOptions(
 				filterType,
 				plans.map( ( plan ) => getPressablePlan( plan.slug ) ),
-				PLAN_CATEGORY_ENTERPRISE,
+				useSignaturePlans ? PLAN_CATEGORY_SIGNATURE_HIGH : PLAN_CATEGORY_ENTERPRISE,
 				isMobile
 			),
 			...( showHighResourceTab
@@ -79,7 +85,7 @@ export default function PlanSelectionFilter( {
 						},
 				  ] ),
 		],
-		[ filterType, isMobile, plans, showHighResourceTab, translate ]
+		[ filterType, isMobile, plans, showHighResourceTab, translate, useSignaturePlans ]
 	);
 
 	const onSelectOption = useCallback(
@@ -96,7 +102,9 @@ export default function PlanSelectionFilter( {
 	);
 
 	const selectedOptionIndex = (
-		PLAN_CATEGORY_STANDARD === selectedTab ? standardOptions : enterpriseOptions
+		PLAN_CATEGORY_STANDARD === selectedTab || PLAN_CATEGORY_SIGNATURE === selectedTab
+			? lowPlanOptions
+			: highPlanOptions
 	).findIndex( ( { value } ) => value === ( selectedPlan ? selectedPlan.slug : null ) );
 
 	const onSelectFilterType = useCallback(
@@ -122,15 +130,20 @@ export default function PlanSelectionFilter( {
 			}
 
 			// Depending on the category of the existing plan, we might want to show other category slider at the most min or max
-			if (
-				PLAN_CATEGORY_STANDARD === category &&
-				PLAN_CATEGORY_STANDARD !== pressablePlan?.category
-			) {
+			const isStandardCategory =
+				PLAN_CATEGORY_STANDARD === category || PLAN_CATEGORY_SIGNATURE === category;
+			const isEnterpriseCategory =
+				PLAN_CATEGORY_ENTERPRISE === category || PLAN_CATEGORY_SIGNATURE_HIGH === category;
+			const isPlanStandardCategory =
+				PLAN_CATEGORY_STANDARD === pressablePlan?.category ||
+				PLAN_CATEGORY_SIGNATURE === pressablePlan?.category;
+			const isPlanEnterpriseCategory =
+				PLAN_CATEGORY_ENTERPRISE === pressablePlan?.category ||
+				PLAN_CATEGORY_SIGNATURE_HIGH === pressablePlan?.category;
+
+			if ( isStandardCategory && ! isPlanStandardCategory ) {
 				return categoryOptions.length - 1;
-			} else if (
-				PLAN_CATEGORY_ENTERPRISE === category &&
-				PLAN_CATEGORY_ENTERPRISE !== pressablePlan?.category
-			) {
+			} else if ( isEnterpriseCategory && ! isPlanEnterpriseCategory ) {
 				return 0;
 			}
 
@@ -146,20 +159,42 @@ export default function PlanSelectionFilter( {
 	);
 
 	useEffect( () => {
+		// If there's no existing plan, set the default tab based on useSignaturePlans
 		if ( ! pressablePlan ) {
+			setSelectedTab( useSignaturePlans ? PLAN_CATEGORY_SIGNATURE : PLAN_CATEGORY_STANDARD );
+			setDisableStandardTab( false ); // Ensure standard tab is not disabled if no existing plan
 			return;
 		}
 
-		setSelectedTab( pressablePlan.category ?? PLAN_CATEGORY_STANDARD );
+		// If there is an existing plan, map its category to the appropriate tab
+		let tabCategory = pressablePlan.category;
+		if ( useSignaturePlans ) {
+			if ( pressablePlan.category === PLAN_CATEGORY_STANDARD ) {
+				tabCategory = PLAN_CATEGORY_SIGNATURE;
+			} else if ( pressablePlan.category === PLAN_CATEGORY_ENTERPRISE ) {
+				tabCategory = PLAN_CATEGORY_SIGNATURE_HIGH;
+			}
+		} else if ( pressablePlan.category === PLAN_CATEGORY_SIGNATURE ) {
+			// If not using signature plans, map signature categories back to standard/enterprise
+			tabCategory = PLAN_CATEGORY_STANDARD;
+		} else if ( pressablePlan.category === PLAN_CATEGORY_SIGNATURE_HIGH ) {
+			tabCategory = PLAN_CATEGORY_ENTERPRISE;
+		}
+		setSelectedTab( tabCategory );
 
 		// Disable the standard tab if the existing plan is the highest standard plan or higher
+		const isStandardCategory =
+			pressablePlan.category === PLAN_CATEGORY_STANDARD ||
+			pressablePlan.category === PLAN_CATEGORY_SIGNATURE;
 		if (
-			pressablePlan.category !== PLAN_CATEGORY_STANDARD ||
-			pressablePlan.slug === standardOptions[ standardOptions.length - 1 ]?.value
+			! isStandardCategory ||
+			pressablePlan.slug === lowPlanOptions[ lowPlanOptions.length - 1 ]?.value
 		) {
 			setDisableStandardTab( true );
+		} else {
+			setDisableStandardTab( false );
 		}
-	}, [ pressablePlan, standardOptions ] );
+	}, [ pressablePlan, lowPlanOptions, useSignaturePlans ] );
 
 	useEffect( () => {
 		if ( selectedTab === PLAN_CATEGORY_HIGH_RESOURCE ) {
@@ -206,49 +241,89 @@ export default function PlanSelectionFilter( {
 				activeClass="pressable-overview-plan-selection__plan-category-tab-is-active"
 				onSelect={ setSelectedTab }
 				initialTabName={ selectedTab }
-				tabs={ [
-					{
-						name: PLAN_CATEGORY_STANDARD,
-						title: translate( 'Signature Plans' ),
-						disabled: disableStandardTab,
-					},
-					{
-						name: PLAN_CATEGORY_ENTERPRISE,
-						title: translate( 'Enterprise Plans' ),
-					},
-					...( showHighResourceTab
+				tabs={
+					useSignaturePlans
 						? [
 								{
-									name: PLAN_CATEGORY_HIGH_RESOURCE,
-									title: translate( 'High Resource Plans' ),
+									name: PLAN_CATEGORY_SIGNATURE,
+									title: translate( 'Signature Plans 1-10' ),
+									disabled: disableStandardTab,
 								},
+								{
+									name: PLAN_CATEGORY_SIGNATURE_HIGH,
+									title: translate( 'Signature Plans 11-17' ),
+								},
+								...( showHighResourceTab
+									? [
+											{
+												name: PLAN_CATEGORY_HIGH_RESOURCE,
+												title: translate( 'High Resource Plans' ),
+											},
+									  ]
+									: [] ),
 						  ]
-						: [] ),
-				] }
+						: [
+								{
+									name: PLAN_CATEGORY_STANDARD,
+									title: translate( 'Signature Plans' ),
+									disabled: disableStandardTab,
+								},
+								{
+									name: PLAN_CATEGORY_ENTERPRISE,
+									title: translate( 'Enterprise Plans' ),
+								},
+								...( showHighResourceTab
+									? [
+											{
+												name: PLAN_CATEGORY_HIGH_RESOURCE,
+												title: translate( 'High Resource Plans' ),
+											},
+									  ]
+									: [] ),
+						  ]
+				}
 			>
 				{ ( tab ) => {
 					switch ( tab.name ) {
 						case PLAN_CATEGORY_STANDARD:
+						case PLAN_CATEGORY_SIGNATURE:
 							return (
 								<>
 									<FilterByPicker />
 									<A4ASlider
-										value={ PLAN_CATEGORY_STANDARD === selectedTab ? selectedOptionIndex : 0 }
+										value={
+											PLAN_CATEGORY_STANDARD === selectedTab ||
+											PLAN_CATEGORY_SIGNATURE === selectedTab
+												? selectedOptionIndex
+												: 0
+										}
 										onChange={ onSelectOption }
-										options={ standardOptions }
-										minimum={ getSliderMinimum( PLAN_CATEGORY_STANDARD, standardOptions ) }
+										options={ lowPlanOptions }
+										minimum={ getSliderMinimum(
+											useSignaturePlans ? PLAN_CATEGORY_SIGNATURE : PLAN_CATEGORY_STANDARD,
+											lowPlanOptions
+										) }
 									/>
 								</>
 							);
 						case PLAN_CATEGORY_ENTERPRISE:
+						case PLAN_CATEGORY_SIGNATURE_HIGH:
 							return (
 								<>
 									<FilterByPicker />
 									<A4ASlider
-										value={ PLAN_CATEGORY_ENTERPRISE === selectedTab ? selectedOptionIndex : 0 }
+										value={
+											PLAN_CATEGORY_ENTERPRISE === selectedTab ||
+											PLAN_CATEGORY_SIGNATURE_HIGH === selectedTab
+												? selectedOptionIndex
+												: 0
+										}
 										onChange={ onSelectOption }
-										options={ enterpriseOptions }
-										minimum={ getSliderMinimum( PLAN_CATEGORY_ENTERPRISE, enterpriseOptions ) }
+										options={ highPlanOptions }
+										minimum={ getSliderMinimum(
+											useSignaturePlans ? PLAN_CATEGORY_SIGNATURE_HIGH : PLAN_CATEGORY_ENTERPRISE,
+											highPlanOptions
+										) }
 									/>
 								</>
 							);

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -33,7 +33,7 @@ type Props = {
 	// Whether the existing plan is still being loaded
 	isLoading?: boolean;
 	showHighResourceTab?: boolean;
-	useSignaturePlans?: boolean;
+	areSignaturePlans?: boolean;
 };
 
 export default function PlanSelectionFilter( {
@@ -43,14 +43,14 @@ export default function PlanSelectionFilter( {
 	pressablePlan,
 	isLoading,
 	showHighResourceTab = false,
-	useSignaturePlans = false,
+	areSignaturePlans: areSignaturePlans = false,
 }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
 	const [ filterType, setFilterType ] = useState< FilterType >( FILTER_TYPE_INSTALL );
 	const [ selectedTab, setSelectedTab ] = useState(
-		useSignaturePlans ? PLAN_CATEGORY_SIGNATURE : PLAN_CATEGORY_STANDARD
+		areSignaturePlans ? PLAN_CATEGORY_SIGNATURE : PLAN_CATEGORY_STANDARD
 	);
 	const [ disableStandardTab, setDisableStandardTab ] = useState( false );
 
@@ -61,10 +61,10 @@ export default function PlanSelectionFilter( {
 			getSliderOptions(
 				filterType,
 				plans.map( ( plan ) => getPressablePlan( plan.slug ) ),
-				useSignaturePlans ? PLAN_CATEGORY_SIGNATURE : PLAN_CATEGORY_STANDARD,
+				areSignaturePlans ? PLAN_CATEGORY_SIGNATURE : PLAN_CATEGORY_STANDARD,
 				isMobile
 			),
-		[ filterType, isMobile, plans, useSignaturePlans ]
+		[ filterType, isMobile, plans, areSignaturePlans ]
 	);
 
 	const highPlanOptions = useMemo(
@@ -72,7 +72,7 @@ export default function PlanSelectionFilter( {
 			...getSliderOptions(
 				filterType,
 				plans.map( ( plan ) => getPressablePlan( plan.slug ) ),
-				useSignaturePlans ? PLAN_CATEGORY_SIGNATURE_HIGH : PLAN_CATEGORY_ENTERPRISE,
+				areSignaturePlans ? PLAN_CATEGORY_SIGNATURE_HIGH : PLAN_CATEGORY_ENTERPRISE,
 				isMobile
 			),
 			...( showHighResourceTab
@@ -85,7 +85,7 @@ export default function PlanSelectionFilter( {
 						},
 				  ] ),
 		],
-		[ filterType, isMobile, plans, showHighResourceTab, translate, useSignaturePlans ]
+		[ filterType, isMobile, plans, showHighResourceTab, translate, areSignaturePlans ]
 	);
 
 	const onSelectOption = useCallback(
@@ -159,16 +159,16 @@ export default function PlanSelectionFilter( {
 	);
 
 	useEffect( () => {
-		// If there's no existing plan, set the default tab based on useSignaturePlans
+		// If there's no existing plan, set the default tab based on areSignaturePlans
 		if ( ! pressablePlan ) {
-			setSelectedTab( useSignaturePlans ? PLAN_CATEGORY_SIGNATURE : PLAN_CATEGORY_STANDARD );
+			setSelectedTab( areSignaturePlans ? PLAN_CATEGORY_SIGNATURE : PLAN_CATEGORY_STANDARD );
 			setDisableStandardTab( false ); // Ensure standard tab is not disabled if no existing plan
 			return;
 		}
 
 		// If there is an existing plan, map its category to the appropriate tab
 		let tabCategory = pressablePlan.category;
-		if ( useSignaturePlans ) {
+		if ( areSignaturePlans ) {
 			if ( pressablePlan.category === PLAN_CATEGORY_STANDARD ) {
 				tabCategory = PLAN_CATEGORY_SIGNATURE;
 			} else if ( pressablePlan.category === PLAN_CATEGORY_ENTERPRISE ) {
@@ -194,7 +194,7 @@ export default function PlanSelectionFilter( {
 		} else {
 			setDisableStandardTab( false );
 		}
-	}, [ pressablePlan, lowPlanOptions, useSignaturePlans ] );
+	}, [ pressablePlan, lowPlanOptions, areSignaturePlans ] );
 
 	useEffect( () => {
 		if ( selectedTab === PLAN_CATEGORY_HIGH_RESOURCE ) {
@@ -242,7 +242,7 @@ export default function PlanSelectionFilter( {
 				onSelect={ setSelectedTab }
 				initialTabName={ selectedTab }
 				tabs={
-					useSignaturePlans
+					areSignaturePlans
 						? [
 								{
 									name: PLAN_CATEGORY_SIGNATURE,
@@ -300,7 +300,7 @@ export default function PlanSelectionFilter( {
 										onChange={ onSelectOption }
 										options={ lowPlanOptions }
 										minimum={ getSliderMinimum(
-											useSignaturePlans ? PLAN_CATEGORY_SIGNATURE : PLAN_CATEGORY_STANDARD,
+											areSignaturePlans ? PLAN_CATEGORY_SIGNATURE : PLAN_CATEGORY_STANDARD,
 											lowPlanOptions
 										) }
 									/>
@@ -321,7 +321,7 @@ export default function PlanSelectionFilter( {
 										onChange={ onSelectOption }
 										options={ highPlanOptions }
 										minimum={ getSliderMinimum(
-											useSignaturePlans ? PLAN_CATEGORY_SIGNATURE_HIGH : PLAN_CATEGORY_ENTERPRISE,
+											areSignaturePlans ? PLAN_CATEGORY_SIGNATURE_HIGH : PLAN_CATEGORY_ENTERPRISE,
 											highPlanOptions
 										) }
 									/>

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -246,12 +246,12 @@ export default function PlanSelectionFilter( {
 						? [
 								{
 									name: PLAN_CATEGORY_SIGNATURE,
-									title: translate( 'Signature Plans 1-10' ),
+									title: translate( 'Signature Plans 1–10' ),
 									disabled: disableStandardTab,
 								},
 								{
 									name: PLAN_CATEGORY_SIGNATURE_HIGH,
-									title: translate( 'Signature Plans 11-17' ),
+									title: translate( 'Signature Plans 11–17' ),
 								},
 								...( showHighResourceTab
 									? [

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-features/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-features/index.tsx
@@ -53,6 +53,7 @@ export default function MigrationsHostingFeatures() {
 							translate( 'High-burst capacity' ),
 							translate( 'Automated datacenter failover' ),
 							translate( 'Extremely fast DNS with SSL' ),
+							// todo: update this for new plans. If new plan: 5 PHP workers
 							translate( '10 PHP workers w/ auto-scaling' ),
 							translate( 'Uptime monitoring' ),
 						] }

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-features/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-features/index.tsx
@@ -53,8 +53,7 @@ export default function MigrationsHostingFeatures() {
 							translate( 'High-burst capacity' ),
 							translate( 'Automated datacenter failover' ),
 							translate( 'Extremely fast DNS with SSL' ),
-							// todo: update this for new plans. If new plan: 5 PHP workers
-							translate( '10 PHP workers w/ auto-scaling' ),
+							translate( '5 PHP workers w/ auto-scaling' ),
 							translate( 'Uptime monitoring' ),
 						] }
 					/>


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/2445

- Part of A4A-1161

## Proposed Changes

<img width="1487" height="1550" alt="image" src="https://github.com/user-attachments/assets/66c2f138-6723-4252-8797-f2d665b7a8fd" />

**Marketplace (Pressable page)**

- **New customers:**
   - Change tab names to “Signature Plans 1—10” & “Signature Plans 11—17”
   - Ensure all plan names are updated in plan CTA and title, as seen in the screenshot below.
- **Current customers:**
   - No changes needed to verbiage or plan names.
   - No adjustment to PHP worker count.

**PHP Workers feature**

- **Previous/old plans** => “10 PHP workers w/ auto-scaling” 
- **For the new Pressable Signature plans** => “5 PHP workers w/ scaling”

**Referrals:**

- Ensure new plans are displayed when any agency turns on referral mode on the Pressable marketplace page.
- Ensure plans names within the referrals dashboard are updated when new plans are referred.

(This does not work on this PR. The issue will be addressed in another PR)

**Client experience**

- Ensure new plan names are properly displayed when purchased from referrals.

**Pressable Signature plan after purchase it**

<img width="1143" height="683" alt="image" src="https://github.com/user-attachments/assets/e6d1cd23-65bf-4e7c-8a38-7bd4b6ab5a26" />

**Referrals:**

<img width="1017" height="334" alt="image" src="https://github.com/user-attachments/assets/fd423e8c-9bf4-4cd6-9fa1-7404fa6f7c57" />

---

**More screenshots in the GH issue**

## Why are these changes being made?

- Linear issue: A4A-1161

## Testing Instructions

- Check the code
- Launch a Live site.
- Go to the Marketplace section: `marketplace/hosting/pressable`
- If you don't have any Pressable plans, you will see the new Pressable Signature plans.
- Use the slider and switch between the two tabs, and check each plan:
   - Signature 1
   - Signature 2
   - Signature 3
   - ...
   - The features and prices are the same as the old ones (Build, Growth, ...)
- Checkout and buy a Pressable Signature plan.
- After purchasing a new Pressable Signature plan, ensure that in the MC Agency tool (Licenses), the new Signature license appears and it's active.
- Activate the Referral mode
- If you have an existing Pressable plan (old), you will see all the old plans, and you can upgrade the plan as always
- If you activate the Referral mode, you will see only the new Pressable Signature plans (You can send the referral but on the Client side, it won't work (it will be done in a follow up PR)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
