### PR TITLE
Connect Refresh: Fix Magic Login headers not updating on confirmation screen

### DIFF
--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import RedirectWhenLoggedIn from 'calypso/components/redirect-when-logged-in';
-import { preventWidows } from 'calypso/lib/formatting/prevent-widows';
 import { login } from 'calypso/lib/paths';
 import {
 	recordPageViewWithClientId as recordPageView,
@@ -38,33 +37,6 @@ class EmailedLoginLinkSuccessfully extends Component {
 
 	componentDidMount() {
 		this.props.recordPageView( '/log-in/link', 'Login > Link > Emailed' );
-		this.context?.setHeaders( {
-			heading: this.props.translate( 'Check your email' ),
-			subHeading: this.getSubHeaderText(),
-		} );
-	}
-
-	componentDidUpdate( prevProps ) {
-		if ( prevProps.emailAddress !== this.props.emailAddress ) {
-			this.context?.setHeaders( {
-				heading: this.context?.heading,
-				subHeading: this.getSubHeaderText(),
-			} );
-		}
-	}
-
-	getSubHeaderText() {
-		return preventWidows(
-			this.props.emailAddress
-				? this.props.translate(
-						"We've sent a login link to {{strong}}%(emailAddress)s{{/strong}}",
-						{
-							args: { emailAddress: this.props.emailAddress },
-							components: { strong: <strong /> },
-						}
-				  )
-				: this.props.translate( 'We just emailed you a link.' )
-		);
 	}
 
 	onLostPasswordClick = ( event ) => {

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -8,6 +8,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import LoggedOutForm from 'calypso/components/logged-out-form';
 import Notice from 'calypso/components/notice';
+import { preventWidows } from 'calypso/lib/formatting/prevent-widows';
 import wpcom from 'calypso/lib/wp';
 import { LoginContext } from 'calypso/login/login-context';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -77,6 +78,33 @@ class RequestLoginEmailForm extends Component {
 
 	usernameOrEmailRef = createRef();
 
+	setRequestLoginHeaders() {
+		this.context?.setHeaders( {
+			heading: this.props.translate( 'Email me a login link' ),
+			subHeading: this.getSubHeaderText(),
+		} );
+	}
+
+	setCheckYourEmailHeaders() {
+		const usernameOrEmail = this.getUsernameOrEmailFromState();
+		const emailAddress = usernameOrEmail.indexOf( '@' ) > 0 ? usernameOrEmail : null;
+
+		this.context?.setHeaders( {
+			heading: this.props.translate( 'Check your email' ),
+			subHeading: preventWidows(
+				emailAddress
+					? this.props.translate(
+							"We've sent a login link to {{strong}}%(emailAddress)s{{/strong}}",
+							{
+								args: { emailAddress },
+								components: { strong: <strong /> },
+							}
+					  )
+					: this.props.translate( 'We just emailed you a link.' )
+			),
+		} );
+	}
+
 	componentDidMount() {
 		const blogId = this.props.blogId;
 		if ( blogId ) {
@@ -85,10 +113,11 @@ class RequestLoginEmailForm extends Component {
 				.then( ( result ) => this.setState( { site: result } ) );
 		}
 
-		this.context?.setHeaders( {
-			heading: this.props.translate( 'Email me a login link' ),
-			subHeading: this.getSubHeaderText(),
-		} );
+		if ( this.props.showCheckYourEmail ) {
+			this.setCheckYourEmailHeaders();
+		} else {
+			this.setRequestLoginHeaders();
+		}
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -97,10 +126,11 @@ class RequestLoginEmailForm extends Component {
 		}
 
 		if ( this.state.site?.name && prevProps.site?.name !== this.state.site?.name ) {
-			this.context?.setHeaders( {
-				heading: this.context?.heading,
-				subHeading: this.getSubHeaderText(),
-			} );
+			this.setRequestLoginHeaders();
+		}
+
+		if ( ! prevProps.showCheckYourEmail && this.props.showCheckYourEmail ) {
+			this.setCheckYourEmailHeaders();
 		}
 	}
 
@@ -207,7 +237,7 @@ class RequestLoginEmailForm extends Component {
 					onResendEmail={ this.onSubmit }
 				/>
 			) : (
-				<EmailedLoginLinkSuccessfully emailAddress={ emailAddress } />
+				<EmailedLoginLinkSuccessfully key={ emailAddress } emailAddress={ emailAddress } />
 			);
 		}
 

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -237,7 +237,7 @@ class RequestLoginEmailForm extends Component {
 					onResendEmail={ this.onSubmit }
 				/>
 			) : (
-				<EmailedLoginLinkSuccessfully key={ emailAddress } emailAddress={ emailAddress } />
+				<EmailedLoginLinkSuccessfully emailAddress={ emailAddress } />
 			);
 		}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTOBRD-259/email-me-a-link-copy-doesnt-correspond-to-action
Props to @keoshi for flagging this.

## Proposed Changes

When using an email on the main Login page, the action directs to Magic Login.
Navigating back/forth and using the same email again causes inconsistent headers rendering. The result is:

<img width="500" height="342" alt="Screenshot 2025-07-21 at 8 19 43 PM" src="https://github.com/user-attachments/assets/56483852-a8cb-4bbf-a3cd-95b657218fcd" />


Whilst it should be:

<img width="500" height="343" alt="Screenshot 2025-07-21 at 8 19 12 PM" src="https://github.com/user-attachments/assets/46c9bd7a-b5fb-4ccb-aa60-68b2279473bc" />

### Cause

The child component would not reset the headers when the email address hasn't changed between updates.

### Solution

It's a little more complicated than letting the child always update the headers. Our use of context will force the parent component to reset the headers, either resulting in the same scenario or in an infinite loop. We instead control the headers from the parent component alone now.

We may explore removing context in the future as it feels a little fragile for setting headers in these screens. Memoizing the value prop in the context Provider might work too, so we can explore that too. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fixes https://linear.app/a8c/issue/DOTOBRD-259/email-me-a-link-copy-doesnt-correspond-to-action


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to main Login, enter an email, and click continue
* Click continue on Magic Login page to get to the confirmation screen
* On confirmation screen go back in the browser (or through the links in the footer)
* Now back to main Login, add the same email and click continue. The next page should render correctly like below:

<img width="500" height="343" alt="Screenshot 2025-07-21 at 8 19 12 PM" src="https://github.com/user-attachments/assets/00035652-8d15-453c-984e-7cae930a3f44" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
