### PR TITLE
Render basic plan and purchase info

### DIFF
--- a/client/dashboard/app/queries/site-purchases.ts
+++ b/client/dashboard/app/queries/site-purchases.ts
@@ -1,3 +1,4 @@
+import { queryOptions } from '@tanstack/react-query';
 import { fetchSitePurchases } from '../../data/site-purchases';
 import type { Purchase } from '../../data/site-purchases';
 
@@ -19,3 +20,10 @@ export const siteHasCancelablePurchasesQuery = ( siteId: number, userId: number 
 		return cancelables.length > 0;
 	},
 } );
+
+export const sitePurchaseQuery = ( siteId: number, purchaseId: string ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'purchases', purchaseId ],
+		queryFn: () => fetchSitePurchases( siteId ),
+		select: ( purchases ) => purchases.find( ( p ) => p.ID === purchaseId ),
+	} );

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -37,6 +37,7 @@ import { sitePHPVersionQuery } from './queries/site-php-version';
 import { siteCurrentPlanQuery } from './queries/site-plans';
 import { sitePreviewLinksQuery } from './queries/site-preview-links';
 import { sitePrimaryDataCenterQuery } from './queries/site-primary-data-center';
+import { sitePurchaseQuery } from './queries/site-purchases';
 import { siteScanQuery } from './queries/site-scan';
 import { siteSettingsQuery } from './queries/site-settings';
 import { siteSftpUsersQuery } from './queries/site-sftp';
@@ -141,7 +142,11 @@ const siteOverviewRoute = createRoute( {
 				hasHostingFeature( site, DotcomFeatures.BACKUPS ) &&
 					queryClient.ensureQueryData( siteLastBackupQuery( site.ID ) ),
 				site.is_a4a_dev_site && queryClient.ensureQueryData( sitePreviewLinksQuery( site.ID ) ),
-			] );
+			] ).then( ( [ currentPlan ] ) => {
+				if ( currentPlan.id ) {
+					queryClient.ensureQueryData( sitePurchaseQuery( site.ID, currentPlan.id ) );
+				}
+			} );
 		}
 	},
 } ).lazy( () =>

--- a/client/dashboard/data/site-plans.ts
+++ b/client/dashboard/data/site-plans.ts
@@ -1,10 +1,11 @@
 import wpcom from 'calypso/lib/wp';
 
 export interface Plan {
-	id: string | null;
+	id?: string | null;
 	current_plan?: boolean;
 	expiry?: string;
 	has_domain_credit?: boolean;
+	product_slug?: string;
 	subscribed_date?: string;
 	user_facing_expiry?: string;
 }

--- a/client/dashboard/data/site-purchases.ts
+++ b/client/dashboard/data/site-purchases.ts
@@ -1,11 +1,12 @@
 import wpcom from 'calypso/lib/wp';
 
 export interface Purchase {
-	ID: number | string;
+	ID: string;
 	active: boolean;
+	expiry_message: string;
 	is_cancelable: boolean;
 	product_slug: string;
-	user_id: number | string;
+	user_id: string;
 }
 
 export async function fetchSitePurchases( siteId: number ): Promise< Purchase[] > {

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -16,6 +16,7 @@ export type * from './site-media-storage';
 export type * from './site-jetpack-monitor-uptime';
 export type * from './site-jetpack-rewind-backups';
 export type * from './site-owner-transfer';
+export type * from './site-plans';
 export type * from './site-preview-links';
 export type * from './site-profiler';
 export type * from './site-purchases';

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -21,6 +21,7 @@ import AgencySiteShareCard from './agency-site-share-card';
 import BackupCard from './backup-card';
 import DomainsCard from './domains-card';
 import LatestActivitiesCard from './latest-activities-card';
+import PlanCard from './plan-card';
 import ScanCard from './scan-card';
 import SiteOverviewFields from './site-overview-fields';
 import SitePreviewCard from './site-preview-card';
@@ -126,13 +127,7 @@ function SiteOverview( {
 						) }
 						<ScanCard site={ site } />
 					</VStack>
-					<OverviewCard
-						title={ __( 'Plan' ) }
-						icon={ wordpress }
-						heading="TBA"
-						description="TBA"
-						bottom={ <div /> }
-					/>
+					<PlanCard site={ site } />
 				</Grid>
 				<Divider
 					orientation="horizontal"

--- a/client/dashboard/sites/overview/plan-card.tsx
+++ b/client/dashboard/sites/overview/plan-card.tsx
@@ -1,0 +1,46 @@
+import { useQuery } from '@tanstack/react-query';
+import { cloneElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { wordpress } from '@wordpress/icons';
+import { siteCurrentPlanQuery } from '../../app/queries/site-plans';
+import { sitePurchaseQuery } from '../../app/queries/site-purchases';
+import { DotcomPlans } from '../../data/constants';
+import OverviewCard from '../overview-card';
+import type { Site, Plan, Purchase } from '../../data/types';
+
+export default function PlanCard( { site }: { site: Site } ) {
+	const { data: plan, isLoading: isLoadingPlan } = useQuery( siteCurrentPlanQuery( site.ID ) );
+	const { data: purchase, isLoading: isLoadingPurchase } = useQuery( {
+		...sitePurchaseQuery( site.ID, plan?.id ?? '' ),
+		enabled: !! plan?.id,
+	} );
+
+	const icon = cloneElement( wordpress, {
+		style: { color: 'var( --wp-admin-brand-color )' },
+	} );
+
+	return (
+		<OverviewCard
+			title={ __( 'Plan' ) }
+			icon={ icon }
+			heading={ site.plan?.product_name_short || '\u00A0' }
+			description={ getCardDescription( plan, purchase ) }
+			tracksId="plan"
+			variant={ isLoadingPlan || isLoadingPurchase ? 'loading' : undefined }
+			link={ site.plan?.is_free ? undefined : '/v2/me/billing/active-subscriptions' }
+			bottom={ <div /> }
+		/>
+	);
+}
+
+function getCardDescription( plan?: Plan, purchase?: Purchase ) {
+	if ( plan?.product_slug === DotcomPlans.FREE_PLAN ) {
+		return __( 'Upgrade to access all hosting features.' );
+	}
+
+	if ( purchase?.expiry_message ) {
+		return purchase.expiry_message;
+	}
+
+	return '\u00A0'; // non-breaking space
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-114


## Proposed Changes

Initial PR to get the basic info in the plan card.

* Renders short plan name in the plan card
* Renders purchase "expiry" date if applicable
* Fix colour of WordPress logo
* Links to purchases if it is a paid plan

<img width="2592" height="752" alt="CleanShot 2025-07-17 at 17 31 10@2x" src="https://github.com/user-attachments/assets/6a314300-e8ef-42eb-bc09-a3fe8db7da26" />




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test using sites with various plans. However I have only tested this so far for sites using dotcom plans. Do not expect a4a sites to work as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
