### PR TITLE
A4A > Reports: Remove feature/section flag logic

### DIFF
--- a/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour-sections.tsx
+++ b/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour-sections.tsx
@@ -15,7 +15,6 @@ import OnboardingTourBannerSites from 'calypso/assets/images/a8c-for-agencies/on
 import OnboardingTourBannerTeam from 'calypso/assets/images/a8c-for-agencies/onboarding-tour-banner-team.svg';
 import OnboardingTourBannerWelcome from 'calypso/assets/images/a8c-for-agencies/onboarding-tour-banner-welcome.svg';
 import OnboardingTourBannerWooPayments from 'calypso/assets/images/a8c-for-agencies/onboarding-tour-banner-woopayments.svg';
-import { isSectionNameEnabled } from 'calypso/sections-filter';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { RenderableAction, RenderableActionProps } from '../../../onboarding-tour-modal/section';
@@ -310,45 +309,38 @@ export default function useOnboardingTourSections() {
 					];
 				},
 			},
-			...( isSectionNameEnabled( 'a8c-for-agencies-reports' )
-				? [
+			{
+				id: 'reports',
+				title: translate( 'Reports' ),
+				bannerImage: OnboardingTourBannerReports,
+				isDarkBanner: true,
+				content: {
+					title: translate( 'Create professional reports for your clients' ),
+					descriptions: [
+						translate(
+							"Prove your agency's impact with polished, easy-to-read reports that highlight key traffic stats from your clients' sites."
+						),
+						translate(
+							'Our streamlined report builder makes it easy to create professional client reports in minutes.'
+						),
+					],
+				},
+				renderableActions: ( { onNext, onClose }: RenderableActionProps ): RenderableAction[] => {
+					return [
 						{
-							id: 'reports',
-							title: translate( 'Reports' ),
-							bannerImage: OnboardingTourBannerReports,
-							isDarkBanner: true,
-							content: {
-								title: translate( 'Create professional reports for your clients' ),
-								descriptions: [
-									translate(
-										"Prove your agency's impact with polished, easy-to-read reports that highlight key traffic stats from your clients' sites."
-									),
-									translate(
-										'Our streamlined report builder makes it easy to create professional client reports in minutes.'
-									),
-								],
-							},
-							renderableActions: ( {
-								onNext,
-								onClose,
-							}: RenderableActionProps ): RenderableAction[] => {
-								return [
-									{
-										label: translate( 'Check out Client Reports' ),
-										variant: 'secondary',
-										href: A4A_REPORTS_OVERVIEW_LINK,
-										onClick: () => onExplore( 'reports', onClose ),
-									},
-									{
-										label: translate( 'Next benefit' ),
-										variant: 'primary',
-										onClick: () => onNextBenefit( 'reports', onNext ),
-									},
-								];
-							},
+							label: translate( 'Check out Client Reports' ),
+							variant: 'secondary',
+							href: A4A_REPORTS_OVERVIEW_LINK,
+							onClick: () => onExplore( 'reports', onClose ),
 						},
-				  ]
-				: [] ),
+						{
+							label: translate( 'Next benefit' ),
+							variant: 'primary',
+							onClick: () => onNextBenefit( 'reports', onNext ),
+						},
+					];
+				},
+			},
 			{
 				id: 'partner-directory',
 				title: translate( 'Partner Directories' ),

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
@@ -143,25 +143,21 @@ const useMainMenuItems = ( path: string ) => {
 						},
 				  ]
 				: [] ),
-			...( isSectionNameEnabled( 'a8c-for-agencies-reports' )
-				? [
-						{
-							icon: chartBar,
-							path: A4A_REPORTS_LINK,
-							link: A4A_REPORTS_LINK,
-							title: (
-								<div className="sidebar-menu-item__title-with-badge">
-									<span>{ translate( 'Reports' ) }</span>
-									<Badge type="info">{ translate( 'Beta' ) }</Badge>
-								</div>
-							),
-							trackEventProps: {
-								menu_item: 'Automattic for Agencies / Reports',
-							},
-							withChevron: true,
-						},
-				  ]
-				: [] ),
+			{
+				icon: chartBar,
+				path: A4A_REPORTS_LINK,
+				link: A4A_REPORTS_LINK,
+				title: (
+					<div className="sidebar-menu-item__title-with-badge">
+						<span>{ translate( 'Reports' ) }</span>
+						<Badge type="info">{ translate( 'Beta' ) }</Badge>
+					</div>
+				),
+				trackEventProps: {
+					menu_item: 'Automattic for Agencies / Reports',
+				},
+				withChevron: true,
+			},
 			...( config.isEnabled( 'a4a-partner-directory' ) ||
 			config.isEnabled( 'a8c-for-agencies-agency-tier' )
 				? [


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1044/reports-janitorial-after-launch-remove-the-feature-flag-logic

## Proposed Changes

This PR removes the section flag logic for Reports.

## Why are these changes being made?

* Code cleanup

## Testing Instructions

* Open the A4A live link
* On the Overview page > Click the `Relaunch welcome tour` button > Verify that the `Reports` section tour is still shown

<img width="715" height="628" alt="Screenshot 2025-07-21 at 9 57 01 AM" src="https://github.com/user-attachments/assets/24e928b3-8eeb-43d9-80c3-8d4cf4224240" />

* Verify the `Reports: Beta` sidebar is still visible, and you can click and the Reports page loads

<img width="274" height="578" alt="Screenshot 2025-07-21 at 9 57 19 AM" src="https://github.com/user-attachments/assets/d857ccb7-0679-4518-a689-a3af609ce2d1" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
