### PR TITLE
Bump composite-checkout package to v2

### DIFF
--- a/packages/composite-checkout/CHANGELOG.md
+++ b/packages/composite-checkout/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## v1.0.0
 
 - Initial release.
+
+## v2.0.0
+
+A lot of changes have happened in the last 4 years. You'll probably need to look at the changelog to find details.

--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/composite-checkout",
-	"version": "1.0.0",
+	"version": "2.0.0",
 	"description": "A set of React components and helpers that can be used to create a checkout flow.",
 	"main": "dist/cjs/public-api.js",
 	"module": "dist/esm/public-api.js",


### PR DESCRIPTION

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of CHE-223

## Proposed Changes

This PR bumps the version of the `@automattic/composite-checkout` package from 1.0 to 2.0.

This seems like a safe idea. It's too hard to try to figure out what may have changed.

## Why are these changes being made?

As part of a new project (https://linear.app/a8c/project/ciab-billing-581df72549f7/overview) we want to attempt to render the `mini-cart` in wp-admin on a remote site. This was always the intent of the `@automattic/mini-cart` package, but since we didn't have a use-case, it was never yet attempted. As a first step to doing this, we need to publish the package, but it depends on the current version of the `@automattic/composite-checkout` package which hasn't been updated in 4 years.

## Testing Instructions

None should be required.
