### PR TITLE
Reader - fix hovercards showing 0 for non wpcom users.

### DIFF
--- a/client/components/gravatar-with-hovercards/hovercard-content.jsx
+++ b/client/components/gravatar-with-hovercards/hovercard-content.jsx
@@ -51,7 +51,7 @@ function HovercardContent( props ) {
 				</div>
 
 				{ /* Below is custom for wpcom users, and can use wpcom data more freely */ }
-				{ userID && (
+				{ !! userID && (
 					<>
 						<div className="gravatar-hovercard__body">
 							<PrimaryBlog


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/CML-658/gravatars-in-reader-comments-showing-null-hovercards

## Proposed Changes

Convert the userID check to a pure boolean, so we don't show 0 when the id is 0.

BEFORE
<img width="350" height="284" alt="Screenshot 2025-07-15 at 10 13 54 AM" src="https://github.com/user-attachments/assets/e2895f38-9b9a-4881-a2a7-adb2ee4faa0d" />

AFTER
<img width="375" height="283" alt="Screenshot 2025-07-15 at 10 13 26 AM" src="https://github.com/user-attachments/assets/e8ec56ef-6dad-4ccb-9e70-6a14b69af5ce" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to /reader/blogs/1047865/posts/143509 and hover the gravatars on the comments,v erify there are no trailing 0s.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
