### PR TITLE
A4A: Use BD purchase details on client subscriptions page

### DIFF
--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/field-content.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/field-content.tsx
@@ -57,10 +57,12 @@ export function SubscriptionPrice( {
 	const formatted = formatCurrency( Number( amount ?? 0 ), currency );
 
 	return interval === 'year'
-		? translate( '%(total)s/yr', {
+		? /* translators: %(total)s is the price of the subscription per year */
+		  translate( '%(total)s/yr', {
 				args: { total: formatted },
 		  } )
-		: translate( '%(total)s/mo', {
+		: /* translators: %(total)s is the price of the subscription per month */
+		  translate( '%(total)s/mo', {
 				args: { total: formatted },
 		  } );
 }

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/field-content.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/field-content.tsx
@@ -42,16 +42,27 @@ export function SubscriptionPurchase( {
 	);
 }
 
-export function SubscriptionPrice( { isFetching, amount }: Props & { amount?: string } ) {
+export function SubscriptionPrice( {
+	isFetching,
+	amount,
+	currency = 'USD',
+	interval = 'month',
+}: Props & { amount?: string; currency?: string; interval?: string } ) {
 	const translate = useTranslate();
 
-	return isFetching ? (
-		<TextPlaceholder />
-	) : (
-		translate( '%(total)s/mo', {
-			args: { total: formatCurrency( Number( amount ?? 0 ), 'USD' ) },
-		} )
-	);
+	if ( isFetching ) {
+		return <TextPlaceholder />;
+	}
+
+	const formatted = formatCurrency( Number( amount ?? 0 ), currency );
+
+	return interval === 'year'
+		? translate( '%(total)s/yr', {
+				args: { total: formatted },
+		  } )
+		: translate( '%(total)s/mo', {
+				args: { total: formatted },
+		  } );
 }
 
 export function SubscriptionStatus( {

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/index.tsx
@@ -12,6 +12,8 @@ import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar
 import useFetchClientProducts from 'calypso/a8c-for-agencies/data/client/use-fetch-client-products';
 import LayoutBody from 'calypso/layout/hosting-dashboard/body';
 import LayoutHeader, { LayoutHeaderTitle as Title } from 'calypso/layout/hosting-dashboard/header';
+import { useSelector } from 'calypso/state';
+import { getUserBillingType } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import useFetchClientSubscriptions from '../../hooks/use-fetch-client-subscriptions';
 import {
 	SubscriptionAction,
@@ -36,6 +38,8 @@ export default function SubscriptionsList() {
 
 	const { data, isFetching, refetch } = useFetchClientSubscriptions();
 	const { data: products, isFetching: isFetchingProducts } = useFetchClientProducts();
+	const userBillingType = useSelector( getUserBillingType );
+	const isBillingTypeBD = userBillingType === 'billingdragon';
 
 	const title = translate( 'Your subscriptions' );
 
@@ -52,10 +56,14 @@ export default function SubscriptionsList() {
 				render: ( { item }: { item: Subscription } ): ReactNode => {
 					const product = products?.find( ( product ) => product.product_id === item.product_id );
 					const isPressable = product?.slug.startsWith( 'pressable' );
+					const name =
+						isBillingTypeBD && item.subscription?.product_name
+							? item.subscription.product_name
+							: product?.name;
 					return (
 						<SubscriptionPurchase
 							isFetching={ isFetchingProducts }
-							name={ product?.name }
+							name={ name }
 							isPressable={ isPressable }
 						/>
 					);
@@ -68,8 +76,28 @@ export default function SubscriptionsList() {
 				label: translate( 'Price' ).toUpperCase(),
 				getValue: () => '-',
 				render: ( { item }: { item: Subscription } ): ReactNode => {
-					const product = products?.find( ( product ) => product.product_id === item.product_id );
-					return <SubscriptionPrice isFetching={ isFetchingProducts } amount={ product?.amount } />;
+					if ( isBillingTypeBD && item.status === 'error' ) {
+						return '---';
+					}
+					let amount = '';
+					let currency = 'USD';
+					let interval = 'month';
+					if ( isBillingTypeBD ) {
+						amount = item.subscription?.purchase_price || '';
+						currency = item.subscription?.purchase_currency || '';
+						interval = item.subscription?.billing_interval_unit || '';
+					} else {
+						const product = products?.find( ( product ) => product.product_id === item.product_id );
+						amount = product?.amount || '';
+					}
+					return (
+						<SubscriptionPrice
+							isFetching={ isFetchingProducts }
+							amount={ amount }
+							currency={ currency }
+							interval={ interval }
+						/>
+					);
 				},
 				enableHiding: false,
 				enableSorting: false,
@@ -100,7 +128,7 @@ export default function SubscriptionsList() {
 				enableSorting: false,
 			},
 		],
-		[ isFetchingProducts, onCancelSubscription, products, translate ]
+		[ isBillingTypeBD, isFetchingProducts, onCancelSubscription, products, translate ]
 	);
 	const { data: items, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( data ?? [], dataViewsState, fields );

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/index.tsx
@@ -38,8 +38,7 @@ export default function SubscriptionsList() {
 
 	const { data, isFetching, refetch } = useFetchClientSubscriptions();
 	const { data: products, isFetching: isFetchingProducts } = useFetchClientProducts();
-	const userBillingType = useSelector( getUserBillingType );
-	const isBillingTypeBD = userBillingType === 'billingdragon';
+	const isBillingTypeBD = useSelector( getUserBillingType ) === 'billingdragon';
 
 	const title = translate( 'Your subscriptions' );
 

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/index.tsx
@@ -1,3 +1,4 @@
+import { Gridicon } from '@automattic/components';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import clsx from 'clsx';
@@ -76,7 +77,7 @@ export default function SubscriptionsList() {
 				getValue: () => '-',
 				render: ( { item }: { item: Subscription } ): ReactNode => {
 					if ( isBillingTypeBD && item.status === 'error' ) {
-						return '---';
+						return <Gridicon icon="minus" />;
 					}
 					let amount = '';
 					let currency = 'USD';

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/mobile-view/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/mobile-view/index.tsx
@@ -1,4 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'calypso/state';
+import { getUserBillingType } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import {
 	SubscriptionAction,
 	SubscriptionPrice,
@@ -24,9 +26,23 @@ const SubscriptionItem = ( {
 	onCancelSubscription,
 }: SubscriptionItemProps ) => {
 	const translate = useTranslate();
+	const isBillingTypeBD = useSelector( getUserBillingType ) === 'billingdragon';
 
 	const product = products?.find( ( product ) => product.product_id === subscription.product_id );
 	const isPressable = product?.slug.startsWith( 'pressable' );
+
+	let name = product?.name;
+	let amount = '';
+	let currency = 'USD';
+	let interval = 'month';
+	if ( isBillingTypeBD ) {
+		name = subscription.subscription?.product_name || '';
+		amount = subscription.subscription?.purchase_price || '';
+		currency = subscription.subscription?.purchase_currency || '';
+		interval = subscription.subscription?.billing_interval_unit || '';
+	} else {
+		amount = product?.amount || '';
+	}
 
 	return (
 		<div className="subscriptions-mobile">
@@ -37,7 +53,7 @@ const SubscriptionItem = ( {
 				<p className="subscriptions-mobile__product-name">
 					<SubscriptionPurchase
 						isFetching={ isFetching }
-						name={ product?.name }
+						name={ name }
 						isPressable={ isPressable }
 					/>
 				</p>
@@ -45,7 +61,16 @@ const SubscriptionItem = ( {
 			<div className="subscriptions-mobile__content">
 				<h3>{ translate( 'PRICE' ).toUpperCase() }</h3>
 				<p>
-					<SubscriptionPrice isFetching={ isFetching } amount={ product?.amount } />
+					{ isBillingTypeBD && subscription.status === 'error' ? (
+						'---'
+					) : (
+						<SubscriptionPrice
+							isFetching={ isFetching }
+							amount={ amount }
+							currency={ currency }
+							interval={ interval }
+						/>
+					) }
 				</p>
 			</div>
 			<div className="subscriptions-mobile__content">

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/mobile-view/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/mobile-view/index.tsx
@@ -32,7 +32,7 @@ const SubscriptionItem = ( {
 	const isPressable = product?.slug.startsWith( 'pressable' );
 
 	let name = product?.name;
-	let amount = '';
+	let amount = product?.amount;
 	let currency = 'USD';
 	let interval = 'month';
 	if ( isBillingTypeBD ) {
@@ -40,8 +40,6 @@ const SubscriptionItem = ( {
 		amount = subscription.subscription?.purchase_price || '';
 		currency = subscription.subscription?.purchase_currency || '';
 		interval = subscription.subscription?.billing_interval_unit || '';
-	} else {
-		amount = product?.amount || '';
 	}
 
 	return (

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/mobile-view/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/mobile-view/index.tsx
@@ -1,3 +1,4 @@
+import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import { getUserBillingType } from 'calypso/state/a8c-for-agencies/agency/selectors';
@@ -60,7 +61,7 @@ const SubscriptionItem = ( {
 				<h3>{ translate( 'PRICE' ).toUpperCase() }</h3>
 				<p>
 					{ isBillingTypeBD && subscription.status === 'error' ? (
-						'---'
+						<Gridicon icon="minus" />
 					) : (
 						<SubscriptionPrice
 							isFetching={ isFetching }

--- a/client/a8c-for-agencies/sections/client/types.ts
+++ b/client/a8c-for-agencies/sections/client/types.ts
@@ -5,6 +5,14 @@ export interface ReferralProduct {
 	license: {
 		license_key: string;
 	};
+	subscription?: {
+		id: string;
+		product_name: string;
+		purchase_price?: string;
+		purchase_currency?: string;
+		billing_interval_unit?: string;
+		status: string;
+	};
 	site_assigned: string;
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Linear issue: https://linear.app/a8c/issue/A4A-1059/client-subscriptions-should-reflect-the-product-and-billing-info
Backend PR: 188546-ghe-Automattic/wpcom

## Proposed Changes

* If the user's billing type is billingdragon then incorporate product and price data from BD on the `client/subscriptions` page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To show accurate purchase data

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test this with this backend PR applied on your sandbox: 188546-ghe-Automattic/wpcom
* You'll need 2 different clients. One that has purchased only through the existing (non /v2) checkout (we'll call this client-v1), and another that has purchased through the /v2 checkout (we'll call this client-v2).
  * If you don't have a client with a variety of purchases using the v2 checkout, you can follow steps in this PR (188433-ghe-Automattic/wpcom) to make some purchases.
  * If you can, also change the currency of your v2 client from store admin and make purchases in a different currency (at least non-USD).
  * Test with products of both monthly and yearly intervals.

* As client-v1, visit `/client/subscriptions`.
* You should your list of subscriptions as they've always appeared. Always showing in USD and with `/mo`.
* Cancel a subscription and make sure that still works as normal.

<img width="1431" height="577" alt="Screenshot 2025-07-22 at 3 44 38 PM" src="https://github.com/user-attachments/assets/90d0274c-5aff-44f9-b9db-833bc104b785" />

* As client-v2, visit `/client/subscriptions`.
* You should see a familiar list of subscriptions but the price column should reflect the currency and billing interval (/mo or /yr) of the purchase.
* The product name should appear correctly as normal.
* Cancel a subscription and make sure that works as normal.

<img width="1601" height="1160" alt="Screenshot 2025-07-22 at 3 52 51 PM" src="https://github.com/user-attachments/assets/5d2717ed-8c74-4395-8b08-c83652c7f930" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?