### PR TITLE
Safe Image URLs: do not pass AVIF images through Photon

### DIFF
--- a/packages/calypso-url/src/safe-image-url/index.ts
+++ b/packages/calypso-url/src/safe-image-url/index.ts
@@ -82,8 +82,8 @@ export function safeImageUrl( url?: string | null ) {
 		url = getUrlFromParts( parsedUrl ).toString();
 	}
 
-	// Photon doesn't support SVGs
-	if ( parsedUrl.pathname.endsWith( '.svg' ) ) {
+	// Photon doesn't support SVGs or AVIF
+	if ( parsedUrl.pathname.endsWith( '.svg' ) || parsedUrl.pathname.endsWith( '.avif' ) ) {
 		return null;
 	}
 

--- a/packages/calypso-url/src/safe-image-url/test/index.js
+++ b/packages/calypso-url/src/safe-image-url/test/index.js
@@ -135,6 +135,11 @@ describe( 'safeImageUrl()', () => {
 			expect( safeImageUrl( 'https://example.com/foo.svg' ) ).toBeNull();
 			expect( safeImageUrl( 'https://example.com/foo.svg?ssl=1' ) ).toBeNull();
 		} );
+
+		test( 'should return null for AVIF images', () => {
+			expect( safeImageUrl( 'https://example.com/foo.avif' ) ).toBeNull();
+			expect( safeImageUrl( 'https://example.com/foo.avif?ssl=1' ) ).toBeNull();
+		} );
 	}
 
 	describe( 'browser', () => {


### PR DESCRIPTION
Fixes CML-653

## Proposed Changes, why are these changes being made?

Photon does not support AVIF yet, so we should not attempt to display AVIF images through Photon in places like the Reader.

Related: https://github.com/Automattic/jetpack/issues/35432

Past work on this, for SVGs: #26102

## Testing Instructions

* Load http://calypso.localhost:3000/reader/feeds/157579156/posts/5685097858
* You should see the image
* Check if tests pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
