### PR TITLE
Hundred year flows: Fix domain page layout issues and step wrapper logo

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
@@ -186,9 +186,9 @@ const StyledFoldableCard = styled( FoldableCard )`
 	}
 `;
 
-const WordPressLogoWrapper = styled.div`
+const WordPressLogoWrapper = styled.div< { isMobile: boolean } >`
 	position: absolute;
-	top: 16px;
+	top: ${ ( props ) => ( props.isMobile ? '24px' : '16px' ) };
 	left: 16px;
 `;
 
@@ -248,7 +248,7 @@ function InfoColumn( {
 				className="hundred-year-plan-step-wrapper__info-column-container"
 				isMobile={ isMobile }
 			>
-				<WordPressLogoWrapper>
+				<WordPressLogoWrapper isMobile={ isMobile }>
 					<WordPressWordmark />
 				</WordPressLogoWrapper>
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/style.scss
@@ -1,4 +1,4 @@
-@import "@automattic/onboarding/styles/mixins";
+@import '@automattic/onboarding/styles/mixins';
 
 /**
  * A different selector (not `.step-container.${flowName}`) is needed for the 100-year domain transfer
@@ -8,47 +8,57 @@
  */
 .step-container.hundred-year-plan.hundred-year-plan,
 .step-container.hundred-year-domain.hundred-year-domain,
-.hundred-year-domain-transfer>.step-container.domain-transfer {
-	max-width: none;
-	height: 100%;
-	padding: 0;
-	
-	.step-container__content {
-		min-height: 100%;
-	}
+.hundred-year-domain-transfer > .step-container.domain-transfer {
+	&,
+	.domain-search-legacy--stepper & {
+		max-width: none;
+		height: 100%;
+		padding: 0;
 
-	.step-container__navigation.action-buttons .step-container__navigation-logo {
-		fill: var(--studio-gray-0);
-		stroke: var(--studio-gray-0);
-	}
-
-	.hundred-year-plan-step-wrapper__info-column-container {
-		@media (min-width: 960px) {
-			background-image: url(calypso/assets/images/hundred-year-plan-onboarding/stars-solo.webp);
-			background-color: #000;
+		.step-container__content {
+			min-height: 100%;
 		}
 
-		.is-price-loading {
-			@include onboarding-placeholder;
-			width: 100px;
-		}
-	}
-
-	&.step-container.domain-transfer {
-		margin-top: 0;
-		width: 100%;
-
-		.hundred-year-plan-step-wrapper__step-container {
-			max-width: $break-large;
-			box-sizing: border-box;
-			padding: 0 20px;
+		.step-container__navigation.action-buttons .step-container__navigation-logo {
+			fill: var( --studio-gray-0 );
+			stroke: var( --studio-gray-0 );
 		}
 
 		.hundred-year-plan-step-wrapper__info-column-container {
+			@media ( min-width: 960px ) {
+				background-image: url( calypso/assets/images/hundred-year-plan-onboarding/stars-solo.webp );
+				background-color: #000;
+			}
+
 			.is-price-loading {
 				@include onboarding-placeholder;
 				width: 100px;
 			}
 		}
+
+		&.step-container.domain-transfer {
+			margin-top: 0;
+			width: 100%;
+
+			.hundred-year-plan-step-wrapper__step-container {
+				max-width: $break-large;
+				box-sizing: border-box;
+				padding: 0 20px;
+			}
+
+			.hundred-year-plan-step-wrapper__info-column-container {
+				.is-price-loading {
+					@include onboarding-placeholder;
+					width: 100px;
+				}
+			}
+		}
+	}
+}
+
+.hundred-year-plan.step-route,
+.hundred-year-domain.step-route {
+	.signup-header {
+		display: none;
 	}
 }


### PR DESCRIPTION
## Proposed Changes

Fixes a bug, probably introduced in https://github.com/Automattic/wp-calypso/pull/104633, which made the 100-year domains page feel broken. It also fixes an unrelated issue with the logo where the 100-year logo was overlapping the WPCOM logo. The 100-year logo was also in black and kind of redundant because we're rendering the WPCOM trademark, so I just removed it.

### Mobile

| Before | After |
| ------ | ----- |
| <img width="979" height="1167" alt="Screenshot 2025-07-11 alle 7 57 42 PM" src="https://github.com/user-attachments/assets/d89bde25-0ef1-4863-abf5-149d740aabf7" /> | <img width="979" height="1167" alt="Screenshot 2025-07-11 alle 7 57 46 PM" src="https://github.com/user-attachments/assets/705281de-c7c7-4f1f-9e3d-c202a56aa8db" /> |

### Desktop

| Before | After |
| ------ | ----- |
| <img width="2032" height="1167" alt="Screenshot 2025-07-11 alle 7 57 37 PM" src="https://github.com/user-attachments/assets/e581ac50-0992-4d7e-a5ee-2d571e496579" /> | <img width="2032" height="1167" alt="Screenshot 2025-07-11 alle 7 57 24 PM" src="https://github.com/user-attachments/assets/48250b82-2a0a-4215-a612-ae1196fe832b" /> |


## Testing Instructions

Enter `/setup/hundred-year-plan` and go through the steps. They should render to the full width of the screen, including the domains page. Enable the `domains/ui-redesign` feature flag and verify it doesn't change the visuals of the page - you should see the same with the feature flag enabled and disabled.

Do the same for `/setup/hundred-year-domain`.