### PR TITLE
Site Domains: Enable premium suggestions

### DIFF
--- a/packages/domain-picker/src/utils/index.ts
+++ b/packages/domain-picker/src/utils/index.ts
@@ -18,7 +18,7 @@ interface DomainSuggestionsVendorOptions {
 	isSignup?: boolean;
 	isDomainOnly?: boolean;
 	isPremium?: boolean;
-	flowName?: typeof NEWSLETTER_FLOW | typeof DOMAIN_FOR_GRAVATAR_FLOW;
+	flowName?: typeof NEWSLETTER_FLOW | typeof DOMAIN_FOR_GRAVATAR_FLOW | 'domains/add';
 }
 type DomainSuggestionsVendor =
 	| 'variation2_front'
@@ -37,6 +37,9 @@ export function getDomainSuggestionsVendor(
 	}
 	if ( isHundredYearPlanFlow( options.flowName ) || isHundredYearDomainFlow( options.flowName ) ) {
 		return '100-year-domains';
+	}
+	if ( options.flowName === 'domains/add' ) {
+		return 'variation8_front';
 	}
 	if ( options.flowName === NEWSLETTER_FLOW ) {
 		return 'newsletter';


### PR DESCRIPTION
## Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/104123, we enabled the multi domain cart in `/domains/add/%s` but also introduced a regression where premium domains were not returned. This PR fixes that.


## Testing Instructions

Enter `/domains/add/%s` and search for a keyword like `books`. Verify that premium domains are included.