### PR TITLE
Clean up deprecation and otherwise problematic warnings from scan dashboard

### DIFF
--- a/client/components/jetpack/scan-threats/index.tsx
+++ b/client/components/jetpack/scan-threats/index.tsx
@@ -124,9 +124,13 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 		triggerScanRun( site.ID )( dispatch );
 	}, [ dispatch, site ] );
 
-	const allFixableThreats = threats.filter(
-		( threat ): threat is FixableThreat =>
-			threat.fixable !== false && threat.fixerStatus !== 'in_progress'
+	const allFixableThreats = React.useMemo(
+		() =>
+			threats.filter(
+				( threat ): threat is FixableThreat =>
+					threat.fixable !== false && threat.fixerStatus !== 'in_progress'
+			),
+		[ threats ]
 	);
 	const hasFixableThreats = !! allFixableThreats.length;
 
@@ -185,15 +189,24 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 		[ updatingThreats ]
 	);
 
-	const maxSeverity = threats.reduce( ( max, threat ) => Math.max( max, threat.severity ), 0 );
-	const countMap = {
-		low: threats.filter( ( threat ) => threat.severity < 3 ).length,
-		high: threats.filter( ( threat ) => threat.severity >= 3 ).length,
-	};
-	const countMapFixable = {
-		low: allFixableThreats.filter( ( threat ) => threat.severity < 3 ).length,
-		high: allFixableThreats.filter( ( threat ) => threat.severity >= 3 ).length,
-	};
+	const maxSeverity = React.useMemo(
+		() => threats.reduce( ( max, threat ) => Math.max( max, threat.severity ), 0 ),
+		[ threats ]
+	);
+	const countMap = React.useMemo(
+		() => ( {
+			low: threats.filter( ( threat ) => threat.severity < 3 ).length,
+			high: threats.filter( ( threat ) => threat.severity >= 3 ).length,
+		} ),
+		[ threats ]
+	);
+	const countMapFixable = React.useMemo(
+		() => ( {
+			low: allFixableThreats.filter( ( threat ) => threat.severity < 3 ).length,
+			high: allFixableThreats.filter( ( threat ) => threat.severity >= 3 ).length,
+		} ),
+		[ allFixableThreats ]
+	);
 
 	const headerSummary = getThreatCountMessage(
 		countMap.high,
@@ -216,10 +229,17 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 		securityIcon = 'okay';
 	}
 
-	const highSeverityThreats = threats
-		.filter( ( threat ) => threat.severity >= 3 )
-		.sort( ( a, b ) => b.severity - a.severity );
-	const lowSeverityThreats = threats.filter( ( threat ) => threat.severity < 3 );
+	const highSeverityThreats = React.useMemo(
+		() =>
+			threats
+				.filter( ( threat ) => threat.severity >= 3 )
+				.sort( ( a, b ) => b.severity - a.severity ),
+		[ threats ]
+	);
+	const lowSeverityThreats = React.useMemo(
+		() => threats.filter( ( threat ) => threat.severity < 3 ),
+		[ threats ]
+	);
 
 	return (
 		<>

--- a/client/components/jetpack/security-icon/index.tsx
+++ b/client/components/jetpack/security-icon/index.tsx
@@ -12,7 +12,7 @@ interface Props {
 }
 
 function SecurityIcon( props: Props ) {
-	const { icon, className } = props;
+	const { icon = 'success', className } = props;
 
 	let iconPath;
 	switch ( icon ) {
@@ -46,9 +46,5 @@ function SecurityIcon( props: Props ) {
 		/>
 	);
 }
-
-SecurityIcon.defaultProps = {
-	icon: 'success',
-};
 
 export default SecurityIcon;

--- a/client/components/jetpack/security-icon/index.tsx
+++ b/client/components/jetpack/security-icon/index.tsx
@@ -7,7 +7,7 @@ import infoIcon from './images/security-info.svg';
 import okayIcon from './images/security-okay.svg';
 
 interface Props {
-	icon: string;
+	icon?: string;
 	className?: string;
 }
 

--- a/client/components/jetpack/threat-history-list/index.tsx
+++ b/client/components/jetpack/threat-history-list/index.tsx
@@ -5,6 +5,7 @@ import { useCallback, useMemo, useState } from 'react';
 import * as React from 'react';
 import QueryJetpackScanHistory from 'calypso/components/data/query-jetpack-scan-history';
 import QueryJetpackScanThreatCounts from 'calypso/components/data/query-jetpack-scan-threat-counts';
+import { Threat } from 'calypso/components/jetpack/threat-item/types';
 import ThreatListHeader from 'calypso/components/jetpack/threat-list-header';
 import Pagination from 'calypso/components/pagination';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -80,7 +81,7 @@ const ThreatHistoryList: React.FC< ThreatHistoryListProps > = ( { filter } ) => 
 		isRequestingJetpackScanHistory( state, siteId )
 	);
 
-	const threats = useSelector( ( state ) => getSiteScanHistory( state, siteId ) );
+	const threats = useSelector( ( state ) => getSiteScanHistory( state, siteId ) as Threat[] );
 	const [ currentPage, setCurrentPage ] = useState( 1 );
 	const showPagination = ! isRequestingThreatCounts && filteredThreatCount > THREATS_PER_PAGE;
 

--- a/client/components/section-nav/tabs.jsx
+++ b/client/components/section-nav/tabs.jsx
@@ -4,9 +4,9 @@ import clsx from 'clsx';
 import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, Children, cloneElement, Component } from 'react';
