### PR TITLE
A4A > Marketplace: Handle assign license error scenarios

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-assign-licenses-to-site.ts
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-assign-licenses-to-site.ts
@@ -36,7 +36,7 @@ const useAssignLicensesToSite = (
 	const assignLicensesToSite = useCallback(
 		async ( licenseKeys: string[] ): Promise< PurchasedProductsInfo > => {
 			// Only proceed if the mutation is in a fresh/ready state
-			if ( ! assignLicense.isIdle ) {
+			if ( assignLicense.isPending ) {
 				throw new Error( 'The mutation for assigning licenses is not ready' );
 			}
 


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1017/assign-license-do-not-redirect-or-show-feedback-survey-on-failure

## Proposed Changes

This PR handles the assign license error scenarios:

- By showing the appropriate error messages
- By not doing any success-related activities on failure, like showing a survey, and redirecting. 

## Why are these changes being made?

* To better handle the error scenarios while assigning a license. 

## Testing Instructions

* Open the A4A live link
* Go to Marketplace > Assign a Woo license to a site > Ensure you are redirected to /download-products
* Assign a Jetpack license > Ensure you are redirected to the Licenses page. It appears that we are not displaying any success indication here. I have created an issue: https://linear.app/a8c/issue/A4A-1303/assign-license-show-success-notice-or-highlight-the-license-after-the
* Assign a Woo license to the same site you assigned earlier > Verify that an error message is shown and you are not redirected.
* Do the same for Jetpack license and verify you are not redirected. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
