### PR TITLE
ActivityPub: Redirect to Onboarding after activation

### DIFF
--- a/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
+++ b/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
@@ -10,6 +10,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import useSiteDomains from 'calypso/my-sites/checkout/src/hooks/use-site-domains.ts';
 import { domainAddNew } from 'calypso/my-sites/domains/paths';
+import { getSiteAdminUrl } from 'calypso/sites-dashboard/utils';
 import { useActivityPubStatus } from 'calypso/state/activitypub/use-activitypub-status';
 import { successNotice } from 'calypso/state/notices/actions';
 import {
@@ -191,6 +192,11 @@ export const WpcomFediverseSettingsSection = ( { siteId } ) => {
 	const { isEnabled, setEnabled, isLoading, isError, data } = useActivityPubStatus(
 		siteId,
 		( response ) => {
+			if ( response.enabled ) {
+				// Redirect to the ActivityPub onboarding checklist.
+				window.location.href = getSiteAdminUrl( site ) + 'options-general.php?page=activitypub';
+			}
+
 			const message = response.enabled
 				? translate( '%(site_title)s has entered the fediverse!', noticeArgs )
 				: translate( '%(site_title)s has exited the fediverse.', noticeArgs );

--- a/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
+++ b/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
@@ -10,13 +10,13 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import useSiteDomains from 'calypso/my-sites/checkout/src/hooks/use-site-domains.ts';
 import { domainAddNew } from 'calypso/my-sites/domains/paths';
-import { getSiteAdminUrl } from 'calypso/sites-dashboard/utils';
 import { useActivityPubStatus } from 'calypso/state/activitypub/use-activitypub-status';
 import { successNotice } from 'calypso/state/notices/actions';
 import {
 	getSiteTitle,
 	getSiteDomain,
 	getSite,
+	getSiteAdminUrl,
 	getSitePlanSlug,
 } from 'calypso/state/sites/selectors';
 
@@ -183,6 +183,9 @@ export const WpcomFediverseSettingsSection = ( { siteId } ) => {
 	const siteTitle = useSelector( ( state ) => getSiteTitle( state, siteId ) );
 	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
 	const site = useSelector( ( state ) => getSite( state, siteId ) );
+	const activityPubSettingsUrl = useSelector( ( state ) =>
+		getSiteAdminUrl( state, siteId, 'options-general.php?page=activitypub' )
+	);
 	const isPrivate = site?.is_private || site?.is_coming_soon;
 	const noticeArgs = {
 		args: {
@@ -194,7 +197,7 @@ export const WpcomFediverseSettingsSection = ( { siteId } ) => {
 		( response ) => {
 			if ( response.enabled ) {
 				// Redirect to the ActivityPub onboarding checklist.
-				window.location.href = getSiteAdminUrl( site ) + 'options-general.php?page=activitypub';
+				window.location.href = activityPubSettingsUrl;
 			}
 
 			const message = response.enabled


### PR DESCRIPTION
## Proposed Changes

* Redirects to ActivityPub onboarding checklist after activating the feature.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We're hoping this will make it easier for folks to get started with the feature, by familiarizing themselves with some key concepts.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR and start the dev env: `yarn && yarn start` or use Calypso.live.
* Select a test site on Simple. It doesn't matter whether it has ActivityPub enabled or not.
* Go to Tools (Marketing) > Connections and find "Fediverse"
* Enable the setting and make sure you get redirected to the correct onboarding screen successfully.
* If already enabled, disable and make sure the notice still appears. Then go back to the step above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
