### PR TITLE
Theme showcase: fix pagination

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -146,9 +146,8 @@ class ThemesSelection extends Component {
 			}
 
 			this.trackScrollPage();
+			this.props.incrementPage();
 		}
-
-		this.props.incrementPage();
 	};
 
 	//intercept preview and add primary and secondary


### PR DESCRIPTION
Fixes: https://linear.app/a8c/issue/DOTTHEM-46/theme-showcase-the-theme-list-flashes-briefly-before-disappearing

**🎸 Feel free to merge and deploy on approval. No need to wait for me.**

## Proposed Changes

The infinite-scroll component checks if there are any items in the list, and if there are none, it calls `fetchNextPage`. `fetchNextPage` only means `goToNextPage` when `triggeredByScroll`, which is a parameter of `fetchNextPage` is true. When the flag is false, it means `fetch` only, but don't increment the page.

The theme showcase uses this component but makes the mistake of incrementing the page number whenever `fetchNextPage` is called regardless of the value of the flag. So when you go back from the individual theme page, the infinite-scroll sees zero items in the first render because the filters didn't run yet, so it calls `fetchNextPage` to repopulate the items. This wrongly increments the page, and results in zero results on page 2, because they all fit on page 1.

This makes the theme showcase consider the `triggeredByScroll` flag and only increment the page when it is true.

## Why are these changes being made?
To bring back the missing results.

## Testing Instructions

1. Go to /themes.
2. Search for a generic term like "shop".
3. You should see many themes.
4. Click one.
5. Go back.
6. You should still see many themes.
7. Scroll down to the bottom.
8. You should see many themes. This is to verify that fetch-on-scroll still works.

### Optional deeper testing

1. Open DevTools > Network.
2. Filter by `themes`.
3. Search for a broad term.
4. Scroll down.
5. You should see another request firing with `page=2`.