### PR TITLE
A4A > Referrals: Show estimated earnings for previous and current quarter

### DIFF
--- a/client/a8c-for-agencies/constants/index.ts
+++ b/client/a8c-for-agencies/constants/index.ts
@@ -1,3 +1,6 @@
 export const REFERRAL_EMAIL_QUERY_PARAM_KEY = 'referral_email';
 
 export const AGENCY_FIRST_PURCHASE_SESSION_STORAGE_KEY = 'a4a_first_purchase';
+
+export const AGENCY_EARNINGS_LEARN_MORE_LINK =
+	'https://agencieshelp.automattic.com/knowledge-base/automattic-for-agencies-earnings/';

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
@@ -6,7 +6,7 @@ import {
 } from 'calypso/a8c-for-agencies/components/consolidated-stats-card';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import useGetConsolidatedPayoutData from '../hooks/use-get-consolidated-payout-data';
-import useGetPayoutData from '../hooks/use-get-payout-data';
+import PayoutCards from './payout-cards';
 import type { Referral } from '../types';
 
 type ConsolidatedViewsProps = {
@@ -17,11 +17,8 @@ type ConsolidatedViewsProps = {
 export default function ConsolidatedViews( { referrals, totalPayouts }: ConsolidatedViewsProps ) {
 	const translate = useTranslate();
 	const { data: productsData, isFetching } = useProductsQuery( false, false, true );
-	const { expectedCommission, pendingOrders } = useGetConsolidatedPayoutData(
-		referrals,
-		productsData
-	);
-	const { nextPayoutActivityWindow, nextPayoutDate } = useGetPayoutData();
+	const { previousQuarterExpectedCommission, pendingOrders, currentQuarterExpectedCommission } =
+		useGetConsolidatedPayoutData( referrals, productsData );
 
 	const learnMoreLink =
 		'https://agencieshelp.automattic.com/knowledge-base/automattic-for-agencies-earnings/';
@@ -45,44 +42,10 @@ export default function ConsolidatedViews( { referrals, totalPayouts }: Consolid
 					) }
 				/>
 			) }
-			<ConsolidatedStatsCard
-				value={ formatCurrency( expectedCommission, 'USD' ) }
-				footerText={ translate( 'Next estimated payout amount' ) }
-				popoverTitle={ translate( 'Estimated amount' ) }
-				popoverContent={ translate(
-					'When your client buys products or hosting from Automattic for Agencies, they are billed on the first of every month rather than immediately. ' +
-						'We estimate the commission based on the active use for the current month. ' +
-						'{{br/}}{{br}}{{/br}}The next payout range is for:' +
-						'{{br/}}{{b}}%(nextPayoutActivityWindow)s{{/b}}' +
-						'{{br/}}{{br/}}{{a}}Learn more{{/a}} ↗',
-					{
-						components: {
-							a: <a href={ learnMoreLink } target="_blank" rel="noreferrer noopener" />,
-							br: <br />,
-							b: <b />,
-						},
-						args: {
-							nextPayoutActivityWindow,
-						},
-					}
-				) }
-				isLoading={ isFetching }
-			/>
-			<ConsolidatedStatsCard
-				value={ nextPayoutDate + '*' }
-				footerText={ translate( 'Next estimated payout date' ) }
-				popoverTitle={ translate( 'Estimated date' ) }
-				popoverContent={ translate(
-					'*Commissions are paid quarterly, after a 60-day waiting period, excluding refunds and chargebacks. ' +
-						'Payout dates mark the start of processing, which may take a few extra days. Payments scheduled on weekends are processed the next business day. ' +
-						'{{br/}}{{br/}}{{a}}Learn more{{/a}} ↗',
-					{
-						components: {
-							a: <a href={ learnMoreLink } target="_blank" rel="noreferrer noopener" />,
-							br: <br />,
-						},
-					}
-				) }
+			<PayoutCards
+				isFetching={ isFetching }
+				previousQuarterExpectedCommission={ previousQuarterExpectedCommission }
+				currentQuarterExpectedCommission={ currentQuarterExpectedCommission }
 			/>
 			<ConsolidatedStatsCard
 				value={ pendingOrders }

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
@@ -4,6 +4,7 @@ import {
 	ConsolidatedStatsCard,
 	ConsolidatedStatsGroup,
 } from 'calypso/a8c-for-agencies/components/consolidated-stats-card';
+import { AGENCY_EARNINGS_LEARN_MORE_LINK } from 'calypso/a8c-for-agencies/constants';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import useGetConsolidatedPayoutData from '../hooks/use-get-consolidated-payout-data';
 import PayoutCards from './payout-cards';
