### PR TITLE
A4A: Hide internal a4a domains in a few more billing spots

### DIFF
--- a/client/me/purchases/billing-history/field-definitions.tsx
+++ b/client/me/purchases/billing-history/field-definitions.tsx
@@ -1,6 +1,7 @@
 import { type Operator } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { capitalPDangit } from 'calypso/lib/formatting';
+import { isInternalA4AAgencyDomain } from 'calypso/me/purchases/utils';
 import {
 	getTransactionTermLabel,
 	groupDomainProducts,
@@ -24,7 +25,8 @@ function renderServiceNameDescription(
 	const isSitelessDomain = /^siteless\.(marketplace\.wp|agencies\.automattic|a4a)\.com/.test(
 		transaction.domain
 	);
-	const shouldShowDomain = transaction.domain && ! isSitelessDomain;
+	const shouldShowDomain =
+		transaction.domain && ! isSitelessDomain && ! isInternalA4AAgencyDomain( transaction.domain );
 	return (
 		<div>
 			<strong>{ plan }</strong>

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -24,6 +24,7 @@ import TextareaAutosize from 'calypso/components/textarea-autosize';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { billingHistory, vatDetails as vatDetailsPath } from 'calypso/me/purchases/paths';
 import titles from 'calypso/me/purchases/titles';
+import { isInternalA4AAgencyDomain } from 'calypso/me/purchases/utils';
 import useVatDetails from 'calypso/me/purchases/vat-info/use-vat-details';
 import { useTaxName } from 'calypso/my-sites/checkout/src/hooks/use-country-list';
 import { useDispatch } from 'calypso/state';
@@ -564,6 +565,11 @@ function ReceiptLineItem( {
 		isSmallestUnit: true,
 		stripZeros: true,
 	} );
+
+	const isSitelessDomain = /^siteless\.(agencies\.automattic|a4a)\.com/.test( item.domain );
+	const shouldShowDomain =
+		item.domain && ! isSitelessDomain && ! isInternalA4AAgencyDomain( item.domain );
+
 	return (
 		<>
 			<tr>
@@ -571,7 +577,7 @@ function ReceiptLineItem( {
 					<span>{ item.variation }</span>
 					<small>({ item.type_localized })</small>
 					{ termLabel && <em>{ termLabel }</em> }
-					{ item.domain && <em>{ item.domain }</em> }
+					{ shouldShowDomain && <em>{ item.domain }</em> }
 					{ item.licensed_quantity && (
 						<em>{ renderTransactionQuantitySummary( item, translate ) }</em>
 					) }

--- a/client/me/purchases/utils.ts
+++ b/client/me/purchases/utils.ts
@@ -78,3 +78,12 @@ export function getCancelPurchaseSurveyCompletedPreferenceKey(
 ): string {
 	return `cancel-purchase-survey-completed-${ purchaseId }`;
 }
+
+/**
+ * Checks if a domain is for an internal A4A agency site.
+ * @param domain The domain to check
+ * @returns True if the domain is an internal A4A agency domain
+ */
+export function isInternalA4AAgencyDomain( domain: string ): boolean {
+	return domain?.endsWith( '.agencies.automattic.com' );
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

This is a followup to #103968 with a few more changes.

Linear issue: https://linear.app/a8c/issue/A4A-897/dont-show-confusing-purchase-messaging-to-client

## Proposed Changes

* On billing history page also hide domain if it's an internal agency site. This is the case with Pressable subscriptions.
* On the receipt page hide domains if it's an internal agency site or a siteless site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox `public-api.wordpress.com`
* Use store sandbox by adding this to your `0-sandbox.php` file: `define( 'USE_STORE_SANDBOX', true );`
* Send two separate referrals to a client - one for Pressable and another for any non-Pressable product.
* As the client, visit the links in the emails and on the checkout page change `/client/checkout` to `/client/checkout/v2`. 
* Purchase both products.
* With this branch, either using the live link or booting the wpcom environment, visit `/me/purchases/billing` as the client (eg. http://calypso.localhost:3000/me/purchases/billing).
* Under the "Billing History" tab, for the Pressable product, the purchase should not show the domain.
* Click the three dots on the right and click "View receipt"
* Make sure the domain doesn't show there either.
* Check the receipt of the other non-Pressable and the domain should not show either.
* Check for any other regular wpcom purchase and the domains should still show as normal.
* As the client cancel the Pressable subscription.

| **Before** | **After** |
|-----------------|-----------------|
| <img width="400" src="https://github.com/user-attachments/assets/5569ab65-3f13-4e21-a1b5-74aa17b9d6cd" /> | <img width="400" src="https://github.com/user-attachments/assets/6d10413d-9403-453a-a192-8996d0154f90" /> |
| <img width="400" src="https://github.com/user-attachments/assets/b8c03a88-b012-4227-8161-2a23e8d2056b" /> | <img width="400" src="https://github.com/user-attachments/assets/3d718837-fe4b-4fae-b152-7818081ea2bd" /> |
| <img width="400" src="https://github.com/user-attachments/assets/b41a71c6-4090-4149-a984-3fc8dbfc6c24" /> | <img width="400" src="https://github.com/user-attachments/assets/010cffe3-5555-460a-863c-82dad77c395b" /> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
