### PR TITLE
Connect Refresh: Update ToS in Magic Login to not mention "By creating an account..."

### DIFF
--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -4,7 +4,7 @@ import { Gridicon, FormLabel } from '@automattic/components';
 import { addLocaleToPath, localizeUrl, getLanguage } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import emailValidator from 'email-validator';
-import { localize } from 'i18n-calypso';
+import { localize, fixMe } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -1227,6 +1227,7 @@ class MagicLogin extends Component {
 	}
 
 	renderTos = () => {
+		const { translate } = this.props;
 		const options = {
 			components: {
 				tosLink: (
@@ -1245,10 +1246,17 @@ class MagicLogin extends Component {
 				),
 			},
 		};
-		const tosText = this.props.translate(
-			'By creating an account you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
-			options
-		);
+		const tosText = fixMe( {
+			text: 'By continuing you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+			newCopy: translate(
+				'By continuing you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+				options
+			),
+			oldCopy: translate(
+				'By creating an account you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+				options
+			),
+		} );
 
 		return <p className="magic-login__tos wp-login__tos">{ tosText }</p>;
 	};


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-13907/login-magic-login-update-tos-to-not-mention-by-creating-an-account

## Proposed Changes

- Updates the ToS in Magic Login to the text below (no longer mentioning "By creating an account...")
- We wrap these with `fixMe` so we deploy straight away / not wait for translations. We'll return to clean up.

| Link | Code |
|--------|--------|
| <img width="640" height="532" alt="Screenshot 2025-07-16 at 7 09 40 PM" src="https://github.com/user-attachments/assets/67b12b9a-9e76-4c28-b3f5-4635636411b8" /> | <img width="631" height="517" alt="Screenshot 2025-07-16 at 7 08 49 PM" src="https://github.com/user-attachments/assets/0303f721-ead1-49c3-a50a-cf552ff44279" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-13907/login-magic-login-update-tos-to-not-mention-by-creating-an-account


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm Woo/Default/Studio Magic Login (Link) screens render with correct ToS
* Confirm JP Magic Login (Code) screen renders with correct ToS

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
