### PR TITLE
Staging Sync: Add Database synchronization

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -226,6 +226,13 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 		]
 	);
 
+	const renderLabel = ( label: string ) => {
+		if ( fileBrowserConfig?.transformLabels?.[ label ] ) {
+			return fileBrowserConfig.transformLabels[ label ];
+		}
+		return label;
+	};
+
 	const renderChildren = () => {
 		if ( isInitialLoading ) {
 			return (
@@ -301,7 +308,11 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 	const nodeItemClassName = clsx( 'file-browser-node__item', {
 		'is-alternate': isAlternate,
 	} );
-	const [ label, isLabelTruncated ] = useTruncatedFileName( item.name, 30, item.type );
+	const [ label, isLabelTruncated ] = useTruncatedFileName(
+		renderLabel( item.name ),
+		30,
+		item.type
+	);
 
 	const nodeClassName = clsx( 'file-browser-node', item.type, {
 		'is-root': isRoot,

--- a/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
@@ -11,9 +11,9 @@ export interface FileBrowserConfig {
 	restrictedTypes?: string[];
 	excludeTypes?: string[];
 	alwaysInclude?: string[];
+	transformLabels?: Record< string, string >;
 	showHeaderButtons?: boolean;
 	showFileCard?: boolean;
-	siteId?: number;
 }
 
 interface FileBrowserProps {

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -30,9 +30,10 @@ import './style.scss';
 
 const fileBrowserConfig: FileBrowserConfig = {
 	restrictedTypes: [ 'plugin', 'theme' ],
-	restrictedPaths: [ 'wp-content' ],
+	restrictedPaths: [ 'wp-content', 'sql' ],
 	excludeTypes: [ 'wordpress' ],
 	alwaysInclude: [ 'wp-config.php' ],
+	transformLabels: { sql: 'Database' },
 	showHeaderButtons: false,
 	showFileCard: false,
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTDEV-211

## Proposed Changes

* Add the `sql` folder to the synchronization tree
* Allow to change the labels of the nodes
* Change `sql` to `Database`

> [!NOTE]
> The `Database` value will not be translated in the same way than other are not translated 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To be able to synchronize database values

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TBD

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
