### PR TITLE
Sites List v2: Make URL field clickable

### DIFF
--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -89,7 +89,9 @@ export function URL( { site, value }: { site: Site; value: string } ) {
 	return site.is_deleted ? (
 		<Text variant="muted">{ value }</Text>
 	) : (
-		<span style={ titleFieldTextOverflowStyles }>{ value }</span>
+		<ExternalLink style={ titleFieldTextOverflowStyles } href={ site.URL }>
+			{ value }
+		</ExternalLink>
 	);
 }
 

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -33,6 +33,8 @@ import SitePreview from '../site-preview';
 import { JetpackLogo } from './jetpack-logo';
 import type { AtomicTransferStatus, Site } from '../../data/types';
 
+import './style.scss';
+
 function IneligibleIndicator() {
 	return <Text color="#CCCCCC">-</Text>;
 }
@@ -89,7 +91,11 @@ export function URL( { site, value }: { site: Site; value: string } ) {
 	return site.is_deleted ? (
 		<Text variant="muted">{ value }</Text>
 	) : (
-		<ExternalLink style={ titleFieldTextOverflowStyles } href={ site.URL }>
+		<ExternalLink
+			className="dataviews-url-field"
+			style={ titleFieldTextOverflowStyles }
+			href={ site.URL }
+		>
 			{ value }
 		</ExternalLink>
 	);

--- a/client/dashboard/sites/site-fields/style.scss
+++ b/client/dashboard/sites/site-fields/style.scss
@@ -1,0 +1,13 @@
+@import '@wordpress/base-styles/colors';
+
+.dataviews-url-field {
+	color: $gray-700;
+
+	&:hover {
+		color: var(--wp-admin-theme-color);
+	}
+
+	span {
+		text-decoration: none;
+	}
+}


### PR DESCRIPTION
Ref DOTDASH-141

## Proposed Changes

This PR makes the DataViews site URL clickable and open the site front end in a new tab. IMO it makes the table view a bit too busy, while in the grid view is okay. I'll defer to @matt-west whether this is acceptable design-wise.

| Table view | Grid view |
| --- | --- |
| <img width="1381" height="970" alt="SCR-20250714-jlhm" src="https://github.com/user-attachments/assets/6234e442-3a89-4a34-a5f1-faf0ac96455d" /> | <img width="1374" height="706" alt="SCR-20250714-jlnh" src="https://github.com/user-attachments/assets/157b3219-4495-4938-878e-27a5f1d1070b" /> |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Enhancement.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Ensure that the site URL field is now clickable

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
