### PR TITLE
Add domain search filter component

### DIFF
--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -31,6 +31,7 @@ import PropTypes from 'prop-types';
 import { stringify, parse } from 'qs';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import { DropdownFilters } from 'calypso/components/domain-search-v2/search-filters';
 import DomainSearchResults from 'calypso/components/domains/domain-search-results';
 import ExampleDomainSuggestions from 'calypso/components/domains/example-domain-suggestions';
 import FreeDomainExplainer from 'calypso/components/domains/free-domain-explainer';
@@ -58,7 +59,7 @@ import {
 	isMissingVendor,
 	markFeaturedSuggestions,
 } from 'calypso/components/domains/register-domain-step/utility';
-import { DropdownFilters, FilterResetNotice } from 'calypso/components/domains/search-filters';
+import { FilterResetNotice } from 'calypso/components/domains/search-filters';
 import TrademarkClaimsNotice from 'calypso/components/domains/trademark-claims-notice';
 import EmptyContent from 'calypso/components/empty-content';
 import Notice from 'calypso/components/notice';

--- a/client/components/domain-search-v2/search-filters/analytics.js
+++ b/client/components/domain-search-v2/search-filters/analytics.js
@@ -1,0 +1,20 @@
+import {
+	composeAnalytics,
+	recordGoogleEvent,
+	recordTracksEvent,
+} from 'calypso/state/analytics/actions';
+
+export function recordTldFilterSelected( tld, position, isSelecting ) {
+	return composeAnalytics(
+		recordGoogleEvent(
+			'Domain Search',
+			isSelecting ? 'Clicked TLD Filter Button To Select' : 'Clicked TLD Filter Button To Deselect'
+		),
+		recordTracksEvent(
+			isSelecting
+				? 'calypso_domain_search_results_tld_filter_select'
+				: 'calypso_domain_search_results_tld_filter_deselect',
+			{ tld, position }
+		)
+	);
+}

--- a/client/components/domain-search-v2/search-filters/dropdown-filters.jsx
+++ b/client/components/domain-search-v2/search-filters/dropdown-filters.jsx
@@ -1,4 +1,4 @@
-import { Count, FormLabel, Popover } from '@automattic/components';
+import { Popover } from '@automattic/components';
 import { isWithinBreakpoint } from '@automattic/viewport';
 import { Button, Icon, CheckboxControl } from '@wordpress/components';
 import { funnel } from '@wordpress/icons';
@@ -7,7 +7,6 @@ import { localize } from 'i18n-calypso';
 import { includes, isEqual, pick } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
-import FormFieldset from 'calypso/components/forms/form-fieldset';
 import TokenField from 'calypso/components/token-field';
 import ValidationFieldset from 'calypso/signup/validation-fieldset';
 
@@ -136,9 +135,11 @@ export class DropdownFilters extends Component {
 				>
 					<span className="search-filters__dropdown-filters-button-text" aria-label={ ariaLabel }>
 						<Icon icon={ funnel } />
-						{ hasFilterValues && <Count primary count={ this.getFiltercounts() } /> }
 					</span>
 				</Button>
+				{ hasFilterValues && (
+					<span className="search-filters__dropdown-filters-count">{ this.getFiltercounts() }</span>
+				) }
 
 				{ this.state.showPopover && this.renderPopover() }
 			</div>
@@ -201,22 +202,15 @@ export class DropdownFilters extends Component {
 					</ValidationFieldset>
 				) }
 
