### PR TITLE
Site Overview v2: Implement A4A Share card

### DIFF
--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -35,6 +35,7 @@ import { siteDefensiveModeSettingsQuery } from './queries/site-defensive-mode';
 import { siteDomainsQuery } from './queries/site-domains';
 import { sitePHPVersionQuery } from './queries/site-php-version';
 import { siteCurrentPlanQuery } from './queries/site-plans';
+import { sitePreviewLinksQuery } from './queries/site-preview-links';
 import { sitePrimaryDataCenterQuery } from './queries/site-primary-data-center';
 import { siteScanQuery } from './queries/site-scan';
 import { siteSettingsQuery } from './queries/site-settings';
@@ -139,6 +140,8 @@ const siteOverviewRoute = createRoute( {
 					queryClient.ensureQueryData( siteScanQuery( site.ID ) ),
 				hasHostingFeature( site, DotcomFeatures.BACKUPS ) &&
 					queryClient.ensureQueryData( siteLastBackupQuery( site.ID ) ),
+				hasPlanFeature( site, DotcomFeatures.SITE_PREVIEW_LINKS ) &&
+					queryClient.ensureQueryData( sitePreviewLinksQuery( site.ID ) ),
 			] );
 		}
 	},

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -19,7 +19,7 @@ import {
 	canViewStaticFile404Settings,
 	canViewCachingSettings,
 } from '../sites/features';
-import { hasHostingFeature, hasPlanFeature } from '../utils/site-features';
+import { hasHostingFeature } from '../utils/site-features';
 import NotFound from './404';
 import UnknownError from './500';
 import { domainsQuery } from './queries/domains';
@@ -140,8 +140,7 @@ const siteOverviewRoute = createRoute( {
 					queryClient.ensureQueryData( siteScanQuery( site.ID ) ),
 				hasHostingFeature( site, DotcomFeatures.BACKUPS ) &&
 					queryClient.ensureQueryData( siteLastBackupQuery( site.ID ) ),
-				hasPlanFeature( site, DotcomFeatures.SITE_PREVIEW_LINKS ) &&
-					queryClient.ensureQueryData( sitePreviewLinksQuery( site.ID ) ),
+				site.is_a4a_dev_site && queryClient.ensureQueryData( sitePreviewLinksQuery( site.ID ) ),
 			] );
 		}
 	},

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -19,7 +19,7 @@ import {
 	canViewStaticFile404Settings,
 	canViewCachingSettings,
 } from '../sites/features';
-import { hasHostingFeature } from '../utils/site-features';
+import { hasHostingFeature, hasPlanFeature } from '../utils/site-features';
 import NotFound from './404';
 import UnknownError from './500';
 import { domainsQuery } from './queries/domains';

