### PR TITLE
Fix line clamp issue with hovercards

### DIFF
--- a/client/components/gravatar-with-hovercards/styles.scss
+++ b/client/components/gravatar-with-hovercards/styles.scss
@@ -64,7 +64,10 @@
 				color: var( --color-text );
 				overflow: hidden;
 				text-overflow: ellipsis;
-				white-space: nowrap;
+				display: -webkit-box;
+				-webkit-line-clamp: 1;
+				line-clamp: 1;
+				-webkit-box-orient: vertical;
 			}
 
 			.gravatar-hovercard__primary-blog-card-username {


### PR DESCRIPTION
Fixes CML-657

## Description

We've got a line clamp issue where text is extending beyond the hovercard:

### Before

<img width="590" height="720" alt="image" src="https://github.com/user-attachments/assets/ae85cfe9-f4dd-4826-8301-e65eba57ea7c" />

### After

<img width="696" height="886" alt="CleanShot 2025-07-15 at 09 55 10@2x" src="https://github.com/user-attachments/assets/c99133d9-ada7-439a-b995-79a9d30246df" />

## Testing

- Apply this patch
- Go to /reader/search?q=ma.tt
- Test the hovercard