### PR TITLE
Password reset: improve parsing error messages

### DIFF
--- a/client/blocks/login/lost-password-form.jsx
+++ b/client/blocks/login/lost-password-form.jsx
@@ -136,7 +136,7 @@ const LostPasswordForm = ( {
 			 * Check this is a network error first, so that we can run
 			 * Response.text() on it.
 			 */
-			if ( ! ( response instanceof Response ) ) {
+			if ( ! response?.text ) {
 				return setError( defaultError );
 			}
 

--- a/client/blocks/login/lost-password-form.jsx
+++ b/client/blocks/login/lost-password-form.jsx
@@ -73,6 +73,7 @@ const LostPasswordForm = ( {
 		if ( resp.status < 200 || resp.status >= 300 ) {
 			throw resp;
 		}
+
 		return await resp.text();
 	};
 
@@ -125,8 +126,18 @@ const LostPasswordForm = ( {
 					isJetpack: isWooJPC || isJetpack,
 				} )
 			);
-		} catch ( _httpError ) {
+		} catch ( response ) {
 			setBusy( false );
+			const result = await response.text();
+
+			const parser = new DOMParser();
+			const resultHTML = parser.parseFromString( result, 'text/html' );
+
+			const wpDieMessage = resultHTML.querySelector( '.wp-die-message' );
+			if ( wpDieMessage ) {
+				return setError( wpDieMessage.textContent.trim() );
+			}
+
 			setError(
 				translate( 'There was an error sending the password reset email. Please try again.' )
 			);

--- a/client/blocks/login/lost-password-form.jsx
+++ b/client/blocks/login/lost-password-form.jsx
@@ -128,7 +128,27 @@ const LostPasswordForm = ( {
 			);
 		} catch ( response ) {
 			setBusy( false );
+			const defaultError = translate(
+				'There was an error sending the password reset email. Please try again.'
+			);
+
+			/**
+			 * Check this is a network error first, so that we can run
+			 * Response.text() on it.
+			 */
+			if ( ! ( response instanceof Response ) ) {
+				return setError( defaultError );
+			}
+
 			const result = await response.text();
+
+			/**
+			 * Check if DOMParser is available, in case it's missing in the
+			 * server-side rendering context.
+			 */
+			if ( typeof DOMParser === 'undefined' ) {
+				return setError( defaultError );
+			}
 
 			const parser = new DOMParser();
 			const resultHTML = parser.parseFromString( result, 'text/html' );
@@ -138,9 +158,7 @@ const LostPasswordForm = ( {
 				return setError( wpDieMessage.textContent.trim() );
 			}
 
-			setError(
-				translate( 'There was an error sending the password reset email. Please try again.' )
-			);
+			return setError( defaultError );
 		}
 	};
 


### PR DESCRIPTION
Fixes DOTCOM-13715

## Proposed Changes

* We're now calling `/wp-login.php?action=lostpassword` from our front end to reset the password and it returns HTML. This PR parses that HTML to display the error message in the `wp_die` page.

<img width="640" height="529" alt="image" src="https://github.com/user-attachments/assets/4475b2f6-ae8c-4284-8559-bb7baeb83e0f" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The new password form doesn't provide a granular error message, to guide the users in the flow. This PR improves the error messages.

## Testing Instructions

* We need to be able to trigger the password request to WordPress.com, and by default it doesn't work. We'll use the `MOCK_WORDPRESSDOTCOM` environment variable and tweak things a bit. 
* To tweak it, please download and apply the patch [proxy-tweaks.patch.txt](https://github.com/user-attachments/files/21428682/proxy-tweaks.patch.txt): `git apply proxy-tweaks.patch.txt`
* Instead of `yarn start`, please run `yarn run start-mock-wordpress-com`
* [Request a password reset](https://wpcalypso.wordpress.com/log-in/lostpassword?redirect_to=%2Fdevdocs%2Fstart) multiple times, to get hit with a rate limit. Confirm you see the rate limit error.
    * From what I observed, you need to request it five times in a short duration, to hit the rate limit.
* See the new error message.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?