### PR TITLE
Update text in FREE_PLAN_PAID_DOMAIN_DIALOG modal

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-paid-domain-dialog.tsx
@@ -43,7 +43,7 @@ export function FreePlanPaidDomainDialog( {
 			</Heading>
 			<SubHeading id="plan-upsell-modal-description">
 				{ translate(
-					'Your custom domain can only be used as the primary domain with a paid plan and is free for the first year with an annual paid plan. For more details, please read {{a}}our support document{{/a}}.',
+					'Your custom domain can only be used as the primary domain with a paid plan and is free for the first year with an annual or multi-year plan. For more details, please read {{a}}our support document{{/a}}.',
 					{
 						components: {
 							a: (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes CHE-228

## Proposed Changes

* Updates the copy in the FREE_PLAN_PAID_DOMAIN_DIALOG modal

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is a small copy update to make it clearer that 2 and 3-year plans also come with a free domain.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* From http://calypso.localhost:3000/start/onboarding-pm/domains, select a paid domain
* You'll then hit this page http://calypso.localhost:3000/start/onboarding-pm/plans. Click start with a free plan.
* You should see the updated text that reads:
> Your custom domain can only be used as the primary domain with a paid plan and is free for the first year with an annual or multi-year plan. For more details, please read [our support document](https://wordpress.com/support/domains/set-a-primary-address/).

### Before:
<img width="530" height="192" alt="Screenshot 2025-07-22 at 9 51 58 PM" src="https://github.com/user-attachments/assets/325a93fe-7225-42c9-aa4d-c655f74d2a4e" />

### After:
<img width="548" height="207" alt="Screenshot 2025-07-22 at 9 51 12 PM" src="https://github.com/user-attachments/assets/c5dd423b-1efc-4a97-a43d-36d085343654" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?