### PR TITLE
Stats: Restore Jetpack App promotion banner when the Traffic page is not gated

### DIFF
--- a/client/my-sites/stats/promo-cards/style.scss
+++ b/client/my-sites/stats/promo-cards/style.scss
@@ -1,7 +1,7 @@
 // Style overrides for when the MoblePromoCard is inside a DotPager component.
 
 .stats__promo-container {
-	margin-bottom: 20px;
+	margin-bottom: 32px;
 }
 
 .stats__promo-card {

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -793,7 +793,7 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 			{ ! shouldShowUpsells ? null : (
 				<AsyncLoad require="calypso/my-sites/stats/jetpack-upsell-section" />
 			) }
-			{ ! config.isEnabled( 'stats/paid-wpcom-v3' ) && (
+			{ ! wpcomShowUpsell && (
 				<PromoCards isOdysseyStats={ isOdysseyStats } pageSlug="traffic" slug={ slug } />
 			) }
 			{ supportUserFeedback && <StatsFeedbackPresentor siteId={ siteId } /> }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes STATS-129.

## Proposed Changes

* Restore the Jetpack App promotion banner and hide it only when the WPCOM upsell of the traffic page is shown.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* pbArwn-7uB-p2#comment-8617

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page for a Simple site without a plan purchased.
* Ensure the Jetpack App promotion banner is not shown.

<img width="1419" height="880" alt="截圖 2025-07-11 下午2 23 01" src="https://github.com/user-attachments/assets/3c76ae8b-9593-4625-b56c-6c82ab60a4c0" />

* Navigate to Stats > Traffic page with a Simple site that has purchased a plan to show the Traffic page modules.
* Ensure the promotion banner is shown.

<img width="1541" height="808" alt="截圖 2025-07-11 下午2 22 48" src="https://github.com/user-attachments/assets/3186a8ee-4caa-42c4-b64a-a422139b591c" />

* Navigate to Stats > Traffic page for a self-hosted site regardless of the Stats purchase.
* Ensure the promotion banner is shown.

<img width="1432" height="750" alt="截圖 2025-07-11 下午2 22 11" src="https://github.com/user-attachments/assets/c982778e-2344-4bf6-bf3c-c6ea8e8aa1f4" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?