### PR TITLE
Revert "Disable sorting by PHP version, which crashes"

### DIFF
--- a/client/dashboard/app/query-client.ts
+++ b/client/dashboard/app/query-client.ts
@@ -20,10 +20,7 @@ export const queryClient = new QueryClient( {
 	},
 } );
 
-const persister = createSyncStoragePersister( {
-	storage: typeof window !== 'undefined' ? window.localStorage : null,
-} );
-
+const persister = createSyncStoragePersister( { storage: window.localStorage } );
 const maxAge = 1000 * 60 * 60 * 24; // 24 hours
 
 const [ , persistPromise ] = persistQueryClient( {

--- a/client/dashboard/sites/fields.tsx
+++ b/client/dashboard/sites/fields.tsx
@@ -21,7 +21,7 @@ import {
 import type { Site } from '../data/types';
 import type { Field, Operator } from '@wordpress/dataviews';
 
-export const DEFAULT_FIELDS: Field< Site >[] = [
+const DEFAULT_FIELDS: Field< Site >[] = [
 	{
 		id: 'name',
 		label: __( 'Site' ),
@@ -129,7 +129,6 @@ export const DEFAULT_FIELDS: Field< Site >[] = [
 		id: 'php_version',
 		label: __( 'PHP version' ),
 		render: ( { item }: { item: Site } ) => <PHPVersion site={ item } />,
-		enableSorting: false,
 	},
 	{
 		id: 'storage',

--- a/client/dashboard/sites/views.ts
+++ b/client/dashboard/sites/views.ts
@@ -1,5 +1,4 @@
 import fastDeepEqual from 'fast-deep-equal/es6';
-import { DEFAULT_FIELDS } from './fields';
 import type { AnalyticsClient } from '../app/analytics';
 import type { User, SitesView, SitesViewPreferences } from '../data/types';
 import type { Operator, SortDirection, SupportedLayouts } from '@wordpress/dataviews';
@@ -112,13 +111,13 @@ export function getView( {
 
 	const type = viewSearchParams.type || viewPreferences?.type || defaultView.type;
 
-	const view = sanitizeView( {
+	const view = {
 		...defaultView,
 		...DEFAULT_LAYOUTS[ type ],
 		...DEFAULT_LAYOUT_FIELDS[ type ],
 		...viewPreferences,
 		...viewSearchParams,
-	} as SitesView );
+	} as SitesView;
 
 	return {
 		defaultView,
@@ -266,23 +265,6 @@ export function recordViewChanges(
 			field: removed,
 		} );
 	}
-}
-
-/**
- * Sanitize the view preference data by removing any invalid or malformed entries.
- */
-function sanitizeView( { sort, ...view }: SitesView ) {
-	if ( sort?.field ) {
-		const field = DEFAULT_FIELDS.find( ( field ) => field.id === sort?.field );
-		if ( ! field || field.enableSorting === false ) {
-			return view;
-		}
-	}
-
-	return {
-		...view,
-		sort,
-	};
 }
 
 // Ponyfill for Set.prototype.difference, which is not available in all target environments.


### PR DESCRIPTION
Reverts Automattic/wp-calypso#104847 since the Build ICFY stats failed 🤔