### PR TITLE
Forward the `ref` parameter from URL to createSiteWithCart

### DIFF
--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -179,6 +179,9 @@ export const createSiteWithCart = async (
 	const segmentationSurveyAnswersAnonId = localStorage.getItem( 'ss-anon-id' );
 	localStorage.removeItem( 'ss-anon-id' );
 
+	// This is the parameter that will contain the internal referral, e.g. a landing page.
+	const refParam = new URLSearchParams( document.location.search ).get( 'ref' );
+
 	const siteCreationResponse: NewSiteSuccessResponse = await wpcomRequest( {
 		path: '/sites/new',
 		apiVersion: '1.1',
@@ -196,6 +199,7 @@ export const createSiteWithCart = async (
 					? { segmentation_survey_answers_anon_id: segmentationSurveyAnswersAnonId }
 					: {} ),
 				...( siteGoals && { site_goals: siteGoals } ),
+				...( refParam && { ref: refParam } ),
 			},
 		},
 	} );


### PR DESCRIPTION
 This is a better alternative to https://github.com/Automattic/wp-calypso/pull/104717, as we don't have to do an extra blocking HTTP request in the onboarding flow.
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Forwards the ref paramter, which can then be used for conditional logic in the backend.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The ref parameter is used in many instances, e.g. to identify if the user came from a certain landing page.
* This gives us a generic way of checking ref parameters, which can be adapted to other logic as well.
* 
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch locally, and go through the onboarding flow, supplying a ref paramter. E.g. calypso.localhost:3000/start/?ref=calypsotest
* In the HTTP request to /sites/new, you'll see that the `ref` parameter is now supplied to the endpoint.
* Going through the flow with no `ref` parameter present should not add this parameter to the request.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
