### PR TITLE
Site Overview: Responsive layout

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -505,6 +505,7 @@ module.exports = {
 				'@wordpress/components': [
 					'__experimentalConfirmDialog',
 					'__experimentalDivider',
+					'__experimentalGrid',
 					'__experimentalHStack',
 					'__experimentalVStack',
 					'__experimentalSpacer',

--- a/client/dashboard/app-a4a/style.scss
+++ b/client/dashboard/app-a4a/style.scss
@@ -14,6 +14,9 @@
 	--wp-admin-theme-color-darker-20--rgb: 0, 90, 135;
 	--wp-admin-border-width-focus: 2px;
 
+	// Components
+	--wp-components-color-gray-100: #f0f0f0;
+
 	// Layout
 	--dashboard__background-color: #fcfcfc;
 	--dashboard__text-color: #{$gray-900};

--- a/client/dashboard/app-a4a/style.scss
+++ b/client/dashboard/app-a4a/style.scss
@@ -14,9 +14,6 @@
 	--wp-admin-theme-color-darker-20--rgb: 0, 90, 135;
 	--wp-admin-border-width-focus: 2px;
 
-	// Components
-	--wp-components-color-gray-100: #f0f0f0;
-
 	// Layout
 	--dashboard__background-color: #fcfcfc;
 	--dashboard__text-color: #{$gray-900};
@@ -36,4 +33,7 @@
 
 	// Headings
 	--dashboard-h1__font-weight: 600;
+
+	// Overview
+	--dashboard-overview__divider-color: #{$gray-100};
 }

--- a/client/dashboard/app-a4a/style.scss
+++ b/client/dashboard/app-a4a/style.scss
@@ -17,6 +17,7 @@
 	// Layout
 	--dashboard__background-color: #fcfcfc;
 	--dashboard__text-color: #{$gray-900};
+	--dashboard__text-max-width: 660px;
 
 	// Header bar
 	--dashboard-header__background-color: #021A23;

--- a/client/dashboard/app-dotcom/style.scss
+++ b/client/dashboard/app-dotcom/style.scss
@@ -35,6 +35,7 @@
 	// Headings
 	--dashboard-h1__font-size: 40px;
 	--dashboard-h1__font-weight: 400;
+	--dashboard-h1__line-height: 54px;
 	--dashboard-h1__font-family: Recoleta, sans-serif;
 
 	// Overview

--- a/client/dashboard/app-dotcom/style.scss
+++ b/client/dashboard/app-dotcom/style.scss
@@ -17,6 +17,7 @@
 	// Layout
 	--dashboard__background-color: #fcfcfc;
 	--dashboard__text-color: #{$gray-900};
+	--dashboard__text-max-width: 660px;
 
 	// Header bar
 	--dashboard-header__background-color: rgba(252, 252, 252, 0.90);

--- a/client/dashboard/app-dotcom/style.scss
+++ b/client/dashboard/app-dotcom/style.scss
@@ -14,9 +14,6 @@
 	--wp-admin-theme-color-darker-20--rgb: 24, 58, 214;
 	--wp-admin-border-width-focus: 2px;
 
-	// Components
-	--wp-components-color-gray-100: #f0f0f0;
-
 	// Layout
 	--dashboard__background-color: #fcfcfc;
 	--dashboard__text-color: #{$gray-900};
@@ -37,4 +34,7 @@
 	// Headings
 	--dashboard-h1__font-weight: 400;
 	--dashboard-h1__font-family: Recoleta, sans-serif;
+
+	// Overview
+	--dashboard-overview__divider-color: #{$gray-100};
 }

--- a/client/dashboard/app-dotcom/style.scss
+++ b/client/dashboard/app-dotcom/style.scss
@@ -33,6 +33,7 @@
 	--dashboard-secondary-menu-item__color: #{$gray-900};
 
 	// Headings
+	--dashboard-h1__font-size: 40px;
 	--dashboard-h1__font-weight: 400;
 	--dashboard-h1__font-family: Recoleta, sans-serif;
 

--- a/client/dashboard/app-dotcom/style.scss
+++ b/client/dashboard/app-dotcom/style.scss
@@ -14,6 +14,9 @@
 	--wp-admin-theme-color-darker-20--rgb: 24, 58, 214;
 	--wp-admin-border-width-focus: 2px;
 
