### PR TITLE
One Tap Auth: Show error message

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -43,6 +43,7 @@ import {
 } from 'calypso/state/login/selectors';
 import { isPasswordlessAccount } from 'calypso/state/login/utils';
 import { logoutUser } from 'calypso/state/logout/actions';
+import { errorNotice as errorNoticeAction } from 'calypso/state/notices/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
@@ -118,6 +119,14 @@ class Login extends Component {
 					locale: this.props.locale,
 					currentQuery: this.props.currentQuery,
 				} )
+			);
+		}
+
+		if ( this.props.currentQuery?.error === 'google_one_tap_auth' ) {
+			this.props.showErrorNotice(
+				this.props.translate(
+					'Something went wrong when trying to connect with Google. Please use any of the login options below.'
+				)
 			);
 		}
 
@@ -685,11 +694,14 @@ export default connect(
 		sendEmailLogin,
 		logoutUser,
 		redirectToLogout,
+		errorNoticeAction,
 	},
 	( stateProps, dispatchProps, ownProps ) => ( {
 		...ownProps,
 		...stateProps,
 		...dispatchProps,
+		showErrorNotice: ( text, noticeOptions ) =>
+			dispatchProps.errorNoticeAction( text, noticeOptions ),
 		sendEmailLogin: ( options = {} ) => {
 			return dispatchProps.sendEmailLogin( stateProps.usernameOrEmail, {
 				redirectTo: stateProps.redirectTo,


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/DOTOBRD-213/show-an-error-notice-if-google-one-tap-fails

## Proposed Changes

* Show error notice message based on `error=google_one_tap_auth` query param

## Why are these changes being made?

* Handle google_one_tap_auth error message

## Testing Instructions

The one-tap auth flow, where an error occurs during token exchange, will redirect the "Log In" screen with a proper query parameter. Based on it, we are going to show an error message notice with a message:
> Something went wrong when trying to connect with Google. Please use any of the login options below.

* Go to `/log-in?error=google_one_tap_auth`
* Check if there is an error notice

<img width="1211" alt="Screenshot 2025-07-10 at 11 53 52" src="https://github.com/user-attachments/assets/30589c08-bb94-4c29-97f3-d8c9acb1e695" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
