### PR TITLE
Use risk instead of threat

### DIFF
--- a/client/dashboard/sites/overview/scan-card.tsx
+++ b/client/dashboard/sites/overview/scan-card.tsx
@@ -45,8 +45,8 @@ function ScanCardUnavailable() {
 function ScanCardWithThreats( { site, scan }: { site: Site; scan: SiteScan } ) {
 	const threatCount = scan.threats.length;
 	const description = sprintf(
-		/* translators: %d: number of threats */
-		_n( '%d threat found', '%d threats found', threatCount ),
+		/* translators: %d: number of risks */
+		_n( '%d risk found', '%d risks found', threatCount ),
 		threatCount
 	);
 
@@ -76,7 +76,7 @@ function ScanCardNoThreats( { site, scan }: { site: Site; scan: SiteScan } ) {
 	return (
 		<OverviewCard
 			{ ...CARD_PROPS }
-			heading={ __( 'No threats found' ) }
+			heading={ __( 'No risks found' ) }
 			description={ description }
 			externalLink={ getScanURL( site ) }
 			variant="success"


### PR DESCRIPTION
See https://github.com/Automattic/wp-calypso/pull/104690#pullrequestreview-3016584279

## Proposed Changes

This PR updates the copy to use "risk" instead of "threat"

<img width="348" height="165" alt="SCR-20250716-ipzk" src="https://github.com/user-attachments/assets/1e4f0e96-7319-4685-b892-6376f94e8cc4" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
