### PR TITLE
One Tap Login: Show full logo during login flow

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -961,7 +961,7 @@ export class LoginForm extends Component {
 
 		return (
 			<>
-				{ isOneTapAuth && ! linkingSocialUser && <OneTapAuthLoaderOverlay showCompactLogo /> }
+				{ isOneTapAuth && ! linkingSocialUser && <OneTapAuthLoaderOverlay /> }
 				<form
 					className={ clsx( {
 						'is-social-first': isSocialFirst,

--- a/client/dashboard/sites/overview/agency-site-share-card.tsx
+++ b/client/dashboard/sites/overview/agency-site-share-card.tsx
@@ -16,7 +16,7 @@ export default function AgencySiteShareCard( { site }: { site: Site } ) {
 			description={ __( 'Collaborators with the link can view your site' ) }
 			link={ `/sites/${ site.slug }/settings/site-visibility` }
 			title={ __( 'Share' ) }
-			trackId="agency-site-share"
+			tracksId="agency-site-share"
 		/>
 	);
 }


### PR DESCRIPTION
Part of pdtkmj-3O7-p2

## Proposed Changes

* Replaced compact logo with the full version  (W logo + text) 

## Why are these changes being made?

* CFT feedback

## Testing Instructions

* Make sure you are logged out
* Go to `/log-in?oneTapAuth=true`
* Check the logo version

| Before | After |
|--------|--------|
| <img width="622" height="237" alt="Screenshot 2025-07-18 at 08 41 37" src="https://github.com/user-attachments/assets/f6105aba-9eb1-4e1b-8d46-be1343b39dd1" /> | <img width="621" height="226" alt="Screenshot 2025-07-18 at 08 42 01" src="https://github.com/user-attachments/assets/1887feab-15f4-48f3-bc7e-59d9a2c4f9f9" /> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?