### PR TITLE
A4A: Add TOS link in the User profile dropdown menu.

### DIFF
--- a/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
@@ -1,4 +1,4 @@
-import { Button, Gridicon, Gravatar } from '@automattic/components';
+import { Button, Gravatar } from '@automattic/components';
 import { Icon, chevronDown } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -35,6 +35,11 @@ const DropdownMenu = ( { isExpanded, setMenuExpanded }: DropdownMenuProps ) => {
 	const onProvideFeedback = useCallback( () => {
 		setMenuExpanded( false );
 		dispatch( recordTracksEvent( 'calypso_a4a_sidebar_provide_feedback' ) );
+	}, [ dispatch, setMenuExpanded ] );
+
+	const onPlatformAgreement = useCallback( () => {
+		setMenuExpanded( false );
+		dispatch( recordTracksEvent( 'calypso_a4a_sidebar_platform_agreement' ) );
 	}, [ dispatch, setMenuExpanded ] );
 
 	const onSignOut = useCallback( () => {
@@ -74,7 +79,7 @@ const DropdownMenu = ( { isExpanded, setMenuExpanded }: DropdownMenuProps ) => {
 					target="_blank"
 					rel="noopener noreferrer"
 				>
-					{ translate( 'View Knowledge Base' ) } <Gridicon icon="external" size={ 18 } />
+					{ translate( 'View Knowledge Base ↗' ) }
 				</Button>
 			</li>
 			<li className="a4a-sidebar__profile-dropdown-menu-item">
@@ -84,7 +89,18 @@ const DropdownMenu = ( { isExpanded, setMenuExpanded }: DropdownMenuProps ) => {
 					target="_blank"
 					rel="noopener noreferrer"
 				>
-					{ translate( 'Manage your profile' ) } <Gridicon icon="external" size={ 18 } />
+					{ translate( 'Manage your profile ↗' ) }
+				</Button>
+			</li>
+			<li className="a4a-sidebar__profile-dropdown-menu-item">
+				<Button
+					borderless
+					onClick={ onPlatformAgreement }
+					href="https://automattic.com/for-agencies/platform-agreement/"
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					{ translate( 'Platform Agreement ↗' ) }
 				</Button>
 			</li>
 			<li className="a4a-sidebar__profile-dropdown-menu-item">

--- a/client/a8c-for-agencies/components/sidebar/header/style.scss
+++ b/client/a8c-for-agencies/components/sidebar/header/style.scss
@@ -4,6 +4,8 @@
 // Rules in this file inspired by:
 // client/components/jetpack/profile-dropdown/style.scss
 
+$profile-dropdown-menu-height: 250px;
+
 .a4a-sidebar__header {
 	display: flex;
 	justify-content: space-between;
@@ -84,9 +86,8 @@ html.accessible-focus .a4a-sidebar__profile-dropdown-button:focus {
 }
 
 .a4a-sidebar__profile-dropdown.is-align-menu-up .a4a-sidebar__profile-dropdown-menu {
-	inset-block-start: calc(-100% + -92px);
+	inset-block-start: -$profile-dropdown-menu-height;
 }
-
 
 .a4a-sidebar__profile-dropdown-menu-item {
 	padding: 1px 0;


### PR DESCRIPTION
This PR adds the TOS link in the A4A User profile dropdown menu to allow user to reference the TOS after signup.

Closes https://linear.app/a8c/issue/A4A-1284/add-link-to-tos-under-profile

## Proposed Changes

* We added the 'Platform agreement' menu item that links to https://automattic.com/for-agencies/platform-agreement/
* We've also updated the other external links to use ↗ symbol to indicate that it is an external link.


| Before | After |
|--------|--------|
| <img width="248" height="219" alt="Screenshot 2025-07-11 at 9 15 16 PM" src="https://github.com/user-attachments/assets/dca32999-4c22-444e-88d8-796e9b0bfec1" /> | <img width="254" height="272" alt="Screenshot 2025-07-11 at 9 15 23 PM" src="https://github.com/user-attachments/assets/c083b983-758f-4328-a338-b6e8d2b2567e" /> | 

## Why are these changes being made?

* It is important that the user can easily reference our terms and conditions from the A4A dashboard itself.

## Testing Instructions

* Use the A4A live link and navigate to `/overview` page.
* Click the user icon at the bottom of the sidebar.
* Confirm you see the TOS link.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
