### PR TITLE
Hide Blogger from onboarding and importers page

### DIFF
--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -91,49 +91,50 @@ function getConfig( {
 		weight: 1,
 	};
 
-	importerConfig.blogger = {
-		engine: 'blogger',
-		key: 'importer-type-blogger',
-		type: 'file',
-		priority: 'primary',
-		title: 'Blogger',
-		icon: 'blogger-alt',
-		description: (
-			<p>
-				{ translate(
-					'Import posts, pages, comments, tags, and images from a %(importerName)s export file to {{b}}%(siteTitle)s{{/b}}.',
-					{
-						args: {
-							importerName: 'Blogger',
-							siteTitle,
-						},
-						components: {
-							b: <strong />,
-						},
-					}
-				) }
-			</p>
-		),
-		uploadDescription: translate(
-			'A %(importerName)s export file is an XML file ' +
-				'containing your page and post content. ' +
-				'{{supportLink/}}',
-			{
-				args: {
-					importerName: 'Blogger',
-				},
-				components: {
-					supportLink: (
-						<InlineSupportLink supportContext="importers-blogger" showIcon={ false }>
-							{ translate( 'Need help exporting your content?' ) }
-						</InlineSupportLink>
-					),
-				},
-			}
-		),
-		acceptedFileTypes: [ '.xml' ],
-		weight: 0,
-	};
+	// Hide Blogger as they currently do not work. See DOTCON-98.
+	// importerConfig.blogger = {
+	// 	engine: 'blogger',
+	// 	key: 'importer-type-blogger',
+	// 	type: 'file',
+	// 	priority: 'primary',
+	// 	title: 'Blogger',
+	// 	icon: 'blogger-alt',
+	// 	description: (
+	// 		<p>
+	// 			{ translate(
+	// 				'Import posts, pages, comments, tags, and images from a %(importerName)s export file to {{b}}%(siteTitle)s{{/b}}.',
+	// 				{
+	// 					args: {
+	// 						importerName: 'Blogger',
+	// 						siteTitle,
+	// 					},
+	// 					components: {
+	// 						b: <strong />,
+	// 					},
+	// 				}
+	// 			) }
+	// 		</p>
+	// 	),
+	// 	uploadDescription: translate(
+	// 		'A %(importerName)s export file is an XML file ' +
+	// 			'containing your page and post content. ' +
+	// 			'{{supportLink/}}',
+	// 		{
+	// 			args: {
+	// 				importerName: 'Blogger',
+	// 			},
+	// 			components: {
+	// 				supportLink: (
+	// 					<InlineSupportLink supportContext="importers-blogger" showIcon={ false }>
+	// 						{ translate( 'Need help exporting your content?' ) }
+	// 					</InlineSupportLink>
+	// 				),
+	// 			},
+	// 		}
+	// 	),
+	// 	acceptedFileTypes: [ '.xml' ],
+	// 	weight: 0,
+	// };
 
 	importerConfig.medium = {
 		engine: 'medium',

--- a/packages/calypso-e2e/src/lib/pages/site-import-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/site-import-page.ts
@@ -21,7 +21,14 @@ const selectors = {
  * Class representing the Site Import page.
  */
 export class SiteImportPage {
-	static services = [ 'WordPress', 'Blogger', 'Medium', 'Squarespace', 'Wix' ] as const;
+	static services = [
+		'WordPress',
+		// Blogger is currently hidden because it does not work. See DOTCON-98.
+		// 'Blogger',
+		'Medium',
+		'Squarespace',
+		'Wix',
+	] as const;
 	private page: Page;
 
 	/**


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCON-98

## Proposed Changes

Prevent users from using Blogger to import by removing it from the list of configured importers in Calypso.

For removing it from wp-admin see this change 188077-ghe-Automattic/wpcom

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

More details are in DOTCON-95.

Blogger now exports an atom feed, which means our Blogger importer (the one in our repo, not the public blogger-importer plugin) does not work.

While the decisions get made about how we will support Blogger imports, in the mean time we do not want to show a broken import button in our interface.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check importer availability at `/import/{{ site }}`
* Blogger is not available
* Try the `/start/import` signup flow
* When you eventually land on the importer choice screen, confirm there is no Blogger option


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?