### PR TITLE
Domain Search Retrofitting: Fix continue button variant

### DIFF
--- a/packages/domain-search/src/components/domain-suggestion-cta/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-cta/index.tsx
@@ -32,7 +32,8 @@ export const DomainSuggestionCTA = ( {
 
 		return (
 			<Button
-				variant="primary"
+				isPressed
+				aria-pressed="mixed"
 				__next40pxDefaultSize
 				icon={ arrowRight }
 				className="domain-suggestion-cta domain-suggestion-cta--continue"

--- a/packages/domain-search/src/components/domain-suggestion-cta/style.scss
+++ b/packages/domain-search/src/components/domain-suggestion-cta/style.scss
@@ -7,14 +7,3 @@
 		color: rgba( 0, 0, 0, 0.1 ) !important;
 	}
 }
-
-.domain-suggestion-cta--continue {
-	// We need to use !important here because WPCOM adds overrides to the button with a very high specificity.
-	--wp-components-color-accent: var( --domain-search-secondary-action-color ) !important;
-	--wp-components-color-accent-darker-10: var(
-		--domain-search-secondary-action-color-darker-10
-	) !important;
-	--wp-components-color-accent-darker-20: var(
-		--domain-search-secondary-action-color-darker-10
-	) !important;
-}


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/DOMAINS-1545/continue-button-becomes-blue-on-hover

## Proposed Changes

* Fixes continue button variant color; removed overridden style and relies on the existing isPressed with a proper aria attribute that covers this exact use case

## Why are these changes being made?

https://linear.app/a8c/issue/DOMAINS-1545/continue-button-becomes-blue-on-hover

## Testing Instructions

* Turn ON the feature, flag is: domains/ui-redesign
* Go to `/setup/onboarding/domains`
* Add a domain to the cart
* Check the Continue button style, try hover/press actions

<img width="405" height="128" alt="Screenshot 2025-07-18 at 08 10 34" src="https://github.com/user-attachments/assets/1f513ebc-bf5b-4ba9-a603-4ff4dd4e0262" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
