### PR TITLE
Disable sync submit button when nothing selected

### DIFF
--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -428,7 +428,11 @@ export default function SyncModal( {
 						<Button variant="tertiary" onClick={ onClose }>
 							{ __( 'Cancel' ) }
 						</Button>
-						<Button variant="primary" onClick={ handleConfirm }>
+						<Button
+							variant="primary"
+							onClick={ handleConfirm }
+							disabled={ ! browserCheckList.totalItems }
+						>
 							{ syncConfig.submit }
 						</Button>
 					</HStack>


### PR DESCRIPTION
Fixes DOTCOM-13961

## Proposed Changes

When nothing selected insoide Sync dialoig's tree, then submit button shoudl be disabled

<img width="673" height="491" alt="Screenshot 2025-07-18 at 16 37 57" src="https://github.com/user-attachments/assets/eaafc1ee-e935-4671-abda-ae183fc7e538" />


## Testing Instructions
1. Open `http://calypso.localhost:3000/sites`
2. Create a site
3. Create staging site
4. Click on Pull to staging or Push button
5. Try to deselect items in the tree
6. Assert when nothing selected, then Pull/Push button is disabled