### PR TITLE
Site Overview: Refine the domains card

### DIFF
--- a/client/dashboard/data/domains.ts
+++ b/client/dashboard/data/domains.ts
@@ -21,6 +21,8 @@ export interface Domain {
 	is_wpcom_staging_domain: boolean;
 	type: `${ DomainTypes }`;
 	site_slug: string;
+	auto_renewing: boolean;
+	is_hundred_year_domain: boolean;
 }
 
 export async function fetchDomains(): Promise< Domain[] > {

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -1,61 +1,176 @@
-import { __experimentalText as Text } from '@wordpress/components';
+import { Badge } from '@automattic/ui';
+import { Link } from '@tanstack/react-router';
+import {
+	Icon,
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
 import { dateI18n } from '@wordpress/date';
-import { __ } from '@wordpress/i18n';
-import type { Domain } from '../../data/types';
+import { sprintf, __ } from '@wordpress/i18n';
+import { caution, reusableBlock } from '@wordpress/icons';
+import { useMemo } from 'react';
+import { DomainTypes } from '../../data/domains';
+import type { Domain, Site } from '../../data/types';
 import type { Field } from '@wordpress/dataviews';
+
+const textOverflowStyles = {
+	overflowX: 'hidden',
+	textOverflow: 'ellipsis',
+	whiteSpace: 'nowrap',
+} as const;
 
 const IneligibleIndicator = () => <Text color="#CCCCCC">-</Text>;
 
-export const fields: Field< Domain >[] = [
-	{
-		id: 'domain',
-		label: __( 'Domains' ),
-		enableHiding: false,
-		enableSorting: true,
-		enableGlobalSearch: true,
-		getValue: ( { item }: { item: Domain } ) => item.domain,
-	},
-	{
-		id: 'type',
-		label: __( 'Type' ),
-		enableHiding: false,
-		enableSorting: false,
-	},
-	// {
-	// 	id: 'owner',
-	// 	label: __( 'Owner' ),
-	// 	enableHiding: false,
-	// 	enableSorting: true,
-	// },
-	{
-		id: 'blog_name',
-		label: __( 'Site' ),
-		enableHiding: false,
-		enableSorting: true,
-		getValue: ( { item }: { item: Domain } ) => item.blog_name ?? '',
-	},
-	// {
-	// 	id: 'ssl_status',
-	// 	label: __( 'SSL' ),
-	// 	enableHiding: false,
-	// 	enableSorting: true,
-	// },
-	{
-		id: 'expiry',
-		label: __( 'Expires/Renews on' ),
-		enableHiding: false,
-		enableSorting: true,
-		getValue: ( { item }: { item: Domain } ) =>
-			item.expiry ? dateI18n( 'F j, Y', item.expiry ) : '',
-		render: ( { item } ) =>
-			item.expiry ? dateI18n( 'F j, Y', item.expiry ) : <IneligibleIndicator />,
-	},
-	{
-		id: 'domain_status',
-		label: __( 'Status' ),
-		enableHiding: false,
-		enableSorting: true,
-		getValue: ( { item }: { item: Domain } ) => item.domain_status?.status ?? '',
-		render: ( { item } ) => item.domain_status?.status ?? <IneligibleIndicator />,
-	},
-];
+const DomainName = ( { domain, site, value }: { domain: Domain; site?: Site; value: string } ) => {
+	const siteSlug = site?.slug ?? domain.site_slug;
+	const domainManagementUrl = site
+		? `${ window.location.origin }/overview/site-domain/domain/${ domain.domain }/${ siteSlug }`
+		: `${ window.location.origin }/domains/manage/all/overview/${ domain.domain }/${ siteSlug }`;
+
+	return (
+		<Link to={ domainManagementUrl } disabled={ domain.type === DomainTypes.WPCOM }>
+			<HStack alignment="center" spacing={ 1 }>
+				<span style={ textOverflowStyles }>{ value }</span>
+				{ domain.primary_domain && (
+					<span style={ { flexShrink: 0 } }>
+						<Badge>{ __( 'Primary' ) }</Badge>
+					</span>
+				) }
+			</HStack>
+		</Link>
+	);
+};
+
+const DomainExpiry = ( {
+	domain,
+	value,
+	isCompact = false,
+}: {
+	domain: Domain;
+	value: string;
+	isCompact?: boolean;
+} ) => {
+	if ( ! domain.expiry ) {
+		return __( 'Free forever' );
+	}
+
+	const isAutoRenewing = Boolean( domain.auto_renewing );
+	const isExpired = new Date( domain.expiry ) < new Date();
+	const isHundredYearDomain = Boolean( domain.is_hundred_year_domain );
+	const renderExpiry = () => {
+		if ( isHundredYearDomain ) {
+			return sprintf(
+				/* translators: %s - The date until which a domain was paid for */
+				__( 'Paid until %s' ),
+				value
+			);
+		}
+
+		if ( isExpired ) {
+			return sprintf(
+				/* translators: %s - The date on which a domain has expired */
+				__( 'Expired on %s' ),
+				value
+			);
+		}
+
+		if ( ! isAutoRenewing ) {
+			return sprintf(
+				/* translators: %s - The date on which a domain expires */
+				__( 'Expires on %s' ),
+				value
+			);
+		}
+
+		return sprintf(
+			/* translators: %s - The future date on which a domain renews */
+			__( 'Renews on %s' ),
+			value
+		);
+	};
+
+	return (
+		<HStack justify="flex-start" alignment="center" spacing={ 1 }>
+			{ ! isCompact && (
+				<Icon
+					icon={ isExpired || isHundredYearDomain ? caution : reusableBlock }
+					size={ 16 }
+					style={ { fill: 'currentColor' } }
+				/>
+			) }
+			<span>{ renderExpiry() }</span>
+		</HStack>
+	);
+};
+
+export const useFields = ( { site }: { site?: Site } = {} ) => {
+	const fields: Field< Domain >[] = useMemo(
+		() => [
+			{
+				id: 'domain',
+				label: __( 'Domains' ),
+				enableHiding: false,
+				enableSorting: true,
+				enableGlobalSearch: true,
+				getValue: ( { item }: { item: Domain } ) => item.domain,
+				render: ( { field, item } ) => (
+					<DomainName domain={ item } site={ site } value={ field.getValue( { item } ) } />
+				),
+			},
+			{
+				id: 'type',
+				label: __( 'Type' ),
+				enableHiding: false,
+				enableSorting: false,
+			},
+			// {
+			// 	id: 'owner',
+			// 	label: __( 'Owner' ),
+			// 	enableHiding: false,
+			// 	enableSorting: true,
+			// },
+			{
+				id: 'blog_name',
+				label: __( 'Site' ),
+				enableHiding: false,
+				enableSorting: true,
+				getValue: ( { item }: { item: Domain } ) => item.blog_name ?? '',
+			},
+			// {
+			// 	id: 'ssl_status',
+			// 	label: __( 'SSL' ),
+			// 	enableHiding: false,
+			// 	enableSorting: true,
+			// },
+			{
+				id: 'expiry',
+				label: __( 'Expires/Renews on' ),
+				enableHiding: false,
+				enableSorting: true,
+				getValue: ( { item }: { item: Domain } ) =>
+					item.expiry ? dateI18n( 'F j, Y', item.expiry ) : '',
+				render: ( { field, item } ) => (
+					<DomainExpiry
+						domain={ item }
+						value={ field.getValue( { item } ) }
+						isCompact={ !! site }
+					/>
+				),
+			},
+			{
+				id: 'domain_status',
+				label: __( 'Status' ),
+				enableHiding: false,
+				enableSorting: true,
+				getValue: ( { item }: { item: Domain } ) => item.domain_status?.status ?? '',
+				render: ( { field, item } ) => {
+					const value = field.getValue( { item } );
+					return value || <IneligibleIndicator />;
+				},
+			},
+		],
+		[ site ]
+	);
+
+	return fields;
+};

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -7,7 +7,7 @@ import { domainsQuery } from '../app/queries/domains';
 import DataViewsCard from '../components/dataviews-card';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
-import { actions, fields, DEFAULT_VIEW, DEFAULT_LAYOUTS } from './dataviews';
+import { actions, useFields, DEFAULT_VIEW, DEFAULT_LAYOUTS } from './dataviews';
 import type { DomainsView } from './dataviews';
 import type { Domain } from '../data/types';
 
@@ -16,6 +16,7 @@ export function getDomainId( domain: Domain ): string {
 }
 
 function Domains() {
+	const fields = useFields();
 	const [ view, setView ] = useState< DomainsView >( () => ( {
 		...DEFAULT_VIEW,
 		type: 'table',

--- a/client/dashboard/sites/overview/domains-card.tsx
+++ b/client/dashboard/sites/overview/domains-card.tsx
@@ -6,7 +6,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { useState, useEffect } from 'react';
 import { siteDomainsQuery } from '../../app/queries/site-domains';
 import { SectionHeader } from '../../components/section-header';
-import { fields, actions, DEFAULT_VIEW, DEFAULT_LAYOUTS } from '../../domains/dataviews';
+import { useFields, actions, DEFAULT_VIEW, DEFAULT_LAYOUTS } from '../../domains/dataviews';
 import type { Site, SiteDomain } from '../../data/types';
 import type { DomainsView } from '../../domains/dataviews';
 
@@ -21,6 +21,7 @@ export default function DomainsCard( {
 	site: Site;
 	type?: DomainsView[ 'type' ];
 } ) {
+	const fields = useFields( { site } );
 	const [ view, setView ] = useState< DomainsView >( {
 		...DEFAULT_VIEW,
 		fields: [ 'expiry' ],


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-111

## Proposed Changes

* Add the `primary` badge to the primary domain. As the existing staging badge, the color is not correct because we cannot hide the icon with the intent.
* Make the domain name clickable if it's not the wpcom domain
* Add the `Expired on`, `Renew on`, etc to the `EXPIRED/RENEW on` column

<img width="993" height="250" alt="image" src="https://github.com/user-attachments/assets/03a341fb-636b-4fd2-853a-9e34e72d7b7b" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Navigate to Site Overview by selecting a site
* On the domains card
  * Ensure the primary badge is shown on the primary domain
  * Ensure the non-wpcom domain name is clickable
  * Ensure the value on the `EXPIRED/RENEW on` column has correct prefix

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
