### PR TITLE
reader - explore using existing hooks and components to add follow button on feeds.

### DIFF
--- a/client/blocks/reader-feed-header/follow.jsx
+++ b/client/blocks/reader-feed-header/follow.jsx
@@ -2,8 +2,12 @@ import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useDispatch, shallowEqual } from 'react-redux';
+import FollowButton from 'calypso/blocks/follow-button/button.jsx';
 import ReaderSiteNotificationSettings from 'calypso/blocks/reader-site-notification-settings';
 import ReaderSuggestedFollowsDialog from 'calypso/blocks/reader-suggested-follows/dialog';
+import { useRecommendedSite } from 'calypso/landing/subscriptions/hooks/use-recommended-site';
+import ReaderFollowFeedIcon from 'calypso/reader/components/icons/follow-feed-icon';
+import ReaderFollowingFeedIcon from 'calypso/reader/components/icons/following-feed-icon';
 import ReaderFollowButton from 'calypso/reader/follow-button';
 import { getSiteUrl, isEligibleForUnseen } from 'calypso/reader/get-helpers';
 import { useSelector } from 'calypso/state';
@@ -23,6 +27,7 @@ export default function ReaderFeedHeaderFollow( props ) {
 	const [ isSuggestedFollowsModalOpen, setIsSuggestedFollowsModalOpen ] = useState( false );
 	const siteId = site?.ID;
 	const siteUrl = getSiteUrl( { feed, site } );
+	const { isRecommended, toggleRecommended } = useRecommendedSite( Number( feed?.feed_ID ) );
 
 	const { following, hasOrganization, isEmailBlocked, isWPForTeamsItem, subscriptionId } =
 		useSelector( ( state ) => {
@@ -96,6 +101,17 @@ export default function ReaderFeedHeaderFollow( props ) {
 					</div>
 				) }
 			</div>
+			{ ( following || isRecommended ) && (
+				<FollowButton
+					following={ isRecommended }
+					onFollowToggle={ toggleRecommended }
+					followLabel={ translate( 'Recommend' ) }
+					followingLabel={ translate( 'Recommended' ) }
+					hasButtonStyle
+					followIcon={ <ReaderFollowFeedIcon /> }
+					followingIcon={ <ReaderFollowingFeedIcon /> }
+				/>
+			) }
 			{ isEligibleForUnseen( { isWPForTeamsItem, hasOrganization } ) && feed && (
 				<button
 					onClick={ markAllAsSeen }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

this is an alternate approach exploration / proposal for adding a recommend button on feeds. https://github.com/Automattic/wp-calypso/pull/104793
We just use the existing hook, and the existing follow button component. The functionality all seems in place, but lacks style updates.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
