### PR TITLE
Support events: Add check for null

### DIFF
--- a/apps/happy-blocks/block-library/search-card/view.js
+++ b/apps/happy-blocks/block-library/search-card/view.js
@@ -30,10 +30,12 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		} );
 	} );
 
-	form.addEventListener( 'submit', function () {
-		recordTracksEvent( 'calypso_happyblocks_support_custom_search', {
-			query: input.value,
-			location: window.location.href,
+	if ( form ) {
+		form.addEventListener( 'submit', function () {
+			recordTracksEvent( 'calypso_happyblocks_support_custom_search', {
+				query: input.value,
+				location: window.location.href,
+			} );
 		} );
-	} );
+	}
 } );


### PR DESCRIPTION
We added events for the search card that shows on /support.
This PR adds a check that form is present before adding the tracking event, to avoid an error

<img width="451" height="63" alt="image" src="https://github.com/user-attachments/assets/3020df5a-bd5d-4fce-92f7-a71ea4a6a3b1" />