-				<FormFieldset className="search-filters__checkboxes-fieldset">
-					<FormLabel
-						className="search-filters__label"
-						htmlFor="search-filters-show-exact-matches-only"
-					>
-						<CheckboxControl
-							className="search-filters__checkbox"
-							label={ translate( 'Show exact matches only' ) }
-							checked={ exactSldMatchesOnly }
-							id="search-filters-show-exact-matches-only"
-							name="exactSldMatchesOnly"
-							onChange={ this.handleExactMatchCheckboxChange }
-							value="exactSldMatchesOnly"
-						/>
-					</FormLabel>
-				</FormFieldset>
+				<CheckboxControl
+					className="search-filters__checkbox"
+					label={ translate( 'Show exact matches only' ) }
+					checked={ exactSldMatchesOnly }
+					id="search-filters-show-exact-matches-only"
+					name="exactSldMatchesOnly"
+					onChange={ this.handleExactMatchCheckboxChange }
+					value="exactSldMatchesOnly"
+				/>
 
 				<ValidationFieldset className="search-filters__buttons-fieldset">
 					<div className="search-filters__buttons">

--- a/client/components/domain-search-v2/search-filters/dropdown-filters.jsx
+++ b/client/components/domain-search-v2/search-filters/dropdown-filters.jsx
@@ -1,0 +1,236 @@
+import { Count, FormLabel, Popover } from '@automattic/components';
+import { isWithinBreakpoint } from '@automattic/viewport';
+import { Button, Icon, CheckboxControl } from '@wordpress/components';
+import { funnel } from '@wordpress/icons';
+import clsx from 'clsx';
+import { localize } from 'i18n-calypso';
+import { includes, isEqual, pick } from 'lodash';
+import PropTypes from 'prop-types';
+import { createRef, Component } from 'react';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import TokenField from 'calypso/components/token-field';
+import ValidationFieldset from 'calypso/signup/validation-fieldset';
+
+const HANDLED_FILTER_KEYS = [ 'tlds', 'exactSldMatchesOnly' ];
+
+export class DropdownFilters extends Component {
+	static propTypes = {
+		availableTlds: PropTypes.array,
+		filters: PropTypes.shape( {
+			exactSldMatchesOnly: PropTypes.bool,
+			tlds: PropTypes.array,
+		} ).isRequired,
+		lastFilters: PropTypes.shape( {
+			exactSldMatchesOnly: PropTypes.bool,
+			tlds: PropTypes.array,
+		} ).isRequired,
+		popoverId: PropTypes.string,
+		showTldFilter: PropTypes.bool,
+		showTldFilterPlaceholder: PropTypes.bool,
+		onChange: PropTypes.func.isRequired,
+		onReset: PropTypes.func.isRequired,
+		onSubmit: PropTypes.func.isRequired,
+	};
+
+	static defaultProps = {
+		popoverId: 'search-filters-dropdown-filters',
+	};
+
+	state = {
+		showPopover: false,
+	};
+
+	constructor( props ) {
+		super( props );
+		this.button = createRef();
+	}
+
+	togglePopover = ( { discardChanges = true } = {} ) => {
+		this.setState(
+			{
+				showPopover: ! this.state.showPopover,
+			},
+			() => {
+				if ( discardChanges && ! this.state.showPopover ) {
+					this.props.onChange( this.props.lastFilters );
+				}
+			}
+		);
+	};
+
+	getFiltercounts() {
+		return (
+			( this.props.lastFilters.tlds?.length || 0 ) +
+			( this.props.lastFilters.exactSldMatchesOnly && 1 )
+		);
+	}
+
+	updateFilterValues = ( name, value ) => {
+		this.props.onChange( {
+			[ name ]: value,
+		} );
+	};
+
+	handleExactMatchCheckboxChange = ( value ) => {
+		this.updateFilterValues( 'exactSldMatchesOnly', value );
+	};
+
+	handleOnChange = ( event ) => {
+		const { currentTarget } = event;
+		if ( currentTarget.type === 'checkbox' ) {
+			this.updateFilterValues( currentTarget.name, currentTarget.checked );
+		} else if ( currentTarget.type === 'number' ) {
+			this.updateFilterValues( currentTarget.name, currentTarget.value );
+		}
+	};
+
+	handleFiltersReset = () => {
+		this.togglePopover( { discardChanges: false } );
+		this.props.onReset( 'tlds', 'exactSldMatchesOnly' );
+	};
+
+	handleFiltersSubmit = () => {
+		this.togglePopover( { discardChanges: false } );
+		this.hasFiltersChanged() && this.props.onSubmit();
+	};
+
+	hasFiltersChanged() {
+		return ! isEqual(
+			pick( this.props.filters, HANDLED_FILTER_KEYS ),
+			pick( this.props.lastFilters, HANDLED_FILTER_KEYS )
+		);
+	}
+
+	render() {
+		const hasFilterValues = this.getFiltercounts() > 0;
+		const { translate } = this.props;
+
+		let ariaLabel = '';
+		if ( hasFilterValues ) {
+			ariaLabel = translate(
+				'Filter, %(filterCount)s filter applied',
+				'Filter, %(filterCount)s filters applied',
+				{
+					count: this.getFiltercounts(),
+					args: { filterCount: this.getFiltercounts() },
+				}
+			);
+		} else {
+			ariaLabel = translate( 'Filter, no filters applied' );
+		}
+
+		return (
+			<div
+				className={ clsx( 'search-filters__dropdown-filters', {
+					'search-filters__dropdown-filters--has-filter-values': hasFilterValues,
+					'search-filters__dropdown-filters--is-open': this.state.showPopover,
+				} ) }
+			>
+				<Button
+					variant="secondary"
+					aria-describedby={ this.props.popoverId }
+					aria-expanded={ this.state.showPopover }
+					aria-haspopup="true"
+					ref={ this.button }
+					onClick={ this.togglePopover }
+				>
+					<span className="search-filters__dropdown-filters-button-text" aria-label={ ariaLabel }>
+						<Icon icon={ funnel } />
+						{ hasFilterValues && <Count primary count={ this.getFiltercounts() } /> }
+					</span>
+				</Button>
+
+				{ this.state.showPopover && this.renderPopover() }
+			</div>
+		);
+	}
+
+	handleTokenChange = ( newTlds ) => {
+		const tlds = newTlds.filter( ( tld ) => includes( this.props.availableTlds, tld ) );
+		this.props.onChange( { tlds } );
+	};
+
+	/**
+	 * Show the first 5 TLDs from the TLD endpoint as recommended and sort the rest alphabetically
+	 * @param availableTlds array of TLDs
+	 */
+	addTldsLabels = ( availableTlds ) => {
+		const { translate } = this.props;
+		return [
+			{ label: translate( 'Recommended endings' ) },
+			...availableTlds.slice( 0, 5 ),
+			{ label: translate( 'Explore more endings' ) },
+			...availableTlds.slice( 5 ).sort(),
+		];
+	};
+
+	renderPopover() {
+		const {
+			filters: { exactSldMatchesOnly },
+			popoverId,
+			translate,
+			showTldFilter,
+		} = this.props;
+
+		return (
+			<Popover
+				aria-label="Domain Search Filters"
+				autoPosition={ false }
+				className="search-filters__popover"
+				context={ this.button.current }
+				id={ popoverId }
+				isVisible={ this.state.showPopover }
+				onClose={ this.handleFiltersSubmit }
+				position={ isWithinBreakpoint( '>660px' ) ? 'bottom' : 'bottom left' }
+				{ ...( isWithinBreakpoint( '>660px' ) && { relativePosition: { left: -238 } } ) }
+				hideArrow
+			>
+				{ showTldFilter && (
+					<ValidationFieldset className="search-filters__tld-filters">
+						<TokenField
+							isExpanded
+							displayTransform={ ( item ) => `.${ item }` }
+							saveTransform={ ( query ) => ( query[ 0 ] === '.' ? query.substr( 1 ) : query ) }
+							maxSuggestions={ 500 }
+							onChange={ this.handleTokenChange }
+							placeholder={ translate( 'Search for an ending' ) }
+							suggestions={ this.addTldsLabels( this.props.availableTlds ) }
+							tokenizeOnSpace
+							value={ this.props.filters.tlds }
+						/>
+					</ValidationFieldset>
+				) }
+
+				<FormFieldset className="search-filters__checkboxes-fieldset">
+					<FormLabel
+						className="search-filters__label"
+						htmlFor="search-filters-show-exact-matches-only"
+					>
+						<CheckboxControl
+							className="search-filters__checkbox"
+							label={ translate( 'Show exact matches only' ) }
+							checked={ exactSldMatchesOnly }
+							id="search-filters-show-exact-matches-only"
+							name="exactSldMatchesOnly"
+							onChange={ this.handleExactMatchCheckboxChange }
+							value="exactSldMatchesOnly"
+						/>
+					</FormLabel>
+				</FormFieldset>
+
+				<ValidationFieldset className="search-filters__buttons-fieldset">
+					<div className="search-filters__buttons">
+						<Button variant="secondary" onClick={ this.handleFiltersReset }>
+							{ translate( 'Clear' ) }
+						</Button>
+						<Button variant="primary" onClick={ this.handleFiltersSubmit }>
+							{ translate( 'Apply' ) }
+						</Button>
+					</div>
+				</ValidationFieldset>
+			</Popover>
+		);
+	}
+}
+
+export default localize( DropdownFilters );

