### PR TITLE
Connect Refresh: Magic login - deprecate `calypso_magic_login_lost_password_click` Tracks event

### DIFF
--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -69,6 +69,7 @@ class EmailedLoginLinkSuccessfully extends Component {
 
 	onLostPasswordClick = ( event ) => {
 		event.preventDefault();
+		// This was tracked with `calypso_magic_login_lost_password_click`, check that event for older analytics
 		recordTracksEvent( 'calypso_login_lost_password_click', {
 			from: 'magic-login',
 		} );

--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -69,7 +69,9 @@ class EmailedLoginLinkSuccessfully extends Component {
 
 	onLostPasswordClick = ( event ) => {
 		event.preventDefault();
-		recordTracksEvent( 'calypso_magic_login_lost_password_click' );
+		recordTracksEvent( 'calypso_login_lost_password_click', {
+			from: 'magic-login',
+		} );
 		page(
 			login( {
 				redirectTo: this.props.redirectTo,


### PR DESCRIPTION


<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13219/login-magic-login-update-and-unify-magic-login-screens

## Proposed Changes

We have two Tracks events used for "lost-password" click tracking (one for the regular Login screen and another for Magic Login):
- `calypso_magic_login_lost_password_click`
- `calypso_login_lost_password_click`

We deprecate the first in favour of using the second as a default. We pass the property `from: "magic-login"` instead.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13219/login-magic-login-update-and-unify-magic-login-screens

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm with someone from data/analytics that this is ok cc @vladolaru perhaps? 🤔 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
