### PR TITLE
Disable sorting by PHP version, which crashes

### DIFF
--- a/client/dashboard/app/query-client.ts
+++ b/client/dashboard/app/query-client.ts
@@ -20,7 +20,10 @@ export const queryClient = new QueryClient( {
 	},
 } );
 
-const persister = createSyncStoragePersister( { storage: window.localStorage } );
+const persister = createSyncStoragePersister( {
+	storage: typeof window !== 'undefined' ? window.localStorage : null,
+} );
+
 const maxAge = 1000 * 60 * 60 * 24; // 24 hours
 
 const [ , persistPromise ] = persistQueryClient( {

--- a/client/dashboard/sites/fields.tsx
+++ b/client/dashboard/sites/fields.tsx
@@ -129,6 +129,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		id: 'php_version',
 		label: __( 'PHP version' ),
 		render: ( { item }: { item: Site } ) => <PHPVersion site={ item } />,
+		enableSorting: false,
 	},
 	{
 		id: 'storage',

--- a/client/dashboard/sites/fields.tsx
+++ b/client/dashboard/sites/fields.tsx
@@ -21,7 +21,7 @@ import {
 import type { Site } from '../data/types';
 import type { Field, Operator } from '@wordpress/dataviews';
 
-const DEFAULT_FIELDS: Field< Site >[] = [
+export const DEFAULT_FIELDS: Field< Site >[] = [
 	{
 		id: 'name',
 		label: __( 'Site' ),

--- a/client/dashboard/sites/views.ts
+++ b/client/dashboard/sites/views.ts
@@ -1,4 +1,5 @@
 import fastDeepEqual from 'fast-deep-equal/es6';
+import { DEFAULT_FIELDS } from './fields';
 import type { AnalyticsClient } from '../app/analytics';
 import type { User, SitesView, SitesViewPreferences } from '../data/types';
 import type { Operator, SortDirection, SupportedLayouts } from '@wordpress/dataviews';
@@ -84,15 +85,15 @@ function getDefaultView( {
 		];
 	}
 
-	return defaultView;
+	return sanitizeView( defaultView );
 }
 
 export function getView( {
 	user,
 	isAutomattician,
 	isRestoringAccount,
-	viewPreferences: rawViewPreferences,
-	viewSearchParams: rawViewSearchParams,
+	viewPreferences,
+	viewSearchParams,
 }: {
 	user: User;
 	isAutomattician: boolean;
@@ -103,8 +104,6 @@ export function getView( {
 	defaultView: SitesView;
 	view: SitesView;
 } {
-	const viewPreferences = rawViewPreferences && upgradeViewPreferences( rawViewPreferences );
-	const viewSearchParams = upgradeSearchParams( rawViewSearchParams );
 	const defaultView = getDefaultView( {
 		user,
 		isAutomattician,
@@ -113,13 +112,13 @@ export function getView( {
 
 	const type = viewSearchParams.type || viewPreferences?.type || defaultView.type;
 
-	const view = {
+	const view = sanitizeView( {
 		...defaultView,
 		...DEFAULT_LAYOUTS[ type ],
 		...DEFAULT_LAYOUT_FIELDS[ type ],
 		...viewPreferences,
 		...viewSearchParams,
-	} as SitesView;
+	} as SitesView );
 
 	return {
 		defaultView,
@@ -270,35 +269,20 @@ export function recordViewChanges(
 }
 
 /**
- * An opportunity to process the user preference data which has been saved in the past
- * and could now be out of date.
- * @param oldPreferences Old preferences which have been fetched from the database.
- * @returns The upgraded view preferences without any unsupported fields.
+ * Sanitize the view preference data by removing any invalid or malformed entries.
  */
-export function upgradeViewPreferences(
-	oldPreferences: SitesViewPreferences
-): SitesViewPreferences {
-	if ( oldPreferences?.sort?.field === 'php_version' ) {
-		const { sort, ...rest } = oldPreferences;
-		return { ...rest };
+function sanitizeView( { sort, ...view }: SitesView ) {
+	if ( sort?.field ) {
+		const field = DEFAULT_FIELDS.find( ( field ) => field.id === sort?.field );
+		if ( ! field || field.enableSorting === false ) {
+			return view;
+		}
 	}
 
-	return oldPreferences;
-}
-
-/**
- * An opportunity to process the search param data which has been kept in the URL but
- * could now be out of date after a page refresh.
- * @param oldParams Old search params.
- * @returns The upgraded search params without any unsupported fields.
- */
-export function upgradeSearchParams( oldParams: ViewSearchParams ): ViewSearchParams {
-	if ( oldParams?.sort?.field === 'php_version' ) {
-		const { sort, ...rest } = oldParams;
-		return { ...rest };
-	}
-
-	return oldParams;
+	return {
+		...view,
+		sort,
+	};
 }
 
 // Ponyfill for Set.prototype.difference, which is not available in all target environments.

--- a/client/dashboard/sites/views.ts
+++ b/client/dashboard/sites/views.ts
@@ -91,8 +91,8 @@ export function getView( {
 	user,
 	isAutomattician,
 	isRestoringAccount,
-	viewPreferences,
-	viewSearchParams,
+	viewPreferences: rawViewPreferences,
+	viewSearchParams: rawViewSearchParams,
 }: {
 	user: User;
 	isAutomattician: boolean;
@@ -103,6 +103,8 @@ export function getView( {
 	defaultView: SitesView;
 	view: SitesView;
 } {
+	const viewPreferences = rawViewPreferences && upgradeViewPreferences( rawViewPreferences );
+	const viewSearchParams = upgradeSearchParams( rawViewSearchParams );
 	const defaultView = getDefaultView( {
 		user,
 		isAutomattician,
@@ -265,6 +267,38 @@ export function recordViewChanges(
 			field: removed,
 		} );
 	}
+}
+
+/**
+ * An opportunity to process the user preference data which has been saved in the past
+ * and could now be out of date.
+ * @param oldPreferences Old preferences which have been fetched from the database.
+ * @returns The upgraded view preferences without any unsupported fields.
+ */
+export function upgradeViewPreferences(
+	oldPreferences: SitesViewPreferences
+): SitesViewPreferences {
+	if ( oldPreferences?.sort?.field === 'php_version' ) {
+		const { sort, ...rest } = oldPreferences;
+		return { ...rest };
+	}
+
+	return oldPreferences;
+}
+
+/**
+ * An opportunity to process the search param data which has been kept in the URL but
+ * could now be out of date after a page refresh.
+ * @param oldParams Old search params.
+ * @returns The upgraded search params without any unsupported fields.
+ */
+export function upgradeSearchParams( oldParams: ViewSearchParams ): ViewSearchParams {
+	if ( oldParams?.sort?.field === 'php_version' ) {
+		const { sort, ...rest } = oldParams;
+		return { ...rest };
+	}
+
+	return oldParams;
 }
 
 // Ponyfill for Set.prototype.difference, which is not available in all target environments.

--- a/client/dashboard/sites/views.ts
+++ b/client/dashboard/sites/views.ts
@@ -85,7 +85,7 @@ function getDefaultView( {
 		];
 	}
 
-	return sanitizeView( defaultView );
+	return defaultView;
 }
 
 export function getView( {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Prevent any future sorting by PHP in the future
* Ensure we don't attempt to sort by PHP when that is saved as a preference or in query params

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

An exception is thrown when trying to sort by PHP.
p1753113232469989-slack-C08JZTRS6NA

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use `wpcalypso.wordpress.com/sites` to sort by `php_versions`
  * It will crash, but it will persist the bad field value to your preferences, which helps with testing
  * Also you should copy the bad query string which includes the `php_version` sorting
* Load `calypso.localhost:3000/sites?flags=dashboard/v2/backport/sites-list`
  * Append your saved query parameter too for good measure
* It shouldn't crash and `php_version` shouldn't be sortable

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?