### PR TITLE
A4A > Reports: Fix disabled state on site selector

### DIFF
--- a/client/a8c-for-agencies/components/a4a-select-site/site-table.tsx
+++ b/client/a8c-for-agencies/components/a4a-select-site/site-table.tsx
@@ -1,6 +1,6 @@
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import A4ATablePlaceholder from 'calypso/a8c-for-agencies/components/a4a-table-placeholder';
 import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
@@ -37,7 +37,20 @@ const A4ASelectSiteTable = ( {
 		[ dispatch, setSelectedSite ]
 	);
 
-	const updatedSelectedSiteId = selectedSite?.rawSite.blog_id || selectedSiteId;
+	const prevSelectedSiteId = useRef< number | undefined >();
+
+	// Only update when selectedSiteId actually changes, not when items array is recreated
+	useEffect( () => {
+		if ( selectedSiteId && selectedSiteId !== prevSelectedSiteId.current && items?.length > 0 ) {
+			const foundSite = items.find( ( item ) => item.rawSite.blog_id === selectedSiteId );
+			if ( foundSite ) {
+				setSelectedSite( foundSite );
+				prevSelectedSiteId.current = selectedSiteId;
+			}
+		}
+	}, [ items, selectedSiteId, setSelectedSite ] );
+
+	const updatedSelectedSiteId = selectedSite?.rawSite.blog_id;
 
 	const fields = useMemo( () => {
 		const siteColumn = {


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1281/report-builder-fix-the-disabled-state-bug-on-site-selector

## Proposed Changes

* This PR fixes a bug that shows a disabled button on the site selector even when a site is already selected.


## Testing Instructions

* Open the A4A live link
* Go to Reports > Build a new report > Select a site > Open the site selector again and ensure the Select site is not disabled.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
