### PR TITLE
Site Overview: Implement DomainsCard

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -40,6 +40,8 @@ module.exports = {
 							'!@automattic/components/src/breadcrumbs',
 							'!@automattic/components/src/breadcrumbs/types',
 							'!@automattic/calypso-analytics',
+							'!@automattic/domains-table',
+							'!@automattic/domains-table/src/utils/*',
 							'!@automattic/number-formatters',
 							'!@automattic/ui',
 							'!@automattic/viewport',

--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -18,13 +18,13 @@
 	text-transform: uppercase;
 }
 
-// Need to fix in upstream.
-.components-card__header:has(~ .components-card__body:has(> .dataviews-wrapper .dataviews-view-list) ) {
-	border-bottom: 0;
-}
-
-.components-card__body:has(> .dataviews-wrapper):not(:has(.dataviews__view-actions)) {
+// We manually compose the UI of the dataview without including the view actions, which results in extra padding and a border.
+.components-card__header + .components-card__body:has( > .dataviews-wrapper ):not( :has( .dataviews__view-actions ) ) {
 	padding-top: 0;
+
+	.dataviews-view-list div[role="row"]:first-child {
+		border-top: none;
+	}
 }
 
 // Global Styles
@@ -43,7 +43,7 @@ body {
 	line-height: $font-line-height-small;
 
 	/* stylelint-disable-next-line unit-allowed-list */
-	@media (-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi) {
+	@media ( -webkit-min-device-pixel-ratio: 1.25 ), ( min-resolution: 120dpi ) {
 		text-rendering: optimizeLegibility;
 		-moz-osx-font-smoothing: grayscale;
 		-webkit-font-smoothing: antialiased;

--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -18,6 +18,15 @@
 	text-transform: uppercase;
 }
 
+// Need to fix in upstream.
+.components-card__header:has(~ .components-card__body:has(> .dataviews-wrapper .dataviews-view-list) ) {
+	border-bottom: 0;
+}
+
+.components-card__body:has(> .dataviews-wrapper):not(:has(.dataviews__view-actions)) {
+	padding-top: 0;
+}
+
 // Global Styles
 html,
 body,

--- a/client/dashboard/components/section-header/index.tsx
+++ b/client/dashboard/components/section-header/index.tsx
@@ -36,7 +36,7 @@ export const SectionHeader = ( {
 				{ decoration && (
 					<span className="dashboard-section-header__decoration">{ decoration }</span>
 				) }
-				<HStack justify="space-between" alignment="center">
+				<HStack justify="space-between" alignment="center" spacing={ 3 }>
 					<HeadingTag className="dashboard-section-header__heading" id={ headingId }>
 						{ title }
 					</HeadingTag>
@@ -46,6 +46,7 @@ export const SectionHeader = ( {
 						expanded={ false }
 						alignment="center"
 						className="dashboard-section-header__actions"
+						spacing={ 3 }
 					>
 						{ actions }
 					</HStack>

--- a/client/dashboard/data/domains.ts
+++ b/client/dashboard/data/domains.ts
@@ -1,15 +1,25 @@
 import wpcom from 'calypso/lib/wp';
 
+export enum DomainTypes {
+	MAPPED = 'mapping',
+	REGISTERED = 'registered',
+	SITE_REDIRECT = 'redirect',
+	WPCOM = 'wpcom',
+	TRANSFER = 'transfer',
+}
+
 export interface Domain {
+	primary_domain: boolean;
 	domain: string;
 	blog_id: number;
 	blog_name: string;
-	expiry: string;
-	domain_status: {
+	expiry: string | false;
+	domain_status?: {
 		status: string;
 	};
 	wpcom_domain: boolean;
-	type: string;
+	is_wpcom_staging_domain: boolean;
+	type: `${ DomainTypes }`;
 }
 
 export async function fetchDomains(): Promise< Domain[] > {

--- a/client/dashboard/data/domains.ts
+++ b/client/dashboard/data/domains.ts
@@ -20,6 +20,7 @@ export interface Domain {
 	wpcom_domain: boolean;
 	is_wpcom_staging_domain: boolean;
 	type: `${ DomainTypes }`;
+	site_slug: string;
 }
 
 export async function fetchDomains(): Promise< Domain[] > {

--- a/client/dashboard/data/site-domains.ts
+++ b/client/dashboard/data/site-domains.ts
@@ -1,15 +1,7 @@
 import wpcom from 'calypso/lib/wp';
+import type { Domain } from './domains';
 
-export interface SiteDomain {
-	domain: string;
-	blog_id: number;
-	blog_name: string;
-	expiry: string;
-	wpcom_domain: boolean;
-	type: string;
-	primary_domain: boolean;
-	is_wpcom_staging_domain: boolean;
-}
+export type SiteDomain = Omit< Domain, 'domain_status' >;
 
 export async function fetchSiteDomains( siteId: number ): Promise< SiteDomain[] > {
 	const { domains } = await wpcom.req.get( {

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -1,5 +1,10 @@
-import { isDomainRenewable } from '@automattic/domains-table/src/utils/is-renewable'; // eslint-disable-line
-import { domainManagementLink as getDomainManagementLink } from '@automattic/domains-table/src/utils/paths'; // eslint-disable-line
+/* eslint-disable no-restricted-imports */
+import { isDomainRenewable } from '@automattic/domains-table/src/utils/is-renewable';
+import {
+	domainManagementLink,
+	domainMappingSetup,
+} from '@automattic/domains-table/src/utils/paths';
+/* eslint-enable no-restricted-imports */
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { payment, tool } from '@wordpress/icons';
@@ -24,8 +29,8 @@ export const actions: Action< Domain >[] = [
 		label: __( 'Setup' ),
 		callback: ( items: Domain[] ) => {
 			const domain = items[ 0 ];
-			const primaryDomain = items.find( ( item ) => item.primary_domain ) ?? domain;
-			window.location.pathname = `/domains/mapping/${ primaryDomain.domain }/setup/${ domain.domain }`;
+			const siteSlug = domain.primary_domain ? domain.domain : domain.site_slug;
+			window.location.pathname = domainMappingSetup( siteSlug, domain.domain );
 		},
 		isEligible: ( item: Domain ) => item.type === DomainTypes.MAPPED,
 	},
@@ -38,10 +43,12 @@ export const actions: Action< Domain >[] = [
 		supportsBulk: false,
 		callback: ( items: Domain[] ) => {
 			const domain = items[ 0 ];
-			const primaryDomain = items.find( ( item ) => item.primary_domain ) ?? domain;
-			window.location.pathname = getDomainManagementLink( domain, primaryDomain.domain, false );
+			const siteSlug = domain.primary_domain ? domain.domain : domain.site_slug;
+			window.location.pathname = domainManagementLink( domain, siteSlug, false );
 		},
-		isEligible: ( item: Domain ) => item.wpcom_domain,
+		isEligible: ( item: Domain ) => {
+			return item.type !== DomainTypes.WPCOM;
+		},
 	},
 	{
 		id: 'manage-dns-settings',

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -1,0 +1,95 @@
+import { isDomainRenewable } from '@automattic/domains-table/src/utils/is-renewable'; // eslint-disable-line
+import { domainManagementLink as getDomainManagementLink } from '@automattic/domains-table/src/utils/paths'; // eslint-disable-line
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { payment, tool } from '@wordpress/icons';
+import { DomainTypes } from '../../data/domains';
+import type { Domain } from '../../data/types';
+import type { Action } from '@wordpress/dataviews';
+
+// TODO: Complete all actions and verify whether it works.
+export const actions: Action< Domain >[] = [
+	{
+		id: 'renew',
+		isPrimary: true,
+		icon: <Icon icon={ payment } />,
+		label: __( 'Renew now' ),
+		callback: () => {},
+		isEligible: ( item: Domain ) => isDomainRenewable( item ),
+	},
+	{
+		id: 'setup',
+		isPrimary: true,
+		icon: <Icon icon={ tool } />,
+		label: __( 'Setup' ),
+		callback: ( items: Domain[] ) => {
+			const domain = items[ 0 ];
+			const primaryDomain = items.find( ( item ) => item.primary_domain ) ?? domain;
+			window.location.pathname = `/domains/mapping/${ primaryDomain.domain }/setup/${ domain.domain }`;
+		},
+		isEligible: ( item: Domain ) => item.type === DomainTypes.MAPPED,
+	},
+	{
+		id: 'manage-domain',
+		label: ( items: Domain[] ) => {
+			const domain = items[ 0 ];
+			return domain.type === DomainTypes.TRANSFER ? __( 'View transfer' ) : __( 'View settings' );
+		},
+		supportsBulk: false,
+		callback: ( items: Domain[] ) => {
+			const domain = items[ 0 ];
+			const primaryDomain = items.find( ( item ) => item.primary_domain ) ?? domain;
+			window.location.pathname = getDomainManagementLink( domain, primaryDomain.domain, false );
+		},
+		isEligible: ( item: Domain ) => item.wpcom_domain,
+	},
+	{
+		id: 'manage-dns-settings',
+		label: __( 'Manage DNS' ),
+		supportsBulk: false,
+		callback: () => {},
+		isEligible: () => false,
+	},
+	{
+		id: 'manage-contact-info',
+		label: __( 'Manage contact information' ),
+		supportsBulk: true,
+		callback: () => {},
+		isEligible: () => false,
+	},
+	{
+		id: 'set-primary-site-address',
+		label: __( 'Make primary site address' ),
+		supportsBulk: false,
+		callback: () => {},
+		isEligible: () => false,
+	},
+	{
+		id: 'transfer-domain',
+		label: __( 'Transfer to WordPress.com' ),
+		supportsBulk: false,
+		callback: () => {},
+		isEligible: () => false,
+	},
+	{
+		id: 'connect-to-site',
+		label: __( 'Attach to an existing site' ),
+		supportsBulk: false,
+		callback: () => {},
+		isEligible: () => false,
+	},
+	{
+		id: 'change-site-address',
+		label: __( 'Change site address' ),
+		supportsBulk: false,
+		callback: () => {},
+		isEligible: () => false,
+	},
+	{
+		id: 'manage-auto-renew',
+		label: __( 'Manage auto-renew' ),
+		supportsBulk: true,
+		callback: () => {},
+		isEligible: () => false,
+	},
+];

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -1,15 +1,14 @@
-/* eslint-disable no-restricted-imports */
 import { isDomainRenewable } from '@automattic/domains-table/src/utils/is-renewable';
 import {
 	domainManagementLink,
 	domainMappingSetup,
 } from '@automattic/domains-table/src/utils/paths';
-/* eslint-enable no-restricted-imports */
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { payment, tool } from '@wordpress/icons';
 import { DomainTypes } from '../../data/domains';
 import type { Domain } from '../../data/types';
+import type { ResponseDomain } from '@automattic/domains-table';
 import type { Action } from '@wordpress/dataviews';
 
 // TODO: Complete all actions and verify whether it works.
@@ -20,7 +19,8 @@ export const actions: Action< Domain >[] = [
 		icon: <Icon icon={ payment } />,
 		label: __( 'Renew now' ),
 		callback: () => {},
-		isEligible: ( item: Domain ) => isDomainRenewable( item ),
+		// TODO: Fix types here.
+		isEligible: ( item: Domain ) => isDomainRenewable( item as unknown as ResponseDomain ),
 	},
 	{
 		id: 'setup',

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -1,0 +1,56 @@
+import { __experimentalText as Text } from '@wordpress/components';
+import { dateI18n } from '@wordpress/date';
+import { __ } from '@wordpress/i18n';
+import type { Domain } from '../../data/types';
+import type { Field } from '@wordpress/dataviews';
+
+export const fields: Field< Domain >[] = [
+	{
+		id: 'domain',
+		label: __( 'Domains' ),
+		enableHiding: false,
+		enableSorting: true,
+		enableGlobalSearch: true,
+		getValue: ( { item }: { item: Domain } ) => item.domain,
+	},
+	{
+		id: 'type',
+		label: __( 'Type' ),
+		enableHiding: false,
+		enableSorting: false,
+	},
+	// {
+	// 	id: 'owner',
+	// 	label: __( 'Owner' ),
+	// 	enableHiding: false,
+	// 	enableSorting: true,
+	// },
+	{
+		id: 'blog_name',
+		label: __( 'Site' ),
+		enableHiding: false,
+		enableSorting: true,
+		getValue: ( { item }: { item: Domain } ) => item.blog_name ?? '',
+	},
+	// {
+	// 	id: 'ssl_status',
+	// 	label: __( 'SSL' ),
+	// 	enableHiding: false,
+	// 	enableSorting: true,
+	// },
+	{
+		id: 'expiry',
+		label: __( 'Expires/Renews on' ),
+		enableHiding: false,
+		enableSorting: true,
+		getValue: ( { item }: { item: Domain } ) =>
+			item.expiry ? dateI18n( 'F j, Y', item.expiry ) : <Text color="#CCCCCC">-</Text>,
+	},
+	{
+		id: 'domain_status',
+		label: __( 'Status' ),
+		enableHiding: false,
+		enableSorting: true,
+		getValue: ( { item }: { item: Domain } ) => item.domain_status?.status,
+	},
+];

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -4,6 +4,8 @@ import { __ } from '@wordpress/i18n';
 import type { Domain } from '../../data/types';
 import type { Field } from '@wordpress/dataviews';
 
+const IneligibleIndicator = () => <Text color="#CCCCCC">-</Text>;
+
 export const fields: Field< Domain >[] = [
 	{
 		id: 'domain',
@@ -44,13 +46,16 @@ export const fields: Field< Domain >[] = [
 		enableHiding: false,
 		enableSorting: true,
 		getValue: ( { item }: { item: Domain } ) =>
-			item.expiry ? dateI18n( 'F j, Y', item.expiry ) : <Text color="#CCCCCC">-</Text>,
+			item.expiry ? dateI18n( 'F j, Y', item.expiry ) : '',
+		render: ( { item } ) =>
+			item.expiry ? dateI18n( 'F j, Y', item.expiry ) : <IneligibleIndicator />,
 	},
 	{
 		id: 'domain_status',
 		label: __( 'Status' ),
 		enableHiding: false,
 		enableSorting: true,
-		getValue: ( { item }: { item: Domain } ) => item.domain_status?.status,
+		getValue: ( { item }: { item: Domain } ) => item.domain_status?.status ?? '',
+		render: ( { item } ) => item.domain_status?.status ?? <IneligibleIndicator />,
 	},
 ];

--- a/client/dashboard/domains/dataviews/index.tsx
+++ b/client/dashboard/domains/dataviews/index.tsx
@@ -1,0 +1,3 @@
+export * from './actions';
+export * from './fields';
+export * from './views';

--- a/client/dashboard/domains/dataviews/views.ts
+++ b/client/dashboard/domains/dataviews/views.ts
@@ -1,0 +1,31 @@
+import type { ViewTable, ViewList } from '@wordpress/dataviews';
+
+export type DomainsView = ViewTable | ViewList;
+
+export const DEFAULT_VIEW: Partial< DomainsView > = {
+	filters: [],
+	sort: {
+		field: 'domain',
+		direction: 'asc',
+	},
+	page: 1,
+	perPage: 10,
+	search: '',
+	showMedia: false,
+	titleField: 'domain',
+	// descriptionField: 'domain_type',
+	fields: [
+		'type',
+		// 'owner',
+		'blog_name',
+		// 'ssl_status',
+		'expiry',
+		'domain_status',
+	],
+};
+
+// Default layouts
+export const DEFAULT_LAYOUTS = {
+	table: {},
+	list: {},
+};

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -1,104 +1,33 @@
 import { useQuery } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
-import { DataViews, filterSortAndPaginate, View } from '@wordpress/dataviews';
-import { dateI18n } from '@wordpress/date';
+import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import { domainsQuery } from '../app/queries/domains';
 import DataViewsCard from '../components/dataviews-card';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
+import { actions, fields, DEFAULT_VIEW, DEFAULT_LAYOUTS } from './dataviews';
+import type { DomainsView } from './dataviews';
 import type { Domain } from '../data/types';
 
-const fields = [
-	{
-		id: 'domain',
-		label: __( 'Domains' ),
-		enableHiding: false,
-		enableSorting: true,
-		enableGlobalSearch: true,
-		getValue: ( { item }: { item: Domain } ) => item.domain,
-	},
-	{
-		id: 'type',
-		label: __( 'Type' ),
-		enableHiding: false,
-		enableSorting: false,
-	},
-	// {
-	// 	id: 'owner',
-	// 	label: __( 'Owner' ),
-	// 	enableHiding: false,
-	// 	enableSorting: true,
-	// },
-	{
-		id: 'blog_name',
-		label: __( 'Site' ),
-		enableHiding: false,
-		enableSorting: true,
-		getValue: ( { item }: { item: Domain } ) => item.blog_name ?? '',
-	},
-	// {
-	// 	id: 'ssl_status',
-	// 	label: __( 'SSL' ),
-	// 	enableHiding: false,
-	// 	enableSorting: true,
-	// },
-	{
-		id: 'expiry',
-		label: __( 'Expires/Renews on' ),
-		enableHiding: false,
-		enableSorting: true,
-		getValue: ( { item }: { item: Domain } ) => dateI18n( 'F j, Y', item.expiry ),
-	},
-	{
-		id: 'domain_status',
-		label: __( 'Status' ),
-		enableHiding: false,
-		enableSorting: true,
-		getValue: ( { item }: { item: Domain } ) => item.domain_status?.status,
-	},
-];
-
-const initialViewState: View = {
-	filters: [],
-	sort: {
-		field: 'domain',
-		direction: 'asc',
-	},
-	page: 1,
-	perPage: 10,
-	search: '',
-	type: 'table',
-	showMedia: false,
-	titleField: 'domain',
-	// descriptionField: 'domain_type',
-	fields: [
-		'type',
-		// 'owner',
-		'blog_name',
-		// 'ssl_status',
-		'expiry',
-		'domain_status',
-	],
-};
-
-// Default layouts
-const defaultLayouts = {
-	table: {},
-};
-
-function getDomainId( domain: Domain ): string {
+export function getDomainId( domain: Domain ): string {
 	return `${ domain.domain }-${ domain.blog_id }`;
 }
 
 function Domains() {
-	const [ view, setView ] = useState( () => initialViewState );
-	const domains = useQuery( domainsQuery() ).data;
-	if ( ! domains ) {
-		return;
-	}
-	const { data: filteredData, paginationInfo } = filterSortAndPaginate( domains, view, fields );
+	const [ view, setView ] = useState< DomainsView >( () => ( {
+		...DEFAULT_VIEW,
+		type: 'table',
+	} ) );
+
+	const { data: domains, isLoading } = useQuery( domainsQuery() );
+	const { data: filteredData, paginationInfo } = filterSortAndPaginate(
+		domains ?? [],
+		view,
+		fields
+	);
+
 	return (
 		<PageLayout
 			header={
@@ -113,17 +42,17 @@ function Domains() {
 			}
 		>
 			<DataViewsCard>
-				<DataViews
+				<DataViews< Domain >
 					data={ filteredData || [] }
 					fields={ fields }
-					onChangeView={ ( newView ) => setView( () => newView ) }
+					onChangeView={ ( nextView ) => setView( () => nextView as DomainsView ) }
 					view={ view }
-					actions={ [] }
+					actions={ actions }
 					search
 					paginationInfo={ paginationInfo }
 					getItemId={ getDomainId }
-					isLoading={ false }
-					defaultLayouts={ defaultLayouts }
+					isLoading={ isLoading }
+					defaultLayouts={ DEFAULT_LAYOUTS }
 				/>
 			</DataViewsCard>
 		</PageLayout>

--- a/client/dashboard/sites/overview/domains-card.tsx
+++ b/client/dashboard/sites/overview/domains-card.tsx
@@ -155,7 +155,12 @@ export default function DomainsCard( {
 					getItemId={ getDomainId }
 					isLoading={ isLoading }
 					defaultLayouts={ defaultLayouts }
-				/>
+				>
+					<>
+						<DataViews.Layout />
+						<DataViews.Pagination />
+					</>
+				</DataViews>
 			</CardBody>
 		</Card>
 	);

--- a/client/dashboard/sites/overview/domains-card.tsx
+++ b/client/dashboard/sites/overview/domains-card.tsx
@@ -1,0 +1,162 @@
+import { isDomainRenewable } from '@automattic/domains-table/src/utils/is-renewable'; // eslint-disable-line
+import { domainManagementLink as getDomainManagementLink } from '@automattic/domains-table/src/utils/paths'; // eslint-disable-line
+import { useQuery } from '@tanstack/react-query';
+import {
+	Button,
+	Card,
+	CardHeader,
+	CardBody,
+	Icon,
+	__experimentalText as Text,
+} from '@wordpress/components';
+import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { dateI18n } from '@wordpress/date';
+import { __ } from '@wordpress/i18n';
+import { payment, tool } from '@wordpress/icons';
+import { addQueryArgs } from '@wordpress/url';
+import { useState } from 'react';
+import { type as domainTypes } from 'calypso/lib/domains/constants'; // eslint-disable-line
+import { siteDomainsQuery } from '../../app/queries/site-domains';
+import { SectionHeader } from '../../components/section-header';
+import type { Site, SiteDomain } from '../../data/types';
+import type { Action, Field, View } from '@wordpress/dataviews';
+
+const fields: Field< SiteDomain >[] = [
+	{
+		id: 'domain',
+		label: __( 'Domains' ),
+		enableHiding: false,
+		enableSorting: true,
+		enableGlobalSearch: true,
+		getValue: ( { item }: { item: SiteDomain } ) => item.domain,
+	},
+	{
+		id: 'expiry',
+		label: __( 'Expires/Renews on' ),
+		enableHiding: false,
+		enableSorting: true,
+		getValue: ( { item }: { item: SiteDomain } ) =>
+			item.expiry ? dateI18n( 'F j, Y', item.expiry ) : <Text color="#CCCCCC">-</Text>,
+	},
+];
+
+const actions: Action< SiteDomain >[] = [
+	{
+		id: 'renew',
+		isPrimary: true,
+		icon: <Icon icon={ payment } />,
+		label: __( 'Renew now' ),
+		callback: () => {},
+		isEligible: ( item: SiteDomain ) => isDomainRenewable( item ),
+	},
+	{
+		id: 'setup',
+		isPrimary: true,
+		icon: <Icon icon={ tool } />,
+		label: __( 'Setup' ),
+		callback: ( items: SiteDomain[] ) => {
+			const domain = items[ 0 ];
+			const primaryDomain = items.find( ( item ) => item.primary_domain ) ?? domain;
+			window.location.pathname = `/domains/mapping/${ primaryDomain.domain }/setup/${ domain.domain }`;
+		},
+		isEligible: ( item: SiteDomain ) => item.type === domainTypes.MAPPED,
+	},
+	{
+		id: 'manage-domain',
+		label: ( items: SiteDomain[] ) => {
+			const domain = items[ 0 ];
+			return domain.type === domainTypes.TRANSFER ? __( 'View transfer' ) : __( 'View settings' );
+		},
+		callback: ( items: SiteDomain[] ) => {
+			const domain = items[ 0 ];
+			const primaryDomain = items.find( ( item ) => item.primary_domain ) ?? domain;
+			window.location.pathname = getDomainManagementLink( domain, primaryDomain.domain, false );
+		},
+		isEligible: ( item: SiteDomain ) => item.wpcom_domain,
+	},
+];
+
+const initialViewState: View = {
+	filters: [],
+	sort: {
+		field: 'domain',
+		direction: 'asc',
+	},
+	page: 1,
+	perPage: 10,
+	search: '',
+	type: 'table',
+	showMedia: false,
+	titleField: 'domain',
+	fields: [ 'expiry' ],
+};
+
+// Default layouts
+const defaultLayouts = {
+	table: {},
+};
+
+const getDomainId = ( domain: SiteDomain ): string => {
+	return `${ domain.domain }-${ domain.blog_id }`;
+};
+
+export default function DomainsCard( {
+	site,
+	type = 'table',
+}: {
+	site: Site;
+	type?: View[ 'type' ];
+} ) {
+	const [ view, setView ] = useState( { ...initialViewState, type } );
+	const { data: siteDomains, isLoading } = useQuery( siteDomainsQuery( site.ID ) );
+	const { data: filteredData, paginationInfo } = filterSortAndPaginate(
+		siteDomains ?? [],
+		view,
+		fields
+	);
+
+	return (
+		<Card>
+			<CardHeader style={ { flexDirection: 'column', alignItems: 'stretch' } }>
+				<SectionHeader
+					title={ __( 'Domains' ) }
+					level={ 3 }
+					actions={
+						<>
+							<Button
+								variant="tertiary"
+								href={ addQueryArgs( `/domains/add/use-my-domain/${ site.slug }`, {
+									redirect_to: window.location.pathname,
+								} ) }
+							>
+								{ __( 'Transfer domain' ) }
+							</Button>
+							<Button
+								variant="primary"
+								href={ addQueryArgs( `/domains/add/${ site.slug }`, {
+									redirect_to: window.location.pathname,
+								} ) }
+							>
+								{ __( 'Add domain' ) }
+							</Button>
+						</>
+					}
+				/>
+			</CardHeader>
+			<CardBody>
+				<DataViews< SiteDomain >
+					data={ filteredData || [] }
+					fields={ fields }
+					onChangeView={ ( newView ) => setView( () => newView ) }
+					view={ view }
+					actions={ actions }
+					search={ false }
+					paginationInfo={ paginationInfo }
+					getItemId={ getDomainId }
+					isLoading={ isLoading }
+					defaultLayouts={ defaultLayouts }
+				/>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/sites/overview/domains-card.tsx
+++ b/client/dashboard/sites/overview/domains-card.tsx
@@ -55,6 +55,7 @@ export default function DomainsCard( {
 						<>
 							<Button
 								variant="tertiary"
+								size="compact"
 								href={ addQueryArgs( `/domains/add/use-my-domain/${ site.slug }`, {
 									redirect_to: window.location.pathname,
 								} ) }
@@ -62,7 +63,8 @@ export default function DomainsCard( {
 								{ __( 'Transfer domain' ) }
 							</Button>
 							<Button
-								variant="primary"
+								variant="secondary"
+								size="compact"
 								href={ addQueryArgs( `/domains/add/${ site.slug }`, {
 									redirect_to: window.location.pathname,
 								} ) }

--- a/client/dashboard/sites/overview/domains-card.tsx
+++ b/client/dashboard/sites/overview/domains-card.tsx
@@ -42,7 +42,12 @@ export default function DomainsCard( {
 
 	return (
 		<Card>
-			<CardHeader style={ { flexDirection: 'column', alignItems: 'stretch' } }>
+			<CardHeader
+				style={ {
+					flexDirection: 'column',
+					alignItems: 'stretch',
+				} }
+			>
 				<SectionHeader
 					title={ __( 'Domains' ) }
 					level={ 3 }

--- a/client/dashboard/sites/overview/domains-card.tsx
+++ b/client/dashboard/sites/overview/domains-card.tsx
@@ -1,100 +1,14 @@
-import { isDomainRenewable } from '@automattic/domains-table/src/utils/is-renewable'; // eslint-disable-line
-import { domainManagementLink as getDomainManagementLink } from '@automattic/domains-table/src/utils/paths'; // eslint-disable-line
 import { useQuery } from '@tanstack/react-query';
-import {
-	Button,
-	Card,
-	CardHeader,
-	CardBody,
-	Icon,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { Button, Card, CardHeader, CardBody } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
-import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
-import { payment, tool } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
-import { useState } from 'react';
-import { type as domainTypes } from 'calypso/lib/domains/constants'; // eslint-disable-line
+import { useState, useEffect } from 'react';
 import { siteDomainsQuery } from '../../app/queries/site-domains';
 import { SectionHeader } from '../../components/section-header';
+import { fields, actions, DEFAULT_VIEW, DEFAULT_LAYOUTS } from '../../domains/dataviews';
 import type { Site, SiteDomain } from '../../data/types';
-import type { Action, Field, View } from '@wordpress/dataviews';
-
-const fields: Field< SiteDomain >[] = [
-	{
-		id: 'domain',
-		label: __( 'Domains' ),
-		enableHiding: false,
-		enableSorting: true,
-		enableGlobalSearch: true,
-		getValue: ( { item }: { item: SiteDomain } ) => item.domain,
-	},
-	{
-		id: 'expiry',
-		label: __( 'Expires/Renews on' ),
-		enableHiding: false,
-		enableSorting: true,
-		getValue: ( { item }: { item: SiteDomain } ) =>
-			item.expiry ? dateI18n( 'F j, Y', item.expiry ) : <Text color="#CCCCCC">-</Text>,
-	},
-];
-
-const actions: Action< SiteDomain >[] = [
-	{
-		id: 'renew',
-		isPrimary: true,
-		icon: <Icon icon={ payment } />,
-		label: __( 'Renew now' ),
-		callback: () => {},
-		isEligible: ( item: SiteDomain ) => isDomainRenewable( item ),
-	},
-	{
-		id: 'setup',
-		isPrimary: true,
-		icon: <Icon icon={ tool } />,
-		label: __( 'Setup' ),
-		callback: ( items: SiteDomain[] ) => {
-			const domain = items[ 0 ];
-			const primaryDomain = items.find( ( item ) => item.primary_domain ) ?? domain;
-			window.location.pathname = `/domains/mapping/${ primaryDomain.domain }/setup/${ domain.domain }`;
-		},
-		isEligible: ( item: SiteDomain ) => item.type === domainTypes.MAPPED,
-	},
-	{
-		id: 'manage-domain',
-		label: ( items: SiteDomain[] ) => {
-			const domain = items[ 0 ];
-			return domain.type === domainTypes.TRANSFER ? __( 'View transfer' ) : __( 'View settings' );
-		},
-		callback: ( items: SiteDomain[] ) => {
-			const domain = items[ 0 ];
-			const primaryDomain = items.find( ( item ) => item.primary_domain ) ?? domain;
-			window.location.pathname = getDomainManagementLink( domain, primaryDomain.domain, false );
-		},
-		isEligible: ( item: SiteDomain ) => item.wpcom_domain,
-	},
-];
-
-const initialViewState: View = {
-	filters: [],
-	sort: {
-		field: 'domain',
-		direction: 'asc',
-	},
-	page: 1,
-	perPage: 10,
-	search: '',
-	type: 'table',
-	showMedia: false,
-	titleField: 'domain',
-	fields: [ 'expiry' ],
-};
-
-// Default layouts
-const defaultLayouts = {
-	table: {},
-};
+import type { DomainsView } from '../../domains/dataviews';
 
 const getDomainId = ( domain: SiteDomain ): string => {
 	return `${ domain.domain }-${ domain.blog_id }`;
@@ -105,15 +19,26 @@ export default function DomainsCard( {
 	type = 'table',
 }: {
 	site: Site;
-	type?: View[ 'type' ];
+	type?: DomainsView[ 'type' ];
 } ) {
-	const [ view, setView ] = useState( { ...initialViewState, type } );
+	const [ view, setView ] = useState< DomainsView >( {
+		...DEFAULT_VIEW,
+		fields: [ 'expiry' ],
+		type,
+	} );
+
 	const { data: siteDomains, isLoading } = useQuery( siteDomainsQuery( site.ID ) );
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate(
 		siteDomains ?? [],
 		view,
 		fields
 	);
+
+	useEffect( () => {
+		if ( type ) {
+			setView( ( currentView ) => ( { ...currentView, type } ) );
+		}
+	}, [ type ] );
 
 	return (
 		<Card>
@@ -147,14 +72,14 @@ export default function DomainsCard( {
 				<DataViews< SiteDomain >
 					data={ filteredData || [] }
 					fields={ fields }
-					onChangeView={ ( newView ) => setView( () => newView ) }
+					onChangeView={ ( nextView ) => setView( () => nextView as DomainsView ) }
 					view={ view }
 					actions={ actions }
 					search={ false }
 					paginationInfo={ paginationInfo }
 					getItemId={ getDomainId }
 					isLoading={ isLoading }
-					defaultLayouts={ defaultLayouts }
+					defaultLayouts={ DEFAULT_LAYOUTS }
 				>
 					<>
 						<DataViews.Layout />

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -18,11 +18,11 @@ import { getSiteDisplayName } from '../../utils/site-name';
 import OverviewCard from '../overview-card';
 import OverviewCardUpsellDIFM from '../overview-card-upsell-difm';
 import BackupCard from './backup-card';
+import DomainsCard from './domains-card';
 import PerformanceCards from './performance-cards';
 import ScanCard from './scan-card';
 import SiteOverviewFields from './site-overview-fields';
 import SitePreviewCard from './site-preview-card';
-import StorageCard from './storage-card';
 import UptimeCard from './uptime-card';
 import './style.scss';
 
@@ -143,7 +143,7 @@ function SiteOverview( {
 					</VStack>
 					<VStack spacing={ spacing } justify="start">
 						<OverviewCardUpsellDIFM site={ site } />
-						<StorageCard site={ site } />
+						<DomainsCard site={ site } type={ isSmallViewport ? 'list' : 'table' } />
 						<UptimeCard site={ site } />
 					</VStack>
 				</HStack>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-111

## Proposed Changes

* Implement DomainsCard
* Out of scope
  * The all actions of the domain dataviews - DOTCOM-13923
  * The upsell - DOTDASH-100, DOTDASH-99
  * The track events

| Table | List |
| - | - |
|<img width="674" height="371" alt="image" src="https://github.com/user-attachments/assets/4177f70d-7532-46b5-bfcf-196d0fc70876" />|<img width="606" height="427" alt="image" src="https://github.com/user-attachments/assets/66ea09fa-d6b4-4419-bbec-1e6b07be16fc" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Navigate to Site Overview by selecting any site
* Ensure the domains card looks good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
