### PR TITLE
Connect Refresh: Clean up obsolete Login parts - shouldRenderToS

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -565,7 +565,7 @@ class Login extends Component {
 				sendMagicLoginLink={ this.sendMagicLoginLink }
 				isFromAkismet={ this.props.isFromAkismet }
 				isSendingEmail={ this.props.isSendingEmail }
-				isSocialFirst={ isSocialFirst }
+				isSocialFirst={ isSocialFirst } // TODO just not gravatar
 				isJetpack={ isJetpack }
 				isFromAutomatticForAgenciesPlugin={ isFromAutomatticForAgenciesPlugin }
 				loginButtonText={

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -1006,7 +1006,6 @@ export class LoginForm extends Component {
 		const {
 			oauth2Client,
 			currentQuery,
-			isWoo,
 			isWooJPC,
 			isSocialFirst,
 			isJetpack,
@@ -1048,8 +1047,6 @@ export class LoginForm extends Component {
 							trackLoginAndRememberRedirect={ this.trackLoginAndRememberRedirect }
 							resetLastUsedAuthenticationMethod={ this.resetLastUsedAuthenticationMethod }
 							socialServiceResponse={ this.props.socialServiceResponse }
-							shouldRenderToS={ false }
-							isWoo={ isWoo }
 							isSocialFirst={ isSocialFirst }
 							magicLoginLink={ ! isWooJPC ? this.getMagicLoginPageLink() : null }
 							qrLoginLink={ this.getQrLoginLink() }
@@ -1106,7 +1103,6 @@ export class LoginForm extends Component {
 						handleLogin={ this.handleSocialLogin }
 						trackLoginAndRememberRedirect={ this.trackLoginAndRememberRedirect }
 						socialServiceResponse={ this.props.socialServiceResponse }
-						shouldRenderToS={ false }
 						isJetpack={ isJetpack }
 					/>
 				</Fragment>

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -2,7 +2,6 @@ import { Card } from '@automattic/components';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import SocialToS from 'calypso/blocks/authentication/social/social-tos.jsx';
 import {
 	GoogleSocialButton,
 	AppleLoginButton,
@@ -19,17 +18,12 @@ class SocialLoginForm extends Component {
 		handleLogin: PropTypes.func.isRequired,
 		trackLoginAndRememberRedirect: PropTypes.func.isRequired,
 		socialServiceResponse: PropTypes.object,
-		shouldRenderToS: PropTypes.bool,
 		magicLoginLink: PropTypes.string,
 		qrLoginLink: PropTypes.string,
 		isSocialFirst: PropTypes.bool,
 		lastUsedAuthenticationMethod: PropTypes.string,
 		resetLastUsedAuthenticationMethod: PropTypes.func,
 		isJetpack: PropTypes.bool,
-	};
-
-	static defaultProps = {
-		shouldRenderToS: false,
 	};
 
 	socialLoginButtons = [
@@ -70,7 +64,7 @@ class SocialLoginForm extends Component {
 		},
 		{
 			service: 'magic-login',
-			button: ( this.props.isSocialFirst || this.props.isWoo ) && this.props.magicLoginLink && (
+			button: this.props.isSocialFirst && this.props.magicLoginLink && (
 				<MagicLoginButton
 					loginUrl={ this.props.magicLoginLink }
 					key={ 4 }
@@ -80,14 +74,14 @@ class SocialLoginForm extends Component {
 		},
 		{
 			service: 'qr-code',
-			button: ( this.props.isSocialFirst || this.props.isWoo ) && this.props.qrLoginLink && (
+			button: this.props.isSocialFirst && this.props.qrLoginLink && (
 				<QrCodeLoginButton loginUrl={ this.props.qrLoginLink } key={ 5 } />
 			),
 		},
 	];
 
 	render() {
-		const { shouldRenderToS, isWoo, isSocialFirst, lastUsedAuthenticationMethod } = this.props;
+		const { isSocialFirst, lastUsedAuthenticationMethod } = this.props;
 
 		return (
 			<Card
@@ -106,9 +100,7 @@ class SocialLoginForm extends Component {
 							)
 						) }
 					</div>
-					{ ! isWoo && shouldRenderToS && <SocialToS /> }
 				</div>
-				{ isWoo && shouldRenderToS && <SocialToS /> }
 			</Card>
 		);
 	}

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -142,10 +142,6 @@ export class Login extends Component {
 		this.props.recordPageView( url, title );
 	}
 
-	recordBackToWpcomLinkClick = () => {
-		this.props.recordTracksEvent( 'calypso_login_back_to_wpcom_link_click' );
-	};
-
 	handleUsernameChange( usernameOrEmail ) {
 		this.setState( { usernameOrEmail } );
 	}
@@ -159,10 +155,6 @@ export class Login extends Component {
 
 		return <LocaleSuggestions locale={ locale } path={ path } />;
 	}
-
-	recordResetPasswordLinkClick = () => {
-		this.props.recordTracksEvent( 'calypso_login_reset_password_link_click' );
-	};
 
 	getLostPasswordLink() {
 		if ( this.props.twoFactorAuthType ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13220/login-make-the-two-columnwhite-layout-the-default-across-all-contexts

## Proposed Changes

Some cleanup to obsolete code. 
- The `shouldRenderToS` used in social form is no longer relevant (always false). The actual component `SocialToS` has uses elsewhere.
- Some leftover code from the main wp-login component

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13220/login-make-the-two-columnwhite-layout-the-default-across-all-contexts

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Confirm [Gravatar and Woo Login](https://linear.app/a8c/issue/DOTCOM-13220/login-make-the-two-columnwhite-layout-the-default-across-all-contexts) that they render correctly, with TOS at the right place. These should be the only ones possibly affected. 
- Try other client and default Logins

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