--- a/client/dashboard/sites/overview-card/index.tsx
+++ b/client/dashboard/sites/overview-card/index.tsx
@@ -1,3 +1,4 @@
+import { Link } from '@tanstack/react-router';
 import {
 	Card,
 	CardBody,
@@ -9,6 +10,7 @@ import {
 	ProgressBar,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { chevronRight } from '@wordpress/icons';
 import { useAnalytics } from '../../app/analytics';
 import ComponentViewTracker from '../../components/component-view-tracker';
 import type { ReactElement, ReactNode } from 'react';
@@ -18,6 +20,7 @@ export interface OverviewCardProps {
 	title: string;
 	customHeading?: ReactNode;
 	description?: string;
+	link?: string;
 	externalLink?: string;
 	heading?: ReactNode;
 	icon?: ReactElement;
@@ -34,6 +37,7 @@ export default function OverviewCard( {
 	externalLink,
 	heading,
 	icon,
+	link,
 	metaText,
 	title,
 	trackId,
@@ -77,9 +81,12 @@ export default function OverviewCard( {
 								{ title }
 							</Text>
 						</HStack>
+						{ link && (
+							<Icon className="dashboard-overview-card__link-icon" icon={ chevronRight } />
+						) }
 						{ externalLink && (
 							<span
-								className="components-external-link__icon"
+								className="dashboard-overview-card__link-icon components-external-link__icon"
 								aria-label={
 									/* translators: accessibility text */
 									__( '(opens in a new tab)' )
@@ -122,6 +129,14 @@ export default function OverviewCard( {
 			</CardBody>
 		</Card>
 	);
+
+	if ( link ) {
+		return (
+			<Link to={ link } className="dashboard-overview-card__link">
+				{ content }
+			</Link>
+		);
+	}
 
 	if ( externalLink ) {
 		return (

--- a/client/dashboard/sites/overview-card/style.scss
+++ b/client/dashboard/sites/overview-card/style.scss
@@ -18,7 +18,7 @@
 }
 
 .dashboard-overview-card__icon {
-	fill: $gray-700;
+	fill: var(--wp-admin-theme-color);
 
 	.dashboard-overview-card--upsell & path {
 		fill: var( --wp-admin-theme-color );
@@ -31,6 +31,19 @@
 	.dashboard-overview-card--error & {
 		fill: $alert-red;
 		background-color: color-mix(in srgb, $alert-red 8%, transparent);
+	}
+}
+
+.dashboard-overview-card__link-icon {
+	color: $gray-600;
+	fill: $gray-600;
+	height: 24px;
+	margin: 0;
+	text-align: center;
+	width: 24px;
+
+	.rtl & {
+		transform: scaleX(-1);
 	}
 }
 
@@ -50,7 +63,8 @@
 				color: var( --wp-admin-theme-color );
 			}
 
-			.dashboard-overview-card__icon {
+			.dashboard-overview-card__icon,
+			.dashboard-overview-card__link-icon {
 				fill: var( --wp-admin-theme-color );
 				background-color: transparent;
 			}	

--- a/client/dashboard/sites/overview/agency-site-share-card.tsx
+++ b/client/dashboard/sites/overview/agency-site-share-card.tsx
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import { __ } from '@wordpress/i18n';
+import { link } from '@wordpress/icons';
+import { sitePreviewLinksQuery } from '../../app/queries/site-preview-links';
+import OverviewCard from '../overview-card';
+import type { Site } from '../../data/types';
+
+export default function AgencySiteShareCard( { site }: { site: Site } ) {
+	const { data: links = [] } = useQuery( sitePreviewLinksQuery( site.ID ) );
+	const heading = links.length > 0 ? __( 'Preview link enabled' ) : __( 'Preview link disabled' );
+
+	return (
+		<OverviewCard
+			icon={ link }
+			heading={ heading }
+			description={ __( 'Share a preview link with clients' ) }
+			link={ `/sites/${ site.slug }/settings/site-visibility` }
+			title={ __( 'Share' ) }
+			trackId="agency-site-share"
+		/>
+	);
+}

--- a/client/dashboard/sites/overview/agency-site-share-card.tsx
+++ b/client/dashboard/sites/overview/agency-site-share-card.tsx
@@ -7,13 +7,13 @@ import type { Site } from '../../data/types';
 
 export default function AgencySiteShareCard( { site }: { site: Site } ) {
 	const { data: links = [] } = useQuery( sitePreviewLinksQuery( site.ID ) );
-	const heading = links.length > 0 ? __( 'Preview link enabled' ) : __( 'Preview link disabled' );
+	const heading = links.length > 0 ? __( 'Preview link enabled' ) : __( 'Share a preview link' );
 
 	return (
 		<OverviewCard
 			icon={ link }
 			heading={ heading }
-			description={ __( 'Share a preview link with clients' ) }
+			description={ __( 'Collaborators with the link can view your site' ) }
 			link={ `/sites/${ site.slug }/settings/site-visibility` }
 			title={ __( 'Share' ) }
 			trackId="agency-site-share"

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -17,6 +17,7 @@ import PageLayout from '../../components/page-layout';
 import { getSiteDisplayName } from '../../utils/site-name';
 import OverviewCard from '../overview-card';
 import OverviewCardUpsellDIFM from '../overview-card-upsell-difm';
+import AgencySiteShareCard from './agency-site-share-card';
 import BackupCard from './backup-card';
 import PerformanceCards from './performance-cards';
 import ScanCard from './scan-card';
@@ -117,12 +118,16 @@ function SiteOverview( {
 						<BackupCard site={ site } />
 					</VStack>
 					<VStack className="site-overview-cards" spacing={ spacing }>
-						<OverviewCard
-							title={ __( 'Performance' ) }
-							icon={ chartBar }
-							heading="TBA"
-							description="TBA"
-						/>
+						{ site.is_a4a_dev_site ? (
+							<AgencySiteShareCard site={ site } />
+						) : (
+							<OverviewCard
+								title={ __( 'Performance' ) }
+								icon={ chartBar }
+								heading="TBA"
+								description="TBA"
+							/>
+						) }
 						<ScanCard site={ site } />
 					</VStack>
 					<OverviewCard title={ __( 'Plan' ) } icon={ wordpress } heading="TBA" />


### PR DESCRIPTION
Ref DOTDASH-139

## Proposed Changes

This PR implements the A4A Share cards, only available for A4A development sites.
<img width="303" height="171" alt="SCR-20250716-pbsw" src="https://github.com/user-attachments/assets/311bb607-d28a-492f-b8f0-31362b660e06" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Select an A4A development site, and ensure you see the card
* Ensure that it links to Site Visibility setting

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
