### PR TITLE
Connect Refresh: Stop showing JP app promo on confirm email screen (magic code/link pages)

### DIFF
--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -288,22 +288,10 @@ class MagicLogin extends Component {
 			oauth2Client,
 		} = this.props;
 
-		const isA4A = query?.redirect_to?.includes( 'agencies.automattic.com/client' ) ?? false;
+		const shouldShowAppPromo = ! oauth2Client && ! showCheckYourEmail;
 
 		if ( showCheckYourEmail ) {
-			if ( isA4A ) {
-				return null;
-			}
-			return (
-				<AppPromo
-					title={ translate( 'Stay logged in with the Jetpack Mobile App' ) }
-					campaign="calypso-login-link-check-email"
-					className="magic-link-app-promo"
-					iconSize={ 32 }
-					hasQRCode
-					hasGetAppButton={ false }
-				/>
-			);
+			return null;
 		}
 
 		// The email address from the URL (if present) is added to the login
@@ -336,7 +324,7 @@ class MagicLogin extends Component {
 						{ linkBack }
 					</a>
 				</div>
-				{ ! oauth2Client && (
+				{ shouldShowAppPromo && (
 					<AppPromo
 						title={ translate( 'Stay logged in with the Jetpack Mobile App' ) }
 						campaign="calypso-login-link"


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DSGCOM-146/login-magic-login-remove-jetpack-mobile-app-callout

## Proposed Changes

Stops from rendering the JP app promo on email/code confirmation screens in Magic Login

| Before | After |
|--------|--------|
|<img width="623" height="688" alt="Screenshot 2025-07-24 at 12 01 25 PM" src="https://github.com/user-attachments/assets/fa4728d5-565c-42eb-a3e7-25336a9318d3" /> | <img width="602" height="584" alt="Screenshot 2025-07-24 at 12 01 59 PM" src="https://github.com/user-attachments/assets/8b570230-9461-4b2f-a58c-788a5e827abe" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fixes https://linear.app/a8c/issue/DSGCOM-146/login-magic-login-remove-jetpack-mobile-app-callout

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [JP & Default WP Login](https://linear.app/a8c/project/login-and-signup-unify-design-and-layout-16a857e58712/overview) and choose to either magic code or link form the options
* On the next page, you should see the JP app promo
* Enter a valid email. On next page, the confirmation screen, the JP app promo should not be visible

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
