### PR TITLE
Login: Fix UI issues with Jetpack login code input

### DIFF
--- a/client/login/magic-login/verify-login-code.jsx
+++ b/client/login/magic-login/verify-login-code.jsx
@@ -79,7 +79,9 @@ const VerifyLoginCode = ( {
 
 	// Update local error state when authError changes
 	useEffect( () => {
-		setShowError( !! authError );
+		if ( authError ) {
+			setShowError( true );
+		}
 	}, [ authError ] );
 
 	// Focus the last input when an auth error is detected
@@ -182,8 +184,20 @@ const VerifyLoginCode = ( {
 		authenticate( loginToken, redirectTo, null, true );
 	};
 
+	const handleResendEmail = () => {
+		// Reset all form states when resending email
+		setCodeCharacters( Array( CODE_LENGTH ).fill( '' ) );
+		setShowError( false );
+
+		// Focus the first input field
+		inputRefs?.current[ 0 ]?.current?.focus();
+
+		// Call the parent's resend function
+		onResendEmail();
+	};
+
 	const isDisabled = isValidating || isRedirecting;
-	const submitEnabled = getVerificationCode().length === CODE_LENGTH && ! isDisabled;
+	const submitEnabled = getVerificationCode().length === CODE_LENGTH && ! isDisabled && ! showError;
 
 	return (
 		<div className="magic-login__successfully-jetpack">
@@ -218,7 +232,7 @@ const VerifyLoginCode = ( {
 
 				{ showError && (
 					<div className="magic-login__verify-code-error-message">
-						{ translate( "Oops, that's the wrong code. Please verify it." ) }
+						{ translate( "Oops, that's the wrong code. Please verify or resend the email." ) }
 					</div>
 				) }
 
@@ -244,7 +258,7 @@ const VerifyLoginCode = ( {
 									<Button
 										className="magic-login__resend-button"
 										variant="link"
-										onClick={ onResendEmail }
+										onClick={ handleResendEmail }
 										disabled={ isRedirecting }
 									/>
 								),


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes MYJP-180

## Proposed Changes

* Fix magic code submit button not re-enabling after failed submission when user starts editing
* Update error message text to include "resend the email" option for better UX
* Reset all form states (input fields, errors) when user clicks resend email button

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Setup:**
1. Go to `log-in/jetpack`

**Submit button re-enables after wrong code**
1. Enter an incorrect 6-digit code
2. Verify the error message appears and submit button becomes disabled
3. Start typing in any of the input fields
4. ✅ **Expected**: Submit button should re-enable as soon as you remove and refill the code
5. ✅ **Expected**: Error message should disappear

**Form reset on email resend**
1. Enter an incorrect code (or partial code)
2. Click the "resend the email" button
3. ✅ **Expected**: All input fields should be cleared
4. ✅ **Expected**: Error message should disappear
5. ✅ **Expected**: Focus should return to first input field

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?