### PR TITLE
Staging sites: disable creating staging sites due to list of reasons

### DIFF
--- a/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
@@ -4,7 +4,6 @@ import { Button } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { translate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useAddStagingSiteMutation } from 'calypso/sites/staging-site/hooks/use-add-staging-site';
 import { USE_STAGING_SITE_LOCK_QUERY_KEY } from 'calypso/sites/staging-site/hooks/use-get-lock-query';
@@ -100,14 +99,18 @@ export default function HeaderStagingSiteButton( {
 		return null;
 	}
 
+	const hasCompletedLoading = ! isLoadingQuotaValidation;
+
 	let disabledReason: string | undefined;
-	if ( isA4ADevSite ) {
-		disabledReason = translate( 'Staging sites are not available for development sites.' );
-	} else if ( isErrorValidQuota && ! isLoadingQuotaValidation ) {
+	if ( ! hasCompletedLoading ) {
+		disabledReason = __( 'Loading…' );
+	} else if ( isA4ADevSite ) {
+		disabledReason = __( 'Staging sites are not available for development sites.' );
+	} else if ( isErrorValidQuota ) {
 		disabledReason = __(
 			'Unable to validate your site quota. Please contact support if you believe you are seeing this message in error.'
 		);
-	} else if ( ! hasValidQuota && ! isLoadingQuotaValidation ) {
+	} else if ( ! hasValidQuota ) {
 		disabledReason = __(
 			'Your available storage space is lower than 50%, which is insufficient for creating a staging site.'
 		);
@@ -125,7 +128,7 @@ export default function HeaderStagingSiteButton( {
 			disabled={ !! disabledReason }
 			label={ disabledReason }
 		>
-			{ translate( 'Add staging site' ) }
+			{ __( 'Add staging site' ) }
 		</Button>
 	);
 }

--- a/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
@@ -9,12 +9,13 @@ import { useCallback } from 'react';
 import { useAddStagingSiteMutation } from 'calypso/sites/staging-site/hooks/use-add-staging-site';
 import { USE_STAGING_SITE_LOCK_QUERY_KEY } from 'calypso/sites/staging-site/hooks/use-get-lock-query';
 import { useStagingSite } from 'calypso/sites/staging-site/hooks/use-staging-site';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
 import { setStagingSiteStatus } from 'calypso/state/staging-site/actions';
 import { StagingSiteStatus } from 'calypso/state/staging-site/constants';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 interface HeaderStagingSiteButtonProps {
 	siteId: number;
@@ -32,6 +33,8 @@ export default function HeaderStagingSiteButton( {
 	const dispatch = useDispatch();
 	const { __ } = useI18n();
 	const queryClient = useQueryClient();
+	const site = useSelector( getSelectedSite );
+	const isA4ADevSite = site?.is_a4a_dev_site || false;
 
 	// Notice IDs for staging site operations
 	const stagingSiteAddFailureNoticeId = 'staging-site-add-failure';
@@ -91,6 +94,11 @@ export default function HeaderStagingSiteButton( {
 		return null;
 	}
 
+	let errorMessage = '';
+	if ( isA4ADevSite ) {
+		errorMessage = translate( 'Staging sites are not available for development sites.' );
+	}
+
 	return (
 		<Button
 			variant="link"
@@ -98,6 +106,10 @@ export default function HeaderStagingSiteButton( {
 			className="hosting-dashboard-item-view__header-add-staging"
 			icon={ plus }
 			iconPosition="right"
+			disabled={ isA4ADevSite }
+			accessibleWhenDisabled
+			showTooltip
+			label={ errorMessage }
 		>
 			{ translate( 'Add staging site' ) }
 		</Button>

--- a/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
@@ -8,6 +8,7 @@ import { translate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useAddStagingSiteMutation } from 'calypso/sites/staging-site/hooks/use-add-staging-site';
 import { USE_STAGING_SITE_LOCK_QUERY_KEY } from 'calypso/sites/staging-site/hooks/use-get-lock-query';
+import { useHasValidQuotaQuery } from 'calypso/sites/staging-site/hooks/use-has-valid-quota';
 import { useStagingSite } from 'calypso/sites/staging-site/hooks/use-staging-site';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -35,6 +36,11 @@ export default function HeaderStagingSiteButton( {
 	const queryClient = useQueryClient();
 	const site = useSelector( getSelectedSite );
 	const isA4ADevSite = site?.is_a4a_dev_site || false;
+	const {
+		data: hasValidQuota,
+		isLoading: isLoadingQuotaValidation,
+		error: isErrorValidQuota,
+	} = useHasValidQuotaQuery( siteId );
 
 	// Notice IDs for staging site operations
 	const stagingSiteAddFailureNoticeId = 'staging-site-add-failure';
@@ -94,9 +100,17 @@ export default function HeaderStagingSiteButton( {
 		return null;
 	}
 
-	let errorMessage = '';
+	let disabledReason: string | undefined;
 	if ( isA4ADevSite ) {
-		errorMessage = translate( 'Staging sites are not available for development sites.' );
+		disabledReason = translate( 'Staging sites are not available for development sites.' );
+	} else if ( isErrorValidQuota && ! isLoadingQuotaValidation ) {
+		disabledReason = __(
+			'Unable to validate your site quota. Please contact support if you believe you are seeing this message in error.'
+		);
+	} else if ( ! hasValidQuota && ! isLoadingQuotaValidation ) {
+		disabledReason = __(
+			'Your available storage space is lower than 50%, which is insufficient for creating a staging site.'
+		);
 	}
 
 	return (
@@ -106,10 +120,10 @@ export default function HeaderStagingSiteButton( {
 			className="hosting-dashboard-item-view__header-add-staging"
 			icon={ plus }
 			iconPosition="right"
-			disabled={ isA4ADevSite }
 			accessibleWhenDisabled
 			showTooltip
-			label={ errorMessage }
+			disabled={ !! disabledReason }
+			label={ disabledReason }
 		>
 			{ translate( 'Add staging site' ) }
 		</Button>

--- a/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
@@ -127,6 +127,7 @@ export default function HeaderStagingSiteButton( {
 			showTooltip
 			disabled={ !! disabledReason }
 			label={ disabledReason }
+			tooltipPosition="top"
 		>
 			{ __( 'Add staging site' ) }
 		</Button>

--- a/client/sites/staging-site/components/staging-site-card/card-content/new-staging-site-card-content.tsx
+++ b/client/sites/staging-site/components/staging-site-card/card-content/new-staging-site-card-content.tsx
@@ -64,9 +64,12 @@ export const NewStagingSiteCardContent = ( {
 					</WPNotice>
 				</NoticeContainer>
 			) }
+
+			{ /* Can be removed. Handled in new UI. */ }
 			{ isDevelopmentSite && (
 				<p>{ translate( 'Staging sites are only available to sites launched in production.' ) }</p>
 			) }
+
 			{ isButtonDisabled && disabledMessage && (
 				<Notice status="is-error" showDismiss={ false }>
 					{ disabledMessage }
@@ -79,6 +82,8 @@ export const NewStagingSiteCardContent = ( {
 				__next40pxDefaultSize
 				text={ translate( 'Add staging site' ) }
 			></StyledButton>
+
+			{ /* Can be removed. Handled in new UI. */ }
 			{ showQuotaError && <ExceedQuotaErrorContent /> }
 		</>
 	);

--- a/client/sites/staging-site/components/staging-site-card/index.js
+++ b/client/sites/staging-site/components/staging-site-card/index.js
@@ -436,6 +436,7 @@ export const StagingSiteCard = ( {
 			/>
 		);
 	} else if ( hasCompletedInitialLoading && isErrorValidQuota ) {
+		// Can be removed. Handled in new UI.
 		stagingSiteCardContent = (
 			<StagingSiteLoadingErrorCardContent
 				message={ __(

--- a/client/sites/staging-site/hooks/use-has-valid-quota.ts
+++ b/client/sites/staging-site/hooks/use-has-valid-quota.ts
@@ -5,7 +5,7 @@ export const USE_VALID_QUOTA_QUERY_KEY = 'valid-quota';
 
 type HasValidQuotaOptions = Pick< UseQueryOptions, 'enabled' >;
 
-export const useHasValidQuotaQuery = ( siteId: number, options: HasValidQuotaOptions ) => {
+export const useHasValidQuotaQuery = ( siteId: number, options?: HasValidQuotaOptions ) => {
 	return useQuery< boolean, unknown, boolean >( {
 		queryKey: [ USE_VALID_QUOTA_QUERY_KEY, siteId ],
 		queryFn: () =>


### PR DESCRIPTION
Fixes DOTCOM-13948

## Proposed Changes

We should disable `Add staging site` button when it's forbidden due to some reasons. And we should render the reason why it's disabled as tooltip.
<img width="1055" height="227" alt="Screenshot 2025-07-18 at 16 11 52" src="https://github.com/user-attachments/assets/cd4192c8-4c2f-42ce-ba86-3fc85c03e649" />


## Testing Instructions
### A4A dev site
1. Open https://agencies.automattic.com/sites
2. Click on `Add sites` -> `Start building for free`
3. Create this dev site
4. Open http://calypso.localhost:3000/sites
5. Select that A4A site and mouse over on "Add staging site"
6. Assert that it's disabled and you see tooltip `Staging sites are not available for development sites.`

### Simple site 
1. Create site on dotcom 
2. Open http://calypso.localhost:3000/sites
3. Select that site
4. Assert that "Add staging site" is not disabled

### Error storage space limit
``` diff
diff --git a/client/sites/staging-site/hooks/use-has-valid-quota.ts b/client/sites/staging-site/hooks/use-has-valid-quota.ts
index f60a79fff83..be5efdfe9d8 100644
--- a/client/sites/staging-site/hooks/use-has-valid-quota.ts
+++ b/client/sites/staging-site/hooks/use-has-valid-quota.ts
@@ -13,6 +13,7 @@ export const useHasValidQuotaQuery = ( siteId: number, options?: HasValidQuotaOp
                                path: `/sites/${ siteId }/staging-site/validate-quota`,
                                apiNamespace: 'wpcom/v2',
                        } ),
+               select: () => false,
                enabled: !! siteId && ( options?.enabled ?? true ),
                meta: {
                        persist: false,
```

1. Open simple site from previous test and assert that teh button is disabled and you see error `Your available storage space is lower than 50%, which is insufficient for creating a staging site.`


### Error fetching storage space limit
``` diff
diff --git a/client/sites/staging-site/hooks/use-has-valid-quota.ts b/client/sites/staging-site/hooks/use-has-valid-quota.ts
index f60a79fff83..d925a4288e5 100644
--- a/client/sites/staging-site/hooks/use-has-valid-quota.ts
+++ b/client/sites/staging-site/hooks/use-has-valid-quota.ts
@@ -10,7 +10,7 @@ export const useHasValidQuotaQuery = ( siteId: number, options?: HasValidQuotaOp
                queryKey: [ USE_VALID_QUOTA_QUERY_KEY, siteId ],
                queryFn: () =>
                        wp.req.post( {
-                               path: `/sites/${ siteId }/staging-site/validate-quota`,
+                               path: `/sites/${ siteId }/staging-site/vali11date-quota`,
                                apiNamespace: 'wpcom/v2',
                        } ),
                enabled: !! siteId && ( options?.enabled ?? true ),
```

1. Open simple site from previous test and assert that teh button is disabled and you see error `Unable to validate your site quota. Please contact support if you believe you are seeing this message in error.`
2. Also, assert that why data is fetching, teh button is disabled and you see "Loading" tooltip