+import ReactDom from 'react-dom';
 import TranslatableString from 'calypso/components/translatable/proptype';
 import afterLayoutFlush from 'calypso/lib/after-layout-flush';
-
 import './tabs.scss';
 
 /**
@@ -143,10 +143,12 @@ class NavTabs extends Component {
 	}
 
 	getTabWidths() {
-		const totalWidth = Array.from( this.tabRefMap.values() ).reduce(
-			( sum, tabElement ) => sum + tabElement.offsetWidth,
-			0
-		);
+		let totalWidth = 0;
+
+		this.tabRefMap.forEach( ( tabElement ) => {
+			const tabWidth = ReactDom.findDOMNode( tabElement ).offsetWidth;
+			totalWidth += tabWidth;
+		} );
 
 		this.tabsWidth = Math.max( totalWidth, this.tabsWidth || 0 );
 	}

--- a/client/components/section-nav/tabs.jsx
+++ b/client/components/section-nav/tabs.jsx
@@ -4,7 +4,6 @@ import clsx from 'clsx';
 import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, Children, cloneElement, Component } from 'react';
-import ReactDom from 'react-dom';
 import TranslatableString from 'calypso/components/translatable/proptype';
 import afterLayoutFlush from 'calypso/lib/after-layout-flush';
 
@@ -144,12 +143,10 @@ class NavTabs extends Component {
 	}
 
 	getTabWidths() {
-		let totalWidth = 0;
-
-		this.tabRefMap.forEach( ( tabElement ) => {
-			const tabWidth = ReactDom.findDOMNode( tabElement ).offsetWidth;
-			totalWidth += tabWidth;
-		} );
+		const totalWidth = Array.from( this.tabRefMap.values() ).reduce(
+			( sum, tabElement ) => sum + tabElement.offsetWidth,
+			0
+		);
 
 		this.tabsWidth = Math.max( totalWidth, this.tabsWidth || 0 );
 	}

--- a/client/controller/web-util.js
+++ b/client/controller/web-util.js
@@ -1,24 +1,9 @@
-import { createRoot, hydrateRoot } from 'react-dom/client';
-
-// Store the root instances to reuse them across renders
-let rootInstance = null;
-let hydrateRootInstance = null;
+import ReactDom from 'react-dom';
 
 export function render( context ) {
-	// Reuse the existing root if available, otherwise create a new one
-	if ( ! rootInstance ) {
-		rootInstance = createRoot( document.getElementById( 'wpcom' ) );
-	}
-
-	rootInstance.render( context.layout );
+	ReactDom.render( context.layout, document.getElementById( 'wpcom' ) );
 }
 
 export function hydrate( context ) {
-	// Reuse the existing hydrate root if available, otherwise create a new one
-	if ( ! hydrateRootInstance ) {
-		hydrateRootInstance = hydrateRoot( document.getElementById( 'wpcom' ), context.layout );
-	} else {
-		// For subsequent calls, use the update method on the existing instance
-		hydrateRootInstance.render( context.layout );
-	}
+	ReactDom.hydrate( context.layout, document.getElementById( 'wpcom' ) );
 }

--- a/client/controller/web-util.js
+++ b/client/controller/web-util.js
@@ -1,9 +1,12 @@
-import ReactDom from 'react-dom';
+import { createRoot, hydrateRoot } from 'react-dom/client';
 
 export function render( context ) {
-	ReactDom.render( context.layout, document.getElementById( 'wpcom' ) );
+	const container = document.getElementById( 'wpcom' );
+	const root = createRoot( container );
+	root.render( context.layout );
 }
 
 export function hydrate( context ) {
-	ReactDom.hydrate( context.layout, document.getElementById( 'wpcom' ) );
+	const container = document.getElementById( 'wpcom' );
+	hydrateRoot( container, context.layout );
 }

--- a/client/controller/web-util.js
+++ b/client/controller/web-util.js
@@ -1,12 +1,24 @@
 import { createRoot, hydrateRoot } from 'react-dom/client';
 
+// Store the root instances to reuse them across renders
+let rootInstance = null;
+let hydrateRootInstance = null;
+
 export function render( context ) {
-	const container = document.getElementById( 'wpcom' );
-	const root = createRoot( container );
-	root.render( context.layout );
+	// Reuse the existing root if available, otherwise create a new one
+	if ( ! rootInstance ) {
+		rootInstance = createRoot( document.getElementById( 'wpcom' ) );
+	}
+
+	rootInstance.render( context.layout );
 }
 
 export function hydrate( context ) {
-	const container = document.getElementById( 'wpcom' );
-	hydrateRoot( container, context.layout );
+	// Reuse the existing hydrate root if available, otherwise create a new one
+	if ( ! hydrateRootInstance ) {
+		hydrateRootInstance = hydrateRoot( document.getElementById( 'wpcom' ), context.layout );
+	} else {
+		// For subsequent calls, use the update method on the existing instance
+		hydrateRootInstance.render( context.layout );
+	}
 }

--- a/client/lib/jetpack/use-threats.ts
+++ b/client/lib/jetpack/use-threats.ts
@@ -12,7 +12,21 @@ import getSiteScanUpdatingThreats from 'calypso/state/selectors/get-site-scan-up
 
 export const useThreats = ( siteId: number ) => {
 	const [ selectedThreat, setSelectedThreat ] = useState< Threat >();
-	const updatingThreats = useSelector( ( state ) => getSiteScanUpdatingThreats( state, siteId ) );
+	const updatingThreats = useSelector(
+		( state ) => {
+			return getSiteScanUpdatingThreats( state, siteId );
+		},
+		( a, b ) => {
+			// Compare arrays by reference first, then by contents
+			if ( a === b ) {
+				return true;
+			}
+			if ( ! a || ! b || a.length !== b.length ) {
+				return false;
+			}
+			return a.every( ( val, idx ) => val === b[ idx ] );
+		}
+	);
 	const dispatch = useDispatch();
 
 	const updateThreat = useCallback(

--- a/client/state/selectors/get-site-scan-history.js
+++ b/client/state/selectors/get-site-scan-history.js
@@ -1,3 +1,4 @@
+import { createSelector } from '@automattic/state-utils';
 import { get } from 'lodash';
 
 import 'calypso/state/data-layer/wpcom/sites/scan';
@@ -9,6 +10,7 @@ import 'calypso/state/data-layer/wpcom/sites/scan';
  * @param  {number}   siteId   The ID of the site we're querying
  * @returns {import('calypso/components/jetpack/threat-item/types').Threat[]} Array of threats found
  */
