### PR TITLE
Connect Refresh: Stop showing the JP AppPromo in OAuth client Magic Login

### DIFF
--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -336,7 +336,7 @@ class MagicLogin extends Component {
 						{ linkBack }
 					</a>
 				</div>
-				{ ! isA4A && (
+				{ ! oauth2Client && (
 					<AppPromo
 						title={ translate( 'Stay logged in with the Jetpack Mobile App' ) }
 						campaign="calypso-login-link"


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-13861/login-magic-login-revisit-how-often-and-when-to-show-the-jp-mobile-app

## Proposed Changes

Stops rendering the JP App Promo in Magic Login pages when viewing through a OAuth client Login.

The app is only relevant for managing JP and WPCOM sites, so it may be a bit of a distraction for users looking to just connect an account.

| Before | After |
|--------|--------|
| <img width="793" height="819" alt="Screenshot 2025-07-16 at 8 08 53 PM" src="https://github.com/user-attachments/assets/117540d9-150b-40e5-856d-0c646c2b53a1" /> | <img width="638" height="585" alt="Screenshot 2025-07-16 at 8 08 31 PM" src="https://github.com/user-attachments/assets/4592d5cf-cf6c-44b4-b9a5-cff3c00d3d4d" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-13861/login-magic-login-revisit-how-often-and-when-to-show-the-jp-mobile-app

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to any [OAuth client Login](https://linear.app/a8c/project/login-and-signup-unify-design-and-layout-16a857e58712/overview), go to "magic login" page - confirm Promo doesn't render
* Go to [JP and default WP Magic Login](https://linear.app/a8c/project/login-and-signup-unify-design-and-layout-16a857e58712/overview) and confirm it renders

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
