### PR TITLE
Remove copy-assets from mini-cart and wpcom-checkout

### DIFF
--- a/packages/mini-cart/package.json
+++ b/packages/mini-cart/package.json
@@ -17,7 +17,7 @@
 	"sideEffects": false,
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && npx rimraf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/wpcom-checkout/package.json
+++ b/packages/wpcom-checkout/package.json
@@ -17,7 +17,7 @@
 	"sideEffects": false,
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},


### PR DESCRIPTION
Part of CHE-223

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->


## Proposed Changes

This PR removes the `copy-assets` call on the `@automattic/mini-cart` package and its dependency `@automattic/wpcom-checkout` to prepare them for publishing to the npm repository.

## Why are these changes being made?

As part of a new project (https://linear.app/a8c/project/ciab-billing-581df72549f7/overview) we want to attempt to render the `mini-cart` in wp-admin on a remote site. This was always the intent of the `@automattic/mini-cart` package, but since we didn't have a use-case, it was never yet attempted. As a first step to doing this, we need to publish the package and therefore it needs to build. Currently it will not build because of a `copy-assets` call in the build script. I believe this was an outdated script.

## Testing Instructions

None should be required.