-export default function getSiteScanHistory( state, siteId ) {
-	return get( state, [ 'jetpackScan', 'history', 'data', siteId, 'threats' ], [] );
-}
+export default createSelector(
+	( state, siteId ) => get( state, [ 'jetpackScan', 'history', 'data', siteId, 'threats' ], [] ),
+	( state, siteId ) => [ state.jetpackScan?.history?.data?.[ siteId ]?.threats ]
+);

--- a/client/state/selectors/get-site-scan-threat-counts.ts
+++ b/client/state/selectors/get-site-scan-threat-counts.ts
@@ -1,3 +1,4 @@
+import { createSelector } from '@automattic/state-utils';
 import { AppState } from 'calypso/types';
 
 import 'calypso/state/data-layer/wpcom/sites/scan';
@@ -25,9 +26,9 @@ const NO_INFO: JetpackScanThreatCounts = {};
  * @param  {number}   siteId   		The ID of the site we're querying
  * @returns {JetpackScanThreatCounts} Threat counts, by status
  */
-export default function getSiteScanThreatCounts(
-	state: AppState,
-	siteId: number
-): JetpackScanThreatCounts {
-	return state.jetpackScan.threatCounts.data?.[ siteId ] || NO_INFO;
-}
+export default createSelector(
+	( state: AppState, siteId: number ): JetpackScanThreatCounts => {
+		return state.jetpackScan.threatCounts.data?.[ siteId ] || NO_INFO;
+	},
+	( state: AppState, siteId: number ) => [ state.jetpackScan?.threatCounts?.data?.[ siteId ] ]
+);

