### PR TITLE
Council banner: fix display

### DIFF
--- a/client/reader/stream/customer-council-banner.jsx
+++ b/client/reader/stream/customer-council-banner.jsx
@@ -42,6 +42,7 @@ export const CustomerCouncilBanner = ( { translate } ) => {
 
 	return (
 		<Banner
+			horizontal
 			callToAction={
 				notActivelySubscribing ? translate( 'Subscribe' ) : `${ translate( 'Subscribing' ) }...`
 			}


### PR DESCRIPTION
See https://github.com/Automattic/wp-calypso/pull/104764#pullrequestreview-3029749631

## Proposed Changes

The big banner is not meant to be used in such a small place. The horizontal variation seems to be a better fit.

**Before**

<img width="790" height="191" alt="image" src="https://github.com/user-attachments/assets/95e25885-ccd0-4d96-a99e-930aae2d32f9" />

**After**

<img width="809" height="162" alt="image" src="https://github.com/user-attachments/assets/5dd76ecf-bcc8-406e-8351-e229d5644b84" />

## Testing Instructions

> [!NOTE]
> You cannot test this with an a11n account; the banner will be hidden for you.

* Navigate to /reader or /discover
* Click "subscribe" on banner
* You should navigate to (https://readercouncilgeneral.wordpress.com/)
* You should be subscribed to the P2
* Navigate back to a Reader feed and the banner should not appear

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
