### PR TITLE
Connect Refresh: Align Login layout spacing a little better. Remove more Woo/JP customisations

### DIFF
--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -19,7 +19,7 @@ form {
 		display: flex;
 		flex-direction: column;
 		justify-content: center;
-		gap: 3rem; // Should match stepContainer V2 styles.
+		gap: 2rem; // Should match OneLoginLayout styles.
 	}
 
 	form {

--- a/client/blocks/login/social.scss
+++ b/client/blocks/login/social.scss
@@ -35,15 +35,10 @@
 		}
 	}
 
-	/**
-	* Jetpack Login
-	*/
-	@at-root .is-jetpack-login & {
-		padding: 16px;
+	padding: 16px;
 
-		@include break-mobile {
-			padding: 24px 0;
-		}
+	@include break-mobile {
+		padding: 24px 0;
 	}
 }
 

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1202,12 +1202,6 @@ $breakpoint-mobile: 660px;
 		}
 
 		.wp-login__login-block-footer {
-			display: flex;
-			align-items: center;
-			width: 100%;
-			flex-direction: column;
-			margin: 12px auto 0;
-
 			@media (max-width: $break-mobile) {
 				max-width: $max-width;
 				margin-bottom: 40px;
@@ -1239,11 +1233,6 @@ $breakpoint-mobile: 660px;
 			&::before,
 			&::after {
 				border-block-start-color: #e0e0e1;
-			}
-
-			+ .auth-form__social.card {
-				border: 0;
-				padding: 0;
 			}
 		}
 

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -131,11 +131,7 @@ $image-height: 47px;
 	flex-direction: column;
 	align-items: center;
 	justify-content: center;
-	gap: 3em;
-
-	.is-magic-login & {
-		gap: 2em;
-	}
+	gap: 2em;
 }
 
 .wp-login__site-return-link {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13627/login-and-signup-centralise-font-and-css-overrides

## Proposed Changes

* Aligns the main gap/spacing in the Login layout a little better. It is now more consistent across.
  * Removes some JP & Woo customisations
  * Sets the main gap to `2rem` (`32px`). We can adjust these more consistently now
* In a future refactor, we will move the footer into the layout (it is currently rendered within the CTAs form). This should make the code a lot easier to adjust/control.

## Media

It is at least consistent now:

| Main layout | Form footer |
|--------|--------|
| <img width="669" height="607" alt="Screenshot 2025-07-18 at 9 26 11 PM" src="https://github.com/user-attachments/assets/b973913f-05b5-499d-8e43-cbb678eca979" /> | <img width="686" height="612" alt="Screenshot 2025-07-18 at 9 26 24 PM" src="https://github.com/user-attachments/assets/44856ff1-d8a9-4e30-8417-d77a943caf33" /> | 
| <img width="676" height="599" alt="Screenshot 2025-07-18 at 9 26 53 PM" src="https://github.com/user-attachments/assets/c77ea1df-cc18-466c-96f7-0e7e8b6a108e" /> | <img width="690" height="624" alt="Screenshot 2025-07-18 at 9 27 00 PM" src="https://github.com/user-attachments/assets/86a21df0-99c7-4b80-bf32-a20d4a56e462" /> |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13627/login-and-signup-centralise-font-and-css-overrides

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to several [Login screens](https://linear.app/a8c/project/login-and-signup-unify-design-and-layout-16a857e58712/overview) and confirm main Login, Magic Login, Lost Password (etc.) screens render correctly
* Confirm especially JP, Woo, and Gravatar (there should be no changes to Gravatar forms)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