--- a/client/state/selectors/is-requesting-jetpack-scan-history.js
+++ b/client/state/selectors/is-requesting-jetpack-scan-history.js
@@ -1,3 +1,4 @@
+import { createSelector } from '@automattic/state-utils';
 import { get } from 'lodash';
 
 import 'calypso/state/data-layer/wpcom/sites/scan/history';
@@ -9,6 +10,8 @@ import 'calypso/state/data-layer/wpcom/sites/scan/history';
  * @param  {number}   siteId   The ID of the site we're querying
  * @returns {?boolean}          Whether the connection data is being requested
  */
-export default function isRequestingJetpackScanHistory( state, siteId ) {
-	return get( state.jetpackScan.history.requestStatus, [ siteId ], false ) === 'pending';
-}
+export default createSelector(
+	( state, siteId ) =>
+		get( state.jetpackScan.history.requestStatus, [ siteId ], false ) === 'pending',
+	( state, siteId ) => [ state.jetpackScan?.history?.requestStatus?.[ siteId ] ]
+);

--- a/client/state/selectors/is-requesting-jetpack-scan-threat-counts.js
+++ b/client/state/selectors/is-requesting-jetpack-scan-threat-counts.js
@@ -1,3 +1,5 @@
+import { createSelector } from '@automattic/state-utils';
+
 import 'calypso/state/data-layer/wpcom/sites/scan/threat-counts';
 
 /**
@@ -7,6 +9,7 @@ import 'calypso/state/data-layer/wpcom/sites/scan/threat-counts';
  * @param  {number}   siteId   The ID of the site we're querying
  * @returns {?boolean}          Whether the connection data is being requested
  */
-export default function isRequestingJetpackScanThreatCounts( state, siteId ) {
-	return state.jetpackScan.threatCounts.requestStatus?.[ siteId ] === 'pending';
-}
+export default createSelector(
+	( state, siteId ) => state.jetpackScan.threatCounts.requestStatus?.[ siteId ] === 'pending',
+	( state, siteId ) => [ state.jetpackScan?.threatCounts?.requestStatus?.[ siteId ] ]
+);


### PR DESCRIPTION
Please excuse the weirdly named git branch - I set out to do something else but then decided to clean this up first. 

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

I have commented on the individual parts, but essentially get rid of all warnings on the `/scan/` pages. With the added memoization and avoiding unnecessary rerenders, this should also improve the performance a little bit.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* So we don't get to a state where we can't see the forst for all the trees.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Locally (or on the calypso cloud links provided here), navigate to `/scan/<your-site-domain>` and then:
* Open your browser console to watch out for any errors / warnings coming up (there should be none, except the ones that have been extracted into https://github.com/Automattic/wp-calypso/pull/104844)
* Click around to navigate between the "Scanner" and "History" tabs
* The individual tabs in the history should also all still work
* Make sure you can still see all the threat details decently (it expands and looks as before).
* Bonus points for clicking around in other places of Calypso, as some of these changes are fairly global and do not only affect the scan pages.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
    - [ ] ~~For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?~~
