### PR TITLE
Domain Search Retrofitting: Create DomainSuggestionLoadMore button component

### DIFF
--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -1,7 +1,11 @@
 import { isBlogger, isFreeWordPressComDomain } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { Button, CompactCard, ResponsiveToolbarGroup } from '@automattic/components';
-import { DomainSearch, DomainSearchNotice } from '@automattic/domain-search';
+import { ResponsiveToolbarGroup } from '@automattic/components';
+import {
+	DomainSearch,
+	DomainSearchNotice,
+	DomainSuggestionLoadMore,
+} from '@automattic/domain-search';
 import { formatCurrency } from '@automattic/number-formatters';
 import {
 	AI_SITE_BUILDER_FLOW,
@@ -16,7 +20,6 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
-import clsx from 'clsx';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
 import {
@@ -770,20 +773,12 @@ class RegisterDomainStep extends Component {
 			return null;
 		}
 
-		const className = clsx( 'register-domain-step__next-page', {
-			'register-domain-step__next-page--is-loading': isLoading,
-		} );
 		return (
-			<CompactCard className={ className }>
-				<Button
-					className="register-domain-step__next-page-button"
-					disabled={ isLoading }
-					busy={ isLoading }
-					onClick={ this.showNextPage }
-				>
-					{ this.props.translate( 'Show more results' ) }
-				</Button>
-			</CompactCard>
+			<DomainSuggestionLoadMore
+				isBusy={ isLoading }
+				disabled={ isLoading }
+				onClick={ this.showNextPage }
+			/>
 		);
 	}
 

--- a/packages/domain-search/src/components/domain-search/style.scss
+++ b/packages/domain-search/src/components/domain-search/style.scss
@@ -2,6 +2,7 @@
 
 .domain-search {
 	--domain-search-secondary-action-color: #{$gray-900};
+	--domain-search-secondary-action-box-shadow-color: #{$gray-400};
 	--domain-search-promotional-price-color: #048015;
 	--domain-search-warning-badge-border-color: #f4df7b;
 	--domain-search-warning-badge-background-color: #f9edb4;

--- a/packages/domain-search/src/components/domain-suggestion-load-more/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-load-more/index.tsx
@@ -1,0 +1,20 @@
+import { Button } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
+import type { ComponentProps } from 'react';
+
+import './style.scss';
+
+export const DomainSuggestionLoadMore = ( props: ComponentProps< typeof Button > ) => {
+	const { __ } = useI18n();
+
+	return (
+		<Button
+			{ ...props }
+			className="domain-suggestion-load-more__btn"
+			variant="secondary"
+			__next40pxDefaultSize
+		>
+			{ __( 'Show more results' ) }
+		</Button>
+	);
+};

--- a/packages/domain-search/src/components/domain-suggestion-load-more/style.scss
+++ b/packages/domain-search/src/components/domain-suggestion-load-more/style.scss
@@ -1,0 +1,6 @@
+.domain-suggestion-load-more__btn {
+	&.is-secondary {
+		color: var(--domain-search-secondary-action-color);
+		box-shadow: inset 0 0 0 1px var(--domain-search-secondary-action-box-shadow-color);
+	}
+}

--- a/packages/domain-search/src/components/domain-suggestion-load-more/style.scss
+++ b/packages/domain-search/src/components/domain-suggestion-load-more/style.scss
@@ -1,6 +1,8 @@
+@import '@wordpress/base-styles/colors';
+
 .domain-suggestion-load-more__btn {
 	&.is-secondary {
 		color: var(--domain-search-secondary-action-color);
-		box-shadow: inset 0 0 0 1px var(--domain-search-secondary-action-box-shadow-color);
+		box-shadow: inset 0 0 0 1px #{$gray-300};
 	}
 }

--- a/packages/domain-search/src/index.ts
+++ b/packages/domain-search/src/index.ts
@@ -8,3 +8,4 @@ export { DomainSuggestionsList } from './components/domain-suggestions-list';
 export { DomainSuggestion } from './components/domain-suggestion';
 export { DomainSuggestionBadge } from './components/domain-suggestion-badge';
 export { DomainSuggestionPrice } from './components/domain-suggestion-price';
+export { DomainSuggestionLoadMore } from './components/domain-suggestion-load-more';


### PR DESCRIPTION
Closes: https://linear.app/a8c/issue/DOMAINS-1542/apply-new-designs-to-the-load-more-results-button

## Proposed Changes

* Creates a new `<DomainSuggestionLoadMore />` component which supports original ButtonProps but with predefined styles
* Replace the "Load more results" button with the new one

## Why are these changes being made?

https://linear.app/a8c/issue/DOMAINS-1542/apply-new-designs-to-the-load-more-results-button

## Testing Instructions

* Turn ON the feature, flag is: domains/ui-redesign
* Go to `/setup/onboarding/domains`
* Search by some term
* Check if there is a new `<DomainSuggestionLoadMore />` component that matches Figma design
* Check if click triggers loading of more results

**Before:**
<img width="839" height="310" alt="Screenshot 2025-07-17 at 19 15 12" src="https://github.com/user-attachments/assets/b27594da-86a5-46ae-b62c-7f39a396de77" />

**After:**
<img width="1188" height="342" alt="Screenshot 2025-07-17 at 19 13 58" src="https://github.com/user-attachments/assets/a760f0cf-984b-4de5-8552-2b158b0c768e" />
-> hover
<img width="1164" height="182" alt="Screenshot 2025-07-17 at 19 14 19" src="https://github.com/user-attachments/assets/f1420277-fcad-44fe-bef5-9759f3eff265" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
