### PR TITLE
Revert "Enable Sites List backport in all envs (#104820)"

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -50,7 +50,7 @@
 		"current-site/notice": true,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-settings": true,
-		"dashboard/v2/backport/sites-list": true,
+		"dashboard/v2/backport/sites-list": false,
 		"design-picker/use-assembler-styles": true,
 		"dev/account-settings-helper": true,
 		"dev/auth-helper": true,

--- a/config/production.json
+++ b/config/production.json
@@ -39,7 +39,7 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"dashboard/v2/backport/site-settings": true,
-		"dashboard/v2/backport/sites-list": true,
+		"dashboard/v2/backport/sites-list": false,
 		"domains/ui-redesign": false,
 		"global-styles/on-personal-plan": false,
 		"google-my-business": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -37,7 +37,7 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"dashboard/v2/backport/site-settings": true,
-		"dashboard/v2/backport/sites-list": true,
+		"dashboard/v2/backport/sites-list": false,
 		"dev/preferences-helper": true,
 		"dev/store-sandbox-helper": true,
 		"global-styles/on-personal-plan": false,


### PR DESCRIPTION
This reverts commit 610caf10f8c183ef6e4366d885a154e8b53a25a1.


## Why are these changes being made?

Regression: p1753113232469989-slack-C08JZTRS6NA

## Testing Instructions

Verify `/sites` loads as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?