### PR TITLE
Connect Refresh: Clean up some of the Woo customisations to Login / Magic Login

### DIFF
--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -156,8 +156,7 @@ $breakpoint-mobile: 660px;
 	}
 
 	a:not(.components-button),
-	.button,
-	.magic-login__footer a {
+	.button {
 		color: $gray-50;
 		text-decoration: underline;
 
@@ -359,16 +358,6 @@ $breakpoint-mobile: 660px;
 		}
 	}
 
-	.login__form {
-		display: flex;
-		flex-direction: column;
-		padding: 54px 24px 32px;
-
-		@media (max-width: $break-mobile) {
-			padding: 32px 16px 28px;
-		}
-	}
-
 	.form-password-input .form-password-input__toggle-visibility {
 		top: 10px;
 	}
@@ -427,26 +416,26 @@ $breakpoint-mobile: 660px;
 		}
 	}
 
-	.magic-login__form-action {
-		text-align: center;
-		margin-top: 25px;
-	}
-
-	.step-wrapper,
-	.wp-login__main.main,
-	.magic-login.main {
+	.step-wrapper {
 		max-width: 96%;
+		margin: 0 auto 50px;
 
 		@media screen and (min-width: 617px) {
 			max-width: 617px;
 		}
+
+		.formatted-header {
+			margin: 0;
+		}
 	}
 
-	.card {
-		box-shadow: none;
-		padding-left: 0;
-		padding-right: 0;
-		background-color: initial;
+	&:not(.is-section-login) {
+		.card {
+			box-shadow: none;
+			padding-left: 0;
+			padding-right: 0;
+			background-color: initial;
+		}
 	}
 
 	.step-wrapper,
@@ -478,7 +467,6 @@ $breakpoint-mobile: 660px;
 	}
 
 	.login__social-connect-prompt,
-	.magic-login__request-link,
 	.signup-form,
 	.login__two-factor-footer {
 		padding-left: $woo-form-whitespace;
@@ -487,30 +475,6 @@ $breakpoint-mobile: 660px;
 			padding-left: $woo-form-whitespace-660;
 			padding-right: $woo-form-whitespace-660;
 		}
-	}
-
-	.magic-login__form-header {
-		margin-bottom: 0;
-	}
-
-	.magic-login__form {
-		border: none;
-		.logged-out-form {
-			max-width: 100%;
-			box-shadow: none;
-			padding-left: 0;
-			padding-right: 0;
-
-			p {
-				text-align: center;
-				max-width: 415px;
-				margin: 0 auto 24px;
-			}
-		}
-	}
-
-	.magic-login__request-link .magic-login__form > p {
-		text-align: center;
 	}
 
 	.continue-as-user {
@@ -718,15 +682,6 @@ $breakpoint-mobile: 660px;
 
 	.logged-out-form__links {
 		text-align: center;
-	}
-
-	// Signup styles
-	.step-wrapper {
-		margin: 0 auto 50px;
-
-		.formatted-header {
-			margin: 0;
-		}
 	}
 
 	.formatted-header__title {
@@ -1220,7 +1175,6 @@ $breakpoint-mobile: 660px;
 				flex-direction: column;
 				justify-content: center;
 				width: 100%;
-				max-width: $max-width;
 				margin: 0;
 
 				~ .auth-form__social.card {
@@ -1391,27 +1345,6 @@ $breakpoint-mobile: 660px;
 				}
 			}
 
-			.magic-login__form-action {
-				margin-top: 8px;
-			}
-
-			.magic-login__form {
-				border: none;
-
-				p {
-					text-align: center;
-				}
-
-				.logged-out-form {
-					max-width: 100%;
-					box-shadow: none;
-
-					form {
-						max-width: $max-width;
-					}
-				}
-			}
-
 			.magic-login__form p.magic-login__form-sub-header,
 			.magic-login__form-text {
 				color: var(--studio-gray-60);
@@ -1426,46 +1359,6 @@ $breakpoint-mobile: 660px;
 				strong {
 					font-weight: 600;
 					display: inline-block;
-				}
-			}
-
-			.magic-login__emails-list {
-				max-width: $max-width;
-				margin-inline: auto;
-
-				li {
-					border-radius: 8px; // stylelint-disable-line scales/radii
-					border: 2px solid var(--studio-gray-10);
-				}
-
-				a {
-					color: var(--studio-gray-100);
-					text-decoration: none;
-					font-size: 1rem;
-					font-style: normal;
-					font-weight: 500;
-					line-height: 24px;
-				}
-			}
-
-			.magic-login__footer {
-				margin: 0;
-				max-width: $max-width;
-				margin-inline: auto;
-
-				p {
-					color: var(--studio-gray-60);
-					text-align: center;
-					font-size: rem(14px);
-					font-style: normal;
-					font-weight: 400;
-					line-height: 20px;
-				}
-
-				a {
-					font-size: rem(14px);
-					font-style: normal;
-					line-height: 20px;
 				}
 			}
 		}

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1366,6 +1366,22 @@ $breakpoint-mobile: 660px;
 					display: inline-block;
 				}
 			}
