### PR TITLE
Connect Refresh: Update Magic Code buttons to core components

### DIFF
--- a/client/login/magic-login/request-login-code.jsx
+++ b/client/login/magic-login/request-login-code.jsx
@@ -1,10 +1,9 @@
 import { FormLabel } from '@automattic/components';
-import { Spinner } from '@wordpress/components';
+import { Spinner, Button } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useRef, useState, useEffect } from 'react';
 import { connect } from 'react-redux';
-import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import LoggedOutForm from 'calypso/components/logged-out-form';
@@ -164,14 +163,15 @@ const RequestLoginCode = ( {
 					) }
 
 					<div className="magic-login__form-action">
-						<FormButton
-							primary
+						<Button
+							variant="primary"
 							disabled={ ! submitEnabled && ! isFetching }
-							busy={ isFetching }
+							isBusy={ isFetching }
 							type="submit"
+							__next40pxDefaultSize
 						>
 							{ isFetching ? translate( 'Sending code…' ) : translate( 'Send Code' ) }
-						</FormButton>
+						</Button>
 					</div>
 				</FormFieldset>
 			</LoggedOutForm>

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -39,23 +39,6 @@
 		.magic-login__form-form {
 			box-shadow: none;
 		}
-		.magic-login__form {
-			.magic-login__form-action {
-				.button.is-primary {
-					background-color: var(--studio-jetpack-green-50);
-					border-color: var(--studio-jetpack-green-50);
-
-					&:hover,
-					&:focus {
-						background-color: var(--studio-jetpack-green-60);
-					}
-
-					.accessible-focus &:focus {
-						box-shadow: 0 0 0 2px var(--studio-jetpack-green-30);
-					}
-				}
-			}
-		}
 
 		.magic-login__form-header {
 			font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;

--- a/client/login/magic-login/verify-login-code.jsx
+++ b/client/login/magic-login/verify-login-code.jsx
@@ -4,7 +4,6 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useState, useEffect, useRef, createRef } from 'react';
 import { connect } from 'react-redux';
-import FormButton from 'calypso/components/forms/form-button';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import LoggedOutForm from 'calypso/components/logged-out-form';
 import { navigate } from 'calypso/lib/navigate';
@@ -223,14 +222,15 @@ const VerifyLoginCode = ( {
 				) }
 
 				<div className="magic-login__form-action">
-					<FormButton
-						primary
+					<Button
+						variant="primary"
 						disabled={ ! submitEnabled && ! isDisabled }
-						busy={ isDisabled }
+						isBusy={ isDisabled }
 						type="submit"
+						__next40pxDefaultSize
 					>
 						{ isDisabled ? translate( 'Verifying code…' ) : translate( 'Verify code' ) }
-					</FormButton>
+					</Button>
 				</div>
 			</LoggedOutForm>
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DSGCOM-149/login-magic-login-button-color-does-not-correspond-to-the-product

## Proposed Changes

- Updates the buttons used in Magic Code screens to utilise Core components.
- Removes style customisations for JP (hover styles and colors are adapted to the default overrides for JP Login)

### Media

These are the various states being updated:

| Before | After |
|--------|--------|
| <img width="500" alt="Screenshot 2025-07-22 at 11 58 05 AM" src="https://github.com/user-attachments/assets/afe839d9-7710-435a-8186-c0921626dbc4" /> | <img width="500" alt="Screenshot 2025-07-22 at 11 57 43 AM" src="https://github.com/user-attachments/assets/cb3fae80-9c63-4c7d-89dc-a391b4c82be3" /> |
| <img width="500" alt="Screenshot 2025-07-22 at 11 58 20 AM" src="https://github.com/user-attachments/assets/fb6257a7-1bd0-452d-896a-e0360ae41997" /> | <img width="500" alt="Screenshot 2025-07-22 at 11 58 56 AM" src="https://github.com/user-attachments/assets/631da620-e03f-4035-a1f5-4626183d43b1" /> |
| <img width="500" alt="Screenshot 2025-07-22 at 11 58 32 AM" src="https://github.com/user-attachments/assets/d189d390-5bbd-4f53-bcdc-cc55f45b0f1a" /> | <img width="500" alt="Screenshot 2025-07-22 at 12 00 10 PM" src="https://github.com/user-attachments/assets/0afbb26a-d5ca-4865-9202-b97086b59e74" /> |






## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fixes https://linear.app/a8c/issue/DSGCOM-149/login-magic-login-button-color-does-not-correspond-to-the-product

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [JP client Login](https://linear.app/a8c/project/login-and-signup-unify-design-and-layout-16a857e58712/overview) (as the only one currently using Magic Code)
* Click on "Email me a magic code" and work through the flow
* Confirm focus/hover/static states are consistent with other buttons/CTAs in Login

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
