### PR TITLE
My Home: Fix the site preview so it loads the expected admin-bar-blocking code

### DIFF
--- a/client/dashboard/sites/site-preview/index.tsx
+++ b/client/dashboard/sites/site-preview/index.tsx
@@ -1,3 +1,5 @@
+import { __ } from '@wordpress/i18n';
+
 export default function SitePreview( {
 	url,
 	scale = 1,
@@ -27,7 +29,7 @@ export default function SitePreview( {
 			loading="lazy"
 			// @ts-expect-error For some reason there's no inert type.
 			inert="true"
-			title="Site Preview"
+			title={ __( 'Site Preview' ) }
 			// Hide banners + `preview` hides cookie banners + `iframe` hides
 			// admin bar for atomic sites.
 			src={ `${ secureUrl }/?hide_banners=true&preview=true&iframe=true` }

--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -108,11 +108,17 @@ const SitePreview = ( {
 				<div className="home-site-preview__thumbnail">
 					{ selectedSite ? (
 						<iframe
+							// Enabling sandbox disables most features, such as autoplay,
+							// alerts, popups, fullscreen, etc.
+							sandbox="allow-scripts allow-same-origin"
+							// Officially deprecated, but still widely supported. Hides
+							// scrollbars in case they are set to always visible.
 							scrolling="no"
 							loading="lazy"
+							// @ts-expect-error For some reason there's no inert type.
+							inert="true"
 							title={ __( 'Site Preview' ) }
 							src={ iframeSrcKeepHomepage }
-							tabIndex={ -1 }
 						/>
 					) : (
 						<div className="home-site-preview__thumbnail-placeholder" />

--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -91,7 +91,7 @@ const SitePreview = ( {
 
 	// We use an iframe rather than mShot to not cache changes.
 	const iframeSrcKeepHomepage = selectedSite
-		? `//${ selectedSite.slug }/?hide_banners=true&preview_overlay=true&preview=true`
+		? `//${ selectedSite.slug }/?hide_banners=true&preview_overlay=true&preview=true&iframe=true`
 		: '#';
 
 	const selectedSiteURL = selectedSite ? selectedSite.URL : '#';

--- a/client/my-sites/customer-home/cards/features/site-preview/style.scss
+++ b/client/my-sites/customer-home/cards/features/site-preview/style.scss
@@ -41,7 +41,6 @@
 				max-width: 357%;
 				transform: scale(0.28);
 				transform-origin: top left;
-				translate: 0 -10px;
 			}
 
 			.home-site-preview__thumbnail-placeholder {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-137

## Proposed Changes

* Adds `?iframe=true` query param to iframe preview on My Home
* Now that the admin bar is hidden, the manual `-10px` translation can be removed
* Backport the iframe sandbox code from Hosting Dashboard
* Add a quick translation fix to the Hosting Dashboard's a11y label

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Working on ensuring iframe previews never play audio. The My Home preview will need `?iframe=true` to get them. It is a parameter that other previews use too.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open My Home
* Observe that the preview doesn't look any different than it used to

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