+
+			.magic-login__emails-list {
+				li {
+					border-radius: 8px; // stylelint-disable-line scales/radii
+					border: 2px solid var(--studio-gray-10);
+				}
+
+				a {
+					color: var(--studio-gray-100);
+					text-decoration: none;
+					font-size: 1rem;
+					font-style: normal;
+					font-weight: 500;
+					line-height: 24px;
+				}
+			}
 		}
 
 		.two-factor-authentication__verification-code-form-wrapper {

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -990,6 +990,11 @@ $breakpoint-mobile: 660px;
 		.wp-login__heading-text {
 			font-family: var(--woo-font-family-header);
 			font-feature-settings: "ss01" on, "salt" on;
+
+			* {
+				font-family: inherit;
+				font-feature-settings: inherit;
+			}
 		}
 
 		h1,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13627/login-and-signup-centralise-font-and-css-overrides
Part of https://linear.app/a8c/issue/DOTCOM-13219/login-magic-login-update-and-unify-magic-login-screens

## Proposed Changes

* Fix font settings for client name "Woo" in heading
* Clean up obsolete code in Magic Login form from pre-unification
* Adjust the margin/width on Magic Login pages to align with the defaults (no real need to be narrower)

| Before | After |
|--------|--------|
| <img width="610" height="399" alt="Screenshot 2025-07-16 at 6 26 02 PM" src="https://github.com/user-attachments/assets/1e2f79e4-76f9-4cc5-a0b6-b52ec99510b4" /> | <img width="531" height="401" alt="Screenshot 2025-07-16 at 6 30 44 PM" src="https://github.com/user-attachments/assets/4e7a5805-ee3c-4937-88dd-a6c11eac77da" /> |

| Before | After |
|--------|--------|
| <img width="608" height="531" alt="Screenshot 2025-07-16 at 6 24 59 PM" src="https://github.com/user-attachments/assets/0c621ba7-554f-428f-8754-9576a6205f3a" /> | <img width="670" height="559" alt="Screenshot 2025-07-16 at 6 24 43 PM" src="https://github.com/user-attachments/assets/f763d439-aa9f-430f-8fb3-154d9328e543" /> |

| Before | After |
|--------|--------|
| <img width="878" height="695" alt="Screenshot 2025-07-16 at 6 32 33 PM" src="https://github.com/user-attachments/assets/178bb994-fc20-4cf5-b6c3-c5b195fe4fb9" /> | <img width="880" height="692" alt="Screenshot 2025-07-16 at 6 32 14 PM" src="https://github.com/user-attachments/assets/34a3ccb3-8824-4b19-938c-8c51a182082e" /> |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13627/login-and-signup-centralise-font-and-css-overrides
Part of https://linear.app/a8c/issue/DOTCOM-13219/login-magic-login-update-and-unify-magic-login-screens

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [Woo](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Db30d4e6a81f72b803c873f517f4189601c46a1bc8b9bfdb9ed27cf3d17ad5601%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26from-calypso%3D1&client_id=50916&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D50916%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%252F%253Fresponse_type%253Dcode%2526client_id%253D50916%2526state%253Db30d4e6a81f72b803c873f517f4189601c46a1bc8b9bfdb9ed27cf3d17ad5601%2526redirect_uri%253Dhttps%25253A%25252F%25252Fwoocommerce.com%25252Fwc-api%25252Fwpcom-signin%25253Fnext%25253D%2525252F%2526blog_id%253D0%2526wpcom_connect%253D1%2526wccom-from%2526calypso_env%253Dproduction%2526from-calypso%253D1)
  * Ensure "Woo" in title renders with correct font size
  * Click on Magic Login, enter an email - ensure screens render correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