@@ -20,9 +21,6 @@ export default function ConsolidatedViews( { referrals, totalPayouts }: Consolid
 	const { previousQuarterExpectedCommission, pendingOrders, currentQuarterExpectedCommission } =
 		useGetConsolidatedPayoutData( referrals, productsData );
 
-	const learnMoreLink =
-		'https://agencieshelp.automattic.com/knowledge-base/automattic-for-agencies-earnings/';
-
 	return (
 		<ConsolidatedStatsGroup className="consolidated-view">
 			{ totalPayouts !== undefined && (
@@ -35,7 +33,13 @@ export default function ConsolidatedViews( { referrals, totalPayouts }: Consolid
 							'{{br/}}{{br/}}{{a}}Learn more{{/a}} ↗',
 						{
 							components: {
-								a: <a href={ learnMoreLink } target="_blank" rel="noreferrer noopener" />,
+								a: (
+									<a
+										href={ AGENCY_EARNINGS_LEARN_MORE_LINK }
+										target="_blank"
+										rel="noreferrer noopener"
+									/>
+								),
 								br: <br />,
 							},
 						}
@@ -56,7 +60,13 @@ export default function ConsolidatedViews( { referrals, totalPayouts }: Consolid
 						'{{br/}}{{br/}}{{a}}Learn more{{/a}} ↗',
 					{
 						components: {
-							a: <a href={ learnMoreLink } target="_blank" rel="noreferrer noopener" />,
+							a: (
+								<a
+									href={ AGENCY_EARNINGS_LEARN_MORE_LINK }
+									target="_blank"
+									rel="noreferrer noopener"
+								/>
+							),
 							br: <br />,
 						},
 					}

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/payout-cards.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/payout-cards.tsx
@@ -2,6 +2,7 @@ import { formatCurrency } from '@automattic/number-formatters';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { ConsolidatedStatsCard } from 'calypso/a8c-for-agencies/components/consolidated-stats-card';
+import { AGENCY_EARNINGS_LEARN_MORE_LINK } from 'calypso/a8c-for-agencies/constants';
 import useGetPayoutData from '../hooks/use-get-payout-data';
 
 import './style.scss';
@@ -22,8 +23,6 @@ function PayoutAmount( {
 	popoverTitle: string;
 } ) {
 	const translate = useTranslate();
-	const learnMoreLink =
-		'https://agencieshelp.automattic.com/knowledge-base/automattic-for-agencies-earnings/';
 
 	return (
 		<ConsolidatedStatsCard
@@ -55,7 +54,12 @@ function PayoutAmount( {
 					</div>
 
 					<div>
-						<Button href={ learnMoreLink } target="_blank" rel="noreferrer noopener" variant="link">
+						<Button
+							href={ AGENCY_EARNINGS_LEARN_MORE_LINK }
+							target="_blank"
+							rel="noreferrer noopener"
+							variant="link"
+						>
 							{ translate( 'Learn more' ) } ↗
 						</Button>
 					</div>

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/payout-cards.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/payout-cards.tsx
@@ -85,6 +85,9 @@ export default function PayoutCards( {
 		areNextAndCurrentPayoutDatesEqual,
 	} = useGetPayoutData();
 
+	const previousQuarterTitle = translate( 'Estimated earnings in previous quarter' );
+	const currentQuarterTitle = translate( 'Estimated earnings in current quarter' );
+
 	return (
 		<>
 			{ ! areNextAndCurrentPayoutDatesEqual && (
@@ -93,8 +96,8 @@ export default function PayoutCards( {
 					activityWindow={ nextPayoutActivityWindow }
 					payoutDate={ nextPayoutDate }
 					isFetching={ isFetching }
-					footerText={ translate( 'Estimated earnings in previous quarter' ) }
-					popoverTitle={ translate( 'Estimated amount' ) }
+					footerText={ previousQuarterTitle }
+					popoverTitle={ previousQuarterTitle }
 				/>
 			) }
 			<PayoutAmount
@@ -102,8 +105,8 @@ export default function PayoutCards( {
 				activityWindow={ currentCycleActivityWindow }
 				payoutDate={ currentCyclePayoutDate }
 				isFetching={ isFetching }
-				footerText={ translate( 'Estimated earnings in current quarter' ) }
-				popoverTitle={ translate( 'Estimated amount' ) }
+				footerText={ currentQuarterTitle }
+				popoverTitle={ currentQuarterTitle }
 			/>
 		</>
 	);

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/payout-cards.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/payout-cards.tsx
@@ -1,0 +1,110 @@
+import { formatCurrency } from '@automattic/number-formatters';
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { ConsolidatedStatsCard } from 'calypso/a8c-for-agencies/components/consolidated-stats-card';
+import useGetPayoutData from '../hooks/use-get-payout-data';
+
+import './style.scss';
+
+function PayoutAmount( {
+	expectedCommission,
+	activityWindow,
+	payoutDate,
+	isFetching,
+	footerText,
+	popoverTitle,
+}: {
+	expectedCommission: number;
+	activityWindow: string;
+	payoutDate: string;
+	isFetching: boolean;
+	footerText: string;
+	popoverTitle: string;
+} ) {
+	const translate = useTranslate();
+	const learnMoreLink =
+		'https://agencieshelp.automattic.com/knowledge-base/automattic-for-agencies-earnings/';
+
+	return (
+		<ConsolidatedStatsCard
+			value={ formatCurrency( expectedCommission, 'USD' ) }
+			footerText={ footerText }
+			popoverTitle={ popoverTitle }
+			popoverContent={
+				<div className="payout-cards__description">
+					<div>
+						{ translate(
+							'When your client buys products or hosting from Automattic for Agencies, they are billed on the first of every month rather than immediately. We estimate the commission based on the active use for the current month.'
+						) }
+					</div>
+
+					<div className="payout-cards__description-item">
+						{ translate( 'Payout range:' ) }
+						<strong>{ activityWindow }</strong>
+					</div>
+
+					<div className="payout-cards__description-item">
+						{ translate( 'Payout date:' ) }
+						<strong>{ payoutDate }*</strong>
+					</div>
+
+					<div>
+						{ translate(
+							'*Commissions are paid quarterly, after a 60-day waiting period, excluding refunds and chargebacks.'
+						) }
+					</div>
+
+					<div>
+						<Button href={ learnMoreLink } target="_blank" rel="noreferrer noopener" variant="link">
+							{ translate( 'Learn more' ) } ↗
+						</Button>
+					</div>
+				</div>
+			}
+			isLoading={ isFetching }
+		/>
+	);
+}
+
+export default function PayoutCards( {
+	isFetching,
+	previousQuarterExpectedCommission,
+	currentQuarterExpectedCommission,
+}: {
+	isFetching: boolean;
+	previousQuarterExpectedCommission: number;
+	currentQuarterExpectedCommission: number;
+} ) {
+	const translate = useTranslate();
+
+	const {
+		nextPayoutActivityWindow,
+		nextPayoutDate,
+		currentCyclePayoutDate,
+		currentCycleActivityWindow,
+		areNextAndCurrentPayoutDatesEqual,
+	} = useGetPayoutData();
+
+	return (
+		<>
+			{ ! areNextAndCurrentPayoutDatesEqual && (
+				<PayoutAmount
+					expectedCommission={ previousQuarterExpectedCommission }
+					activityWindow={ nextPayoutActivityWindow }
+					payoutDate={ nextPayoutDate }
+					isFetching={ isFetching }
+					footerText={ translate( 'Estimated earnings in previous quarter' ) }
+					popoverTitle={ translate( 'Estimated amount' ) }
+				/>
+			) }
+			<PayoutAmount
+				expectedCommission={ currentQuarterExpectedCommission }
+				activityWindow={ currentCycleActivityWindow }
+				payoutDate={ currentCyclePayoutDate }
+				isFetching={ isFetching }
+				footerText={ translate( 'Estimated earnings in current quarter' ) }
+				popoverTitle={ translate( 'Estimated amount' ) }
+			/>
+		</>
+	);
+}

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/style.scss
@@ -1,0 +1,11 @@
+.payout-cards__description {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.payout-cards__description-item {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/test/payout-cards.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/test/payout-cards.tsx
@@ -1,0 +1,139 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import * as useGetPayoutData from '../../hooks/use-get-payout-data';
+import PayoutCards from '../payout-cards';
+
+// Mock the dependencies
+jest.mock( '../../hooks/use-get-payout-data' );
+
+const mockUseGetPayoutData = useGetPayoutData.default as jest.MockedFunction<
+	typeof useGetPayoutData.default
+>;
+
+// Mock the ConsolidatedStatsCard component
+jest.mock( 'calypso/a8c-for-agencies/components/consolidated-stats-card', () => ( {
+	ConsolidatedStatsCard: ( { value, footerText, isLoading }: any ) => (
+		<div data-testid="consolidated-stats-card">
+			<div data-testid="value">{ value }</div>
+			<div data-testid="footer-text">{ footerText }</div>
+			{ isLoading && <div data-testid="loading">Loading...</div> }
+		</div>
+	),
+} ) );
+
+describe( 'PayoutCards', () => {
+	const mockPayoutData = {
+		nextPayoutActivityWindow: '1 Jan 2024 - 31 Mar 2024',
+		nextPayoutDate: '1 June',
+		currentCyclePayoutDate: '2 Mar',
+		currentCycleActivityWindow: '1 Jan - 31 Mar',
+		areNextAndCurrentPayoutDatesEqual: false,
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockUseGetPayoutData.mockReturnValue( mockPayoutData );
+	} );
+
+	it( 'should render both payout cards when dates are different', () => {
+		render(
+			<PayoutCards
+				isFetching={ false }
+				previousQuarterExpectedCommission={ 100.5 }
+				currentQuarterExpectedCommission={ 250.75 }
+			/>
+		);
+
+		const cards = screen.getAllByTestId( 'consolidated-stats-card' );
+		expect( cards ).toHaveLength( 2 );
+
+		// Check previous quarter card
+		expect( screen.getByText( '$100.50' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Estimated earnings in previous quarter' ) ).toBeInTheDocument();
+
+		// Check current quarter card
+		expect( screen.getByText( '$250.75' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Estimated earnings in current quarter' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render only one payout card when dates are equal', () => {
+		mockUseGetPayoutData.mockReturnValue( {
+			...mockPayoutData,
+			areNextAndCurrentPayoutDatesEqual: true,
+		} );
+
+		render(
+			<PayoutCards
+				isFetching={ false }
+				previousQuarterExpectedCommission={ 100.5 }
+				currentQuarterExpectedCommission={ 250.75 }
+			/>
+		);
+
+		const cards = screen.getAllByTestId( 'consolidated-stats-card' );
+		expect( cards ).toHaveLength( 1 );
+
+		// Should only show current quarter card
+		expect( screen.getByText( '$250.75' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Estimated earnings in current quarter' ) ).toBeInTheDocument();
+
+		// Should not show previous quarter card
+		expect( screen.queryByText( '$100.50' ) ).not.toBeInTheDocument();
+		expect(
+			screen.queryByText( 'Estimated earnings in previous quarter' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should show loading state when fetching', () => {
+		render(
+			<PayoutCards
+				isFetching
+				previousQuarterExpectedCommission={ 100.5 }
+				currentQuarterExpectedCommission={ 250.75 }
+			/>
+		);
+
+		const loadingElements = screen.getAllByTestId( 'loading' );
+		expect( loadingElements ).toHaveLength( 2 );
+	} );
+
+	it( 'should handle decimal precision correctly', () => {
+		render(
+			<PayoutCards
+				isFetching={ false }
+				previousQuarterExpectedCommission={ 123.456 }
+				currentQuarterExpectedCommission={ 789.111 }
+			/>
+		);
+
+		// formatCurrency should handle rounding
+		expect( screen.getByText( '$123.46' ) ).toBeInTheDocument();
+		expect( screen.getByText( '$789.11' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should pass correct props to ConsolidatedStatsCard components', () => {
+		render(
+			<PayoutCards
+				isFetching
+				previousQuarterExpectedCommission={ 150.25 }
+				currentQuarterExpectedCommission={ 300.5 }
+			/>
+		);
+
+		const values = screen.getAllByTestId( 'value' );
+		const footerTexts = screen.getAllByTestId( 'footer-text' );
+		const loadingElements = screen.getAllByTestId( 'loading' );
+
+		expect( values ).toHaveLength( 2 );
+		expect( footerTexts ).toHaveLength( 2 );
+		expect( loadingElements ).toHaveLength( 2 );
+
+		expect( values[ 0 ] ).toHaveTextContent( '$150.25' );
+		expect( values[ 1 ] ).toHaveTextContent( '$300.50' );
+		expect( footerTexts[ 0 ] ).toHaveTextContent( 'Estimated earnings in previous quarter' );
+		expect( footerTexts[ 1 ] ).toHaveTextContent( 'Estimated earnings in current quarter' );
+	} );
+} );

--- a/client/a8c-for-agencies/sections/referrals/hooks/test/use-get-consolidated-payout-data.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/test/use-get-consolidated-payout-data.ts
@@ -1,0 +1,134 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook } from '@testing-library/react';
+import * as getEstimatedCommission from '../../lib/get-estimated-commission';
+import * as getNextPayoutDate from '../../lib/get-next-payout-date';
+import useGetConsolidatedPayoutData from '../use-get-consolidated-payout-data';
+import type { Referral } from '../../types';
+import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+
+// Mock the dependencies
+jest.mock( '../../lib/get-estimated-commission' );
+jest.mock( '../../lib/get-next-payout-date' );
+
+const mockGetEstimatedCommission =
+	getEstimatedCommission.getEstimatedCommission as jest.MockedFunction<
+		typeof getEstimatedCommission.getEstimatedCommission
+	>;
+const mockGetNextPayoutDateActivityWindow =
+	getNextPayoutDate.getNextPayoutDateActivityWindow as jest.MockedFunction<
+		typeof getNextPayoutDate.getNextPayoutDateActivityWindow
+	>;
+const mockGetCurrentCycleActivityWindow =
+	getNextPayoutDate.getCurrentCycleActivityWindow as jest.MockedFunction<
+		typeof getNextPayoutDate.getCurrentCycleActivityWindow
+	>;
+
+describe( 'useGetConsolidatedPayoutData', () => {
+	const mockReferrals: Referral[] = [
+		{
+			referralStatuses: [ 'active', 'pending' ],
+			purchaseStatuses: [ 'active' ],
+			purchases: [
+				{
+					product_id: 1,
+					status: 'active',
+					quantity: 1,
+					license: {
+						issued_at: '2024-01-01T00:00:00Z',
+						revoked_at: null,
+					},
+				},
+			],
+		},
+	] as never;
+
+	const mockProducts: APIProductFamilyProduct[] = [
+		{
+			product_id: 1,
+			family_slug: 'jetpack-backup',
+			price_per_unit: 100,
+			supported_bundles: [],
+			name: 'Mock Product',
+			slug: 'mock-product',
+			currency: 'USD',
+			amount: '100',
+			price_interval: 'month',
+		},
+	];
+
+	const mockActivityWindow = {
+		start: new Date( '2024-01-01' ),
+		finish: new Date( '2024-03-31' ),
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockGetNextPayoutDateActivityWindow.mockReturnValue( mockActivityWindow );
+		mockGetCurrentCycleActivityWindow.mockReturnValue( mockActivityWindow );
+		mockGetEstimatedCommission.mockReturnValue( 50 );
+	} );
+
+	it( 'should calculate previous quarter expected commission', () => {
+		const { result } = renderHook( () =>
+			useGetConsolidatedPayoutData( mockReferrals, mockProducts )
+		);
+
+		expect( mockGetEstimatedCommission ).toHaveBeenCalledWith(
+			mockReferrals,
+			mockProducts,
+			mockActivityWindow
+		);
+		expect( result.current.previousQuarterExpectedCommission ).toBe( 50 );
+	} );
+
+	it( 'should calculate current quarter expected commission', () => {
+		const { result } = renderHook( () =>
+			useGetConsolidatedPayoutData( mockReferrals, mockProducts )
+		);
+
+		expect( mockGetEstimatedCommission ).toHaveBeenCalledWith(
+			mockReferrals,
+			mockProducts,
+			mockActivityWindow
+		);
+		expect( result.current.currentQuarterExpectedCommission ).toBe( 50 );
+	} );
+
+	it( 'should calculate pending orders count', () => {
+		const { result } = renderHook( () =>
+			useGetConsolidatedPayoutData( mockReferrals, mockProducts )
+		);
+
+		expect( result.current.pendingOrders ).toBe( 1 );
+	} );
+
+	it( 'should handle multiple referrals with mixed statuses', () => {
+		const multipleReferrals: Referral[] = [
+			{
+				referralStatuses: [ 'active', 'pending' ],
+				purchaseStatuses: [ 'active' ],
+				purchases: [],
+			},
+			{
+				referralStatuses: [ 'pending', 'pending' ],
+				purchaseStatuses: [ 'active' ],
+				purchases: [],
+			},
+			{
+				referralStatuses: [ 'active' ],
+				purchaseStatuses: [ 'active' ],
+				purchases: [],
+			},
+		] as never;
+
+		const { result } = renderHook( () =>
+			useGetConsolidatedPayoutData( multipleReferrals, mockProducts )
+		);
+
+		// Should count 3 pending orders (1 from first referral, 2 from second referral)
+		expect( result.current.pendingOrders ).toBe( 3 );
+	} );
+} );

--- a/client/a8c-for-agencies/sections/referrals/hooks/test/use-get-consolidated-payout-data.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/test/use-get-consolidated-payout-data.ts
@@ -41,6 +41,15 @@ describe( 'useGetConsolidatedPayoutData', () => {
 						revoked_at: null,
 					},
 				},
+				{
+					product_id: 2,
+					status: 'active',
+					quantity: 1,
+					license: {
+						issued_at: '2024-01-15T00:00:00Z',
+						revoked_at: null,
+					},
+				},
 			],
 		},
 	] as never;
@@ -55,6 +64,17 @@ describe( 'useGetConsolidatedPayoutData', () => {
 			slug: 'mock-product',
 			currency: 'USD',
 			amount: '100',
+			price_interval: 'month',
+		},
+		{
+			product_id: 2,
+			family_slug: 'jetpack-security',
+			price_per_unit: 150,
+			supported_bundles: [],
+			name: 'Mock Product 2',
+			slug: 'mock-product-2',
+			currency: 'USD',
+			amount: '150',
 			price_interval: 'month',
 		},
 	];
@@ -130,5 +150,75 @@ describe( 'useGetConsolidatedPayoutData', () => {
 
 		// Should count 3 pending orders (1 from first referral, 2 from second referral)
 		expect( result.current.pendingOrders ).toBe( 3 );
+	} );
+
+	it( 'should handle scenario where one purchase was revoked in previous quarter', () => {
+		const referralsWithRevokedPurchase: Referral[] = [
+			{
+				referralStatuses: [ 'active', 'pending' ],
+				purchaseStatuses: [ 'active', 'revoked' ],
+				purchases: [
+					{
+						product_id: 1,
+						status: 'active',
+						quantity: 1,
+						license: {
+							issued_at: '2024-01-01T00:00:00Z',
+							revoked_at: null,
+						},
+					},
+					{
+						product_id: 2,
+						status: 'revoked',
+						quantity: 1,
+						license: {
+							issued_at: '2024-01-15T00:00:00Z',
+							revoked_at: '2024-02-15T00:00:00Z', // Revoked in previous quarter
+						},
+					},
+				],
+			},
+		] as never;
+
+		// Mock different activity windows for previous and current quarter
+		const previousQuarterWindow = {
+			start: new Date( '2024-01-01' ),
+			finish: new Date( '2024-03-31' ),
+		};
+		const currentQuarterWindow = {
+			start: new Date( '2024-04-01' ),
+			finish: new Date( '2024-06-30' ),
+		};
+
+		mockGetNextPayoutDateActivityWindow.mockReturnValue( previousQuarterWindow );
+		mockGetCurrentCycleActivityWindow.mockReturnValue( currentQuarterWindow );
+
+		// Mock commission calculation - previous quarter should have 2 products, current should have 1
+		mockGetEstimatedCommission.mockImplementation( ( referrals, products, activityWindow ) => {
+			if ( activityWindow === previousQuarterWindow ) {
+				return 75; // Commission for 2 products (before revocation)
+			} else if ( activityWindow === currentQuarterWindow ) {
+				return 50; // Commission for 1 product (after revocation)
+			}
+			return 0;
+		} );
+
+		const { result } = renderHook( () =>
+			useGetConsolidatedPayoutData( referralsWithRevokedPurchase, mockProducts )
+		);
+
+		expect( mockGetEstimatedCommission ).toHaveBeenCalledWith(
+			referralsWithRevokedPurchase,
+			mockProducts,
+			previousQuarterWindow
+		);
+		expect( mockGetEstimatedCommission ).toHaveBeenCalledWith(
+			referralsWithRevokedPurchase,
+			mockProducts,
+			currentQuarterWindow
+		);
+		expect( result.current.previousQuarterExpectedCommission ).toBe( 75 );
+		expect( result.current.currentQuarterExpectedCommission ).toBe( 50 );
+		expect( result.current.pendingOrders ).toBe( 1 ); // Only 1 pending order (active status)
 	} );
 } );

--- a/client/a8c-for-agencies/sections/referrals/hooks/test/use-get-payout-data.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/test/use-get-payout-data.ts
@@ -51,22 +51,22 @@ describe( 'useGetPayoutData', () => {
 		expect( result.current.nextPayoutActivityWindow ).toBe( '1 Jan 2024 - 31 Mar 2024' );
 	} );
 
-	it( 'should format next payout date without year', () => {
+	it( 'should format next payout date with year', () => {
 		const { result } = renderHook( () => useGetPayoutData() );
 
-		expect( result.current.nextPayoutDate ).toBe( '1 June' );
+		expect( result.current.nextPayoutDate ).toBe( '1 June 2024' );
 	} );
 
-	it( 'should format current cycle payout date without year', () => {
+	it( 'should format current cycle payout date with year', () => {
 		const { result } = renderHook( () => useGetPayoutData() );
 
-		expect( result.current.currentCyclePayoutDate ).toBe( '2 Mar' );
+		expect( result.current.currentCyclePayoutDate ).toBe( '2 Mar 2024' );
 	} );
 
-	it( 'should format current cycle activity window without year', () => {
+	it( 'should format current cycle activity window with year', () => {
 		const { result } = renderHook( () => useGetPayoutData() );
 
-		expect( result.current.currentCycleActivityWindow ).toBe( '1 Jan - 31 Mar' );
+		expect( result.current.currentCycleActivityWindow ).toBe( '1 Jan 2024 - 31 Mar 2024' );
 	} );
 
 	it( 'should determine if next and current payout dates are different', () => {
@@ -100,49 +100,12 @@ describe( 'useGetPayoutData', () => {
 	it( 'should handle cross-year date ranges', () => {
 		const crossYearWindow = {
 			start: new Date( '2023-10-01' ),
-			finish: new Date( '2023-12-31' ),
+			finish: new Date( '2024-01-01' ),
 		};
 		mockGetNextPayoutDateActivityWindow.mockReturnValue( crossYearWindow );
 
 		const { result } = renderHook( () => useGetPayoutData() );
 
-		expect( result.current.nextPayoutActivityWindow ).toBe( '1 Oct 2023 - 31 Dec 2023' );
-	} );
-
-	it( 'should memoize results', () => {
-		const { result, rerender } = renderHook( () => useGetPayoutData() );
-
-		const firstResult = result.current;
-		rerender();
-		const secondResult = result.current;
-
-		expect( firstResult ).toBe( secondResult );
-	} );
-
-	it( 'should call all required functions', () => {
-		renderHook( () => useGetPayoutData() );
-
-		expect( mockGetNextPayoutDate ).toHaveBeenCalledWith( expect.any( Date ) );
-		expect( mockGetCurrentCyclePayoutDate ).toHaveBeenCalledWith( expect.any( Date ) );
-		expect( mockGetNextPayoutDateActivityWindow ).toHaveBeenCalledWith( expect.any( Date ) );
-		expect( mockGetCurrentCycleActivityWindow ).toHaveBeenCalledWith( expect.any( Date ) );
-	} );
-
-	it( 'should handle February dates correctly', () => {
-		const febDate = new Date( '2024-02-15' );
-		mockGetNextPayoutDate.mockReturnValue( febDate );
-
-		const { result } = renderHook( () => useGetPayoutData() );
-
-		expect( result.current.nextPayoutDate ).toBe( '15 Feb' );
-	} );
-
-	it( 'should handle December dates correctly', () => {
-		const decDate = new Date( '2024-12-01' );
-		mockGetCurrentCyclePayoutDate.mockReturnValue( decDate );
-
-		const { result } = renderHook( () => useGetPayoutData() );
-
-		expect( result.current.currentCyclePayoutDate ).toBe( '1 Dec' );
+		expect( result.current.nextPayoutActivityWindow ).toBe( '1 Oct 2023 - 1 Jan 2024' );
 	} );
 } );

--- a/client/a8c-for-agencies/sections/referrals/hooks/test/use-get-payout-data.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/test/use-get-payout-data.ts
@@ -1,0 +1,148 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook } from '@testing-library/react';
+import * as getNextPayoutDate from '../../lib/get-next-payout-date';
+import useGetPayoutData from '../use-get-payout-data';
+
+// Mock the dependencies
+jest.mock( '../../lib/get-next-payout-date' );
+
+const mockGetNextPayoutDate = getNextPayoutDate.getNextPayoutDate as jest.MockedFunction<
+	typeof getNextPayoutDate.getNextPayoutDate
+>;
+const mockGetCurrentCyclePayoutDate =
+	getNextPayoutDate.getCurrentCyclePayoutDate as jest.MockedFunction<
+		typeof getNextPayoutDate.getCurrentCyclePayoutDate
+	>;
+const mockGetNextPayoutDateActivityWindow =
+	getNextPayoutDate.getNextPayoutDateActivityWindow as jest.MockedFunction<
+		typeof getNextPayoutDate.getNextPayoutDateActivityWindow
+	>;
+const mockGetCurrentCycleActivityWindow =
+	getNextPayoutDate.getCurrentCycleActivityWindow as jest.MockedFunction<
+		typeof getNextPayoutDate.getCurrentCycleActivityWindow
+	>;
+
+describe( 'useGetPayoutData', () => {
+	const mockNextPayoutDate = new Date( '2024-06-01' );
+	const mockCurrentCyclePayoutDate = new Date( '2024-03-02' );
+	const mockNextPayoutWindow = {
+		start: new Date( '2024-01-01' ),
+		finish: new Date( '2024-03-31' ),
+	};
+	const mockCurrentCycleWindow = {
+		start: new Date( '2024-01-01' ),
+		finish: new Date( '2024-03-31' ),
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockGetNextPayoutDate.mockReturnValue( mockNextPayoutDate );
+		mockGetCurrentCyclePayoutDate.mockReturnValue( mockCurrentCyclePayoutDate );
+		mockGetNextPayoutDateActivityWindow.mockReturnValue( mockNextPayoutWindow );
+		mockGetCurrentCycleActivityWindow.mockReturnValue( mockCurrentCycleWindow );
+	} );
+
+	it( 'should format next payout activity window with year', () => {
+		const { result } = renderHook( () => useGetPayoutData() );
+
+		expect( result.current.nextPayoutActivityWindow ).toBe( '1 Jan 2024 - 31 Mar 2024' );
+	} );
+
+	it( 'should format next payout date without year', () => {
+		const { result } = renderHook( () => useGetPayoutData() );
+
+		expect( result.current.nextPayoutDate ).toBe( '1 June' );
+	} );
+
+	it( 'should format current cycle payout date without year', () => {
+		const { result } = renderHook( () => useGetPayoutData() );
+
+		expect( result.current.currentCyclePayoutDate ).toBe( '2 Mar' );
+	} );
+
+	it( 'should format current cycle activity window without year', () => {
+		const { result } = renderHook( () => useGetPayoutData() );
+
+		expect( result.current.currentCycleActivityWindow ).toBe( '1 Jan - 31 Mar' );
+	} );
+
+	it( 'should determine if next and current payout dates are different', () => {
+		const { result } = renderHook( () => useGetPayoutData() );
+
+		expect( result.current.areNextAndCurrentPayoutDatesEqual ).toBe( false );
+	} );
+
+	it( 'should determine if next and current payout dates are the same', () => {
+		const sameDateValue = new Date( '2024-06-01' );
+		mockGetNextPayoutDate.mockReturnValue( sameDateValue );
+		mockGetCurrentCyclePayoutDate.mockReturnValue( sameDateValue );
+
+		const { result } = renderHook( () => useGetPayoutData() );
+
+		expect( result.current.areNextAndCurrentPayoutDatesEqual ).toBe( true );
+	} );
+
+	it( 'should handle different activity window date ranges', () => {
+		const differentWindow = {
+			start: new Date( '2024-04-01' ),
+			finish: new Date( '2024-06-30' ),
+		};
+		mockGetNextPayoutDateActivityWindow.mockReturnValue( differentWindow );
+
+		const { result } = renderHook( () => useGetPayoutData() );
+
+		expect( result.current.nextPayoutActivityWindow ).toBe( '1 Apr 2024 - 30 June 2024' );
+	} );
+
+	it( 'should handle cross-year date ranges', () => {
+		const crossYearWindow = {
+			start: new Date( '2023-10-01' ),
+			finish: new Date( '2023-12-31' ),
+		};
+		mockGetNextPayoutDateActivityWindow.mockReturnValue( crossYearWindow );
+
+		const { result } = renderHook( () => useGetPayoutData() );
+
+		expect( result.current.nextPayoutActivityWindow ).toBe( '1 Oct 2023 - 31 Dec 2023' );
+	} );
+
+	it( 'should memoize results', () => {
+		const { result, rerender } = renderHook( () => useGetPayoutData() );
+
+		const firstResult = result.current;
+		rerender();
+		const secondResult = result.current;
+
+		expect( firstResult ).toBe( secondResult );
+	} );
+
+	it( 'should call all required functions', () => {
+		renderHook( () => useGetPayoutData() );
+
+		expect( mockGetNextPayoutDate ).toHaveBeenCalledWith( expect.any( Date ) );
+		expect( mockGetCurrentCyclePayoutDate ).toHaveBeenCalledWith( expect.any( Date ) );
+		expect( mockGetNextPayoutDateActivityWindow ).toHaveBeenCalledWith( expect.any( Date ) );
+		expect( mockGetCurrentCycleActivityWindow ).toHaveBeenCalledWith( expect.any( Date ) );
+	} );
+
+	it( 'should handle February dates correctly', () => {
+		const febDate = new Date( '2024-02-15' );
+		mockGetNextPayoutDate.mockReturnValue( febDate );
+
+		const { result } = renderHook( () => useGetPayoutData() );
+
+		expect( result.current.nextPayoutDate ).toBe( '15 Feb' );
+	} );
+
+	it( 'should handle December dates correctly', () => {
+		const decDate = new Date( '2024-12-01' );
+		mockGetCurrentCyclePayoutDate.mockReturnValue( decDate );
+
+		const { result } = renderHook( () => useGetPayoutData() );
+
+		expect( result.current.currentCyclePayoutDate ).toBe( '1 Dec' );
+	} );
+} );

--- a/client/a8c-for-agencies/sections/referrals/hooks/test/use-get-payout-data.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/test/use-get-payout-data.ts
@@ -25,6 +25,22 @@ const mockGetCurrentCycleActivityWindow =
 		typeof getNextPayoutDate.getCurrentCycleActivityWindow
 	>;
 
+// Mock Date.prototype.toLocaleString to ensure consistent formatting across environments
+const originalToLocaleString = Date.prototype.toLocaleString;
+beforeAll( () => {
+	Date.prototype.toLocaleString = function (
+		locales?: string | string[],
+		options?: Intl.DateTimeFormatOptions
+	) {
+		// Force British English format to match expected test outputs
+		return originalToLocaleString.call( this, 'en-GB', options );
+	};
+} );
+
+afterAll( () => {
+	Date.prototype.toLocaleString = originalToLocaleString;
+} );
+
 describe( 'useGetPayoutData', () => {
 	const mockNextPayoutDate = new Date( '2024-06-01' );
 	const mockCurrentCyclePayoutDate = new Date( '2024-03-02' );
@@ -54,7 +70,7 @@ describe( 'useGetPayoutData', () => {
 	it( 'should format next payout date with year', () => {
 		const { result } = renderHook( () => useGetPayoutData() );
 
-		expect( result.current.nextPayoutDate ).toBe( '1 June 2024' );
+		expect( result.current.nextPayoutDate ).toBe( '1 Jun 2024' );
 	} );
 
 	it( 'should format current cycle payout date with year', () => {
@@ -94,7 +110,7 @@ describe( 'useGetPayoutData', () => {
 
 		const { result } = renderHook( () => useGetPayoutData() );
 
-		expect( result.current.nextPayoutActivityWindow ).toBe( '1 Apr 2024 - 30 June 2024' );
+		expect( result.current.nextPayoutActivityWindow ).toBe( '1 Apr 2024 - 30 Jun 2024' );
 	} );
 
 	it( 'should handle cross-year date ranges', () => {

--- a/client/a8c-for-agencies/sections/referrals/hooks/use-get-consolidated-payout-data.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-get-consolidated-payout-data.ts
@@ -1,16 +1,33 @@
 import { useMemo } from 'react';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { getEstimatedCommission } from '../lib/get-estimated-commission';
+import {
+	getCurrentCycleActivityWindow,
+	getNextPayoutDateActivityWindow,
+} from '../lib/get-next-payout-date';
 import { Referral } from '../types';
 
 export default function useGetConsolidatedPayoutData(
 	referrals: Referral[],
 	products?: APIProductFamilyProduct[]
 ) {
-	const expectedCommission = useMemo(
-		() => getEstimatedCommission( referrals, products || [] ),
-		[ referrals, products ]
-	);
+	const { previousQuarterExpectedCommission, currentQuarterExpectedCommission } = useMemo( () => {
+		const currentDate = new Date();
+		const productsArray = products || [];
+
+		return {
+			previousQuarterExpectedCommission: getEstimatedCommission(
+				referrals,
+				productsArray,
+				getNextPayoutDateActivityWindow( currentDate )
+			),
+			currentQuarterExpectedCommission: getEstimatedCommission(
+				referrals,
+				productsArray,
+				getCurrentCycleActivityWindow( currentDate )
+			),
+		};
+	}, [ referrals, products ] );
 
 	const pendingOrders = useMemo(
 		() =>
@@ -23,7 +40,8 @@ export default function useGetConsolidatedPayoutData(
 	);
 
 	return {
-		expectedCommission,
+		previousQuarterExpectedCommission,
+		currentQuarterExpectedCommission,
 		pendingOrders,
 	};
 }

--- a/client/a8c-for-agencies/sections/referrals/hooks/use-get-payout-data.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-get-payout-data.ts
@@ -1,33 +1,56 @@
 import { useMemo } from 'react';
-import { getNextPayoutDate, getNextPayoutDateActivityWindow } from '../lib/get-next-payout-date';
+import {
+	getCurrentCyclePayoutDate,
+	getCurrentCycleActivityWindow,
+	getNextPayoutDate,
+	getNextPayoutDateActivityWindow,
+} from '../lib/get-next-payout-date';
+
+// Helper functions for date formatting
+const formatDate = ( date: Date ) =>
+	date.toLocaleString( 'default', {
+		month: 'short',
+		day: 'numeric',
+	} );
+
+const formatDateWithYear = ( date: Date ) =>
+	date.toLocaleString( 'default', {
+		month: 'short',
+		day: 'numeric',
+		year: 'numeric',
+	} );
+
+const formatDateRange = ( start: Date, finish: Date, includeYear = false ) => {
+	const formatter = includeYear ? formatDateWithYear : formatDate;
+	return `${ formatter( start ) } - ${ formatter( finish ) }`;
+};
 
 export default function useGetPayoutData() {
-	const nextPayoutActivityWindow = useMemo( () => {
-		const { start, finish } = getNextPayoutDateActivityWindow( new Date() );
-		const startDate = start.toLocaleString( 'default', {
-			month: 'short',
-			day: 'numeric',
-			year: 'numeric',
-		} );
-		const finishDate = finish.toLocaleString( 'default', {
-			month: 'short',
-			day: 'numeric',
-			year: 'numeric',
-		} );
-		return `${ startDate } - ${ finishDate }`;
+	return useMemo( () => {
+		const now = new Date();
+
+		// Get raw dates
+		const nextPayoutDateRaw = getNextPayoutDate( now );
+		const currentCyclePayoutDateRaw = getCurrentCyclePayoutDate( now );
+
+		// Get activity windows
+		const nextPayoutWindow = getNextPayoutDateActivityWindow( now );
+		const currentCycleWindow = getCurrentCycleActivityWindow( now );
+
+		return {
+			nextPayoutActivityWindow: formatDateRange(
+				nextPayoutWindow.start,
+				nextPayoutWindow.finish,
+				true
+			),
+			nextPayoutDate: formatDate( nextPayoutDateRaw ),
+			currentCyclePayoutDate: formatDate( currentCyclePayoutDateRaw ),
+			currentCycleActivityWindow: formatDateRange(
+				currentCycleWindow.start,
+				currentCycleWindow.finish
+			),
+			areNextAndCurrentPayoutDatesEqual:
+				nextPayoutDateRaw.getTime() === currentCyclePayoutDateRaw.getTime(),
+		};
 	}, [] );
-
-	const nextPayoutDate = useMemo(
-		() =>
-			getNextPayoutDate( new Date() ).toLocaleString( 'default', {
-				month: 'short',
-				day: 'numeric',
-			} ),
-		[]
-	);
-
-	return {
-		nextPayoutActivityWindow,
-		nextPayoutDate,
-	};
 }

--- a/client/a8c-for-agencies/sections/referrals/hooks/use-get-payout-data.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-get-payout-data.ts
@@ -6,13 +6,6 @@ import {
 	getNextPayoutDateActivityWindow,
 } from '../lib/get-next-payout-date';
 
-// Helper functions for date formatting
-const formatDate = ( date: Date ) =>
-	date.toLocaleString( 'default', {
-		month: 'short',
-		day: 'numeric',
-	} );
-
 const formatDateWithYear = ( date: Date ) =>
 	date.toLocaleString( 'default', {
 		month: 'short',
@@ -20,9 +13,8 @@ const formatDateWithYear = ( date: Date ) =>
 		year: 'numeric',
 	} );
 
-const formatDateRange = ( start: Date, finish: Date, includeYear = false ) => {
-	const formatter = includeYear ? formatDateWithYear : formatDate;
-	return `${ formatter( start ) } - ${ formatter( finish ) }`;
+const formatDateRange = ( start: Date, finish: Date ) => {
+	return `${ formatDateWithYear( start ) } - ${ formatDateWithYear( finish ) }`;
 };
 
 export default function useGetPayoutData() {
@@ -38,13 +30,9 @@ export default function useGetPayoutData() {
 		const currentCycleWindow = getCurrentCycleActivityWindow( now );
 
 		return {
-			nextPayoutActivityWindow: formatDateRange(
-				nextPayoutWindow.start,
-				nextPayoutWindow.finish,
-				true
-			),
-			nextPayoutDate: formatDate( nextPayoutDateRaw ),
-			currentCyclePayoutDate: formatDate( currentCyclePayoutDateRaw ),
+			nextPayoutActivityWindow: formatDateRange( nextPayoutWindow.start, nextPayoutWindow.finish ),
+			nextPayoutDate: formatDateWithYear( nextPayoutDateRaw ),
+			currentCyclePayoutDate: formatDateWithYear( currentCyclePayoutDateRaw ),
 			currentCycleActivityWindow: formatDateRange(
 				currentCycleWindow.start,
 				currentCycleWindow.finish

--- a/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts
@@ -1,7 +1,6 @@
 import { APIProductFamilyProduct } from '../../../../state/partner-portal/types';
 import { Referral } from '../types';
 import { getProductCommissionPercentage } from './commissions';
-import { getNextPayoutDateActivityWindow } from './get-next-payout-date';
 
 export const getDailyPrice = ( product: APIProductFamilyProduct, quantity: number ) => {
 	// If quantity is not 1 than we search corresponding bundle
@@ -18,10 +17,8 @@ export const getDailyPrice = ( product: APIProductFamilyProduct, quantity: numbe
 export const getEstimatedCommission = (
 	referrals: Referral[],
 	products: APIProductFamilyProduct[],
-	date: Date = new Date()
+	activityWindow: { start: Date; finish: Date }
 ) => {
-	const activityWindow = getNextPayoutDateActivityWindow( date );
-
 	const totalCommissionInCents = referrals.reduce( ( acc, referral ) => {
 		if ( ! referral?.purchases?.length ) {
 			return acc;

--- a/client/a8c-for-agencies/sections/referrals/lib/get-next-payout-date.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/get-next-payout-date.ts
@@ -45,3 +45,42 @@ export const getNextPayoutDateActivityWindow = ( currentDate: Date ) => {
 		finish: new Date( endYear, activityEnd.month - 1, activityEnd.day ),
 	};
 };
+
+const getCurrentCycle = ( currentDate: Date ) => {
+	const currentMonth = currentDate.getMonth() + 1;
+
+	// Find current cycle based on activity periods
+	const currentCycle = PAYOUT_DATES.find(
+		( { activityStart, activityEnd } ) =>
+			currentMonth >= activityStart.month && currentMonth <= activityEnd.month
+	);
+
+	if ( ! currentCycle ) {
+		throw new Error( 'Invalid current date' );
+	}
+
+	return currentCycle;
+};
+
+export const getCurrentCyclePayoutDate = ( currentDate: Date ): Date => {
+	const currentCycle = getCurrentCycle( currentDate );
+	const currentYear = currentDate.getFullYear();
+
+	// For Q4 activity (March payout), the payout is in the next year
+	const payoutYear = currentCycle === PAYOUT_DATES[ 0 ] ? currentYear + 1 : currentYear;
+
+	return new Date( payoutYear, currentCycle.month - 1, currentCycle.day );
+};
+
+export const getCurrentCycleActivityWindow = ( currentDate: Date ) => {
+	const currentCycle = getCurrentCycle( currentDate );
+	const currentYear = currentDate.getFullYear();
+
+	const { activityStart, activityEnd } = currentCycle;
+
+	// Activity window is always in the current year
+	return {
+		start: new Date( currentYear, activityStart.month - 1, activityStart.day ),
+		finish: new Date( currentYear, activityEnd.month - 1, activityEnd.day ),
+	};
+};

--- a/client/a8c-for-agencies/sections/referrals/lib/get-next-payout-date.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/get-next-payout-date.ts
@@ -25,7 +25,7 @@ export const getNextPayoutDate = ( currentDate: Date ): Date => {
 
 export const getNextPayoutDateActivityWindow = ( currentDate: Date ) => {
 	const nextPayoutDate = getNextPayoutDate( currentDate );
-	const nextPayoutMonth = nextPayoutDate.getMonth() + 1;
+	const nextPayoutMonth = nextPayoutDate.getMonth() + 1; // Convert to 1-based month
 
 	const payoutPeriod = PAYOUT_DATES.find( ( { month } ) => month === nextPayoutMonth );
 

--- a/client/a8c-for-agencies/sections/referrals/lib/test/get-estimated-commission.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/test/get-estimated-commission.ts
@@ -43,7 +43,11 @@ describe( 'get-estimated-commission', () => {
 	} );
 
 	describe( 'getEstimatedCommission', () => {
-		const mockDate = new Date( '2024-03-15' );
+		// Activity window for Q1 2024 (Jan 1 - Mar 31)
+		const mockActivityWindow = {
+			start: new Date( '2024-01-01' ),
+			finish: new Date( '2024-03-31' ),
+		};
 		const mockProduct: APIProductFamilyProduct = {
 			product_id: 1,
 			family_slug: 'jetpack-backup',
@@ -57,7 +61,7 @@ describe( 'get-estimated-commission', () => {
 		};
 
 		it( 'returns 0 for empty referrals', () => {
-			expect( getEstimatedCommission( [], [ mockProduct ], mockDate ) ).toBe( 0 );
+			expect( getEstimatedCommission( [], [ mockProduct ], mockActivityWindow ) ).toBe( 0 );
 		} );
 
 		it( 'calculates commission for active purchase within window', () => {
@@ -79,10 +83,12 @@ describe( 'get-estimated-commission', () => {
 				} as never,
 			];
 
-			// Payout window is Jan 1 - Mar 31 for the mock date
+			// Payout window is Jan 1 - Mar 31 for the activity window
 			// License issued on Mar 1, so 31 days (including Mar 1) * $100 daily price * 50% commission = 1550 cents
 			// Convert to dollars by dividing by 100
-			expect( getEstimatedCommission( referrals, [ mockProduct ], mockDate ) ).toBe( 15.5 );
+			expect( getEstimatedCommission( referrals, [ mockProduct ], mockActivityWindow ) ).toBe(
+				15.5
+			);
 		} );
 
 		it( 'handles cancelled purchases', () => {
@@ -106,7 +112,7 @@ describe( 'get-estimated-commission', () => {
 
 			// 10 days * $100 daily price * 50% commission = 500 cents
 			// Convert to dollars by dividing by 100
-			expect( getEstimatedCommission( referrals, [ mockProduct ], mockDate ) ).toBe( 5 );
+			expect( getEstimatedCommission( referrals, [ mockProduct ], mockActivityWindow ) ).toBe( 5 );
 		} );
 
 		it( 'skips pending purchases', () => {
@@ -129,7 +135,7 @@ describe( 'get-estimated-commission', () => {
 			] as never;
 
 			// Pending purchases should not contribute to commission
-			expect( getEstimatedCommission( referrals, [ mockProduct ], mockDate ) ).toBe( 0 );
+			expect( getEstimatedCommission( referrals, [ mockProduct ], mockActivityWindow ) ).toBe( 0 );
 		} );
 
 		it( 'calculates commission for multiple purchases in single referral', () => {
@@ -162,7 +168,7 @@ describe( 'get-estimated-commission', () => {
 
 			// 31 days * $100 daily price * 50% commission * 2 purchases = 3100 cents
 			// Convert to dollars by dividing by 100
-			expect( getEstimatedCommission( referrals, [ mockProduct ], mockDate ) ).toBe( 31 );
+			expect( getEstimatedCommission( referrals, [ mockProduct ], mockActivityWindow ) ).toBe( 31 );
 		} );
 
 		it( 'calculates commission for multiple referrals', () => {
@@ -201,7 +207,7 @@ describe( 'get-estimated-commission', () => {
 
 			// 31 days * $100 daily price * 50% commission * 2 referrals = 3100 cents
 			// Convert to dollars by dividing by 100
-			expect( getEstimatedCommission( referrals, [ mockProduct ], mockDate ) ).toBe( 31 );
+			expect( getEstimatedCommission( referrals, [ mockProduct ], mockActivityWindow ) ).toBe( 31 );
 		} );
 
 		it( 'calculates commission with bundle pricing', () => {
@@ -230,7 +236,9 @@ describe( 'get-estimated-commission', () => {
 
 			// 31 days * $90 daily price * 50% commission = 1395 cents
 			// Convert to dollars by dividing by 100
-			expect( getEstimatedCommission( referrals, [ productWithBundle ], mockDate ) ).toBe( 13.95 );
+			expect( getEstimatedCommission( referrals, [ productWithBundle ], mockActivityWindow ) ).toBe(
+				13.95
+			);
 		} );
 	} );
 } );

--- a/client/a8c-for-agencies/sections/referrals/lib/test/get-next-payout-date.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/test/get-next-payout-date.ts
@@ -1,4 +1,9 @@
-import { getNextPayoutDate, getNextPayoutDateActivityWindow } from '../get-next-payout-date';
+import {
+	getNextPayoutDate,
+	getNextPayoutDateActivityWindow,
+	getCurrentCyclePayoutDate,
+	getCurrentCycleActivityWindow,
+} from '../get-next-payout-date';
 
 describe( 'get-next-payout-date', () => {
 	describe( 'getNextPayoutDate', () => {
@@ -7,7 +12,7 @@ describe( 'get-next-payout-date', () => {
 			expect( result ).toEqual( new Date( '2024-03-02' ) );
 		} );
 
-		it( 'should return June 1st for dates between March 1st and June 1st', () => {
+		it( 'should return June 1st for dates between March 2nd and June 1st', () => {
 			const result = getNextPayoutDate( new Date( '2024-04-15' ) );
 			expect( result ).toEqual( new Date( '2024-06-01' ) );
 		} );
@@ -26,6 +31,7 @@ describe( 'get-next-payout-date', () => {
 			const result = getNextPayoutDate( new Date( '2024-12-15' ) );
 			expect( result ).toEqual( new Date( '2025-03-02' ) );
 		} );
+
 		it( 'should return March 2nd of next year for dates on December 1st', () => {
 			const result = getNextPayoutDate( new Date( '2024-12-01' ) );
 			expect( result ).toEqual( new Date( '2025-03-02' ) );
@@ -40,9 +46,27 @@ describe( 'get-next-payout-date', () => {
 			result = getNextPayoutDate( new Date( '2024-03-02' ) );
 			expect( result ).toEqual( new Date( '2024-06-01' ) );
 
+			// On June 1st, next payout is September 1st
+			result = getNextPayoutDate( new Date( '2024-06-01' ) );
+			expect( result ).toEqual( new Date( '2024-09-01' ) );
+
+			// On September 1st, next payout is December 1st
+			result = getNextPayoutDate( new Date( '2024-09-01' ) );
+			expect( result ).toEqual( new Date( '2024-12-01' ) );
+
 			// On December 1st, next payout is March 2nd of next year
 			result = getNextPayoutDate( new Date( '2024-12-01' ) );
 			expect( result ).toEqual( new Date( '2025-03-02' ) );
+		} );
+
+		it( 'should handle year transitions correctly', () => {
+			// January should return March 2nd of same year
+			const result = getNextPayoutDate( new Date( '2024-01-15' ) );
+			expect( result ).toEqual( new Date( '2024-03-02' ) );
+
+			// Late December should return March 2nd of next year
+			const result2 = getNextPayoutDate( new Date( '2024-12-31' ) );
+			expect( result2 ).toEqual( new Date( '2025-03-02' ) );
 		} );
 	} );
 
@@ -80,15 +104,15 @@ describe( 'get-next-payout-date', () => {
 		} );
 
 		it( 'should return Q4 activity window for dates after December 1st', () => {
-			const result = getNextPayoutDateActivityWindow( new Date( '2023-12-15' ) );
+			const result = getNextPayoutDateActivityWindow( new Date( '2024-12-15' ) );
 			expect( result ).toEqual( {
-				start: new Date( '2023-10-01' ),
-				finish: new Date( '2023-12-31' ),
+				start: new Date( '2024-10-01' ),
+				finish: new Date( '2024-12-31' ),
 			} );
 		} );
 
 		it( 'should handle exact payout dates correctly', () => {
-			// On March 1st, next payout is March 2nd, so Q4 activity
+			// On March 1st, next payout is March 2nd, so Q4 activity of previous year
 			let result = getNextPayoutDateActivityWindow( new Date( '2024-03-01' ) );
 			expect( result ).toEqual( {
 				start: new Date( '2023-10-01' ),
@@ -102,11 +126,133 @@ describe( 'get-next-payout-date', () => {
 				finish: new Date( '2024-03-31' ),
 			} );
 
-			// On December 1st, next payout is March 2nd of next year, so Q4 activity
-			result = getNextPayoutDateActivityWindow( new Date( '2023-12-01' ) );
+			// On December 1st, next payout is March 2nd of next year, so Q4 activity of current year
+			result = getNextPayoutDateActivityWindow( new Date( '2024-12-01' ) );
 			expect( result ).toEqual( {
-				start: new Date( '2023-10-01' ),
-				finish: new Date( '2023-12-31' ),
+				start: new Date( '2024-10-01' ),
+				finish: new Date( '2024-12-31' ),
+			} );
+		} );
+	} );
+
+	describe( 'getCurrentCyclePayoutDate', () => {
+		it( 'should return March 2nd for dates in Q4 activity period (Oct-Dec)', () => {
+			// October
+			let result = getCurrentCyclePayoutDate( new Date( '2024-10-15' ) );
+			expect( result ).toEqual( new Date( '2025-03-02' ) );
+
+			// November
+			result = getCurrentCyclePayoutDate( new Date( '2024-11-15' ) );
+			expect( result ).toEqual( new Date( '2025-03-02' ) );
+
+			// December
+			result = getCurrentCyclePayoutDate( new Date( '2024-12-15' ) );
+			expect( result ).toEqual( new Date( '2025-03-02' ) );
+		} );
+
+		it( 'should return June 1st for dates in Q1 activity period (Jan-Mar)', () => {
+			// January
+			let result = getCurrentCyclePayoutDate( new Date( '2024-01-15' ) );
+			expect( result ).toEqual( new Date( '2024-06-01' ) );
+
+			// February
+			result = getCurrentCyclePayoutDate( new Date( '2024-02-15' ) );
+			expect( result ).toEqual( new Date( '2024-06-01' ) );
+
+			// March
+			result = getCurrentCyclePayoutDate( new Date( '2024-03-15' ) );
+			expect( result ).toEqual( new Date( '2024-06-01' ) );
+		} );
+
+		it( 'should return September 1st for dates in Q2 activity period (Apr-Jun)', () => {
+			// April
+			let result = getCurrentCyclePayoutDate( new Date( '2024-04-15' ) );
+			expect( result ).toEqual( new Date( '2024-09-01' ) );
+
+			// May
+			result = getCurrentCyclePayoutDate( new Date( '2024-05-15' ) );
+			expect( result ).toEqual( new Date( '2024-09-01' ) );
+
+			// June
+			result = getCurrentCyclePayoutDate( new Date( '2024-06-15' ) );
+			expect( result ).toEqual( new Date( '2024-09-01' ) );
+		} );
+
+		it( 'should return December 1st for dates in Q3 activity period (Jul-Sep)', () => {
+			// July
+			let result = getCurrentCyclePayoutDate( new Date( '2024-07-15' ) );
+			expect( result ).toEqual( new Date( '2024-12-01' ) );
+
+			// August
+			result = getCurrentCyclePayoutDate( new Date( '2024-08-15' ) );
+			expect( result ).toEqual( new Date( '2024-12-01' ) );
+
+			// September
+			result = getCurrentCyclePayoutDate( new Date( '2024-09-15' ) );
+			expect( result ).toEqual( new Date( '2024-12-01' ) );
+		} );
+	} );
+
+	describe( 'getCurrentCycleActivityWindow', () => {
+		it( 'should return Q4 activity window for dates in Q4 period (Oct-Dec)', () => {
+			const result = getCurrentCycleActivityWindow( new Date( '2024-10-15' ) );
+			expect( result ).toEqual( {
+				start: new Date( '2024-10-01' ),
+				finish: new Date( '2024-12-31' ),
+			} );
+		} );
+
+		it( 'should return Q1 activity window for dates in Q1 period (Jan-Mar)', () => {
+			const result = getCurrentCycleActivityWindow( new Date( '2024-02-15' ) );
+			expect( result ).toEqual( {
+				start: new Date( '2024-01-01' ),
+				finish: new Date( '2024-03-31' ),
+			} );
+		} );
+
+		it( 'should return Q2 activity window for dates in Q2 period (Apr-Jun)', () => {
+			const result = getCurrentCycleActivityWindow( new Date( '2024-05-15' ) );
+			expect( result ).toEqual( {
+				start: new Date( '2024-04-01' ),
+				finish: new Date( '2024-06-30' ),
+			} );
+		} );
+
+		it( 'should return Q3 activity window for dates in Q3 period (Jul-Sep)', () => {
+			const result = getCurrentCycleActivityWindow( new Date( '2024-08-15' ) );
+			expect( result ).toEqual( {
+				start: new Date( '2024-07-01' ),
+				finish: new Date( '2024-09-30' ),
+			} );
+		} );
+
+		it( 'should handle edge dates correctly', () => {
+			// First day of Q1
+			let result = getCurrentCycleActivityWindow( new Date( '2024-01-01' ) );
+			expect( result ).toEqual( {
+				start: new Date( '2024-01-01' ),
+				finish: new Date( '2024-03-31' ),
+			} );
+
+			// Last day of Q1
+			result = getCurrentCycleActivityWindow( new Date( '2024-03-31' ) );
+			expect( result ).toEqual( {
+				start: new Date( '2024-01-01' ),
+				finish: new Date( '2024-03-31' ),
+			} );
+
+			// First day of Q4
+			result = getCurrentCycleActivityWindow( new Date( '2024-10-01' ) );
+			expect( result ).toEqual( {
+				start: new Date( '2024-10-01' ),
+				finish: new Date( '2024-12-31' ),
+			} );
+
+			// Last day of Q4
+			result = getCurrentCycleActivityWindow( new Date( '2024-12-31' ) );
+			expect( result ).toEqual( {
+				start: new Date( '2024-10-01' ),
+				finish: new Date( '2024-12-31' ),
 			} );
 		} );
 	} );

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/commissions-column.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/commissions-column.tsx
@@ -1,15 +1,64 @@
+import { Tooltip } from '@automattic/components';
 import { formatCurrency } from '@automattic/number-formatters';
+import { useTranslate } from 'i18n-calypso';
+import { useRef, useState } from 'react';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import useGetConsolidatedPayoutData from '../hooks/use-get-consolidated-payout-data';
+import useGetPayoutData from '../hooks/use-get-payout-data';
 import type { Referral } from '../types';
 
 export default function CommissionsColumn( { referral }: { referral: Referral } ) {
+	const translate = useTranslate();
 	const { data, isFetching } = useProductsQuery( false, false, true );
+	const tooltipRef = useRef< HTMLSpanElement >( null );
+	const [ showTooltip, setShowTooltip ] = useState( false );
 
-	const { expectedCommission } = useGetConsolidatedPayoutData( [ referral ], data );
+	const { previousQuarterExpectedCommission, currentQuarterExpectedCommission } =
+		useGetConsolidatedPayoutData( [ referral ], data );
 
-	const pendingCommission = formatCurrency( expectedCommission, 'USD' );
+	const { areNextAndCurrentPayoutDatesEqual } = useGetPayoutData();
 
-	return isFetching ? <TextPlaceholder /> : pendingCommission;
+	const totalPendingCommission = areNextAndCurrentPayoutDatesEqual
+		? formatCurrency( previousQuarterExpectedCommission, 'USD' )
+		: formatCurrency( previousQuarterExpectedCommission + currentQuarterExpectedCommission, 'USD' );
+
+	if ( isFetching ) {
+		return <TextPlaceholder />;
+	}
+
+	return (
+		<>
+			<span
+				ref={ tooltipRef }
+				onMouseEnter={ () => setShowTooltip( true ) }
+				onMouseLeave={ () => setShowTooltip( false ) }
+				role="button"
+				tabIndex={ 0 }
+			>
+				{ totalPendingCommission }
+			</span>
+			<Tooltip
+				context={ tooltipRef.current }
+				isVisible={ showTooltip }
+				position="bottom"
+				showOnMobile
+			>
+				<div>
+					{ ! areNextAndCurrentPayoutDatesEqual && (
+						<div>
+							{ translate( 'Previous quarter: %(amount)s', {
+								args: { amount: formatCurrency( previousQuarterExpectedCommission, 'USD' ) },
+							} ) }
+						</div>
+					) }
+					<div>
+						{ translate( 'Current quarter: %(amount)s', {
+							args: { amount: formatCurrency( currentQuarterExpectedCommission, 'USD' ) },
+						} ) }
+					</div>
+				</div>
+			</Tooltip>
+		</>
+	);
 }


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1012/mismatch-between-payout-amount-display-and-tooltip-date-range

Note: There are around 900+ changes on this PR. It is because of the newly added test cases. 

## Proposed Changes

This PR:

- Creates a reusable `PayoutCards` component that can be used for a consolidated view and a details view.
- The `PayoutCards` will display two cards: Estimated earnings in the previous quarter & current quarter. It will hide the previous quarter if the payout date is the same for both the previous and current quarters. 
- We have now moved the payout date and range to the tooltip of the cards to show both the cards
- The `Estimated Commissions` column is now the sum of the commission for the previous and current quarters. We don't add if the dates are the same. 
- Adds tests to cover different scenarios

## Why are these changes being made?

* To show the estimated commission in the previous and current quarters.

## Testing Instructions

**Note: Please perform some manual testing by changing the dates in `client/a8c-for-agencies/sections/referrals/hooks/use-get-payout-data.ts` &  `client/a8c-for-agencies/sections/referrals/hooks/use-get-consolidated-payout-data.ts` from new Date() to  something like in this format: new Date( '2025-12-01' ) to verify the data is correct, and you can set the date to the start of the quarter, like new Date( '2025-09-01' ) to verify only 1 card: Current quarter is shown.** 

* Open the A4A live link
* Go to Referrals: Dashboard: Verify you can see two new cards, instead of two old ones (compare with https://agencies.automattic.com/referrals/dashboard)
* Verify the data is correct for previous and current quarters, including the estimated commissions, payout range, and payout date. 

<img width="1512" height="855" alt="Screenshot 2025-07-18 at 3 52 49 PM" src="https://github.com/user-attachments/assets/a517f058-ccc4-4e36-9c38-c7a924682f86" />

<img width="640" height="453" alt="Screenshot 2025-07-18 at 3 53 12 PM" src="https://github.com/user-attachments/assets/e1d7a8df-eec5-4944-8024-6d4971067bca" />

<img width="616" height="453" alt="Screenshot 2025-07-18 at 3 53 25 PM" src="https://github.com/user-attachments/assets/508f53da-c3c1-4dcc-bda9-ae9b30863c88" />

* The `Estimated Commissions` column should show the total of previous + current quarter referrals. Hover over it to see the previous and current quarter commissions

<img width="543" height="302" alt="Screenshot 2025-07-18 at 4 00 28 PM" src="https://github.com/user-attachments/assets/587c5dd9-e294-4560-bc34-d4745d493d2c" />

* Open the preview for any referrals where you have previous and current quarter data and verify that the `Commissions` tab shows the accurate data.

<img width="907" height="302" alt="Screenshot 2025-07-18 at 3 54 54 PM" src="https://github.com/user-attachments/assets/c40b823d-0831-40b5-8b80-96b48860287a" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
