### PR TITLE
Help Center: Correct styling for buttons in articles

### DIFF
--- a/packages/help-center/src/components/help-center-article.scss
+++ b/packages/help-center/src/components/help-center-article.scss
@@ -158,9 +158,13 @@
 					background-color: var(--color-surface);
 					border: 1px solid var(--color-neutral-10);
 					border-radius: 2px;
+					box-sizing: border-box;
 					color: var(--color-neutral-70);
+					display: inline-block;
 					font-size: $font-body-small;
 					padding: 8px 14px;
+					text-align: center;
+					text-decoration: none;
 					width: 100%;
 				}
 			}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/TMPFRG-429/help-center-improve-button-stylings

## Proposed Changes

| Before | After |
|--------|--------|
| <img width="448" height="344" alt="image" src="https://github.com/user-attachments/assets/0f01701b-f7f3-436d-877e-05d149c3c4c5" /> | <img width="442" height="321" alt="image" src="https://github.com/user-attachments/assets/18bc2e4a-8bad-4d62-b640-1a0bd498b6f2" /> | 


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Help Center, search for Seo and open `Introduction to SEO` article
* Scroll to the bottom and check the button