### PR TITLE
M4R73CH-1018 - Update modal width for FREE_PLAN_PAID_DOMAIN_DIALOG

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/index.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/index.tsx
@@ -62,9 +62,9 @@ export default function PlanUpsellModal( props: ModalContainerProps ) {
 
 	const modalWidth = () => {
 		switch ( modalType ) {
-			case FREE_PLAN_PAID_DOMAIN_DIALOG:
 			case FREE_PLAN_FREE_DOMAIN_DIALOG:
 				return '605px';
+			case FREE_PLAN_PAID_DOMAIN_DIALOG:
 			case PAID_PLAN_PAID_DOMAIN_DIALOG:
 			case PAID_PLAN_IS_REQUIRED_DIALOG:
 			default:


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes # M4R73CH-1018

## Proposed Changes

* Updates the modal width for FREE_PLAN_PAID_DOMAIN_DIALOG to use 700px instead of 605px

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* A recent [PR](https://github.com/Automattic/wp-calypso/pull/103109) introduced a change to update some spacing in the paid domain required modal. The PR fixed issues in that modal, but because this modal has less room, it caused buttons to wrap to the left side instead of staying aligned on the right. This change increases the modal width from 605px to 700px to match other modals and provide adequate space for the larger buttons.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* From http://calypso.localhost:3000/start/onboarding-pm/domains, select a paid domain
* You'll then hit this page http://calypso.localhost:3000/start/onboarding-pm/plans. Click `start with a free plan.`
<img width="625" height="344" alt="Screenshot 2025-07-22 at 9 29 55 PM" src="https://github.com/user-attachments/assets/41da4146-3243-4cf0-b5e8-efbcf0a60613" />

* From there, you should see the modal. The buttons should be aligned on the right with plenty of room. 

### **Before:**
<img width="621" height="667" alt="Screenshot 2025-07-22 at 5 10 51 PM" src="https://github.com/user-attachments/assets/9f4963fc-287c-4a68-a282-296f6b3a0ab8" />

### **After:**
<img width="803" height="579" alt="Screenshot 2025-07-22 at 9 05 43 PM" src="https://github.com/user-attachments/assets/97834009-67d6-42a7-9b74-02d6c9d7a805" />

### If you switch your Interface language to another language from https://wordpress.com/me/account, then refresh the modal, the buttons should still look good:
<img width="744" height="518" alt="Screenshot 2025-07-22 at 9 07 33 PM" src="https://github.com/user-attachments/assets/a66c7b22-1ca8-4df6-a98d-591144aa386c" />
<img width="735" height="499" alt="Screenshot 2025-07-22 at 9 08 03 PM" src="https://github.com/user-attachments/assets/32a55afe-e8f1-471c-a933-afe34756bc0b" />
<img width="743" height="534" alt="Screenshot 2025-07-22 at 9 08 37 PM" src="https://github.com/user-attachments/assets/c5c08819-b9e5-4310-afd0-2fc434a24e70" />
<img width="752" height="544" alt="Screenshot 2025-07-22 at 9 09 04 PM" src="https://github.com/user-attachments/assets/7825a06e-d5f3-46c6-a439-b69770b9f500" />

### Other modals, such as PAID_PLAN_IS_REQUIRED_DIALOG and FREE_PLAN_FREE_DOMAIN_DIALOG should remain unchanged:
![440342420-0cbbf748-36a8-4484-9558-6a57f5464ba6](https://github.com/user-attachments/assets/5980f1a0-d349-4b9f-95e6-1825d9a7aecf)
<img width="672" height="772" alt="Screenshot 2025-07-22 at 9 13 53 PM" src="https://github.com/user-attachments/assets/ab7416c9-c77c-4123-b7e1-ed921eb9c8cb" />
<img width="727" height="431" alt="Screenshot 2025-07-22 at 9 39 09 PM" src="https://github.com/user-attachments/assets/9aed2082-83ab-4dfc-8408-26d271736fbb" />
<img width="645" height="672" alt="Screenshot 2025-07-22 at 9 13 23 PM" src="https://github.com/user-attachments/assets/78ff0bfe-20ba-4e5b-ae54-311178689144" />
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
