### PR TITLE
Bump wpcom-checkout package to 1.0.1

### DIFF
--- a/packages/wpcom-checkout/package.json
+++ b/packages/wpcom-checkout/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-checkout",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Functions and components used by WordPress.com checkout.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of CHE-223

## Proposed Changes

This PR bumps `@automattic/wpcom-checkout` from 1.0.0 to 1.0.1 since https://github.com/Automattic/wp-calypso/pull/104740 was merged.


## Testing Instructions

None
