### PR TITLE
Site Overview v2: Implement site action menu

### DIFF
--- a/client/dashboard/app/queries/site-themes.ts
+++ b/client/dashboard/app/queries/site-themes.ts
@@ -6,7 +6,7 @@ export const siteThemesActiveQuery = ( siteId: number ) => ( {
 	queryFn: () => fetchSiteThemesActive( siteId ),
 } );
 
-export const isFSEActiveQuery = ( siteId: number ) => ( {
+export const isSiteUsingBlockThemeQuery = ( siteId: number ) => ( {
 	...siteThemesActiveQuery( siteId ),
 	select: ( themes: Theme[] ) => {
 		return themes[ 0 ]?.is_block_theme ?? false;

--- a/client/dashboard/app/queries/site-themes.ts
+++ b/client/dashboard/app/queries/site-themes.ts
@@ -1,13 +1,13 @@
-import { fetchSiteThemesActive } from '../../data/site-themes';
+import { fetchSiteActiveThemes } from '../../data/site-themes';
 import type { Theme } from '../../data/site-themes';
 
-export const siteThemesActiveQuery = ( siteId: number ) => ( {
+export const siteActiveThemesQuery = ( siteId: number ) => ( {
 	queryKey: [ 'site', siteId, 'themes', 'active' ],
-	queryFn: () => fetchSiteThemesActive( siteId ),
+	queryFn: () => fetchSiteActiveThemes( siteId ),
 } );
 
 export const isSiteUsingBlockThemeQuery = ( siteId: number ) => ( {
-	...siteThemesActiveQuery( siteId ),
+	...siteActiveThemesQuery( siteId ),
 	select: ( themes: Theme[] ) => {
 		return themes[ 0 ]?.is_block_theme ?? false;
 	},

--- a/client/dashboard/app/queries/site-themes.ts
+++ b/client/dashboard/app/queries/site-themes.ts
@@ -1,0 +1,14 @@
+import { fetchSiteThemesActive } from '../../data/site-themes';
+import type { Theme } from '../../data/site-themes';
+
+export const siteThemesActiveQuery = ( siteId: number ) => ( {
+	queryKey: [ 'site', siteId, 'themes', 'active' ],
+	queryFn: () => fetchSiteThemesActive( siteId ),
+} );
+
+export const isFSEActiveQuery = ( siteId: number ) => ( {
+	...siteThemesActiveQuery( siteId ),
+	select: ( themes: Theme[] ) => {
+		return themes[ 0 ]?.is_block_theme ?? false;
+	},
+} );

--- a/client/dashboard/data/site-themes.ts
+++ b/client/dashboard/data/site-themes.ts
@@ -4,7 +4,7 @@ export interface Theme {
 	is_block_theme: boolean;
 }
 
-export async function fetchSiteThemesActive( siteId: number ) {
+export async function fetchSiteActiveThemes( siteId: number ) {
 	return wpcom.req.get( {
 		path: `/sites/${ siteId }/themes?status=active`,
 		apiNamespace: 'wp/v2',

--- a/client/dashboard/data/site-themes.ts
+++ b/client/dashboard/data/site-themes.ts
@@ -1,0 +1,12 @@
+import wpcom from 'calypso/lib/wp';
+
+export interface Theme {
+	is_block_theme: boolean;
+}
+
+export async function fetchSiteThemesActive( siteId: number ) {
+	return wpcom.req.get( {
+		path: `/sites/${ siteId }/themes?status=active`,
+		apiNamespace: 'wp/v2',
+	} );
+}

--- a/client/dashboard/sites/features.ts
+++ b/client/dashboard/sites/features.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { DotcomFeatures } from '../data/constants';
 import { hasAtomicFeature, hasPlanFeature } from '../utils/site-features';
 import { isSelfHostedJetpackConnected, isP2 } from '../utils/site-types';
@@ -37,8 +36,8 @@ export function canManageSite( site: Site ) {
 	}
 
 	// Self-hosted Jetpack-connected sites are not supported, yet.
-	// Only enable for the development environment, for now.
-	if ( isSelfHostedJetpackConnected( site ) && config( 'env_id' ) !== 'development' ) {
+	// Disable this check for v2 for development purposes, as it's not yet user-facing.
+	if ( isSelfHostedJetpackConnected( site ) && ! window?.location?.pathname?.startsWith( '/v2' ) ) {
 		return false;
 	}
 

--- a/client/dashboard/sites/features.ts
+++ b/client/dashboard/sites/features.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { DotcomFeatures } from '../data/constants';
 import { hasAtomicFeature, hasPlanFeature } from '../utils/site-features';
 import { isSelfHostedJetpackConnected, isP2 } from '../utils/site-types';

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -22,6 +22,7 @@ import BackupCard from './backup-card';
 import DomainsCard from './domains-card';
 import LatestActivitiesCard from './latest-activities-card';
 import ScanCard from './scan-card';
+import SiteActionMenu from './site-action-menu';
 import SiteOverviewFields from './site-overview-fields';
 import SitePreviewCard from './site-preview-card';
 import UptimeCard from './uptime-card';
@@ -91,14 +92,17 @@ function SiteOverview( {
 						title={ getSiteDisplayName( site ) }
 						actions={
 							site.options?.admin_url && (
-								<Button
-									__next40pxDefaultSize
-									variant="primary"
-									href={ site.options.admin_url }
-									icon={ wordpress }
-								>
-									{ __( 'WP Admin' ) }
-								</Button>
+								<>
+									<Button
+										__next40pxDefaultSize
+										variant="primary"
+										href={ site.options.admin_url }
+										icon={ wordpress }
+									>
+										{ __( 'WP Admin' ) }
+									</Button>
+									<SiteActionMenu site={ site } />
+								</>
 							)
 						}
 					/>

--- a/client/dashboard/sites/overview/site-action-menu.tsx
+++ b/client/dashboard/sites/overview/site-action-menu.tsx
@@ -1,0 +1,43 @@
+import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { moreVertical } from '@wordpress/icons';
+import { addQueryArgs } from '@wordpress/url';
+import { useAnalytics } from '../../app/analytics';
+import type { Site } from '../../data/types';
+
+const SiteActionMenu = ( { site }: { site: Site } ) => {
+	const { recordTracksEvent } = useAnalytics();
+
+	const trackActionClick = ( action: string ) => {
+		recordTracksEvent( 'calypso_sites_dashboard_site_action_menu_click', { action } );
+	};
+
+	const handleEditSite = () => {
+		trackActionClick( 'edit_site' );
+		window.open( site.options?.admin_url, '_blank' );
+	};
+
+	const handleWritePost = () => {
+		trackActionClick( 'write_post' );
+		window.open( `${ site.options?.admin_url }post-new.php`, '_blank' );
+	};
+
+	const handleImportSite = () => {
+		trackActionClick( 'import_site' );
+		window.open( addQueryArgs( '/setup/site-migration', { siteSlug: site.slug } ), '_blank' );
+	};
+
+	return (
+		<DropdownMenu icon={ moreVertical } label={ __( 'Quick actions' ) }>
+			{ () => (
+				<MenuGroup>
+					<MenuItem onClick={ handleEditSite }>{ __( 'Edit site ↗' ) }</MenuItem>
+					<MenuItem onClick={ handleWritePost }>{ __( 'Write a post ↗' ) }</MenuItem>
+					<MenuItem onClick={ handleImportSite }>{ __( 'Import site ↗' ) }</MenuItem>
+				</MenuGroup>
+			) }
+		</DropdownMenu>
+	);
+};
+
+export default SiteActionMenu;

--- a/client/dashboard/sites/overview/site-action-menu.tsx
+++ b/client/dashboard/sites/overview/site-action-menu.tsx
@@ -4,32 +4,32 @@ import { __ } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import { useAnalytics } from '../../app/analytics';
-import { isFSEActiveQuery } from '../../app/queries/site-themes';
+import { isSiteUsingBlockThemeQuery } from '../../app/queries/site-themes';
 import { getSiteEditUrl } from '../../utils/site-url';
 import type { Site } from '../../data/types';
 
 const SiteActionMenu = ( { site }: { site: Site } ) => {
 	const { recordTracksEvent } = useAnalytics();
-	const { data: isFSEActive, isLoading: isFSEActiveLoading } = useQuery(
-		isFSEActiveQuery( site.ID )
+	const { data: isSiteUsingBlockTheme, isLoading: isSiteUsingBlockThemeLoading } = useQuery(
+		isSiteUsingBlockThemeQuery( site.ID )
 	);
 
 	const trackActionClick = ( action: string ) => {
-		recordTracksEvent( 'calypso_sites_dashboard_site_action_menu_click', { action } );
+		recordTracksEvent( 'calypso_dashboard_site_action_menu_click', { action } );
 	};
 
 	const handleEditSite = () => {
-		trackActionClick( 'edit_site' );
-		window.open( getSiteEditUrl( site, isFSEActive ), '_blank' );
+		trackActionClick( 'edit-site' );
+		window.open( getSiteEditUrl( site, isSiteUsingBlockTheme ), '_blank' );
 	};
 
 	const handleWritePost = () => {
-		trackActionClick( 'write_post' );
+		trackActionClick( 'write-post' );
 		window.open( `${ site.options?.admin_url }post-new.php`, '_blank' );
 	};
 
 	const handleImportSite = () => {
-		trackActionClick( 'import_site' );
+		trackActionClick( 'import-site' );
 		window.open( addQueryArgs( '/setup/site-migration', { siteSlug: site.slug } ), '_blank' );
 	};
 
@@ -37,7 +37,7 @@ const SiteActionMenu = ( { site }: { site: Site } ) => {
 		<DropdownMenu icon={ moreVertical } label={ __( 'Quick actions' ) }>
 			{ () => (
 				<MenuGroup>
-					<MenuItem disabled={ isFSEActiveLoading } onClick={ handleEditSite }>
+					<MenuItem disabled={ isSiteUsingBlockThemeLoading } onClick={ handleEditSite }>
 						{ __( 'Edit site ↗' ) }
 					</MenuItem>
 					<MenuItem onClick={ handleWritePost }>{ __( 'Write a post ↗' ) }</MenuItem>

--- a/client/dashboard/sites/overview/site-action-menu.tsx
+++ b/client/dashboard/sites/overview/site-action-menu.tsx
@@ -5,6 +5,7 @@ import { moreVertical } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import { useAnalytics } from '../../app/analytics';
 import { isSiteUsingBlockThemeQuery } from '../../app/queries/site-themes';
+import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { getSiteEditUrl } from '../../utils/site-url';
 import type { Site } from '../../data/types';
 
@@ -29,8 +30,12 @@ const SiteActionMenu = ( { site }: { site: Site } ) => {
 	};
 
 	const handleImportSite = () => {
+		const url = isSelfHostedJetpackConnected( site )
+			? 'https://wordpress.com/move'
+			: addQueryArgs( '/setup/site-migration', { siteSlug: site.slug } );
+
 		trackActionClick( 'import-site' );
-		window.open( addQueryArgs( '/setup/site-migration', { siteSlug: site.slug } ), '_blank' );
+		window.open( url, '_blank' );
 	};
 
 	return (

--- a/client/dashboard/sites/overview/site-action-menu.tsx
+++ b/client/dashboard/sites/overview/site-action-menu.tsx
@@ -1,12 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import { useAnalytics } from '../../app/analytics';
+import { isFSEActiveQuery } from '../../app/queries/site-themes';
+import { getSiteEditUrl } from '../../utils/site-url';
 import type { Site } from '../../data/types';
 
 const SiteActionMenu = ( { site }: { site: Site } ) => {
 	const { recordTracksEvent } = useAnalytics();
+	const { data: isFSEActive, isLoading: isFSEActiveLoading } = useQuery(
+		isFSEActiveQuery( site.ID )
+	);
 
 	const trackActionClick = ( action: string ) => {
 		recordTracksEvent( 'calypso_sites_dashboard_site_action_menu_click', { action } );
@@ -14,7 +20,7 @@ const SiteActionMenu = ( { site }: { site: Site } ) => {
 
 	const handleEditSite = () => {
 		trackActionClick( 'edit_site' );
-		window.open( site.options?.admin_url, '_blank' );
+		window.open( getSiteEditUrl( site, isFSEActive ), '_blank' );
 	};
 
 	const handleWritePost = () => {
@@ -31,7 +37,9 @@ const SiteActionMenu = ( { site }: { site: Site } ) => {
 		<DropdownMenu icon={ moreVertical } label={ __( 'Quick actions' ) }>
 			{ () => (
 				<MenuGroup>
-					<MenuItem onClick={ handleEditSite }>{ __( 'Edit site ↗' ) }</MenuItem>
+					<MenuItem disabled={ isFSEActiveLoading } onClick={ handleEditSite }>
+						{ __( 'Edit site ↗' ) }
+					</MenuItem>
 					<MenuItem onClick={ handleWritePost }>{ __( 'Write a post ↗' ) }</MenuItem>
 					<MenuItem onClick={ handleImportSite }>{ __( 'Import site ↗' ) }</MenuItem>
 				</MenuGroup>

--- a/client/dashboard/utils/site-url.ts
+++ b/client/dashboard/utils/site-url.ts
@@ -1,3 +1,4 @@
+import { addQueryArgs } from '@wordpress/url';
 import type { Site } from '../data/types';
 
 /**
@@ -9,4 +10,27 @@ import type { Site } from '../data/types';
  */
 export function getSiteDisplayUrl( site: Site ) {
 	return site.URL.replace( 'https://', '' ).replace( 'http://', '' );
+}
+
+/**
+ * Returns the URL for editing the site.
+ */
+export function getSiteEditUrl( site: Site, isFSEActive?: boolean ) {
+	const location = typeof window !== 'undefined' ? window.location : null;
+	const queryArgs: Record< string, string > = {};
+	const siteAdminUrl = site.options?.admin_url;
+
+	if ( isFSEActive ) {
+		if ( location && location.origin !== 'https://wordpress.com' ) {
+			queryArgs.calypso_origin = location.origin;
+		}
+
+		return addQueryArgs( `${ siteAdminUrl }site-editor.php`, queryArgs );
+	}
+
+	if ( location ) {
+		queryArgs.return = location.href;
+	}
+
+	return addQueryArgs( `${ siteAdminUrl }customize.php`, queryArgs );
 }

--- a/client/dashboard/utils/site-url.ts
+++ b/client/dashboard/utils/site-url.ts
@@ -15,12 +15,12 @@ export function getSiteDisplayUrl( site: Site ) {
 /**
  * Returns the URL for editing the site.
  */
-export function getSiteEditUrl( site: Site, isFSEActive?: boolean ) {
+export function getSiteEditUrl( site: Site, isSiteUsingBlockTheme?: boolean ) {
 	const location = typeof window !== 'undefined' ? window.location : null;
 	const queryArgs: Record< string, string > = {};
 	const siteAdminUrl = site.options?.admin_url;
 
-	if ( isFSEActive ) {
+	if ( isSiteUsingBlockTheme ) {
 		if ( location && location.origin !== 'https://wordpress.com' ) {
 			queryArgs.calypso_origin = location.origin;
 		}


### PR DESCRIPTION
Ref DOTDASH-102
 
## Proposed Changes

This PR implements the Site Overview action menu, with the first three items:
* Edit site - opens either the Site Editor or the Customizer
* Write a post - opens the Post Editor
* Import site - opens the Site Migration flow

<img width="230" height="220" alt="SCR-20250722-nrnr" src="https://github.com/user-attachments/assets/1a582ab2-c0c4-43ba-919c-cabadfdd2a65" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Site Overview v2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Select any site
* Open the site action menu and ensure that the actions work as described above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