--- a/client/components/domain-search-v2/search-filters/filter-reset-notice.jsx
+++ b/client/components/domain-search-v2/search-filters/filter-reset-notice.jsx
@@ -1,0 +1,47 @@
+import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+
+export class FilterResetNotice extends Component {
+	static propTypes = {
+		isLoading: PropTypes.bool.isRequired,
+		lastFilters: PropTypes.shape( {
+			exactSldMatchesOnly: PropTypes.bool,
+			tlds: PropTypes.arrayOf( PropTypes.string ),
+		} ).isRequired,
+		suggestions: PropTypes.arrayOf( PropTypes.object ),
+	};
+
+	hasActiveFilters() {
+		const { lastFilters: { exactSldMatchesOnly, tlds = [] } = {} } = this.props;
+		return exactSldMatchesOnly || tlds.length > 0;
+	}
+
+	hasTooFewSuggestions() {
+		const { suggestions } = this.props;
+		return Array.isArray( suggestions ) && suggestions.length < 10;
+	}
+
+	onReset = () => {
+		this.props.onReset();
+	};
+
+	render() {
+		return (
+			this.hasActiveFilters() &&
+			this.hasTooFewSuggestions() && (
+				<Card
+					className={ this.props.className }
+					disabled={ this.props.isLoading }
+					onClick={ this.onReset }
+					tagName="button"
+				>
+					{ this.props.translate( 'Click here to disable filters for more results' ) }
+				</Card>
+			)
+		);
+	}
+}
+
+export default localize( FilterResetNotice );

