### PR TITLE
Site list v2: prevent possible race condition when typing on the search box

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -89,10 +89,10 @@ export default function Sites() {
 		} );
 
 		navigate( {
-			search: {
-				...currentSearchParams,
+			search: ( prevSearchParams: { view: ViewSearchParams } ) => ( {
+				...prevSearchParams,
 				view: updatedViewSearchParams,
-			},
+			} ),
 		} );
 
 		updateViewPreferences( updatedViewPreferences as Record< string, unknown > );


### PR DESCRIPTION


## Proposed Changes

Sometimes, when typing on the site list v2's search box, with a CERTAIN pace (slowness), the input can be reset to an early value (e.g. suddenly the last character will be lost).

One theory is that after we type something the search box, we call `navigate()` with the next query param, but there can be a race condition when, before the code reaches that call, BUT after React starts rerendering, we type something again. It could be the case that the first `navigate()` will execute last, 

## Why are these changes being made?

Fixes a possible race condition.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
