### PR TITLE
Hosting Overview: Adds storage stats to the plans card

### DIFF
--- a/client/dashboard/app-a4a/style.scss
+++ b/client/dashboard/app-a4a/style.scss
@@ -13,6 +13,7 @@
 	--wp-admin-theme-color-darker-20: #005a87;
 	--wp-admin-theme-color-darker-20--rgb: 0, 90, 135;
 	--wp-admin-border-width-focus: 2px;
+	--wp-components-color-foreground: var(--wp-admin-theme-color);
 
 	// Layout
 	--dashboard__background-color: #fcfcfc;

--- a/client/dashboard/app-dotcom/style.scss
+++ b/client/dashboard/app-dotcom/style.scss
@@ -13,6 +13,7 @@
 	--wp-admin-theme-color-darker-20: #183ad6;
 	--wp-admin-theme-color-darker-20--rgb: 24, 58, 214;
 	--wp-admin-border-width-focus: 2px;
+	--wp-components-color-foreground: var(--wp-admin-theme-color);
 
 	// Layout
 	--dashboard__background-color: #fcfcfc;

--- a/client/dashboard/components/stat/index.stories.tsx
+++ b/client/dashboard/components/stat/index.stories.tsx
@@ -1,0 +1,22 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { Stat } from './';
+
+const meta: Meta< typeof Stat > = {
+	title: 'client/dashboard/Stat',
+	component: Stat,
+	tags: [ 'autodocs' ],
+};
+
+export default meta;
+type Story = StoryObj< typeof Stat >;
+
+export const Default: Story = {
+	args: {
+		density: 'low',
+		strapline: 'Views',
+		metric: '1.3 M',
+		description: '33% left',
+		descriptionAlignment: 'start',
+		progressValue: 15,
+	},
+};

--- a/client/dashboard/components/stat/index.tsx
+++ b/client/dashboard/components/stat/index.tsx
@@ -7,6 +7,7 @@ interface StatProps {
 	descriptionAlignment?: 'start' | 'end';
 	metric: string;
 	progressColor?: 'alert-yellow' | 'alert-red' | 'alert-green';
+	progressLabel?: string;
 	progressValue?: number;
 	strapline?: string;
 }
