### PR TITLE
Hosting dashboard card padding matches dataviews card padding

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/a4a/site-error-preview/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/site-error-preview/style.scss
@@ -12,7 +12,7 @@
 		display: block;
 
 		@include break-large {
-			padding: 48px;
+			padding: 48px 24px;
 		}
 	}
 

--- a/client/layout/hosting-dashboard/item-view/item-view-content/style.scss
+++ b/client/layout/hosting-dashboard/item-view/item-view-content/style.scss
@@ -1,7 +1,7 @@
 .hosting-dashboard-item-view__content {
 	flex-grow: 1;
 	background-color: var(--color-light-backdrop);
-	padding: 48px;
+	padding: 48px 24px;
 	text-align: left;
 	overflow-y: auto;
 	overflow-x: hidden;

--- a/client/layout/hosting-dashboard/item-view/item-view-header/style.scss
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/style.scss
@@ -80,7 +80,7 @@ $blueberry-color: #3858e9;
 		}
 
 		.hosting-dashboard-item-view__header-content {
-			padding: 48px 48px 24px 48px;
+			padding: 24px;
 			display: flex;
 			align-items: top;
 

--- a/client/layout/hosting-dashboard/item-view/style.scss
+++ b/client/layout/hosting-dashboard/item-view/style.scss
@@ -23,7 +23,7 @@
 		}
 
 		.section-nav-tabs__list {
-			padding: 0 32px;
+			padding: 0 8px;
 		}
 
 		.section-nav-tab__text {

--- a/client/my-sites/domains/domain-management/domain-overview-pane/style.scss
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/style.scss
@@ -34,7 +34,7 @@
 		}
 
 		@include break-large {
-			padding: 32px 48px 48px;
+			padding: 32px 24px 24px;
 		}
 
 		> * {

--- a/client/sites/components/dotcom-style.scss
+++ b/client/sites/components/dotcom-style.scss
@@ -251,7 +251,7 @@
 		}
 	}
 	.hosting-dashboard-item-view__content {
-		padding: 32px 48px 48px;
+		padding: 32px 24px 24px;
 		font-size: rem(14px);
 		color: var(--studio-gray-100);
 

--- a/client/sites/components/style.scss
+++ b/client/sites/components/style.scss
@@ -793,7 +793,7 @@
 		}
 
 		@include break-large {
-			padding: 32px 48px 48px;
+			padding: 32px 24px 24px;
 		}
 	}
 }

--- a/client/sites/logs/components/style.scss
+++ b/client/sites/logs/components/style.scss
@@ -32,8 +32,8 @@
 
 // This is to compensate the padding set by the wrapper .hosting-dashboard-item-view__content
 .site-logs .dataviews-wrapper {
-	margin-right: -48px;
-	margin-left: -48px;
+	margin-right: -24px;
+	margin-left: -24px;
 }
 
 // https://github.com/WordPress/gutenberg/issues/69194


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Raised at p1753194863947259-slack-C08JZTRS6NA

## Proposed Changes

Tightens up the padding inside the hosting dashboard cards

<img width="2762" height="1532" alt="image" src="https://github.com/user-attachments/assets/114e31d8-fe6b-467e-b11d-7d251cb92487" />


When the vertical scrollbar in the sites sidebar appears it can look a bit busy in that whole area now.

<img width="2760" height="1352" alt="CleanShot 2025-07-23 at 11 00 25@2x" src="https://github.com/user-attachments/assets/d714ce12-79e0-4fad-b5da-c9d9ee307c9e" />


Note the selected tab style used by the hosting dashboard. It allows the tab label text to align nicely. But that underline is getting kinda close to the edge of the card now. It's how it used to work, just wanted to point it out.

<img width="670" height="612" alt="CleanShot 2025-07-23 at 11 00 11@2x" src="https://github.com/user-attachments/assets/794a7ddc-4cc2-41dc-bc41-c2625c029c40" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Since the dataviews in cards always use 24px padding now, that means the site logs no longer align with the rest of the hosting dashboard card content.

<img width="3418" height="1958" alt="image" src="https://github.com/user-attachments/assets/917dc9ee-45fa-49ec-9efd-8e5561e95c01" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites`
* Choose a site
* Test all the tabs, and check at different browser widths.
* Header content and tab content should align vertically.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?