### PR TITLE
Connect Refresh: Login - Update sub-headers for WooJPC. Introduce secondaries.

### DIFF
--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -985,8 +985,6 @@ $breakpoint-mobile: 660px;
 		}
 
 		h1,
-		h2,
-		h3:not(.wp-login__heading-subtext),
 		.wp-login__heading-text {
 			font-family: var(--woo-font-family-header);
 			font-feature-settings: "ss01" on, "salt" on;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -986,7 +986,7 @@ $breakpoint-mobile: 660px;
 
 		h1,
 		h2,
-		h3,
+		h3:not(.wp-login__heading-subtext),
 		.wp-login__heading-text {
 			font-family: var(--woo-font-family-header);
 			font-feature-settings: "ss01" on, "salt" on;
@@ -998,7 +998,7 @@ $breakpoint-mobile: 660px;
 		}
 
 		h1,
-		h3 {
+		h3:not(.wp-login__heading-subtext) {
 			color: var(--studio-gray-100);
 			text-align: center;
 			font-size: 2.25rem;

--- a/client/login/login-context.tsx
+++ b/client/login/login-context.tsx
@@ -4,12 +4,15 @@ import { type TranslateResult } from 'i18n-calypso';
 export interface LoginContextType {
 	headingText?: TranslateResult | null;
 	subHeadingText?: TranslateResult | null;
+	subHeadingTextSecondary?: TranslateResult | null;
 	setHeaders: ( {
 		heading,
 		subHeading,
+		subHeadingSecondary,
 	}: {
 		heading?: TranslateResult | null;
 		subHeading?: TranslateResult | null;
+		subHeadingSecondary?: TranslateResult | null;
 	} ) => void;
 }
 
@@ -22,16 +25,23 @@ const LoginContextProvider = ( { children }: { children: React.ReactNode } ) => 
 	const [ subHeadingText, setSubHeadingText ] = useState< TranslateResult | undefined | null >(
 		undefined
 	);
+	const [ subHeadingTextSecondary, setSubHeadingTextSecondary ] = useState<
+		TranslateResult | undefined | null
+	>( undefined );
+
 	const setHeaders = useCallback(
 		( {
 			heading,
 			subHeading,
+			subHeadingSecondary,
 		}: {
 			heading?: TranslateResult | null;
 			subHeading?: TranslateResult | null;
+			subHeadingSecondary?: TranslateResult | null;
 		} ) => {
 			setHeadingText( heading );
 			setSubHeadingText( subHeading );
+			setSubHeadingTextSecondary( subHeadingSecondary );
 		},
 		[]
 	);
@@ -41,6 +51,7 @@ const LoginContextProvider = ( { children }: { children: React.ReactNode } ) => 
 			value={ {
 				headingText,
 				subHeadingText,
+				subHeadingTextSecondary,
 				setHeaders,
 			} }
 		>

--- a/client/login/wp-login/components/one-login-layout.tsx
+++ b/client/login/wp-login/components/one-login-layout.tsx
@@ -28,7 +28,7 @@ const OneLoginLayout = ( {
 	const currentRoute = useSelector( getCurrentRoute );
 	const currentQuery = useSelector( getCurrentQueryArguments );
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
-	const { headingText, subHeadingText } = useLoginContext();
+	const { headingText, subHeadingText, subHeadingTextSecondary } = useLoginContext();
 
 	const SignUpLink = () => {
 		// use '?signup_url' if explicitly passed as URL query param
@@ -60,7 +60,14 @@ const OneLoginLayout = ( {
 				<div className="wp-login__header">
 					<HeadingLogo isFromAkismet={ isFromAkismet } isJetpack={ isJetpack } />
 					<Step.Heading text={ <div className="wp-login__heading-text">{ headingText }</div> } />
-					<h2 className="wp-login__heading-subtext">{ subHeadingText }</h2>
+					<div className="wp-login__heading-subtext-wrapper">
+						<h2 className="wp-login__heading-subtext">{ subHeadingText }</h2>
+						{ subHeadingTextSecondary && (
+							<h3 className="wp-login__heading-subtext is-secondary">
+								{ subHeadingTextSecondary }
+							</h3>
+						) }
+					</div>
 				</div>
 				{ children }
 			</div>

--- a/client/login/wp-login/hooks/get-heading-subtext.tsx
+++ b/client/login/wp-login/hooks/get-heading-subtext.tsx
@@ -1,78 +1,71 @@
 import { localizeUrl } from '@automattic/i18n-utils';
-import { type LocalizeProps, fixMe } from 'i18n-calypso';
+import { type LocalizeProps } from 'i18n-calypso';
 
 interface Props {
 	isSocialFirst: boolean;
 	twoFactorAuthType: string;
 	action?: string;
+	isWoo?: boolean;
 	translate: LocalizeProps[ 'translate' ];
 }
 
 /**
  * TODO This will be replaced by a hook in the future.
  */
-const getHeadingSubText = ( { isSocialFirst, twoFactorAuthType, action, translate }: Props ) => {
+const getHeadingSubText = ( {
+	isSocialFirst,
+	twoFactorAuthType,
+	action,
+	translate,
+	isWoo,
+}: Props ) => {
 	if ( ! isSocialFirst || twoFactorAuthType ) {
 		return null;
 	}
 
-	const tos = fixMe( {
-		text: 'Just a little reminder that by continuing with any of the options below, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and {{privacyLink}}Privacy Policy{{/privacyLink}}.',
-		newCopy: translate(
-			'Just a little reminder that by continuing with any of the options below, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and {{privacyLink}}Privacy Policy{{/privacyLink}}.',
-			{
-				components: {
-					tosLink: (
-						<a
-							href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-							target="_blank"
-							rel="noopener noreferrer"
-						/>
-					),
-					privacyLink: (
-						<a
-							href={ localizeUrl( 'https://automattic.com/privacy/' ) }
-							target="_blank"
-							rel="noopener noreferrer"
-						/>
-					),
-				},
-			}
-		),
-		oldCopy: translate(
-			'By continuing you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
-			{
-				components: {
-					tosLink: (
-						<a
-							href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-							target="_blank"
-							rel="noopener noreferrer"
-						/>
-					),
-					privacyLink: (
-						<a
-							href={ localizeUrl( 'https://automattic.com/privacy/' ) }
-							target="_blank"
-							rel="noopener noreferrer"
-						/>
-					),
-				},
-			}
-		),
-	} );
-
-	return (
-		<>
-			{ 'lostpassword' === action ? (
-				translate(
-					"Please enter your username or email address. You'll receive a link to create a new password via email."
-				)
-			) : (
-				<span className="wp-login__tos">{ tos }</span>
+	const tos = (
+		<span className="wp-login__tos">
+			{ translate(
+				'Just a little reminder that by continuing with any of the options below, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+				{
+					components: {
+						tosLink: (
+							<a
+								href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+						privacyLink: (
+							<a
+								href={ localizeUrl( 'https://automattic.com/privacy/' ) }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+					},
+				}
 			) }
-		</>
+		</span>
 	);
+
+	const primary = isWoo
+		? translate(
+				"To access all of the features and functionality of the extensions you've chosen, you'll first need to connect your store to an account."
+		  )
+		: tos;
+
+	const secondary = isWoo && 'lostpassword' !== action ? tos : null;
+
+	return {
+		primary:
+			'lostpassword' === action
+				? translate(
+						"Please enter your username or email address. You'll receive a link to create a new password via email."
+				  )
+				: primary,
+		secondary,
+	};
 };
 
 export default getHeadingSubText;

--- a/client/login/wp-login/hooks/get-heading-subtext.tsx
+++ b/client/login/wp-login/hooks/get-heading-subtext.tsx
@@ -5,7 +5,7 @@ interface Props {
 	isSocialFirst: boolean;
 	twoFactorAuthType: string;
 	action?: string;
-	isWoo?: boolean;
+	isWooJPC?: boolean;
 	translate: LocalizeProps[ 'translate' ];
 }
 
@@ -17,7 +17,7 @@ const getHeadingSubText = ( {
 	twoFactorAuthType,
 	action,
 	translate,
-	isWoo,
+	isWooJPC,
 }: Props ) => {
 	if ( ! isSocialFirst || twoFactorAuthType ) {
 		return null;
@@ -49,13 +49,13 @@ const getHeadingSubText = ( {
 		</span>
 	);
 
-	const primary = isWoo
+	const primary = isWooJPC
 		? translate(
 				"To access all of the features and functionality of the extensions you've chosen, you'll first need to connect your store to an account."
 		  )
 		: tos;
 
-	const secondary = isWoo && 'lostpassword' !== action ? tos : null;
+	const secondary = isWooJPC && 'lostpassword' !== action ? tos : null;
 
 	return {
 		primary:

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -101,6 +101,7 @@ export class Login extends Component {
 			'linkingSocialService',
 			'action',
 			'oauth2Client',
+			'isWoo',
 			'isWooJPC',
 			'isJetpack',
 			'isWCCOM',
@@ -287,6 +288,7 @@ export class Login extends Component {
 			twoFactorEnabled,
 			currentQuery,
 			translate,
+			isWoo,
 		} = this.props;
 
 		// TODO: remove isGravPoweredClient when login pages are unified.
@@ -316,11 +318,13 @@ export class Login extends Component {
 			twoFactorAuthType,
 			action,
 			translate,
+			isWoo,
 		} );
 
 		this.context.setHeaders( {
 			heading: headingText,
-			subHeading: headingSubText,
+			subHeading: headingSubText.primary,
+			subHeadingSecondary: headingSubText.secondary,
 		} );
 	}
 

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -101,7 +101,6 @@ export class Login extends Component {
 			'linkingSocialService',
 			'action',
 			'oauth2Client',
-			'isWoo',
 			'isWooJPC',
 			'isJetpack',
 			'isWCCOM',
@@ -288,7 +287,6 @@ export class Login extends Component {
 			twoFactorEnabled,
 			currentQuery,
 			translate,
-			isWoo,
 		} = this.props;
 
 		// TODO: remove isGravPoweredClient when login pages are unified.
@@ -318,13 +316,13 @@ export class Login extends Component {
 			twoFactorAuthType,
 			action,
 			translate,
-			isWoo,
+			isWooJPC,
 		} );
 
 		this.context.setHeaders( {
 			heading: headingText,
-			subHeading: headingSubText.primary,
-			subHeadingSecondary: headingSubText.secondary,
+			subHeading: headingSubText?.primary,
+			subHeadingSecondary: headingSubText?.secondary,
 		} );
 	}
 

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -85,14 +85,30 @@ $image-height: 47px;
 	}
 }
 
+.wp-login__heading-subtext-wrapper {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
 .wp-login__heading-subtext {
 	text-wrap: balance;
 	color: var(--studio-gray-50, #646970);
 	margin-block: 0.5rem 0;
+	font-size: $font-body;
 
 	a {
 		color: var(--studio-gray-50, #646970);
 		text-decoration: underline;
+	}
+
+	&.is-secondary {
+		font-size: $font-body-extra-small;
+		color: var(--studio-gray-30);
+
+		a {
+			color: var(--studio-gray-30);
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13850/login-and-signup-add-optional-subtitle-above-tos-test (only Login, not Signup)

## Proposed Changes

* Adds a generic secondary sub-headers option to Login
* Updates Woo Core Profiler (WooJPC) main Login with ToS as secondary and the promo as primary (Figma: ZiYj4ukUuFLVXtfHvbXS1c-fi-66_2841). This applies to all Woo client OAuth screens (WooJPC, etc.), but not the main Woo Login.
  * Font-size: primary `16px`, secondary `12px`
  * Colors: these differ from Figma in order to keep the primary with a consistent color across the remaining Login pages (Figma has it a darker body text)
  * Width/margins: Kept a gap closer to the Figma, but width differs as we're still adjusting the component used for headers. It will take a bigger refactor to extend these as it borrows from Stepper, and we are not making changes there.

## Media

| Before | After |
|--------|--------|
| <img width="700" alt="Screenshot 2025-07-17 at 9 16 49 PM" src="https://github.com/user-attachments/assets/e7601b98-2d17-4203-bda0-0e99411c700f" /> | <img width="700" alt="Screenshot 2025-07-17 at 9 16 26 PM" src="https://github.com/user-attachments/assets/fc1d15d7-ce8b-4ea7-81ae-c600f24d6883" /> | 

Other screens and OAuth clients should have no effect:

| Woo Login | WooJPC lost-password |
|--------|--------|
|  <img width="500" alt="Screenshot 2025-07-17 at 9 18 50 PM" src="https://github.com/user-attachments/assets/39eabbcd-fa30-4794-8ce3-3f6b8a00b168" /> | <img width="500" alt="Screenshot 2025-07-17 at 9 19 00 PM" src="https://github.com/user-attachments/assets/faa9124a-33fe-48bd-a532-be3fb559214c" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-13850/login-and-signup-add-optional-subtitle-above-tos-test


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [Woo, WooJPC, Woo JP DNA Logins](https://linear.app/a8c/project/login-and-signup-unify-design-and-layout-16a857e58712/overview) and confirm
  * mutliple sub-headers in main Login for WooJPC - single for Woo
  * as before (single sub-header) for everything else
* Go default WP Login and other OAuth clients and confirm single sub-headers as before (no changes)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?