### PR TITLE
Update Studio download links on /me/get-apps to v1.5.5

### DIFF
--- a/client/blocks/get-apps/apps-config.tsx
+++ b/client/blocks/get-apps/apps-config.tsx
@@ -160,17 +160,17 @@ export const createWordPressStudioConfig = (
 			[ PlatformType.MacIntel ]: {
 				...platformConfigs[ PlatformType.MacIntel ],
 				onClick: () => recordTracksEvent( 'calypso_studio_download_mac_click' ),
-				link: 'https://cdn.a8c-ci.services/studio/studio-darwin-x64-v1.5.4.dmg',
+				link: 'https://cdn.a8c-ci.services/studio/studio-darwin-x64-v1.5.5.dmg',
 			},
 			[ PlatformType.MacSilicon ]: {
 				...platformConfigs[ PlatformType.MacSilicon ],
 				onClick: () => recordTracksEvent( 'calypso_studio_download_mac_silicon_click' ),
-				link: 'https://cdn.a8c-ci.services/studio/studio-darwin-arm64-v1.5.4.dmg',
+				link: 'https://cdn.a8c-ci.services/studio/studio-darwin-arm64-v1.5.5.dmg',
 			},
 			[ PlatformType.Windows ]: {
 				...platformConfigs[ PlatformType.Windows ],
 				onClick: () => recordTracksEvent( 'calypso_studio_download_windows_click' ),
-				link: 'https://cdn.a8c-ci.services/studio/studio-win32-v1.5.4.exe',
+				link: 'https://cdn.a8c-ci.services/studio/studio-win32-v1.5.5.exe',
 			},
 		},
 	};


### PR DESCRIPTION
## Proposed Changes

* Update the download links for Studio on https://wordpress.com/me/get-apps to match with the latest Studio release version 1.5.5.

## Why are these changes being made?

pfHvTO-zo-p2

## Testing Instructions

Visual review should suffice, but optionally:
* Navigate to `/me/get-apps`.
* Ensure that the download URLs for Studio are for v1.5.5 and work as expected.