### PR TITLE
Connect Refresh: Remove `isWhiteLogin`. Replace with `! isGravatar` where relevant

### DIFF
--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -91,8 +91,8 @@
 }
 
 /* Akismet */
-.is-white-login.is-akismet .login,
-.is-white-login.is-akismet .magic-login,
+.is-akismet .login,
+.is-akismet .magic-login,
 .is-akismet .signup-form,
 .is-akismet .auth-form__social {
 	.components-button:not(.is-destructive) {

--- a/client/blocks/authentication/form-divider/style.scss
+++ b/client/blocks/authentication/form-divider/style.scss
@@ -73,7 +73,7 @@ $breakpoint-mobile: 660px;
 
 // In this case we want the separator to be vertical
 .signup-form,
-.is-white-login .is-social-first,
+:not(.is-grav-powered-client) .is-social-first,
 .login form.is-woo-passwordless,
 .login form.is-blaze-pro {
 	.auth-form__separator {

--- a/client/blocks/authentication/form-divider/style.scss
+++ b/client/blocks/authentication/form-divider/style.scss
@@ -73,7 +73,7 @@ $breakpoint-mobile: 660px;
 
 // In this case we want the separator to be vertical
 .signup-form,
-:not(.is-grav-powered-client) .is-social-first,
+.layout:not(.is-grav-powered-client) .is-social-first,
 .login form.is-woo-passwordless,
 .login form.is-blaze-pro {
 	.auth-form__separator {

--- a/client/blocks/login/continue-as-user.scss
+++ b/client/blocks/login/continue-as-user.scss
@@ -45,7 +45,7 @@
 	}
 }
 
-.is-white-login {
+:not(.is-grav-powered-client) {
 	.continue-as-user {
 		height: auto;
 	}

--- a/client/blocks/login/continue-as-user.scss
+++ b/client/blocks/login/continue-as-user.scss
@@ -45,7 +45,7 @@
 	}
 }
 
-:not(.is-grav-powered-client) {
+.layout:not(.is-grav-powered-client) {
 	.continue-as-user {
 		height: auto;
 	}

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -66,7 +66,6 @@ class Login extends Component {
 		disableAutoFocus: PropTypes.bool,
 		isLinking: PropTypes.bool,
 		isJetpack: PropTypes.bool.isRequired,
-		isWhiteLogin: PropTypes.bool.isRequired,
 		isFromAkismet: PropTypes.bool,
 		isFromAutomatticForAgenciesPlugin: PropTypes.bool,
 		isManualRenewalImmediateLoginAttempt: PropTypes.bool,
@@ -106,7 +105,6 @@ class Login extends Component {
 
 	static defaultProps = {
 		isJetpack: false,
-		isWhiteLogin: false,
 	};
 
 	componentDidMount() {
@@ -594,7 +592,6 @@ class Login extends Component {
 			isGravPoweredLoginPage,
 			isManualRenewalImmediateLoginAttempt,
 			isSignupExistingAccount,
-			isWhiteLogin,
 			linkingSocialService,
 			socialConnect,
 			twoStepNonce,
@@ -635,7 +632,7 @@ class Login extends Component {
 
 				{ this.renderNotice() }
 
-				{ ! isWhiteLogin && this.renderToS() }
+				{ isGravPoweredClient && this.renderToS() }
 
 				{ this.renderContent() }
 

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -1,5 +1,4 @@
 import page from '@automattic/calypso-router';
-import { localizeUrl } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import emailValidator from 'email-validator';
 import { localize } from 'i18n-calypso';
@@ -359,37 +358,6 @@ class Login extends Component {
 		);
 	}
 
-	renderToS() {
-		const { isSocialFirst, translate, twoFactorAuthType } = this.props;
-		if ( ! isSocialFirst || twoFactorAuthType ) {
-			return null;
-		}
-
-		const tos = translate(
-			'By continuing you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
-			{
-				components: {
-					tosLink: (
-						<a
-							href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-							target="_blank"
-							rel="noopener noreferrer"
-						/>
-					),
-					privacyLink: (
-						<a
-							href={ localizeUrl( 'https://automattic.com/privacy/' ) }
-							target="_blank"
-							rel="noopener noreferrer"
-						/>
-					),
-				},
-			}
-		);
-
-		return <div className="login__form-subheader-terms">{ tos }</div>;
-	}
-
 	renderNotice() {
 		const { requestNotice } = this.props;
 
@@ -631,8 +599,6 @@ class Login extends Component {
 				{ ! isWCCOM && <ErrorNotice locale={ locale } /> }
 
 				{ this.renderNotice() }
-
-				{ isGravPoweredClient && this.renderToS() }
 
 				{ this.renderContent() }
 

--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -14,7 +14,7 @@ form {
 	}
 }
 
-:not(.is-grav-powered-client) {
+.layout:not(.is-grav-powered-client) {
 	.login {
 		display: flex;
 		flex-direction: column;

--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -14,7 +14,7 @@ form {
 	}
 }
 
-.is-white-login {
+:not(.is-grav-powered-client) {
 	.login {
 		display: flex;
 		flex-direction: column;

--- a/client/blocks/login/stories/shared.tsx
+++ b/client/blocks/login/stories/shared.tsx
@@ -30,7 +30,7 @@ export const A4AWrapper = ( Story: StoryFn ) => (
 );
 
 export const AkismetWrapper = ( Story: StoryFn ) => (
-	<div className="is-white-login is-akismet">
+	<div className="is-akismet">
 		<Story />
 	</div>
 );

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -309,7 +309,7 @@ $breakpoint-mobile: 782px; //Mobile size.
 	display: none;
 }
 
-:not(.is-grav-powered-client) {
+.layout:not(.is-grav-powered-client) {
 	.is-social-first {
 		.login__form-subheader-terms {
 			display: block;

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -309,7 +309,7 @@ $breakpoint-mobile: 782px; //Mobile size.
 	display: none;
 }
 
-.is-white-login {
+:not(.is-grav-powered-client) {
 	.is-social-first {
 		.login__form-subheader-terms {
 			display: block;

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -305,30 +305,8 @@ $breakpoint-mobile: 782px; //Mobile size.
 	text-transform: initial;
 }
 
-.login__form-subheader-terms {
-	display: none;
-}
-
 .layout:not(.is-grav-powered-client) {
 	.is-social-first {
-		.login__form-subheader-terms {
-			display: block;
-			max-width: 450px;
-			margin: 0 auto;
-
-			color: var(--studio-gray-50, #646970);
-			text-align: center;
-			font-size: $font-body-small;
-			font-style: normal;
-			font-weight: 400;
-			line-height: 20px;
-
-			a {
-				color: var(--studio-gray-50, #646970);
-				text-decoration: underline;
-			}
-		}
-
 		.login__form-terms {
 			display: none;
 		}

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -19,17 +19,12 @@ import isAkismetRedirect from 'calypso/lib/akismet/is-akismet-redirect';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import {
-	isCrowdsignalOAuth2Client,
 	isWooOAuth2Client,
 	isGravatarOAuth2Client,
 	isJetpackCloudOAuth2Client,
-	isA4AOAuth2Client,
 	isWPJobManagerOAuth2Client,
 	isGravPoweredOAuth2Client,
 	isBlazeProOAuth2Client,
-	isPartnerPortalOAuth2Client,
-	isStudioAppOAuth2Client,
-	isVIPOAuth2Client,
 	isAndroidOAuth2Client,
 	isIosOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
@@ -60,7 +55,6 @@ import './style.scss';
 const LayoutLoggedOut = ( {
 	isAkismet,
 	isJetpackLogin,
-	isWhiteLogin,
 	isPopup,
 	isGravatar,
 	isWPJobManager,
@@ -135,7 +129,6 @@ const LayoutLoggedOut = ( {
 		'is-akismet': isAkismet,
 		'is-jetpack-login': isJetpackLogin,
 		'is-jetpack-site': isJetpackCheckout,
-		'is-white-login': isWhiteLogin,
 		'is-popup': isPopup,
 		'is-gravatar': isGravatar,
 		'is-mobile': isMobile,
@@ -166,7 +159,7 @@ const LayoutLoggedOut = ( {
 		window.open( createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ), '_blank' );
 	}
 
-	if ( ( isBlazePro || isWoo ) && isWhiteLogin ) {
+	if ( isBlazePro || isWoo ) {
 		/**
 		 * This effectively removes the masterbar completely from Login pages (only).
 		 * However, in some cases, we want the styles imported from the masterbar to be applied.
@@ -342,35 +335,13 @@ export default withCurrentRoute(
 			const oauth2Client = getCurrentOAuth2Client( state );
 			const isGravatar = isGravatarOAuth2Client( oauth2Client );
 			const isWPJobManager = isWPJobManagerOAuth2Client( oauth2Client );
-			const isBlazePro = getIsBlazePro( state );
 			const isGravPoweredClient = isGravPoweredOAuth2Client( oauth2Client );
 			const isMobile = isAndroidOAuth2Client( oauth2Client ) || isIosOAuth2Client( oauth2Client );
-			const isPartnerPortal = isPartnerPortalOAuth2Client( oauth2Client );
 			const isWooJPC = isWooJPCFlow( state );
 			const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
-			const isJetpackCloudClient = isJetpackCloudOAuth2Client( oauth2Client );
-			const isWoo = getIsWoo( state );
+			const isGravPoweredLogin = currentRoute.startsWith( '/log-in' ) && isGravPoweredClient;
 
-			const isStudioClient = isStudioAppOAuth2Client( oauth2Client );
-			const isCrowdsignalClient = isCrowdsignalOAuth2Client( oauth2Client );
-			const isA4AClient = isA4AOAuth2Client( oauth2Client );
-			const isVIPClient = isVIPOAuth2Client( oauth2Client );
-			const isWhiteLogin =
-				( currentRoute.startsWith( '/log-in' ) &&
-					( ( Boolean( currentQuery?.client_id ) === false &&
-						Boolean( currentQuery?.oauth2_client_id ) === false ) ||
-						isStudioClient ||
-						isCrowdsignalClient ||
-						isBlazePro ||
-						isA4AClient ||
-						isWoo ||
-						isJetpackCloudClient ||
-						isJetpackLogin ||
-						isVIPClient ||
-						isMobile ) ) ||
-				isPartnerPortal;
-
-			const noMasterbarForRoute = ( isWhiteLogin && ! isBlazePro ) || isInvitationURL;
+			const noMasterbarForRoute = isGravPoweredLogin || isInvitationURL;
 			const isPopup = '1' === currentQuery?.is_popup;
 			const noMasterbarForSection =
 				! isWooOAuth2Client( oauth2Client ) &&
@@ -395,7 +366,6 @@ export default withCurrentRoute(
 			return {
 				isAkismet,
 				isJetpackLogin,
-				isWhiteLogin,
 				isPopup,
 				isGravatar,
 				isMobile,

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -339,9 +339,9 @@ export default withCurrentRoute(
 			const isMobile = isAndroidOAuth2Client( oauth2Client ) || isIosOAuth2Client( oauth2Client );
 			const isWooJPC = isWooJPCFlow( state );
 			const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
-			const isGravPoweredLogin = currentRoute.startsWith( '/log-in' ) && isGravPoweredClient;
+			const isLogin = currentRoute.startsWith( '/log-in' );
 
-			const noMasterbarForRoute = isGravPoweredLogin || isInvitationURL;
+			const noMasterbarForRoute = isLogin || isInvitationURL;
 			const isPopup = '1' === currentQuery?.is_popup;
 			const noMasterbarForSection =
 				! isWooOAuth2Client( oauth2Client ) &&

--- a/client/layout/masterbar/blaze-pro.scss
+++ b/client/layout/masterbar/blaze-pro.scss
@@ -440,7 +440,7 @@ body.is-section-signup {
 		}
 	}
 
-	&.layout.is-white-login,
+	&.layout:not(.is-grav-powered-client),
 	.card.login__form,
 	.signup-form .logged-out-form,
 	.login__lostpassword-form {

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -182,7 +182,7 @@ $breakpoint-mobile: 660px;
 
 	.button.is-primary,
 	.login .button.is-primary,
-	.magic-login.is-white-login .magic-login__form-action .button.is-primary:not([disabled]) {
+	.magic-login .magic-login__form-action .button.is-primary:not([disabled]) {
 		background-color: var(--woo-purple-60);
 		border: none;
 		color: #fff;
@@ -1099,7 +1099,7 @@ $breakpoint-mobile: 660px;
 
 		.button.is-primary,
 		.login .button.is-primary,
-		.magic-login.is-white-login .magic-login__form-action .button.is-primary:not([disabled]) {
+		.magic-login .magic-login__form-action .button.is-primary:not([disabled]) {
 			background-color: var(--woo-purple-50);
 			font-family: $woo-inter-font;
 			font-size: 1rem;
@@ -1863,7 +1863,7 @@ $breakpoint-mobile: 660px;
 
 	.button.is-primary,
 	.login .button.is-primary,
-	.magic-login.is-white-login .magic-login__form-action .button.is-primary:not([disabled]) {
+	.magic-login .magic-login__form-action .button.is-primary:not([disabled]) {
 		@include button-primary;
 	}
 

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -1,22 +1,12 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
-import {
-	isGravPoweredOAuth2Client,
-	isPartnerPortalOAuth2Client,
-	isStudioAppOAuth2Client,
-	isCrowdsignalOAuth2Client,
-	isA4AOAuth2Client,
-	isJetpackCloudOAuth2Client,
-	isVIPOAuth2Client,
-} from 'calypso/lib/oauth2-clients';
+import { isGravPoweredOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { DesktopLoginStart, DesktopLoginFinalize } from 'calypso/login/desktop-login';
 import { SOCIAL_HANDOFF_CONNECT_ACCOUNT } from 'calypso/state/action-types';
 import { isUserLoggedIn, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
 import { getOAuth2Client } from 'calypso/state/oauth2-clients/selectors';
-import getIsBlazePro from 'calypso/state/selectors/get-is-blaze-pro';
-import getIsWoo from 'calypso/state/selectors/get-is-woo';
 import LoginContextProvider from './login-context';
 import MagicLogin from './magic-login';
 import HandleEmailedLinkForm from './magic-login/handle-emailed-link-form';
@@ -64,34 +54,13 @@ const enhanceContextWithLogin = ( context ) => {
 	const oauth2ClientId = query?.oauth2_client_id;
 	const oauth2Client = getOAuth2Client( currentState, Number( clientId || oauth2ClientId ) ) || {};
 	const isGravPoweredClient = isGravPoweredOAuth2Client( oauth2Client );
-	const isPartnerPortalClient = isPartnerPortalOAuth2Client( oauth2Client );
-	const isWoo = getIsWoo( currentState );
-	const isBlazePro = getIsBlazePro( currentState );
-	const isStudioLogin = isStudioAppOAuth2Client( oauth2Client );
-	const isCrowdsignalLogin = isCrowdsignalOAuth2Client( oauth2Client );
-	const isA4AClient = isA4AOAuth2Client( oauth2Client );
 	const isJetpackLogin = isJetpack === 'jetpack';
-	const isJetpackCloudClient = isJetpackCloudOAuth2Client( oauth2Client );
-	const isVIPClient = isVIPOAuth2Client( oauth2Client );
-
-	const isWhiteLogin =
-		( Boolean( clientId ) === false && Boolean( oauth2ClientId ) === false ) ||
-		isPartnerPortalClient ||
-		isStudioLogin ||
-		isCrowdsignalLogin ||
-		isBlazePro ||
-		isA4AClient ||
-		isJetpackCloudClient ||
-		isJetpackLogin ||
-		isWoo ||
-		isVIPClient;
 
 	context.primary = (
 		<LoginContextProvider>
 			<WPLogin
 				action={ action }
 				isJetpack={ isJetpackLogin }
-				isWhiteLogin={ isWhiteLogin }
 				isGravPoweredClient={ isGravPoweredClient }
 				path={ path }
 				twoFactorAuthType={ twoFactorAuthType }

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -1300,8 +1300,6 @@ class MagicLogin extends Component {
 		// "query?.redirect_to" is used to determine if Studio app users are creating a new account (vs. logging in)
 		const isStudio = isStudioAppOAuth2Client( oauth2Client ) && query?.redirect_to;
 
-		const isWhiteLogin = ! this.props.isWCCOM && ! this.props.isFromAutomatticForAgenciesPlugin;
-
 		// If this is part of the Jetpack login flow, some steps will display a different UI
 		const requestLoginEmailFormProps = {
 			...( this.props.isJetpackLogin ? { flow: 'jetpack' } : {} ),
@@ -1318,11 +1316,7 @@ class MagicLogin extends Component {
 		};
 
 		const mainContent = (
-			<Main
-				className={ clsx( 'magic-login magic-login__request-link', {
-					'is-white-login': isWhiteLogin,
-				} ) }
-			>
+			<Main className="magic-login magic-login__request-link">
 				<GlobalNotices id="notices" />
 
 				{ isWooJPC ? (

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -168,8 +168,8 @@
 	}
 }
 
-.is-white-login .magic-login__handle-link,
-.is-white-login .magic-login__link-expired {
+:not(.is-grav-powered-client) .magic-login__handle-link,
+:not(.is-grav-powered-client) .magic-login__link-expired {
 	.empty-content__title {
 		font-family: $brand-serif;
 		font-size: rem(42px);
@@ -299,7 +299,7 @@
 	height: 240px;
 }
 
-.magic-login.is-white-login {
+.magic-login:not(.is-grav-powered-client) {
 	.magic-login__form-header {
 		@include onboarding-heading-text-mobile;
 

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -168,8 +168,8 @@
 	}
 }
 
-:not(.is-grav-powered-client) .magic-login__handle-link,
-:not(.is-grav-powered-client) .magic-login__link-expired {
+.layout:not(.is-grav-powered-client) .magic-login__handle-link,
+.layout:not(.is-grav-powered-client) .magic-login__link-expired {
 	.empty-content__title {
 		font-family: $brand-serif;
 		font-size: rem(42px);

--- a/client/login/qr-code-login-page/index.jsx
+++ b/client/login/qr-code-login-page/index.jsx
@@ -13,7 +13,6 @@ function QrCodeLoginPlaceholder() {
 
 function QrCodeLoginPage( { locale, redirectTo, isJetpack = false } ) {
 	const translate = useTranslate();
-	const isWhiteLogin = true;
 
 	return (
 		<Main className={ clsx( 'qr-code-login-page', { 'is-jetpack': isJetpack } ) }>
@@ -57,7 +56,7 @@ function QrCodeLoginPage( { locale, redirectTo, isJetpack = false } ) {
 					isJetpack={ isJetpack }
 				/>
 				<div className="qr-code-login-page__footer">
-					<a href={ login( { locale, redirectTo, isWhiteLogin, isJetpack } ) }>
+					<a href={ login( { locale, redirectTo, isJetpack } ) }>
 						{ translate( 'Enter a password instead' ) }
 					</a>
 				</div>

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -53,7 +53,6 @@ export class Login extends Component {
 		clientId: PropTypes.string,
 		isLoginView: PropTypes.bool,
 		isJetpack: PropTypes.bool.isRequired,
-		isWhiteLogin: PropTypes.bool.isRequired,
 		locale: PropTypes.string.isRequired,
 		oauth2Client: PropTypes.object,
 		path: PropTypes.string.isRequired,
@@ -67,7 +66,7 @@ export class Login extends Component {
 		isGravPoweredClient: PropTypes.bool,
 	};
 
-	static defaultProps = { isJetpack: false, isWhiteLogin: false, isLoginView: true };
+	static defaultProps = { isJetpack: false, isLoginView: true };
 	static contextType = LoginContext;
 
 	state = {
@@ -96,7 +95,6 @@ export class Login extends Component {
 
 		// List all props that affect the heading text
 		const headingProps = [
-			'isWhiteLogin',
 			'twoFactorAuthType',
 			'isManualRenewalImmediateLoginAttempt',
 			'socialConnect',
@@ -216,7 +214,6 @@ export class Login extends Component {
 			clientId,
 			domain,
 			isJetpack,
-			isWhiteLogin,
 			isGravPoweredClient,
 			oauth2Client,
 			socialConnect,
@@ -247,7 +244,6 @@ export class Login extends Component {
 				socialConnect={ socialConnect }
 				clientId={ clientId }
 				isJetpack={ isJetpack }
-				isWhiteLogin={ isWhiteLogin }
 				isGravPoweredClient={ isGravPoweredClient }
 				isGravPoweredLoginPage={ isGravPoweredLoginPage }
 				oauth2Client={ oauth2Client }
@@ -276,7 +272,6 @@ export class Login extends Component {
 
 	updateHeadingText() {
 		const {
-			isWhiteLogin,
 			twoFactorAuthType,
 			isManualRenewalImmediateLoginAttempt,
 			socialConnect,
@@ -295,7 +290,7 @@ export class Login extends Component {
 		} = this.props;
 
 		// TODO: remove isGravPoweredClient when login pages are unified.
-		const isSocialFirst = isWhiteLogin && ! isGravPoweredClient;
+		const isSocialFirst = ! isGravPoweredClient;
 
 		const headingText = getHeaderText( {
 			isSocialFirst,
@@ -330,20 +325,13 @@ export class Login extends Component {
 	}
 
 	render() {
-		const {
-			locale,
-			translate,
-			isGenericOauth,
-			isGravPoweredClient,
-			isWhiteLogin,
-			isJetpack,
-			isFromAkismet,
-		} = this.props;
+		const { locale, translate, isGenericOauth, isGravPoweredClient, isJetpack, isFromAkismet } =
+			this.props;
 
 		const canonicalUrl = localizeUrl( 'https://wordpress.com/log-in', locale );
 
 		// TODO: remove isGravPoweredClient when login pages are unified.
-		const isSocialFirst = isWhiteLogin && ! isGravPoweredClient;
+		const isSocialFirst = ! isGravPoweredClient;
 
 		const mainContent = (
 			<Main
@@ -353,7 +341,7 @@ export class Login extends Component {
 					'is-jetpack': isJetpack,
 				} ) }
 			>
-				{ ! isWhiteLogin && this.renderI18nSuggestions() }
+				{ isGravPoweredClient && this.renderI18nSuggestions() }
 
 				<DocumentHead
 					title={ translate( 'Log In' ) }
@@ -370,13 +358,13 @@ export class Login extends Component {
 
 				<div className="wp-login__container">{ this.renderContent( isSocialFirst ) }</div>
 
-				{ isWhiteLogin && this.renderI18nSuggestions() }
+				{ ! isGravPoweredClient && this.renderI18nSuggestions() }
 			</Main>
 		);
 
 		return (
 			<>
-				{ isWhiteLogin && (
+				{ ! isGravPoweredClient && (
 					<OneLoginLayout
 						isJetpack={ isJetpack }
 						isFromAkismet={ isFromAkismet }
@@ -385,7 +373,7 @@ export class Login extends Component {
 						{ mainContent }
 					</OneLoginLayout>
 				) }
-				{ ! isWhiteLogin && mainContent }
+				{ isGravPoweredClient && mainContent }
 			</>
 		);
 	}

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -468,6 +468,8 @@ $image-height: 47px;
 
 /* stylelint-disable scales/font-weights, scales/radii */
 .layout.is-section-login.is-grav-powered-client {
+	padding-bottom: $image-height;
+	min-height: calc(100% - #{$image-height});
 	background-color: #fff;
 
 	&.is-wp-job-manager {

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -13,13 +13,6 @@ $image-height: 47px;
 	position: relative;
 	min-height: 100%; // Needed for any screen not yet using a StepContainerV2 wireframe (e.g. magic login).
 
-	// This adjustment is only necessary when rendering the Jetpack colophon.
-	// isWhiteLogin screens don't need it.
-	&:where(:not(.is-white-login)) {
-		padding-bottom: $image-height;
-		min-height: calc(100% - #{$image-height});
-	}
-
 	.layout__content {
 		position: static;
 	}
@@ -257,7 +250,7 @@ $image-height: 47px;
 	display: none;
 }
 
-.layout.is-white-login {
+.layout:not(.is-grav-powered-client) {
 	background-color: var( --color-main-background, #fcfcfc );
 
 	// Specificity bump.

--- a/test/e2e/specs/martech/tos-screenshots__login-white.ts
+++ b/test/e2e/specs/martech/tos-screenshots__login-white.ts
@@ -6,7 +6,7 @@ import { Page, Browser } from 'playwright';
 import uploadScreenshotsToBlog from '../../lib/martech-tos-helper';
 
 const selectors = {
-	isWhiteLogin: '.is-section-login.is-white-login',
+	isSectionLogin: '.is-section-login',
 };
 declare const browser: Browser;
 
@@ -43,7 +43,7 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 			for ( const locale of [ 'en', ...magnificientNonEnLocales ] ) {
 				page.setViewportSize( { width: 1280, height: 720 } );
 				await loginPage.visit( { path: locale } );
-				page.waitForSelector( selectors.isWhiteLogin );
+				page.waitForSelector( selectors.isSectionLogin );
 				await page.screenshot( {
 					path: `tos_white_login_desktop_${ locale }.png`,
 					fullPage: true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13620/login-remove-iswhitelogin-and-make-the-relevant-code-the-default-only

## Proposed Changes

- A long story wrapping up with this. Not yet in full, but at least with one exception (Gravatar).
- We may re-introduce a different context ("full" or "compact"), but certainly not "white"

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13620/login-remove-iswhitelogin-and-make-the-relevant-code-the-default-only

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through as many [Login screens](https://linear.app/a8c/issue/DOTCOM-13220/login-make-the-two-columnwhite-layout-the-default-across-all-contexts) and confirm things rendering correcty with right colors/spacing/etc.
* Confirm lost-password screen
* Confirm magic-login screen(s)
* Confirm grav-powered-client Login screens render correctly (Gravatar and WP Job Manager)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
