### PR TITLE
A4A > Reports: Hide the reports without a managed site

### DIFF
--- a/client/a8c-for-agencies/sections/reports/lib/get-site-reports.ts
+++ b/client/a8c-for-agencies/sections/reports/lib/get-site-reports.ts
@@ -9,7 +9,7 @@ export const getSiteReports = ( reports: Report[] ): SiteReports[] => {
 	const grouped = reports.reduce(
 		( acc, report ) => {
 			// Only include reports with "sent" status
-			if ( report.status !== 'sent' ) {
+			if ( report.status !== 'sent' || ! report.data.managed_site_id ) {
 				return acc;
 			}
 


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1301/hide-the-reports-with-no-site-on-the-ui

## Proposed Changes

This PR hides the reports without a managed site.

## Testing Instructions

* Patch 187937-ghe-Automattic/wpcom and follow the instructions.
* Verify the sent report is hidden from the dashboard if a managed site for a report is deleted.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