--- a/client/components/domain-search-v2/search-filters/index.js
+++ b/client/components/domain-search-v2/search-filters/index.js
@@ -1,0 +1,6 @@
+import DropdownFilters from './dropdown-filters';
+import FilterResetNotice from './filter-reset-notice';
+
+import './style.scss';
+
+export { DropdownFilters, FilterResetNotice };

--- a/client/components/domain-search-v2/search-filters/style.scss
+++ b/client/components/domain-search-v2/search-filters/style.scss
@@ -20,12 +20,8 @@
 		justify-content: center;
 		padding: 0 1em;
 		transition: 0.1s all linear;
-		width: 100%;
+		width: 56px;
 		color: var(--color-text);
-
-		@include break-mobile {
-			min-width: 96px;
-		}
 
 		background-color: var(--studio-white);
 
@@ -206,4 +202,23 @@ body.is-section-signup {
 	.search-filters__buttons .button {
 		border-radius: 4px;
 	}
+}
+
+
+.search-filters__dropdown-filters-count {
+	position: absolute;
+	top: 0;
+	right: 0;
+	transform: translate(50%, -50%);
+	background: var(--wp-admin-theme-color, #3858e9);
+	height: $grid-unit-30;
+	min-width: $grid-unit-30;
+	line-height: $grid-unit-30;
+	padding: 0 $grid-unit-05;
+	text-align: center;
+	border-radius: $grid-unit-20;
+	font-size: 12px;
+	outline: var(--wp-admin-border-width-focus) solid $white;
+	color: $white;
+	box-sizing: border-box;
 }

--- a/client/components/domain-search-v2/search-filters/style.scss
+++ b/client/components/domain-search-v2/search-filters/style.scss
@@ -12,7 +12,7 @@
 		height: 48px;
 	}
 
