### PR TITLE
Site Overview Retrofit: Backport the site overview v2 to the current hosting dashboard

### DIFF
--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -146,7 +146,7 @@ const siteOverviewRoute = createRoute( {
 } ).lazy( () =>
 	import( '../sites/overview' ).then( ( d ) =>
 		createLazyRoute( 'site-overview' )( {
-			component: d.default,
+			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
 		} )
 	)
 );

--- a/client/dashboard/sites/overview-card/index.tsx
+++ b/client/dashboard/sites/overview-card/index.tsx
@@ -80,7 +80,7 @@ export default function OverviewCard( {
 
 	const topContent = (
 		<HStack justify="space-between" className="dashboard-overview-card__content">
-			<VStack spacing={ 4 } style={ { flexGrow: 1, flexShrink: 0 } }>
+			<VStack spacing={ 4 } style={ { flexGrow: 1 } }>
 				<HStack justify="space-between">
 					<HStack spacing={ 2 } alignment="center" expanded={ false }>
 						{ icon && <Icon className="dashboard-overview-card__icon" icon={ icon } /> }

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -27,8 +27,7 @@ import SiteOverviewFields from '../overview-site-fields';
 import SitePreviewCard from '../overview-site-preview-card';
 import VisibilityCard from '../overview-visibility-card';
 import './style.scss';
-
-type Breakpoint = Parameters< typeof useViewportMatch >[ 0 ];
+import type { WPBreakpoint } from '@wordpress/compose/build-types/hooks/use-viewport-match';
 
 const SPACING = {
 	DEFAULT: 6,
@@ -71,7 +70,7 @@ function SiteOverview( {
 }: {
 	siteSlug: string;
 	hideSitePreview?: boolean;
-	breakpoints?: { large: Breakpoint; small: Breakpoint };
+	breakpoints?: { large: WPBreakpoint; small: WPBreakpoint };
 } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const isLargeViewport = useViewportMatch( breakpoints?.large ?? 'xlarge' );

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -11,7 +11,6 @@ import { __ } from '@wordpress/i18n';
 import { chartBar, wordpress } from '@wordpress/icons';
 import clsx from 'clsx';
 import { siteBySlugQuery } from '../../app/queries/site';
-import { siteRoute } from '../../app/router';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { getSiteDisplayName } from '../../utils/site-name';
@@ -66,13 +65,14 @@ function getGridLayout( {
 }
 
 function SiteOverview( {
+	siteSlug,
 	hideSitePreview = false,
 	breakpoints,
 }: {
-	hideSitePreview: boolean;
+	siteSlug: string;
+	hideSitePreview?: boolean;
 	breakpoints?: { large: Breakpoint; small: Breakpoint };
 } ) {
-	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const isLargeViewport = useViewportMatch( breakpoints?.large ?? 'xlarge' );
 	const isSmallViewport = useViewportMatch( breakpoints?.small ?? 'medium', '<' );
@@ -113,11 +113,11 @@ function SiteOverview( {
 			<VStack alignment="stretch" spacing={ isSmallViewport ? 5 : 10 }>
 				<Grid { ...gridLayout } gap={ spacing }>
 					{ showSitePreview && <SitePreviewCard site={ site } /> }
-					<VStack className="site-overview-cards" spacing={ spacing }>
+					<Grid columns={ 1 } rows={ 2 } gap={ spacing }>
 						<VisibilityCard site={ site } />
 						<BackupCard site={ site } />
-					</VStack>
-					<VStack className="site-overview-cards" spacing={ spacing }>
+					</Grid>
+					<Grid columns={ 1 } rows={ 2 } gap={ spacing }>
 						{ site.is_a4a_dev_site ? (
 							<AgencySiteShareCard site={ site } />
 						) : (
@@ -130,7 +130,7 @@ function SiteOverview( {
 							/>
 						) }
 						<ScanCard site={ site } />
-					</VStack>
+					</Grid>
 					<PlanCard site={ site } />
 				</Grid>
 				<Divider

--- a/client/sites/components/site-preview-pane/constants.ts
+++ b/client/sites/components/site-preview-pane/constants.ts
@@ -21,7 +21,7 @@ export const PLAN = 'plan';
 
 export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
 	[ OVERVIEW ]: isEnabled( 'dashboard/v2/backport/site-overview' )
-		? 'sites/overview/v2/:site'
+		? 'sites/v2/:site'
 		: 'overview/:site',
 	[ MONITORING ]: 'site-monitoring/:site',
 	[ LOGS_PHP ]: 'site-logs/:site/php',

--- a/client/sites/components/site-preview-pane/constants.ts
+++ b/client/sites/components/site-preview-pane/constants.ts
@@ -21,7 +21,7 @@ export const PLAN = 'plan';
 
 export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
 	[ OVERVIEW ]: isEnabled( 'dashboard/v2/backport/site-overview' )
-		? 'sites/v2/:site'
+		? 'sites/:site'
 		: 'overview/:site',
 	[ MONITORING ]: 'site-monitoring/:site',
 	[ LOGS_PHP ]: 'site-logs/:site/php',

--- a/client/sites/components/site-preview-pane/constants.ts
+++ b/client/sites/components/site-preview-pane/constants.ts
@@ -20,7 +20,9 @@ export const SETTINGS_PERFORMANCE = 'settings-performance';
 export const PLAN = 'plan';
 
 export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
-	[ OVERVIEW ]: 'overview/:site',
+	[ OVERVIEW ]: isEnabled( 'dashboard/v2/backport/site-overview' )
+		? 'sites/overview/v2/:site'
+		: 'overview/:site',
 	[ MONITORING ]: 'site-monitoring/:site',
 	[ LOGS_PHP ]: 'site-logs/:site/php',
 	[ LOGS_WEB ]: 'site-logs/:site/web',

--- a/client/sites/index.tsx
+++ b/client/sites/index.tsx
@@ -1,26 +1,17 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender, setSelectedSiteIdByOrigin } from 'calypso/controller';
-import { navigation, siteSelection } from 'calypso/my-sites/controller';
+import { siteSelection, navigation } from 'calypso/my-sites/controller';
 import { siteDashboard } from 'calypso/sites/controller';
-import { getSiteBySlug, getSiteHomeUrl } from 'calypso/state/sites/selectors';
-import { SETTINGS_SITE } from './components/site-preview-pane/constants';
+import { OVERVIEW, SETTINGS_SITE } from './components/site-preview-pane/constants';
 import {
 	maybeRemoveCheckoutSuccessNotice,
 	sanitizeQueryParameters,
 	sitesDashboard,
 } from './controller';
+import { dashboardBackportSiteOverview } from './overview/controller';
 import { dashboardBackportSiteSettings } from './settings/controller';
 
 export default function () {
-	// Maintain old `/sites/:id` URLs by redirecting them to My Home
-	page( '/sites/:site', ( context ) => {
-		const state = context.store.getState();
-		const site = getSiteBySlug( state, context.params.site );
-		// The site may not be loaded into state yet.
-		const siteId = site?.ID;
-		page.redirect( getSiteHomeUrl( state, siteId ) );
-	} );
-
 	/**
 	 * Backport dashboard v2
 	 */
@@ -30,6 +21,16 @@ export default function () {
 		navigation,
 		dashboardBackportSiteSettings,
 		siteDashboard( SETTINGS_SITE ),
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/sites/:site',
+		siteSelection,
+		navigation,
+		dashboardBackportSiteOverview,
+		siteDashboard( OVERVIEW ),
 		makeLayout,
 		clientRender
 	);

--- a/client/sites/overview/controller.tsx
+++ b/client/sites/overview/controller.tsx
@@ -21,7 +21,6 @@ export function overview( context: PageJSContext, next: () => void ) {
  */
 export async function dashboardBackportSiteOverview( context: PageJSContext, next: () => void ) {
 	const { site: siteSlug } = context.params;
-
 	if ( ! isEnabled( 'dashboard/v2/backport/site-overview' ) ) {
 		return page.redirect( `/overview/${ siteSlug }` );
 	}

--- a/client/sites/overview/controller.tsx
+++ b/client/sites/overview/controller.tsx
@@ -1,5 +1,8 @@
+import { isEnabled } from '@automattic/calypso-config';
+import page from '@automattic/calypso-router';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getRouteFromContext } from 'calypso/utils';
+import DashboardBackportSiteOverview from '../v2/site-overview';
 import HostingOverview from './components/hosting-overview';
 import type { Context as PageJSContext } from '@automattic/calypso-router';
 
@@ -10,5 +13,22 @@ export function overview( context: PageJSContext, next: () => void ) {
 			<HostingOverview />
 		</>
 	);
+	next();
+}
+
+/**
+ * Backport Hosting Dashboard Site Overview page to the current one.
+ */
+export async function dashboardBackportSiteOverview( context: PageJSContext, next: () => void ) {
+	const { site: siteSlug } = context.params;
+
+	if ( ! isEnabled( 'dashboard/v2/backport/site-overview' ) ) {
+		return page.redirect( `/overview/${ siteSlug }` );
+	}
+
+	// Route doesn't require a <PageViewTracker /> because the dashboard
+	// fires its own page view events.
+	context.primary = <DashboardBackportSiteOverview siteSlug={ siteSlug } />;
+
 	next();
 }

--- a/client/sites/overview/controller.tsx
+++ b/client/sites/overview/controller.tsx
@@ -1,5 +1,4 @@
 import { isEnabled } from '@automattic/calypso-config';
-import page from '@automattic/calypso-router';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getRouteFromContext } from 'calypso/utils';
 import DashboardBackportSiteOverview from '../v2/site-overview';
@@ -22,7 +21,7 @@ export function overview( context: PageJSContext, next: () => void ) {
 export async function dashboardBackportSiteOverview( context: PageJSContext, next: () => void ) {
 	const { site: siteSlug } = context.params;
 	if ( ! isEnabled( 'dashboard/v2/backport/site-overview' ) ) {
-		return page.redirect( `/overview/${ siteSlug }` );
+		return overview( context, next );
 	}
 
 	// Route doesn't require a <PageViewTracker /> because the dashboard

--- a/client/sites/overview/index.tsx
+++ b/client/sites/overview/index.tsx
@@ -25,7 +25,7 @@ import emailController from 'calypso/my-sites/email/controller';
 import { OVERVIEW } from 'calypso/sites/components/site-preview-pane/constants';
 import { siteDashboard } from 'calypso/sites/controller';
 import { redirectToHostingDashboardBackportIfEnabled } from '../v2/site-overview/controller';
-import { overview, dashboardBackportSiteOverview } from './controller';
+import { overview } from './controller';
 
 function registerSiteDomainPage( { path, controllers }: { path: string; controllers: any[] } ) {
 	page(
@@ -141,18 +141,4 @@ export default function () {
 			domainManagementController.domainManagementSubpageView,
 		],
 	} );
-
-	/**
-	 * Overview V2
-	 */
-	page( '/sites/overview/v2', siteSelection, sites, makeLayout, clientRender );
-	page(
-		'/sites/overview/v2/:site',
-		siteSelection,
-		navigation,
-		dashboardBackportSiteOverview,
-		siteDashboard( OVERVIEW ),
-		makeLayout,
-		clientRender
-	);
 }

--- a/client/sites/overview/index.tsx
+++ b/client/sites/overview/index.tsx
@@ -24,7 +24,8 @@ import {
 import emailController from 'calypso/my-sites/email/controller';
 import { OVERVIEW } from 'calypso/sites/components/site-preview-pane/constants';
 import { siteDashboard } from 'calypso/sites/controller';
-import { overview } from './controller';
+import { redirectToHostingDashboardBackportIfEnabled } from '../v2/site-overview/controller';
+import { overview, dashboardBackportSiteOverview } from './controller';
 
 function registerSiteDomainPage( { path, controllers }: { path: string; controllers: any[] } ) {
 	page(
@@ -51,6 +52,7 @@ export default function () {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
 		redirectIfCurrentUserCannot( 'manage_options' ),
+		redirectToHostingDashboardBackportIfEnabled,
 		redirectIfP2,
 		redirectIfJetpackNonAtomic,
 		navigation,
@@ -139,4 +141,18 @@ export default function () {
 			domainManagementController.domainManagementSubpageView,
 		],
 	} );
+
+	/**
+	 * Overview V2
+	 */
+	page( '/sites/overview/v2', siteSelection, sites, makeLayout, clientRender );
+	page(
+		'/sites/overview/v2/:site',
+		siteSelection,
+		navigation,
+		dashboardBackportSiteOverview,
+		siteDashboard( OVERVIEW ),
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/sites/v2/router.tsx
+++ b/client/sites/v2/router.tsx
@@ -1,0 +1,34 @@
+import page from '@automattic/calypso-router';
+import { Outlet, createRootRoute, createRoute } from '@tanstack/react-router';
+import { siteBySlugQuery } from 'calypso/dashboard/app/queries/site';
+import { queryClient } from 'calypso/dashboard/app/query-client';
+import { canManageSite } from 'calypso/dashboard/sites/features';
+import Root from './components/root';
+
+/**
+ * Define general routes
+ */
+export const rootRoute = createRootRoute( { component: Root } );
+
+export const dashboardSitesCompatibilityRoute = createRoute( {
+	getParentRoute: () => rootRoute,
+	path: 'sites',
+	beforeLoad: ( { cause } ) => {
+		if ( cause !== 'enter' ) {
+			return;
+		}
+		page.replace( '/sites' );
+	},
+} );
+
+export const siteRoute = createRoute( {
+	getParentRoute: () => rootRoute,
+	path: 'sites/$siteSlug',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( ! canManageSite( site ) ) {
+			page.redirect( '/sites' );
+		}
+	},
+	component: () => <Outlet />,
+} );

--- a/client/sites/v2/site-overview/controller.tsx
+++ b/client/sites/v2/site-overview/controller.tsx
@@ -7,7 +7,7 @@ export function redirectToHostingDashboardBackportIfEnabled(
 	next: () => void
 ) {
 	if ( isEnabled( 'dashboard/v2/backport/site-overview' ) ) {
-		return page.redirect( `/sites/overview/v2/${ context.params.site }` );
+		return page.redirect( `/sites/v2/${ context.params.site }` );
 	}
 
 	next();

--- a/client/sites/v2/site-overview/controller.tsx
+++ b/client/sites/v2/site-overview/controller.tsx
@@ -7,7 +7,7 @@ export function redirectToHostingDashboardBackportIfEnabled(
 	next: () => void
 ) {
 	if ( isEnabled( 'dashboard/v2/backport/site-overview' ) ) {
-		return page.redirect( `/sites/v2/${ context.params.site }` );
+		return page.redirect( `/sites/${ context.params.site }` );
 	}
 
 	next();

--- a/client/sites/v2/site-overview/controller.tsx
+++ b/client/sites/v2/site-overview/controller.tsx
@@ -1,0 +1,14 @@
+import { isEnabled } from '@automattic/calypso-config';
+import page from '@automattic/calypso-router';
+import type { Context as PageJSContext } from '@automattic/calypso-router';
+
+export function redirectToHostingDashboardBackportIfEnabled(
+	context: PageJSContext,
+	next: () => void
+) {
+	if ( isEnabled( 'dashboard/v2/backport/site-overview' ) ) {
+		return page.redirect( `/sites/overview/v2/${ context.params.site }` );
+	}
+
+	next();
+}

--- a/client/sites/v2/site-overview/index.tsx
+++ b/client/sites/v2/site-overview/index.tsx
@@ -43,7 +43,7 @@ export default function DashboardBackportSiteOverview( { siteSlug }: { siteSlug?
 		Promise.all( [
 			persistPromise,
 			router.preloadRoute( {
-				to: `/${ siteSlug }`,
+				to: `/sites/${ siteSlug }`,
 			} ),
 		] ).then( () => {
 			rootInstanceRef.current?.render(

--- a/client/sites/v2/site-overview/index.tsx
+++ b/client/sites/v2/site-overview/index.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useRef } from 'react';
+import { createRoot } from 'react-dom/client';
+import { AUTH_QUERY_KEY } from 'calypso/dashboard/app/auth';
+import { siteBySlugQuery } from 'calypso/dashboard/app/queries/site';
+import { queryClient, persistPromise } from 'calypso/dashboard/app/query-client';
+import { useSelector } from 'calypso/state';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getSite } from 'calypso/state/sites/selectors';
+import { useAnalyticsClient } from '../hooks/use-analytics-client';
+import Layout, { router } from './layout';
+import './style.scss';
+
+export default function DashboardBackportSiteOverview( { siteSlug }: { siteSlug?: string } ) {
+	const rootInstanceRef = useRef< ReturnType< typeof createRoot > | null >( null );
+	const containerRef = useRef< HTMLDivElement >( null );
+	const user = useSelector( ( state ) => getCurrentUser( state ) );
+	const site = useSelector( ( state ) => getSite( state, siteSlug ) );
+	const analyticsClient = useAnalyticsClient();
+
+	// Initialize the root instance.
+	useEffect( () => {
+		if ( ! containerRef.current || rootInstanceRef.current ) {
+			return;
+		}
+
+		rootInstanceRef.current = createRoot( containerRef.current );
+		return () => {
+			const currentRoot = rootInstanceRef.current;
+			if ( currentRoot ) {
+				currentRoot.unmount();
+				rootInstanceRef.current = null;
+			}
+		};
+	}, [] );
+
+	// Update the root instance upon dependency change.
+	useEffect( () => {
+		if ( ! rootInstanceRef.current ) {
+			return;
+		}
+
+		Promise.all( [
+			persistPromise,
+			router.preloadRoute( {
+				to: `/${ siteSlug }`,
+			} ),
+		] ).then( () => {
+			rootInstanceRef.current?.render(
+				<Layout analyticsClient={ analyticsClient } siteSlug={ siteSlug } />
+			);
+		} );
+	}, [ analyticsClient, user, siteSlug ] );
+
+	// Use data already available in Redux to seed the React Query cache and avoid redundant data fetching.
+	useEffect( () => {
+		if ( user ) {
+			queryClient.setQueryData( AUTH_QUERY_KEY, user );
+		}
+
+		if ( site ) {
+			queryClient.setQueryData( siteBySlugQuery( site.slug ).queryKey, site );
+		}
+	}, [ user, site ] );
+
+	return <div className="dashboard-backport-site-overview" ref={ containerRef } />;
+}

--- a/client/sites/v2/site-overview/index.tsx
+++ b/client/sites/v2/site-overview/index.tsx
@@ -7,7 +7,8 @@ import { useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getSite } from 'calypso/state/sites/selectors';
 import { useAnalyticsClient } from '../hooks/use-analytics-client';
-import Layout, { router } from './layout';
+import Layout from './layout';
+import router from './router';
 import './style.scss';
 
 export default function DashboardBackportSiteOverview( { siteSlug }: { siteSlug?: string } ) {

--- a/client/sites/v2/site-overview/layout.tsx
+++ b/client/sites/v2/site-overview/layout.tsx
@@ -4,14 +4,11 @@ import { useEffect } from 'react';
 import { AnalyticsProvider, type AnalyticsClient } from 'calypso/dashboard/app/analytics';
 import { AuthProvider, useAuth } from 'calypso/dashboard/app/auth';
 import { queryClient } from 'calypso/dashboard/app/query-client';
-import { getRouter, syncBrowserHistoryToRouter, syncMemoryRouterToBrowserHistory } from './router';
-
-// Serves a similar purpose to AppConfig form v2 dashboard.
-const config = {
-	basePath: '/sites/v2',
-};
-
-export const router = getRouter( config );
+import router, {
+	routerConfig,
+	syncBrowserHistoryToRouter,
+	syncMemoryRouterToBrowserHistory,
+} from './router';
 
 function RouterProviderWithAuth( { siteSlug }: { siteSlug?: string } ) {
 	const auth = useAuth();
@@ -34,7 +31,7 @@ function RouterProviderWithAuth( { siteSlug }: { siteSlug?: string } ) {
 		};
 	}, [] );
 
-	return <RouterProvider router={ router } context={ { auth, config } } />;
+	return <RouterProvider router={ router } context={ { auth, config: routerConfig } } />;
 }
 
 function Layout( {

--- a/client/sites/v2/site-overview/layout.tsx
+++ b/client/sites/v2/site-overview/layout.tsx
@@ -1,0 +1,58 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { RouterProvider } from '@tanstack/react-router';
+import { useEffect } from 'react';
+import { AnalyticsProvider, type AnalyticsClient } from 'calypso/dashboard/app/analytics';
+import { AuthProvider, useAuth } from 'calypso/dashboard/app/auth';
+import { queryClient } from 'calypso/dashboard/app/query-client';
+import { getRouter, syncBrowserHistoryToRouter, syncMemoryRouterToBrowserHistory } from './router';
+
+// Serves a similar purpose to AppConfig form v2 dashboard.
+const config = {
+	basePath: '/sites/overview/v2',
+};
+
+export const router = getRouter( config );
+
+function RouterProviderWithAuth( { siteSlug }: { siteSlug?: string } ) {
+	const auth = useAuth();
+
+	useEffect( () => {
+		syncBrowserHistoryToRouter( router );
+	}, [ siteSlug ] );
+
+	useEffect( () => {
+		const handlePopstate = () => {
+			syncBrowserHistoryToRouter( router );
+		};
+
+		const unsubscribe = syncMemoryRouterToBrowserHistory( router );
+		window.addEventListener( 'popstate', handlePopstate );
+
+		return () => {
+			unsubscribe();
+			window.removeEventListener( 'popstate', handlePopstate );
+		};
+	}, [] );
+
+	return <RouterProvider router={ router } context={ { auth, config } } />;
+}
+
+function Layout( {
+	analyticsClient,
+	siteSlug,
+}: {
+	analyticsClient: AnalyticsClient;
+	siteSlug?: string;
+} ) {
+	return (
+		<QueryClientProvider client={ queryClient }>
+			<AuthProvider>
+				<AnalyticsProvider client={ analyticsClient }>
+					<RouterProviderWithAuth siteSlug={ siteSlug } />
+				</AnalyticsProvider>
+			</AuthProvider>
+		</QueryClientProvider>
+	);
+}
+
+export default Layout;

--- a/client/sites/v2/site-overview/layout.tsx
+++ b/client/sites/v2/site-overview/layout.tsx
@@ -8,7 +8,7 @@ import { getRouter, syncBrowserHistoryToRouter, syncMemoryRouterToBrowserHistory
 
 // Serves a similar purpose to AppConfig form v2 dashboard.
 const config = {
-	basePath: '/sites/overview/v2',
+	basePath: '/sites/v2',
 };
 
 export const router = getRouter( config );

--- a/client/sites/v2/site-overview/router.tsx
+++ b/client/sites/v2/site-overview/router.tsx
@@ -3,6 +3,7 @@ import { useBreakpoint } from '@automattic/viewport-react';
 import { createLazyRoute, createRoute, createRouter } from '@tanstack/react-router';
 import * as appRouter from 'calypso/dashboard/app/router';
 import { rootRoute, dashboardSitesCompatibilityRoute, siteRoute } from '../router';
+import siteSettingsRouter from '../site-settings/router';
 import { getRouterOptions, createBrowserHistoryAndMemoryRouterSync } from '../utils/router';
 import type { WPBreakpoint } from '@wordpress/compose/build-types/hooks/use-viewport-match';
 
@@ -29,23 +30,19 @@ const siteOverviewRoute = createRoute( {
 	)
 );
 
-const siteSettingsPreloadRoute = createRoute( {
-	...appRouter.siteSettingsRoute.options,
-	getParentRoute: () => siteRoute,
-} );
-
-const siteSettingsSiteVisibilityPreloadRoute = createRoute( {
-	...appRouter.siteSettingsSiteVisibilityRoute.options,
-	getParentRoute: () => siteRoute,
+const siteSettingsWithFeaturePreloadRoute = createRoute( {
+	getParentRoute: () => rootRoute,
+	path: 'sites/$siteSlug/settings/$feature',
+	loader: async ( { params: { siteSlug, feature } } ) => {
+		siteSettingsRouter.preloadRoute( {
+			to: `/sites/${ siteSlug }/settings/${ feature }`,
+		} );
+	},
 } );
 
 const createRouteTree = () =>
 	rootRoute.addChildren( [
-		siteRoute.addChildren( [
-			siteOverviewRoute,
-			siteSettingsPreloadRoute,
-			siteSettingsSiteVisibilityPreloadRoute,
-		] ),
+		siteRoute.addChildren( [ siteOverviewRoute, siteSettingsWithFeaturePreloadRoute ] ),
 		dashboardSitesCompatibilityRoute,
 	] );
 

--- a/client/sites/v2/site-overview/router.tsx
+++ b/client/sites/v2/site-overview/router.tsx
@@ -1,58 +1,14 @@
-import page from '@automattic/calypso-router';
 import { WIDE_BREAKPOINT } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
-import {
-	Outlet,
-	createLazyRoute,
-	createRootRoute,
-	createRoute,
-	createRouter,
-	redirect,
-} from '@tanstack/react-router';
-import { siteBySlugQuery } from 'calypso/dashboard/app/queries/site';
-import { siteLastBackupQuery } from 'calypso/dashboard/app/queries/site-backups';
-import { siteCurrentPlanQuery } from 'calypso/dashboard/app/queries/site-plans';
-import { sitePreviewLinksQuery } from 'calypso/dashboard/app/queries/site-preview-links';
-import { siteScanQuery } from 'calypso/dashboard/app/queries/site-scan';
-import { queryClient } from 'calypso/dashboard/app/query-client';
-import { DotcomFeatures } from 'calypso/dashboard/data/constants';
-import { canManageSite } from 'calypso/dashboard/sites/features';
-import { hasHostingFeature } from 'calypso/dashboard/utils/site-features';
-import Root from '../components/root';
-import siteSettingsRouter from '../site-settings/router';
+import { createLazyRoute, createRoute, createRouter } from '@tanstack/react-router';
+import * as appRouter from 'calypso/dashboard/app/router';
+import { rootRoute, dashboardSitesCompatibilityRoute, siteRoute } from '../router';
 import { getRouterOptions, createBrowserHistoryAndMemoryRouterSync } from '../utils/router';
 import type { WPBreakpoint } from '@wordpress/compose/build-types/hooks/use-viewport-match';
 
-const rootRoute = createRootRoute( { component: Root } );
-
-const siteRoute = createRoute( {
-	getParentRoute: () => rootRoute,
-	path: '$siteSlug',
-	loader: async ( { params: { siteSlug } } ) => {
-		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		if ( ! canManageSite( site ) ) {
-			page.redirect( '/sites' );
-		}
-	},
-	component: () => <Outlet />,
-} );
-
 const siteOverviewRoute = createRoute( {
+	...appRouter.siteOverviewRoute.options,
 	getParentRoute: () => siteRoute,
-	path: '/',
-	loader: async ( { params: { siteSlug }, preload } ) => {
-		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		if ( preload ) {
-			Promise.all( [
-				queryClient.ensureQueryData( siteCurrentPlanQuery( site.ID ) ),
-				hasHostingFeature( site, DotcomFeatures.SCAN ) &&
-					queryClient.ensureQueryData( siteScanQuery( site.ID ) ),
-				hasHostingFeature( site, DotcomFeatures.BACKUPS ) &&
-					queryClient.ensureQueryData( siteLastBackupQuery( site.ID ) ),
-				site.is_a4a_dev_site && queryClient.ensureQueryData( sitePreviewLinksQuery( site.ID ) ),
-			] );
-		}
-	},
 } ).lazy( () =>
 	import( 'calypso/dashboard/sites/overview' ).then( ( d ) =>
 		createLazyRoute( 'overview' )( {
@@ -73,65 +29,28 @@ const siteOverviewRoute = createRoute( {
 	)
 );
 
-const siteOverviewCompatibilityRoute = createRoute( {
-	getParentRoute: () => rootRoute,
-	path: 'sites/$siteSlug',
-	beforeLoad: ( { cause, params: { siteSlug } } ) => {
-		if ( cause !== 'enter' ) {
-			return;
-		}
-		throw redirect( { to: `/${ siteSlug }`, replace: true } );
-	},
+const siteSettingsPreloadRoute = createRoute( {
+	...appRouter.siteSettingsRoute.options,
+	getParentRoute: () => siteRoute,
 } );
 
-const siteSettingsCompatibilityRoute = createRoute( {
-	getParentRoute: () => rootRoute,
-	path: 'sites/$siteSlug/settings',
-	beforeLoad: ( { cause, params: { siteSlug } } ) => {
-		if ( cause !== 'enter' ) {
-			return;
-		}
-		throw redirect( { to: `/${ siteSlug }/settings`, replace: true } );
-	},
-	loader: ( { params: { siteSlug } } ) => {
-		siteSettingsRouter.preloadRoute( {
-			to: `/${ siteSlug }/settings`,
-		} );
-	},
-} );
-
-const siteSettingsWithFeatureCompatibilityRoute = createRoute( {
-	getParentRoute: () => rootRoute,
-	path: 'sites/$siteSlug/settings/$feature',
-	beforeLoad: ( { cause, params: { siteSlug, feature } } ) => {
-		if ( cause !== 'enter' ) {
-			return;
-		}
-		throw redirect( { to: `/${ siteSlug }/settings/${ feature }`, replace: true } );
-	},
-	loader: ( { params: { siteSlug, feature } } ) => {
-		siteSettingsRouter.preloadRoute( {
-			to: `/${ siteSlug }/settings/${ feature }`,
-		} );
-	},
+const siteSettingsSiteVisibilityPreloadRoute = createRoute( {
+	...appRouter.siteSettingsSiteVisibilityRoute.options,
+	getParentRoute: () => siteRoute,
 } );
 
 const createRouteTree = () =>
 	rootRoute.addChildren( [
-		siteRoute.addChildren( [ siteOverviewRoute ] ),
-		siteOverviewCompatibilityRoute,
-		siteSettingsCompatibilityRoute,
-		siteSettingsWithFeatureCompatibilityRoute,
+		siteRoute.addChildren( [
+			siteOverviewRoute,
+			siteSettingsPreloadRoute,
+			siteSettingsSiteVisibilityPreloadRoute,
+		] ),
+		dashboardSitesCompatibilityRoute,
 	] );
 
-const compatibilityRoutes = [
-	siteOverviewCompatibilityRoute,
-	siteSettingsCompatibilityRoute,
-	siteSettingsWithFeatureCompatibilityRoute,
-];
-
 export const { syncBrowserHistoryToRouter, syncMemoryRouterToBrowserHistory } =
-	createBrowserHistoryAndMemoryRouterSync( { compatibilityRoutes } );
+	createBrowserHistoryAndMemoryRouterSync();
 
 export const getRouter = ( { basePath }: { basePath: string } ) => {
 	const routeTree = createRouteTree();
@@ -145,7 +64,7 @@ export const getRouter = ( { basePath }: { basePath: string } ) => {
 };
 
 export const routerConfig = {
-	basePath: '/sites/v2',
+	basePath: '/',
 };
 
 export default getRouter( routerConfig );

--- a/client/sites/v2/site-overview/router.tsx
+++ b/client/sites/v2/site-overview/router.tsx
@@ -19,6 +19,7 @@ import { DotcomFeatures } from 'calypso/dashboard/data/constants';
 import { canManageSite } from 'calypso/dashboard/sites/features';
 import { hasHostingFeature } from 'calypso/dashboard/utils/site-features';
 import Root from '../components/root';
+import siteSettingsRouter from '../site-settings/router';
 import { getRouterOptions, createBrowserHistoryAndMemoryRouterSync } from '../utils/router';
 import type { WPBreakpoint } from '@wordpress/compose/build-types/hooks/use-viewport-match';
 
@@ -79,7 +80,7 @@ const siteOverviewCompatibilityRoute = createRoute( {
 		if ( cause !== 'enter' ) {
 			return;
 		}
-		throw redirect( { to: `/${ siteSlug }/overview`, replace: true } );
+		throw redirect( { to: `/${ siteSlug }`, replace: true } );
 	},
 } );
 
@@ -92,6 +93,11 @@ const siteSettingsCompatibilityRoute = createRoute( {
 		}
 		throw redirect( { to: `/${ siteSlug }/settings`, replace: true } );
 	},
+	loader: ( { params: { siteSlug } } ) => {
+		siteSettingsRouter.preloadRoute( {
+			to: `/${ siteSlug }/settings`,
+		} );
+	},
 } );
 
 const siteSettingsWithFeatureCompatibilityRoute = createRoute( {
@@ -102,6 +108,11 @@ const siteSettingsWithFeatureCompatibilityRoute = createRoute( {
 			return;
 		}
 		throw redirect( { to: `/${ siteSlug }/settings/${ feature }`, replace: true } );
+	},
+	loader: ( { params: { siteSlug, feature } } ) => {
+		siteSettingsRouter.preloadRoute( {
+			to: `/${ siteSlug }/settings/${ feature }`,
+		} );
 	},
 } );
 
@@ -132,3 +143,9 @@ export const getRouter = ( { basePath }: { basePath: string } ) => {
 
 	return router;
 };
+
+export const routerConfig = {
+	basePath: '/sites/v2',
+};
+
+export default getRouter( routerConfig );

--- a/client/sites/v2/site-overview/router.tsx
+++ b/client/sites/v2/site-overview/router.tsx
@@ -20,6 +20,7 @@ import { canManageSite } from 'calypso/dashboard/sites/features';
 import { hasHostingFeature } from 'calypso/dashboard/utils/site-features';
 import Root from '../components/root';
 import { getRouterOptions, createBrowserHistoryAndMemoryRouterSync } from '../utils/router';
+import type { WPBreakpoint } from '@wordpress/compose/build-types/hooks/use-viewport-match';
 
 const rootRoute = createRootRoute( { component: Root } );
 
@@ -57,13 +58,13 @@ const siteOverviewRoute = createRoute( {
 			component: function SiteOverview() {
 				const isWide = useBreakpoint( WIDE_BREAKPOINT );
 				const breakpoints = isWide
-					? { large: 'huge', small: 'huge' }
-					: { large: 'large', small: 'large' };
+					? { large: 'huge' as WPBreakpoint, small: 'huge' as WPBreakpoint }
+					: { large: 'large' as WPBreakpoint, small: 'large' as WPBreakpoint };
 				return (
 					<d.default
 						siteSlug={ siteRoute.useParams().siteSlug }
 						hideSitePreview
-						breakpoints={ breakpoints as any }
+						breakpoints={ breakpoints }
 					/>
 				);
 			},
@@ -71,24 +72,52 @@ const siteOverviewRoute = createRoute( {
 	)
 );
 
-const sitesOverviewCompatibilityRoute = createRoute( {
+const siteOverviewCompatibilityRoute = createRoute( {
 	getParentRoute: () => rootRoute,
-	path: '/sites/$siteSlug',
+	path: 'sites/$siteSlug',
 	beforeLoad: ( { cause, params: { siteSlug } } ) => {
 		if ( cause !== 'enter' ) {
 			return;
 		}
-		throw redirect( { to: `/overview/${ siteSlug }`, replace: true } );
+		throw redirect( { to: `/${ siteSlug }/overview`, replace: true } );
+	},
+} );
+
+const siteSettingsCompatibilityRoute = createRoute( {
+	getParentRoute: () => rootRoute,
+	path: 'sites/$siteSlug/settings',
+	beforeLoad: ( { cause, params: { siteSlug } } ) => {
+		if ( cause !== 'enter' ) {
+			return;
+		}
+		throw redirect( { to: `/${ siteSlug }/settings`, replace: true } );
+	},
+} );
+
+const siteSettingsWithFeatureCompatibilityRoute = createRoute( {
+	getParentRoute: () => rootRoute,
+	path: 'sites/$siteSlug/settings/$feature',
+	beforeLoad: ( { cause, params: { siteSlug, feature } } ) => {
+		if ( cause !== 'enter' ) {
+			return;
+		}
+		throw redirect( { to: `/${ siteSlug }/settings/${ feature }`, replace: true } );
 	},
 } );
 
 const createRouteTree = () =>
 	rootRoute.addChildren( [
 		siteRoute.addChildren( [ siteOverviewRoute ] ),
-		sitesOverviewCompatibilityRoute,
+		siteOverviewCompatibilityRoute,
+		siteSettingsCompatibilityRoute,
+		siteSettingsWithFeatureCompatibilityRoute,
 	] );
 
-const compatibilityRoutes = [ sitesOverviewCompatibilityRoute ];
+const compatibilityRoutes = [
+	siteOverviewCompatibilityRoute,
+	siteSettingsCompatibilityRoute,
+	siteSettingsWithFeatureCompatibilityRoute,
+];
 
 export const { syncBrowserHistoryToRouter, syncMemoryRouterToBrowserHistory } =
 	createBrowserHistoryAndMemoryRouterSync( { compatibilityRoutes } );

--- a/client/sites/v2/site-overview/router.tsx
+++ b/client/sites/v2/site-overview/router.tsx
@@ -10,8 +10,14 @@ import {
 	redirect,
 } from '@tanstack/react-router';
 import { siteBySlugQuery } from 'calypso/dashboard/app/queries/site';
+import { siteLastBackupQuery } from 'calypso/dashboard/app/queries/site-backups';
+import { siteCurrentPlanQuery } from 'calypso/dashboard/app/queries/site-plans';
+import { sitePreviewLinksQuery } from 'calypso/dashboard/app/queries/site-preview-links';
+import { siteScanQuery } from 'calypso/dashboard/app/queries/site-scan';
 import { queryClient } from 'calypso/dashboard/app/query-client';
+import { DotcomFeatures } from 'calypso/dashboard/data/constants';
 import { canManageSite } from 'calypso/dashboard/sites/features';
+import { hasHostingFeature } from 'calypso/dashboard/utils/site-features';
 import Root from '../components/root';
 import { getRouterOptions, createBrowserHistoryAndMemoryRouterSync } from '../utils/router';
 
@@ -32,6 +38,19 @@ const siteRoute = createRoute( {
 const siteOverviewRoute = createRoute( {
 	getParentRoute: () => siteRoute,
 	path: '/',
+	loader: async ( { params: { siteSlug }, preload } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( preload ) {
+			Promise.all( [
+				queryClient.ensureQueryData( siteCurrentPlanQuery( site.ID ) ),
+				hasHostingFeature( site, DotcomFeatures.SCAN ) &&
+					queryClient.ensureQueryData( siteScanQuery( site.ID ) ),
+				hasHostingFeature( site, DotcomFeatures.BACKUPS ) &&
+					queryClient.ensureQueryData( siteLastBackupQuery( site.ID ) ),
+				site.is_a4a_dev_site && queryClient.ensureQueryData( sitePreviewLinksQuery( site.ID ) ),
+			] );
+		}
+	},
 } ).lazy( () =>
 	import( 'calypso/dashboard/sites/overview' ).then( ( d ) =>
 		createLazyRoute( 'overview' )( {

--- a/client/sites/v2/site-overview/router.tsx
+++ b/client/sites/v2/site-overview/router.tsx
@@ -1,0 +1,86 @@
+import page from '@automattic/calypso-router';
+import { WIDE_BREAKPOINT } from '@automattic/viewport';
+import { useBreakpoint } from '@automattic/viewport-react';
+import {
+	Outlet,
+	createLazyRoute,
+	createRootRoute,
+	createRoute,
+	createRouter,
+	redirect,
+} from '@tanstack/react-router';
+import { siteBySlugQuery } from 'calypso/dashboard/app/queries/site';
+import { queryClient } from 'calypso/dashboard/app/query-client';
+import { canManageSite } from 'calypso/dashboard/sites/features';
+import Root from '../components/root';
+import { getRouterOptions, createBrowserHistoryAndMemoryRouterSync } from '../utils/router';
+
+const rootRoute = createRootRoute( { component: Root } );
+
+const siteRoute = createRoute( {
+	getParentRoute: () => rootRoute,
+	path: '$siteSlug',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( ! canManageSite( site ) ) {
+			page.redirect( '/sites' );
+		}
+	},
+	component: () => <Outlet />,
+} );
+
+const siteOverviewRoute = createRoute( {
+	getParentRoute: () => siteRoute,
+	path: '/',
+} ).lazy( () =>
+	import( 'calypso/dashboard/sites/overview' ).then( ( d ) =>
+		createLazyRoute( 'overview' )( {
+			component: function SiteOverview() {
+				const isWide = useBreakpoint( WIDE_BREAKPOINT );
+				const breakpoints = isWide
+					? { large: 'huge', small: 'huge' }
+					: { large: 'large', small: 'large' };
+				return (
+					<d.default
+						siteSlug={ siteRoute.useParams().siteSlug }
+						hideSitePreview
+						breakpoints={ breakpoints as any }
+					/>
+				);
+			},
+		} )
+	)
+);
+
+const sitesOverviewCompatibilityRoute = createRoute( {
+	getParentRoute: () => rootRoute,
+	path: '/sites/$siteSlug',
+	beforeLoad: ( { cause, params: { siteSlug } } ) => {
+		if ( cause !== 'enter' ) {
+			return;
+		}
+		throw redirect( { to: `/overview/${ siteSlug }`, replace: true } );
+	},
+} );
+
+const createRouteTree = () =>
+	rootRoute.addChildren( [
+		siteRoute.addChildren( [ siteOverviewRoute ] ),
+		sitesOverviewCompatibilityRoute,
+	] );
+
+const compatibilityRoutes = [ sitesOverviewCompatibilityRoute ];
+
+export const { syncBrowserHistoryToRouter, syncMemoryRouterToBrowserHistory } =
+	createBrowserHistoryAndMemoryRouterSync( { compatibilityRoutes } );
+
+export const getRouter = ( { basePath }: { basePath: string } ) => {
+	const routeTree = createRouteTree();
+	const router = createRouter( {
+		...getRouterOptions(),
+		routeTree,
+		basepath: basePath,
+	} );
+
+	return router;
+};

--- a/client/sites/v2/site-overview/style.scss
+++ b/client/sites/v2/site-overview/style.scss
@@ -1,0 +1,24 @@
+@import 'calypso/dashboard/app-dotcom/style.scss';
+
+.dashboard-backport-site-overview {
+	.dashboard-page-layout {
+		align-self: center;
+		margin: 0;
+		padding: 0;
+		gap: 0;
+	}
+
+	.dashboard-page-header,
+	.dashboard-page-header + .site-overview-fields {
+		display: none;
+	}
+
+	// We manually compose the UI of the dataview without including the view actions, which results in extra padding and a border.
+	.components-card__header + .components-card__body:has( > .dataviews-wrapper ):not( :has( .dataviews__view-actions ) ) {
+		padding-top: 0;
+
+		.dataviews-view-list div[role="row"]:first-child {
+			border-top: none;
+		}
+	}
+}

--- a/client/sites/v2/site-settings/index.tsx
+++ b/client/sites/v2/site-settings/index.tsx
@@ -9,7 +9,8 @@ import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getSiteSettings } from 'calypso/state/site-settings/selectors';
 import { getSite } from 'calypso/state/sites/selectors';
 import { useAnalyticsClient } from '../hooks/use-analytics-client';
-import Layout, { router } from './layout';
+import Layout from './layout';
+import router from './router';
 import type { Store } from 'redux';
 import './style.scss';
 

--- a/client/sites/v2/site-settings/index.tsx
+++ b/client/sites/v2/site-settings/index.tsx
@@ -55,7 +55,7 @@ export default function DashboardBackportSiteSettingsRenderer( {
 		Promise.all( [
 			persistPromise,
 			router.preloadRoute( {
-				to: `/${ siteSlug }`,
+				to: `/sites/${ siteSlug }/settings`,
 			} ),
 		] ).then( () => {
 			rootInstanceRef.current?.render(

--- a/client/sites/v2/site-settings/layout.tsx
+++ b/client/sites/v2/site-settings/layout.tsx
@@ -5,15 +5,12 @@ import { Provider as ReduxProvider } from 'react-redux';
 import { AnalyticsProvider, type AnalyticsClient } from 'calypso/dashboard/app/analytics';
 import { AuthProvider, useAuth } from 'calypso/dashboard/app/auth';
 import { queryClient } from 'calypso/dashboard/app/query-client';
-import { getRouter, syncBrowserHistoryToRouter, syncMemoryRouterToBrowserHistory } from './router';
+import router, {
+	routerConfig,
+	syncBrowserHistoryToRouter,
+	syncMemoryRouterToBrowserHistory,
+} from './router';
 import type { Store } from 'redux';
-
-// Serves a similar purpose to AppConfig form v2 dashboard.
-const config = {
-	basePath: '/',
-};
-
-export const router = getRouter( config );
 
 function RouterProviderWithAuth( { siteSlug, feature }: { siteSlug?: string; feature?: string } ) {
 	const auth = useAuth();
@@ -36,7 +33,7 @@ function RouterProviderWithAuth( { siteSlug, feature }: { siteSlug?: string; fea
 		};
 	}, [] );
 
-	return <RouterProvider router={ router } context={ { auth, config } } />;
+	return <RouterProvider router={ router } context={ { auth, config: routerConfig } } />;
 }
 
 function Layout( {

--- a/client/sites/v2/site-settings/router.tsx
+++ b/client/sites/v2/site-settings/router.tsx
@@ -1,43 +1,7 @@
-import page from '@automattic/calypso-router';
-import {
-	Outlet,
-	Router,
-	createLazyRoute,
-	createRootRoute,
-	createRoute,
-} from '@tanstack/react-router';
-import { siteBySlugQuery } from 'calypso/dashboard/app/queries/site';
-import { siteSettingsQuery } from 'calypso/dashboard/app/queries/site-settings';
-import { queryClient } from 'calypso/dashboard/app/query-client';
+import { Router, createLazyRoute, createRoute } from '@tanstack/react-router';
 import * as appRouter from 'calypso/dashboard/app/router';
-import { canManageSite } from 'calypso/dashboard/sites/features';
-import Root from '../components/root';
+import { rootRoute, dashboardSitesCompatibilityRoute, siteRoute } from '../router';
 import { getRouterOptions, createBrowserHistoryAndMemoryRouterSync } from '../utils/router';
-
-const rootRoute = createRootRoute( { component: Root } );
-const dashboardSitesCompatibilityRoute = createRoute( {
-	getParentRoute: () => rootRoute,
-	path: 'sites',
-	beforeLoad: ( { cause } ) => {
-		if ( cause !== 'enter' ) {
-			return;
-		}
-		page.show( '/sites' );
-	},
-} );
-
-const siteRoute = createRoute( {
-	getParentRoute: () => rootRoute,
-	path: 'sites/$siteSlug',
-	loader: async ( { params: { siteSlug } } ) => {
-		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		if ( ! canManageSite( site ) ) {
-			page.redirect( '/sites' );
-		}
-		queryClient.ensureQueryData( siteSettingsQuery( site.ID ) );
-	},
-	component: () => <Outlet />,
-} );
 
 const settingsRoute = createRoute( {
 	...appRouter.siteSettingsRoute.options,
@@ -227,7 +191,7 @@ const createRouteTree = () =>
 	] );
 
 export const { syncBrowserHistoryToRouter, syncMemoryRouterToBrowserHistory } =
-	createBrowserHistoryAndMemoryRouterSync( {} );
+	createBrowserHistoryAndMemoryRouterSync();
 
 export const getRouter = ( { basePath }: { basePath: string } ) => {
 	const routeTree = createRouteTree();
@@ -241,7 +205,7 @@ export const getRouter = ( { basePath }: { basePath: string } ) => {
 };
 
 export const routerConfig = {
-	basePath: '/sites/v2',
+	basePath: '/',
 };
 
 export default getRouter( routerConfig );

--- a/client/sites/v2/site-settings/router.tsx
+++ b/client/sites/v2/site-settings/router.tsx
@@ -239,3 +239,9 @@ export const getRouter = ( { basePath }: { basePath: string } ) => {
 
 	return router;
 };
+
+export const routerConfig = {
+	basePath: '/sites/v2',
+};
+
+export default getRouter( routerConfig );

--- a/client/sites/v2/sites-list/index.tsx
+++ b/client/sites/v2/sites-list/index.tsx
@@ -5,7 +5,8 @@ import { queryClient, persistPromise } from 'calypso/dashboard/app/query-client'
 import { useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { useAnalyticsClient } from '../hooks/use-analytics-client';
-import Layout, { router } from './layout';
+import Layout from './layout';
+import router from './router';
 import './style.scss';
 
 export default function DashboardBackportSitesList() {

--- a/client/sites/v2/sites-list/layout.tsx
+++ b/client/sites/v2/sites-list/layout.tsx
@@ -4,14 +4,11 @@ import { useEffect } from 'react';
 import { AnalyticsProvider, type AnalyticsClient } from 'calypso/dashboard/app/analytics';
 import { AuthProvider, useAuth } from 'calypso/dashboard/app/auth';
 import { queryClient } from 'calypso/dashboard/app/query-client';
-import { getRouter, syncBrowserHistoryToRouter, syncMemoryRouterToBrowserHistory } from './router';
-
-// Serves a similar purpose to AppConfig form v2 dashboard.
-const config = {
-	basePath: '/',
-};
-
-export const router = getRouter( config );
+import router, {
+	routerConfig,
+	syncBrowserHistoryToRouter,
+	syncMemoryRouterToBrowserHistory,
+} from './router';
 
 function RouterProviderWithAuth( { siteSlug }: { siteSlug?: string } ) {
 	const auth = useAuth();
@@ -34,7 +31,7 @@ function RouterProviderWithAuth( { siteSlug }: { siteSlug?: string } ) {
 		};
 	}, [] );
 
-	return <RouterProvider router={ router } context={ { auth, config } } />;
+	return <RouterProvider router={ router } context={ { auth, config: routerConfig } } />;
 }
 
 function Layout( {

--- a/client/sites/v2/sites-list/router.tsx
+++ b/client/sites/v2/sites-list/router.tsx
@@ -3,7 +3,6 @@ import {
 	createRootRoute,
 	createRoute,
 	createRouter,
-	redirect,
 } from '@tanstack/react-router';
 import { isAutomatticianQuery } from 'calypso/dashboard/app/queries/me-a8c';
 import { rawUserPreferencesQuery } from 'calypso/dashboard/app/queries/me-preferences';
@@ -49,31 +48,19 @@ const sitesRoute = createRoute( {
 		} )
 	)
 );
-const dummySitesOverviewRoute = createRoute( {
+
+const dummySiteOverviewRoute = createRoute( {
 	getParentRoute: () => rootRoute,
-	path: 'overview/$siteSlug',
+	path: 'sites/$siteSlug',
 	loader: infiniteLoader,
 	component: () => null,
 } );
 
-const sitesOverviewCompatibilityRoute = createRoute( {
-	getParentRoute: () => rootRoute,
-	path: '/sites/$siteSlug',
-	beforeLoad: ( { cause, params: { siteSlug } } ) => {
-		if ( cause !== 'enter' ) {
-			return;
-		}
-		throw redirect( { to: `/overview/${ siteSlug }`, replace: true } );
-	},
-} );
-
-const createRouteTree = () =>
-	rootRoute.addChildren( [ sitesRoute, dummySitesOverviewRoute, sitesOverviewCompatibilityRoute ] );
-
-const compatibilityRoutes = [ sitesOverviewCompatibilityRoute ];
+const createRouteTree = () => rootRoute.addChildren( [ sitesRoute, dummySiteOverviewRoute ] );
 
 export const { syncBrowserHistoryToRouter, syncMemoryRouterToBrowserHistory } =
-	createBrowserHistoryAndMemoryRouterSync( { compatibilityRoutes } );
+	createBrowserHistoryAndMemoryRouterSync();
+
 export const getRouter = ( { basePath }: { basePath: string } ) => {
 	const routeTree = createRouteTree();
 	const router = createRouter( {

--- a/client/sites/v2/sites-list/router.tsx
+++ b/client/sites/v2/sites-list/router.tsx
@@ -1,14 +1,6 @@
-import {
-	createLazyRoute,
-	createRootRoute,
-	createRoute,
-	createRouter,
-} from '@tanstack/react-router';
-import { isAutomatticianQuery } from 'calypso/dashboard/app/queries/me-a8c';
-import { rawUserPreferencesQuery } from 'calypso/dashboard/app/queries/me-preferences';
-import { sitesQuery } from 'calypso/dashboard/app/queries/sites';
-import { queryClient } from 'calypso/dashboard/app/query-client';
-import Root from '../components/root';
+import { createLazyRoute, createRoute, createRouter } from '@tanstack/react-router';
+import * as appRouter from 'calypso/dashboard/app/router';
+import { rootRoute } from '../router';
 import siteOverviewRouter from '../site-overview/router';
 import siteSettingsRouter from '../site-settings/router';
 import { getRouterOptions, createBrowserHistoryAndMemoryRouterSync } from '../utils/router';
@@ -16,33 +8,9 @@ import { getRouterOptions, createBrowserHistoryAndMemoryRouterSync } from '../ut
 // Keep the loading state active to prevent displaying a white screen during the redirection.
 const infiniteLoader = () => new Promise( () => {} );
 
-const rootRoute = createRootRoute( { component: Root } );
-
 const sitesRoute = createRoute( {
+	...appRouter.sitesRoute.options,
 	getParentRoute: () => rootRoute,
-	path: 'sites',
-	loader: async () => {
-		// Preload the default sites list response without blocking.
-		queryClient.ensureQueryData( sitesQuery() );
-
-		await Promise.all( [
-			queryClient.ensureQueryData( isAutomatticianQuery() ),
-			queryClient.ensureQueryData( rawUserPreferencesQuery() ),
-		] );
-	},
-	validateSearch: ( search ) => {
-		// Deserialize the view search param if it exists on the first page load.
-		if ( typeof search.view === 'string' ) {
-			let parsedView;
-			try {
-				parsedView = JSON.parse( search.view );
-			} catch ( e ) {
-				// pass
-			}
-			return { ...search, view: parsedView };
-		}
-		return search;
-	},
 } ).lazy( () =>
 	import( 'calypso/dashboard/sites' ).then( ( d ) =>
 		createLazyRoute( 'sites' )( {

--- a/client/sites/v2/sites-list/router.tsx
+++ b/client/sites/v2/sites-list/router.tsx
@@ -9,6 +9,8 @@ import { rawUserPreferencesQuery } from 'calypso/dashboard/app/queries/me-prefer
 import { sitesQuery } from 'calypso/dashboard/app/queries/sites';
 import { queryClient } from 'calypso/dashboard/app/query-client';
 import Root from '../components/root';
+import siteOverviewRouter from '../site-overview/router';
+import siteSettingsRouter from '../site-settings/router';
 import { getRouterOptions, createBrowserHistoryAndMemoryRouterSync } from '../utils/router';
 
 // Keep the loading state active to prevent displaying a white screen during the redirection.
@@ -51,12 +53,53 @@ const sitesRoute = createRoute( {
 
 const dummySiteOverviewRoute = createRoute( {
 	getParentRoute: () => rootRoute,
-	path: 'sites/$siteSlug',
-	loader: infiniteLoader,
-	component: () => null,
+	path: 'overview/$siteSlug',
+	loader: async () => {
+		await infiniteLoader();
+	},
 } );
 
-const createRouteTree = () => rootRoute.addChildren( [ sitesRoute, dummySiteOverviewRoute ] );
+const siteOverviewPreloadRoute = createRoute( {
+	getParentRoute: () => rootRoute,
+	path: 'sites/$siteSlug',
+	loader: async ( { params: { siteSlug } } ) => {
+		siteOverviewRouter.preloadRoute( {
+			to: `/sites/${ siteSlug }`,
+		} );
+		await infiniteLoader();
+	},
+} );
+
+const siteSettingsPreloadRoute = createRoute( {
+	getParentRoute: () => rootRoute,
+	path: 'sites/$siteSlug/settings',
+	loader: async ( { params: { siteSlug } } ) => {
+		siteSettingsRouter.preloadRoute( {
+			to: `/sites/${ siteSlug }/settings`,
+		} );
+		await infiniteLoader();
+	},
+} );
+
+const siteSettingsWithFeaturePreloadRoute = createRoute( {
+	getParentRoute: () => rootRoute,
+	path: 'sites/$siteSlug/settings/$feature',
+	loader: async ( { params: { siteSlug, feature } } ) => {
+		siteSettingsRouter.preloadRoute( {
+			to: `/sites/${ siteSlug }/settings/${ feature }`,
+		} );
+		await infiniteLoader();
+	},
+} );
+
+const createRouteTree = () =>
+	rootRoute.addChildren( [
+		sitesRoute,
+		dummySiteOverviewRoute,
+		siteOverviewPreloadRoute,
+		siteSettingsPreloadRoute,
+		siteSettingsWithFeaturePreloadRoute,
+	] );
 
 export const { syncBrowserHistoryToRouter, syncMemoryRouterToBrowserHistory } =
 	createBrowserHistoryAndMemoryRouterSync();
@@ -71,3 +114,9 @@ export const getRouter = ( { basePath }: { basePath: string } ) => {
 
 	return router;
 };
+
+export const routerConfig = {
+	basePath: '/',
+};
+
+export default getRouter( routerConfig );

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -78,7 +78,6 @@ function getSiteDashboardRoutes( state: AppState ) {
 		'/site-logs/',
 		'/hosting-features/',
 		'/staging-site/',
-		'/sites/overview',
 		'/sites/settings',
 		...( isPlansPageUntangled( state ) ? [ '/plans' ] : [] ),
 

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -78,6 +78,7 @@ function getSiteDashboardRoutes( state: AppState ) {
 		'/site-logs/',
 		'/hosting-features/',
 		'/staging-site/',
+		'/sites/overview',
 		'/sites/settings',
 		...( isPlansPageUntangled( state ) ? [ '/plans' ] : [] ),
 

--- a/config/development.json
+++ b/config/development.json
@@ -49,6 +49,7 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"dashboard/v2": true,
+		"dashboard/v2/backport/site-overview": false,
 		"dashboard/v2/backport/site-settings": true,
 		"dashboard/v2/backport/sites-list": true,
 		"dashboard/v2/security-settings": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -26,6 +26,7 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"dashboard/v2": false,
+		"dashboard/v2/backport/site-overview": false,
 		"dashboard/v2/backport/site-settings": true,
 		"dashboard/v2/backport/sites-list": true,
 		"dashboard/v2/security-settings": false,

--- a/config/production.json
+++ b/config/production.json
@@ -38,6 +38,7 @@
 		"cookie-banner": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
+		"dashboard/v2/backport/site-overview": false,
 		"dashboard/v2/backport/site-settings": true,
 		"dashboard/v2/backport/sites-list": true,
 		"dashboard/v2/security-settings": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -36,6 +36,7 @@
 		"cookie-banner": false,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
+		"dashboard/v2/backport/site-overview": false,
 		"dashboard/v2/backport/site-settings": true,
 		"dashboard/v2/backport/sites-list": true,
 		"dashboard/v2/security-settings": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -35,6 +35,7 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"dashboard/v2": true,
+		"dashboard/v2/backport/site-overview": false,
 		"dashboard/v2/backport/site-settings": true,
 		"dashboard/v2/backport/sites-list": true,
 		"dashboard/v2/security-settings": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-145

## Proposed Changes

* Introduce the `dashboard/v2/backport/site-overview` flag to control the backport
* Backport the site overview v2 to the current hosting dashboard
* Update the backport URL prefix to enable seamless tab navigation (e.g., between Overview and Settings) without triggering a full page reload
* Adjust the grid layout to prevent the content from overflowing
  * Use `Grid` for the nested cards instead of `VStack` to make the items with the same height
  * Adjust the style of the `OverviewCard` to prevent the content from overflowing
* The breakpoint of the layout
  * with site list: 1440px
  * without site list: 960px

| | Large screen | Small screen |
|-|-|-|
| With site list |<img width="1634" height="1292" alt="image" src="https://github.com/user-attachments/assets/7ceed2ea-ecdd-496b-a7c4-5a12ac05213f" />|<img width="1429" height="1293" alt="image" src="https://github.com/user-attachments/assets/840eb073-760a-4529-9f9c-1941af92f8e0" />|
| Without site list |<img width="1272" height="1293" alt="image" src="https://github.com/user-attachments/assets/41423e3b-537b-4b4d-b63c-90972475b7e4" />|<img width="949" height="1293" alt="image" src="https://github.com/user-attachments/assets/da0cbb60-044b-45be-b598-3a3c1b814ea0" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites?flags=dashboard/v2/backport/site-overview`
* Select any site
* Ensure the backport looks good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
