### PR TITLE
Connections: Add tracking to Fediverse toggle

### DIFF
--- a/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
+++ b/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
@@ -211,6 +211,16 @@ export const WpcomFediverseSettingsSection = ( { siteId } ) => {
 	const settingsLink = isJetpackCloud()
 		? `https://wordpress.com${ baseSettingsLink }`
 		: baseSettingsLink;
+	const toggleActivityPubFeature = ( value ) => {
+		setEnabled( value );
+
+		recordTracksEvent(
+			value
+				? 'calypso_connections_enter_fediverse_button_click'
+				: 'calypso_connections_exit_fediverse_button_click'
+		);
+	};
+
 	return (
 		<>
 			<div className="fediverse-settings-wrapper">
@@ -228,7 +238,7 @@ export const WpcomFediverseSettingsSection = ( { siteId } ) => {
 					label={ translate( 'Enter the fediverse' ) }
 					disabled={ disabled }
 					checked={ isEnabled }
-					onChange={ ( value ) => setEnabled( value ) }
+					onChange={ toggleActivityPubFeature }
 				/>
 				{ isPrivate && (
 					<Notice status="is-warning" translate={ translate } isCompact>


### PR DESCRIPTION


## Proposed Changes

* Introduced a `toggleActivityPubFeature` function to handle enabling/disabling the Fediverse feature and record corresponding Tracks events. 
* Updated the toggle's `onChange` handler to use this new function for better analytics.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* So we can build a tracks funnel of users making their way to the Fediverse toggle.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Marketing > Connections.
* Toggle the Fediverse feature and make sure it works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
