### PR TITLE
Reader lists - add authorname for unowned lists.

### DIFF
--- a/client/reader/list-stream/header.jsx
+++ b/client/reader/list-stream/header.jsx
@@ -2,6 +2,7 @@ import { Gridicon, Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import FollowButton from 'calypso/blocks/follow-button/button';
+import AutoDirection from 'calypso/components/auto-direction';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { isExternal } from 'calypso/lib/url';
 import ReaderFollowFeedIcon from 'calypso/reader/components/icons/follow-feed-icon';
@@ -18,34 +19,48 @@ const ListStreamHeader = ( {
 	onFollowToggle,
 	translate,
 } ) => {
+	const formattedTitle = (
+		<AutoDirection>
+			<div>{ title }</div>
+		</AutoDirection>
+	);
+
+	const formattedDescription = (
+		<AutoDirection>
+			<div>{ description }</div>
+		</AutoDirection>
+	);
+
 	return (
-		<NavigationHeader title={ title } subtitle={ description }>
-			{ ! isPublic && (
-				<div className="list-stream__header-title-privacy">
-					<Gridicon icon="lock" size={ 24 } title={ translate( 'Private list' ) } />
-				</div>
-			) }
+		<AutoDirection>
+			<NavigationHeader title={ formattedTitle } subtitle={ formattedDescription }>
+				{ ! isPublic && (
+					<div className="list-stream__header-title-privacy">
+						<Gridicon icon="lock" size={ 24 } title={ translate( 'Private list' ) } />
+					</div>
+				) }
 
-			{ showFollow && (
-				<div className="list-stream__header-follow">
-					<FollowButton
-						iconSize={ 24 }
-						following={ following }
-						onFollowToggle={ onFollowToggle }
-						followIcon={ ReaderFollowFeedIcon( { iconSize: 24 } ) }
-						followingIcon={ ReaderFollowingFeedIcon( { iconSize: 24 } ) }
-					/>
-				</div>
-			) }
+				{ showFollow && (
+					<div className="list-stream__header-follow">
+						<FollowButton
+							iconSize={ 24 }
+							following={ following }
+							onFollowToggle={ onFollowToggle }
+							followIcon={ ReaderFollowFeedIcon( { iconSize: 24 } ) }
+							followingIcon={ ReaderFollowingFeedIcon( { iconSize: 24 } ) }
+						/>
+					</div>
+				) }
 
-			{ showEdit && editUrl && (
-				<div className="list-stream__header-edit">
-					<Button rel={ isExternal( editUrl ) ? 'external' : '' } href={ editUrl }>
-						{ translate( 'Edit' ) }
-					</Button>
-				</div>
-			) }
-		</NavigationHeader>
+				{ showEdit && editUrl && (
+					<div className="list-stream__header-edit">
+						<Button rel={ isExternal( editUrl ) ? 'external' : '' } href={ editUrl }>
+							{ translate( 'Edit' ) }
+						</Button>
+					</div>
+				) }
+			</NavigationHeader>
+		</AutoDirection>
 	);
 };
 

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -5,6 +5,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import QueryReaderList from 'calypso/components/data/query-reader-list';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import Stream from 'calypso/reader/stream';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { followList, unfollowList } from 'calypso/state/reader/lists/actions';
 import {
@@ -65,7 +66,10 @@ class ListStream extends Component {
 		}
 
 		if ( list ) {
-			this.title = list.title;
+			// Show author name in parentheses if the list is owned by someone other than the current user
+			const isOwnedByCurrentUser =
+				this.props.currentUser && list.owner === this.props.currentUser.username;
+			this.title = isOwnedByCurrentUser ? list.title : `${ list.title } (${ list.owner })`;
 		}
 
 		if ( this.props.isMissing ) {
@@ -127,6 +131,7 @@ export default connect(
 			isSubscribed: isSubscribedByOwnerAndSlug( state, ownProps.owner, ownProps.slug ),
 			hasRequested: hasRequestedListByOwnerAndSlug( state, ownProps.owner, ownProps.slug ),
 			isMissing: isMissingByOwnerAndSlug( state, ownProps.owner, ownProps.slug ),
+			currentUser: getCurrentUser( state ),
 		};
 	},
 	{ followList, recordReaderTracksEvent, unfollowList }

--- a/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
@@ -3,16 +3,20 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
+import AutoDirection from 'calypso/components/auto-direction';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import ReaderSidebarHelper from '../helper';
 import { MenuItem, MenuItemLink } from '../menu';
+
 export class ReaderSidebarListsListItem extends Component {
 	static propTypes = {
 		list: PropTypes.object.isRequired,
 		path: PropTypes.string.isRequired,
 		currentListOwner: PropTypes.string,
 		currentListSlug: PropTypes.string,
+		currentUser: PropTypes.object,
 	};
 
 	componentDidMount() {
@@ -35,7 +39,7 @@ export class ReaderSidebarListsListItem extends Component {
 	};
 
 	render() {
-		const { list, translate } = this.props;
+		const { list, translate, currentUser } = this.props;
 		const listRelativeUrl = `/reader/list/${ list.owner }/${ list.slug }`;
 		const listManagementUrls = [
 			listRelativeUrl + '/items',
@@ -58,6 +62,11 @@ export class ReaderSidebarListsListItem extends Component {
 		);
 
 		const selected = isCurrentList || isCurrentListManage;
+
+		// Show author name in parentheses if the list is owned by someone other than the current user
+		const isOwnedByCurrentUser = currentUser && list.owner === currentUser.username;
+		const displayTitle = isOwnedByCurrentUser ? list.title : `${ list.title } (${ list.owner })`;
+
 		return (
 			<MenuItem className="sidebar__menu-item--reader-list" key={ list.ID } selected={ selected }>
 				<MenuItemLink
@@ -70,13 +79,20 @@ export class ReaderSidebarListsListItem extends Component {
 						},
 					} ) }
 				>
-					<div className="sidebar__menu-item-title">{ list.title }</div>
+					<AutoDirection>
+						<div className="sidebar__menu-item-title">{ displayTitle }</div>
+					</AutoDirection>
 				</MenuItemLink>
 			</MenuItem>
 		);
 	}
 }
 
-export default connect( null, {
-	recordReaderTracksEvent,
-} )( localize( ReaderSidebarListsListItem ) );
+export default connect(
+	( state ) => ( {
+		currentUser: getCurrentUser( state ),
+	} ),
+	{
+		recordReaderTracksEvent,
+	}
+)( localize( ReaderSidebarListsListItem ) );

--- a/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
@@ -80,7 +80,9 @@ export class ReaderSidebarListsListItem extends Component {
 					} ) }
 				>
 					<AutoDirection>
