### PR TITLE
Staging sites: Show a confirmation form before synchronizing

### DIFF
--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -8,6 +8,7 @@ import {
 	__experimentalVStack as VStack,
 	CheckboxControl,
 	SelectControl,
+	Notice,
 } from '@wordpress/components';
 import { createInterpolateElement, useState, useCallback, useEffect } from '@wordpress/element';
 import { __, isRTL } from '@wordpress/i18n';
@@ -29,6 +30,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { setNodeCheckState } from 'calypso/state/rewind/browser/actions';
 import getBackupBrowserCheckList from 'calypso/state/rewind/selectors/get-backup-browser-check-list';
 import getBackupBrowserNode from 'calypso/state/rewind/selectors/get-backup-browser-node';
+import isSiteStore from 'calypso/state/selectors/is-site-store';
 import { getSiteSlug, getSiteTitle } from 'calypso/state/sites/selectors';
 import type { FileBrowserConfig } from 'calypso/my-sites/backup/backup-contents-page/file-browser';
 
@@ -212,6 +214,8 @@ export default function SyncModal( {
 		getBackupBrowserNode( state, querySiteId, WP_CONFIG_PATH )
 	);
 	const sqlNode = useSelector( ( state ) => getBackupBrowserNode( state, querySiteId, SQL_PATH ) );
+
+	const isSiteWooStore = !! useSelector( ( state ) => isSiteStore( state, querySiteId ) );
 
 	const getFilesAndFoldersNodesCheckState = useCallback( () => {
 		const nodes = [ wpContentNode, wpConfigNode ].filter( Boolean );
@@ -414,6 +418,19 @@ export default function SyncModal( {
 							onChange={ handleDatabaseCheckboxChange }
 						/>
 					</div>
+					{ isSiteWooStore && targetEnvironment === 'production' && (
+						<Notice status="warning" isDismissible={ false }>
+							<Text>{ __( 'Syncing WooCommerce sites can overwrite orders' ) }</Text>
+							{ createInterpolateElement(
+								__(
+									'Syncing the staging database to production will overwrite orders, products, pages and posts. <a>Learn more</a>'
+								),
+								{
+									a: <InlineSupportLink supportContext="staging-to-production-sync" />,
+								}
+							) }
+						</Notice>
+					) }
 				</div>
 				<HStack className="staging-site-card__footer">
 					<HStack>

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -428,7 +428,7 @@ export default function SyncModal( {
 					<VStack spacing={ 7 }>
 						{ showWooCommerceWarning && (
 							<Notice status="warning" isDismissible={ false }>
-								<Text as="p" weight="600" style={ { marginBottom: '8px' } }>
+								<Text as="p" weight="bold" style={ { marginBottom: '8px' } }>
 									{ __( 'Warning! WooCommerce data will be overwritten.' ) }
 								</Text>
 								{ createInterpolateElement(

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -11,7 +11,7 @@ import {
 	SelectControl,
 	Notice,
 } from '@wordpress/components';
-import { createInterpolateElement, useState, useCallback, useEffect } from '@wordpress/element';
+import { createInterpolateElement, useState, useCallback } from '@wordpress/element';
 import { __, isRTL } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
@@ -37,7 +37,6 @@ import type { FileBrowserConfig } from 'calypso/my-sites/backup/backup-contents-
 
 import './style.scss';
 
-const ROOT_PATH = '/';
 const WP_CONFIG_PATH = '/wp-config.php';
 const WP_CONTENT_PATH = '/wp-content';
 const SQL_PATH = '/sql';
@@ -221,8 +220,8 @@ export default function SyncModal( {
 	const getFilesAndFoldersNodesCheckState = useCallback( () => {
 		const nodes = [ wpContentNode, wpConfigNode ].filter( Boolean );
 		if ( nodes.length === 0 ) {
-			// If nodes don't exist yet, default to 'checked' since we set the root to checked by default
-			return 'checked';
+			// If nodes don't exist yet, default to 'unchecked' since we set the root to unchecked by default
+			return 'unchecked';
 		}
 
 		const checkedCount = nodes.filter( ( node ) => node?.checkState === 'checked' ).length;
@@ -244,13 +243,6 @@ export default function SyncModal( {
 	}, [ wpContentNode, wpConfigNode ] );
 
 	const filesAndFoldersNodesCheckState = getFilesAndFoldersNodesCheckState();
-
-	useEffect( () => {
-		dispatch( setNodeCheckState( querySiteId, ROOT_PATH, 'checked' ) );
-		dispatch( setNodeCheckState( querySiteId, WP_CONTENT_PATH, 'checked' ) );
-		dispatch( setNodeCheckState( querySiteId, WP_CONFIG_PATH, 'checked' ) );
-		dispatch( setNodeCheckState( querySiteId, SQL_PATH, 'checked' ) );
-	}, [ dispatch, querySiteId ] );
 
 	const { pullFromStaging } = usePullFromStagingMutation( productionSiteId, stagingSiteId, {
 		onSuccess: () => {
@@ -319,6 +311,11 @@ export default function SyncModal( {
 		[ dispatch, querySiteId ]
 	);
 
+	const handleDomainConfirmation = useCallback(
+		( value: string | undefined ) => setDomainConfirmation( value || '' ),
+		[]
+	);
+
 	const onCheckboxChange = () => {
 		updateFilesAndFoldersCheckState(
 			filesAndFoldersNodesCheckState === 'checked' ? 'unchecked' : 'checked'
@@ -348,7 +345,7 @@ export default function SyncModal( {
 
 	const showDomainConfirmation = sqlNode?.checkState === 'checked';
 
-	const disableButton =
+	const isButtonDisabled =
 		( showDomainConfirmation && domainConfirmation !== productionSiteSlug ) ||
 		! browserCheckList.totalItems;
 
@@ -424,7 +421,7 @@ export default function SyncModal( {
 						<CheckboxControl
 							__nextHasNoMarginBottom
 							label={ __( 'Database tables' ) }
-							checked={ ! sqlNode || sqlNode.checkState === 'checked' }
+							checked={ sqlNode?.checkState === 'checked' }
 							onChange={ handleDatabaseCheckboxChange }
 						/>
 					</div>
@@ -444,12 +441,12 @@ export default function SyncModal( {
 						) }
 						{ showDomainConfirmation && (
 							<VStack>
-								<HStack alignment="left">
+								<HStack alignment="left" spacing={ 1 }>
 									<Text>{ __( "Enter your site's name" ) }</Text>
 									<Text color="#D63638">{ productionSiteSlug }</Text>
 									<Text>{ __( 'to confirm.' ) }</Text>
 								</HStack>
-								<InputControl onChange={ setDomainConfirmation } />
+								<InputControl onChange={ handleDomainConfirmation } />
 							</VStack>
 						) }
 					</VStack>
@@ -467,7 +464,7 @@ export default function SyncModal( {
 						<Button variant="tertiary" onClick={ onClose }>
 							{ __( 'Cancel' ) }
 						</Button>
-						<Button variant="primary" onClick={ handleConfirm } disabled={ disableButton }>
+						<Button variant="primary" onClick={ handleConfirm } disabled={ isButtonDisabled }>
 							{ syncConfig.submit }
 						</Button>
 					</HStack>

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -441,12 +441,17 @@ export default function SyncModal( {
 						) }
 						{ showDomainConfirmation && (
 							<VStack>
-								<HStack alignment="left" spacing={ 1 }>
-									<Text>{ __( "Enter your site's name" ) }</Text>
-									<Text color="#D63638">{ productionSiteSlug }</Text>
-									<Text>{ __( 'to confirm.' ) }</Text>
-								</HStack>
-								<InputControl onChange={ handleDomainConfirmation } />
+								<InputControl
+									__next40pxDefaultSize
+									label={
+										<HStack style={ { textTransform: 'none' } } alignment="left" spacing={ 1 }>
+											<Text>{ __( "Enter your site's name" ) }</Text>
+											<Text color="var(--studio-red-50)">{ productionSiteSlug }</Text>
+											<Text>{ __( 'to confirm.' ) }</Text>
+										</HStack>
+									}
+									onChange={ handleDomainConfirmation }
+								/>
 							</VStack>
 						) }
 					</VStack>

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -343,7 +343,9 @@ export default function SyncModal( {
 	const showWooCommerceWarning =
 		isSiteWooStore && targetEnvironment === 'production' && sqlNode?.checkState === 'checked';
 
-	const showDomainConfirmation = sqlNode?.checkState === 'checked';
+	const showDomainConfirmation =
+		targetEnvironment === 'production' &&
+		( browserCheckList.totalItems > 0 || browserCheckList.includeList.length > 0 );
 
 	const isButtonDisabled =
 		( showDomainConfirmation && domainConfirmation !== productionSiteSlug ) ||

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -428,7 +428,9 @@ export default function SyncModal( {
 					<VStack spacing={ 7 }>
 						{ showWooCommerceWarning && (
 							<Notice status="warning" isDismissible={ false }>
-								<Text>{ __( 'Syncing WooCommerce sites can overwrite orders' ) }</Text>
+								<Text as="p" weight="600" style={ { marginBottom: '8px' } }>
+									{ __( 'Warning! WooCommerce data will be overwritten.' ) }
+								</Text>
 								{ createInterpolateElement(
 									__(
 										'This site has WooCommerce installed. We do not recommend syncing or pushing data from a staging site to live production news sites or sites that use eCommerce plugins, such as WooCommerce, without proper planning and testing. Keep in mind that data on the destination site could have newer transactions, such as customers and orders, and would be lost when overwritten by the staging site’s data. <a>Learn more</a>'

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -6,6 +6,7 @@ import {
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
+	__experimentalInputControl as InputControl,
 	CheckboxControl,
 	SelectControl,
 	Notice,
@@ -34,7 +35,6 @@ import isSiteStore from 'calypso/state/selectors/is-site-store';
 import { getSiteSlug, getSiteTitle } from 'calypso/state/sites/selectors';
 import type { FileBrowserConfig } from 'calypso/my-sites/backup/backup-contents-page/file-browser';
 
-// TODO: Temporary style for the PoC
 import './style.scss';
 
 const ROOT_PATH = '/';
@@ -182,6 +182,7 @@ export default function SyncModal( {
 	const dispatch = useDispatch();
 	const syncConfig = getSyncConfig( syncType );
 	const [ isFileBrowserVisible, setIsFileBrowserVisible ] = useState( false );
+	const [ domainConfirmation, setDomainConfirmation ] = useState( '' );
 
 	const targetEnvironment = syncConfig[ environment ].syncTo;
 	const sourceEnvironment = syncConfig[ environment ].syncFrom;
@@ -342,6 +343,15 @@ export default function SyncModal( {
 		}
 	};
 
+	const showWooCommerceWarning =
+		isSiteWooStore && targetEnvironment === 'production' && sqlNode?.checkState === 'checked';
+
+	const showDomainConfirmation = sqlNode?.checkState === 'checked';
+
+	const disableButton =
+		( showDomainConfirmation && domainConfirmation !== productionSiteSlug ) ||
+		! browserCheckList.totalItems;
+
 	return (
 		<Modal
 			title={ syncConfig[ environment ].title }
@@ -418,19 +428,31 @@ export default function SyncModal( {
 							onChange={ handleDatabaseCheckboxChange }
 						/>
 					</div>
-					{ isSiteWooStore && targetEnvironment === 'production' && (
-						<Notice status="warning" isDismissible={ false }>
-							<Text>{ __( 'Syncing WooCommerce sites can overwrite orders' ) }</Text>
-							{ createInterpolateElement(
-								__(
-									'Syncing the staging database to production will overwrite orders, products, pages and posts. <a>Learn more</a>'
-								),
-								{
-									a: <InlineSupportLink supportContext="staging-to-production-sync" />,
-								}
-							) }
-						</Notice>
-					) }
+					<VStack spacing={ 7 }>
+						{ showWooCommerceWarning && (
+							<Notice status="warning" isDismissible={ false }>
+								<Text>{ __( 'Syncing WooCommerce sites can overwrite orders' ) }</Text>
+								{ createInterpolateElement(
+									__(
+										'Syncing the staging database to production will overwrite orders, products, pages and posts. <a>Learn more</a>'
+									),
+									{
+										a: <InlineSupportLink supportContext="staging-to-production-sync" />,
+									}
+								) }
+							</Notice>
+						) }
+						{ showDomainConfirmation && (
+							<VStack>
+								<HStack alignment="left">
+									<Text>{ __( "Enter your site's name" ) }</Text>
+									<Text color="#D63638">{ productionSiteSlug }</Text>
+									<Text>{ __( 'to confirm.' ) }</Text>
+								</HStack>
+								<InputControl onChange={ setDomainConfirmation } />
+							</VStack>
+						) }
+					</VStack>
 				</div>
 				<HStack className="staging-site-card__footer">
 					<HStack>
@@ -445,7 +467,7 @@ export default function SyncModal( {
 						<Button variant="tertiary" onClick={ onClose }>
 							{ __( 'Cancel' ) }
 						</Button>
-						<Button variant="primary" onClick={ handleConfirm }>
+						<Button variant="primary" onClick={ handleConfirm } disabled={ disableButton }>
 							{ syncConfig.submit }
 						</Button>
 					</HStack>

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -431,10 +431,15 @@ export default function SyncModal( {
 								<Text>{ __( 'Syncing WooCommerce sites can overwrite orders' ) }</Text>
 								{ createInterpolateElement(
 									__(
-										'Syncing the staging database to production will overwrite orders, products, pages and posts. <a>Learn more</a>'
+										'This site has WooCommerce installed. We do not recommend syncing or pushing data from a staging site to live production news sites or sites that use eCommerce plugins, such as WooCommerce, without proper planning and testing. Keep in mind that data on the destination site could have newer transactions, such as customers and orders, and would be lost when overwritten by the staging site’s data. <a>Learn more</a>'
 									),
 									{
-										a: <InlineSupportLink supportContext="staging-to-production-sync" />,
+										a: (
+											<ExternalLink
+												href="https://developer.wordpress.com/docs/developer-tools/staging-sites/sync-staging-production/#staging-to-production"
+												children={ null }
+											/>
+										),
 									}
 								) }
 							</Notice>

--- a/client/sites/staging-site/components/staging-site-sync-modal/style.scss
+++ b/client/sites/staging-site/components/staging-site-sync-modal/style.scss
@@ -14,8 +14,10 @@
 
 	.database-item {
 		border-top: 1px solid var(--wp-components-color-gray-300, #ddd);
+		border-bottom: 1px solid var(--wp-components-color-gray-300, #ddd);
 		padding: 16px 0;
 		margin-top: 8px;
+		margin-bottom: 20px
 	}
 
 	&__back-button.components-button.is-link {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTCOM-13932
Resolves DOTCOM-13962
Resolves DOTCOM-13961

## Proposed Changes

* Adds a warning when the site to be synced is a Woo site and the database is checked
* Adds a domain confirmation input when the database is checked
* Unselects by default the values to be synced so they needs to be explicitly checked

|Before | After|
|-------|------|
| <img width="1678" height="1362" alt="CleanShot 2025-07-23 at 16 44 30@2x" src="https://github.com/user-attachments/assets/98c45194-a8b1-4c00-a126-2fcca583ea8f" />|  <img width="1866" height="1564" alt="CleanShot 2025-07-24 at 18 58 22@2x" src="https://github.com/user-attachments/assets/c4e30245-c794-4661-9ba2-93255c9c2d02" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To notify the user about dangerous changes

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
#### WooCommerce site
* Apply these changes and start Calypso locally
* Open a site with WooCommerce installed and active, e.g. `/overview/:siteSlug`
* Add a Staging site to it by clicking `Add Staging site +`
* Once the Staging site exists, select `Sync` dropdown on the top-right of the page
* Select `Pull from Staging`
* Check that there are no nodes selected and that the `Pull` button is disabled
* Select the database node
* Check that the Warning and Domain confirmation input are displayed
* Check the `Pull` button is disabled
* Insert the proper domain and check that the `Pull` button activates. Try with valid/invalid values.
* Unselect the database and select `Files and folders`
* Check the Pull button is enabled
* Check different combinations of selecting/unselecting Database and `Files and folders`. Also, expand `All files and folders` and select individual nodes
* Check that the Warnings and Domain confirmation input appears/disappears as expected, as well as the `Pull` button is enabled/disabled as expected.
- Close the modal and on the `Sync` dropdown select Push to Staging
- Check `Database tables`  
- Check that the Domain confirmation input is displayed and the `Push` button is disabled
- Check that the Domain confirmation input appears/disappears as expected, as well as the `Push` button is enabled/disabled as expected.
* Open the staging site and repeat the above steps
* This time, the WooCommerce warning should be displayed when selecting `Push to production`


#### Non WooCommerce site
- Repeat previous steps and check that the WooCommerce warning is not displayed
- Check that the Domain confirmation input is displayed as expected as well as the `Pull` button activation

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
