### PR TITLE
Vertically align payment method expiration notice

### DIFF
--- a/client/me/purchases/payment-methods/style.scss
+++ b/client/me/purchases/payment-methods/style.scss
@@ -67,7 +67,7 @@ $card_width: $font-body * 3.75; // roughly 60px wide
 			flex-wrap: wrap;
 			flex-grow: 1;
 			gap: 0.25rem 0.5rem;
-			align-items: baseline;
+			align-items: center;
 			min-width: 0; // Prevents overflow issues
 		}
 
@@ -89,6 +89,17 @@ $card_width: $font-body * 3.75; // roughly 60px wide
 			font-size: $font-body-small;
 			display: inline-flex;
 			min-width: 0;
+		}
+
+		&__expiration-notice {
+			display: flex;
+			align-items: center;
+			color: var( --color-warning );
+			font-size: $font-body-small;
+
+			.gridicon {
+				margin-right: 2px;
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-224/

## Proposed Changes

This vertically aligns the expiration notice for expired payment methods on Payment Method management pages. It also changes the color of the notice to the `--warning` color.

| Before | After |
| ----------- | ----------- |
| <img width="525" height="145" alt="Screenshot 2025-07-16 at 14 29 46" src="https://github.com/user-attachments/assets/e329796d-cfa2-41cc-a6d2-0908d24598c8" /> | <img width="525" height="141" alt="Screenshot 2025-07-16 at 14 30 08" src="https://github.com/user-attachments/assets/d1105d60-6953-4dd6-bdb2-39be7d2c641d" /> |

## Testing Instructions

- On an account with an expired payment method (you can use `cainstesting`)
- Visit `Me > Purchases > Payment Methods`
- Verify that the expiration notice icon is correctly aligned and uses the warning color