-	button {
+	button.components-button {
 		align-items: center;
 		display: flex;
 		font-weight: normal;
@@ -25,32 +25,8 @@
 
 		background-color: var(--studio-white);
 
-		border: 1px solid var(--color-neutral-20);
-		border-radius: 4px;
-
-		&.is-borderless {
-			&:hover,
-			&:focus {
-				border-color: var(--color-neutral);
-			}
-		}
-
-		.material-icon {
-			top: 0;
-			margin-right: 4px;
-
-			@include breakpoint-deprecated( "<660px" ) {
-				top: 2px;
-			}
-		}
-
-		.count {
-			margin-left: 6px;
-		}
-
-		.search-filters__dropdown-filters-button-text {
-			white-space: nowrap;
-		}
+		border: none;
+		box-shadow: inset 0 0 0 1px var(--color-neutral-20);
 	}
 }
 

--- a/client/components/domain-search-v2/search-filters/style.scss
+++ b/client/components/domain-search-v2/search-filters/style.scss
@@ -1,0 +1,209 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.search-filters__dropdown-filters {
+	align-items: center;
+	height: 40px;
+	z-index: z-index("root", ".search");
+	margin-left: 12px;
+
+	@include break-mobile {
+		margin-left: 20px;
+		height: 48px;
+	}
+
+	button {
+		align-items: center;
+		display: flex;
+		font-weight: normal;
+		height: 100%;
+		justify-content: center;
+		padding: 0 1em;
+		transition: 0.1s all linear;
+		width: 100%;
+		color: var(--color-text);
+
+		@include break-mobile {
+			min-width: 96px;
+		}
+
+		background-color: var(--studio-white);
+
+		border: 1px solid var(--color-neutral-20);
+		border-radius: 4px;
+
+		&.is-borderless {
+			&:hover,
+			&:focus {
+				border-color: var(--color-neutral);
+			}
+		}
+
+		.material-icon {
+			top: 0;
+			margin-right: 4px;
+
+			@include breakpoint-deprecated( "<660px" ) {
+				top: 2px;
+			}
+		}
+
+		.count {
+			margin-left: 6px;
+		}
+
+		.search-filters__dropdown-filters-button-text {
+			white-space: nowrap;
+		}
+	}
+}
+
+.search-filters__popover {
+	width: 28em;
+
+	// Use increased specificty to override default z-index for popovers
+	&.popover {
+		z-index: z-index(".popover", ".search-filters__popover");
+	}
+
+	.popover__inner {
+		padding: 2em;
+	}
+
+	.form-fieldset {
+		text-align: left;
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+
+	.validation-fieldset {
+		margin-bottom: 1em;
+	}
+	.validation-fieldset__validation-message {
+		min-height: initial;
+	}
+}
+
+.search-filters__buttons {
+	display: flex;
+	flex-flow: row;
+	overflow: hidden;
+	justify-content: space-between;
+
+	button {
+		flex: 1 0 auto;
+		margin-left: 1em;
+		&:first-child {
+			margin-left: 0;
+		}
+
+		&.search-filters__button--is-placeholder {
+			animation: loading-fade 1.6s ease-in-out infinite;
+			background-color: var(--color-neutral-0);
+			color: transparent;
+			height: 40px;
+		}
+	}
+
+	// Increase specificity to override button styles in signup
+	body.is-section-signup .layout & {
+		button.search-filters__popover-button {
+			font-size: $font-body-small;
+			padding-top: 0.5em;
+			padding-bottom: 0.5em;
+		}
+	}
+}
+
+.search-filters__popover-button .gridicon {
+	margin-left: 2px;
+}
+
+.search-filters__tld-filters {
+	.token-field__token {
+		margin: 4px 8px 4px 0;
+	}
+	.token-field__token-text,
+	.token-field__remove-token {
+		background: var(--color-surface);
+		color: var(--color-neutral-50);
+		border: 1px solid var(--color-neutral-10);
+	}
+	.token-field__token-text {
+		border-right: none;
+	}
+	.token-field__remove-token {
+		border-left: none;
+	}
+
+	.token-field__input-container {
+		margin: 5px 5px 5px 16px;
+	}
+
+	input[type="text"].token-field__input {
+		margin-left: 0;
+		padding-left: 0;
+	}
+
+	.token-field__suggestions-list.is-expanded {
+		padding-top: 0;
+		overflow-y: scroll;
+		max-height: 18.5em;
+	}
+
+	.token-field__suggestion-match {
+		color: inherit;
+	}
+
+	.token-field__suggestion {
+		padding: 6px 8px 6px 16px;
+		color: var(--color-neutral-70);
+		&.is-selected span {
+			color: var(--color-text-inverted);
+		}
+		&:first-child {
+			padding-top: 12px;
+		}
+	}
+}
+
+body.is-section-signup {
+	.search-filters-extensions__popover {
+		@include break-medium {
+			transform: translateX(65px);
+		}
+	}
+
+	.search-filters__popover-button {
+		order: 7;
+		margin-left: 1em;
+		background: #fdfdfd;
+		border: 1px solid #d5d5d7;
+		border-radius: 4px;
+		font-weight: 500;
+		color: var(--studio-gray-60);
+
+		&.is-active {
+			background: initial;
+			font-weight: 500;
+			border-color: var(--studio-gray-50);
+			color: #2b2d2f;
+		}
+	}
+	.search-filters__buttons {
+		margin: 0 20px 0;
+		padding: 0;
+		box-shadow: none;
+
+		@include break-large {
+			margin-left: 0;
+			margin-right: 0;
+		}
+	}
+
+	.search-filters__buttons .button {
+		border-radius: 4px;
+	}
+}


### PR DESCRIPTION
Implement the new design for the filter button and popover

| before | after |
| ----- | ----- |
| <img width="395" height="600" alt="Screenshot 2025-07-17 at 16 00 36" src="https://github.com/user-attachments/assets/a1a48190-78d2-42e6-96ac-223468b98b34" /> | <img width="406" height="624" alt="Screenshot 2025-07-17 at 16 00 23" src="https://github.com/user-attachments/assets/1cc9e509-542c-45b6-960b-0b10f6fdc273" /> |
| <img width="132" height="79" alt="Screenshot 2025-07-17 at 16 02 42" src="https://github.com/user-attachments/assets/9480824a-0880-4937-b101-642ae8fd3887" /> | <img width="157" height="168" alt="Screenshot 2025-07-17 at 16 02 36" src="https://github.com/user-attachments/assets/82553b9c-5c16-4b5b-9153-fb7421405333" /> |

Related to https://linear.app/a8c/issue/DOMAINS-1410/apply-new-designs-to-the-filter-button

## Proposed Changes

* Replace all the calypso components with the Gutenberg version (except the TokenField)
* Use icon instead of "Filter" text
* Show the number of applied filters

## Why are these changes being made?

* This is part of the redesign for the domain search experience

## Testing Instructions

* Apply the PR and make sure that the input looks as it should in the design

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
