### PR TITLE
Hosting Dashboard: Consolidate upsell events

### DIFF
--- a/client/dashboard/components/component-view-tracker/index.tsx
+++ b/client/dashboard/components/component-view-tracker/index.tsx
@@ -12,7 +12,7 @@ export default function ComponentViewTracker( {
 
 	useEffect( () => {
 		recordTracksEvent( eventName, properties );
-	}, [ recordTracksEvent, eventName, properties ] );
+	}, [ recordTracksEvent, eventName, JSON.stringify( properties ) ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	return null;
 }

--- a/client/dashboard/components/upsell-cta-button/index.tsx
+++ b/client/dashboard/components/upsell-cta-button/index.tsx
@@ -7,24 +7,27 @@ import type { ComponentProps } from 'react';
 import './style.scss';
 
 type UpsellCTAButtonProps = ComponentProps< typeof Button > & {
-	trackId: string;
+	tracksId: string;
 	onClick?: ( event: React.MouseEvent< HTMLButtonElement | HTMLAnchorElement > ) => void;
 };
 
 export default function UpsellCTAButton( props: UpsellCTAButtonProps ) {
-	const { trackId, ...buttonProps } = props;
+	const { tracksId, onClick, ...buttonProps } = props;
 	const { recordTracksEvent } = useAnalytics();
 
 	const handleClick = ( event: React.MouseEvent< HTMLButtonElement | HTMLAnchorElement > ) => {
-		recordTracksEvent( 'calypso_dashboard_upsell_cta_button_click', { type: trackId } );
-		buttonProps.onClick?.( event );
+		recordTracksEvent( 'calypso_dashboard_upsell_click', {
+			feature: tracksId,
+			type: 'cta-button',
+		} );
+		onClick?.( event );
 	};
 
 	return (
 		<>
 			<ComponentViewTracker
-				eventName="calypso_dashboard_upsell_cta_button_impression"
-				properties={ { type: trackId } }
+				eventName="calypso_dashboard_upsell_impression"
+				properties={ { feature: tracksId, type: 'cta-button' } }
 			/>
 			<Button
 				className="dashboard-upsell-cta-button"

--- a/client/dashboard/components/upsell-cta-button/index.tsx
+++ b/client/dashboard/components/upsell-cta-button/index.tsx
@@ -33,6 +33,7 @@ export default function UpsellCTAButton( props: UpsellCTAButtonProps ) {
 				className="dashboard-upsell-cta-button"
 				icon={ upsell }
 				onClick={ handleClick }
+				size="compact"
 				{ ...buttonProps }
 			/>
 		</>

--- a/client/dashboard/sites/deployments/index.tsx
+++ b/client/dashboard/sites/deployments/index.tsx
@@ -8,7 +8,7 @@ import { CalloutOverlay } from '../../components/callout-overlay';
 import DataViewsCard from '../../components/dataviews-card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import RouterLinkButton from '../../components/router-link-button';
+import UpsellCTAButton from '../../components/upsell-cta-button';
 import { SitePlan } from '../../data/types';
 import illustrationUrl from './deployments-callout-illustration.svg';
 import ghIconUrl from './gh-icon.svg';
@@ -46,9 +46,11 @@ function SiteDeployments() {
 							</>
 						}
 						actions={
-							<RouterLinkButton __next40pxDefaultSize variant="primary" to="#">
-								{ __( 'Upgrade plan' ) }
-							</RouterLinkButton>
+							<UpsellCTAButton
+								text={ __( 'Upgrade plan' ) }
+								tracksId="deployments"
+								variant="primary"
+							/>
 						}
 					/>
 				}

--- a/client/dashboard/sites/hosting-feature-gate/index.tsx
+++ b/client/dashboard/sites/hosting-feature-gate/index.tsx
@@ -1,5 +1,5 @@
-import { ReactNode } from 'react';
-import { hasHostingFeature, hasPlanFeature } from '../../utils/site-features';
+import React, { ReactNode } from 'react';
+import { hasAtomicFeature, hasPlanFeature } from '../../utils/site-features';
 import HostingFeatureActivation from './activation';
 import HostingFeatureUpsell from './upsell';
 import type { Site } from '../../data/types';
@@ -22,7 +22,7 @@ export default function HostingFeatureGate( {
 	renderUpsellComponent,
 	renderActivationComponent,
 }: HostingFeatureGateProps ) {
-	if ( hasHostingFeature( site, feature ) ) {
+	if ( hasAtomicFeature( site, feature ) ) {
 		return children;
 	}
 

--- a/client/dashboard/sites/hosting-feature-gate/index.tsx
+++ b/client/dashboard/sites/hosting-feature-gate/index.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import { hasAtomicFeature, hasPlanFeature } from '../../utils/site-features';
+import { hasHostingFeature, hasPlanFeature } from '../../utils/site-features';
 import HostingFeatureActivation from './activation';
 import HostingFeatureUpsell from './upsell';
 import type { Site } from '../../data/types';
@@ -22,7 +22,7 @@ export default function HostingFeatureGate( {
 	renderUpsellComponent,
 	renderActivationComponent,
 }: HostingFeatureGateProps ) {
-	if ( hasAtomicFeature( site, feature ) ) {
+	if ( hasHostingFeature( site, feature ) ) {
 		return children;
 	}
 

--- a/client/dashboard/sites/hosting-feature-gate/upsell.tsx
+++ b/client/dashboard/sites/hosting-feature-gate/upsell.tsx
@@ -12,14 +12,16 @@ export default function HostingFeatureUpsell( {
 }: HostingFeatureUpsellProps ) {
 	const { recordTracksEvent } = useAnalytics();
 	useEffect( () => {
-		recordTracksEvent( 'calypso_dashboard_hosting_feature_upsell_impression', {
-			feature_id: tracksFeatureId,
+		recordTracksEvent( 'calypso_dashboard_upsell_impression', {
+			feature: tracksFeatureId,
+			type: 'hosting-feature-gate',
 		} );
 	}, [ recordTracksEvent, tracksFeatureId ] );
 
 	const handleClick = () => {
-		recordTracksEvent( 'calypso_dashboard_hosting_feature_upsell_click', {
-			feature_id: tracksFeatureId,
+		recordTracksEvent( 'calypso_dashboard_upsell_click', {
+			feature: tracksFeatureId,
+			type: 'hosting-feature-gate',
 		} );
 	};
 

--- a/client/dashboard/sites/hosting-feature-gated-with-callout/index.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-callout/index.tsx
@@ -16,7 +16,7 @@ export default function HostingFeatureGatedWithCallout( {
 	upsellDescription,
 	...props
 }: HostingFeatureGatedWithCalloutProps ) {
-	const { site } = props;
+	const { site, tracksFeatureId } = props;
 
 	return (
 		<HostingFeatureGate
@@ -24,6 +24,7 @@ export default function HostingFeatureGatedWithCallout( {
 			renderUpsellComponent={ ( { onClick } ) => (
 				<UpsellCallout
 					site={ site }
+					tracksFeatureId={ tracksFeatureId }
 					onClick={ onClick }
 					upsellIcon={ upsellIcon }
 					upsellImage={ upsellImage }

--- a/client/dashboard/sites/hosting-feature-gated-with-callout/upsell.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-callout/upsell.tsx
@@ -66,7 +66,6 @@ export default function UpsellCallout( {
 			}
 			actions={
 				<UpsellCTAButton
-					size="compact"
 					text={ __( 'Upgrade plan' ) }
 					tracksId={ tracksFeatureId }
 					variant="primary"

--- a/client/dashboard/sites/hosting-feature-gated-with-callout/upsell.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-callout/upsell.tsx
@@ -1,8 +1,9 @@
-import { __experimentalText as Text, Button } from '@wordpress/components';
+import { __experimentalText as Text } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { settings } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import { Callout } from '../../components/callout';
+import UpsellCTAButton from '../../components/upsell-cta-button';
 import illustrationUrl from './upsell-illustration.svg';
 import type { CalloutProps } from '../../components/callout/types';
 import type { Site } from '../../data/types';
@@ -16,6 +17,7 @@ export interface UpsellCalloutProps {
 
 export default function UpsellCallout( {
 	site,
+	tracksFeatureId,
 	onClick,
 	upsellIcon,
 	upsellImage,
@@ -23,6 +25,7 @@ export default function UpsellCallout( {
 	upsellDescription,
 }: {
 	site: Site;
+	tracksFeatureId: string;
 	onClick: () => void;
 } & UpsellCalloutProps ) {
 	const handleUpsellClick = () => {
@@ -62,9 +65,13 @@ export default function UpsellCallout( {
 				</>
 			}
 			actions={
-				<Button variant="primary" size="compact" onClick={ handleUpsellClick }>
-					{ __( 'Upgrade plan' ) }
-				</Button>
+				<UpsellCTAButton
+					size="compact"
+					text={ __( 'Upgrade plan' ) }
+					tracksId={ tracksFeatureId }
+					variant="primary"
+					onClick={ handleUpsellClick }
+				/>
 			}
 		/>
 	);

--- a/client/dashboard/sites/overview-card-upsell-difm/index.tsx
+++ b/client/dashboard/sites/overview-card-upsell-difm/index.tsx
@@ -41,7 +41,7 @@ export default function OverviewCardUpsellDIFM( { site }: { site: Site } ) {
 					target="_blank"
 					text={ __( 'Build it for me' ) }
 					variant="secondary"
-					trackId="difm"
+					tracksId="difm"
 				/>
 			}
 		/>

--- a/client/dashboard/sites/overview-card/index.tsx
+++ b/client/dashboard/sites/overview-card/index.tsx
@@ -22,7 +22,7 @@ export interface OverviewCardProps {
 	heading?: ReactNode;
 	icon?: ReactElement;
 	metaText?: string;
-	trackId?: string;
+	tracksId?: string;
 	variant?: 'upsell' | 'disabled' | 'loading' | 'success' | 'error';
 	children?: ReactNode;
 	onClick?: () => void;
@@ -36,7 +36,7 @@ export default function OverviewCard( {
 	icon,
 	metaText,
 	title,
-	trackId,
+	tracksId,
 	variant,
 	children,
 	onClick,
@@ -56,10 +56,16 @@ export default function OverviewCard( {
 			} }
 		>
 			<CardBody>
-				{ trackId && (
+				{ tracksId && (
 					<ComponentViewTracker
 						eventName="calypso_dashboard_overview_card_impression"
-						properties={ { type: trackId, variant } }
+						properties={ { feature: tracksId, variant } }
+					/>
+				) }
+				{ tracksId && variant === 'upsell' && (
+					<ComponentViewTracker
+						eventName="calypso_dashboard_upsell_impression"
+						properties={ { feature: tracksId, type: 'card' } }
 					/>
 				) }
 				<VStack spacing={ 4 }>
@@ -135,9 +141,16 @@ export default function OverviewCard( {
 
 					if ( trackId ) {
 						recordTracksEvent( 'calypso_dashboard_overview_card_click', {
-							type: trackId,
+							type: tracksId,
 							variant,
 						} );
+
+						if ( variant === 'upsell' ) {
+							recordTracksEvent( 'calypso_dashboard_upsell_click', {
+								feature: tracksId,
+								type: 'card',
+							} );
+						}
 					}
 				} }
 			>

--- a/client/dashboard/sites/overview-card/index.tsx
+++ b/client/dashboard/sites/overview-card/index.tsx
@@ -56,18 +56,18 @@ export default function OverviewCard( {
 			} }
 		>
 			<CardBody>
-				{ tracksId && (
-					<ComponentViewTracker
-						eventName="calypso_dashboard_overview_card_impression"
-						properties={ { feature: tracksId, variant } }
-					/>
-				) }
-				{ tracksId && variant === 'upsell' && (
-					<ComponentViewTracker
-						eventName="calypso_dashboard_upsell_impression"
-						properties={ { feature: tracksId, type: 'card' } }
-					/>
-				) }
+				{ tracksId &&
+					( variant === 'upsell' ? (
+						<ComponentViewTracker
+							eventName="calypso_dashboard_upsell_impression"
+							properties={ { feature: tracksId, type: 'card' } }
+						/>
+					) : (
+						<ComponentViewTracker
+							eventName="calypso_dashboard_overview_card_impression"
+							properties={ { feature: tracksId, variant } }
+						/>
+					) ) }
 				<VStack spacing={ 4 }>
 					<HStack justify="space-between">
 						<HStack spacing={ 2 } alignment="center" expanded={ false }>
@@ -139,16 +139,16 @@ export default function OverviewCard( {
 				onClick={ () => {
 					onClick?.();
 
-					if ( trackId ) {
-						recordTracksEvent( 'calypso_dashboard_overview_card_click', {
-							type: tracksId,
-							variant,
-						} );
-
+					if ( tracksId ) {
 						if ( variant === 'upsell' ) {
 							recordTracksEvent( 'calypso_dashboard_upsell_click', {
 								feature: tracksId,
 								type: 'card',
+							} );
+						} else {
+							recordTracksEvent( 'calypso_dashboard_overview_card_click', {
+								type: tracksId,
+								variant,
 							} );
 						}
 					}

--- a/client/dashboard/sites/overview/backup-card.tsx
+++ b/client/dashboard/sites/overview/backup-card.tsx
@@ -49,7 +49,7 @@ export default function BackupCard( { site }: { site: Site } ) {
 			site={ site }
 			feature={ HostingFeatures.BACKUPS }
 			featureIcon={ CARD_PROPS.icon }
-			tracksFeatureId={ CARD_PROPS.trackId }
+			tracksFeatureId={ CARD_PROPS.tracksId }
 			upsellHeading={ __( 'Back up your site' ) }
 			upsellDescription={ __( 'Get back online quickly with one-click restores' ) }
 			upsellExternalLink={ getBackupUrl( site ) }

--- a/client/dashboard/sites/overview/backup-card.tsx
+++ b/client/dashboard/sites/overview/backup-card.tsx
@@ -12,7 +12,7 @@ import type { Site } from '../../data/types';
 const CARD_PROPS = {
 	icon: backup,
 	title: __( 'Last backup' ),
-	trackId: 'backup',
+	tracksId: 'backup',
 };
 
 function getBackupUrl( site: Site ) {
@@ -23,7 +23,6 @@ function getBackupUrl( site: Site ) {
 
 function BackupCardContent( { site }: { site: Site } ) {
 	const { data: lastBackup } = useQuery( siteLastBackupQuery( site.ID ) );
-
 	const timeSinceLastBackup = useTimeSince(
 		lastBackup?.last_updated ?? new Date( 0 ).toISOString(),
 		{ isUtc: true }

--- a/client/dashboard/sites/overview/scan-card.tsx
+++ b/client/dashboard/sites/overview/scan-card.tsx
@@ -13,7 +13,7 @@ import type { Site } from '../../data/types';
 const CARD_PROPS = {
 	icon: shield,
 	title: __( 'Last scan' ),
-	trackId: 'scan',
+	tracksId: 'scan',
 };
 
 function getScanURL( site: Site ) {

--- a/client/dashboard/sites/overview/scan-card.tsx
+++ b/client/dashboard/sites/overview/scan-card.tsx
@@ -88,7 +88,7 @@ export default function ScanCard( { site }: { site: Site } ) {
 			site={ site }
 			feature={ HostingFeatures.SCAN }
 			featureIcon={ CARD_PROPS.icon }
-			tracksFeatureId={ CARD_PROPS.trackId }
+			tracksFeatureId={ CARD_PROPS.tracksId }
 			upsellHeading={ __( 'Scan for security threats' ) }
 			upsellDescription={ __( 'We guard your site. You run your business.' ) }
 			upsellExternalLink={ getScanURL( site ) }

--- a/client/dashboard/sites/settings-site-visibility/trial-upsell-notice.tsx
+++ b/client/dashboard/sites/settings-site-visibility/trial-upsell-notice.tsx
@@ -17,8 +17,23 @@ export default function TrialUpsellNotice( { site }: { site: Site } ) {
 		return null;
 	}
 
-	const handleClick = ( type?: string ) => {
-		recordTracksEvent( 'calypso_dashboard_trial_upsell_notice_click', { type } );
+	const getTrialType = () => {
+		if ( isSiteOnECommerceTrial ) {
+			return 'ecommerce';
+		}
+
+		if ( isSiteOnMigrationTrial ) {
+			return 'migration';
+		}
+
+		return site.plan?.product_slug ?? 'free';
+	};
+
+	const handleClick = () => {
+		recordTracksEvent( 'calypso_dashboard_upsell_click', {
+			feature: 'plans',
+			type: `trial-notice:${ getTrialType() }`,
+		} );
 	};
 
 	const renderContent = () => {
@@ -31,7 +46,7 @@ export default function TrialUpsellNotice( { site }: { site: Site } ) {
 			return createInterpolateElement(
 				__( 'Before you can share your store with the world, you need to <a>pick a plan</a>.' ),
 				{
-					a: <Button { ...buttonProps } onClick={ () => handleClick( 'ecommerce' ) } />,
+					a: <Button { ...buttonProps } onClick={ handleClick } />,
 				}
 			);
 		}
@@ -40,7 +55,7 @@ export default function TrialUpsellNotice( { site }: { site: Site } ) {
 			return createInterpolateElement(
 				__( 'Ready to launch your site? <a>Upgrade to a paid plan</a>.' ),
 				{
-					a: <Button { ...buttonProps } onClick={ () => handleClick( 'migration' ) } />,
+					a: <Button { ...buttonProps } onClick={ handleClick } />,
 				}
 			);
 		}
@@ -48,14 +63,17 @@ export default function TrialUpsellNotice( { site }: { site: Site } ) {
 		return createInterpolateElement(
 			__( 'Ready to launch your site? <a>Upgrade to a paid plan</a>.' ),
 			{
-				a: <Button { ...buttonProps } onClick={ () => handleClick() } />,
+				a: <Button { ...buttonProps } onClick={ handleClick } />,
 			}
 		);
 	};
 
 	return (
 		<>
-			<ComponentViewTracker eventName="calypso_dashboard_trial_upsell_notice_impression" />
+			<ComponentViewTracker
+				eventName="calypso_dashboard_upsell_impression"
+				properties={ { feature: 'plans', type: `trial-notice:${ getTrialType() }` } }
+			/>
 			<Notice variant="warning">{ renderContent() }</Notice>
 		</>
 	);


### PR DESCRIPTION
Ref DOTDASH-144

## Proposed Changes

This PR renames all upsell events to be consistent. Impressions are named `calypso_dashboard_upsell_impression`, and clicks are named `calypso_dashboard_upsell_click`. Properties are:

* feature - e.g.: difm, domain, scan, etc.
* type - e.g: cta-button, card, etc.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Refactor

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Ensure that the upsell events are updated as shown above and triggering as intended 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
