### PR TITLE
Billing history: Increase the number of receipts per endpoint call

### DIFF
--- a/client/state/billing-transactions/actions.ts
+++ b/client/state/billing-transactions/actions.ts
@@ -18,7 +18,7 @@ export const requestBillingTransactions = ( transactionType?: BillingTransaction
 			type: BILLING_TRANSACTIONS_REQUEST,
 		} );
 
-		const limit = 200;
+		const limit = 600;
 		let url = '/me/billing-history' + ( transactionType ? `/${ transactionType }` : '' );
 		if ( transactionType !== 'upcoming' ) {
 			url = url + '?limit=' + limit;

--- a/client/state/billing-transactions/test/actions.js
+++ b/client/state/billing-transactions/test/actions.js
@@ -15,7 +15,7 @@ describe( 'actions', () => {
 		spy = jest.fn();
 	} );
 
-	const endpointLimit = 200;
+	const endpointLimit = 600;
 
 	describe( '#requestBillingTransactions()', () => {
 		describe( 'success', () => {


### PR DESCRIPTION
This is part of fixing https://linear.app/a8c/issue/SHILL-921/billing-history-increase-the-number-of-receipts-returned-per-endpoint

## Proposed Changes

We currently request only 200 receipts per endpoint call when loading a user's billing history.  For users with large numbers of receipts, this is inefficient because it results in many separate calls to the API endpoint.  Now that the endpoint is much better-performing than it used to be, it should be safe to increase this number and get a noticeable performance boost.

This pull request increases the number to 600.  I probably could have gone higher, but didn't want to have enormous amounts of data returned by a single API endpoint call either.

## Testing Instructions

This requires 188565-ghe-Automattic/wpcom in order to test.

Otherwise, I just tested in with a user account that has a lot of receipts and made sure that the `/me/purchases/billing` page worked correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?