### PR TITLE
Connect Refresh: Remove customisations to Magic Login form-header

### DIFF
--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -1341,11 +1341,7 @@ class MagicLogin extends Component {
 								onPublicTokenReceived={ this.handlePublicTokenReceived }
 							/>
 						) : (
-							<RequestLoginEmailForm
-								{ ...requestLoginEmailFormProps }
-								hideHeaderText
-								hideSubHeaderText
-							/>
+							<RequestLoginEmailForm { ...requestLoginEmailFormProps } />
 						) }
 					</>
 				) }

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -1044,7 +1044,6 @@ class MagicLogin extends Component {
 						flow={ getGravatarOAuth2Flow( oauth2Client ) }
 						headerText={ headerText }
 						subHeaderText={ subHeader }
-						hideSubHeaderText={ ! subHeader }
 						inputPlaceholder={ translate( 'Enter your email address' ) }
 						submitButtonLabel={ submitButtonLabel }
 						tosComponent={ ! isGravatar && this.renderGravPoweredMagicLoginTos() }

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -208,12 +208,16 @@ class RequestLoginEmailForm extends Component {
 
 	getGravatarHeader() {
 		const { headerText } = this.props;
-		return headerText ? <h1 className="magic-login__form-header">{ headerText }</h1> : null;
+		return headerText ? (
+			<h1 className="grav-powered-magic-login__form-header">{ headerText }</h1>
+		) : null;
 	}
 
 	getGravatarSubHeader() {
 		const { subHeaderText } = this.props;
-		return subHeaderText ? <p className="magic-login__form-sub-header">{ subHeaderText }</p> : null;
+		return subHeaderText ? (
+			<p className="grav-powered-magic-login__form-sub-header">{ subHeaderText }</p>
+		) : null;
 	}
 
 	render() {

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -9,6 +9,7 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import LoggedOutForm from 'calypso/components/logged-out-form';
 import Notice from 'calypso/components/notice';
 import { preventWidows } from 'calypso/lib/formatting/prevent-widows';
+import { isGravPoweredOAuth2Client } from 'calypso/lib/oauth2-clients';
 import wpcom from 'calypso/lib/wp';
 import { LoginContext } from 'calypso/login/login-context';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -20,6 +21,7 @@ import {
 	getRedirectToOriginal,
 	getLastCheckedUsernameOrEmail,
 } from 'calypso/state/login/selectors';
+import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
@@ -49,10 +51,8 @@ class RequestLoginEmailForm extends Component {
 		hideMagicLoginRequestNotice: PropTypes.func.isRequired,
 
 		tosComponent: PropTypes.node,
-		hideHeaderText: PropTypes.bool,
 		headerText: PropTypes.string,
 		subHeaderText: PropTypes.string,
-		hideSubHeaderText: PropTypes.bool,
 		customFormLabel: PropTypes.string,
 		inputPlaceholder: PropTypes.string,
 		submitButtonLabel: PropTypes.string,
@@ -66,6 +66,7 @@ class RequestLoginEmailForm extends Component {
 		isEmailInputError: PropTypes.bool,
 		isSubmitButtonDisabled: PropTypes.bool,
 		isSubmitButtonBusy: PropTypes.bool,
+		isGravPoweredClient: PropTypes.bool,
 	};
 
 	// @ts-ignore
@@ -113,11 +114,18 @@ class RequestLoginEmailForm extends Component {
 				.then( ( result ) => this.setState( { site: result } ) );
 		}
 
+<<<<<<< HEAD
 		if ( this.props.showCheckYourEmail ) {
 			this.setCheckYourEmailHeaders();
 		} else {
 			this.setRequestLoginHeaders();
 		}
+=======
+		this.context?.setHeaders( {
+			heading: this.props.headerText || this.props.translate( 'Email me a login link' ),
+			subHeading: this.getSubHeaderText(),
+		} );
+>>>>>>> 50f06aa6bff (isolate gravatar header/subheader)
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -198,6 +206,16 @@ class RequestLoginEmailForm extends Component {
 		return translate( 'We’ll send you an email with a link that will log you in right away.' );
 	}
 
+	getGravatarHeader() {
+		const { headerText } = this.props;
+		return headerText ? <h1 className="magic-login__form-header">{ headerText }</h1> : null;
+	}
+
+	getGravatarSubHeader() {
+		const { subHeaderText } = this.props;
+		return subHeaderText ? <p className="magic-login__form-sub-header">{ subHeaderText }</p> : null;
+	}
+
 	render() {
 		const {
 			currentUser,
@@ -208,9 +226,7 @@ class RequestLoginEmailForm extends Component {
 			showCheckYourEmail,
 			translate,
 			tosComponent,
-			headerText,
-			hideHeaderText,
-			hideSubHeaderText,
+			isGravPoweredClient,
 			inputPlaceholder,
 			submitButtonLabel,
 			customFormLabel,
@@ -275,11 +291,7 @@ class RequestLoginEmailForm extends Component {
 						/>
 					</div>
 				) }
-				{ ! hideHeaderText && (
-					<h1 className="magic-login__form-header">
-						{ headerText || translate( 'Email me a login link' ) }
-					</h1>
-				) }
+				{ isGravPoweredClient && this.getGravatarHeader() }
 				<LoggedOutForm className="magic-login__form-form" onSubmit={ onSubmit }>
 					{ currentUser && currentUser.username && (
 						<Notice
@@ -294,9 +306,7 @@ class RequestLoginEmailForm extends Component {
 							} ) }
 						></Notice>
 					) }
-					{ ! hideSubHeaderText && (
-						<p className="magic-login__form-sub-header">{ this.getSubHeaderText() }</p>
-					) }
+					{ isGravPoweredClient && this.getGravatarSubHeader() }
 					<FormLabel htmlFor="usernameOrEmail">{ formLabel }</FormLabel>
 					<FormFieldset className="magic-login__email-fields">
 						<FormTextInput
@@ -350,6 +360,8 @@ class RequestLoginEmailForm extends Component {
 }
 
 const mapState = ( state ) => {
+	const oauth2Client = getCurrentOAuth2Client( state );
+
 	return {
 		locale: getCurrentLocaleSlug( state ),
 		currentUser: getCurrentUser( state ),
@@ -363,6 +375,7 @@ const mapState = ( state ) => {
 			getLastCheckedUsernameOrEmail( state ) ||
 			getCurrentQueryArguments( state ).email_address ||
 			getInitialQueryArguments( state ).email_address,
+		isGravPoweredClient: isGravPoweredOAuth2Client( oauth2Client ),
 	};
 };
 

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -114,18 +114,15 @@ class RequestLoginEmailForm extends Component {
 				.then( ( result ) => this.setState( { site: result } ) );
 		}
 
-<<<<<<< HEAD
 		if ( this.props.showCheckYourEmail ) {
 			this.setCheckYourEmailHeaders();
 		} else {
 			this.setRequestLoginHeaders();
 		}
-=======
 		this.context?.setHeaders( {
 			heading: this.props.headerText || this.props.translate( 'Email me a login link' ),
 			subHeading: this.getSubHeaderText(),
 		} );
->>>>>>> 50f06aa6bff (isolate gravatar header/subheader)
 	}
 
 	componentDidUpdate( prevProps ) {

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -66,7 +66,7 @@ class RequestLoginEmailForm extends Component {
 		isEmailInputError: PropTypes.bool,
 		isSubmitButtonDisabled: PropTypes.bool,
 		isSubmitButtonBusy: PropTypes.bool,
-		isGravPoweredClient: PropTypes.bool,
+		isGravPoweredClient: PropTypes.bool.isRequired,
 	};
 
 	// @ts-ignore

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -86,6 +86,9 @@ class RequestLoginEmailForm extends Component {
 		} );
 	}
 
+	/**
+	 * Unreachable by Gravatar flow
+	 */
 	setCheckYourEmailHeaders() {
 		const usernameOrEmail = this.getUsernameOrEmailFromState();
 		const emailAddress = usernameOrEmail.indexOf( '@' ) > 0 ? usernameOrEmail : null;
@@ -115,10 +118,16 @@ class RequestLoginEmailForm extends Component {
 		}
 
 		if ( this.props.showCheckYourEmail ) {
+			/**
+			 * Unreachable by Gravatar flow
+			 */
 			this.setCheckYourEmailHeaders();
+		} else {
+			/**
+			 * Reachable by Gravatar flow
+			 */
+			this.setRequestLoginHeaders();
 		}
-
-		this.setRequestLoginHeaders();
 	}
 
 	componentDidUpdate( prevProps ) {

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -81,7 +81,7 @@ class RequestLoginEmailForm extends Component {
 
 	setRequestLoginHeaders() {
 		this.context?.setHeaders( {
-			heading: this.props.translate( 'Email me a login link' ),
+			heading: this.props.headerText || this.props.translate( 'Email me a login link' ),
 			subHeading: this.getSubHeaderText(),
 		} );
 	}
@@ -116,13 +116,9 @@ class RequestLoginEmailForm extends Component {
 
 		if ( this.props.showCheckYourEmail ) {
 			this.setCheckYourEmailHeaders();
-		} else {
-			this.setRequestLoginHeaders();
 		}
-		this.context?.setHeaders( {
-			heading: this.props.headerText || this.props.translate( 'Email me a login link' ),
-			subHeading: this.getSubHeaderText(),
-		} );
+
+		this.setRequestLoginHeaders();
 	}
 
 	componentDidUpdate( prevProps ) {

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -115,10 +115,6 @@
 		}
 	}
 
-	.magic-login__form-sub-header {
-		text-align: center;
-	}
-
 	.logged-out-form {
 		.form-label {
 			font-weight: 400;
@@ -209,7 +205,7 @@
 	}
 }
 
-.magic-login__form-header {
+.grav-powered-magic-login__form-header {
 	font-size: $font-title-small;
 	margin-bottom: 24px;
 	margin-top: 16px;
@@ -292,11 +288,6 @@
 	}
 
 	.logged-out-form {
-		.magic-login__form-sub-header {
-			color: var(--studio-gray-70);
-			margin: 4px 0 48px 0;
-		}
-
 		.form-label {
 			color: var(--studio-gray-60);
 		}
@@ -372,7 +363,7 @@
 	line-height: 1.5;
 
 	&.grav-powered-magic-login--has-sub-header {
-		.magic-login__form-header {
+		.grav-powered-magic-login__form-header {
 			margin-bottom: 3px;
 		}
 	}
@@ -422,7 +413,7 @@
 		}
 
 		.grav-powered-magic-login__header,
-		.magic-login__form-header {
+		.grav-powered-magic-login__form-header {
 			font-size: 24px;
 			margin: 32px 0 24px;
 		}
@@ -509,7 +500,7 @@
 	}
 
 	.grav-powered-magic-login__header,
-	.magic-login__form-header {
+	.grav-powered-magic-login__form-header {
 		font-family: "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 		font-size: 32px;
 		font-weight: 900;
@@ -519,7 +510,7 @@
 	}
 
 	.grav-powered-magic-login__sub-header,
-	p.magic-login__form-sub-header {
+	p.grav-powered-magic-login__form-sub-header {
 		margin-bottom: 24px;
 	}
 
@@ -531,7 +522,7 @@
 		}
 	}
 
-	p.magic-login__form-sub-header {
+	p.grav-powered-magic-login__form-sub-header {
 		font-size: 13px;
 		color: #50575e;
 	}
@@ -717,7 +708,7 @@
 			}
 
 			.grav-powered-magic-login__header,
-			.magic-login__form-header {
+			.grav-powered-magic-login__form-header {
 				font-size: 40px;
 				margin-top: 48px;
 			}
@@ -744,12 +735,12 @@
 		}
 
 		.grav-powered-magic-login__header,
-		.magic-login__form-header {
+		.grav-powered-magic-login__form-header {
 			font-size: 40px;
 		}
 
-		.magic-login__form-header,
-		p.magic-login__form-sub-header {
+		.grav-powered-magic-login__form-header,
+		p.grav-powered-magic-login__form-sub-header {
 			margin-bottom: 40px;
 		}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13627/login-and-signup-centralise-font-and-css-overrides
Part of https://linear.app/a8c/issue/DOTCOM-13689/login-do-a-cleaner-separation-between-default-and-grav-powered-login

## Proposed Changes

- Removes some general and Woo-specific customisations to the Magic Login page
- Makes explicit in the code that the header/subheader components are only Gravatar specific - abstracts into `getGravatarHeader` and `getGravatarSubHeader`). These are no longer rendered inside the components for the remaining Logins - they are part of the `OneLoginLayout` component and populated through context.

| Magic Login | Magic Login confirm |
|--------|--------|
| <img width="527" height="665" alt="Screenshot 2025-07-24 at 12 13 18 PM" src="https://github.com/user-attachments/assets/3f11302a-97f6-4a9f-9e67-d227d311172a" /> | <img width="535" height="552" alt="Screenshot 2025-07-24 at 12 13 25 PM" src="https://github.com/user-attachments/assets/b5c9ea34-1259-4335-92ad-c3c1a5e58aef" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13627/login-and-signup-centralise-font-and-css-overrides
Part of https://linear.app/a8c/issue/DOTCOM-13689/login-do-a-cleaner-separation-between-default-and-grav-powered-login

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [Gravatar and Woo Login](https://linear.app/a8c/project/login-and-signup-unify-design-and-layout-16a857e58712/overview) screens and choose the Magic Login option. 
* Ensure screens render correctly and are identical to production. Ensure headers and sub-headers are populated properly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
