### PR TITLE
Move the cancel API to the end of the flow

### DIFF
--- a/client/components/marketing-survey/cancel-jetpack-form/index.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/index.tsx
@@ -13,7 +13,6 @@ import JetpackCancellationOfferAccepted from 'calypso/components/marketing-surve
 import JetpackCancellationSurvey from 'calypso/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-survey';
 import { CANCEL_FLOW_TYPE } from 'calypso/components/marketing-survey/cancel-purchase-form/constants';
 import enrichedSurveyData from 'calypso/components/marketing-survey/cancel-purchase-form/enriched-survey-data';
-import Notice from 'calypso/components/notice';
 import { getName, isExpired } from 'calypso/lib/purchases';
 import { submitSurvey } from 'calypso/lib/purchases/actions';
 import { isOutsideCalypso } from 'calypso/lib/url';
@@ -45,8 +44,6 @@ interface Props {
 	translate?: () => void;
 	isAkismet?: boolean;
 	cancellationInProgress?: boolean;
-	cancellationCompleted?: boolean;
-	cancellationMessage?: string;
 }
 
 const CancelJetpackForm: React.FC< Props > = ( {
@@ -434,7 +431,6 @@ const CancelJetpackForm: React.FC< Props > = ( {
 	 */
 	const renderCurrentStep = () => {
 		const productName = getName( purchase );
-		const { cancellationMessage } = props;
 
 		if ( steps.CANCEL_CONFIRM_STEP === cancellationStep ) {
 			return (
@@ -477,26 +473,11 @@ const CancelJetpackForm: React.FC< Props > = ( {
 			// follow similar pattern used in the Jetpack disconnection flow
 			// make sure the user has the ability to skip the question
 			return (
-				<>
-					{ cancellationMessage && (
-						<div className="cancel-jetpack-form__notice-container">
-							<Notice
-								status="is-success"
-								className="cancel-jetpack-form__notice"
-								theme="light"
-								showDismiss={ false }
-							>
-								{ cancellationMessage }
-							</Notice>
-						</div>
-					) }
-
-					<JetpackCancellationSurvey
-						onAnswerChange={ onSurveyAnswerChange }
-						selectedAnswerId={ surveyAnswerId }
-						isAkismet={ !! props?.isAkismet }
-					/>
-				</>
+				<JetpackCancellationSurvey
+					onAnswerChange={ onSurveyAnswerChange }
+					selectedAnswerId={ surveyAnswerId }
+					isAkismet={ !! props?.isAkismet }
+				/>
 			);
 		}
 

--- a/client/components/marketing-survey/cancel-jetpack-form/index.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/index.tsx
@@ -44,6 +44,7 @@ interface Props {
 	translate?: () => void;
 	isAkismet?: boolean;
 	cancellationInProgress?: boolean;
+	cancellationCompleted?: boolean;
 }
 
 const CancelJetpackForm: React.FC< Props > = ( {
@@ -66,12 +67,13 @@ const CancelJetpackForm: React.FC< Props > = ( {
 			return steps.CANCELLATION_REASON_STEP;
 		}
 
-		// In these cases, the subscription is getting removed.
-		// Show the benefits step first.
-		if (
-			flowType === CANCEL_FLOW_TYPE.REMOVE ||
-			flowType === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND
-		) {
+		// For refundable plans, go directly to survey (no intermediate confirmation needed)
+		if ( flowType === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND ) {
+			return steps.CANCELLATION_REASON_STEP;
+		}
+
+		// For non-refundable plans (REMOVE), show the benefits step first
+		if ( flowType === CANCEL_FLOW_TYPE.REMOVE ) {
 			return steps.FEATURES_LOST_STEP;
 		}
 

--- a/client/components/marketing-survey/cancel-purchase-form/domain-cancellation-survey.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/domain-cancellation-survey.tsx
@@ -1,7 +1,6 @@
-import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { TRANSFER_DOMAIN_REGISTRATION, UPDATE_NAMESERVERS } from '@automattic/urls';
-import { SelectControl, TextareaControl } from '@wordpress/components';
+import { Button, SelectControl, TextareaControl } from '@wordpress/components';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { useState, useEffect, useMemo } from 'react';
 import * as React from 'react';
@@ -145,8 +144,8 @@ const DomainCancellationSurvey: React.FC< Props > = ( {
 			<div className="cancel-purchase-form__actions">
 				<div className="cancel-purchase-form__buttons">
 					<Button
-						primary
-						busy={ cancellationInProgress }
+						variant="primary"
+						isBusy={ cancellationInProgress }
 						disabled={ disabled }
 						onClick={ handleSubmit }
 					>

--- a/client/components/marketing-survey/cancel-purchase-form/domain-cancellation-survey.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/domain-cancellation-survey.tsx
@@ -148,7 +148,7 @@ const DomainCancellationSurvey: React.FC< Props > = ( {
 						disabled={ disabled }
 						onClick={ handleSubmit }
 					>
-						{ translate( 'Submit feedback' ) }
+						{ translate( 'Submit' ) }
 					</button>
 				</div>
 			</div>

--- a/client/components/marketing-survey/cancel-purchase-form/domain-cancellation-survey.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/domain-cancellation-survey.tsx
@@ -6,7 +6,6 @@ import { useState, useEffect, useMemo } from 'react';
 import * as React from 'react';
 import { BlankCanvas } from 'calypso/components/blank-canvas';
 import FormattedHeader from 'calypso/components/formatted-header';
-import Notice from 'calypso/components/notice';
 import { getName } from 'calypso/lib/purchases';
 import { submitSurvey } from 'calypso/lib/purchases/actions';
 import { useDispatch } from 'calypso/state';
@@ -27,8 +26,6 @@ interface Props {
 	onClose: () => void;
 	onSurveyComplete: () => void;
 	cancellationInProgress?: boolean;
-	cancellationCompleted?: boolean;
-	cancellationMessage?: string;
 }
 
 interface DomainCancellationReason {
@@ -140,7 +137,7 @@ const DomainCancellationSurvey: React.FC< Props > = ( {
 	}, [ selectedReason, cancellationReasons ] );
 
 	const renderButtons = () => {
-		const { disableButtons, cancellationCompleted } = props;
+		const { disableButtons } = props;
 		const disabled = disableButtons || ! selectedReason;
 
 		return (
@@ -151,7 +148,7 @@ const DomainCancellationSurvey: React.FC< Props > = ( {
 						disabled={ disabled }
 						onClick={ handleSubmit }
 					>
-						{ cancellationCompleted ? translate( 'Submit' ) : translate( 'Submit feedback' ) }
+						{ translate( 'Submit feedback' ) }
 					</button>
 				</div>
 			</div>
@@ -165,7 +162,7 @@ const DomainCancellationSurvey: React.FC< Props > = ( {
 
 		return (
 			<div className="cancel-purchase-form__feedback-question">
-				<Notice status="is-warning" className="cancel-purchase-form__notice">
+				<div className="cancel-purchase-form__notice">
 					{ selectedReasonData.helpMessage }
 					{ selectedReasonData.showLink && (
 						<>
@@ -179,7 +176,7 @@ const DomainCancellationSurvey: React.FC< Props > = ( {
 							</a>
 						</>
 					) }
-				</Notice>
+				</div>
 			</div>
 		);
 	};
@@ -198,19 +195,6 @@ const DomainCancellationSurvey: React.FC< Props > = ( {
 				</span>
 			</BlankCanvas.Header>
 			<BlankCanvas.Content>
-				{ props.cancellationMessage && (
-					<div className="cancel-purchase-form__notice-container">
-						<Notice
-							status="is-success"
-							className="cancel-purchase-form__notice"
-							theme="light"
-							showDismiss={ false }
-						>
-							{ props.cancellationMessage }
-						</Notice>
-					</div>
-				) }
-
 				<div className="cancel-purchase-form__feedback">
 					<FormattedHeader
 						brandFont

--- a/client/components/marketing-survey/cancel-purchase-form/domain-cancellation-survey.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/domain-cancellation-survey.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { TRANSFER_DOMAIN_REGISTRATION, UPDATE_NAMESERVERS } from '@automattic/urls';
 import { SelectControl, TextareaControl } from '@wordpress/components';
@@ -137,19 +138,20 @@ const DomainCancellationSurvey: React.FC< Props > = ( {
 	}, [ selectedReason, cancellationReasons ] );
 
 	const renderButtons = () => {
-		const { disableButtons } = props;
+		const { disableButtons, cancellationInProgress } = props;
 		const disabled = disableButtons || ! selectedReason;
 
 		return (
 			<div className="cancel-purchase-form__actions">
 				<div className="cancel-purchase-form__buttons">
-					<button
-						className="components-button is-primary"
+					<Button
+						primary
+						busy={ cancellationInProgress }
 						disabled={ disabled }
 						onClick={ handleSubmit }
 					>
 						{ translate( 'Submit' ) }
-					</button>
+					</Button>
 				</div>
 			</div>
 		);

--- a/client/components/marketing-survey/cancel-purchase-form/get-upsell-type.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/get-upsell-type.ts
@@ -39,7 +39,7 @@ export type UpsellType =
  * @returns {UpsellType} The upsell nudge type
  */
 export function getUpsellType( reason: string, opts: UpsellOptions ): UpsellType {
-	const { productSlug, canRefund, canDowngrade, canOfferFreeMonth } = opts;
+	const { productSlug, canDowngrade, canOfferFreeMonth } = opts;
 	const liveChatSupported = config.isEnabled( 'livechat_solution' );
 
 	if ( ! productSlug ) {
@@ -53,7 +53,7 @@ export function getUpsellType( reason: string, opts: UpsellOptions ): UpsellType
 				return '';
 			}
 
-			if ( isWpComPremiumPlan( productSlug ) && isWpComAnnualPlan( productSlug ) && canRefund ) {
+			if ( isWpComPremiumPlan( productSlug ) && isWpComAnnualPlan( productSlug ) ) {
 				return 'downgrade-personal';
 			}
 

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -314,14 +314,6 @@ class CancelPurchaseForm extends Component {
 		this.recordEvent( 'calypso_purchases_cancel_form_submit' );
 	};
 
-	onSkipSurvey = () => {
-		this.recordEvent( 'calypso_purchases_cancel_form_skip' );
-
-		if ( this.props.onSurveyComplete ) {
-			this.props.onSurveyComplete();
-		}
-	};
-
 	downgradeClick = ( upsell ) => {
 		if ( ! this.state.isSubmitting ) {
 			this.props.downgradeClick( upsell );
@@ -578,19 +570,14 @@ class CancelPurchaseForm extends Component {
 
 		if ( ! isLastStep ) {
 			return (
-				<>
-					<GutenbergButton
-						isPrimary
-						isDefault
-						disabled={ ! this.canGoNext() }
-						onClick={ this.clickNext }
-					>
-						{ translate( 'Submit' ) }
-					</GutenbergButton>
-					<GutenbergButton isSecondary isBusy={ isCancelling } onClick={ this.onSkipSurvey }>
-						{ translate( 'Skip' ) }
-					</GutenbergButton>
-				</>
+				<GutenbergButton
+					isPrimary
+					isDefault
+					disabled={ ! this.canGoNext() }
+					onClick={ this.clickNext }
+				>
+					{ translate( 'Submit' ) }
+				</GutenbergButton>
 			);
 		}
 
@@ -614,29 +601,21 @@ class CancelPurchaseForm extends Component {
 					>
 						{ translate( 'Keep plan' ) }
 					</GutenbergButton>
-					<GutenbergButton isSecondary isBusy={ isCancelling } onClick={ this.onSkipSurvey }>
-						{ translate( 'Skip' ) }
-					</GutenbergButton>
 				</>
 			);
 		}
 
 		return (
-			<>
-				<GutenbergButton
-					isPrimary={ surveyStep !== UPSELL_STEP }
-					isSecondary={ surveyStep === UPSELL_STEP }
-					isDefault={ surveyStep !== UPSELL_STEP }
-					isBusy={ isCancelling }
-					disabled={ ! this.canGoNext() }
-					onClick={ this.onSubmit }
-				>
-					{ translate( 'Submit' ) }
-				</GutenbergButton>
-				<GutenbergButton isSecondary isBusy={ isCancelling } onClick={ this.onSkipSurvey }>
-					{ translate( 'Skip' ) }
-				</GutenbergButton>
-			</>
+			<GutenbergButton
+				isPrimary={ surveyStep !== UPSELL_STEP }
+				isSecondary={ surveyStep === UPSELL_STEP }
+				isDefault={ surveyStep !== UPSELL_STEP }
+				isBusy={ isCancelling }
+				disabled={ ! this.canGoNext() }
+				onClick={ this.onSubmit }
+			>
+				{ translate( 'Submit' ) }
+			</GutenbergButton>
 		);
 	};
 

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -634,7 +634,7 @@ class CancelPurchaseForm extends Component {
 					{ translate( 'Submit' ) }
 				</GutenbergButton>
 				<GutenbergButton isSecondary isBusy={ isCancelling } onClick={ this.onSkipSurvey }>
-					{ translate( 'Skip survey' ) }
+					{ translate( 'Skip' ) }
 				</GutenbergButton>
 			</>
 		);

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -16,7 +16,6 @@ import QueryProducts from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import Notice from 'calypso/components/notice';
 import { isAgencyPartnerType, isPartnerPurchase, isRefundable } from 'calypso/lib/purchases';
 import { cancelPurchaseSurveyCompleted, submitSurvey } from 'calypso/lib/purchases/actions';
 import wpcom from 'calypso/lib/wp';
@@ -72,8 +71,6 @@ class CancelPurchaseForm extends Component {
 		linkedPurchases: PropTypes.array,
 		skipRemovePlanSurvey: PropTypes.bool,
 		cancellationInProgress: PropTypes.bool,
-		cancellationCompleted: PropTypes.bool,
-		cancellationMessage: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -717,7 +714,7 @@ class CancelPurchaseForm extends Component {
 		}
 	}
 	render() {
-		const { purchase, site, cancellationCompleted, cancellationMessage } = this.props;
+		const { purchase, site } = this.props;
 		const { surveyStep } = this.state;
 
 		if ( ! surveyStep ) {
@@ -744,21 +741,7 @@ class CancelPurchaseForm extends Component {
 								surveyStep={ surveyStep }
 							/>
 						</BlankCanvas.Header>
-						<BlankCanvas.Content>
-							{ cancellationCompleted && cancellationMessage && (
-								<div className="cancel-purchase-form__notice-container">
-									<Notice
-										status="is-success"
-										className="cancel-purchase-form__notice"
-										theme="light"
-										showDismiss={ false }
-									>
-										{ cancellationMessage }
-									</Notice>
-								</div>
-							) }
-							{ this.surveyContent() }
-						</BlankCanvas.Content>
+						<BlankCanvas.Content>{ this.surveyContent() }</BlankCanvas.Content>
 						<BlankCanvas.Footer>
 							<div className="cancel-purchase-form__actions">
 								<div

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -314,6 +314,14 @@ class CancelPurchaseForm extends Component {
 		this.recordEvent( 'calypso_purchases_cancel_form_submit' );
 	};
 
+	onSkipSurvey = () => {
+		this.recordEvent( 'calypso_purchases_cancel_form_skip' );
+
+		if ( this.props.onSurveyComplete ) {
+			this.props.onSurveyComplete();
+		}
+	};
+
 	downgradeClick = ( upsell ) => {
 		if ( ! this.state.isSubmitting ) {
 			this.props.downgradeClick( upsell );
@@ -570,14 +578,19 @@ class CancelPurchaseForm extends Component {
 
 		if ( ! isLastStep ) {
 			return (
-				<GutenbergButton
-					isPrimary
-					isDefault
-					disabled={ ! this.canGoNext() }
-					onClick={ this.clickNext }
-				>
-					{ translate( 'Submit' ) }
-				</GutenbergButton>
+				<>
+					<GutenbergButton
+						isPrimary
+						isDefault
+						disabled={ ! this.canGoNext() }
+						onClick={ this.clickNext }
+					>
+						{ translate( 'Submit' ) }
+					</GutenbergButton>
+					<GutenbergButton isSecondary isBusy={ isCancelling } onClick={ this.onSkipSurvey }>
+						{ translate( 'Skip' ) }
+					</GutenbergButton>
+				</>
 			);
 		}
 
@@ -601,21 +614,29 @@ class CancelPurchaseForm extends Component {
 					>
 						{ translate( 'Keep plan' ) }
 					</GutenbergButton>
+					<GutenbergButton isSecondary isBusy={ isCancelling } onClick={ this.onSkipSurvey }>
+						{ translate( 'Skip' ) }
+					</GutenbergButton>
 				</>
 			);
 		}
 
 		return (
-			<GutenbergButton
-				isPrimary={ surveyStep !== UPSELL_STEP }
-				isSecondary={ surveyStep === UPSELL_STEP }
-				isDefault={ surveyStep !== UPSELL_STEP }
-				isBusy={ isCancelling }
-				disabled={ ! this.canGoNext() }
-				onClick={ this.onSubmit }
-			>
-				{ translate( 'Submit' ) }
-			</GutenbergButton>
+			<>
+				<GutenbergButton
+					isPrimary={ surveyStep !== UPSELL_STEP }
+					isSecondary={ surveyStep === UPSELL_STEP }
+					isDefault={ surveyStep !== UPSELL_STEP }
+					isBusy={ isCancelling }
+					disabled={ ! this.canGoNext() }
+					onClick={ this.onSubmit }
+				>
+					{ translate( 'Submit' ) }
+				</GutenbergButton>
+				<GutenbergButton isSecondary isBusy={ isCancelling } onClick={ this.onSkipSurvey }>
+					{ translate( 'Skip survey' ) }
+				</GutenbergButton>
+			</>
 		);
 	};
 

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -576,7 +576,7 @@ class CancelPurchaseForm extends Component {
 					disabled={ ! this.canGoNext() }
 					onClick={ this.clickNext }
 				>
-					{ translate( 'Submit' ) }
+					{ translate( 'Continue' ) }
 				</GutenbergButton>
 			);
 		}

--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -184,6 +184,9 @@
 	position: relative;
 	padding: 3px;
 	margin: 0 auto;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
 
 	.components-button {
 		font-size: 0.875rem;

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -1,7 +1,5 @@
 import {
 	isDomainRegistration,
-	getMonthlyPlanByYearly,
-	getPlan,
 	isJetpackPlan,
 	isJetpackProduct,
 	isAkismetProduct,
@@ -21,15 +19,10 @@ import {
 	isOneTimePurchase,
 	isSubscription,
 } from 'calypso/lib/purchases';
-import {
-	cancelAndRefundPurchase,
-	extendPurchaseWithFreeMonth,
-} from 'calypso/lib/purchases/actions';
 import { getPurchaseCancellationFlowType } from 'calypso/lib/purchases/utils';
 import { purchasesRoot } from 'calypso/me/purchases/paths';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { clearPurchases } from 'calypso/state/purchases/actions';
-import { getDowngradePlanFromPurchase } from 'calypso/state/purchases/selectors';
 import { refreshSitePlans } from 'calypso/state/sites/plans/actions';
 import { MarketPlaceSubscriptionsDialog } from '../marketplace-subscriptions-dialog';
 import { willShowDomainOptionsRadioButtons } from './domain-options';
@@ -52,6 +45,9 @@ class CancelPurchaseButton extends Component {
 		isLoading: PropTypes.bool,
 		onDialogClose: PropTypes.func,
 		onSetLoading: PropTypes.func,
+		// Methods from parent component
+		downgradeClick: PropTypes.func,
+		freeMonthOfferClick: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -103,59 +99,6 @@ class CancelPurchaseButton extends Component {
 
 		// Always redirect to purchases page when dialog is closed
 		page.redirect( this.props.purchaseListUrl );
-	};
-
-	downgradeClick = ( upsell ) => {
-		const { purchase } = this.props;
-		let downgradePlan = getDowngradePlanFromPurchase( purchase );
-		if ( 'downgrade-monthly' === upsell ) {
-			const monthlyProductSlug = getMonthlyPlanByYearly( purchase.productSlug );
-			downgradePlan = getPlan( monthlyProductSlug );
-		}
-
-		this.setDisabled( true );
-
-		cancelAndRefundPurchase(
-			purchase.id,
-			{
-				product_id: purchase.productId,
-				type: 'downgrade',
-				to_product_id: downgradePlan.getProductId(),
-			},
-			( error, response ) => {
-				this.setDisabled( false );
-
-				if ( error ) {
-					this.props.errorNotice( error.message );
-					return;
-				}
-
-				this.props.refreshSitePlans( purchase.siteId );
-				this.props.clearPurchases();
-				this.props.successNotice( response.message, { displayOnNextPage: true } );
-				page.redirect( this.props.purchaseListUrl );
-			}
-		);
-	};
-
-	freeMonthOfferClick = async () => {
-		const { purchase } = this.props;
-
-		this.setDisabled( true );
-
-		try {
-			const res = await extendPurchaseWithFreeMonth( purchase.id );
-			if ( res.status === 'completed' ) {
-				this.props.refreshSitePlans( purchase.siteId );
-				this.props.clearPurchases();
-				this.props.successNotice( res.message, { displayOnNextPage: true } );
-				page.redirect( this.props.purchaseListUrl );
-			}
-		} catch ( err ) {
-			this.props.errorNotice( err.message );
-		} finally {
-			this.setDisabled( false );
-		}
 	};
 
 	shouldHandleMarketplaceSubscriptions() {
@@ -227,8 +170,8 @@ class CancelPurchaseButton extends Component {
 						isVisible={ showDialog }
 						onClose={ this.closeDialog }
 						onSurveyComplete={ this.handleSurveyComplete }
-						downgradeClick={ this.downgradeClick }
-						freeMonthOfferClick={ this.freeMonthOfferClick }
+						downgradeClick={ this.props.downgradeClick }
+						freeMonthOfferClick={ this.props.freeMonthOfferClick }
 						flowType={ getPurchaseCancellationFlowType( purchase ) }
 						cancelBundledDomain={ cancelBundledDomain }
 						includedDomainPurchase={ includedDomainPurchase }

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -22,9 +22,7 @@ import {
 	isSubscription,
 } from 'calypso/lib/purchases';
 import {
-	cancelAndRefundPurchaseAsync,
 	cancelAndRefundPurchase,
-	cancelPurchaseAsync,
 	extendPurchaseWithFreeMonth,
 } from 'calypso/lib/purchases/actions';
 import { getPurchaseCancellationFlowType } from 'calypso/lib/purchases/utils';
@@ -51,8 +49,6 @@ class CancelPurchaseButton extends Component {
 		moment: PropTypes.func,
 		// Props from parent component
 		showDialog: PropTypes.bool,
-		cancellationCompleted: PropTypes.bool,
-		cancellationMessage: PropTypes.string,
 		isLoading: PropTypes.bool,
 		onDialogClose: PropTypes.func,
 		onSetLoading: PropTypes.func,
@@ -72,38 +68,14 @@ class CancelPurchaseButton extends Component {
 	};
 
 	handleCancelPurchaseClick = async () => {
-		// Handle domain cancellations immediately instead of redirecting to confirmation page
-		if ( isDomainRegistration( this.props.purchase ) ) {
-			// Set loading state using parent callback
-			if ( this.props.onSetLoading ) {
-				this.props.onSetLoading( true );
-			}
-
-			if ( this.props.onCancellationStart ) {
-				this.props.onCancellationStart();
-			}
-
-			try {
-				const result = await this.submitCancelAndRefundPurchase();
-				if ( result.success ) {
-					// Use parent state management instead of local state
-					if ( this.props.onCancellationComplete ) {
-						this.props.onCancellationComplete( result.message );
-					}
-				} else {
-					this.cancellationFailed( result.error );
-				}
-			} catch ( error ) {
-				this.cancellationFailed( error.message );
-			}
-			return;
-		}
+		// For all purchases, including domain registrations, show the survey first
+		// The API call will happen at the end of the survey flow
 
 		// For other purchases, determine if we need domain options step
 		// If onCancellationStart is null, we're already in the domain options step
 		if ( this.props.onCancellationStart === null ) {
-			// We're in the domain options step, perform cancellation directly
-			await this.performCancellation();
+			// We're in the domain options step, show survey directly
+			this.props.onCancellationStart();
 		} else {
 			const needsDomainOptionsStep =
 				this.props.includedDomainPurchase &&
@@ -113,8 +85,8 @@ class CancelPurchaseButton extends Component {
 				// Step 1: Show domain options step
 				this.props.onCancellationStart();
 			} else {
-				// Step 2: Perform cancellation immediately
-				await this.performCancellation();
+				// Step 2: Show survey directly (API call will happen in survey)
+				this.props.onCancellationStart();
 			}
 		}
 	};
@@ -131,72 +103,6 @@ class CancelPurchaseButton extends Component {
 
 		// Always redirect to purchases page when dialog is closed
 		page.redirect( this.props.purchaseListUrl );
-	};
-
-	cancelPurchase = async ( purchase ) => {
-		const { translate } = this.props;
-
-		try {
-			const success = await cancelPurchaseAsync( purchase.id );
-
-			if ( success ) {
-				const purchaseName = getName( purchase );
-				const subscriptionEndDate = this.props.moment( purchase.expiryDate ).format( 'LL' );
-
-				return {
-					success: true,
-					message: translate(
-						'%(purchaseName)s was successfully cancelled. It will be available for use until it expires on %(subscriptionEndDate)s.',
-						{
-							args: {
-								purchaseName,
-								subscriptionEndDate,
-							},
-						}
-					),
-				};
-			}
-
-			return {
-				success: false,
-				error: translate(
-					'There was a problem canceling %(purchaseName)s. ' +
-						'Please try again later or contact support.',
-					{
-						args: { purchaseName: getName( purchase ) },
-					}
-				),
-			};
-		} catch ( error ) {
-			return {
-				success: false,
-				error: translate(
-					'There was a problem canceling %(purchaseName)s. ' +
-						'Please try again later or contact support.',
-					{
-						args: { purchaseName: getName( purchase ) },
-					}
-				),
-			};
-		}
-	};
-
-	cancelAndRefund = async ( purchase ) => {
-		const { cancelBundledDomain, translate } = this.props;
-
-		try {
-			await cancelAndRefundPurchaseAsync( purchase.id, {
-				product_id: purchase.productId,
-				cancel_bundled_domain: cancelBundledDomain ? 1 : 0,
-			} );
-
-			return {
-				success: true,
-				message: translate( 'Your refund has been processed and your purchase removed.' ),
-			};
-		} catch ( error ) {
-			return { success: false, error: error.message };
-		}
 	};
 
 	downgradeClick = ( upsell ) => {
@@ -220,7 +126,7 @@ class CancelPurchaseButton extends Component {
 				this.setDisabled( false );
 
 				if ( error ) {
-					this.cancellationFailed( error.message );
+					this.props.errorNotice( error.message );
 					return;
 				}
 
@@ -246,7 +152,7 @@ class CancelPurchaseButton extends Component {
 				page.redirect( this.props.purchaseListUrl );
 			}
 		} catch ( err ) {
-			this.cancellationFailed( err.message );
+			this.props.errorNotice( err.message );
 		} finally {
 			this.setDisabled( false );
 		}
@@ -262,96 +168,6 @@ class CancelPurchaseButton extends Component {
 		this.setState( {
 			isShowingMarketplaceSubscriptionsDialog: true,
 		} );
-	};
-
-	submitCancelAndRefundPurchase = async () => {
-		const { purchase } = this.props;
-		const refundable = hasAmountAvailableToRefund( purchase );
-
-		if ( refundable ) {
-			return await this.cancelAndRefund( purchase );
-		}
-		return await this.cancelPurchase( purchase );
-	};
-
-	handleMarketplaceSubscriptions = async ( isPlanRefundable ) => {
-		if ( this.shouldHandleMarketplaceSubscriptions() ) {
-			return Promise.all(
-				this.props.activeSubscriptions.map( async ( s ) => {
-					if ( isPlanRefundable && hasAmountAvailableToRefund( s ) ) {
-						await this.cancelAndRefund( s );
-					} else {
-						await this.cancelPurchase( s );
-					}
-				} )
-			);
-		}
-	};
-
-	handleSurveyComplete = () => {
-		// Handle success flow after survey completion
-		if ( this.props.cancellationCompleted ) {
-			this.props.refreshSitePlans( this.props.purchase.siteId );
-			this.props.clearPurchases();
-
-			// Show success notice after survey completion using the API response message
-			if ( this.props.cancellationMessage ) {
-				this.props.successNotice( this.props.cancellationMessage, {
-					displayOnNextPage: true,
-					duration: 10000,
-				} );
-			}
-		}
-
-		// Close dialog and redirect after handling the completion
-		this.closeDialog();
-	};
-
-	performCancellation = async () => {
-		const { purchase, onCancellationComplete, onCancellationStart, onSetLoading } = this.props;
-
-		// Set loading state if callback is provided
-		if ( onSetLoading ) {
-			onSetLoading( true );
-		}
-
-		// Notify parent that cancellation is starting (for loading state)
-		// Only call if onCancellationStart is provided and not null
-		if ( onCancellationStart ) {
-			onCancellationStart();
-		}
-
-		try {
-			const result = await this.submitCancelAndRefundPurchase();
-
-			if ( result.success ) {
-				// Handle marketplace subscriptions if any
-				const refundable = hasAmountAvailableToRefund( purchase );
-				await this.handleMarketplaceSubscriptions( refundable );
-
-				// Always call the callback to notify the parent component
-				if ( onCancellationComplete ) {
-					onCancellationComplete( result.message );
-				}
-			} else {
-				this.cancellationFailed( result.error );
-			}
-		} catch ( error ) {
-			this.cancellationFailed( error.message );
-		}
-	};
-
-	cancellationFailed = ( errorMessage ) => {
-		// Reset loading state using parent callback
-		if ( this.props.onSetLoading ) {
-			this.props.onSetLoading( false );
-		}
-
-		if ( this.props.onSurveyComplete ) {
-			this.props.onSurveyComplete();
-		}
-
-		this.props.errorNotice( errorMessage );
 	};
 
 	render() {
@@ -384,16 +200,8 @@ class CancelPurchaseButton extends Component {
 		} )();
 
 		const disableButtons = this.state.disabled || this.props.disabled;
-		const {
-			isJetpack,
-			isAkismet,
-			purchaseListUrl,
-			activeSubscriptions,
-			isLoading,
-			showDialog,
-			cancellationCompleted,
-			cancellationMessage,
-		} = this.props;
+		const { isJetpack, isAkismet, purchaseListUrl, activeSubscriptions, isLoading, showDialog } =
+			this.props;
 
 		const planName = getName( purchase );
 
@@ -424,8 +232,6 @@ class CancelPurchaseButton extends Component {
 						flowType={ getPurchaseCancellationFlowType( purchase ) }
 						cancelBundledDomain={ cancelBundledDomain }
 						includedDomainPurchase={ includedDomainPurchase }
-						cancellationCompleted={ cancellationCompleted }
-						cancellationMessage={ cancellationMessage }
 						cancellationInProgress={ isLoading }
 					/>
 				) }
@@ -440,8 +246,6 @@ class CancelPurchaseButton extends Component {
 						onSurveyComplete={ this.handleSurveyComplete }
 						flowType={ getPurchaseCancellationFlowType( purchase ) }
 						isAkismet={ isAkismet }
-						cancellationCompleted={ cancellationCompleted }
-						cancellationMessage={ cancellationMessage }
 						cancellationInProgress={ isLoading }
 					/>
 				) }
@@ -454,8 +258,6 @@ class CancelPurchaseButton extends Component {
 						isVisible={ showDialog }
 						onClose={ this.closeDialog }
 						onSurveyComplete={ this.handleSurveyComplete }
-						cancellationCompleted={ cancellationCompleted }
-						cancellationMessage={ cancellationMessage }
 						cancellationInProgress={ isLoading }
 					/>
 				) }

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -113,6 +113,16 @@ class CancelPurchaseButton extends Component {
 		} );
 	};
 
+	handleMarketplaceDialogContinue = () => {
+		// Close the marketplace dialog
+		this.setState( {
+			isShowingMarketplaceSubscriptionsDialog: false,
+		} );
+
+		// Show the appropriate survey based on purchase type
+		this.handleCancelPurchaseClick();
+	};
+
 	handleSurveyComplete = () => {
 		// Call the parent's survey complete handler
 		if ( this.props.onSurveyComplete ) {
@@ -216,7 +226,7 @@ class CancelPurchaseButton extends Component {
 					<MarketPlaceSubscriptionsDialog
 						isDialogVisible={ this.state.isShowingMarketplaceSubscriptionsDialog }
 						closeDialog={ this.closeDialog }
-						removePlan={ this.props.onSurveyComplete }
+						removePlan={ this.handleMarketplaceDialogContinue }
 						planName={ planName }
 						activeSubscriptions={ activeSubscriptions }
 						sectionHeadingText={ translate( 'Cancel %(plan)s', {

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -75,7 +75,7 @@ class CancelPurchaseButton extends Component {
 		// If onCancellationStart is null, we're already in the domain options step
 		if ( this.props.onCancellationStart === null ) {
 			// We're in the domain options step, show survey directly
-			this.props.onCancellationStart();
+			this.props.onCancellationComplete();
 		} else {
 			const needsDomainOptionsStep =
 				this.props.includedDomainPurchase &&

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -243,7 +243,7 @@ class CancelPurchaseButton extends Component {
 						purchaseListUrl={ purchaseListUrl }
 						isVisible={ showDialog }
 						onClose={ this.closeDialog }
-						onSurveyComplete={ this.handleSurveyComplete }
+						onSurveyComplete={ this.props.onSurveyComplete }
 						flowType={ getPurchaseCancellationFlowType( purchase ) }
 						isAkismet={ isAkismet }
 						cancellationInProgress={ isLoading }
@@ -257,7 +257,7 @@ class CancelPurchaseButton extends Component {
 						purchaseListUrl={ purchaseListUrl }
 						isVisible={ showDialog }
 						onClose={ this.closeDialog }
-						onSurveyComplete={ this.handleSurveyComplete }
+						onSurveyComplete={ this.props.onSurveyComplete }
 						cancellationInProgress={ isLoading }
 					/>
 				) }
@@ -266,7 +266,7 @@ class CancelPurchaseButton extends Component {
 					<MarketPlaceSubscriptionsDialog
 						isDialogVisible={ this.state.isShowingMarketplaceSubscriptionsDialog }
 						closeDialog={ this.closeDialog }
-						removePlan={ this.handleSurveyComplete }
+						removePlan={ this.props.onSurveyComplete }
 						planName={ planName }
 						activeSubscriptions={ activeSubscriptions }
 						sectionHeadingText={ translate( 'Cancel %(plan)s', {

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -113,6 +113,13 @@ class CancelPurchaseButton extends Component {
 		} );
 	};
 
+	handleSurveyComplete = () => {
+		// Call the parent's survey complete handler
+		if ( this.props.onSurveyComplete ) {
+			this.props.onSurveyComplete();
+		}
+	};
+
 	render() {
 		const { purchase, translate, cancelBundledDomain, includedDomainPurchase } = this.props;
 

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -48,10 +48,13 @@ class CancelPurchaseButton extends Component {
 		// Methods from parent component
 		downgradeClick: PropTypes.func,
 		freeMonthOfferClick: PropTypes.func,
+		// Control marketplace dialog visibility
+		showMarketplaceDialog: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		purchaseListUrl: purchasesRoot,
+		showMarketplaceDialog: true,
 	};
 
 	state = {
@@ -102,9 +105,9 @@ class CancelPurchaseButton extends Component {
 	};
 
 	shouldHandleMarketplaceSubscriptions() {
-		const { activeSubscriptions } = this.props;
+		const { activeSubscriptions, showMarketplaceDialog } = this.props;
 
-		return activeSubscriptions?.length > 0;
+		return activeSubscriptions?.length > 0 && showMarketplaceDialog;
 	}
 
 	showMarketplaceDialog = () => {

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -265,6 +265,9 @@ class CancelPurchase extends Component {
 	};
 
 	onSurveyComplete = async () => {
+		// Set loading state to show busy button
+		this.setState( { isLoading: true } );
+
 		try {
 			const result = await this.submitCancelAndRefundPurchase( this.props.purchase );
 			if ( result.success ) {
@@ -279,8 +282,10 @@ class CancelPurchase extends Component {
 			}
 		} catch ( error ) {
 			this.props.errorNotice( error.message );
+		} finally {
+			// Reset loading state
+			this.setState( { surveyShown: false, isLoading: false } );
 		}
-		this.setState( { surveyShown: false, isLoading: false } );
 	};
 
 	onDialogClose = () => {

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -158,7 +158,13 @@ class CancelPurchase extends Component {
 	};
 
 	onCancellationStart = () => {
-		const { includedDomainPurchase, purchase } = this.props;
+		const { includedDomainPurchase, purchase, isJetpack, isAkismet } = this.props;
+
+		// For Jetpack/Akismet products, call onCancellationComplete to show the dialog
+		if ( isJetpack || isAkismet ) {
+			this.onCancellationComplete();
+			return;
+		}
 
 		// Only show domain options as a separate step if radio buttons will be displayed
 		if (
@@ -721,17 +727,19 @@ class CancelPurchase extends Component {
 
 		return (
 			<>
-				<CancelPurchaseForm
-					disableButtons={ this.state.isLoading }
-					purchase={ purchase }
-					isVisible={ this.state.surveyShown }
-					onClose={ () => this.setState( { surveyShown: false } ) }
-					onSurveyComplete={ this.onSurveyComplete }
-					flowType={ getPurchaseCancellationFlowType( purchase ) }
-					cancelBundledDomain={ this.state.cancelBundledDomain }
-					includedDomainPurchase={ this.props.includedDomainPurchase }
-					cancellationInProgress={ this.state.isLoading }
-				/>
+				{ ! this.props.isJetpack && ! this.props.isAkismet && (
+					<CancelPurchaseForm
+						disableButtons={ this.state.isLoading }
+						purchase={ purchase }
+						isVisible={ this.state.surveyShown }
+						onClose={ () => this.setState( { surveyShown: false } ) }
+						onSurveyComplete={ this.onSurveyComplete }
+						flowType={ getPurchaseCancellationFlowType( purchase ) }
+						cancelBundledDomain={ this.state.cancelBundledDomain }
+						includedDomainPurchase={ this.props.includedDomainPurchase }
+						cancellationInProgress={ this.state.isLoading }
+					/>
+				) }
 				<Card className="cancel-purchase__wrapper-card">
 					<QueryProductsList />
 					<TrackPurchasePageView

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -34,6 +34,7 @@ import {
 	isRefundable,
 	isSubscription,
 } from 'calypso/lib/purchases';
+import { cancelPurchaseAsync, cancelAndRefundPurchaseAsync } from 'calypso/lib/purchases/actions';
 import { getPurchaseCancellationFlowType } from 'calypso/lib/purchases/utils';
 import CancelPurchaseLoadingPlaceholder from 'calypso/me/purchases/cancel-purchase/loading-placeholder';
 import { managePurchase, purchasesRoot } from 'calypso/me/purchases/paths';
@@ -90,8 +91,6 @@ class CancelPurchase extends Component {
 		showDomainOptionsStep: false,
 		// Cancellation state moved from button component
 		showDialog: false,
-		cancellationCompleted: false,
-		cancellationMessage: '',
 	};
 
 	static defaultProps = {
@@ -168,47 +167,119 @@ class CancelPurchase extends Component {
 		) {
 			this.setState( { showDomainOptionsStep: true } );
 		} else {
-			// For direct cancellations (no domain options step), set loading state
-			this.setState( { isLoading: true } );
+			// For direct cancellations (no domain options step), show survey directly
+			this.setState( { surveyShown: true } );
 		}
 	};
 
 	onDomainOptionsComplete = ( domainOptions ) => {
 		this.setState( {
 			showDomainOptionsStep: false,
-			isLoading: true,
+			surveyShown: true,
 			cancelBundledDomain: domainOptions.cancelBundledDomain,
 			confirmCancelBundledDomain: domainOptions.confirmCancelBundledDomain,
 		} );
-		// Don't show survey yet - wait for cancellation to complete
 	};
 
-	onSurveyComplete = () => {
-		// Handle success flow after survey completion
-		if ( this.state.cancellationCompleted ) {
-			// Refresh data and show success notice
-			this.props.refreshSitePlans( this.props.purchase.siteId );
-			this.props.clearPurchases();
-
-			if ( this.state.cancellationMessage ) {
-				this.props.successNotice( this.state.cancellationMessage, {
-					displayOnNextPage: true,
-					duration: 10000,
-				} );
+	// --- Robust cancellation logic moved from button.jsx ---
+	cancelPurchase = async ( purchase ) => {
+		const { translate, moment } = this.props;
+		try {
+			const success = await cancelPurchaseAsync( purchase.id );
+			if ( success ) {
+				const purchaseName = getName( purchase );
+				const subscriptionEndDate = moment( purchase.expiryDate ).format( 'LL' );
+				return {
+					success: true,
+					message: translate(
+						'%(purchaseName)s was successfully cancelled. It will be available for use until it expires on %(subscriptionEndDate)s.',
+						{
+							args: { purchaseName, subscriptionEndDate },
+						}
+					),
+				};
 			}
-
-			// Redirect to purchases page
-			page.redirect( this.props.purchaseListUrl );
+			return {
+				success: false,
+				error: translate(
+					'There was a problem canceling %(purchaseName)s. Please try again later or contact support.',
+					{ args: { purchaseName: getName( purchase ) } }
+				),
+			};
+		} catch ( error ) {
+			return {
+				success: false,
+				error: translate(
+					'There was a problem canceling %(purchaseName)s. Please try again later or contact support.',
+					{ args: { purchaseName: getName( purchase ) } }
+				),
+			};
 		}
+	};
 
+	cancelAndRefund = async ( purchase ) => {
+		const { cancelBundledDomain } = this.state;
+		try {
+			await cancelAndRefundPurchaseAsync( purchase.id, {
+				product_id: purchase.productId,
+				cancel_bundled_domain: cancelBundledDomain ? 1 : 0,
+			} );
+			return {
+				success: true,
+				message: this.props.translate(
+					'Your refund has been processed and your purchase removed.'
+				),
+			};
+		} catch ( error ) {
+			return { success: false, error: error.message };
+		}
+	};
+
+	submitCancelAndRefundPurchase = async ( purchase ) => {
+		const refundable = hasAmountAvailableToRefund( purchase );
+		if ( refundable ) {
+			return await this.cancelAndRefund( purchase );
+		}
+		return await this.cancelPurchase( purchase );
+	};
+
+	handleMarketplaceSubscriptions = async ( isPlanRefundable ) => {
+		const activeSubscriptions = this.getActiveMarketplaceSubscriptions();
+		if ( activeSubscriptions?.length > 0 ) {
+			return Promise.all(
+				activeSubscriptions.map( async ( s ) => {
+					if ( isPlanRefundable && hasAmountAvailableToRefund( s ) ) {
+						await this.cancelAndRefund( s );
+					} else {
+						await this.cancelPurchase( s );
+					}
+				} )
+			);
+		}
+	};
+
+	onSurveyComplete = async () => {
+		try {
+			const result = await this.submitCancelAndRefundPurchase( this.props.purchase );
+			if ( result.success ) {
+				const refundable = hasAmountAvailableToRefund( this.props.purchase );
+				await this.handleMarketplaceSubscriptions( refundable );
+				this.props.refreshSitePlans( this.props.purchase.siteId );
+				this.props.clearPurchases();
+				this.props.successNotice( result.message, { displayOnNextPage: true, duration: 10000 } );
+				page.redirect( this.props.purchaseListUrl );
+			} else {
+				this.props.errorNotice( result.error );
+			}
+		} catch ( error ) {
+			this.props.errorNotice( error.message );
+		}
 		this.setState( { surveyShown: false, isLoading: false } );
 	};
 
 	onDialogClose = () => {
 		this.setState( {
 			showDialog: false,
-			cancellationCompleted: false,
-			cancellationMessage: '',
 			isLoading: false,
 		} );
 	};
@@ -217,24 +288,20 @@ class CancelPurchase extends Component {
 		this.setState( { isLoading } );
 	};
 
-	onCancellationComplete = ( message ) => {
-		const { isJetpack, isAkismet, purchase } = this.props;
+	onCancellationComplete = () => {
+		const { isJetpack, isAkismet } = this.props;
 
-		// For Jetpack/Akismet products and domain registrations, show the button's own dialog
-		// For other products, show the main component's survey
-		if ( isJetpack || isAkismet || isDomainRegistration( purchase ) ) {
+		// For Jetpack/Akismet products, show the button's own dialog
+		// For all other products (including domain registrations), show the main component's survey
+		if ( isJetpack || isAkismet ) {
 			this.setState( {
 				showDialog: true,
 				isLoading: false,
-				cancellationCompleted: true,
-				cancellationMessage: message,
 			} );
 		} else {
 			this.setState( {
 				surveyShown: true,
 				isLoading: false,
-				cancellationCompleted: true,
-				cancellationMessage: message,
 			} );
 		}
 	};
@@ -418,8 +485,6 @@ class CancelPurchase extends Component {
 				moment={ this.props.moment }
 				// Cancellation state props
 				showDialog={ this.state.showDialog }
-				cancellationCompleted={ this.state.cancellationCompleted }
-				cancellationMessage={ this.state.cancellationMessage }
 				isLoading={ this.state.isLoading }
 				onDialogClose={ this.onDialogClose }
 				onSetLoading={ this.onSetLoading }
@@ -607,8 +672,6 @@ class CancelPurchase extends Component {
 						onCancellationStart={ null }
 						// Cancellation state props
 						showDialog={ this.state.showDialog }
-						cancellationCompleted={ this.state.cancellationCompleted }
-						cancellationMessage={ this.state.cancellationMessage }
 						isLoading={ this.state.isLoading }
 						onDialogClose={ this.onDialogClose }
 						onSetLoading={ this.onSetLoading }
@@ -667,8 +730,6 @@ class CancelPurchase extends Component {
 					flowType={ getPurchaseCancellationFlowType( purchase ) }
 					cancelBundledDomain={ this.state.cancelBundledDomain }
 					includedDomainPurchase={ this.props.includedDomainPurchase }
-					cancellationCompleted={ this.state.cancellationCompleted }
-					cancellationMessage={ this.state.cancellationMessage }
 					cancellationInProgress={ this.state.isLoading }
 				/>
 				<Card className="cancel-purchase__wrapper-card">

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -751,6 +751,8 @@ class CancelPurchase extends Component {
 						onSetLoading={ this.onSetLoading }
 						downgradeClick={ this.downgradeClick }
 						freeMonthOfferClick={ this.freeMonthOfferClick }
+						// Disable marketplace dialog in domain options step to prevent double display
+						showMarketplaceDialog={ false }
 					/>
 					{ this.renderKeepSubscriptionButton() }
 				</div>

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -165,10 +165,11 @@ class CancelPurchase extends Component {
 	};
 
 	onCancellationStart = () => {
-		const { includedDomainPurchase, purchase, isJetpack, isAkismet } = this.props;
+		const { includedDomainPurchase, purchase, isJetpack, isAkismet, isDomainRegistrationPurchase } =
+			this.props;
 
-		// For Jetpack/Akismet products, call onCancellationComplete to show the dialog
-		if ( isJetpack || isAkismet ) {
+		// For Jetpack/Akismet products and domain registrations, call onCancellationComplete to show the dialog
+		if ( isJetpack || isAkismet || isDomainRegistrationPurchase ) {
 			this.onCancellationComplete();
 			return;
 		}
@@ -306,11 +307,11 @@ class CancelPurchase extends Component {
 	};
 
 	onCancellationComplete = () => {
-		const { isJetpack, isAkismet } = this.props;
+		const { isJetpack, isAkismet, isDomainRegistrationPurchase } = this.props;
 
-		// For Jetpack/Akismet products, show the button's own dialog
-		// For all other products (including domain registrations), show the main component's survey
-		if ( isJetpack || isAkismet ) {
+		// For Jetpack/Akismet products and domain registrations, show the button's own dialog
+		// For all other products, show the main component's survey
+		if ( isJetpack || isAkismet || isDomainRegistrationPurchase ) {
 			this.setState( {
 				showDialog: true,
 				isLoading: false,
@@ -526,6 +527,7 @@ class CancelPurchase extends Component {
 			siteSlug,
 			purchaseListUrl,
 			getConfirmCancelDomainUrlFor,
+			isDomainRegistrationPurchase,
 		} = this.props;
 
 		// Check if we need atomic revert confirmation
@@ -537,7 +539,7 @@ class CancelPurchase extends Component {
 			( needsAtomicRevertConfirmation &&
 				! this.state.atomicRevertConfirmed &&
 				isPlan( purchase ) ) ||
-			( isDomainRegistration( purchase ) && ! this.state.domainConfirmationConfirmed );
+			( isDomainRegistrationPurchase && ! this.state.domainConfirmationConfirmed );
 
 		return (
 			<CancelPurchaseButton
@@ -628,7 +630,7 @@ class CancelPurchase extends Component {
 	};
 
 	renderProductRevertContent = () => {
-		const { purchase } = this.props;
+		const { purchase, isDomainRegistrationPurchase } = this.props;
 		const purchaseName = getName( purchase );
 		const plan = getPlan( purchase?.productSlug );
 		const planDescription = plan?.getPlanCancellationDescription?.();
@@ -645,7 +647,7 @@ class CancelPurchase extends Component {
 				</CompactCard>
 
 				<CompactCard className="cancel-purchase__footer">
-					{ isDomainRegistration( purchase ) && (
+					{ isDomainRegistrationPurchase && (
 						<div className="cancel-purchase__domain-confirmation">
 							<FormCheckbox
 								checked={ this.state.domainConfirmationConfirmed }
@@ -775,7 +777,7 @@ class CancelPurchase extends Component {
 			return null;
 		}
 
-		const { purchase } = this.props;
+		const { purchase, isJetpack, isAkismet, isDomainRegistrationPurchase } = this.props;
 		const purchaseName = getName( purchase );
 		const { siteName, siteId } = purchase;
 
@@ -795,7 +797,7 @@ class CancelPurchase extends Component {
 
 		return (
 			<>
-				{ ! this.props.isJetpack && ! this.props.isAkismet && (
+				{ ! isJetpack && ! isAkismet && ! isDomainRegistrationPurchase && (
 					<CancelPurchaseForm
 						disableButtons={ this.state.isLoading }
 						purchase={ purchase }
@@ -873,6 +875,7 @@ export default connect(
 			isJetpackPurchase,
 			isJetpack: purchase && ( isJetpackPlan( purchase ) || isJetpackProduct( purchase ) ),
 			isAkismet: purchase && isAkismetProduct( purchase ),
+			isDomainRegistrationPurchase: purchase && isDomainRegistration( purchase ),
 			purchase,
 			purchases,
 			productsList,

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -187,7 +187,6 @@ class CancelPurchase extends Component {
 		} );
 	};
 
-	// --- Robust cancellation logic moved from button.jsx ---
 	cancelPurchase = async ( purchase ) => {
 		const { translate, moment } = this.props;
 		try {

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -7,6 +7,7 @@ import {
 	isJetpackProduct,
 	isAkismetProduct,
 	getPlan,
+	getMonthlyPlanByYearly,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Card, CompactCard } from '@automattic/components';
@@ -34,7 +35,12 @@ import {
 	isRefundable,
 	isSubscription,
 } from 'calypso/lib/purchases';
-import { cancelPurchaseAsync, cancelAndRefundPurchaseAsync } from 'calypso/lib/purchases/actions';
+import {
+	cancelPurchaseAsync,
+	cancelAndRefundPurchaseAsync,
+	cancelAndRefundPurchase,
+	extendPurchaseWithFreeMonth,
+} from 'calypso/lib/purchases/actions';
 import { getPurchaseCancellationFlowType } from 'calypso/lib/purchases/utils';
 import CancelPurchaseLoadingPlaceholder from 'calypso/me/purchases/cancel-purchase/loading-placeholder';
 import { managePurchase, purchasesRoot } from 'calypso/me/purchases/paths';
@@ -43,7 +49,7 @@ import PurchaseSiteHeader from 'calypso/me/purchases/purchases-site/header';
 import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
 import { isDataLoading } from 'calypso/me/purchases/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { successNotice } from 'calypso/state/notices/actions';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import { clearPurchases } from 'calypso/state/purchases/actions';
 import {
@@ -51,6 +57,7 @@ import {
 	getSitePurchases,
 	hasLoadedUserPurchasesFromServer,
 	getIncludedDomainPurchase,
+	getDowngradePlanFromPurchase,
 } from 'calypso/state/purchases/selectors';
 import getAtomicTransfer from 'calypso/state/selectors/get-atomic-transfer';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
@@ -316,6 +323,59 @@ class CancelPurchase extends Component {
 		}
 	};
 
+	downgradeClick = ( upsell ) => {
+		const { purchase } = this.props;
+		let downgradePlan = getDowngradePlanFromPurchase( purchase );
+		if ( 'downgrade-monthly' === upsell ) {
+			const monthlyProductSlug = getMonthlyPlanByYearly( purchase.productSlug );
+			downgradePlan = getPlan( monthlyProductSlug );
+		}
+
+		this.setState( { isLoading: true } );
+
+		cancelAndRefundPurchase(
+			purchase.id,
+			{
+				product_id: purchase.productId,
+				type: 'downgrade',
+				to_product_id: downgradePlan.getProductId(),
+			},
+			( error, response ) => {
+				this.setState( { isLoading: false } );
+
+				if ( error ) {
+					this.props.errorNotice( error.message );
+					return;
+				}
+
+				this.props.refreshSitePlans( purchase.siteId );
+				this.props.clearPurchases();
+				this.props.successNotice( response.message, { displayOnNextPage: true } );
+				page.redirect( this.props.purchaseListUrl );
+			}
+		);
+	};
+
+	freeMonthOfferClick = async () => {
+		const { purchase } = this.props;
+
+		this.setState( { isLoading: true } );
+
+		try {
+			const res = await extendPurchaseWithFreeMonth( purchase.id );
+			if ( res.status === 'completed' ) {
+				this.props.refreshSitePlans( purchase.siteId );
+				this.props.clearPurchases();
+				this.props.successNotice( res.message, { displayOnNextPage: true } );
+				page.redirect( this.props.purchaseListUrl );
+			}
+		} catch ( err ) {
+			this.props.errorNotice( err.message );
+		} finally {
+			this.setState( { isLoading: false } );
+		}
+	};
+
 	onAtomicRevertConfirmationChange = ( isConfirmed ) => {
 		this.setState( { atomicRevertConfirmed: isConfirmed } );
 	};
@@ -498,6 +558,8 @@ class CancelPurchase extends Component {
 				isLoading={ this.state.isLoading }
 				onDialogClose={ this.onDialogClose }
 				onSetLoading={ this.onSetLoading }
+				downgradeClick={ this.downgradeClick }
+				freeMonthOfferClick={ this.freeMonthOfferClick }
 			/>
 		);
 	};
@@ -685,6 +747,8 @@ class CancelPurchase extends Component {
 						isLoading={ this.state.isLoading }
 						onDialogClose={ this.onDialogClose }
 						onSetLoading={ this.onSetLoading }
+						downgradeClick={ this.downgradeClick }
+						freeMonthOfferClick={ this.freeMonthOfferClick }
 					/>
 					{ this.renderKeepSubscriptionButton() }
 				</div>
@@ -742,6 +806,8 @@ class CancelPurchase extends Component {
 						cancelBundledDomain={ this.state.cancelBundledDomain }
 						includedDomainPurchase={ this.props.includedDomainPurchase }
 						cancellationInProgress={ this.state.isLoading }
+						downgradeClick={ this.downgradeClick }
+						freeMonthOfferClick={ this.freeMonthOfferClick }
 					/>
 				) }
 				<Card className="cancel-purchase__wrapper-card">
@@ -816,5 +882,5 @@ export default connect(
 			atomicTransfer: getAtomicTransfer( state, purchase?.siteId ),
 		};
 	},
-	{ recordTracksEvent, clearPurchases, refreshSitePlans, successNotice }
+	{ recordTracksEvent, clearPurchases, refreshSitePlans, successNotice, errorNotice }
 )( localize( withLocalizedMoment( CancelPurchase ) ) );

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
@@ -14,6 +14,8 @@ import {
 	PurchasesPage,
 	MyProfilePage,
 	MeSidebarComponent,
+	cancelSubscriptionFlow,
+	cancelAtomicPurchaseFlow,
 	WPAdminSidebarComponent,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
@@ -117,11 +119,15 @@ describe(
 				await meSidebarComponent.navigate( 'Purchases' );
 			} );
 
-			it( 'View details of purchased add-on and cancel add-on renewal', async function () {
+			it( 'View details of purchased add-on', async function () {
 				purchasesPage = new PurchasesPage( page );
 
 				await purchasesPage.clickOnPurchase( 'Storage Add-On Space Upgrade 50 GB', siteSlug );
 				await purchasesPage.cancelPurchase( 'Cancel subscription' );
+			} );
+
+			it( 'Cancel add-on renewal', async function () {
+				await cancelSubscriptionFlow( page );
 
 				noticeComponent = new NoticeComponent( page );
 				await noticeComponent.noticeShown(
@@ -151,6 +157,13 @@ describe(
 
 				await purchasesPage.clickOnPurchase( `WordPress.com ${ planName }`, siteSlug );
 				await purchasesPage.cancelPurchase( 'Cancel plan' );
+			} );
+
+			it( 'Cancel plan renewal', async function () {
+				await cancelAtomicPurchaseFlow( page, {
+					reason: 'Another reason…',
+					customReasonText: 'E2E TEST CANCELLATION',
+				} );
 
 				noticeComponent = new NoticeComponent( page );
 				await noticeComponent.noticeShown(

--- a/test/e2e/specs/onboarding/signup__with-theme-premium.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-premium.ts
@@ -19,6 +19,7 @@ import {
 	PurchasesPage,
 	ThemesDetailPage,
 	ThemesPage,
+	cancelAtomicPurchaseFlow,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { apiCloseAccount } from '../shared';
@@ -149,6 +150,10 @@ describe( 'Lifecyle: Premium theme signup, onboard, launch and cancel subscripti
 				newSiteDetails.blog_details.site_slug
 			);
 			await purchasesPage.cancelPurchase( 'Cancel plan' );
+			await cancelAtomicPurchaseFlow( page, {
+				reason: 'Another reason…',
+				customReasonText: 'E2E TEST CANCELLATION',
+			} );
 			noticeComponent = new NoticeComponent( page );
 			await noticeComponent.noticeShown(
 				'Your refund has been processed and your purchase removed.',


### PR DESCRIPTION
This change comes with two updated e2e tests that failed during the pre-release checks, attempt 2

Part of DOTCOM-13834

## Proposed Changes

* It was decided that the cancel api calls should go back to the end of the survey again
* This will happen without reverting the last 5-6 PRs and preserving most of the changes done in them, like removing unrelated steps
* It restores the cancellation solutions to the state from right before, including the downgrade Premium to Personal
* It introduces a Skip button that skips the survey and goes straight to cancellation

## Why are these changes being made?

* Part of the broader Cancel Survey redesign + regulation requirements

## Testing Instructions

You have to test each one of the following
* Get a plan without a domain
* Get a plan with a domain
* Get a domain without a plan
* Buy an add-on like space
* Get Jetpack Boost or another Jetpack/Akismet upgrade

Then go ahead and cancel them.

For the plan+domain, go over the cancellation solutions one by one and see if they match your expectations

Highlights:
* With an annual Premium plan, selecting too expensive gives you the downgrade to Personal option
* With an annual Personal plan, selecting too expensive gives you a downgrade to monthly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

