### PR TITLE
Hovercards - fix issue with low resolution gravatar in hovercard.

### DIFF
--- a/client/components/gravatar-with-hovercards/gravatar-header/index.jsx
+++ b/client/components/gravatar-with-hovercards/gravatar-header/index.jsx
@@ -1,8 +1,31 @@
 import page from '@automattic/calypso-router';
 import AutoDirection from 'calypso/components/auto-direction';
 
-function GravatarHeader( { gravatarData, userLogin, closeCard } ) {
+function getFallbackAvatarUrl( gravatarData ) {
+	const defaultUrl = 'https://www.gravatar.com/avatar/0?d=mm&s=256&r=G';
+	if ( ! gravatarData?.avatarUrl ) {
+		return defaultUrl;
+	}
+
+	try {
+		const url = new URL( gravatarData?.avatarUrl );
+		url.searchParams.set( 'd', 'mm' );
+		url.searchParams.set( 'r', 'G' );
+		url.searchParams.set( 's', '256' );
+		return url.toString();
+	} catch {
+		return defaultUrl;
+	}
+}
+
+function GravatarHeader( { gravatarData, processedAvatarUrl, userLogin, closeCard } ) {
 	const profileUrl = userLogin ? `/reader/users/${ userLogin }` : gravatarData.profileUrl;
+
+	// We prefer the processedAvatarUrl from the gravatar hovercard itself, as they have logic to
+	// evaluate data and set params on the url. However, lets also provide a basic fallback being
+	// the avatarUrl from the gavatarData and set some basic params we know we want in this context
+	// (default avatar, rating, and size).
+	const fallbackAvatarUrl = getFallbackAvatarUrl( gravatarData );
 
 	const clickProfileLink = ( e ) => {
 		e.preventDefault();
@@ -21,7 +44,7 @@ function GravatarHeader( { gravatarData, userLogin, closeCard } ) {
 				>
 					<img
 						className="gravatar-hovercard__avatar"
-						src={ gravatarData.avatarUrl }
+						src={ processedAvatarUrl || fallbackAvatarUrl }
 						alt={ gravatarData.displayName }
 						width={ 104 }
 						height={ 104 }

--- a/client/components/gravatar-with-hovercards/hovercard-content.jsx
+++ b/client/components/gravatar-with-hovercards/hovercard-content.jsx
@@ -12,7 +12,7 @@ import './styles.scss';
 
 function HovercardContent( props ) {
 	const dispatch = useDispatch();
-	const { user, gravatarData, closeCard } = props;
+	const { user, gravatarData, processedAvatarUrl, closeCard } = props;
 
 	// Prefer wpcom_id when it is given. Sometimes ID is specific to another site and wpcom_id is
 	// accurate. Use ID as a fallback as sometimes wpcom_id isn't provided (like self user data).
@@ -44,6 +44,7 @@ function HovercardContent( props ) {
 				<div className="gravatar-hovercard__header">
 					<GravatarHeader
 						gravatarData={ gravatarData }
+						processedAvatarUrl={ processedAvatarUrl }
 						userLogin={ userLogin }
 						closeCard={ closeCard }
 					/>

--- a/client/components/gravatar-with-hovercards/index.jsx
+++ b/client/components/gravatar-with-hovercards/index.jsx
@@ -22,9 +22,9 @@ function GravatarWithHovercards( props ) {
 					const extractedAvatarUrl = avatarImg ? avatarImg.src : null;
 
 					inner.innerHTML = '';
+					// Our custom components for the card will render through this portal.
 					setMountNode( inner );
 
-					// Pass the processed URL to your component
 					setProcessedAvatarUrl( extractedAvatarUrl );
 				}
 			}

--- a/client/components/gravatar-with-hovercards/index.jsx
+++ b/client/components/gravatar-with-hovercards/index.jsx
@@ -9,18 +9,23 @@ import '@gravatar-com/hovercards/dist/style.css';
 function GravatarWithHovercards( props ) {
 	const containerRef = useRef( null );
 	const [ mountNode, setMountNode ] = useState( null );
+	const [ processedAvatarUrl, setProcessedAvatarUrl ] = useState( null );
 	const [ gravatarData, setGravatarData ] = useState( {} );
 
 	const { attach, detach } = useHovercards( {
 		onHovercardShown: ( hash, hovercardElement ) => {
-			// Customize the hovercard.
 			if ( hovercardElement ) {
 				const inner = hovercardElement.querySelector( '.gravatar-hovercard__inner' );
 				if ( inner ) {
-					inner.innerHTML = '';
+					// Get the processed avatar URL before clearing innerHTML
+					const avatarImg = inner.querySelector( '.gravatar-hovercard__avatar' );
+					const extractedAvatarUrl = avatarImg ? avatarImg.src : null;
 
-					// Our custom components for the card will render through this portal.
+					inner.innerHTML = '';
 					setMountNode( inner );
+
+					// Pass the processed URL to your component
+					setProcessedAvatarUrl( extractedAvatarUrl );
 				}
 			}
 		},
@@ -53,6 +58,7 @@ function GravatarWithHovercards( props ) {
 			<HovercardContentPortal
 				mountNode={ mountNode }
 				gravatarData={ gravatarData }
+				processedAvatarUrl={ processedAvatarUrl }
 				closeCard={ closeCard }
 				{ ...props }
 			/>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/CML-649/gravatar-image-should-be-2x-display-width#comment-80af6905

## Proposed Changes

Resolves an issue with the gravatar shown in our hovercards being low resolution. Here we resolve this in two ways.
1. Instead of always using the `avatarUrl` returned from the gravatar profile request, we try to pull the src off the gravatar image element the hovercard would render by default. The hovercards do some extra logic to evaluate data and set params on the `avatarUrl` they show. 
2. We continue to use the `avatarUrl` as a fallback in case we are not able to pull the src off what the card would normally render. However, we add some params to it that make sense for our context (size, rating, and default avatar type).
    * In testing, it seems that the above with those added params is same as the src from part 1 (at least for the users I have tried in the reader). We could potentially just skip doing point 1 above and just use this (2) all the time, but it seems useful to try and leverage the logic and functionality that already exists in the hovercard as there may be other situations params are added or changed.

BEFORE
<img width="339" height="205" alt="Screenshot 2025-07-11 at 10 00 13 AM" src="https://github.com/user-attachments/assets/2f788318-7870-49fd-9f59-61672ff5c0ff" />

AFTER
<img width="308" height="204" alt="Screenshot 2025-07-11 at 10 00 19 AM" src="https://github.com/user-attachments/assets/fbe6ddef-8eab-443a-b638-873efc9edb92" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the reader.
* Smoke test hovercards and verify the gravatar in the hovercards continue to appear as expected, but with better resolution.
    * If you have trouble seeing the resolution difference, right click on the avatar in the hovercard and select "open image in a new tab". Compared to what you see from doing this on horizon, this image should be double the height and width (at 256px) 
* Test the fallbacks look good as well. To do this go into the code for the changed gravatar-header file and force it to render the fallback instead. Test the same way as above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