-						<div className="sidebar__menu-item-title">{ displayTitle }</div>
+						<div className="sidebar__menu-item-title" title={ displayTitle }>
+							{ displayTitle }
+						</div>
 					</AutoDirection>
 				</MenuItemLink>
 			</MenuItem>

--- a/client/reader/sidebar/reader-sidebar-lists/style.scss
+++ b/client/reader/sidebar/reader-sidebar-lists/style.scss
@@ -9,3 +9,14 @@
 		}
 	}
 }
+
+.sidebar__menu-item--reader-list {
+	.sidebar__menu-item-title {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		line-clamp: 2;
+		-webkit-box-orient: vertical;
+	}
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/CML-670/recommended-blogs-handle-display-of-multiple-lists-in-sidebar

## Proposed Changes

Adds the authorname to list titles for lists that are not owned by the user.
* Adds this to the sidebar, and to the list stream header.
* Also adds `<AutoDirection>` to the list steam header and sidebar items. Since these can be user generated items they can appear in languages that may be different directionality than the set interface language, in which case AutoDirection helps formatting.
* Updates styles for the sidebar items to now clamp at 2 lines with ellipsis (it just overflowed hidden completely before).
* Updates sidebar items to show the name on the title so it appears on hover.

BEFORE
<img width="260" height="429" alt="Screenshot 2025-07-22 at 7 35 36 AM" src="https://github.com/user-attachments/assets/158c0f2d-de3e-4a0d-9750-1b249179a105" />
<img width="603" height="145" alt="Screenshot 2025-07-22 at 7 35 50 AM" src="https://github.com/user-attachments/assets/ddf34e3d-04f5-4299-9c4c-7aceeab6275e" />
<img width="250" height="135" alt="Screenshot 2025-07-22 at 7 42 12 AM" src="https://github.com/user-attachments/assets/930c7f93-5717-4042-8bc8-63f84044f1ba" />


AFTER
<img width="272" height="471" alt="Screenshot 2025-07-22 at 6 54 08 AM" src="https://github.com/user-attachments/assets/11c7ec8a-45bd-4755-8202-4b832562ac09" />
<img width="585" height="132" alt="Screenshot 2025-07-22 at 7 01 20 AM" src="https://github.com/user-attachments/assets/2fe693a2-7735-48b6-8543-902830bbb47b" />
<img width="484" height="121" alt="Screenshot 2025-07-22 at 7 01 17 AM" src="https://github.com/user-attachments/assets/a8f484a1-37e9-4780-8072-fe8f93e52839" />
<img width="236" height="79" alt="Screenshot 2025-07-22 at 6 52 14 AM" src="https://github.com/user-attachments/assets/27f1f522-fad1-4226-97ea-366152deeb32" />

AutoDirection formatting

Also after, these items in the stream header and sidebar should format per AutoDirection, (I manually tested with this string ` 'قائمة بلدي (john_doe)'`):

<img width="310" height="138" alt="Screenshot 2025-07-22 at 7 28 47 AM" src="https://github.com/user-attachments/assets/30c82e0d-c35e-4c08-95e1-312fd7d3568f" />
<img width="253" height="183" alt="Screenshot 2025-07-22 at 7 28 36 AM" src="https://github.com/user-attachments/assets/506cdd8e-69cc-47c3-9c4f-19dbd7f80445" />

Or LTR content in RTL interface:
<img width="369" height="151" alt="Screenshot 2025-07-22 at 7 46 41 AM" src="https://github.com/user-attachments/assets/133cb75e-38d1-4a69-b721-d85a944a67e4" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Its unclear to distinguish between lists of the same name that you follow, but at least one is owned by another person.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the reader
* Test subscribing to other peoples lists and recommended blogs lists.
* Verify the author name is added for lists you do not own, both in the sidebar and in the list stream header.
* Hover the sidebar item, verify the title popup shows the entire name.
* Adjust a list name in the html to be very long, verify it clamps at 2 lines with ellipsis.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
