### PR TITLE
Add Studio to nav and footer, update links

### DIFF
--- a/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
@@ -85,6 +85,16 @@ export const PureUniversalNavbarFooter = ( {
 									</a>
 								</li>
 								<li>
+									<a href={ localizeUrl( 'https://wordpress.com/for-agencies/' ) } target="_self">
+										{ __( 'WordPress for Agencies', __i18n_text_domain__ ) }
+									</a>
+								</li>
+								<li>
+									<a href={ localizeUrl( 'https://wordpress.com/affiliates/' ) } target="_self">
+										{ __( 'Become an Affiliate', __i18n_text_domain__ ) }
+									</a>
+								</li>
+								<li>
 									<a href={ localizeUrl( 'https://wordpress.com/domains/' ) } target="_self">
 										{ __( 'Domain Names', __i18n_text_domain__ ) }
 									</a>
@@ -120,19 +130,26 @@ export const PureUniversalNavbarFooter = ( {
 								</li>
 								<li>
 									<a
-										href={ localizeUrl(
-											'https://wordpress.com/website-design-service/?ref=footer_pricing'
-										) }
-										title="WordPress Website Building Service"
+										href={ localizeUrl( 'https://wordpress.com/website-design-service/' ) }
 										target="_self"
 									>
 										{ __( 'Website Design Services', __i18n_text_domain__ ) }
 									</a>
 								</li>
 								<li>
+									<a
+										href={ localizeUrl( 'https://developer.wordpress.com/studio/' ) }
+										target="_self"
+									>
+										<span className="lp-link-chevron-external">
+											{ __( 'WordPress Studio', __i18n_text_domain__ ) }
+										</span>
+									</a>
+								</li>
+								<li>
 									<a href="https://wpvip.com/" data-is_external="1" target="_self">
 										<span className="lp-link-chevron-external">
-											{ __( 'Enterprise', __i18n_text_domain__ ) }
+											{ __( 'WordPress Enterprise', __i18n_text_domain__ ) }
 										</span>
 									</a>
 								</li>
@@ -142,11 +159,7 @@ export const PureUniversalNavbarFooter = ( {
 							<h3>{ __( 'Features', __i18n_text_domain__ ) }</h3>
 							<ul>
 								<li>
-									<a
-										href={ localizeUrl( 'https://wordpress.com/features/' ) }
-										title="WordPress.com Features"
-										target="_self"
-									>
+									<a href={ localizeUrl( 'https://wordpress.com/features/' ) } target="_self">
 										{ __( 'Overview', __i18n_text_domain__ ) }
 									</a>
 								</li>
@@ -160,7 +173,7 @@ export const PureUniversalNavbarFooter = ( {
 								</li>
 								<li>
 									<a
-										href={ localizeUrl( 'https://wordpress.com/plugins/', locale, isLoggedIn ) }
+										href={ localizeUrl( 'https://wordpress.com/plugins', locale, isLoggedIn ) }
 										target="_self"
 									>
 										{ __( 'WordPress Plugins', __i18n_text_domain__ ) }
@@ -168,7 +181,7 @@ export const PureUniversalNavbarFooter = ( {
 								</li>
 								<li>
 									<a
-										href={ localizeUrl( 'https://wordpress.com/patterns/', locale, isLoggedIn ) }
+										href={ localizeUrl( 'https://wordpress.com/patterns', locale, isLoggedIn ) }
 										target="_self"
 									>
 										{ __( 'WordPress Patterns', __i18n_text_domain__ ) }
@@ -384,11 +397,11 @@ export const PureUniversalNavbarFooter = ( {
 							<h2 className="lp-hidden">{ __( 'Social Media', __i18n_text_domain__ ) }</h2>
 							<ul className="lp-footer-social-icons">
 								<li>
-									<a href="https://twitter.com/wordpressdotcom" title="WordPress.com on Twitter">
+									<a href="https://x.com/wordpressdotcom" title="WordPress.com on X (Twitter)">
 										<span className="lp-hidden">
-											{ __( 'WordPress.com on Twitter', __i18n_text_domain__ ) }
+											{ __( 'WordPress.com on X (Twitter)', __i18n_text_domain__ ) }
 										</span>
-										<SocialLogo size={ 24 } icon="twitter-alt" className="lp-icon" />
+										<SocialLogo size={ 24 } icon="x" className="lp-icon" />
 									</a>
 								</li>
 								<li>

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -593,7 +593,7 @@ const UniversalNavbarHeader = ( {
 											<ClickableItem
 												titleValue=""
 												content={ __( 'WordPress Studio', __i18n_text_domain__ ) }
-												urlValue={ localizeUrl( '//developer.wordpress.com/' ) }
+												urlValue={ localizeUrl( '//developer.wordpress.com/studio/' ) }
 												type="dropdown"
 												target="_self"
 											/>
@@ -706,21 +706,21 @@ const UniversalNavbarHeader = ( {
 											<ClickableItem
 												titleValue=""
 												content={ __( 'Discover New Posts', __i18n_text_domain__ ) }
-												urlValue={ localizeUrl( '//wordpress.com/discover/' ) }
+												urlValue={ localizeUrl( '//wordpress.com/discover' ) }
 												type="menu"
 												tabIndex={ mobileMenuTabIndex }
 											/>
 											<ClickableItem
 												titleValue=""
 												content={ __( 'Popular Tags', __i18n_text_domain__ ) }
-												urlValue={ localizeUrl( '//wordpress.com/tags/' ) }
+												urlValue={ localizeUrl( '//wordpress.com/tags' ) }
 												type="menu"
 												tabIndex={ mobileMenuTabIndex }
 											/>
 											<ClickableItem
 												titleValue=""
 												content={ __( 'Blog Search', __i18n_text_domain__ ) }
-												urlValue={ localizeUrl( '//wordpress.com/reader/search/' ) }
+												urlValue={ localizeUrl( '//wordpress.com/reader/search' ) }
 												type="menu"
 												tabIndex={ mobileMenuTabIndex }
 											/>

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -139,6 +139,20 @@ const UniversalNavbarHeader = ( {
 														/>
 														<ClickableItem
 															titleValue=""
+															content={ __( 'WordPress for Agencies', __i18n_text_domain__ ) }
+															urlValue={ localizeUrl( '//wordpress.com/for-agencies/' ) }
+															type="dropdown"
+															target="_self"
+														/>
+														<ClickableItem
+															titleValue=""
+															content={ __( 'Become an Affiliate', __i18n_text_domain__ ) }
+															urlValue={ localizeUrl( '//wordpress.com/affiliates/' ) }
+															type="dropdown"
+															target="_self"
+														/>
+														<ClickableItem
+															titleValue=""
 															content={ __( 'Domain Names', __i18n_text_domain__ ) }
 															urlValue={ localizeUrl( '//wordpress.com/domains/' ) }
 															type="dropdown"
@@ -171,7 +185,7 @@ const UniversalNavbarHeader = ( {
 															titleValue=""
 															content={ __( 'Newsletter', __i18n_text_domain__ ) }
 															urlValue={ localizeUrl(
-																'//wordpress.com/newsletter',
+																'//wordpress.com/newsletter/',
 																locale,
 																isLoggedIn,
 																true
@@ -204,12 +218,19 @@ const UniversalNavbarHeader = ( {
 															type="dropdown"
 															target="_self"
 														/>
+														<ClickableItem
+															titleValue=""
+															content={ __( 'WordPress Studio', __i18n_text_domain__ ) }
+															urlValue={ localizeUrl( '//developer.wordpress.com/studio/' ) }
+															type="dropdown"
+															target="_self"
+														/>
 													</ul>
 													<div className="x-dropdown-content-separator"></div>
 													<ul>
 														<ClickableItem
 															titleValue=""
-															content={ __( 'Enterprise', __i18n_text_domain__ ) }
+															content={ __( 'Enterprise WordPress', __i18n_text_domain__ ) }
 															urlValue="https://wpvip.com/?utm_source=WordPresscom&utm_medium=automattic_referral&utm_campaign=top_nav"
 															type="dropdown"
 														/>
@@ -303,7 +324,7 @@ const UniversalNavbarHeader = ( {
 														/>
 														<ClickableItem
 															titleValue=""
-															content={ __( 'News', __i18n_text_domain__ ) }
+															content={ __( 'WordPress News', __i18n_text_domain__ ) }
 															urlValue={ localizeUrl( '//wordpress.com/blog/' ) }
 															type="dropdown"
 															target="_self"
@@ -332,21 +353,21 @@ const UniversalNavbarHeader = ( {
 														<ClickableItem
 															titleValue=""
 															content={ __( 'Discover New Posts', __i18n_text_domain__ ) }
-															urlValue={ localizeUrl( '//wordpress.com/discover/' ) }
+															urlValue={ localizeUrl( '//wordpress.com/discover' ) }
 															type="dropdown"
 															target="_self"
 														/>
 														<ClickableItem
 															titleValue=""
 															content={ __( 'Popular Tags', __i18n_text_domain__ ) }
-															urlValue={ localizeUrl( '//wordpress.com/tags/' ) }
+															urlValue={ localizeUrl( '//wordpress.com/tags' ) }
 															type="dropdown"
 															target="_self"
 														/>
 														<ClickableItem
 															titleValue=""
 															content={ __( 'Blog Search', __i18n_text_domain__ ) }
-															urlValue={ localizeUrl( '//wordpress.com/reader/search/' ) }
+															urlValue={ localizeUrl( '//wordpress.com/reader/search' ) }
 															type="dropdown"
 															target="_self"
 														/>
@@ -493,6 +514,20 @@ const UniversalNavbarHeader = ( {
 											/>
 											<ClickableItem
 												titleValue=""
+												content={ __( 'WordPress for Agencies', __i18n_text_domain__ ) }
+												urlValue={ localizeUrl( '//wordpress.com/for-agencies/' ) }
+												type="dropdown"
+												target="_self"
+											/>
+											<ClickableItem
+												titleValue=""
+												content={ __( 'Become an Affiliate', __i18n_text_domain__ ) }
+												urlValue={ localizeUrl( '//wordpress.com/affiliates/' ) }
+												type="dropdown"
+												target="_self"
+											/>
+											<ClickableItem
+												titleValue=""
 												content={ __( 'Domain Names', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/domains/' ) }
 												type="menu"
@@ -523,7 +558,7 @@ const UniversalNavbarHeader = ( {
 												titleValue=""
 												content={ __( 'Newsletter', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl(
-													'//wordpress.com/newsletter',
+													'//wordpress.com/newsletter/',
 													locale,
 													isLoggedIn,
 													true
@@ -554,6 +589,13 @@ const UniversalNavbarHeader = ( {
 												urlValue={ localizeUrl( '//wordpress.com/ecommerce/' ) }
 												type="menu"
 												tabIndex={ mobileMenuTabIndex }
+											/>
+											<ClickableItem
+												titleValue=""
+												content={ __( 'WordPress Studio', __i18n_text_domain__ ) }
+												urlValue={ localizeUrl( '//developer.wordpress.com/' ) }
+												type="dropdown"
+												target="_self"
 											/>
 											<ClickableItem
 												titleValue=""


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # M4R73CH-1016

## Proposed Changes

* Adds a link to WordPress Studio in the nav and footer
* Adds missing links for `WordPress for Agencies` and `Become an Affiliate`
* Updates anchor text to match LOHP
* Removes unneeded title elements
* Adds trailing slash to Newsletter link
* Updates old Twitter social logo with new X logo
* Updates Twitter profile link to new X profile link

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This PR adds a new link to the nav and footer for WordPress Studio, pointing to https://developer.wordpress.com/studio/. There were also several small changes to make the nav and footer more closely match that of the LOHP. There are a few differences still, mainly in the footer, but these changes bring things a little more in sync. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch or use the live testing link
* Visit /plugins while logged out or in a private browser window
* View the nav and footer and verify that you see the updated links, correct anchor text, and updated social icon for X

**Before:**
<img width="399" height="423" alt="Screenshot 2025-07-22 at 12 51 21 PM" src="https://github.com/user-attachments/assets/c30fccc9-cec5-4e49-aefe-35038d98eb03" />
<img width="699" height="341" alt="Screenshot 2025-07-22 at 6 33 57 AM" src="https://github.com/user-attachments/assets/20587db8-46f1-4eb3-95d7-90cf77224d8c" />
<img width="1098" height="552" alt="Screenshot 2025-07-22 at 6 33 36 AM" src="https://github.com/user-attachments/assets/3339a70d-eb7a-41d3-b575-866f46f498dc" />
<img width="1073" height="491" alt="Screenshot 2025-07-22 at 6 34 12 AM" src="https://github.com/user-attachments/assets/340d0a13-c854-4d0a-bf3e-8cba33d02fd3" />
<img width="180" height="52" alt="Screenshot 2025-07-22 at 1 01 04 PM" src="https://github.com/user-attachments/assets/9bcb7f95-fa43-4a86-bf38-165089e3d3fb" />

**After:**
<img width="710" height="519" alt="Screenshot 2025-07-22 at 1 19 40 PM" src="https://github.com/user-attachments/assets/e3d370e5-c5e0-4b15-a210-82f0980d45d1" />
<img width="721" height="353" alt="Screenshot 2025-07-22 at 1 19 45 PM" src="https://github.com/user-attachments/assets/18341ec5-9ded-45e9-897d-7f2f85b71d26" />
<img width="1010" height="476" alt="Screenshot 2025-07-22 at 1 19 56 PM" src="https://github.com/user-attachments/assets/9354476b-4a1d-4ec9-a298-5b3eef193621" />
<img width="197" height="55" alt="Screenshot 2025-07-22 at 1 00 54 PM" src="https://github.com/user-attachments/assets/7ed4e150-c1d7-4e19-8050-a633b8309f3e" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
