### PR TITLE
A4A: Change Woo event date to July 14th.

### DIFF
--- a/client/a8c-for-agencies/components/upcoming-event/style.scss
+++ b/client/a8c-for-agencies/components/upcoming-event/style.scss
@@ -35,11 +35,11 @@
 .a4a-event__logo {
 	width: 64px;
 	height: 64px;
-	border-radius: 4px;
 	img {
 		width: 100%;
 		height: 100%;
 		object-fit: contain;
+		border-radius: 4px;
 	}
 }
 

--- a/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
@@ -15,10 +15,10 @@ export const useUpcomingEvents = () => {
 	return useMemo( () => {
 		const eventsData: UpcomingEventProps[] = [
 			{
-				id: 'woo-2025-07-25',
+				id: 'woo-2025-07-14',
 				date: {
-					from: moment( '2025-07-25' ),
-					to: moment( '2025-07-25' ),
+					from: moment( '2025-07-14' ),
+					to: moment( '2025-07-14' ),
 				},
 				title: translate( 'How are you preparing for the busiest time of year?' ),
 				subtitle: translate( 'Woo and Automattic for Agencies' ),
@@ -41,15 +41,15 @@ export const useUpcomingEvents = () => {
 				},
 				logoUrl: wooLogo,
 				imageUrl: wooEventImage,
-				trackEventName: 'calypso_a4a_overview_events_register_click_woo_marketing_2025_07_25',
+				trackEventName: 'calypso_a4a_overview_events_register_click_woo_marketing_2025_07_14',
 				dateClassName: 'a4a-event__date--woo',
 				imageClassName: 'a4a-event__image--woo',
 			},
 			{
-				id: 'a4a-2025-07-25',
+				id: 'a4a-2025-07-14',
 				date: {
-					from: moment( '2025-07-25' ),
-					to: moment( '2025-07-25' ),
+					from: moment( '2025-07-14' ),
+					to: moment( '2025-07-14' ),
 				},
 				title: translate( 'Automattic for Agencies Partner Empowerment Survey' ),
 				subtitle: translate( 'Automattic for Agencies' ),
@@ -58,7 +58,7 @@ export const useUpcomingEvents = () => {
 						"Participate in the Automattic for Agencies Partner Empowerment Survey and directly influence the training and resources we develop to better support your agency's success with WordPress and Automattic products. Your feedback is essential in helping us understand your needs and identify opportunities for improvement."
 					),
 					translate(
-						'{{b}}Share your insights by July 25th{{/b}} and play a key role in shaping our future offerings. Together, we can ensure that our programs and resources are tailored to help your agency thrive!',
+						'{{b}}Share your insights by July 14th{{/b}} and play a key role in shaping our future offerings. Together, we can ensure that our programs and resources are tailored to help your agency thrive!',
 						{
 							components: {
 								b: <b />,
@@ -72,7 +72,7 @@ export const useUpcomingEvents = () => {
 				},
 				logoUrl: a4aLogo,
 				imageUrl: a4aEventImage,
-				trackEventName: 'calypso_a4a_overview_events_register_click_a4a_2025_07_25',
+				trackEventName: 'calypso_a4a_overview_events_register_click_a4a_2025_07_14',
 				dateClassName: 'a4a-event__date--a4a',
 				imageClassName: 'a4a-event__image--a4a',
 			},

--- a/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
@@ -46,10 +46,10 @@ export const useUpcomingEvents = () => {
 				imageClassName: 'a4a-event__image--woo',
 			},
 			{
-				id: 'a4a-2025-07-14',
+				id: 'a4a-2025-07-25',
 				date: {
-					from: moment( '2025-07-14' ),
-					to: moment( '2025-07-14' ),
+					from: moment( '2025-07-25' ),
+					to: moment( '2025-07-25' ),
 				},
 				title: translate( 'Automattic for Agencies Partner Empowerment Survey' ),
 				subtitle: translate( 'Automattic for Agencies' ),
@@ -58,7 +58,7 @@ export const useUpcomingEvents = () => {
 						"Participate in the Automattic for Agencies Partner Empowerment Survey and directly influence the training and resources we develop to better support your agency's success with WordPress and Automattic products. Your feedback is essential in helping us understand your needs and identify opportunities for improvement."
 					),
 					translate(
-						'{{b}}Share your insights by July 14th{{/b}} and play a key role in shaping our future offerings. Together, we can ensure that our programs and resources are tailored to help your agency thrive!',
+						'{{b}}Share your insights by July 25th{{/b}} and play a key role in shaping our future offerings. Together, we can ensure that our programs and resources are tailored to help your agency thrive!',
 						{
 							components: {
 								b: <b />,
@@ -72,7 +72,7 @@ export const useUpcomingEvents = () => {
 				},
 				logoUrl: a4aLogo,
 				imageUrl: a4aEventImage,
-				trackEventName: 'calypso_a4a_overview_events_register_click_a4a_2025_07_14',
+				trackEventName: 'calypso_a4a_overview_events_register_click_a4a_2025_07_25',
 				dateClassName: 'a4a-event__date--a4a',
 				imageClassName: 'a4a-event__image--a4a',
 			},


### PR DESCRIPTION
Quick update: the Woo event date has been moved from July 25th to July 14th.

<img width="891" alt="Screenshot 2025-07-10 at 6 07 49 PM" src="https://github.com/user-attachments/assets/b0c2f2ea-5cf9-4c10-b0e0-c6d5c4e3d224" />



Context: p1752135550391239/1752058512.717419-slack-C047ACYM8UQ
Follow up: https://github.com/Automattic/wp-calypso/pull/104668

## Proposed Changes

* Update the date.

## Why are these changes being made?

*

## Testing Instructions

* Use the A4A live link and navigate to the `/overview` page.
* Confirm the event dates are correct for both Woo and A4A.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?