### PR TITLE
Help Center: Wait to set notice until the chat has been loaded

### DIFF
--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -45,7 +45,6 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 		useOdieAssistantContext();
 	const createZendeskConversation = useCreateZendeskConversation();
 	const resetSupportInteraction = useResetSupportInteraction();
-	useViewMostRecentOpenConversationNotice( chat?.provider === 'odie' && ! forceEmailSupport );
 	const [ searchParams, setSearchParams ] = useSearchParams();
 	const isForwardingToZendesk =
 		searchParams.get( 'provider' ) === 'zendesk' && chat.provider !== 'zendesk';
@@ -56,6 +55,10 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 
 	const messagesContainerRef = useRef< HTMLDivElement >( null );
 	const scrollParentRef = useRef< HTMLElement | null >( null );
+
+	useViewMostRecentOpenConversationNotice(
+		chatMessagesLoaded && chat?.provider === 'odie' && ! forceEmailSupport
+	);
 
 	const { alreadyHasActiveZendeskChat, chatHasEnded } = useSelect( ( select ) => {
 		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTSUP-251/help-center-do-not-show-open-conversation-notice-on-chats

## Proposed Changes

* Wait for the chat to be loaded before deciding whether to show the notice or not.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The notice that the user already has open conversation with Zendesk was shown inside open conversations with Zendesk.

The notice:
<img width="456" height="144" alt="image" src="https://github.com/user-attachments/assets/311e3534-b613-4c54-8750-7990078f1948" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Have an ongoing chat with Zendesk
* Open a new chat with AI
* You should see the notice 
* Escalate to Zendesk
* Refresh the page and return to the new chat. You should not be seeing the notice.