### PR TITLE
Site overview v2: add Last Backup card

### DIFF
--- a/client/dashboard/app/queries/site-backups.ts
+++ b/client/dashboard/app/queries/site-backups.ts
@@ -6,19 +6,13 @@ export const siteBackupsQuery = ( siteId: number ) => ( {
 	queryFn: () => fetchSiteBackups( siteId ),
 } );
 
-export const siteLastBackupTimeQuery = ( siteId: number ) => ( {
+export const siteLastBackupQuery = ( siteId: number ) => ( {
 	...siteBackupsQuery( siteId ),
 	select: ( backups: Backup[] ) => {
 		if ( ! Array.isArray( backups ) ) {
 			return null;
 		}
 
-		const lastBackup = backups.find( ( backup ) => backup.status === 'finished' );
-		if ( ! lastBackup ) {
-			return null;
-		}
-
-		// Return last_updated in UTC in ISO-8601 format.
-		return lastBackup.last_updated.replace( ' ', 'T' ) + 'Z';
+		return backups.find( ( backup ) => backup.status === 'finished' ) ?? null;
 	},
 } );

--- a/client/dashboard/app/queries/site-backups.ts
+++ b/client/dashboard/app/queries/site-backups.ts
@@ -1,13 +1,24 @@
-import { fetchSiteBackups, Backup } from '../../data/site-jetpack-rewind-backups';
+import { fetchSiteBackups } from '../../data/site-jetpack-rewind-backups';
+import type { Backup } from '../../data/site-jetpack-rewind-backups';
 
-export const siteBackupLastEntryQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'backup-last-entry' ],
+export const siteBackupsQuery = ( siteId: number ) => ( {
+	queryKey: [ 'site', siteId, 'backups' ],
 	queryFn: () => fetchSiteBackups( siteId ),
+} );
+
+export const siteLastBackupTimeQuery = ( siteId: number ) => ( {
+	...siteBackupsQuery( siteId ),
 	select: ( backups: Backup[] ) => {
 		if ( ! Array.isArray( backups ) ) {
 			return null;
 		}
 
-		return backups.find( ( backup ) => backup.status === 'finished' );
+		const lastBackup = backups.find( ( backup ) => backup.status === 'finished' );
+		if ( ! lastBackup ) {
+			return null;
+		}
+
+		// Return last_updated in UTC in ISO-8601 format.
+		return lastBackup.last_updated.replace( ' ', 'T' ) + 'Z';
 	},
 } );

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -17,7 +17,9 @@ import {
 	canViewPrimaryDataCenterSettings,
 	canViewStaticFile404Settings,
 	canViewCachingSettings,
+	HostingFeatures,
 } from '../sites/features';
+import { hasAtomicFeature } from '../utils/site-features';
 import NotFound from './404';
 import UnknownError from './500';
 import { domainsQuery } from './queries/domains';
@@ -27,6 +29,7 @@ import { userPreferencesQuery } from './queries/me-preferences';
 import { profileQuery } from './queries/me-profile';
 import { siteByIdQuery, siteBySlugQuery } from './queries/site';
 import { siteAgencyBlogQuery } from './queries/site-agency';
+import { siteLastBackupQuery } from './queries/site-backups';
 import { siteEdgeCacheStatusQuery } from './queries/site-cache';
 import { siteDefensiveModeSettingsQuery } from './queries/site-defensive-mode';
 import { siteDomainsQuery } from './queries/site-domains';
@@ -129,10 +132,14 @@ const siteOverviewRoute = createRoute( {
 	path: '/',
 	loader: async ( { params: { siteSlug }, preload } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		return Promise.all( [
-			preload ? queryClient.ensureQueryData( siteCurrentPlanQuery( site.ID ) ) : undefined,
-			preload ? queryClient.ensureQueryData( siteScanQuery( site.ID ) ) : undefined,
-		] );
+		if ( preload ) {
+			Promise.all( [
+				queryClient.ensureQueryData( siteCurrentPlanQuery( site.ID ) ),
+				queryClient.ensureQueryData( siteScanQuery( site.ID ) ),
+				hasAtomicFeature( site, HostingFeatures.BACKUPS ) &&
+					queryClient.ensureQueryData( siteLastBackupQuery( site.ID ) ),
+			] );
+		}
 	},
 } ).lazy( () =>
 	import( '../sites/overview' ).then( ( d ) =>

--- a/client/dashboard/data/site-jetpack-rewind-backups.ts
+++ b/client/dashboard/data/site-jetpack-rewind-backups.ts
@@ -5,7 +5,7 @@ export interface Backup {
 	status: 'started' | 'finished' | 'error';
 }
 
-export async function fetchSiteBackups( siteId: number ) {
+export async function fetchSiteBackups( siteId: number ): Promise< Backup[] > {
 	return wpcom.req.get( {
 		path: `/sites/${ siteId }/rewind/backups`,
 		apiNamespace: 'wpcom/v2',

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -13,6 +13,7 @@ export type * from './site-hosting-sftp';
 export type * from './site-hosting-ssh';
 export type * from './site-media-storage';
 export type * from './site-jetpack-monitor-uptime';
+export type * from './site-jetpack-rewind-backups';
 export type * from './site-owner-transfer';
 export type * from './site-preview-links';
 export type * from './site-profiler';

--- a/client/dashboard/sites/fields.tsx
+++ b/client/dashboard/sites/fields.tsx
@@ -99,7 +99,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		label: __( 'Last published' ),
 		getValue: ( { item } ) => item.options?.updated_at ?? '',
 		render: ( { item } ) =>
-			item.options?.updated_at ? <TimeSince date={ item.options.updated_at } /> : '',
+			item.options?.updated_at ? <TimeSince timestamp={ item.options.updated_at } /> : '',
 	},
 	{
 		id: 'uptime',

--- a/client/dashboard/sites/overview/backup-card.tsx
+++ b/client/dashboard/sites/overview/backup-card.tsx
@@ -33,7 +33,7 @@ function BackupCardUpsell( { site }: { site: Site } ) {
 	);
 }
 
-function BackupCardWithBackups( { site, lastBackup }: { site: Site; lastBackup?: Backup } ) {
+function BackupCardWithBackups( { site, lastBackup }: { site: Site; lastBackup: Backup | null } ) {
 	const timeSinceLastBackup = useTimeSince(
 		lastBackup?.last_updated ?? new Date( 0 ).toISOString(),
 		{ isUtc: true }

--- a/client/dashboard/sites/overview/backup-card.tsx
+++ b/client/dashboard/sites/overview/backup-card.tsx
@@ -1,14 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import { backup } from '@wordpress/icons';
-import { siteLastBackupTimeQuery } from '../../app/queries/site-backups';
+import { siteLastBackupQuery } from '../../app/queries/site-backups';
 import { useTimeSince } from '../../components/time-since';
 import { hasAtomicFeature } from '../../utils/site-features';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { HostingFeatures } from '../features';
 import OverviewCard from '../overview-card';
 import UpsellCard from './upsell-card';
-import type { Site } from '../../data/types';
+import type { Backup, Site } from '../../data/types';
 
 const CARD_PROPS = {
 	icon: backup,
@@ -33,30 +33,27 @@ function BackupCardUpsell( { site }: { site: Site } ) {
 	);
 }
 
-function BackupCardWithBackups( {
-	site,
-	lastBackupTime,
-}: {
-	site: Site;
-	lastBackupTime: string | null;
-} ) {
-	const timeSinceLastBackup = useTimeSince( lastBackupTime ?? new Date( 0 ).toISOString() );
+function BackupCardWithBackups( { site, lastBackup }: { site: Site; lastBackup?: Backup } ) {
+	const timeSinceLastBackup = useTimeSince(
+		lastBackup?.last_updated ?? new Date( 0 ).toISOString(),
+		{ isUtc: true }
+	);
 
 	return (
 		<OverviewCard
 			{ ...CARD_PROPS }
-			heading={ lastBackupTime ? timeSinceLastBackup : __( 'No backups yet' ) }
+			heading={ lastBackup ? timeSinceLastBackup : __( 'No backups yet' ) }
 			description="Next scheduled backup in TBA"
 			externalLink={ getBackupUrl( site ) }
-			variant={ lastBackupTime ? 'success' : undefined }
+			variant={ lastBackup ? 'success' : undefined }
 		/>
 	);
 }
 
 export default function BackupCard( { site }: { site: Site } ) {
 	const isEligible = hasAtomicFeature( site, HostingFeatures.BACKUPS );
-	const { data: lastBackupTime } = useQuery( {
-		...siteLastBackupTimeQuery( site.ID ),
+	const { data: lastBackup } = useQuery( {
+		...siteLastBackupQuery( site.ID ),
 		enabled: isEligible,
 	} );
 
@@ -64,9 +61,9 @@ export default function BackupCard( { site }: { site: Site } ) {
 		return <BackupCardUpsell site={ site } />;
 	}
 
-	if ( lastBackupTime === undefined ) {
+	if ( lastBackup === undefined ) {
 		return <OverviewCard { ...CARD_PROPS } variant="loading" />;
 	}
 
-	return <BackupCardWithBackups site={ site } lastBackupTime={ lastBackupTime } />;
+	return <BackupCardWithBackups site={ site } lastBackup={ lastBackup } />;
 }

--- a/client/dashboard/sites/overview/backup-card.tsx
+++ b/client/dashboard/sites/overview/backup-card.tsx
@@ -1,0 +1,72 @@
+import { useQuery } from '@tanstack/react-query';
+import { __ } from '@wordpress/i18n';
+import { backup } from '@wordpress/icons';
+import { siteLastBackupTimeQuery } from '../../app/queries/site-backups';
+import { useTimeSince } from '../../components/time-since';
+import { hasAtomicFeature } from '../../utils/site-features';
+import { isSelfHostedJetpackConnected } from '../../utils/site-types';
+import { HostingFeatures } from '../features';
+import OverviewCard from '../overview-card';
+import UpsellCard from './upsell-card';
+import type { Site } from '../../data/types';
+
+const CARD_PROPS = {
+	icon: backup,
+	title: __( 'Last backup' ),
+	trackId: 'backup',
+};
+
+function getBackupUrl( site: Site ) {
+	return isSelfHostedJetpackConnected( site )
+		? `https://cloud.jetpack.com/backup/${ site.slug }`
+		: `https://wordpress.com/backup/${ site.slug }`;
+}
+
+function BackupCardUpsell( { site }: { site: Site } ) {
+	return (
+		<UpsellCard
+			heading={ __( 'Real-time backups' ) }
+			description={ __( 'Get back online quickly with one-click restores' ) }
+			externalLink={ getBackupUrl( site ) }
+			trackId={ CARD_PROPS.trackId }
+		/>
+	);
+}
+
+function BackupCardWithBackups( {
+	site,
+	lastBackupTime,
+}: {
+	site: Site;
+	lastBackupTime: string | null;
+} ) {
+	const timeSinceLastBackup = useTimeSince( lastBackupTime ?? new Date( 0 ).toISOString() );
+
+	return (
+		<OverviewCard
+			{ ...CARD_PROPS }
+			heading={ lastBackupTime ? timeSinceLastBackup : __( 'No backups yet' ) }
+			description="Next scheduled backup in TBA"
+			externalLink={ getBackupUrl( site ) }
+			variant={ lastBackupTime ? 'success' : undefined }
+		/>
+	);
+}
+
+export default function BackupCard( { site }: { site: Site } ) {
+	const isEligible = hasAtomicFeature( site, HostingFeatures.BACKUPS );
+	const { data: lastBackupTime } = useQuery( {
+		...siteLastBackupTimeQuery( site.ID ),
+		enabled: isEligible,
+	} );
+
+	if ( ! isEligible ) {
+		return <BackupCardUpsell site={ site } />;
+	}
+
+	if ( lastBackupTime === undefined ) {
+		return <OverviewCard { ...CARD_PROPS } variant="loading" />;
+	}
+
+	return <BackupCardWithBackups site={ site } lastBackupTime={ lastBackupTime } />;
+}

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -7,13 +7,14 @@ import {
 	Button,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { backup, chartBar, published, wordpress } from '@wordpress/icons';
+import { chartBar, published, wordpress } from '@wordpress/icons';
 import { siteBySlugQuery } from '../../app/queries/site';
 import { siteRoute } from '../../app/router';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { getSiteDisplayName } from '../../utils/site-name';
 import OverviewCard from '../overview-card';
+import BackupCard from './backup-card';
 import PerformanceCards from './performance-cards';
 import ScanCard from './scan-card';
 import SiteOverviewFields from './site-overview-fields';
@@ -57,12 +58,7 @@ function SiteOverview() {
 							heading="TBA"
 							description="TBA"
 						/>
-						<OverviewCard
-							title={ __( 'Last backup' ) }
-							icon={ backup }
-							heading="TBA"
-							description="TBA"
-						/>
+						<BackupCard site={ site } />
 					</VStack>
 					<VStack className="site-overview-cards" spacing={ 6 }>
 						<OverviewCard

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -13,7 +13,7 @@ import { useInView } from 'react-intersection-observer';
 import { useAnalytics } from '../../app/analytics';
 import { useAuth } from '../../app/auth';
 import { siteLatestAtomicTransferQuery } from '../../app/queries/site-atomic-transfers';
-import { siteLastBackupTimeQuery } from '../../app/queries/site-backups';
+import { siteLastBackupQuery } from '../../app/queries/site-backups';
 import { siteMediaStorageQuery } from '../../app/queries/site-media-storage';
 import { sitePHPVersionQuery } from '../../app/queries/site-php-version';
 import { siteEngagementStatsQuery } from '../../app/queries/site-stats';
@@ -186,7 +186,7 @@ export function LastBackup( { site }: { site: Site } ) {
 		isLoading,
 		isError,
 	} = useQuery( {
-		...siteLastBackupTimeQuery( site.ID ),
+		...siteLastBackupQuery( site.ID ),
 		enabled: isEligible && inView,
 	} );
 
@@ -203,7 +203,7 @@ export function LastBackup( { site }: { site: Site } ) {
 			return <IneligibleIndicator />;
 		}
 
-		return <TimeSince date={ lastBackupTime } />;
+		return <TimeSince timestamp={ lastBackupTime.last_updated } isUtc />;
 	};
 
 	return <span ref={ ref }>{ renderContent() }</span>;

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -13,7 +13,7 @@ import { useInView } from 'react-intersection-observer';
 import { useAnalytics } from '../../app/analytics';
 import { useAuth } from '../../app/auth';
 import { siteLatestAtomicTransferQuery } from '../../app/queries/site-atomic-transfers';
-import { siteBackupLastEntryQuery } from '../../app/queries/site-backups';
+import { siteLastBackupTimeQuery } from '../../app/queries/site-backups';
 import { siteMediaStorageQuery } from '../../app/queries/site-media-storage';
 import { sitePHPVersionQuery } from '../../app/queries/site-php-version';
 import { siteEngagementStatsQuery } from '../../app/queries/site-stats';
@@ -182,11 +182,11 @@ export function LastBackup( { site }: { site: Site } ) {
 	const isEligible = hasAtomicFeature( site, HostingFeatures.BACKUPS );
 
 	const {
-		data: lastBackup,
+		data: lastBackupTime,
 		isLoading,
 		isError,
 	} = useQuery( {
-		...siteBackupLastEntryQuery( site.ID ),
+		...siteLastBackupTimeQuery( site.ID ),
 		enabled: isEligible && inView,
 	} );
 
@@ -199,11 +199,11 @@ export function LastBackup( { site }: { site: Site } ) {
 			return <LoadingIndicator label="Unknown" />;
 		}
 
-		if ( ! lastBackup || isError ) {
+		if ( ! lastBackupTime || isError ) {
 			return <IneligibleIndicator />;
 		}
 
-		return <TimeSince date={ lastBackup.last_updated } />;
+		return <TimeSince date={ lastBackupTime } />;
 	};
 
 	return <span ref={ ref }>{ renderContent() }</span>;

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -182,7 +182,7 @@ export function LastBackup( { site }: { site: Site } ) {
 	const isEligible = hasAtomicFeature( site, HostingFeatures.BACKUPS );
 
 	const {
-		data: lastBackupTime,
+		data: lastBackup,
 		isLoading,
 		isError,
 	} = useQuery( {
@@ -199,11 +199,11 @@ export function LastBackup( { site }: { site: Site } ) {
 			return <LoadingIndicator label="Unknown" />;
 		}
 
-		if ( ! lastBackupTime || isError ) {
+		if ( ! lastBackup || isError ) {
 			return <IneligibleIndicator />;
 		}
 
-		return <TimeSince timestamp={ lastBackupTime.last_updated } isUtc />;
+		return <TimeSince timestamp={ lastBackup.last_updated } isUtc />;
 	};
 
 	return <span ref={ ref }>{ renderContent() }</span>;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-115

## Proposed Changes

This PR implements the Last Backup card in Site Overview v2.

The `Next scheduled in X` description will be in a follow-up PR due to its complexity. 🥹 

This PR also fixes the timezone calculation in the existing `Backup` column in the Site List.

|Case|Screenshot|
|-|-|
|Upsell|<img width="329" height="153" alt="image" src="https://github.com/user-attachments/assets/48bf2b5a-fd9e-4e8a-96ec-cdd374335004" />|
|Has backup|<img width="330" height="153" alt="image" src="https://github.com/user-attachments/assets/9f29dbeb-1652-4c72-be85-b68599f412a1" />|
|No backups yet|<img width="330" height="152" alt="image" src="https://github.com/user-attachments/assets/b5dfe1ec-d492-44b6-81bb-578b9e1857fc" />


## Testing Instructions

1. Go to `/v2/sites/:siteSlug` of a Free WordPress.com site.
   - Verify you see the upsell.
   - Click the card; verify you are taken to `wp.com/backup/:siteSlug` and you see the upsell.
2. Go to `/v2/sites/:siteSlug` of a Jurassic Ninja site.
   - Verify you see the upsell.
   - Click the card; verify you are taken to `cloud.jetpack.com/backup/:siteSlug` and you see the upsell.
3. Go to `/v2/sites/:siteSlug` of an Atomic site.
   - Verify you see the last backup time.
   - Click the card; verify you are taken to the Vaultpress Backup page and the last backup time is also correct there.

NOTE: It's ALMOST impossible to test the "No backups yet" case... it seems that the backup is automatically triggered for eligible Jetpack sites for the first time. But I implemented it just in case.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
