### PR TITLE
Add new component with a button for filter reset

### DIFF
--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -5,6 +5,7 @@ import {
 	DomainSearch,
 	DomainSearchNotice,
 	DomainSuggestionLoadMore,
+	DomainSuggestionFilterReset,
 } from '@automattic/domain-search';
 import { formatCurrency } from '@automattic/number-formatters';
 import {
@@ -63,7 +64,6 @@ import {
 	isMissingVendor,
 	markFeaturedSuggestions,
 } from 'calypso/components/domains/register-domain-step/utility';
-import { FilterResetNotice } from 'calypso/components/domains/search-filters';
 import TrademarkClaimsNotice from 'calypso/components/domains/trademark-claims-notice';
 import { getDomainsInCart, hasDomainInCart } from 'calypso/lib/cart-values/cart-items';
 import {
@@ -743,13 +743,24 @@ class RegisterDomainStep extends Component {
 	}
 
 	renderFilterResetNotice() {
+		const { exactSldMatchesOnly = false, tlds = [] } = this.state.lastFilters;
+		const hasActiveFilters = exactSldMatchesOnly || tlds.length > 0;
+
+		const suggestions = this.state.searchResults;
+		const hasTooFewSuggestions = Array.isArray( suggestions ) && suggestions.length < 10;
+
+		if ( ! ( hasActiveFilters && hasTooFewSuggestions ) ) {
+			return null;
+		}
+
+		const onClickHandle = () => {
+			this.onFiltersReset( 'tlds', 'exactSldMatchesOnly' );
+		};
+
 		return (
-			<FilterResetNotice
-				className="register-domain-step__filter-reset-notice"
-				isLoading={ this.state.loadingResults }
-				lastFilters={ this.state.lastFilters }
-				onReset={ this.onFiltersReset }
-				suggestions={ this.state.searchResults }
+			<DomainSuggestionFilterReset
+				disabled={ this.state.loadingResults }
+				onClick={ onClickHandle }
 			/>
 		);
 	}

--- a/packages/domain-search/src/components/domain-suggestion-filter-reset/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-filter-reset/index.tsx
@@ -14,7 +14,7 @@ export const DomainSuggestionFilterReset = ( props: ComponentProps< typeof Butto
 			variant="secondary"
 			__next40pxDefaultSize
 		>
-			{ __( 'Click here to disable filters for more results' ) }
+			{ __( 'Disable filters' ) }
 		</Button>
 	);
 };

--- a/packages/domain-search/src/components/domain-suggestion-filter-reset/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-filter-reset/index.tsx
@@ -1,0 +1,20 @@
+import { Button } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
+import type { ComponentProps } from 'react';
+
+import './style.scss';
+
+export const DomainSuggestionFilterReset = ( props: ComponentProps< typeof Button > ) => {
+	const { __ } = useI18n();
+
+	return (
+		<Button
+			{ ...props }
+			className="domain-suggestion-filter-reset__btn"
+			variant="secondary"
+			__next40pxDefaultSize
+		>
+			{ __( 'Click here to disable filters for more results' ) }
+		</Button>
+	);
+};

--- a/packages/domain-search/src/components/domain-suggestion-filter-reset/style.scss
+++ b/packages/domain-search/src/components/domain-suggestion-filter-reset/style.scss
@@ -1,0 +1,8 @@
+@import '@wordpress/base-styles/colors';
+
+.domain-suggestion-filter-reset__btn {
+	&.is-secondary {
+		color: var(--domain-search-secondary-action-color);
+		box-shadow: inset 0 0 0 1px #{$gray-300};
+	}
+}

--- a/packages/domain-search/src/index.ts
+++ b/packages/domain-search/src/index.ts
@@ -8,6 +8,7 @@ export { DomainSuggestion } from './components/domain-suggestion';
 export { DomainSuggestionBadge } from './components/domain-suggestion-badge';
 export { DomainSuggestionPrice } from './components/domain-suggestion-price';
 export { DomainSuggestionLoadMore } from './components/domain-suggestion-load-more';
+export { DomainSuggestionFilterReset } from './components/domain-suggestion-filter-reset';
 export * as DomainSearchControls from './components/domain-search-controls';
 
 export { useContainerQuery } from './hooks/use-container-query';


### PR DESCRIPTION
Change the disable filters notice to use the same design (button) as next page

Part of [DOMAINS-1553: Redesign 'remove filters' button](https://linear.app/a8c/issue/DOMAINS-1553/redesign-remove-filters-button)

This is how it looks:
<img width="1164" height="636" alt="Screenshot 2025-07-21 at 15 47 48" src="https://github.com/user-attachments/assets/a8179f30-2795-4341-a975-3b0531241416" />


## Proposed Changes

* Added a new `DomainSuggestionFilterReset` component
* Style it to look like the next page button and fix it to work properly

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We're doing a redesign of the domain suggestion screens

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Search for something then apply a filter (exact match + couple of TLDs) and make sure that the "Disable filters" button renders at the bottom of the suggestions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
