### PR TITLE
Connect Refresh: Clean up styles for login-form ToS (only used for Gravatar)

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -28,7 +28,11 @@ import {
 	canDoMagicLogin,
 	getLoginLinkPageUrl,
 } from 'calypso/lib/login';
-import { isGravatarFlowOAuth2Client, isGravatarOAuth2Client } from 'calypso/lib/oauth2-clients';
+import {
+	isGravatarFlowOAuth2Client,
+	isGravatarOAuth2Client,
+	isGravPoweredOAuth2Client,
+} from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -625,10 +629,9 @@ export class LoginForm extends Component {
 			requestError,
 			socialAccountIsLinking: linkingSocialUser,
 			isWoo,
-			isBlazePro,
 			isSendingEmail,
 			isSocialFirst,
-			isJetpack,
+			isGravPoweredClient,
 			isGravatarFixedAccountLogin,
 		} = this.props;
 		const { lastUsedAuthenticationMethod } = this.state;
@@ -857,9 +860,7 @@ export class LoginForm extends Component {
 							</div>
 						</div>
 
-						{ ! isBlazePro && ! isJetpack && (
-							<p className="login__form-terms">{ renderTerms() }</p>
-						) }
+						{ isGravPoweredClient && <p className="login__form-terms">{ renderTerms() }</p> }
 
 						{ shouldRenderForgotPasswordLink && this.renderLostPasswordLink() }
 
@@ -1026,6 +1027,7 @@ export default connect(
 			isOneTapAuth: !! get( getCurrentQueryArguments( state ), 'oneTapAuth' ),
 			isGravatarFixedAccountLogin:
 				isFromGravatar3rdPartyApp || isFromGravatarQuickEditor || isGravatarFlowWithEmail,
+			isGravPoweredClient: isGravPoweredOAuth2Client( state ),
 		};
 	},
 	{

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -106,6 +106,7 @@ export class LoginForm extends Component {
 		isJetpack: PropTypes.bool,
 		loginButtonText: PropTypes.string,
 		isGravatarFixedAccountLogin: PropTypes.bool.isRequired,
+		isGravPoweredClient: PropTypes.bool,
 	};
 
 	state = {

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -1027,7 +1027,7 @@ export default connect(
 			isOneTapAuth: !! get( getCurrentQueryArguments( state ), 'oneTapAuth' ),
 			isGravatarFixedAccountLogin:
 				isFromGravatar3rdPartyApp || isFromGravatarQuickEditor || isGravatarFlowWithEmail,
-			isGravPoweredClient: isGravPoweredOAuth2Client( state ),
+			isGravPoweredClient: isGravPoweredOAuth2Client( oauth2Client ),
 		};
 	},
 	{

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -306,21 +306,9 @@ $breakpoint-mobile: 782px; //Mobile size.
 }
 
 .layout:not(.is-grav-powered-client) {
-	.is-social-first {
-		.login__form-terms {
-			display: none;
-		}
-	}
-
 	&.is-mobile {
 		.login__lostpassword-form  {
 			padding: 16px 16px 0;
 		}
-	}
-}
-
-.is-gravatar {
-	.login__form-terms {
-		display: block;
 	}
 }

--- a/client/layout/masterbar/blaze-pro.scss
+++ b/client/layout/masterbar/blaze-pro.scss
@@ -465,14 +465,6 @@ body.is-section-signup {
 		width: 360px;
 	}
 
-	.login__form-terms {
-		a,
-		a:visited {
-			color: var(--studio-gray-60);
-			text-decoration: underline;
-		}
-	}
-
 	.login form.is-blaze-pro {
 		display: flex;
 		flex-direction: row;

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -165,11 +165,6 @@
 		line-height: 23px;
 	}
 
-	.login__form-terms {
-		font-size: $font-body-extra-small;
-		margin-bottom: 1em;
-	}
-
 	.masterbar__oauth-client {
 		height: unset;
 

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -652,10 +652,6 @@ $breakpoint-mobile: 660px;
 		}
 	}
 
-	.login__form-terms {
-		display: none;
-	}
-
 	.signup-form {
 		padding-top: 32px;
 

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -153,17 +153,6 @@ $image-height: 47px;
 		}
 	}
 
-	.login__form-terms a,
-	.login__social-tos a,
-	.form-input-validation a {
-		color: var(--color-accent-dark);
-
-		&:hover,
-		&:focus {
-			color: var(--color-accent);
-		}
-	}
-
 	.translator-invite__content a {
 		border: none;
 	}
@@ -198,18 +187,6 @@ $image-height: 47px;
 
 	.login__form-change-username {
 		color: var(--color-neutral-60);
-	}
-
-	.login__form-terms {
-		text-align: left;
-		color: var(--color-neutral-60);
-		font-size: $font-body-extra-small;
-	}
-
-	.login__form-terms a,
-	.login__form-terms a:hover {
-		text-align: left;
-		font-size: $font-body-extra-small;
 	}
 
 	.auth-form__social {
@@ -425,7 +402,6 @@ $image-height: 47px;
 	}
 
 	.two-factor-authentication__verification-code-form > p,
-	.login__form-terms,
 	.login__social-tos {
 		color: var(--studio-gray-50);
 	}
@@ -434,22 +410,13 @@ $image-height: 47px;
 		text-align: left;
 	}
 
-	.login__form-terms {
-		/* Note: Same as `.login__form .login__form-userdata label` */
-		font-size: 0.875rem;
-	}
-
-	.login__form-terms,
 	.login__social-tos {
+		margin-top: 24px;
 		text-align: left;
 
 		a {
 			text-decoration: underline;
 		}
-	}
-
-	.login__social-tos {
-		margin-top: 24px;
 	}
 
 	.two-factor-authentication__verification-code-form.card {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13689/login-do-a-cleaner-separation-between-default-and-grav-powered-login

## Proposed Changes

The specific ToS in the login form are only ever rendered for Gravatar clients. We remove some of the customisations from before unification and make the condition more explicit that it is for Gravatar. This was a bit of a soup previously - we'd render them for some clients but hide with CSS for all.

### Media

<img width="544" height="724" alt="Screenshot 2025-07-16 at 6 09 09 PM" src="https://github.com/user-attachments/assets/10abe9c4-f5c2-4037-b735-ae3aef17184a" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13689/login-do-a-cleaner-separation-between-default-and-grav-powered-login

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [Gravatar](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D4a5153e30a28e2ef24ca7e599abd80f3969340cd1f88327c1f5d2fbc88593fa1%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1&client_id=1854) and ensure ToS render correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
