### PR TITLE
Help Center History: Remove unused code

### DIFF
--- a/packages/help-center/src/components/help-center-chat-history.scss
+++ b/packages/help-center/src/components/help-center-chat-history.scss
@@ -5,49 +5,6 @@
 		border-color: rgba(0, 0, 0, 0.1);
 	}
 
-
-	.help-center-chat-history__archive-no-results {
-		padding: 92px 58px 16px 58px;
-		font-size: 0.75rem;
-
-		.help-center-chat-history__archive-no-results-header {
-			padding-bottom: 0;
-
-			h4 {
-				font-weight: 400;
-				font-size: 20px;
-				line-height: 26px;
-				text-align: center;
-				width: 100%;
-			}
-		}
-
-		.help-center-chat-history__archive-no-results-body {
-			display: flex;
-			flex-direction: column;
-			align-items: center;
-			gap: 24px;
-			color: var(--studio-gray-70, #3C434A);
-			text-align: center;
-			font-size: 14px;
-			font-style: normal;
-			line-height: 20px;
-		}
-
-		.help-center-chat-history__archive-no-results-button {
-			display: flex;
-			padding: 8px 24px;
-			justify-content: center;
-			align-items: center;
-			gap: 10px;
-
-			border-radius: 4px;
-			border: 1px solid #C3C4C7;
-			background: #FFF;
-			color: var(--studio-gray-100, #101517);
-		}
-	}
-
 	.help-center-chat-history__conversation-card {
 		display: flex;
 		flex-direction: column;

--- a/packages/help-center/src/components/help-center-chat-history.tsx
+++ b/packages/help-center/src/components/help-center-chat-history.tsx
@@ -1,17 +1,8 @@
 /* eslint-disable no-restricted-imports */
-import { HelpCenterSelect } from '@automattic/data-stores';
 import { calculateUnread } from '@automattic/odie-client/src/data/use-get-unread-conversations';
-import { Card, CardHeader, CardBody, Spinner } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
-import { useState } from '@wordpress/element';
-import { comment, Icon } from '@wordpress/icons';
+import { Spinner } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { Link } from 'react-router-dom';
-import SectionNav from 'calypso/components/section-nav';
-import NavItem from 'calypso/components/section-nav/item';
-import NavTabs from 'calypso/components/section-nav/tabs';
 import { useChatStatus, useGetHistoryChats } from '../hooks';
-import { HELP_CENTER_STORE } from '../stores';
 import { HelpCenterSupportChatMessage } from './help-center-support-chat-message';
 import { EmailFallbackNotice } from './notices';
 import { getLastMessage } from './utils';
@@ -21,15 +12,6 @@ import type {
 	SupportInteraction,
 	ZendeskConversation,
 } from '@automattic/odie-client';
-
-// temporarily we want to show a simplified version of the chat history
-// this bool controls it.
-const simplifiedHistoryChat = true;
-
-const TAB_STATES = {
-	recent: 'recent',
-	archived: 'archived',
-};
 
 const Conversations = ( {
 	conversations,
@@ -84,93 +66,17 @@ const Conversations = ( {
 };
 
 export const HelpCenterChatHistory = () => {
-	const { __ } = useI18n();
-	const [ selectedTab, setSelectedTab ] = useState( TAB_STATES.recent );
-	const { supportInteractions, isLoadingInteractions, recentConversations, archivedConversations } =
-		useGetHistoryChats();
+	const { supportInteractions, isLoadingInteractions, recentConversations } = useGetHistoryChats();
 	const { forceEmailSupport } = useChatStatus();
 
-	const { unreadCount } = useSelect( ( select ) => {
-		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
-		return {
-			unreadCount: store.getUnreadCount(),
-		};
-	}, [] );
-
-	// Temporarily simplified version
-	if ( simplifiedHistoryChat ) {
-		return (
-			<>
-				{ forceEmailSupport && <EmailFallbackNotice /> }
-				<Conversations
-					conversations={ recentConversations }
-					supportInteractions={ supportInteractions }
-					isLoadingInteractions={ isLoadingInteractions }
-				/>
-			</>
-		);
-	}
-
 	return (
-		<div className="help-center-chat-history">
-			<SectionNav>
-				<NavTabs>
-					<NavItem
-						selected={ selectedTab === TAB_STATES.recent }
-						onClick={ () => setSelectedTab( TAB_STATES.recent ) }
-						count={ unreadCount > 0 ? unreadCount : undefined }
-					>
-						{ __( 'Recent', __i18n_text_domain__ ) }
-					</NavItem>
-					<NavItem
-						selected={ selectedTab === TAB_STATES.archived }
-						onClick={ () => setSelectedTab( TAB_STATES.archived ) }
-					>
-						{ __( 'Archived', __i18n_text_domain__ ) }
-					</NavItem>
-				</NavTabs>
-			</SectionNav>
-
-			{ selectedTab === TAB_STATES.recent && (
-				<Conversations
-					conversations={ recentConversations }
-					supportInteractions={ supportInteractions }
-				/>
-			) }
-
-			{ selectedTab === TAB_STATES.archived &&
-				( archivedConversations?.length > 0 ? (
-					<Conversations
-						conversations={ archivedConversations }
-						supportInteractions={ supportInteractions }
-					/>
-				) : (
-					<EmptyArchivedConversations />
-				) ) }
-		</div>
+		<>
+			{ forceEmailSupport && <EmailFallbackNotice /> }
+			<Conversations
+				conversations={ recentConversations }
+				supportInteractions={ supportInteractions }
+				isLoadingInteractions={ isLoadingInteractions }
+			/>
+		</>
 	);
-
-	function EmptyArchivedConversations() {
-		return (
-			<Card isBorderless size="small" className="help-center-chat-history__archive-no-results">
-				<CardHeader className="help-center-chat-history__archive-no-results-header">
-					<h4>{ __( 'Your Archive is Empty', __i18n_text_domain__ ) }</h4>
-				</CardHeader>
-				<CardBody className="help-center-chat-history__archive-no-results-body">
-					{ __(
-						'Resolved issues and past conversations will be available here',
-						__i18n_text_domain__
-					) }
-					<Link
-						to="/odie"
-						onClick={ () => {} }
-						className="help-center-chat-history__archive-no-results-button"
-					>
-						<Icon icon={ comment } />
-						{ __( 'Get support', __i18n_text_domain__ ) }
-					</Link>
-				</CardBody>
-			</Card>
-		);
-	}
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-13848/simplify-chat-history

## Proposed Changes

A "temporary" flag was introduced in [this](https://github.com/Automattic/wp-calypso/pull/96139) PR to show a simplified version of the history page in the Help Center.

Now that we know that it is not so temporary, it's better to remove unused code to reduce complexity.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Help Center
* History page should work
