### PR TITLE
Domain Search Retrofitting: Preserve animation state when switching viewports

### DIFF
--- a/packages/domain-search/src/components/domains-full-cart/index.tsx
+++ b/packages/domain-search/src/components/domains-full-cart/index.tsx
@@ -50,7 +50,7 @@ const DomainsFullCart = ( {
 } ) => {
 	const { isFullCartOpen, closeFullCart, onContinue } = useDomainSearch();
 	const { __ } = useI18n();
-	const isMobile = ! useViewportMatch( 'small' );
+	const isMobile = useViewportMatch( 'small', '<' );
 
 	const fullCartRef = useRef< HTMLDivElement >( null );
 
@@ -65,7 +65,8 @@ const DomainsFullCart = ( {
 	return (
 		<AnimatedCard
 			ref={ fullCartRef }
-			initial={ animation.initial }
+			key={ isMobile ? 'mobile' : 'desktop' }
+			initial={ isFullCartOpen ? animation.animateIn : animation.initial }
 			animate={ isFullCartOpen ? animation.animateIn : animation.animateOut }
 			transition={ { type: 'tween', duration: 0.25 } }
 			className={ clsx( 'domains-full-cart', className ) }


### PR DESCRIPTION
Closes DOMAINS-1536.

## Proposed Changes

The cart wasn't showing up on `animateIn` if the viewport changed in the meantime. This PR fixes that.

## Testing Instructions

You can replicate the behavior in trunk by simulating the clicks in the first project update (second 15 onwards.)
