### PR TITLE
Domain Search Retrofitting: Handle unavailable and restricted domains

### DIFF
--- a/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
+++ b/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
@@ -1,5 +1,9 @@
 import { Gridicon } from '@automattic/components';
-import { DomainSuggestion, DomainSuggestionBadge } from '@automattic/domain-search';
+import {
+	DomainSuggestion,
+	DomainSuggestionBadge,
+	DomainSuggestionPrice,
+} from '@automattic/domain-search';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
 import { HUNDRED_YEAR_DOMAIN_FLOW, isHundredYearPlanFlow } from '@automattic/onboarding';
@@ -506,30 +510,43 @@ class DomainRegistrationSuggestion extends Component {
 			zeroCost,
 			flowName,
 			premiumDomain,
-			translate,
 			showHstsNotice,
 			showDotGayNotice,
+			translate,
 		} = this.props;
 
 		const [ domainName, ...tld ] = fullDomain.split( '.' );
 
+		const badges = this.renderBadges();
+
 		if ( premiumDomain?.is_price_limit_exceeded ) {
 			return (
-				<DomainSuggestion.Unavailable
+				<DomainSuggestion
+					badges={ badges }
 					domain={ domainName }
 					tld={ tld.join( '.' ) }
-					getReasonText={ ( { domain } ) =>
-						translate( 'Premium domain {{domain/}} is not available for registration', {
-							components: {
-								domain,
-							},
-						} )
+					disabled
+					price={
+						<DomainSuggestionPrice
+							originalPrice={ renewCost }
+							price={ productSaleCost ?? productCost }
+							subText={ translate( 'Interested in this domain? {{a}}Contact support{{/a}}', {
+								components: {
+									a: (
+										<a
+											href="https://wordpress.com/help/contact"
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+								},
+							} ) }
+						/>
 					}
 				/>
 			);
 		}
 
-		const badges = this.renderBadges();
 		const priceRule = this.getPriceRule();
 
 		return (

--- a/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
+++ b/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
@@ -21,8 +21,6 @@ import {
 	getDomainPriceRule,
 	isPaidDomain,
 	DOMAIN_PRICE_RULE,
-	shouldBundleDomainWithPlan,
-	hasDomainInCart,
 } from 'calypso/lib/cart-values/cart-items';
 import {
 	getDomainPrice,
@@ -31,7 +29,6 @@ import {
 	isHstsRequired,
 	isDotGayNoticeRequired,
 } from 'calypso/lib/domains';
-import { shouldUseMultipleDomainsInCart } from 'calypso/signup/steps/domains/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
@@ -238,134 +235,6 @@ class DomainRegistrationSuggestion extends Component {
 			default:
 				return baseLabel;
 		}
-	}
-
-	getButtonProps() {
-		const {
-			cart,
-			domainsWithPlansOnly,
-			isSignupStep,
-			selectedSite,
-			suggestion,
-			suggestionSelected,
-			translate,
-			pendingCheckSuggestion,
-			premiumDomain,
-			isCartPendingUpdateDomain,
-			flowName,
-			temporaryCart,
-			domainRemovalQueue,
-		} = this.props;
-		const { domain_name: domain } = suggestion;
-
-		let isAdded =
-			suggestionSelected ||
-			hasDomainInCart( cart, domain ) ||
-			( temporaryCart && temporaryCart.some( ( item ) => item.meta === domain ) );
-
-		// If we're removing this domain, let's instantly show that for the user
-		if (
-			domainRemovalQueue?.length > 0 &&
-			domainRemovalQueue.some( ( item ) => item.meta === domain ) &&
-			! ( temporaryCart && temporaryCart.some( ( item ) => item.meta === domain ) )
-		) {
-			isAdded = false;
-		}
-
-		let buttonContent;
-		let ariaLabel;
-		let buttonStyles = this.props.buttonStyles;
-
-		if ( isAdded ) {
-			buttonContent = translate( '{{checkmark/}} In Cart', {
-				context: 'Domain is already added to shopping cart',
-				components: { checkmark: <Gridicon icon="checkmark" /> },
-			} );
-			ariaLabel = translate( 'Domain %(domainName)s is already added to shopping cart', {
-				args: { domainName: suggestion.domain_name },
-				context:
-					'Accessible label for domain that is already added to shopping cart. %(domainName)s is the domain name.',
-			} );
-
-			buttonStyles = { ...buttonStyles, primary: false };
-
-			if ( shouldUseMultipleDomainsInCart( flowName ) ) {
-				buttonStyles = { ...buttonStyles, borderless: true };
-
-				buttonContent = translate( '{{checkmark/}} Selected', {
-					context: 'Domain is already added to shopping cart',
-					components: { checkmark: <Gridicon style={ { height: 21 } } icon="checkmark" /> },
-				} );
-				ariaLabel = translate( 'Selected domain %(domainName)s', {
-					args: { domainName: suggestion.domain_name },
-					context:
-						'Accessible label for domain that is selected. %(domainName)s is the domain name.',
-				} );
-			}
-		} else {
-			const shouldUpgrade =
-				! isSignupStep &&
-				shouldBundleDomainWithPlan( domainsWithPlansOnly, selectedSite, cart, suggestion );
-
-			if ( shouldUpgrade ) {
-				buttonContent = translate( 'Upgrade', {
-					context: 'Domain mapping suggestion button with plan upgrade',
-				} );
-				ariaLabel = translate( 'Upgrade plan to add domain %(domainName)s', {
-					args: { domainName: suggestion.domain_name },
-					context:
-						'Accessible label for domain mapping suggestion button with plan upgrade. %(domainName)s is the domain name.',
-				} );
-			} else {
-				buttonContent = translate( 'Select', {
-					context: 'Domain mapping suggestion button',
-				} );
-				ariaLabel = this.getSelectDomainAriaLabel();
-			}
-		}
-
-		if ( premiumDomain?.pending ) {
-			buttonStyles = { ...buttonStyles, disabled: true };
-		} else if ( premiumDomain?.is_price_limit_exceeded ) {
-			buttonStyles = { ...buttonStyles, disabled: true };
-			buttonContent = translate( 'Restricted', {
-				context: 'Premium domain is not available for registration',
-			} );
-			ariaLabel = translate( 'Premium domain %(domainName)s is not available for registration', {
-				args: { domainName: suggestion.domain_name },
-				context: 'Accessible label for restricted premium domain',
-			} );
-		} else if ( this.isUnavailableDomain( suggestion.domain_name ) ) {
-			buttonStyles = { ...buttonStyles, disabled: true };
-			buttonContent = translate( 'Unavailable', {
-				context: 'Domain suggestion is not available for registration',
-			} );
-			ariaLabel = translate( 'Domain %(domainName)s is not available for registration', {
-				args: { domainName: suggestion.domain_name },
-				context: 'Accessible label for unavailable domain',
-			} );
-		} else if (
-			pendingCheckSuggestion?.domain_name === domain ||
-			( this.props.isCartPendingUpdate && isCartPendingUpdateDomain?.domain_name === domain )
-		) {
-			buttonStyles = { ...buttonStyles, busy: true, disabled: true };
-		} else if (
-			pendingCheckSuggestion ||
-			( this.props.isCartPendingUpdate && isCartPendingUpdateDomain?.domain_name !== domain )
-		) {
-			buttonStyles = { ...buttonStyles, disabled: true };
-		}
-
-		if ( shouldUseMultipleDomainsInCart( flowName ) ) {
-			buttonStyles = { ...buttonStyles, primary: false, busy: false, disabled: false };
-		}
-
-		return {
-			buttonContent,
-			buttonStyles,
-			isAdded,
-			ariaLabel,
-		};
 	}
 
 	getPriceRule() {

--- a/client/components/domain-search-v2/domain-search-results/index.jsx
+++ b/client/components/domain-search-v2/domain-search-results/index.jsx
@@ -7,6 +7,7 @@ import {
 	DomainSuggestionBadge,
 } from '@automattic/domain-search';
 import { formatCurrency } from '@automattic/number-formatters';
+import { __experimentalVStack as VStack } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { get, times } from 'lodash';
@@ -361,7 +362,7 @@ class DomainSearchResults extends Component {
 					! this.props.premiumDomains[ suggestion.domain_name ]?.is_price_limit_exceeded
 			);
 
-			featuredSuggestionElement = (
+			featuredSuggestionElement = featuredSuggestions.length > 0 && (
 				<FeaturedDomainSuggestions
 					cart={ this.props.cart }
 					isCartPendingUpdate={ this.props.isCartPendingUpdate }
@@ -433,20 +434,20 @@ class DomainSearchResults extends Component {
 		}
 
 		return (
-			<div className="domain-search-results__domain-suggestions">
+			<>
 				{ featuredSuggestionElement }
 				{ this.props.showSkipButton && domainSkipSuggestion }
 				<DomainSuggestionsList>{ suggestionElements }</DomainSuggestionsList>
-			</div>
+			</>
 		);
 	}
 
 	render() {
 		return (
-			<div className="domain-search-results">
+			<VStack spacing={ 4 }>
 				{ this.renderDomainAvailability() }
 				{ this.renderDomainSuggestions() }
-			</div>
+			</VStack>
 		);
 	}
 }

--- a/client/components/domain-search-v2/domain-search-results/index.jsx
+++ b/client/components/domain-search-v2/domain-search-results/index.jsx
@@ -1,6 +1,12 @@
 import { PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
 import { CompactCard, MaterialIcon } from '@automattic/components';
-import { DomainSuggestionsList } from '@automattic/domain-search';
+import {
+	DomainSuggestionPrice,
+	DomainSuggestionsList,
+	DomainSuggestion,
+	DomainSuggestionBadge,
+} from '@automattic/domain-search';
+import { formatCurrency } from '@automattic/number-formatters';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { get, times } from 'lodash';
@@ -8,7 +14,6 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import DomainSkipSuggestion from 'calypso/components/domains/domain-skip-suggestion';
-import DomainSuggestion from 'calypso/components/domains/domain-suggestion';
 import FeaturedDomainSuggestions from 'calypso/components/domains/featured-domain-suggestions';
 import Notice from 'calypso/components/notice';
 import { isDomainMappingFree, isNextDomainFree } from 'calypso/lib/cart-values/cart-items';
@@ -16,8 +21,10 @@ import { isSubdomain } from 'calypso/lib/domains';
 import { domainAvailability } from 'calypso/lib/domains/constants';
 import { getRootDomain } from 'calypso/lib/domains/utils';
 import { DESIGN_TYPE_STORE } from 'calypso/signup/constants';
+import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getDesignType } from 'calypso/state/signup/steps/design-type/selectors';
 import DomainRegistrationSuggestion from '../domain-registration-suggestion';
+import PremiumBadge from '../domain-registration-suggestion/premium-badge';
 
 class DomainSearchResults extends Component {
 	static propTypes = {
@@ -85,6 +92,66 @@ class DomainSearchResults extends Component {
 			TRANSFERRABLE,
 			UNKNOWN,
 		} = domainAvailability;
+
+		const premiumDomain = this.props.premiumDomains[ lastDomainSearched ];
+
+		if ( premiumDomain?.is_price_limit_exceeded ) {
+			const [ domainName, ...tld ] = lastDomainSearched.split( '.' );
+
+			const currentUserCurrencyCode =
+				premiumDomain.currency_code || this.props.currentUserCurrencyCode;
+
+			let productSaleCost;
+
+			const badges = [];
+
+			if ( premiumDomain.sale_cost ) {
+				productSaleCost = formatCurrency( premiumDomain.sale_cost, currentUserCurrencyCode, {
+					stripZeros: this.props.showStrikedOutPrice,
+				} );
+
+				const saleBadgeText = translate( 'Sale', {
+					comment: 'Shown next to a domain that has a special discounted sale price',
+				} );
+				badges.push(
+					<DomainSuggestionBadge key="sale" variation="warning">
+						{ saleBadgeText }
+					</DomainSuggestionBadge>
+				);
+			}
+
+			const cost = productSaleCost ?? premiumDomain.cost;
+
+			badges.push( <PremiumBadge key="premium" restrictedPremium /> );
+
+			return (
+				<DomainSuggestion
+					badges={ badges }
+					domain={ domainName }
+					tld={ tld.join( '.' ) }
+					disabled
+					price={
+						<DomainSuggestionPrice
+							originalPrice={
+								premiumDomain.renew_cost === cost ? undefined : premiumDomain.renew_cost
+							}
+							price={ cost }
+							subText={ translate( 'Interested in this domain? {{a}}Contact support{{/a}}', {
+								components: {
+									a: (
+										<a
+											href="https://wordpress.com/help/contact"
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+								},
+							} ) }
+						/>
+					}
+				/>
+			);
+		}
 
 		const domain = get( availableDomain, 'domain_name', lastDomainSearched );
 
@@ -270,8 +337,8 @@ class DomainSearchResults extends Component {
 	};
 
 	renderPlaceholders() {
-		return times( this.props.placeholderQuantity, function ( n ) {
-			return <DomainSuggestion.Placeholder key={ 'suggestion-' + n } />;
+		return times( this.props.placeholderQuantity, function () {
+			return null;
 		} );
 	}
 
@@ -289,7 +356,9 @@ class DomainSearchResults extends Component {
 					! suggestion.isSubDomainSuggestion
 			);
 			const featuredSuggestions = suggestions.filter(
-				( suggestion ) => suggestion.isRecommended || suggestion.isBestAlternative
+				( suggestion ) =>
+					( suggestion.isRecommended || suggestion.isBestAlternative ) &&
+					! this.props.premiumDomains[ suggestion.domain_name ]?.is_price_limit_exceeded
 			);
 
 			featuredSuggestionElement = (
@@ -383,9 +452,12 @@ class DomainSearchResults extends Component {
 }
 
 const mapStateToProps = ( state, ownProps ) => {
+	const currentUserCurrencyCode = getCurrentUserCurrencyCode( state );
+
 	return {
 		// Set site design type only if we're in signup
 		siteDesignType: ownProps.isSignupStep && getDesignType( state ),
+		currentUserCurrencyCode,
 	};
 };
 

--- a/client/components/domain-search-v2/domain-search-results/index.jsx
+++ b/client/components/domain-search-v2/domain-search-results/index.jsx
@@ -1,5 +1,3 @@
-import { PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
-import { CompactCard, MaterialIcon } from '@automattic/components';
 import {
 	DomainSuggestionPrice,
 	DomainSuggestionsList,
@@ -8,7 +6,6 @@ import {
 } from '@automattic/domain-search';
 import { formatCurrency } from '@automattic/number-formatters';
 import { __experimentalVStack as VStack } from '@wordpress/components';
-import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { get, times } from 'lodash';
 import PropTypes from 'prop-types';
@@ -16,7 +13,6 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import DomainSkipSuggestion from 'calypso/components/domains/domain-skip-suggestion';
 import FeaturedDomainSuggestions from 'calypso/components/domains/featured-domain-suggestions';
-import Notice from 'calypso/components/notice';
 import { isDomainMappingFree, isNextDomainFree } from 'calypso/lib/cart-values/cart-items';
 import { isSubdomain } from 'calypso/lib/domains';
 import { domainAvailability } from 'calypso/lib/domains/constants';
@@ -77,10 +73,6 @@ class DomainSearchResults extends Component {
 			translate,
 			isDomainOnly,
 		} = this.props;
-		const availabilityElementClasses = clsx( {
-			'domain-search-results__domain-is-available': availableDomain,
-			'domain-search-results__domain-not-available': ! availableDomain,
-		} );
 		const suggestions = this.props.suggestions || [];
 		const {
 			MAPPABLE,
@@ -156,9 +148,6 @@ class DomainSearchResults extends Component {
 
 		const domain = get( availableDomain, 'domain_name', lastDomainSearched );
 
-		let availabilityElement;
-		let offer;
-
 		if (
 			domain &&
 			suggestions.length !== 0 &&
@@ -175,8 +164,7 @@ class DomainSearchResults extends Component {
 			].includes( lastDomainStatus ) &&
 			get( this.props, 'products.domain_map', false )
 		) {
-			// eslint-disable-next-line jsx-a11y/anchor-is-valid
-			const components = { a: <a href="#" onClick={ this.handleAddMapping } /> };
+			const unavailableDomainProps = {};
 
 			// If the domain is available we shouldn't offer to let people purchase mappings for it.
 			if (
@@ -185,147 +173,80 @@ class DomainSearchResults extends Component {
 				)
 			) {
 				if ( isDomainMappingFree( selectedSite ) || isNextDomainFree( this.props.cart ) ) {
-					offer = translate(
-						'If you purchased %(domain)s elsewhere, you can {{a}}connect it{{/a}} for free.',
-						{ args: { domain }, components }
-					);
+					unavailableDomainProps.onTransferClick = this.handleAddMapping;
 				} else {
-					offer = translate(
-						'If you purchased %(domain)s elsewhere, you can {{a}}connect it{{/a}} with WordPress.com %(premiumPlanName)s.',
-						{
-							args: { domain, premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '' },
-							components,
-						}
-					);
+					unavailableDomainProps.onTransferClick = this.handleAddMapping;
 				}
 			}
 
 			// Domain Mapping not supported for Store NUX yet.
 			if ( this.props.siteDesignType === DESIGN_TYPE_STORE ) {
-				offer = null;
+				unavailableDomainProps.onTransferClick = null;
 			}
-
-			let domainUnavailableMessage;
 
 			const domainArgument = ! isSubdomain( domain ) ? domain : getRootDomain( domain );
 
-			domainUnavailableMessage = [ TLD_NOT_SUPPORTED, UNKNOWN ].includes( lastDomainStatus )
-				? translate(
-						'{{strong}}.%(tld)s{{/strong}} domains are not available for registration on WordPress.com.',
-						{
-							args: { tld: lastDomainTld },
-							components: {
-								strong: <strong />,
-							},
-						}
-				  )
-				: translate(
-						'{{strong}}%(domain)s{{/strong}} is already registered. {{a}}Do you own it?{{/a}}',
-						{
-							args: { domain: domainArgument },
-							components: {
-								strong: <strong />,
-								a: (
-									// eslint-disable-next-line jsx-a11y/anchor-is-valid
-									<a
-										href="#"
-										onClick={ ( event ) =>
-											this.props.onClickUseYourDomain( event, domainArgument )
-										}
-										data-tracks-button-click-source={ this.props.tracksButtonClickSource }
-									/>
-								),
-							},
-						}
-				  );
+			if ( [ TLD_NOT_SUPPORTED, UNKNOWN ].includes( lastDomainStatus ) ) {
+				unavailableDomainProps.tld = lastDomainTld;
+				unavailableDomainProps.reason = 'tld-not-supported';
+				unavailableDomainProps.onTransferClick = null;
+				unavailableDomainProps.transferLink = null;
+			} else {
+				const [ domainName, ...tld ] = domain.split( '.' );
+
+				unavailableDomainProps.domain = domainName;
+				unavailableDomainProps.tld = tld.join( '.' );
+				unavailableDomainProps.reason = 'already-registered';
+				unavailableDomainProps.onTransferClick = this.props.onClickUseYourDomain;
+				unavailableDomainProps.transferLink = null;
+			}
 
 			if (
 				isSubdomain( domain ) &&
 				! [ TLD_NOT_SUPPORTED, UNKNOWN ].includes( lastDomainStatus )
 			) {
 				const rootDomain = getRootDomain( domain );
-				domainUnavailableMessage = translate(
-					'{{strong}}%(rootDomain)s{{/strong}} is already registered. Do you own {{strong}}%(rootDomain)s{{/strong}} and want to {{a}}{{strong}}connect %(domain)s{{/strong}}{{/a}} with WordPress.com?',
-					{
-						args: { rootDomain, domain },
-						components: {
-							strong: <strong />,
-							a: (
-								// eslint-disable-next-line jsx-a11y/anchor-is-valid
-								<a
-									href="#"
-									onClick={ this.props.onClickUseYourDomain }
-									data-tracks-button-click-source={ this.props.tracksButtonClickSource }
-								/>
-							),
-						},
-					}
-				);
+				const [ domainName, ...tld ] = rootDomain.split( '.' );
+
+				unavailableDomainProps.domain = domainName;
+				unavailableDomainProps.tld = tld.join( '.' );
+				unavailableDomainProps.reason = 'already-registered';
+				unavailableDomainProps.onTransferClick = this.props.onClickUseYourDomain;
+				unavailableDomainProps.transferLink = null;
 			}
 
 			if ( isDomainOnly && ! [ TLD_NOT_SUPPORTED, UNKNOWN ].includes( lastDomainStatus ) ) {
-				domainUnavailableMessage = translate(
-					'{{strong}}%(domain)s{{/strong}} is already registered. Do you own this domain? {{a}}Transfer it to WordPress.com{{/a}} now, or try another search.',
-					{
-						args: { domain: domainArgument },
-						components: {
-							strong: <strong />,
-							a: (
-								// eslint-disable-next-line jsx-a11y/anchor-is-valid
-								<a href={ `/setup/domain-transfer?new=${ domain ?? '' }` } />
-							),
-						},
-					}
-				);
+				const [ domainName, ...tld ] = domainArgument.split( '.' );
+
+				unavailableDomainProps.domain = domainName;
+				unavailableDomainProps.tld = tld.join( '.' );
+				unavailableDomainProps.reason = 'already-registered';
+				unavailableDomainProps.onTransferClick = null;
+				unavailableDomainProps.transferLink = `/setup/domain-transfer?new=${
+					domainArgument ?? ''
+				}`;
 			}
 
 			if ( TLD_NOT_SUPPORTED_TEMPORARILY === lastDomainStatus ) {
-				domainUnavailableMessage = translate(
-					'{{strong}}.%(tld)s{{/strong}} domains are temporarily not offered on WordPress.com. ' +
-						'Please try again later or choose a different extension.',
-					{
-						args: { tld: lastDomainTld },
-						components: { strong: <strong /> },
-					}
-				);
+				unavailableDomainProps.domain = undefined;
+				unavailableDomainProps.tld = lastDomainTld;
+				unavailableDomainProps.reason = 'tld-not-supported-temporarily';
+				unavailableDomainProps.onTransferClick = null;
+				unavailableDomainProps.transferLink = null;
 			}
 
 			if ( this.props.offerUnavailableOption || this.props.showAlreadyOwnADomain ) {
 				if ( this.props.siteDesignType !== DESIGN_TYPE_STORE && lastDomainIsTransferrable ) {
-					availabilityElement = (
-						<CompactCard className="domain-search-results__domain-available-notice">
-							<span className="domain-search-results__domain-available-notice-icon">
-								<MaterialIcon icon="info" />
-							</span>
-							<span>{ domainUnavailableMessage }</span>
-						</CompactCard>
-					);
+					return <DomainSuggestion.Unavailable { ...unavailableDomainProps } />;
 				} else if ( lastDomainStatus !== MAPPED ) {
-					availabilityElement = (
-						<CompactCard className="domain-search-results__domain-available-notice">
-							<span className="domain-search-results__domain-available-notice-icon">
-								<MaterialIcon icon="info" />
-							</span>
-							<span>
-								{ domainUnavailableMessage } { offer }
-							</span>
-						</CompactCard>
-					);
+					return <DomainSuggestion.Unavailable { ...unavailableDomainProps } />;
 				}
 			} else {
-				availabilityElement = (
-					<Notice status="is-warning" showDismiss={ false }>
-						{ domainUnavailableMessage }
-					</Notice>
-				);
+				return <DomainSuggestion.Unavailable { ...unavailableDomainProps } />;
 			}
 		}
 
-		return (
-			<div className="domain-search-results__domain-availability">
-				<div className={ availabilityElementClasses }>{ availabilityElement }</div>
-			</div>
-		);
+		return null;
 	}
 
 	handleAddMapping = ( event ) => {

--- a/packages/domain-search/src/components/domain-suggestion-cta/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-cta/index.tsx
@@ -10,9 +10,15 @@ interface DomainSuggestionCTAProps {
 	compact?: boolean;
 	uuid: string;
 	onClick?( action: 'add-to-cart' | 'continue' ): void;
+	disabled?: boolean;
 }
 
-export const DomainSuggestionCTA = ( { compact, uuid, onClick }: DomainSuggestionCTAProps ) => {
+export const DomainSuggestionCTA = ( {
+	compact,
+	uuid,
+	onClick,
+	disabled,
+}: DomainSuggestionCTAProps ) => {
 	const { __ } = useI18n();
 	const { cart, onContinue } = useDomainSearch();
 
@@ -51,6 +57,7 @@ export const DomainSuggestionCTA = ( { compact, uuid, onClick }: DomainSuggestio
 			icon={ shoppingCartIcon }
 			onClick={ handleAddToCartClick }
 			label={ __( 'Add to Cart' ) }
+			disabled={ disabled }
 		>
 			{ compact ? undefined : __( 'Add to Cart' ) }
 		</Button>

--- a/packages/domain-search/src/components/domain-suggestion-cta/style.scss
+++ b/packages/domain-search/src/components/domain-suggestion-cta/style.scss
@@ -1,5 +1,11 @@
 .domain-suggestion-cta {
 	justify-content: center !important;
+
+	&:disabled {
+		background: transparent !important;
+		box-shadow: 0 0 0 1px rgba( 0, 0, 0, 0.1 ) !important;
+		color: rgba( 0, 0, 0, 0.1 ) !important;
+	}
 }
 
 .domain-suggestion-cta--continue {

--- a/packages/domain-search/src/components/domain-suggestion-popover/style.scss
+++ b/packages/domain-search/src/components/domain-suggestion-popover/style.scss
@@ -1,7 +1,8 @@
 .domain-suggestion-popover {
 	.components-popover__content {
 		width: 100%;
-		max-width: 256px;
+		/* stylelint-disable-next-line unit-allowed-list */
+		max-width: 30ch;
 	}
 }
 

--- a/packages/domain-search/src/components/domain-suggestion-price/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-price/index.tsx
@@ -6,17 +6,22 @@ import {
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useDomainSuggestionsListContext } from '../domain-suggestions-list';
+import type { ReactNode } from 'react';
+
+import './style.scss';
 
 interface DomainSuggestionPriceProps {
 	originalPrice?: string;
 	price: string;
 	renewsAnually?: boolean;
+	subText?: ReactNode;
 }
 
 export const DomainSuggestionPrice = ( {
 	originalPrice,
 	price,
 	renewsAnually = true,
+	subText: subTextProp,
 }: DomainSuggestionPriceProps ) => {
 	const { __ } = useI18n();
 	const listContext = useDomainSuggestionsListContext();
@@ -26,6 +31,24 @@ export const DomainSuggestionPrice = ( {
 	}
 
 	const alignment = listContext.activeQuery === 'large' ? 'right' : 'left';
+
+	const getSubText = () => {
+		if ( subTextProp ) {
+			return subTextProp;
+		}
+
+		if ( originalPrice && renewsAnually ) {
+			return sprintf(
+				// translators: %(price)s is the price of the domain.
+				__( 'For first year. %(price)s/year renewal.' ),
+				{ price: originalPrice }
+			);
+		}
+
+		return null;
+	};
+
+	const subText = getSubText();
 
 	return (
 		<VStack spacing={ 0 }>
@@ -40,19 +63,18 @@ export const DomainSuggestionPrice = ( {
 						</Text>
 					</>
 				) : (
-					<HStack spacing={ 1 } alignment="left">
+					<HStack
+						spacing={ 1 }
+						alignment={ listContext.activeQuery === 'large' ? 'right' : 'left' }
+					>
 						<Text size={ 18 }>{ price }</Text>
 						{ renewsAnually && <Text>{ __( '/year' ) }</Text> }
 					</HStack>
 				) }
 			</HStack>
-			{ originalPrice && renewsAnually && (
-				<Text size="body" align={ alignment }>
-					{ sprintf(
-						// translators: %(price)s is the price of the domain.
-						__( 'For first year. %(price)s/year renewal.' ),
-						{ price: originalPrice }
-					) }
+			{ subText && (
+				<Text size="body" align={ alignment } className="domain-suggestion-price__sub-text">
+					{ subText }
 				</Text>
 			) }
 		</VStack>

--- a/packages/domain-search/src/components/domain-suggestion-price/style.scss
+++ b/packages/domain-search/src/components/domain-suggestion-price/style.scss
@@ -1,0 +1,5 @@
+.domain-suggestion-price__sub-text {
+	a {
+		color: inherit;
+	}
+}

--- a/packages/domain-search/src/components/domain-suggestion-price/test/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-price/test/index.tsx
@@ -26,4 +26,19 @@ describe( 'DomainSuggestionPrice', () => {
 
 		expect( screen.getByText( 'For first year. $20/year renewal.' ) ).toBeInTheDocument();
 	} );
+
+	it( 'renders the price with a custom sub text', () => {
+		render(
+			<DomainSuggestionsList>
+				<DomainSuggestionPrice
+					price="$15"
+					originalPrice="$20"
+					subText="Here's a different sub text"
+				/>
+			</DomainSuggestionsList>
+		);
+
+		expect( screen.queryByText( 'For first year. $20/year renewal.' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( "Here's a different sub text" ) ).toBeInTheDocument();
+	} );
 } );

--- a/packages/domain-search/src/components/domain-suggestion/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion/index.tsx
@@ -9,7 +9,7 @@ import { globe, Icon } from '@wordpress/icons';
 import { ComponentProps } from 'react';
 import { DomainSuggestionCTA } from '../domain-suggestion-cta';
 import { DomainSuggestionPopover } from '../domain-suggestion-popover';
-import { useDomainSuggestionsListContext } from '../domain-suggestions-list';
+import { DomainSuggestionsList, useDomainSuggestionsListContext } from '../domain-suggestions-list';
 import { Unavailable } from './unavailable';
 
 import './style.scss';
@@ -21,9 +21,9 @@ type DomainSuggestionProps = {
 	price: React.ReactNode;
 	badges?: React.ReactNode;
 	notice?: React.ReactNode;
-} & Pick< ComponentProps< typeof DomainSuggestionCTA >, 'onClick' >;
+} & Pick< ComponentProps< typeof DomainSuggestionCTA >, 'onClick' | 'disabled' >;
 
-export const DomainSuggestion = ( {
+const DomainSuggestionComponent = ( {
 	uuid,
 	domain,
 	tld,
@@ -31,6 +31,7 @@ export const DomainSuggestion = ( {
 	badges,
 	notice,
 	onClick,
+	disabled,
 }: DomainSuggestionProps ) => {
 	const listContext = useDomainSuggestionsListContext();
 
@@ -73,7 +74,9 @@ export const DomainSuggestion = ( {
 		</span>
 	);
 
-	const cta = <DomainSuggestionCTA onClick={ onClick } compact uuid={ uuid } />;
+	const cta = (
+		<DomainSuggestionCTA onClick={ onClick } compact uuid={ uuid } disabled={ disabled } />
+	);
 
 	const getContent = () => {
 		if ( activeQuery === 'large' ) {
@@ -105,9 +108,23 @@ export const DomainSuggestion = ( {
 
 	return (
 		<Card isBorderless size={ activeQuery === 'large' ? 'medium' : 'small' }>
-			<CardBody>{ getContent() }</CardBody>
+			<CardBody style={ { borderRadius: 0 } }>{ getContent() }</CardBody>
 		</Card>
 	);
+};
+
+export const DomainSuggestion = ( props: DomainSuggestionProps ) => {
+	const listContext = useDomainSuggestionsListContext();
+
+	if ( ! listContext ) {
+		return (
+			<DomainSuggestionsList>
+				<DomainSuggestionComponent { ...props } />
+			</DomainSuggestionsList>
+		);
+	}
+
+	return <DomainSuggestionComponent { ...props } />;
 };
 
 DomainSuggestion.Unavailable = Unavailable;

--- a/packages/domain-search/src/components/domain-suggestion/test/unavailable.tsx
+++ b/packages/domain-search/src/components/domain-suggestion/test/unavailable.tsx
@@ -1,21 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 import { DomainSuggestion } from '..';
 
 describe( 'DomainSuggestion.Unavailable', () => {
 	it( 'shows already registered message', () => {
 		const { container } = render(
-			<DomainSuggestion.Unavailable
-				domain="example"
-				tld="com"
-				getReasonText={ ( { domain } ) =>
-					createInterpolateElement( __( '<domain /> is already registered.' ), {
-						domain,
-					} )
-				}
-			/>
+			<DomainSuggestion.Unavailable domain="example" tld="com" reason="already-registered" />
 		);
 
 		expect( container ).toHaveTextContent( 'example.com is already registered.' );
@@ -29,11 +19,7 @@ describe( 'DomainSuggestion.Unavailable', () => {
 			<DomainSuggestion.Unavailable
 				domain="example"
 				tld="com"
-				getReasonText={ ( { domain } ) =>
-					createInterpolateElement( __( '<domain /> is already registered.' ), {
-						domain,
-					} )
-				}
+				reason="already-registered"
 				onTransferClick={ onTransferClick }
 			/>
 		);

--- a/packages/domain-search/src/components/domain-suggestion/unavailable.stories.tsx
+++ b/packages/domain-search/src/components/domain-suggestion/unavailable.stories.tsx
@@ -1,13 +1,9 @@
-import { createInterpolateElement } from '@wordpress/element';
-import { useI18n } from '@wordpress/react-i18n';
 import { buildDomainSearchCart } from '../../test-helpers/factories';
 import { DomainSearch } from '../domain-search';
 import { DomainSuggestion } from '../domain-suggestion';
 import type { Meta } from '@storybook/react';
 
 export const Default = () => {
-	const { __ } = useI18n();
-
 	return (
 		<div
 			style={ {
@@ -27,11 +23,7 @@ export const Default = () => {
 				<DomainSuggestion.Unavailable
 					domain="example-unavailable"
 					tld="com"
-					getReasonText={ ( { domain } ) =>
-						createInterpolateElement( __( '<domain /> is already registered.' ), {
-							domain,
-						} )
-					}
+					reason="already-registered"
 					onTransferClick={ () => alert( 'Your wish is an order!' ) }
 				/>
 			</DomainSearch>

--- a/packages/domain-search/src/components/domain-suggestion/unavailable.tsx
+++ b/packages/domain-search/src/components/domain-suggestion/unavailable.tsx
@@ -6,7 +6,7 @@ import {
 	__experimentalVStack as VStack,
 	Button,
 } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement, useMemo } from '@wordpress/element';
 import { Icon, notAllowed } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { DomainSuggestionsList, useDomainSuggestionsListContext } from '../domain-suggestions-list';
@@ -14,18 +14,21 @@ import { DomainSuggestionsList, useDomainSuggestionsListContext } from '../domai
 import './unavailable.scss';
 
 export interface UnavailableProps {
-	domain: string;
+	domain?: string;
 	tld: string;
-	getReasonText: ( { domain }: { domain: React.ReactElement } ) => React.ReactNode;
+	reason: 'tld-not-supported' | 'tld-not-supported-temporarily' | 'already-registered';
 	onTransferClick?(): void;
+	transferLink?: string;
 }
 
 const UnavailableComponent = ( {
 	domain,
 	tld,
-	getReasonText,
+	reason,
 	onTransferClick,
-}: UnavailableProps ) => {
+	transferLink,
+	isWithinList,
+}: UnavailableProps & { isWithinList: boolean } ) => {
 	const listContext = useDomainSuggestionsListContext();
 
 	if ( ! listContext ) {
@@ -36,22 +39,54 @@ const UnavailableComponent = ( {
 
 	const { __ } = useI18n();
 
-	const reason = (
-		<Text size={ activeQuery === 'large' ? 18 : 16 }>
-			{ getReasonText( {
-				domain: (
-					<Text size="inherit" aria-label={ `${ domain }.${ tld }` }>
-						{ domain }
-						<Text size="inherit" weight={ 500 }>
-							.{ tld }
-						</Text>
-					</Text>
-				),
-			} ) }
-		</Text>
-	);
+	const reasonText = useMemo( () => {
+		const styledTld = (
+			<Text size="inherit" weight={ 500 }>
+				.{ tld }
+			</Text>
+		);
 
-	const onTransfer = onTransferClick && (
+		const styledDomain = (
+			<Text size="inherit" aria-label={ `${ domain }.${ tld }` }>
+				{ domain }
+				{ styledTld }
+			</Text>
+		);
+
+		if ( reason === 'tld-not-supported' ) {
+			return createInterpolateElement(
+				__( '<tld /> domains are not available for registration on WordPress.com.' ),
+				{
+					tld: styledTld,
+				}
+			);
+		}
+
+		if ( reason === 'tld-not-supported-temporarily' ) {
+			return createInterpolateElement(
+				__(
+					'<tld /> domains are temporarily not offered on WordPress.com. Please try again later or choose a different extension.'
+				),
+				{
+					tld: styledTld,
+				}
+			);
+		}
+
+		if ( reason === 'already-registered' ) {
+			return createInterpolateElement( __( '<domain /> is already registered.' ), {
+				domain: styledDomain,
+			} );
+		}
+	}, [ reason, domain, tld, __ ] );
+
+	if ( ! reasonText ) {
+		throw new Error( `Unknown reason: ${ reason }` );
+	}
+
+	const reasonElement = <Text size={ activeQuery === 'large' ? 18 : 16 }>{ reasonText }</Text>;
+
+	const onTransfer = ( onTransferClick || transferLink ) && (
 		<div
 			style={ {
 				marginLeft: activeQuery === 'large' ? 'auto' : undefined,
@@ -65,6 +100,7 @@ const UnavailableComponent = ( {
 							className="domain-suggestions-list-item-unavailable__transfer-button"
 							variant="link"
 							onClick={ onTransferClick }
+							href={ transferLink }
 						/>
 					),
 				} ) }
@@ -77,7 +113,7 @@ const UnavailableComponent = ( {
 			return (
 				<HStack alignment="left" spacing={ 3 }>
 					<Icon icon={ notAllowed } size={ 24 } style={ { flexShrink: 0 } } />
-					{ reason }
+					{ reasonElement }
 					{ onTransfer }
 				</HStack>
 			);
@@ -85,7 +121,7 @@ const UnavailableComponent = ( {
 
 		return (
 			<VStack spacing={ 3 }>
-				{ reason }
+				{ reasonElement }
 				{ onTransfer }
 			</VStack>
 		);
@@ -93,7 +129,7 @@ const UnavailableComponent = ( {
 
 	return (
 		<Card size={ activeQuery === 'large' ? 'medium' : 'small' }>
-			<CardBody style={ { borderRadius: 0 } } isShady>
+			<CardBody style={ { borderRadius: 0 } } isShady={ isWithinList }>
 				{ getContent() }
 			</CardBody>
 		</Card>
@@ -106,10 +142,10 @@ export const Unavailable = ( props: UnavailableProps ) => {
 	if ( ! listContext ) {
 		return (
 			<DomainSuggestionsList>
-				<UnavailableComponent { ...props } />
+				<UnavailableComponent { ...props } isWithinList={ false } />
 			</DomainSuggestionsList>
 		);
 	}
 
-	return <UnavailableComponent { ...props } />;
+	return <UnavailableComponent { ...props } isWithinList />;
 };

--- a/packages/domain-search/src/components/domain-suggestion/unavailable.tsx
+++ b/packages/domain-search/src/components/domain-suggestion/unavailable.tsx
@@ -9,8 +9,7 @@ import {
 import { createInterpolateElement } from '@wordpress/element';
 import { Icon, notAllowed } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { useContainerQuery } from '../../hooks/use-container-query';
-import { useDomainSuggestionsListContext } from '../domain-suggestions-list';
+import { DomainSuggestionsList, useDomainSuggestionsListContext } from '../domain-suggestions-list';
 
 import './unavailable.scss';
 
@@ -26,9 +25,15 @@ const UnavailableComponent = ( {
 	tld,
 	getReasonText,
 	onTransferClick,
-	activeQuery,
-	isWithinList,
-}: UnavailableProps & { activeQuery: 'small' | 'large'; isWithinList: boolean } ) => {
+}: UnavailableProps ) => {
+	const listContext = useDomainSuggestionsListContext();
+
+	if ( ! listContext ) {
+		throw new Error( 'DomainSuggestion must be used within a DomainSuggestionsList' );
+	}
+
+	const { activeQuery } = listContext;
+
 	const { __ } = useI18n();
 
 	const reason = (
@@ -87,24 +92,11 @@ const UnavailableComponent = ( {
 	};
 
 	return (
-		<Card isBorderless={ isWithinList } size={ activeQuery === 'large' ? 'medium' : 'small' }>
-			<CardBody style={ { borderRadius: 0 } } isShady={ isWithinList }>
+		<Card size={ activeQuery === 'large' ? 'medium' : 'small' }>
+			<CardBody style={ { borderRadius: 0 } } isShady>
 				{ getContent() }
 			</CardBody>
 		</Card>
-	);
-};
-
-const StandaloneUnavailable = ( props: UnavailableProps ) => {
-	const { ref: containerRef, activeQuery } = useContainerQuery( {
-		small: 0,
-		large: 480,
-	} );
-
-	return (
-		<div ref={ containerRef }>
-			<UnavailableComponent { ...props } activeQuery={ activeQuery } isWithinList={ false } />
-		</div>
 	);
 };
 
@@ -112,8 +104,12 @@ export const Unavailable = ( props: UnavailableProps ) => {
 	const listContext = useDomainSuggestionsListContext();
 
 	if ( ! listContext ) {
-		return <StandaloneUnavailable { ...props } />;
+		return (
+			<DomainSuggestionsList>
+				<UnavailableComponent { ...props } />
+			</DomainSuggestionsList>
+		);
 	}
 
-	return <UnavailableComponent { ...props } activeQuery={ listContext.activeQuery } isWithinList />;
+	return <UnavailableComponent { ...props } />;
 };

--- a/packages/domain-search/src/components/domain-suggestions-list/index.stories.tsx
+++ b/packages/domain-search/src/components/domain-suggestions-list/index.stories.tsx
@@ -1,5 +1,3 @@
-import { createInterpolateElement } from '@wordpress/element';
-import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
 import { buildDomain, buildDomainSearchCart } from '../../test-helpers/factories';
 import { DomainSearch } from '../domain-search';
@@ -15,7 +13,6 @@ const SUGGESTIONS = [
 ];
 
 export const Default = () => {
-	const { __ } = useI18n();
 	const [ cartItems, setCartItems ] = useState< string[] >( [] );
 
 	const cart = buildDomainSearchCart( {
@@ -51,11 +48,7 @@ export const Default = () => {
 					<DomainSuggestion.Unavailable
 						domain="example-unavailable"
 						tld="com"
-						getReasonText={ ( { domain } ) =>
-							createInterpolateElement( __( '<domain /> is already registered.' ), {
-								domain,
-							} )
-						}
+						reason="already-registered"
 						onTransferClick={ () => alert( 'Your wish is an order!' ) }
 					/>
 					{ SUGGESTIONS.map( ( suggestion ) => (


### PR DESCRIPTION
Closes DOMAINS-1541.

## Proposed Changes

### Unavailable domains

We only show the non-available domain if searching for a FQDN.

<img width="1097" height="302" alt="image" src="https://github.com/user-attachments/assets/1636fb99-40cb-415b-951c-7c454efed7e8" />


### Restricted domains

These can be within the list (keyword only like "work") or FQDN (e.g., "work.online")

<img width="1145" height="199" alt="image" src="https://github.com/user-attachments/assets/7559178b-6b56-4b22-a6d9-3ab4205f0881" />

## Testing Instructions

Enable the feature flag `domains/ui-redesign`.

### Unavailable domains

Search for a non-available FQDN and verify you see the unavailable row rendered above the featured domains with an optional callback (transfer, connect) just like we have in prod.

### Restricted domains

Visit `/start/domain`. Search for a premium term (e.g., "book", "work") and verify you see the restricted domain in the list or a restricted domain right below the search bar if searching for a FQDN.
