### PR TITLE
Help Center: Scroll to last message on chat open

### DIFF
--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -873,3 +873,30 @@ $custom-border-corner-size: 16px;
 	margin-top: 16px;
 	margin-left: 46px;
 }
+
+.chatbox-messages {
+	position: relative;
+}
+
+.chatbox-messages__content {
+	/* normal scrollable content */
+	overflow-y: auto;
+}
+
+.chatbox-loading-chat__spinner {
+	position: absolute;
+	top: 0; left: 0; right: 0; bottom: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: var( --studio-white );
+	z-index: 10;
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 500ms ease-in-out;
+}
+
+.chatbox-loading-chat__spinner.is-visible {
+	opacity: 1;
+	pointer-events: all;
+}

--- a/packages/odie-client/src/hooks/use-auto-scroll.ts
+++ b/packages/odie-client/src/hooks/use-auto-scroll.ts
@@ -1,14 +1,15 @@
-import { RefObject, useEffect, useRef } from 'react';
+import { RefObject, useEffect, useRef, useState } from 'react';
 import { useOdieAssistantContext } from '../context';
 
 export const useAutoScroll = (
 	messagesContainerRef: RefObject< HTMLDivElement >,
 	isEnabled: boolean
-) => {
+): boolean => {
 	const { chat } = useOdieAssistantContext();
 	const debounceTimeoutRef = useRef< number >( 500 );
 	const debounceTimeoutIdRef = useRef< number | null >( null );
 	const lastChatStatus = useRef< string | null >( null );
+	const [ isScrolling, setIsScrolling ] = useState( false );
 
 	useEffect( () => {
 		if ( ! isEnabled ) {
@@ -23,6 +24,8 @@ export const useAutoScroll = (
 		if ( chat.status === 'dislike' ) {
 			return;
 		}
+
+		setIsScrolling( true );
 
 		if ( debounceTimeoutIdRef.current ) {
 			clearTimeout( debounceTimeoutIdRef.current );
@@ -47,9 +50,12 @@ export const useAutoScroll = (
 					lastMessage = messages?.length ? messages[ messages.length - 2 ] : null;
 				}
 
-				lastMessage?.scrollIntoView( { behavior: 'smooth', block: 'start', inline: 'nearest' } );
+				lastMessage?.scrollIntoView( { behavior: 'instant', block: 'start', inline: 'nearest' } );
+				setIsScrolling( false );
 			} );
 		}, debounceTimeoutRef.current ) as unknown as number;
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ chat.messages.length, chat.status, messagesContainerRef.current, isEnabled ] );
+
+	return isScrolling;
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
https://linear.app/a8c/issue/TMPFRG-557/help-center-chat-scrolls-the-entire-conversation

## Proposed Changes

The root problem was that our container previously toggled either the messages or the spinner. While the spinner was visible, the messages weren’t in the DOM, so we couldn’t scroll to the bottom until after the messages appeared, causing visual hiccups.

Now, the component always renders its messages and simply overlays the spinner on top. This lets us control the messages’ lifecycle independently from the loading indicator.

What changed:
- Refactored useAutoScroll so it returns an isScrolling flag.
- Made the spinner overlay always present in the DOM, rather than conditionally rendering it.
- Replaced the hard swap with a fade animation: once scrolling finishes, the spinner fades out smoothly instead of popping away.

This is how the proposal looks:
https://github.com/user-attachments/assets/b4aeee3c-28bb-4632-85c9-2006382610f4

And here is what we currently have in production:
https://github.com/user-attachments/assets/47a9abae-d08e-4694-a773-8769e0319bcf

Known issues:
Sometimes a double spinner is shown, one is included in the message about there being other existing chats. This error is also present in production, so it's not a regression from this PR.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using the Calypso live link
* Open the help center on a Calypso screen
* View your recent chats, they should all appear scrolled to the end of the conversation

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
