### PR TITLE
Site overview v2: fix unclickable OverviewCard when activating hosting features

### DIFF
--- a/client/dashboard/sites/hosting-feature-gated-with-overview-card/index.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-overview-card/index.tsx
@@ -26,7 +26,6 @@ export default function HostingFeatureGatedWithOverviewCard( {
 		heading: upsellHeading,
 		icon: upsell,
 		description: upsellDescription,
-		tracksId: tracksFeatureId,
 		variant: 'upsell' as const,
 	};
 
@@ -38,6 +37,7 @@ export default function HostingFeatureGatedWithOverviewCard( {
 					{ ...cardProps }
 					title={ __( 'Upgrade to unlock' ) }
 					externalLink={ upsellExternalLink }
+					tracksId={ tracksFeatureId }
 					onClick={ onClick }
 				/>
 			) }
@@ -46,7 +46,6 @@ export default function HostingFeatureGatedWithOverviewCard( {
 					{ ...cardProps }
 					icon={ featureIcon }
 					title={ __( 'Activate to unlock' ) }
-					externalLink=""
 					onClick={ onClick }
 				/>
 			) }

--- a/client/dashboard/sites/overview-card/index.tsx
+++ b/client/dashboard/sites/overview-card/index.tsx
@@ -1,6 +1,7 @@
 import { CircularProgressBar } from '@automattic/components';
 import { Link } from '@tanstack/react-router';
 import {
+	Button,
 	Card,
 	CardBody,
 	__experimentalDivider as Divider,
@@ -128,6 +129,61 @@ export default function OverviewCard( {
 		</HStack>
 	);
 
+	const handleClick = () => {
+		onClick?.();
+
+		if ( tracksId ) {
+			if ( variant === 'upsell' ) {
+				recordTracksEvent( 'calypso_dashboard_upsell_click', {
+					feature: tracksId,
+					type: 'card',
+				} );
+			} else {
+				recordTracksEvent( 'calypso_dashboard_overview_card_click', {
+					type: tracksId,
+					variant,
+				} );
+			}
+		}
+	};
+
+	const renderContent = () => {
+		if ( link ) {
+			return (
+				<Link to={ link } className="dashboard-overview-card__link" onClick={ handleClick }>
+					{ topContent }
+				</Link>
+			);
+		}
+
+		if ( externalLink ) {
+			return (
+				<a
+					href={ externalLink }
+					className="dashboard-overview-card__link"
+					target="_blank"
+					rel="noreferrer"
+					onClick={ handleClick }
+				>
+					{ topContent }
+				</a>
+			);
+		}
+
+		if ( onClick ) {
+			return (
+				<Button
+					className="dashboard-overview-card__link dashboard-overview-card__button"
+					onClick={ handleClick }
+				>
+					{ topContent }
+				</Button>
+			);
+		}
+
+		return topContent;
+	};
+
 	return (
 		<Card
 			className={ clsx( 'dashboard-overview-card', {
@@ -151,39 +207,7 @@ export default function OverviewCard( {
 							properties={ { feature: tracksId, variant } }
 						/>
 					) ) }
-				{ link && (
-					<Link to={ link } className="dashboard-overview-card__link" onClick={ onClick }>
-						{ topContent }
-					</Link>
-				) }
-				{ ! link && externalLink && (
-					<a
-						href={ externalLink }
-						className="dashboard-overview-card__link"
-						target="_blank"
-						rel="noreferrer"
-						onClick={ () => {
-							onClick?.();
-
-							if ( tracksId ) {
-								if ( variant === 'upsell' ) {
-									recordTracksEvent( 'calypso_dashboard_upsell_click', {
-										feature: tracksId,
-										type: 'card',
-									} );
-								} else {
-									recordTracksEvent( 'calypso_dashboard_overview_card_click', {
-										type: tracksId,
-										variant,
-									} );
-								}
-							}
-						} }
-					>
-						{ topContent }
-					</a>
-				) }
-				{ ! link && ! externalLink && topContent }
+				{ renderContent() }
 				{ bottom && (
 					<>
 						<Divider style={ { color: 'var(--dashboard-header__divider-color)' } } />

--- a/client/dashboard/sites/overview-card/style.scss
+++ b/client/dashboard/sites/overview-card/style.scss
@@ -83,9 +83,16 @@
 			.dashboard-overview-card__link-icon {
 				fill: var( --wp-admin-theme-color );
 				background-color: transparent;
-			}	
+			}
 		}
 	}
+}
+
+.dashboard-overview-card__button {
+	height: 100%;
+	width: 100%;
+	padding: 0;
+	text-align: start;
 }
 
 .dashboard-overview-card__description {


### PR DESCRIPTION
Part of DOTDASH-119

Follow-up to:

- https://github.com/Automattic/wp-calypso/pull/104774
- https://github.com/Automattic/wp-calypso/pull/104824#discussion_r2218705098

## Proposed Changes

This PR fixes a bug where the "Activate to unlock" state of OverviewCard can't be clicked:

<img width="681" height="159" alt="image" src="https://github.com/user-attachments/assets/65ad5977-6254-456f-b97e-da7d41cf954d" />

~~I fixed that by allowing the card to render an `<a>` (which calls the `onClick` prop) even though there's no `link` or `externalLink`. So if `onClick` is present but `externalLink` is not, the `href` will be `#`.~~

I fixed that by rendering a `Button` in this case.

## Why are these changes being made?

Fixes a bug.

## Testing Instructions

1. Purchase a Business plan for a site.
2. Don't activate hosting features yet.
3. Go to `/v2/sites/:siteSlug`
4. Verify you see the above cards.
5. Verify you can click the cards and you can go through the hosting feature activation flow.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
