### PR TITLE
Bump mini-cart version to 1.0.1

### DIFF
--- a/packages/mini-cart/package.json
+++ b/packages/mini-cart/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/mini-cart",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "A simple wp.com shopping-cart interface.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/CHE-223/publish-mini-cart-and-wpcom-checkout-packages

## Proposed Changes

This PR bumps `@automattic/mini-cart` to 1.0.1. The only difference is that we've published updated versions of several of its dependencies (notably `@automattic/wpcom-checkout` 1.0.1 and `@automattic/composite-checkout` 2.0.0) which are needed to build this package correctly.

## Testing Instructions

None are needed.
