### PR TITLE
Domain Search Retrofitting: Add loading and error state to the cart operations

### DIFF
--- a/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
+++ b/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
@@ -54,7 +54,6 @@ class DomainRegistrationSuggestion extends Component {
 			currency_code: PropTypes.string,
 		} ).isRequired,
 		suggestionSelected: PropTypes.bool,
-		onButtonClick: PropTypes.func.isRequired,
 		domainsWithPlansOnly: PropTypes.bool.isRequired,
 		premiumDomain: PropTypes.object,
 		selectedSite: PropTypes.object,
@@ -109,8 +108,8 @@ class DomainRegistrationSuggestion extends Component {
 		}
 	}
 
-	onButtonClick = ( action ) => {
-		const { suggestion, railcarId, uiPosition } = this.props;
+	onButtonClick = () => {
+		const { suggestion, railcarId } = this.props;
 
 		if ( this.isUnavailableDomain( suggestion.domain_name ) ) {
 			return;
@@ -124,8 +123,6 @@ class DomainRegistrationSuggestion extends Component {
 				root_vendor: suggestion.vendor,
 			} );
 		}
-
-		this.props.onButtonClick( suggestion, uiPosition, action === 'continue' );
 	};
 
 	isUnavailableDomain = ( domain ) => {

--- a/client/components/domain-search-v2/domain-search-results/index.jsx
+++ b/client/components/domain-search-v2/domain-search-results/index.jsx
@@ -44,7 +44,6 @@ class DomainSearchResults extends Component {
 		mappingSuggestionLabel: PropTypes.string,
 		offerUnavailableOption: PropTypes.bool,
 		showAlreadyOwnADomain: PropTypes.bool,
-		onClickResult: PropTypes.func.isRequired,
 		onAddMapping: PropTypes.func,
 		onAddTransfer: PropTypes.func,
 		onClickMapping: PropTypes.func,
@@ -296,7 +295,6 @@ class DomainSearchResults extends Component {
 					isSignupStep={ this.props.isSignupStep }
 					showStrikedOutPrice={ showStrikedOutPrice }
 					key="featured"
-					onButtonClick={ this.props.onClickResult }
 					premiumDomains={ this.props.premiumDomains }
 					featuredSuggestions={ featuredSuggestions }
 					query={ this.props.lastDomainSearched }
@@ -336,7 +334,6 @@ class DomainSearchResults extends Component {
 						uiPosition={ i + 2 }
 						fetchAlgo={ suggestion.fetch_algo ? suggestion.fetch_algo : this.props.fetchAlgo }
 						query={ this.props.lastDomainSearched }
-						onButtonClick={ this.props.onClickResult }
 						premiumDomain={ this.props.premiumDomains[ suggestion.domain_name ] }
 						pendingCheckSuggestion={ this.props.pendingCheckSuggestion }
 						unavailableDomains={ this.props.unavailableDomains }

--- a/client/components/domain-search-v2/domain-skip-suggestion/index.tsx
+++ b/client/components/domain-search-v2/domain-skip-suggestion/index.tsx
@@ -1,3 +1,4 @@
+import { useDomainSearch } from '@automattic/domain-search';
 import {
 	Button,
 	__experimentalText as Text,
@@ -16,6 +17,7 @@ interface Props {
 
 const DomainSkipSuggestion = ( { domain, onSkip }: Props ) => {
 	const translate = useTranslate();
+	const { cart } = useDomainSearch();
 	const [ subdomain, ...tlds ] = domain.split( '.' );
 
 	return (
@@ -39,7 +41,12 @@ const DomainSkipSuggestion = ( { domain, onSkip }: Props ) => {
 				</Text>
 			}
 			right={
-				<Button className="subdomain-skip-suggestion__btn" variant="secondary" onClick={ onSkip }>
+				<Button
+					className="subdomain-skip-suggestion__btn"
+					variant="secondary"
+					onClick={ onSkip }
+					disabled={ cart.isBusy }
+				>
 					{ translate( 'Skip purchase' ) }
 				</Button>
 			}

--- a/client/components/domain-search-v2/featured-domain-suggestions/index.jsx
+++ b/client/components/domain-search-v2/featured-domain-suggestions/index.jsx
@@ -32,7 +32,6 @@ export class FeaturedDomainSuggestions extends Component {
 			'isDomainOnly',
 			'domainsWithPlansOnly',
 			'showStrikedOutPrice',
-			'onButtonClick',
 			'query',
 			'selectedSite',
 			'pendingCheckSuggestion',

--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -478,6 +478,7 @@ class RegisterDomainStep extends Component {
 
 		return {
 			isBusy: this.props.isMiniCartContinueButtonBusy,
+			errorMessage: this.props.replaceDomainFailedMessage,
 			items: domainsInCart.map( ( domain ) => {
 				const [ domainName, ...tld ] = domain.meta.split( '.' );
 
@@ -531,8 +532,6 @@ class RegisterDomainStep extends Component {
 	};
 
 	renderGeneralNotices() {
-		const { replaceDomainFailedMessage, dismissReplaceDomainFailed } = this.props;
-
 		const {
 			availabilityError,
 			availabilityErrorData,
@@ -559,11 +558,6 @@ class RegisterDomainStep extends Component {
 			),
 			suggestionMessage && availabilityError !== suggestionError && (
 				<DomainSearchNotice status={ suggestionSeverity }>{ suggestionMessage }</DomainSearchNotice>
-			),
-			replaceDomainFailedMessage && (
-				<DomainSearchNotice status="error" onDismiss={ dismissReplaceDomainFailed }>
-					{ replaceDomainFailedMessage }
-				</DomainSearchNotice>
 			),
 		].filter( Boolean );
 

--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -477,6 +477,7 @@ class RegisterDomainStep extends Component {
 		);
 
 		return {
+			isBusy: this.props.isMiniCartContinueButtonBusy,
 			items: domainsInCart.map( ( domain ) => {
 				const [ domainName, ...tld ] = domain.meta.split( '.' );
 

--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -1662,7 +1662,6 @@ class RegisterDomainStep extends Component {
 				lastDomainTld={ lastDomainTld }
 				lastDomainIsTransferrable={ lastDomainIsTransferrable }
 				onAddMapping={ onAddMapping }
-				onClickResult={ this.onAddDomain }
 				onClickMapping={ this.goToMapDomainStep }
 				onAddTransfer={ this.props.onAddTransfer }
 				onClickUseYourDomain={ this.props.handleClickUseYourDomain ?? this.useYourDomainFunction() }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -721,7 +721,7 @@ class RenderDomainsStepComponent extends Component {
 		registration.item_subtotal_integer = ( suggestion.sale_cost ?? suggestion.raw_price ) * 100;
 
 		if ( shouldUseMultipleDomainsInCart( this.props.flowName ) ) {
-			this.setState( { isMiniCartContinueButtonBusy: true } );
+			this.setState( { replaceDomainFailedMessage: null, isMiniCartContinueButtonBusy: true } );
 			if (
 				! this.state.temporaryCart ||
 				! this.state.temporaryCart.some(
@@ -820,6 +820,7 @@ class RenderDomainsStepComponent extends Component {
 			}, 500 );
 		} else {
 			this.setState( {
+				replaceDomainFailedMessage: null,
 				isMiniCartContinueButtonBusy: true,
 			} );
 
@@ -867,6 +868,7 @@ class RenderDomainsStepComponent extends Component {
 		}
 
 		this.setState( {
+			replaceDomainFailedMessage: null,
 			isMiniCartContinueButtonBusy: true,
 			isCartPendingUpdateDomain: { domain_name: domain_name },
 		} );

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -841,13 +841,27 @@ class RenderDomainsStepComponent extends Component {
 			} ) );
 		}
 
-		this.setState( { isCartPendingUpdateDomain: { domain_name: domain_name } } );
+		this.setState( {
+			isMiniCartContinueButtonBusy: true,
+			isCartPendingUpdateDomain: { domain_name: domain_name },
+		} );
 		clearTimeout( this.state.removeDomainTimeout );
 
 		// Avoid too much API calls for Multi-domains flow
 		this.state.removeDomainTimeout = setTimeout( async () => {
 			if ( this.props.currentUser ) {
-				await this.props.shoppingCartManager.reloadFromServer();
+				try {
+					await this.props.shoppingCartManager.reloadFromServer();
+				} catch {
+					this.setState( {
+						replaceDomainFailedMessage: this.props.translate(
+							'Sorry, there was a problem removing that domain. Please try again later.'
+						),
+						isMiniCartContinueButtonBusy: false,
+					} );
+
+					return;
+				}
 			}
 
 			const productsToKeep = this.props.cart.products.filter( ( product ) => {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1194,6 +1194,7 @@ class RenderDomainsStepComponent extends Component {
 				showFreeDomainPromo={
 					! this.shouldHideDomainExplainer() || this.shouldDisplayDomainOnlyExplainer()
 				}
+				isMiniCartContinueButtonBusy={ this.state.isMiniCartContinueButtonBusy }
 			/>
 		);
 	};

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -759,7 +759,18 @@ class RenderDomainsStepComponent extends Component {
 				// Only saves after all domain are checked.
 				Promise.all( this.state.checkDomainAvailabilityPromises ).then( async () => {
 					if ( this.props.currentUser ) {
-						await this.props.shoppingCartManager.reloadFromServer();
+						try {
+							await this.props.shoppingCartManager.reloadFromServer();
+						} catch {
+							this.setState( {
+								replaceDomainFailedMessage: this.props.translate(
+									'Sorry, there was a problem adding that domain. Please try again later.'
+								),
+								isMiniCartContinueButtonBusy: false,
+							} );
+
+							return;
+						}
 					}
 
 					// Add productsToAdd to productsInCart.
@@ -808,7 +819,21 @@ class RenderDomainsStepComponent extends Component {
 				} );
 			}, 500 );
 		} else {
-			await this.props.shoppingCartManager.addProductsToCart( registration );
+			this.setState( {
+				isMiniCartContinueButtonBusy: true,
+			} );
+
+			try {
+				await this.props.shoppingCartManager.addProductsToCart( registration );
+			} catch {
+				this.handleReplaceProductsInCartError(
+					this.props.translate(
+						'Sorry, there was a problem adding that domain. Please try again later.'
+					)
+				);
+			} finally {
+				this.setState( { isMiniCartContinueButtonBusy: false } );
+			}
 		}
 
 		this.setState( { isCartPendingUpdateDomain: null } );

--- a/packages/domain-search/src/components/domain-search/index.tsx
+++ b/packages/domain-search/src/components/domain-search/index.tsx
@@ -12,6 +12,7 @@ export const DomainSearchContext = createContext< DomainSearchContextType >( {
 		items: [],
 		total: '',
 		isBusy: false,
+		errorMessage: null,
 		hasItem: () => false,
 		onAddItem: () => {},
 		onRemoveItem: () => {},

--- a/packages/domain-search/src/components/domain-search/index.tsx
+++ b/packages/domain-search/src/components/domain-search/index.tsx
@@ -18,6 +18,8 @@ export const DomainSearchContext = createContext< DomainSearchContextType >( {
 	isFullCartOpen: false,
 	closeFullCart: () => {},
 	openFullCart: () => {},
+	isBusy: false,
+	setIsBusy: () => {},
 } );
 
 export const DomainSearch = ( {
@@ -35,6 +37,7 @@ export const DomainSearch = ( {
 } ) => {
 	const [ query, setQuery ] = useState( initialQuery ?? '' );
 	const [ isFullCartOpen, setIsFullCartOpen ] = useState( false );
+	const [ isBusy, setIsBusy ] = useState( false );
 
 	useLayoutEffect( () => {
 		setQuery( initialQuery ?? '' );
@@ -57,8 +60,10 @@ export const DomainSearch = ( {
 			closeFullCart,
 			openFullCart,
 			isFullCartOpen,
+			isBusy,
+			setIsBusy,
 		} ),
-		[ query, setQuery, onContinue, cart, closeFullCart, openFullCart, isFullCartOpen ]
+		[ query, setQuery, onContinue, cart, closeFullCart, openFullCart, isFullCartOpen, isBusy ]
 	);
 
 	const cartItemsLength = cart.items.length;

--- a/packages/domain-search/src/components/domain-search/index.tsx
+++ b/packages/domain-search/src/components/domain-search/index.tsx
@@ -11,6 +11,7 @@ export const DomainSearchContext = createContext< DomainSearchContextType >( {
 	cart: {
 		items: [],
 		total: '',
+		isBusy: false,
 		hasItem: () => false,
 		onAddItem: () => {},
 		onRemoveItem: () => {},
@@ -18,8 +19,6 @@ export const DomainSearchContext = createContext< DomainSearchContextType >( {
 	isFullCartOpen: false,
 	closeFullCart: () => {},
 	openFullCart: () => {},
-	isBusy: false,
-	setIsBusy: () => {},
 } );
 
 export const DomainSearch = ( {
@@ -37,7 +36,6 @@ export const DomainSearch = ( {
 } ) => {
 	const [ query, setQuery ] = useState( initialQuery ?? '' );
 	const [ isFullCartOpen, setIsFullCartOpen ] = useState( false );
-	const [ isBusy, setIsBusy ] = useState( false );
 
 	useLayoutEffect( () => {
 		setQuery( initialQuery ?? '' );
@@ -60,10 +58,8 @@ export const DomainSearch = ( {
 			closeFullCart,
 			openFullCart,
 			isFullCartOpen,
-			isBusy,
-			setIsBusy,
 		} ),
-		[ query, setQuery, onContinue, cart, closeFullCart, openFullCart, isFullCartOpen, isBusy ]
+		[ query, setQuery, onContinue, cart, closeFullCart, openFullCart, isFullCartOpen ]
 	);
 
 	const cartItemsLength = cart.items.length;

--- a/packages/domain-search/src/components/domain-search/types.ts
+++ b/packages/domain-search/src/components/domain-search/types.ts
@@ -9,8 +9,8 @@ export interface SelectedDomain {
 export interface DomainSearchCart {
 	items: SelectedDomain[];
 	total: string;
-	onAddItem: ( item: SelectedDomain[ 'uuid' ] ) => void;
-	onRemoveItem: ( item: SelectedDomain[ 'uuid' ] ) => void;
+	onAddItem: ( item: SelectedDomain[ 'uuid' ] ) => Promise< void > | void;
+	onRemoveItem: ( item: SelectedDomain[ 'uuid' ] ) => Promise< void > | void;
 	hasItem: ( uuid: SelectedDomain[ 'uuid' ] ) => boolean;
 }
 
@@ -22,4 +22,6 @@ export interface DomainSearchContextType {
 	isFullCartOpen: boolean;
 	closeFullCart: () => void;
 	openFullCart: () => void;
+	isBusy: boolean;
+	setIsBusy: ( isBusy: boolean ) => void;
 }

--- a/packages/domain-search/src/components/domain-search/types.ts
+++ b/packages/domain-search/src/components/domain-search/types.ts
@@ -13,6 +13,7 @@ export interface DomainSearchCart {
 	onRemoveItem: ( item: SelectedDomain[ 'uuid' ] ) => Promise< void > | void;
 	hasItem: ( uuid: SelectedDomain[ 'uuid' ] ) => boolean;
 	isBusy: boolean;
+	errorMessage: string | null;
 }
 
 export interface DomainSearchContextType {

--- a/packages/domain-search/src/components/domain-search/types.ts
+++ b/packages/domain-search/src/components/domain-search/types.ts
@@ -12,6 +12,7 @@ export interface DomainSearchCart {
 	onAddItem: ( item: SelectedDomain[ 'uuid' ] ) => Promise< void > | void;
 	onRemoveItem: ( item: SelectedDomain[ 'uuid' ] ) => Promise< void > | void;
 	hasItem: ( uuid: SelectedDomain[ 'uuid' ] ) => boolean;
+	isBusy: boolean;
 }
 
 export interface DomainSearchContextType {
@@ -22,6 +23,4 @@ export interface DomainSearchContextType {
 	isFullCartOpen: boolean;
 	closeFullCart: () => void;
 	openFullCart: () => void;
-	isBusy: boolean;
-	setIsBusy: ( isBusy: boolean ) => void;
 }

--- a/packages/domain-search/src/components/domain-suggestion-cta/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-cta/index.tsx
@@ -1,7 +1,8 @@
-import { Button } from '@wordpress/components';
-import { arrowRight } from '@wordpress/icons';
+import { Button, Tooltip } from '@wordpress/components';
+import { arrowRight, warning } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect } from 'react';
+import { useFocusedCartAction } from '../../hooks/use-focused-cart-action';
 import { useDomainSearch } from '../domain-search';
 import { shoppingCartIcon } from './shopping-cart-icon';
 
@@ -24,22 +25,22 @@ export const DomainSuggestionCTA = ( {
 }: DomainSuggestionCTAProps ) => {
 	const { __ } = useI18n();
 	const { cart, onContinue } = useDomainSearch();
-	const [ isBusy, setIsBusy ] = useState( false );
-
-	const initiatedByThisComponent = useRef( false );
+	const { isBusy, errorMessage, removeErrorMessage, callback } = useFocusedCartAction( () => {
+		onClick?.( 'add-to-cart' );
+		cart.onAddItem( uuid );
+	} );
 
 	useEffect( () => {
-		if ( ! initiatedByThisComponent.current ) {
+		if ( ! errorMessage ) {
 			return;
 		}
 
-		if ( cart.isBusy ) {
-			setIsBusy( true );
-		} else {
-			setIsBusy( false );
-			initiatedByThisComponent.current = false;
-		}
-	}, [ cart.isBusy ] );
+		const timeout = setTimeout( () => {
+			removeErrorMessage();
+		}, 3000 );
+
+		return () => clearTimeout( timeout );
+	}, [ errorMessage, removeErrorMessage ] );
 
 	const isDomainOnCart = cart.hasItem( uuid );
 
@@ -65,11 +66,25 @@ export const DomainSuggestionCTA = ( {
 		);
 	}
 
-	const handleAddToCartClick = () => {
-		initiatedByThisComponent.current = true;
-		onClick?.( 'add-to-cart' );
-		cart.onAddItem( uuid );
-	};
+	if ( errorMessage ) {
+		return (
+			// @ts-expect-error open is not a valid prop for the WPDS Tooltip component, but accepted by the underlying Tooltip component.
+			<Tooltip delay={ 0 } text={ errorMessage } placement="top" open>
+				<div style={ { marginTop: 'auto' } }>
+					<Button
+						className="domain-suggestion-cta"
+						isDestructive
+						variant="primary"
+						disabled
+						__next40pxDefaultSize
+						icon={ warning }
+					>
+						{ compact ? undefined : __( 'Add to Cart' ) }
+					</Button>
+				</div>
+			</Tooltip>
+		);
+	}
 
 	return (
 		<Button
@@ -77,7 +92,7 @@ export const DomainSuggestionCTA = ( {
 			variant={ variant }
 			__next40pxDefaultSize
 			icon={ shoppingCartIcon }
-			onClick={ handleAddToCartClick }
+			onClick={ callback }
 			label={ __( 'Add to Cart' ) }
 			disabled={ disabled || cart.isBusy }
 			isBusy={ isBusy }

--- a/packages/domain-search/src/components/domain-suggestion-cta/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-cta/index.tsx
@@ -22,7 +22,7 @@ export const DomainSuggestionCTA = ( {
 	disabled,
 }: DomainSuggestionCTAProps ) => {
 	const { __ } = useI18n();
-	const { cart, isBusy, setIsBusy, onContinue } = useDomainSearch();
+	const { cart, onContinue } = useDomainSearch();
 
 	const isDomainOnCart = cart.hasItem( uuid );
 
@@ -47,15 +47,9 @@ export const DomainSuggestionCTA = ( {
 		);
 	}
 
-	const handleAddToCartClick = async () => {
-		setIsBusy( true );
-
-		try {
-			await cart.onAddItem( uuid );
-			onClick?.( 'add-to-cart' );
-		} finally {
-			setIsBusy( false );
-		}
+	const handleAddToCartClick = () => {
+		onClick?.( 'add-to-cart' );
+		cart.onAddItem( uuid );
 	};
 
 	return (
@@ -66,8 +60,8 @@ export const DomainSuggestionCTA = ( {
 			icon={ shoppingCartIcon }
 			onClick={ handleAddToCartClick }
 			label={ __( 'Add to Cart' ) }
-			disabled={ disabled || isBusy }
-			isBusy={ isBusy }
+			disabled={ disabled || cart.isBusy }
+			isBusy={ cart.isBusy }
 		>
 			{ compact ? undefined : __( 'Add to Cart' ) }
 		</Button>

--- a/packages/domain-search/src/components/domain-suggestion-cta/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-cta/index.tsx
@@ -22,7 +22,7 @@ export const DomainSuggestionCTA = ( {
 	disabled,
 }: DomainSuggestionCTAProps ) => {
 	const { __ } = useI18n();
-	const { cart, onContinue } = useDomainSearch();
+	const { cart, isBusy, setIsBusy, onContinue } = useDomainSearch();
 
 	const isDomainOnCart = cart.hasItem( uuid );
 
@@ -47,9 +47,15 @@ export const DomainSuggestionCTA = ( {
 		);
 	}
 
-	const handleAddToCartClick = () => {
-		onClick?.( 'add-to-cart' );
-		cart.onAddItem( uuid );
+	const handleAddToCartClick = async () => {
+		setIsBusy( true );
+
+		try {
+			await cart.onAddItem( uuid );
+			onClick?.( 'add-to-cart' );
+		} finally {
+			setIsBusy( false );
+		}
 	};
 
 	return (
@@ -60,7 +66,8 @@ export const DomainSuggestionCTA = ( {
 			icon={ shoppingCartIcon }
 			onClick={ handleAddToCartClick }
 			label={ __( 'Add to Cart' ) }
-			disabled={ disabled }
+			disabled={ disabled || isBusy }
+			isBusy={ isBusy }
 		>
 			{ compact ? undefined : __( 'Add to Cart' ) }
 		</Button>

--- a/packages/domain-search/src/components/domain-suggestion-cta/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-cta/index.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@wordpress/components';
 import { arrowRight } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
+import { useEffect, useRef, useState } from 'react';
 import { useDomainSearch } from '../domain-search';
 import { shoppingCartIcon } from './shopping-cart-icon';
 
@@ -23,6 +24,22 @@ export const DomainSuggestionCTA = ( {
 }: DomainSuggestionCTAProps ) => {
 	const { __ } = useI18n();
 	const { cart, onContinue } = useDomainSearch();
+	const [ isBusy, setIsBusy ] = useState( false );
+
+	const initiatedByThisComponent = useRef( false );
+
+	useEffect( () => {
+		if ( ! initiatedByThisComponent.current ) {
+			return;
+		}
+
+		if ( cart.isBusy ) {
+			setIsBusy( true );
+		} else {
+			setIsBusy( false );
+			initiatedByThisComponent.current = false;
+		}
+	}, [ cart.isBusy ] );
 
 	const isDomainOnCart = cart.hasItem( uuid );
 
@@ -41,6 +58,7 @@ export const DomainSuggestionCTA = ( {
 				className="domain-suggestion-cta domain-suggestion-cta--continue"
 				onClick={ handleContinueClick }
 				label={ __( 'Continue' ) }
+				disabled={ disabled || cart.isBusy }
 			>
 				{ compact ? undefined : __( 'Continue' ) }
 			</Button>
@@ -48,6 +66,7 @@ export const DomainSuggestionCTA = ( {
 	}
 
 	const handleAddToCartClick = () => {
+		initiatedByThisComponent.current = true;
 		onClick?.( 'add-to-cart' );
 		cart.onAddItem( uuid );
 	};
@@ -61,7 +80,7 @@ export const DomainSuggestionCTA = ( {
 			onClick={ handleAddToCartClick }
 			label={ __( 'Add to Cart' ) }
 			disabled={ disabled || cart.isBusy }
-			isBusy={ cart.isBusy }
+			isBusy={ isBusy }
 		>
 			{ compact ? undefined : __( 'Add to Cart' ) }
 		</Button>

--- a/packages/domain-search/src/components/domain-suggestion-cta/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-cta/index.tsx
@@ -70,7 +70,7 @@ export const DomainSuggestionCTA = ( {
 		return (
 			// @ts-expect-error open is not a valid prop for the WPDS Tooltip component, but accepted by the underlying Tooltip component.
 			<Tooltip delay={ 0 } text={ errorMessage } placement="top" open>
-				<div style={ { marginTop: 'auto' } }>
+				<div className="domain-suggestion-cta-error-container">
 					<Button
 						className="domain-suggestion-cta"
 						isDestructive
@@ -78,6 +78,7 @@ export const DomainSuggestionCTA = ( {
 						disabled
 						__next40pxDefaultSize
 						icon={ warning }
+						style={ { flex: 1 } }
 					>
 						{ compact ? undefined : __( 'Add to Cart' ) }
 					</Button>

--- a/packages/domain-search/src/components/domain-suggestion-cta/style.scss
+++ b/packages/domain-search/src/components/domain-suggestion-cta/style.scss
@@ -1,5 +1,10 @@
 @use '@wordpress/base-styles/colors';
 
+.domain-suggestion-cta-error-container {
+	margin-top: auto;
+	display: flex;
+}
+
 .domain-suggestion-cta {
 	justify-content: center !important;
 

--- a/packages/domain-search/src/components/domain-suggestion-cta/style.scss
+++ b/packages/domain-search/src/components/domain-suggestion-cta/style.scss
@@ -17,6 +17,6 @@
 .domain-suggestion-cta--continue {
 	&:disabled {
 		background: var( --wp-components-color-foreground, #1e1e1e ) !important;
-		color: rgba( 255, 255, 255, 0.3 );
+		color: rgba( 255, 255, 255, 0.3 ) !important;
 	}
 }

--- a/packages/domain-search/src/components/domain-suggestion-cta/style.scss
+++ b/packages/domain-search/src/components/domain-suggestion-cta/style.scss
@@ -1,3 +1,5 @@
+@use '@wordpress/base-styles/colors';
+
 .domain-suggestion-cta {
 	justify-content: center !important;
 
@@ -6,8 +8,14 @@
 		box-shadow: inset 0 0 0 1px var( --domain-search-secondary-action-box-shadow-color );
 	}
 
-	&:disabled {
+	&:disabled:not( .is-primary ) {
 		box-shadow: 0 0 0 1px rgba( 0, 0, 0, 0.1 ) !important;
 		color: rgba( 0, 0, 0, 0.1 ) !important;
+	}
+}
+
+.domain-suggestion-cta--continue {
+	&:disabled {
+		background: colors.$gray-300 !important;
 	}
 }

--- a/packages/domain-search/src/components/domain-suggestion-cta/style.scss
+++ b/packages/domain-search/src/components/domain-suggestion-cta/style.scss
@@ -8,7 +8,7 @@
 		box-shadow: inset 0 0 0 1px var( --domain-search-secondary-action-box-shadow-color );
 	}
 
-	&:disabled:not( .is-primary ) {
+	&:disabled:not( .is-primary ):not( .is-pressed ) {
 		box-shadow: 0 0 0 1px rgba( 0, 0, 0, 0.1 ) !important;
 		color: rgba( 0, 0, 0, 0.1 ) !important;
 	}
@@ -16,6 +16,7 @@
 
 .domain-suggestion-cta--continue {
 	&:disabled {
-		background: colors.$gray-300 !important;
+		background: var( --wp-components-color-foreground, #1e1e1e ) !important;
+		color: rgba( 255, 255, 255, 0.3 );
 	}
 }

--- a/packages/domain-search/src/components/domain-suggestion-cta/style.scss
+++ b/packages/domain-search/src/components/domain-suggestion-cta/style.scss
@@ -7,7 +7,6 @@
 	}
 
 	&:disabled {
-		background: transparent !important;
 		box-shadow: 0 0 0 1px rgba( 0, 0, 0, 0.1 ) !important;
 		color: rgba( 0, 0, 0, 0.1 ) !important;
 	}

--- a/packages/domain-search/src/components/domain-suggestion/featured.scss
+++ b/packages/domain-search/src/components/domain-suggestion/featured.scss
@@ -14,7 +14,7 @@
 }
 
 .domain-suggestion-featured__content {
-	justify-content: space-between;
+	justify-content: space-between !important;
 }
 
 .domain-suggestion-featured--highlighted {

--- a/packages/domain-search/src/components/domains-full-cart-items/index.tsx
+++ b/packages/domain-search/src/components/domains-full-cart-items/index.tsx
@@ -1,60 +1,16 @@
-import {
-	Card,
-	CardBody,
-	__experimentalText as Text,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	Button,
-} from '@wordpress/components';
-import { sprintf } from '@wordpress/i18n';
-import { useI18n } from '@wordpress/react-i18n';
+import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useDomainSearch } from '../domain-search';
+import { DomainsFullCartItem } from './item';
+
 import './style.scss';
 
 export const DomainsFullCartItems = () => {
-	const { __ } = useI18n();
 	const { cart } = useDomainSearch();
 
 	return (
 		<VStack spacing={ 3 }>
 			{ cart.items.map( ( domain ) => (
-				<Card key={ `${ domain.domain }.${ domain.tld }` }>
-					<CardBody size="small">
-						<HStack alignment="top" justify="space-between" spacing={ 6 }>
-							<VStack spacing={ 2 } alignment="left">
-								<Text size="medium" aria-label={ `${ domain.domain }.${ domain.tld }` }>
-									{ domain.domain }
-									<Text size="inherit" weight={ 500 }>
-										.{ domain.tld }
-									</Text>
-								</Text>
-								<Button
-									variant="link"
-									className="domains-full-cart-items__remove"
-									onClick={ () => cart.onRemoveItem( domain.uuid ) }
-								>
-									{ __( 'Remove' ) }
-								</Button>
-							</VStack>
-							<VStack className="domains-full-cart-items__price">
-								<HStack alignment="right" spacing={ 2 }>
-									{ domain.originalPrice && (
-										<Text size="small" className="domains-full-cart-items__original-price">
-											{ domain.originalPrice }
-										</Text>
-									) }
-									<Text size="small">
-										{ sprintf(
-											// translators: %(price)s is the price of the domain.
-											__( '%(price)s/year' ),
-											{ price: domain.price }
-										) }
-									</Text>
-								</HStack>
-							</VStack>
-						</HStack>
-					</CardBody>
-				</Card>
+				<DomainsFullCartItem key={ domain.uuid } domain={ domain } />
 			) ) }
 		</VStack>
 	);

--- a/packages/domain-search/src/components/domains-full-cart-items/item.tsx
+++ b/packages/domain-search/src/components/domains-full-cart-items/item.tsx
@@ -8,14 +8,32 @@ import {
 } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
+import { useEffect, useRef, useState } from 'react';
 import { useDomainSearch } from '../domain-search';
 import type { SelectedDomain } from '../domain-search/types';
 
 export const DomainsFullCartItem = ( { domain }: { domain: SelectedDomain } ) => {
 	const { __ } = useI18n();
 	const { cart } = useDomainSearch();
+	const [ isBusy, setIsBusy ] = useState( false );
+
+	const initiatedByThisComponent = useRef( false );
+
+	useEffect( () => {
+		if ( ! initiatedByThisComponent.current ) {
+			return;
+		}
+
+		if ( cart.isBusy ) {
+			setIsBusy( true );
+		} else {
+			setIsBusy( false );
+			initiatedByThisComponent.current = false;
+		}
+	}, [ cart.isBusy ] );
 
 	const removeItem = async () => {
+		initiatedByThisComponent.current = true;
 		cart.onRemoveItem( domain.uuid );
 	};
 
@@ -33,6 +51,7 @@ export const DomainsFullCartItem = ( { domain }: { domain: SelectedDomain } ) =>
 							</Text>
 							<Button
 								disabled={ cart.isBusy }
+								isBusy={ isBusy }
 								variant="link"
 								className="domains-full-cart-items__remove"
 								onClick={ removeItem }

--- a/packages/domain-search/src/components/domains-full-cart-items/item.tsx
+++ b/packages/domain-search/src/components/domains-full-cart-items/item.tsx
@@ -5,29 +5,18 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 	Button,
-	Notice,
 } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import { useState } from 'react';
 import { useDomainSearch } from '../domain-search';
 import type { SelectedDomain } from '../domain-search/types';
 
 export const DomainsFullCartItem = ( { domain }: { domain: SelectedDomain } ) => {
 	const { __ } = useI18n();
-	const { cart, isBusy, setIsBusy } = useDomainSearch();
-	const [ error, setError ] = useState< string | null >( null );
+	const { cart } = useDomainSearch();
 
 	const removeItem = async () => {
-		setIsBusy( true );
-
-		try {
-			await cart.onRemoveItem( domain.uuid );
-		} catch {
-			setError( __( 'There was a problem removing your domain. Please try again.' ) );
-		} finally {
-			setIsBusy( false );
-		}
+		cart.onRemoveItem( domain.uuid );
 	};
 
 	return (
@@ -43,7 +32,7 @@ export const DomainsFullCartItem = ( { domain }: { domain: SelectedDomain } ) =>
 								</Text>
 							</Text>
 							<Button
-								disabled={ isBusy }
+								disabled={ cart.isBusy }
 								variant="link"
 								className="domains-full-cart-items__remove"
 								onClick={ removeItem }
@@ -68,11 +57,6 @@ export const DomainsFullCartItem = ( { domain }: { domain: SelectedDomain } ) =>
 							</HStack>
 						</VStack>
 					</HStack>
-					{ error && (
-						<Notice onRemove={ () => setError( null ) } status="error">
-							{ error }
-						</Notice>
-					) }
 				</VStack>
 			</CardBody>
 		</Card>

--- a/packages/domain-search/src/components/domains-full-cart-items/item.tsx
+++ b/packages/domain-search/src/components/domains-full-cart-items/item.tsx
@@ -9,40 +9,16 @@ import {
 } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import { useEffect, useRef, useState } from 'react';
+import { useFocusedCartAction } from '../../hooks/use-focused-cart-action';
 import { useDomainSearch } from '../domain-search';
 import type { SelectedDomain } from '../domain-search/types';
 
 export const DomainsFullCartItem = ( { domain }: { domain: SelectedDomain } ) => {
 	const { __ } = useI18n();
 	const { cart } = useDomainSearch();
-	const [ isBusy, setIsBusy ] = useState( false );
-	const [ errorMessage, setErrorMessage ] = useState< string | null >( null );
-
-	const initiatedByThisComponent = useRef( false );
-
-	useEffect( () => {
-		if ( ! initiatedByThisComponent.current ) {
-			return;
-		}
-
-		if ( cart.isBusy ) {
-			setIsBusy( true );
-			setErrorMessage( null );
-
-			return;
-		}
-
-		initiatedByThisComponent.current = false;
-
-		setIsBusy( false );
-		setErrorMessage( cart.errorMessage );
-	}, [ cart.isBusy, cart.errorMessage ] );
-
-	const removeItem = async () => {
-		initiatedByThisComponent.current = true;
+	const { isBusy, errorMessage, removeErrorMessage, callback } = useFocusedCartAction( () => {
 		cart.onRemoveItem( domain.uuid );
-	};
+	} );
 
 	return (
 		<Card>
@@ -61,7 +37,7 @@ export const DomainsFullCartItem = ( { domain }: { domain: SelectedDomain } ) =>
 								isBusy={ isBusy }
 								variant="link"
 								className="domains-full-cart-items__remove"
-								onClick={ removeItem }
+								onClick={ callback }
 							>
 								{ __( 'Remove' ) }
 							</Button>
@@ -84,7 +60,7 @@ export const DomainsFullCartItem = ( { domain }: { domain: SelectedDomain } ) =>
 						</VStack>
 					</HStack>
 					{ errorMessage && (
-						<Notice status="error" onRemove={ () => setErrorMessage( null ) }>
+						<Notice status="error" onRemove={ removeErrorMessage }>
 							{ errorMessage }
 						</Notice>
 					) }

--- a/packages/domain-search/src/components/domains-full-cart-items/item.tsx
+++ b/packages/domain-search/src/components/domains-full-cart-items/item.tsx
@@ -1,0 +1,80 @@
+import {
+	Card,
+	CardBody,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	Button,
+	Notice,
+} from '@wordpress/components';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
+import { useState } from 'react';
+import { useDomainSearch } from '../domain-search';
+import type { SelectedDomain } from '../domain-search/types';
+
+export const DomainsFullCartItem = ( { domain }: { domain: SelectedDomain } ) => {
+	const { __ } = useI18n();
+	const { cart, isBusy, setIsBusy } = useDomainSearch();
+	const [ error, setError ] = useState< string | null >( null );
+
+	const removeItem = async () => {
+		setIsBusy( true );
+
+		try {
+			await cart.onRemoveItem( domain.uuid );
+		} catch {
+			setError( __( 'There was a problem removing your domain. Please try again.' ) );
+		} finally {
+			setIsBusy( false );
+		}
+	};
+
+	return (
+		<Card>
+			<CardBody size="small">
+				<VStack spacing={ 4 }>
+					<HStack alignment="top" justify="space-between" spacing={ 6 }>
+						<VStack spacing={ 2 } alignment="left">
+							<Text size="medium" aria-label={ `${ domain.domain }.${ domain.tld }` }>
+								{ domain.domain }
+								<Text size="inherit" weight={ 500 }>
+									.{ domain.tld }
+								</Text>
+							</Text>
+							<Button
+								disabled={ isBusy }
+								variant="link"
+								className="domains-full-cart-items__remove"
+								onClick={ removeItem }
+							>
+								{ __( 'Remove' ) }
+							</Button>
+						</VStack>
+						<VStack className="domains-full-cart-items__price">
+							<HStack alignment="right" spacing={ 2 }>
+								{ domain.originalPrice && (
+									<Text size="small" className="domains-full-cart-items__original-price">
+										{ domain.originalPrice }
+									</Text>
+								) }
+								<Text size="small">
+									{ sprintf(
+										// translators: %(price)s is the price of the domain.
+										__( '%(price)s/year' ),
+										{ price: domain.price }
+									) }
+								</Text>
+							</HStack>
+						</VStack>
+					</HStack>
+					{ error && (
+						<Notice onRemove={ () => setError( null ) } status="error">
+							{ error }
+						</Notice>
+					) }
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+};

--- a/packages/domain-search/src/components/domains-full-cart-items/item.tsx
+++ b/packages/domain-search/src/components/domains-full-cart-items/item.tsx
@@ -5,6 +5,7 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 	Button,
+	Notice,
 } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
@@ -16,6 +17,7 @@ export const DomainsFullCartItem = ( { domain }: { domain: SelectedDomain } ) =>
 	const { __ } = useI18n();
 	const { cart } = useDomainSearch();
 	const [ isBusy, setIsBusy ] = useState( false );
+	const [ errorMessage, setErrorMessage ] = useState< string | null >( null );
 
 	const initiatedByThisComponent = useRef( false );
 
@@ -26,11 +28,16 @@ export const DomainsFullCartItem = ( { domain }: { domain: SelectedDomain } ) =>
 
 		if ( cart.isBusy ) {
 			setIsBusy( true );
-		} else {
-			setIsBusy( false );
-			initiatedByThisComponent.current = false;
+			setErrorMessage( null );
+
+			return;
 		}
-	}, [ cart.isBusy ] );
+
+		initiatedByThisComponent.current = false;
+
+		setIsBusy( false );
+		setErrorMessage( cart.errorMessage );
+	}, [ cart.isBusy, cart.errorMessage ] );
 
 	const removeItem = async () => {
 		initiatedByThisComponent.current = true;
@@ -76,6 +83,11 @@ export const DomainsFullCartItem = ( { domain }: { domain: SelectedDomain } ) =>
 							</HStack>
 						</VStack>
 					</HStack>
+					{ errorMessage && (
+						<Notice status="error" onRemove={ () => setErrorMessage( null ) }>
+							{ errorMessage }
+						</Notice>
+					) }
 				</VStack>
 			</CardBody>
 		</Card>

--- a/packages/domain-search/src/components/domains-full-cart/index.stories.tsx
+++ b/packages/domain-search/src/components/domains-full-cart/index.stories.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@wordpress/components';
+import { buildDomain, buildDomainSearchCart } from '../../test-helpers/factories';
 import { DomainSearch, useDomainSearch } from '../domain-search';
 import { DomainsFullCart } from '.';
 import type { Meta } from '@storybook/react';
@@ -23,31 +24,37 @@ export const Default = () => {
 			onContinue={ () => {
 				alert( 'Continue' );
 			} }
-			cart={ {
+			cart={ buildDomainSearchCart( {
 				items: [
-					{ uuid: '1', domain: 'the-lasso', tld: 'net', price: '$74' },
-					{ uuid: '2', domain: 'the-lasso', tld: 'com', originalPrice: '$18', price: '$8' },
-					{
+					buildDomain( { uuid: '1', domain: 'the-lasso', tld: 'net', price: '$74' } ),
+					buildDomain( {
+						uuid: '2',
+						domain: 'the-lasso',
+						tld: 'com',
+						originalPrice: '$18',
+						price: '$8',
+					} ),
+					buildDomain( {
 						uuid: '3',
 						domain: 'the-different-domain',
 						tld: 'com',
 						originalPrice: '$18',
 						price: '$8',
-					},
-					{
+					} ),
+					buildDomain( {
 						uuid: '4',
 						domain: 'the-different-domain1',
 						tld: 'com',
 						originalPrice: '$18',
 						price: '$8',
-					},
-					{
+					} ),
+					buildDomain( {
 						uuid: '5',
 						domain: 'the-different-domain2',
 						tld: 'com',
 						originalPrice: '$18',
 						price: '$8',
-					},
+					} ),
 				],
 				total: '$74',
 				onAddItem: () => {},
@@ -55,7 +62,7 @@ export const Default = () => {
 				onRemoveItem: ( domain ) => {
 					alert( `Remove ${ domain }` );
 				},
-			} }
+			} ) }
 		>
 			<DomainsFullCart />
 			<FullCartManager />

--- a/packages/domain-search/src/components/domains-full-cart/index.tsx
+++ b/packages/domain-search/src/components/domains-full-cart/index.tsx
@@ -48,7 +48,7 @@ const DomainsFullCart = ( {
 	className?: string;
 	children?: React.ReactNode;
 } ) => {
-	const { isFullCartOpen, closeFullCart, onContinue } = useDomainSearch();
+	const { cart, isFullCartOpen, closeFullCart, onContinue } = useDomainSearch();
 	const { __ } = useI18n();
 	const isMobile = useViewportMatch( 'small', '<' );
 
@@ -94,6 +94,7 @@ const DomainsFullCart = ( {
 							__next40pxDefaultSize
 							variant="primary"
 							onClick={ onContinue }
+							disabled={ cart.isBusy }
 						>
 							{ __( 'Continue' ) }
 						</Button>

--- a/packages/domain-search/src/components/domains-mini-cart/actions.tsx
+++ b/packages/domain-search/src/components/domains-mini-cart/actions.tsx
@@ -3,7 +3,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useDomainSearch } from '../domain-search';
 
 export const DomainsMiniCartActions = () => {
-	const { onContinue, openFullCart } = useDomainSearch();
+	const { cart, onContinue, openFullCart } = useDomainSearch();
 	const { __ } = useI18n();
 
 	return (
@@ -16,7 +16,12 @@ export const DomainsMiniCartActions = () => {
 			>
 				{ __( 'View cart' ) }
 			</Button>
-			<Button variant="primary" onClick={ () => onContinue() } __next40pxDefaultSize>
+			<Button
+				variant="primary"
+				onClick={ () => onContinue() }
+				__next40pxDefaultSize
+				disabled={ cart.isBusy }
+			>
 				{ __( 'Continue' ) }
 			</Button>
 		</HStack>

--- a/packages/domain-search/src/hooks/use-focused-cart-action.ts
+++ b/packages/domain-search/src/hooks/use-focused-cart-action.ts
@@ -1,0 +1,39 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useDomainSearch } from '../components/domain-search';
+
+export const useFocusedCartAction = ( action: () => void ) => {
+	const { cart } = useDomainSearch();
+	const [ isBusy, setIsBusy ] = useState( false );
+	const [ errorMessage, setErrorMessage ] = useState< string | null >( null );
+
+	const initiatedByThisComponent = useRef( false );
+
+	useEffect( () => {
+		if ( ! initiatedByThisComponent.current ) {
+			return;
+		}
+
+		if ( cart.isBusy ) {
+			setIsBusy( true );
+			setErrorMessage( null );
+
+			return;
+		}
+
+		initiatedByThisComponent.current = false;
+
+		setIsBusy( false );
+		setErrorMessage( cart.errorMessage );
+	}, [ cart.isBusy, cart.errorMessage ] );
+
+	const callback = async () => {
+		initiatedByThisComponent.current = true;
+		action();
+	};
+
+	const removeErrorMessage = useCallback( () => {
+		setErrorMessage( null );
+	}, [] );
+
+	return { isBusy, errorMessage, removeErrorMessage, callback };
+};

--- a/packages/domain-search/src/hooks/use-focused-cart-action.ts
+++ b/packages/domain-search/src/hooks/use-focused-cart-action.ts
@@ -9,6 +9,12 @@ export const useFocusedCartAction = ( action: () => void ) => {
 	const initiatedByThisComponent = useRef( false );
 
 	useEffect( () => {
+		if ( ! cart.errorMessage ) {
+			setErrorMessage( null );
+		}
+	}, [ cart.errorMessage ] );
+
+	useEffect( () => {
 		if ( ! initiatedByThisComponent.current ) {
 			return;
 		}

--- a/packages/domain-search/src/index.stories.tsx
+++ b/packages/domain-search/src/index.stories.tsx
@@ -5,6 +5,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useState } from 'react';
+import { buildDomainSearchCart } from './test-helpers/factories';
 import {
 	DomainSearch,
 	DomainSearchControls,
@@ -77,13 +78,7 @@ function DomainSearchEmptyState( { onSearch }: { onSearch( query: string ): void
 function DomainSearchResults( { initialQuery }: { initialQuery: string } ) {
 	return (
 		<DomainSearch
-			cart={ {
-				items: [],
-				total: '',
-				onAddItem: () => {},
-				onRemoveItem: () => {},
-				hasItem: () => false,
-			} }
+			cart={ buildDomainSearchCart() }
 			initialQuery={ initialQuery }
 			onContinue={ () => {
 				alert( 'go to checkout' );

--- a/packages/domain-search/src/index.ts
+++ b/packages/domain-search/src/index.ts
@@ -1,4 +1,4 @@
-export { DomainSearch } from './components/domain-search';
+export { DomainSearch, useDomainSearch } from './components/domain-search';
 export type { DomainSearchCart } from './components/domain-search/types';
 export { DomainSearchNotice } from './components/domain-search-notice';
 export { DomainsMiniCart } from './components/domains-mini-cart';

--- a/packages/domain-search/src/test-helpers/factories.ts
+++ b/packages/domain-search/src/test-helpers/factories.ts
@@ -12,6 +12,7 @@ export const buildDomainSearchCart = (
 	onAddItem: () => {},
 	onRemoveItem: () => {},
 	hasItem: () => false,
+	isBusy: false,
 	...overrides,
 } );
 
@@ -25,8 +26,6 @@ export const buildDomainSearchContext = (
 	setQuery: () => {},
 	cart: buildDomainSearchCart(),
 	openFullCart: () => {},
-	isBusy: false,
-	setIsBusy: () => {},
 	...overrides,
 } );
 

--- a/packages/domain-search/src/test-helpers/factories.ts
+++ b/packages/domain-search/src/test-helpers/factories.ts
@@ -13,6 +13,7 @@ export const buildDomainSearchCart = (
 	onRemoveItem: () => {},
 	hasItem: () => false,
 	isBusy: false,
+	errorMessage: null,
 	...overrides,
 } );
 

--- a/packages/domain-search/src/test-helpers/factories.ts
+++ b/packages/domain-search/src/test-helpers/factories.ts
@@ -25,6 +25,8 @@ export const buildDomainSearchContext = (
 	setQuery: () => {},
 	cart: buildDomainSearchCart(),
 	openFullCart: () => {},
+	isBusy: false,
+	setIsBusy: () => {},
 	...overrides,
 } );
 


### PR DESCRIPTION
Closes DOMAINS-1549.

## Proposed Changes

Adds loading and error states to the cart operations (domain addition, removal).


https://github.com/user-attachments/assets/9e2b6406-3ead-4f17-a10c-bb176892474f




## Testing Instructions

Play around by adding and removing domains from the cart. Compare the behavior with production.