### PR TITLE
Make mini-cart and wpcom-checkout packages non-private

### DIFF
--- a/packages/mini-cart/package.json
+++ b/packages/mini-cart/package.json
@@ -68,6 +68,5 @@
 	"peerDependencies": {
 		"@emotion/react": "^11.4.1",
 		"redux": "^5.0.1"
-	},
-	"private": true
+	}
 }

--- a/packages/wpcom-checkout/package.json
+++ b/packages/wpcom-checkout/package.json
@@ -75,6 +75,5 @@
 	"peerDependencies": {
 		"@emotion/react": "^11.4.1",
 		"redux": "^5.0.1"
-	},
-	"private": true
+	}
 }


### PR DESCRIPTION
Fixes CHE-223

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->


## Proposed Changes

This PR removes the `private` flag on the `@automattic/mini-cart` package and its dependency `@automattic/wpcom-checkout` to prepare them for publishing to the npm repository.

## Why are these changes being made?

As part of a new project (https://linear.app/a8c/project/ciab-billing-581df72549f7/overview) we want to attempt to render the `mini-cart` in wp-admin on a remote site. This was always the intent of the `@automattic/mini-cart` package, but since we didn't have a use-case, it was never yet attempted. As a first step to doing this, we need to publish the package and therefore it needs to be public.

## Testing Instructions

None should be required.
