### PR TITLE
Render warning when sync mopdifies production e-commerce site

### DIFF
--- a/client/sites/staging-site/components/staging-site-card/card-content/new-staging-site-card-content.tsx
+++ b/client/sites/staging-site/components/staging-site-card/card-content/new-staging-site-card-content.tsx
@@ -42,6 +42,7 @@ export const NewStagingSiteCardContent = ( {
 
 	return (
 		<>
+			{ /* Can be removed. Handled in the new UI. */ }
 			{ isSiteWooStore && (
 				<NoticeContainer>
 					<WPNotice status="warning" isDismissible={ false }>

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import {
 	Button,
 	ExternalLink,
@@ -8,10 +9,12 @@ import {
 	__experimentalVStack as VStack,
 	CheckboxControl,
 	SelectControl,
+	Notice as WPNotice,
 } from '@wordpress/components';
 import { createInterpolateElement, useState, useCallback, useEffect } from '@wordpress/element';
 import { __, isRTL } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
+import { translate } from 'i18n-calypso';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import InlineSupportLink from 'calypso/dashboard/components/inline-support-link';
 import { SectionHeader } from 'calypso/dashboard/components/section-header';
@@ -29,6 +32,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { setNodeCheckState } from 'calypso/state/rewind/browser/actions';
 import getBackupBrowserCheckList from 'calypso/state/rewind/selectors/get-backup-browser-check-list';
 import getBackupBrowserNode from 'calypso/state/rewind/selectors/get-backup-browser-node';
+import isSiteStore from 'calypso/state/selectors/is-site-store';
 import { getSiteSlug, getSiteTitle } from 'calypso/state/sites/selectors';
 import type { FileBrowserConfig } from 'calypso/my-sites/backup/backup-contents-page/file-browser';
 
@@ -164,6 +168,11 @@ const getSyncConfig = ( type: 'pull' | 'push' ): SyncConfig => {
 	};
 };
 
+const WarningTitle = styled.p( {
+	fontWeight: 600,
+	marginBottom: '8px',
+} );
+
 export default function SyncModal( {
 	onClose,
 	syncType,
@@ -198,6 +207,8 @@ export default function SyncModal( {
 	const browserCheckList = useSelector( ( state ) =>
 		getBackupBrowserCheckList( state, querySiteId )
 	);
+
+	const isSiteWooStore = !! useSelector( ( state ) => isSiteStore( state, querySiteId ) );
 
 	// Calculate checkbox state based only on visible nodes (wp-content and wp-config.php)
 	const wpContentNode = useSelector( ( state ) =>
@@ -333,6 +344,19 @@ export default function SyncModal( {
 						a: <ExternalLink href={ `/backup/${ targetSiteSlug }` } children={ null } />,
 					} ) }
 				</Text>
+				{ isSiteWooStore && targetEnvironment === 'production' && (
+					<WPNotice status="warning" isDismissible={ false }>
+						<WarningTitle>{ __( 'Syncing WooCommerce sites can overwrite orders' ) }</WarningTitle>
+						{ translate(
+							'Syncing the staging database to production will overwrite orders, products, pages and posts. {{a}}Learn more{{/a}}',
+							{
+								components: {
+									a: <InlineSupportLink supportContext="staging-to-production-sync" />,
+								},
+							}
+						) }
+					</WPNotice>
+				) }
 				<HStack spacing={ 4 } alignment="left">
 					<EnvironmentLabel
 						label={ syncConfig.fromLabel }


### PR DESCRIPTION
Related DOTCOM-13962

## Proposed Changes
With the old UI, we have a warning for syncing e-commerce sites. But I find it confusing and located in the wrong place:

1. We have Staging site tab with initial screen for creating staging site and there is totaly no information about Sync functionality, but we render worning about syncing changes to production. It's totally confusing and should be rendered at least when staging site is created, but woudl be much better to rencder only when user is going to push changes to production.

2. Moreover, when staging site is already created, we don't rendert this warning anymore (the second screenshot), what is weird, since it should be renderted when staging site is created and there is a chance that user is going to sync changes.
<img width="1063" height="512" alt="Screenshot 2025-07-18 at 17 36 54" src="https://github.com/user-attachments/assets/180387f0-dbcc-472c-85c3-bc22703d4a3a" />
<img width="840" height="789" alt="Screenshot 2025-07-18 at 17 42 59" src="https://github.com/user-attachments/assets/e2ea5e0b-4870-4481-bf15-eb47ff260e7a" />


With our redesign, I think, we should put this warning inside Sync dialog, so that it's rendered only when a user intends to sync staging site to production:

<img width="668" height="536" alt="Screenshot 2025-07-18 at 20 37 17" src="https://github.com/user-attachments/assets/c1e61cfa-50a9-4209-bfba-cde5f7c4b752" />


## Testing Instructions
1. Purchase a site
2. Crate staging site
3. Try to Push/Pull both Staging and Production sites
4. Assert that you see the warning only in case of `Push to Production` and `Pull from Staging` and DON'T see it in the other two scenarios.
