### PR TITLE
Copy Site: Add useRef to prevent redundant API calls in useEffect

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/automated-copy-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/automated-copy-site/index.tsx
@@ -1,5 +1,5 @@
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
@@ -45,11 +45,20 @@ const AutomatedCopySite: Step = function AutomatedCopySite( { navigation } ) {
 		( select ) => select( SITE_STORE ) as SiteSelect,
 		[]
 	);
+	const instanceRef = useRef< { siteId?: number; sourceSiteId?: number } >( {} );
 
 	useEffect( () => {
 		if ( ! site?.ID || ! sourceSiteId ) {
 			return;
 		}
+		if (
+			instanceRef.current.siteId === site.ID &&
+			instanceRef.current.sourceSiteId === sourceSiteId
+		) {
+			return;
+		}
+		instanceRef.current = { siteId: site.ID, sourceSiteId };
+
 		async function initCopySite() {
 			try {
 				await wpcom.req.post( {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDEV-209

## Proposed Changes

* Add useRef to track siteId and sourceSiteId to redundant API calls in useEffect

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* There are multiple calls made to the backend, resulting in unnecessary logging in Slack. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Goto /sites
- Select eCom site
- Click on︙and select Copy site
- Open the network tab
- Complete a site checkout
- Ensure only one AIP call to the `copy-from-site` endpoint is made to the backend to initiate atomic transfer

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
