### PR TITLE
WIP: Set sticker for sites that come through a specific landing page

### DIFF
--- a/client/blocks/blog-stickers/use-add-blog-sticker-mutation.js
+++ b/client/blocks/blog-stickers/use-add-blog-sticker-mutation.js
@@ -24,12 +24,17 @@ export const useAddBlogStickerMutation = ( options = {} ) => {
 		},
 	} );
 
-	const { mutate } = mutation;
+	const { mutate, mutateAsync } = mutation;
 
 	const addBlogSticker = useCallback(
 		( blogId, stickerName ) => mutate( { blogId, stickerName } ),
 		[ mutate ]
 	);
 
-	return { addBlogSticker, ...mutation };
+	const addBlogStickerAsync = useCallback(
+		( blogId, stickerName ) => mutateAsync( { blogId, stickerName } ),
+		[ mutateAsync ]
+	);
+
+	return { addBlogSticker, addBlogStickerAsync, ...mutation };
 };

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -5,6 +5,7 @@ import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs, removeQueryArgs } from '@wordpress/url';
 import { useState, useEffect } from 'react';
+import { useAddBlogStickerMutation } from 'calypso/blocks/blog-stickers/use-add-blog-sticker-mutation';
 import { isSimplifiedOnboarding } from 'calypso/landing/stepper/hooks/use-simplified-onboarding';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { pathToUrl } from 'calypso/lib/url';
@@ -84,6 +85,10 @@ const onboarding: FlowV2< typeof initialize > = {
 			[]
 		);
 		const coupon = useQuery().get( 'coupon' );
+		const refParam = useQuery().get( 'ref' );
+		const { addBlogStickerAsync } = useAddBlogStickerMutation();
+
+		const isWpcomEsContact = refParam === 'wpcom-es-contact';
 
 		const [ useMyDomainTracksEventProps, setUseMyDomainTracksEventProps ] = useState( {} );
 		const { setShouldShowNotification } = usePurchasePlanNotification();
@@ -242,6 +247,12 @@ const onboarding: FlowV2< typeof initialize > = {
 
 						if ( providedDependencies.goToCheckout ) {
 							const siteSlug = providedDependencies.siteSlug as string;
+
+							if ( isWpcomEsContact ) {
+								try {
+									await addBlogStickerAsync( providedDependencies.siteId, 'wpcom-es-contact' );
+								} catch ( error ) {}
+							}
 
 							/**
 							 * If the user comes from the Playground onboarding flow,


### PR DESCRIPTION

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to `AVA-101` cc: @DavidSaladu 

## Proposed Changes

* This is a test to see what's the best way to set a sticker for a specific blog, if they come from a given landing page (determined via the `ref` param in the URL)
* To make this work, I needed to use the mutation asynchronously, as the flow redirects, and the request cancels. So I exported the async mutation from the same hook. This is a very minimal test, we may not need it and can run this logic somewhere else.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We are looking at a specific case, where we'd like to offer email consultation for certain signups. Using a blog sticker will allow us to set this as long as the site is created, even if they later buy a plan.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch locally, and go to `https://calypso.localhost:3000/start/?ref=wpcom-es-contact`. Go through signup, and when you complete the processing step, there will be a request to `https://public-api.wordpress.com/rest/v1.1/sites/[[blog_id}}/blog-stickers/add/`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