+	// Components
+	--wp-components-color-gray-100: #f0f0f0;
+
 	// Layout
 	--dashboard__background-color: #fcfcfc;
 	--dashboard__text-color: #{$gray-900};

--- a/client/dashboard/components/page-layout/style.scss
+++ b/client/dashboard/components/page-layout/style.scss
@@ -2,7 +2,7 @@
 
 .dashboard-page-layout {
 	margin: auto;
-	padding: $grid-unit-60 $grid-unit-20;
+	padding: $grid-unit-40 $grid-unit-30;
 
 	// Creates a positioning context for CalloutOverlay components. It needs to
 	// be on the PageLayout so that the blurred overlay can cover the entire

--- a/client/dashboard/components/section-header/style.scss
+++ b/client/dashboard/components/section-header/style.scss
@@ -28,7 +28,7 @@
 		font-family: var( --dashboard-h1__font-family );
 		font-size: var( --dashboard-h1__font-size, $font-size-2x-large );
 		font-weight: var( --dashboard-h1__font-weight ) !important;
-		line-height: $font-line-height-2x-large;
+		line-height: var( --dashboard-h1__line-height, $font-line-height-2x-large );
 	}
 
 	.dashboard-section-header.is-level-2 & {

--- a/client/dashboard/components/section-header/style.scss
+++ b/client/dashboard/components/section-header/style.scss
@@ -1,5 +1,5 @@
-@import "@wordpress/base-styles/variables";
-@import "@wordpress/base-styles/mixins";
+@import '@wordpress/base-styles/variables';
+@import '@wordpress/base-styles/mixins';
 
 .dashboard-section-header {
 	position: relative;
@@ -25,9 +25,9 @@
 	font-weight: $font-weight-medium;
 
 	.dashboard-section-header.is-level-1 & {
-	    font-family: var( --dashboard-h1__font-family );
-		font-size: $font-size-2x-large;
-	    font-weight: var( --dashboard-h1__font-weight ) !important;
+		font-family: var( --dashboard-h1__font-family );
+		font-size: var( --dashboard-h1__font-size, $font-size-2x-large );
+		font-weight: var( --dashboard-h1__font-weight ) !important;
 		line-height: $font-line-height-2x-large;
 	}
 

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -57,7 +57,7 @@ function getGridLayout( {
 
 	return {
 		columns: 2,
-		rows: Math.floor( count / 2 ) + ( count % 2 ),
+		rows: Math.ceil( count / 2 ),
 	};
 }
 

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -29,22 +29,22 @@ type Breakpoint = Parameters< typeof useViewportMatch >[ 0 ];
 
 const SPACING = {
 	DEFAULT: 6,
-	MOBILE: 4,
+	SMALL: 4,
 };
 
 function getGridLayout( {
 	count,
-	isLarge,
-	isMobile,
+	isLargeViewport,
+	isSmallViewport,
 }: {
 	count: number;
-	isLarge: boolean;
-	isMobile: boolean;
+	isLargeViewport: boolean;
+	isSmallViewport: boolean;
 } ) {
 	let columns;
-	if ( isLarge ) {
+	if ( isLargeViewport ) {
 		columns = count;
-	} else if ( isMobile ) {
+	} else if ( isSmallViewport ) {
 		columns = 1;
 	} else {
 		columns = Math.min( count / 2 );
@@ -65,11 +65,15 @@ function SiteOverview( {
 } ) {
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const isLarge = useViewportMatch( breakpoints?.large ?? 'large' );
-	const isMobile = useViewportMatch( breakpoints?.small ?? 'small', '<' );
-	const showSitePreview = ! ( hideSitePreview || isMobile );
-	const gridLayout = getGridLayout( { count: showSitePreview ? 4 : 3, isLarge, isMobile } );
-	const spacing = isMobile ? SPACING.MOBILE : SPACING.DEFAULT;
+	const isLargeViewport = useViewportMatch( breakpoints?.large ?? 'xlarge' );
+	const isSmallViewport = useViewportMatch( breakpoints?.small ?? 'medium', '<' );
+	const showSitePreview = ! ( hideSitePreview || isSmallViewport );
+	const spacing = isSmallViewport ? SPACING.SMALL : SPACING.DEFAULT;
+	const gridLayout = getGridLayout( {
+		count: showSitePreview ? 4 : 3,
+		isLargeViewport,
+		isSmallViewport,
+	} );
 
 	return (
 		<PageLayout
@@ -92,7 +96,7 @@ function SiteOverview( {
 				/>
 			}
 		>
-			<VStack alignment="stretch" spacing={ isMobile ? 5 : 10 }>
+			<VStack alignment="stretch" spacing={ isSmallViewport ? 5 : 10 }>
 				<Grid { ...gridLayout } gap={ spacing }>
 					{ showSitePreview && <SitePreviewCard site={ site } /> }
 					<VStack className="site-overview-cards" spacing={ spacing }>
@@ -118,7 +122,7 @@ function SiteOverview( {
 				<Divider orientation="horizontal" style={ { width: '100%', color: '#f0f0f0' } } />
 				<HStack
 					className={ clsx( 'site-overview-cards', 'site-overview-cards--secondary', {
-						'is-large': isLarge,
+						'is-large': isLargeViewport,
 					} ) }
 					spacing={ spacing }
 					alignment="flex-start"

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -41,18 +41,23 @@ function getGridLayout( {
 	isLargeViewport: boolean;
 	isSmallViewport: boolean;
 } ) {
-	let columns;
 	if ( isLargeViewport ) {
-		columns = count;
-	} else if ( isSmallViewport ) {
-		columns = 1;
-	} else {
-		columns = Math.min( count / 2 );
+		return {
+			columns: count,
+			rows: 1,
+		};
+	}
+
+	if ( isSmallViewport ) {
+		return {
+			columns: 1,
+			rows: count,
+		};
 	}
 
 	return {
-		columns,
-		rows: count / columns,
+		columns: 2,
+		rows: Math.floor( count / 2 ) + ( count % 2 ),
 	};
 }
 

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -119,7 +119,10 @@ function SiteOverview( {
 					</VStack>
 					<OverviewCard title={ __( 'Plan' ) } icon={ wordpress } heading="TBA" />
 				</Grid>
-				<Divider orientation="horizontal" style={ { width: '100%', color: '#f0f0f0' } } />
+				<Divider
+					orientation="horizontal"
+					style={ { width: '100%', color: 'var(--wp-components-color-gray-100)' } }
+				/>
 				<HStack
 					className={ clsx( 'site-overview-cards', 'site-overview-cards--secondary', {
 						'is-large': isLargeViewport,

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -78,22 +78,24 @@ function SiteOverview( {
 	return (
 		<PageLayout
 			header={
-				<PageHeader
-					title={ getSiteDisplayName( site ) }
-					description={ <SiteOverviewFields site={ site } /> }
-					actions={
-						site.options?.admin_url && (
-							<Button
-								__next40pxDefaultSize
-								variant="primary"
-								href={ site.options.admin_url }
-								icon={ wordpress }
-							>
-								{ __( 'WP Admin' ) }
-							</Button>
-						)
-					}
-				/>
+				<VStack>
+					<PageHeader
+						title={ getSiteDisplayName( site ) }
+						actions={
+							site.options?.admin_url && (
+								<Button
+									__next40pxDefaultSize
+									variant="primary"
+									href={ site.options.admin_url }
+									icon={ wordpress }
+								>
+									{ __( 'WP Admin' ) }
+								</Button>
+							)
+						}
+					/>
+					<SiteOverviewFields site={ site } />
+				</VStack>
 			}
 		>
 			<VStack alignment="stretch" spacing={ isSmallViewport ? 5 : 10 }>

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -6,8 +6,10 @@ import {
 	__experimentalVStack as VStack,
 	Button,
 } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { chartBar, published, wordpress } from '@wordpress/icons';
+import clsx from 'clsx';
 import { siteBySlugQuery } from '../../app/queries/site';
 import { siteRoute } from '../../app/router';
 import { PageHeader } from '../../components/page-header';
@@ -23,9 +25,51 @@ import StorageCard from './storage-card';
 import UptimeCard from './uptime-card';
 import './style.scss';
 
-function SiteOverview() {
+type Breakpoint = Parameters< typeof useViewportMatch >[ 0 ];
+
+const SPACING = {
+	DEFAULT: 6,
+	MOBILE: 4,
+};
+
+function getGridLayout( {
+	count,
+	isLarge,
+	isMobile,
+}: {
+	count: number;
+	isLarge: boolean;
+	isMobile: boolean;
+} ) {
+	let columns;
+	if ( isLarge ) {
+		columns = count;
+	} else if ( isMobile ) {
+		columns = 1;
+	} else {
+		columns = Math.min( count / 2 );
+	}
+
+	return {
+		columns,
+		rows: count / columns,
+	};
+}
+
+function SiteOverview( {
+	hideSitePreview = false,
+	breakpoints,
+}: {
+	hideSitePreview: boolean;
+	breakpoints?: { large: Breakpoint; small: Breakpoint };
+} ) {
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+	const isLarge = useViewportMatch( breakpoints?.large ?? 'large' );
+	const isMobile = useViewportMatch( breakpoints?.small ?? 'small', '<' );
+	const showSitePreview = ! ( hideSitePreview || isMobile );
+	const gridLayout = getGridLayout( { count: showSitePreview ? 4 : 3, isLarge, isMobile } );
+	const spacing = isMobile ? SPACING.MOBILE : SPACING.DEFAULT;
 
 	return (
 		<PageLayout
@@ -48,10 +92,10 @@ function SiteOverview() {
 				/>
 			}
 		>
-			<VStack alignment="stretch" spacing={ 10 }>
-				<Grid columns={ 4 } rows={ 1 } gap={ 6 }>
-					<SitePreviewCard site={ site } />
-					<VStack className="site-overview-cards" spacing={ 6 }>
+			<VStack alignment="stretch" spacing={ isMobile ? 5 : 10 }>
+				<Grid { ...gridLayout } gap={ spacing }>
+					{ showSitePreview && <SitePreviewCard site={ site } /> }
+					<VStack className="site-overview-cards" spacing={ spacing }>
 						<OverviewCard
 							title={ __( 'Visibility' ) }
 							icon={ published }
@@ -60,7 +104,7 @@ function SiteOverview() {
 						/>
 						<BackupCard site={ site } />
 					</VStack>
-					<VStack className="site-overview-cards" spacing={ 6 }>
+					<VStack className="site-overview-cards" spacing={ spacing }>
 						<OverviewCard
 							title={ __( 'Performance' ) }
 							icon={ chartBar }
@@ -72,11 +116,17 @@ function SiteOverview() {
 					<OverviewCard title={ __( 'Plan' ) } icon={ wordpress } heading="TBA" />
 				</Grid>
 				<Divider orientation="horizontal" style={ { width: '100%', color: '#f0f0f0' } } />
-				<HStack className="site-overview-cards" spacing={ 6 } alignment="flex-start">
-					<VStack spacing={ 6 } justify="start">
+				<HStack
+					className={ clsx( 'site-overview-cards', 'site-overview-cards--secondary', {
+						'is-large': isLarge,
+					} ) }
+					spacing={ spacing }
+					alignment="flex-start"
+				>
+					<VStack spacing={ spacing } justify="start">
 						<PerformanceCards site={ site } />
 					</VStack>
-					<VStack spacing={ 6 } justify="start">
+					<VStack spacing={ spacing } justify="start">
 						<StorageCard site={ site } />
 						<UptimeCard site={ site } />
 					</VStack>

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -121,7 +121,7 @@ function SiteOverview( {
 				</Grid>
 				<Divider
 					orientation="horizontal"
-					style={ { width: '100%', color: 'var(--wp-components-color-gray-100)' } }
+					style={ { color: 'var(--dashboard-overview__divider-color)' } }
 				/>
 				<HStack
 					className={ clsx( 'site-overview-cards', 'site-overview-cards--secondary', {

--- a/client/dashboard/sites/overview/site-overview-fields.scss
+++ b/client/dashboard/sites/overview/site-overview-fields.scss
@@ -1,5 +1,6 @@
 .site-overview-fields {
 	flex-wrap: wrap;
+	max-width: var(--dashboard__text-max-width);
 }
 
 .site-overview-field:not(:last-child) {

--- a/client/dashboard/sites/overview/site-overview-fields.scss
+++ b/client/dashboard/sites/overview/site-overview-fields.scss
@@ -1,5 +1,9 @@
-.site-overview-field + .site-overview-field {
-	&::before {
+.site-overview-fields {
+	flex-wrap: wrap;
+}
+
+.site-overview-field:not(:last-child) {
+	&::after {
 		display: block;
 		content: '•';
 	}

--- a/client/dashboard/sites/overview/site-overview-fields.tsx
+++ b/client/dashboard/sites/overview/site-overview-fields.tsx
@@ -41,22 +41,22 @@ const HostingProvider = ( { site }: { site: Site } ) => {
 	}
 
 	if ( agencyBlog ) {
-		return <Field>{ __( 'Managed by Automattic for Agencies' ) }</Field>;
+		return <Text variant="muted">{ __( 'Managed by Automattic for Agencies' ) }</Text>;
 	}
 
 	const providerName = getSiteProviderName( site );
 	if ( ! providerName && isSelfHostedJetpackConnected( site ) ) {
-		return <Field>{ __( 'Connected via Jetpack' ) }</Field>;
+		return <Text variant="muted">{ __( 'Connected via Jetpack' ) }</Text>;
 	}
 
 	return (
-		<Field>
+		<Text variant="muted">
 			{ sprintf(
 				/* translators: %s: the hosting provider, e.g.: WordPress.com */
 				__( 'Hosted on %s' ),
 				providerName ?? DEFAULT_PROVIDER_NAME
 			) }
-		</Field>
+		</Text>
 	);
 };
 

--- a/client/dashboard/sites/overview/site-preview-card.tsx
+++ b/client/dashboard/sites/overview/site-preview-card.tsx
@@ -36,7 +36,7 @@ const SitePreviewCard = ( { site }: { site: Site } ) => {
 						bottom: 0,
 						left: 0,
 						overflow: 'hidden',
-						backgroundColor: 'var(--wp-components-color-gray-100)',
+						backgroundColor: '#f0f0f0',
 					} }
 				>
 					<SitePreview url={ url } scale={ width / 1200 } height={ height / ( width / 1200 ) } />

--- a/client/dashboard/sites/overview/site-preview-card.tsx
+++ b/client/dashboard/sites/overview/site-preview-card.tsx
@@ -36,6 +36,7 @@ const SitePreviewCard = ( { site }: { site: Site } ) => {
 						bottom: 0,
 						left: 0,
 						overflow: 'hidden',
+						backgroundColor: 'var(--wp-components-color-gray-100)',
 					} }
 				>
 					<SitePreview url={ url } scale={ width / 1200 } height={ height / ( width / 1200 ) } />

--- a/client/dashboard/sites/overview/style.scss
+++ b/client/dashboard/sites/overview/style.scss
@@ -18,7 +18,7 @@
 		flex-wrap: nowrap;
 
 		> * {
-			flex-basis: auto;
+			flex-basis: 0;
 		}
 	}
 }

--- a/client/dashboard/sites/overview/style.scss
+++ b/client/dashboard/sites/overview/style.scss
@@ -7,6 +7,22 @@
 	}
 }
 
+.site-overview-cards--secondary {
+	flex-wrap: wrap-reverse;
+
+	> * {
+		flex-basis: 100%;
+	}
+
+	&.is-large {
+		flex-wrap: nowrap;
+
+		> * {
+			flex-basis: auto;
+		}
+	}
+}
+
 .site-overview-card__badge {
 	// This is hacky way of hiding the badge icon for now.
 	// We need to handle this in the core Badge component.


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-110, DOTCOM-13871

## Proposed Changes

* Make the site overview layout responsive

| Large | Small ~ Large | Small |
| - | - | - |
| <img width="772" height="933" alt="image" src="https://github.com/user-attachments/assets/4d81a07e-529b-4b7d-aecc-6c0302113dbc" /> | <img width="737" height="933" alt="image" src="https://github.com/user-attachments/assets/e2005498-8bbe-43f2-812a-4ca2d9ad79f5" /> | <img width="456" height="933" alt="image" src="https://github.com/user-attachments/assets/fe037f3b-60c7-4f94-9abf-0cfe14c48332" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/v2/sites/:site`
* Adjust the viewport width
* Ensure the layout looks good
  * `width >= 1080px`: 4 columns on the top and 2 columns on the bottom
  * `width < 782px`: 1 columns on both the top and the bottom, and the site preview is hidden
  * Others: 2 columns on the top and 1 columns on the bottom

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
