### PR TITLE
Restore and fix copy-assets to wpcom-checkout

### DIFF
--- a/packages/wpcom-checkout/package.json
+++ b/packages/wpcom-checkout/package.json
@@ -17,7 +17,7 @@
 	"sideEffects": false,
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
@@ -64,6 +64,7 @@
 		"prop-types": "^15.8.1"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@testing-library/dom": "^10.4.0",
 		"@testing-library/jest-dom": "^6.6.3",

--- a/packages/wpcom-checkout/package.json
+++ b/packages/wpcom-checkout/package.json
@@ -61,6 +61,7 @@
 		"@wordpress/react-i18n": "^4.23.0",
 		"debug": "^4.4.1",
 		"i18n-calypso": "workspace:^",
+		"postcss": "^8.5.3",
 		"prop-types": "^15.8.1"
 	},
 	"devDependencies": {
@@ -71,7 +72,8 @@
 		"@testing-library/react": "^16.3.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "^5.8.3"
+		"typescript": "^5.8.3",
+		"webpack": "^5.99.8"
 	},
 	"peerDependencies": {
 		"@emotion/react": "^11.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -698,28 +698,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/calypso-shopping-cart-item-components@workspace:packages/calypso-shopping-cart-item-components":
-  version: 0.0.0-use.local
-  resolution: "@automattic/calypso-shopping-cart-item-components@workspace:packages/calypso-shopping-cart-item-components"
-  dependencies:
-    "@automattic/calypso-config": "workspace:^"
-    "@automattic/calypso-products": "workspace:^"
-    "@automattic/calypso-typescript-config": "workspace:^"
-    "@automattic/composite-checkout": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.0.1"
-    "@automattic/shopping-cart": "workspace:^"
-    "@emotion/styled": "npm:^11.11.0"
-    "@wordpress/i18n": "npm:^5.23.0"
-    "@wordpress/react-i18n": "npm:^4.23.0"
-    react: "npm:^18.3.1"
-    react-dom: "npm:^18.3.1"
-    typescript: "npm:^5.8.3"
-  peerDependencies:
-    "@emotion/react": ^11.4.1
-    redux: ^5.0.1
-  languageName: unknown
-  linkType: soft
-
 "@automattic/calypso-storybook@workspace:^, @automattic/calypso-storybook@workspace:packages/calypso-storybook":
   version: 0.0.0-use.local
   resolution: "@automattic/calypso-storybook@workspace:packages/calypso-storybook"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2424,10 +2424,12 @@ __metadata:
     "@wordpress/react-i18n": "npm:^4.23.0"
     debug: "npm:^4.4.1"
     i18n-calypso: "workspace:^"
+    postcss: "npm:^8.5.3"
     prop-types: "npm:^15.8.1"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     typescript: "npm:^5.8.3"
+    webpack: "npm:^5.99.8"
   peerDependencies:
     "@emotion/react": ^11.4.1
     redux: ^5.0.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -698,6 +698,28 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@automattic/calypso-shopping-cart-item-components@workspace:packages/calypso-shopping-cart-item-components":
+  version: 0.0.0-use.local
+  resolution: "@automattic/calypso-shopping-cart-item-components@workspace:packages/calypso-shopping-cart-item-components"
+  dependencies:
+    "@automattic/calypso-config": "workspace:^"
+    "@automattic/calypso-products": "workspace:^"
+    "@automattic/calypso-typescript-config": "workspace:^"
+    "@automattic/composite-checkout": "workspace:^"
+    "@automattic/number-formatters": "npm:^1.0.1"
+    "@automattic/shopping-cart": "workspace:^"
+    "@emotion/styled": "npm:^11.11.0"
+    "@wordpress/i18n": "npm:^5.23.0"
+    "@wordpress/react-i18n": "npm:^4.23.0"
+    react: "npm:^18.3.1"
+    react-dom: "npm:^18.3.1"
+    typescript: "npm:^5.8.3"
+  peerDependencies:
+    "@emotion/react": ^11.4.1
+    redux: ^5.0.1
+  languageName: unknown
+  linkType: soft
+
 "@automattic/calypso-storybook@workspace:^, @automattic/calypso-storybook@workspace:packages/calypso-storybook":
   version: 0.0.0-use.local
   resolution: "@automattic/calypso-storybook@workspace:packages/calypso-storybook"
@@ -2401,6 +2423,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/wpcom-checkout@workspace:packages/wpcom-checkout"
   dependencies:
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-config": "workspace:^"
     "@automattic/calypso-products": "workspace:^"
     "@automattic/calypso-razorpay": "npm:^0.0.1"


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of CHE-223

## Proposed Changes

This PR reverts part of https://github.com/Automattic/wp-calypso/pull/104709 which removed the `copy-assets` script from the `@automattic/wpcom-checkout` package, but it turns out that package requires it to correctly bundle its svg images. It also fixes the build process which was missing several devDependencies.

## Testing Instructions

Run the following and verify there are no errors

```
cd packages/wpcom-checkout && yarn build
```
