### PR TITLE
Do not allow components shared with dashboard to import Calypso code

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -55,6 +55,13 @@ module.exports = {
 						message: 'Importing from @automattic/ is not allowed in the dashboard folder.',
 					},
 				],
+				paths: [
+					{
+						name: '@automattic/components',
+						message:
+							'Do not import from the barrel file. Use specific imports like @automattic/components/src/summary-button instead.',
+					},
+				],
 			},
 		],
 	},

--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -59,7 +59,7 @@ module.exports = {
 					{
 						name: '@automattic/components',
 						message:
-							'Do not import from the barrel file. Use specific imports like @automattic/components/src/summary-button instead.',
+							'Do not import from the barrel file. Use specific imports like @automattic/components/src/summary-button instead. This prevents the entire package being bundled into the dashboard.',
 					},
 				],
 			},

--- a/client/dashboard/components/summary-button-list/test/index.tsx
+++ b/client/dashboard/components/summary-button-list/test/index.tsx
@@ -4,7 +4,6 @@
 import '@testing-library/jest-dom';
 import SummaryButton from '@automattic/components/src/summary-button';
 import { render, screen } from '@testing-library/react';
-import * as React from 'react';
 import { SummaryButtonList } from '../index';
 import type { Density } from '@automattic/components/src/summary-button/types';
 

--- a/packages/components/.eslintrc.dashboard-shared.js
+++ b/packages/components/.eslintrc.dashboard-shared.js
@@ -17,7 +17,7 @@ module.exports = {
 							// with the #architecture group.
 						],
 						message:
-							'Importing from calypso/ is not allowed for components shared with client/dashboard.',
+							'Importing from calypso/ is not allowed for this component. It is used by the client/dashboard and we should avoid importing legacy Calypso code into the dashboard.',
 					},
 					{
 						group: [
@@ -31,7 +31,7 @@ module.exports = {
 							// with the #architecture group.
 						],
 						message:
-							'Importing from @automattic/ is not allowed for components shared with client/dashboard.',
+							'Importing from @automattic/ is not allowed for this component. It is used by the client/dashboard and we should avoid importing legacy Calypso code into the dashboard.',
 					},
 				],
 			},

--- a/packages/components/.eslintrc.dashboard-shared.js
+++ b/packages/components/.eslintrc.dashboard-shared.js
@@ -1,0 +1,40 @@
+module.exports = {
+	rules: {
+		'no-restricted-imports': [
+			'error',
+			{
+				patterns: [
+					{
+						group: [
+							'calypso/*',
+							// Allowed: calypso/assets/icons
+							// Allowed: calypso/assets/images
+							'!calypso/assets',
+							'calypso/assets/*',
+							'!calypso/assets/icons',
+							'!calypso/assets/images',
+							// Please do not add exceptions unless agreed on
+							// with the #architecture group.
+						],
+						message:
+							'Importing from calypso/ is not allowed for components shared with client/dashboard.',
+					},
+					{
+						group: [
+							'@automattic/*',
+							'!@automattic/calypso-config',
+							'!@automattic/components',
+							'!@automattic/number-formatters',
+							'!@automattic/ui',
+							'!@automattic/viewport',
+							// Please do not add exceptions unless agreed on
+							// with the #architecture group.
+						],
+						message:
+							'Importing from @automattic/ is not allowed for components shared with client/dashboard.',
+					},
+				],
+			},
+		],
+	},
+};

--- a/packages/components/src/breadcrumbs/.eslintrc.js
+++ b/packages/components/src/breadcrumbs/.eslintrc.js
@@ -1,0 +1,5 @@
+const dashboardSharedConfig = require( '../../.eslintrc.dashboard-shared.js' );
+
+module.exports = {
+	...dashboardSharedConfig,
+};

--- a/packages/components/src/circular-progress-bar/.eslintrc.js
+++ b/packages/components/src/circular-progress-bar/.eslintrc.js
@@ -1,0 +1,5 @@
+const dashboardSharedConfig = require( '../../.eslintrc.dashboard-shared.js' );
+
+module.exports = {
+	...dashboardSharedConfig,
+};

--- a/packages/components/src/logos/.eslintrc.js
+++ b/packages/components/src/logos/.eslintrc.js
@@ -1,0 +1,5 @@
+const dashboardSharedConfig = require( '../../.eslintrc.dashboard-shared.js' );
+
+module.exports = {
+	...dashboardSharedConfig,
+};

--- a/packages/components/src/summary-button/.eslintrc.js
+++ b/packages/components/src/summary-button/.eslintrc.js
@@ -1,0 +1,5 @@
+const dashboardSharedConfig = require( '../../.eslintrc.dashboard-shared.js' );
+
+module.exports = {
+	...dashboardSharedConfig,
+};


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Follow up to https://github.com/Automattic/wp-calypso/pull/104870

## Proposed Changes

* Once a `@automattic/` component is allowed in the v2 dashboard, we should make sure new Calypso dependencies aren't added.
* Improve v2 lint rule to prevent components being imported directly from `@automattic/components`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We want to follow a pragmatic approach of reusing components where we can. If a component looks good for sharing, then we should share the code. But we also don't want any new dependencies to surprise s.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the new barrel import rule by trying to to import `SummaryButton` directly from `@automattic/components`. You should now get an error.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
