### PR TITLE
Subscriptions settings: Fix copy for block emails setting

### DIFF
--- a/client/landing/subscriptions/components/fields/block-emails-setting/block-emails-setting.tsx
+++ b/client/landing/subscriptions/components/fields/block-emails-setting/block-emails-setting.tsx
@@ -22,7 +22,9 @@ const BlockEmailsSetting = ( { value, onChange }: BlockEmailsSettingProps ) => {
 					<FormInputCheckbox id="blocked" name="blocked" checked={ value } onChange={ onChange } />
 				</div>
 				<span>
-					{ translate( 'Pause all email updates from sites you’re subscribing on WordPress.com' ) }
+					{ translate(
+						'Pause all email updates from sites you’re subscribed to on WordPress.com'
+					) }
 				</span>
 			</FormLabel>
 		</FormFieldset>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Fix the copy for the logged-out block emails setting, which didn't make sense and should match the logged-in copy.

Before | After
---- | ----
<img width="1107" height="704" alt="Screenshot 2025-07-14 at 11 26 09 AM" src="https://github.com/user-attachments/assets/2643f966-208e-4db8-9ac5-31589812d659" /> | <img width="683" height="675" alt="Screenshot 2025-07-14 at 4 48 40 PM" src="https://github.com/user-attachments/assets/71bcb9e4-74d4-4eb1-bc21-1ad6a60d6e7a" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* I noticed the copy was weird when directing a user there.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In an incog window, go to subscribe.wordpress.com.
* Enter an email that's not associated with a WordPress.com account.
* Click Settings to open that tab.
* Switch your URL to calypso.live or calypso.localhost to see the change.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
