### PR TITLE
Make calypso-razorpay and calypso-stripe public

### DIFF
--- a/packages/calypso-razorpay/package.json
+++ b/packages/calypso-razorpay/package.json
@@ -42,6 +42,5 @@
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"typescript": "^5.8.3"
-	},
-	"private": true
+	}
 }

--- a/packages/calypso-stripe/package.json
+++ b/packages/calypso-stripe/package.json
@@ -52,6 +52,5 @@
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"typescript": "^5.8.3"
-	},
-	"private": true
+	}
 }


### PR DESCRIPTION
Part of CHE-223

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->


## Proposed Changes

This PR removes the `private` flag on the `@automattic/calypso-stripe` and `@automattic/calypso-razorpay` packages to prepare them for publishing to the npm repository.

## Why are these changes being made?

As part of a new project (https://linear.app/a8c/project/ciab-billing-581df72549f7/overview) we want to attempt to render the `mini-cart` in wp-admin on a remote site. This was always the intent of the `@automattic/mini-cart` package, but since we didn't have a use-case, it was never yet attempted. As a first step to doing this, we need to publish the `@automattic/wpcom-checkout` package which is a dependency, and to do that we need to publish its dependencies: `calypso-stripe` and `calypso-razorpay`.

## Testing Instructions

None should be required.