@@ -17,6 +18,7 @@ export function Stat( {
 	descriptionAlignment = 'start',
 	metric,
 	progressColor,
+	progressLabel,
 	progressValue,
 	strapline,
 }: StatProps ) {
@@ -35,7 +37,7 @@ export function Stat( {
 				<ProgressBar
 					className={ `dashboard-stat__progress-bar dashboard-stat__progress-bar--${ progressColor }` }
 					value={ progressValue }
-					aria-label={ `${ progressValue }%` }
+					aria-label={ progressLabel ?? `${ progressValue }%` }
 				/>
 			) }
 		</div>

--- a/client/dashboard/components/stat/index.tsx
+++ b/client/dashboard/components/stat/index.tsx
@@ -1,0 +1,43 @@
+import { __experimentalHStack as HStack, ProgressBar } from '@wordpress/components';
+import './style.scss';
+
+interface StatProps {
+	density?: 'low' | 'high';
+	description?: string;
+	descriptionAlignment?: 'start' | 'end';
+	metric: string;
+	progressColor?: 'alert-yellow' | 'alert-red' | 'alert-green';
+	progressValue?: number;
+	strapline?: string;
+}
+
+export function Stat( {
+	density = 'low',
+	description,
+	descriptionAlignment = 'start',
+	metric,
+	progressColor,
+	progressValue,
+	strapline,
+}: StatProps ) {
+	return (
+		<div className={ `dashboard-stat--density-${ density }` }>
+			{ strapline && <div className="dashboard-stat__strapline">{ strapline }</div> }
+			<HStack
+				alignment="baseline"
+				spacing={ 2 }
+				justify={ descriptionAlignment === 'start' ? 'start' : 'space-between' }
+			>
+				<div className="dashboard-stat__metric">{ metric }</div>
+				{ description && <div className="dashboard-stat__description">{ description }</div> }
+			</HStack>
+			{ progressValue !== undefined && (
+				<ProgressBar
+					className={ `dashboard-stat__progress-bar dashboard-stat__progress-bar--${ progressColor }` }
+					value={ progressValue }
+					aria-label={ `${ progressValue }%` }
+				/>
+			) }
+		</div>
+	);
+}

--- a/client/dashboard/components/stat/style.scss
+++ b/client/dashboard/components/stat/style.scss
@@ -1,0 +1,57 @@
+@import '@wordpress/base-styles/colors';
+@import '@wordpress/base-styles/variables';
+
+.dashboard-stat__strapline {
+	font-size: $font-size-x-small;
+	line-height: $font-line-height-medium;
+	font-weight: $font-weight-medium;
+	color: $gray-700;
+	text-transform: uppercase;
+}
+
+.dashboard-stat__metric {
+	color: $gray-900;
+	font-weight: $font-weight-medium;
+}
+
+.dashboard-stat__description {
+	font-size: $font-size-small;
+	line-height: $font-line-height-small;
+	color: $gray-700;
+}
+
+.dashboard-stat__progress-bar {
+	width: 100% !important;
+	margin-block: 0.25 * $grid-unit;
+}
+
+.dashboard-stat__progress-bar--alert-yellow {
+	--wp-components-color-foreground: #{$alert-yellow};
+}
+
+.dashboard-stat__progress-bar--alert-red {
+	--wp-components-color-foreground: #{$alert-red};
+}
+
+.dashboard-stat__progress-bar--alert-green {
+	--wp-components-color-foreground: #{$alert-green};
+}
+
+.dashboard-stat--density-low {
+	.dashboard-stat__metric {
+		font-size: $font-size-2x-large;
+		line-height: $font-line-height-2x-large;
+	}
+
+	.dashboard-stat__progress-bar {
+		height: $grid-unit-05 !important;
+	}
+}
+
+.dashboard-stat--density-high {
+	.dashboard-stat__metric {
+		font-size: $font-size-large;
+		line-height: $font-line-height-small;
+	}
+}
+

--- a/client/dashboard/data/site-media-storage.ts
+++ b/client/dashboard/data/site-media-storage.ts
@@ -1,16 +1,16 @@
 import wpcom from 'calypso/lib/wp';
 
 export interface SiteMediaStorage {
-	maxStorageBytesFromAddOns: number;
-	maxStorageBytes: number;
-	storageUsedBytes: number;
+	max_storage_bytes_from_add_ons: number;
+	max_storage_bytes: number;
+	storage_used_bytes: number;
 }
 
 export async function fetchSiteMediaStorage( siteId: number ): Promise< SiteMediaStorage > {
 	const mediaStorage = await wpcom.req.get( `/sites/${ siteId }/media-storage` );
 	return {
-		maxStorageBytesFromAddOns: Number( mediaStorage.max_storage_bytes_from_add_ons ),
-		maxStorageBytes: Number( mediaStorage.max_storage_bytes ),
-		storageUsedBytes: Number( mediaStorage.storage_used_bytes ),
+		max_storage_bytes_from_add_ons: Number( mediaStorage.max_storage_bytes_from_add_ons ),
+		max_storage_bytes: Number( mediaStorage.max_storage_bytes ),
+		storage_used_bytes: Number( mediaStorage.storage_used_bytes ),
 	};
 }

--- a/client/dashboard/sites/overview/plan-card.tsx
+++ b/client/dashboard/sites/overview/plan-card.tsx
@@ -3,6 +3,8 @@ import { __experimentalVStack as VStack } from '@wordpress/components';
 import { cloneElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
+import filesize from 'filesize';
+import { siteMediaStorageQuery } from '../../app/queries/site-media-storage';
 import { siteCurrentPlanQuery } from '../../app/queries/site-plans';
 import { sitePurchaseQuery } from '../../app/queries/site-purchases';
 import { Stat } from '../../components/stat';
@@ -10,12 +12,37 @@ import { DotcomPlans } from '../../data/constants';
 import OverviewCard from '../overview-card';
 import type { Site, Plan, Purchase } from '../../data/types';
 
+const MINIMUM_DISPLAYED_USAGE = 2.5;
+const ALERT_PERCENT = 80;
+
 export default function PlanCard( { site }: { site: Site } ) {
 	const { data: plan, isLoading: isLoadingPlan } = useQuery( siteCurrentPlanQuery( site.ID ) );
 	const { data: purchase, isLoading: isLoadingPurchase } = useQuery( {
 		...sitePurchaseQuery( site.ID, plan?.id ?? '' ),
 		enabled: !! plan?.id,
 	} );
+	const { data: mediaStorage, isLoading: isLoadingMediaStorage } = useQuery(
+		siteMediaStorageQuery( site.ID )
+	);
+
+	const storageUsagePercent = ! mediaStorage
+		? 0
+		: Math.round(
+				( ( mediaStorage.storage_used_bytes / mediaStorage.max_storage_bytes ) * 1000 ) / 10
+		  );
+
+	// Ensure that the displayed usage is never fully empty to avoid a confusing UI.
+	const progressBarValue = Math.max(
+		MINIMUM_DISPLAYED_USAGE,
+		Math.min( storageUsagePercent, 100 )
+	);
+
+	let storageWarningColor = undefined;
+	if ( storageUsagePercent > 100 ) {
+		storageWarningColor = 'alert-red' as const;
+	} else if ( storageUsagePercent > ALERT_PERCENT ) {
+		storageWarningColor = 'alert-yellow' as const;
+	}
 
 	const icon = cloneElement( wordpress, {
 		style: { color: 'var( --wp-admin-brand-color )' },
@@ -28,25 +55,27 @@ export default function PlanCard( { site }: { site: Site } ) {
 			heading={ site.plan?.product_name_short }
 			description={ getCardDescription( plan, purchase ) }
 			tracksId="plan"
-			isLoading={ isLoadingPlan || isLoadingPurchase }
+			isLoading={ isLoadingPlan || isLoadingPurchase || isLoadingMediaStorage }
 			link={ site.plan?.is_free ? undefined : '/v2/me/billing/active-subscriptions' }
 			bottom={
 				<VStack spacing={ 4 }>
 					<Stat
 						density="high"
 						strapline={ __( 'Storage' ) }
-						metric="13 MB"
-						description="1 GB"
+						metric={ filesize( mediaStorage?.storage_used_bytes ?? 0, { round: 0 } ) }
+						description={ filesize( mediaStorage?.max_storage_bytes ?? 0, { round: 0 } ) }
 						descriptionAlignment="end"
-						progressValue={ 15 }
+						progressValue={ progressBarValue }
+						progressColor={ storageWarningColor }
+						progressLabel={ `${ storageUsagePercent }%` }
 					/>
 					<Stat
 						density="high"
 						strapline={ __( 'Bandwidth' ) }
-						metric="2.12 MB"
+						metric="7.2 GB"
 						description="Unlimited"
 						descriptionAlignment="end"
-						progressValue={ 15 }
+						progressValue={ 100 }
 						progressColor="alert-green"
 					/>
 				</VStack>

--- a/client/dashboard/sites/overview/plan-card.tsx
+++ b/client/dashboard/sites/overview/plan-card.tsx
@@ -1,9 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
+import { __experimentalVStack as VStack } from '@wordpress/components';
 import { cloneElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 import { siteCurrentPlanQuery } from '../../app/queries/site-plans';
 import { sitePurchaseQuery } from '../../app/queries/site-purchases';
+import { Stat } from '../../components/stat';
 import { DotcomPlans } from '../../data/constants';
 import OverviewCard from '../overview-card';
 import type { Site, Plan, Purchase } from '../../data/types';
@@ -28,7 +30,27 @@ export default function PlanCard( { site }: { site: Site } ) {
 			tracksId="plan"
 			isLoading={ isLoadingPlan || isLoadingPurchase }
 			link={ site.plan?.is_free ? undefined : '/v2/me/billing/active-subscriptions' }
-			bottom={ <div /> }
+			bottom={
+				<VStack spacing={ 4 }>
+					<Stat
+						density="high"
+						strapline={ __( 'Storage' ) }
+						metric="13 MB"
+						description="1 GB"
+						descriptionAlignment="end"
+						progressValue={ 15 }
+					/>
+					<Stat
+						density="high"
+						strapline={ __( 'Bandwidth' ) }
+						metric="2.12 MB"
+						description="Unlimited"
+						descriptionAlignment="end"
+						progressValue={ 15 }
+						progressColor="alert-green"
+					/>
+				</VStack>
+			}
 		/>
 	);
 }

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -265,7 +265,7 @@ export function MediaStorage( { site }: { site: Site } ) {
 
 	const value = mediaStorage ? (
 		`${
-			Math.round( ( mediaStorage.storageUsedBytes / mediaStorage.maxStorageBytes ) * 1000 ) / 10
+			Math.round( ( mediaStorage.storage_used_bytes / mediaStorage.max_storage_bytes ) * 1000 ) / 10
 		}%`
 	) : (
 		<IneligibleIndicator />


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-114

## Proposed Changes

* Implements a `<Stats>` comonent
  * "Stats" comes from this DS component rykv85Ii9RkvP504dtqqaW-fi-158_57558
  * It's the base of a number of other components like `StatButton` and `StatTab`
  * I suppose an alternative name might be "Metric"?
* Display the correct storage usage
* Show red alert when storage is exceeded
* Show yellow alert when storage is over 80%
* Ensure the progress bar never drops below 2.5% (this replicates the v1 behaviour)
* Implement custom aria text to ensure the aria text says the correct number (not 2.5%)
* Show a dummy metric for "bandwidth"

<img width="2812" height="1030" alt="CleanShot 2025-07-23 at 18 51 26@2x" src="https://github.com/user-attachments/assets/e0bf7158-0c0a-4265-8869-e53362a203fd" />

Not implementing in this PR
- There should be a link to buy more storage when the level goes over 80% (DOTDASH-138)
- The correct stat loading behaviour
- The bandwidth stat is still hard-coded
- Plans page needs to link somewhere else in backport

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the storybook for `Stat`. You can test all the various props in real time that way
* Test a free site and buiness site. Ensure the plans card looks correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?