### PR TITLE
Connect Refresh: Magin login - ensure link to reset-your-password is to the unified screen

### DIFF
--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -8,7 +8,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import RedirectWhenLoggedIn from 'calypso/components/redirect-when-logged-in';
 import { preventWidows } from 'calypso/lib/formatting/prevent-widows';
-import { login, lostPassword } from 'calypso/lib/paths';
+import { login } from 'calypso/lib/paths';
 import {
 	recordPageViewWithClientId as recordPageView,
 	enhanceWithSiteType,
@@ -68,21 +68,17 @@ class EmailedLoginLinkSuccessfully extends Component {
 	}
 
 	onLostPasswordClick = ( event ) => {
+		event.preventDefault();
 		recordTracksEvent( 'calypso_magic_login_lost_password_click' );
-
-		if ( this.props.isWCCOM ) {
-			event.preventDefault();
-
-			page(
-				login( {
-					redirectTo: this.props.redirectTo,
-					locale: this.props.locale,
-					action: 'lostpassword',
-					oauth2ClientId: this.props.oauth2Client && this.props.oauth2Client.id,
-					from: get( this.props.currentQuery, 'from' ),
-				} )
-			);
-		}
+		page(
+			login( {
+				redirectTo: this.props.redirectTo,
+				locale: this.props.locale,
+				action: 'lostpassword', // TODO add jetpack/lostpassword
+				oauth2ClientId: this.props.oauth2Client && this.props.oauth2Client.id,
+				from: get( this.props.currentQuery, 'from' ),
+			} )
+		);
 	};
 
 	render() {
@@ -107,13 +103,7 @@ class EmailedLoginLinkSuccessfully extends Component {
 							"Didn't get the email? You might want to double check if the email address is associated with your account,{{a}}or reset your password.{{/a}}",
 							{
 								components: {
-									a: (
-										<a
-											href={ lostPassword( { locale: this.props.locale } ) }
-											onClick={ this.onLostPasswordClick }
-											rel="noopener noreferrer"
-										/>
-									),
+									a: <a href="/" onClick={ this.onLostPasswordClick } rel="noopener noreferrer" />,
 								},
 							}
 						) }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-13795/login-magic-login-fix-lost-password-links-in-footers-to-point-to-the

## Proposed Changes

The links to "reset password" in the Magic Login page should point to the unified lost-password screen, not the WP Admin one.

- From:
  <img width="500" height="426" alt="Screenshot 2025-07-14 at 7 12 36 PM" src="https://github.com/user-attachments/assets/5c5befd0-901c-40e5-872d-d4b7de198101" />

- To:
  <img width="500" height="524" alt="Screenshot 2025-07-14 at 7 14 34 PM" src="https://github.com/user-attachments/assets/ce39b5b0-9aa2-482e-90a5-fb7174aa41d2" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-13795/login-magic-login-fix-lost-password-links-in-footers-to-point-to-the

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/log-in/link`, enter a valid email and confirm
* On next screen, click on on "reset your password" and confirm the unified screen shows
* Try with [different OAuth client Logins](https://linear.app/a8c/project/login-and-signup-unify-design-and-layout-16a857e58712/overview)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
