### PR TITLE
Hosting Dashboard: Explicit imports

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -40,6 +40,7 @@ module.exports = {
 							'!@automattic/components/src/summary-button',
 							'!@automattic/components/src/breadcrumbs',
 							'!@automattic/components/src/breadcrumbs/types',
+							'!@automattic/components/src/logos',
 							'!@automattic/calypso-analytics',
 							'!@automattic/domains-table',
 							'!@automattic/domains-table/src/utils/*',

--- a/client/dashboard/app/root/index.tsx
+++ b/client/dashboard/app/root/index.tsx
@@ -1,4 +1,4 @@
-import { WordPressLogo } from '@automattic/components';
+import { WordPressLogo } from '@automattic/components/src/logos/wordpress-logo';
 import { useIsFetching } from '@tanstack/react-query';
 import { CatchNotFound, Outlet, useRouterState } from '@tanstack/react-router';
 import { Suspense, lazy } from 'react';

--- a/client/dashboard/components/summary-button-list/index.stories.tsx
+++ b/client/dashboard/components/summary-button-list/index.stories.tsx
@@ -1,4 +1,4 @@
-import { SummaryButton } from '@automattic/components';
+import SummaryButton from '@automattic/components/src/summary-button';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon } from '@wordpress/components';
 import { brush, home, seen } from '@wordpress/icons';

--- a/client/dashboard/components/summary-button-list/test/index.tsx
+++ b/client/dashboard/components/summary-button-list/test/index.tsx
@@ -2,11 +2,11 @@
  * @jest-environment jsdom
  */
 import '@testing-library/jest-dom';
-import { SummaryButton } from '@automattic/components';
-import { Density } from '@automattic/components/src/summary-button/types';
+import SummaryButton from '@automattic/components/src/summary-button';
 import { render, screen } from '@testing-library/react';
 import * as React from 'react';
 import { SummaryButtonList } from '../index';
+import type { Density } from '@automattic/components/src/summary-button/types';
 
 describe( 'SummaryButtonList', () => {
 	it( 'renders a title and description', () => {

--- a/client/dashboard/sites/add-new-site/index.tsx
+++ b/client/dashboard/sites/add-new-site/index.tsx
@@ -1,5 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { WordPressLogo, JetpackLogo, BigSkyLogo } from '@automattic/components';
+import { BigSkyLogo } from '@automattic/components/src/logos/big-sky-logo';
+import { JetpackLogo } from '@automattic/components/src/logos/jetpack-logo';
+import { WordPressLogo } from '@automattic/components/src/logos/wordpress-logo';
 import { formatNumber } from '@automattic/number-formatters';
 import {
 	__experimentalHStack as HStack,

--- a/client/dashboard/sites/overview-card/index.tsx
+++ b/client/dashboard/sites/overview-card/index.tsx
@@ -1,4 +1,4 @@
-import { CircularProgressBar } from '@automattic/components';
+import CircularProgressBar from '@automattic/components/src/circular-progress-bar';
 import { Link } from '@tanstack/react-router';
 import {
 	Card,


### PR DESCRIPTION
## Proposed Changes

Update imports of `@automattic/components` to be explicit as per guidelines.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
