### PR TITLE
Site Overview v2: Implement visibility card launchpad

### DIFF
--- a/client/dashboard/app/queries/site-launchpad.ts
+++ b/client/dashboard/app/queries/site-launchpad.ts
@@ -1,0 +1,6 @@
+import { fetchSiteLaunchpad } from '../../data/site-launchpad';
+
+export const siteLaunchpadQuery = ( siteId: number, checklistSlug: string ) => ( {
+	queryKey: [ 'site', siteId, 'launchpad', checklistSlug ],
+	queryFn: () => fetchSiteLaunchpad( siteId, checklistSlug ),
+} );

--- a/client/dashboard/data/site-launchpad.tsx
+++ b/client/dashboard/data/site-launchpad.tsx
@@ -1,0 +1,25 @@
+import wpcom from 'calypso/lib/wp';
+
+export interface LaunchpadTask {
+	completed: boolean;
+}
+
+export interface Launchpad {
+	checklist?: LaunchpadTask[] | null;
+}
+
+export async function fetchSiteLaunchpad(
+	siteId: number,
+	checklistSlug: string
+): Promise< Launchpad > {
+	return wpcom.req.get(
+		{
+			path: `/sites/${ siteId }/launchpad`,
+			apiNamespace: 'wpcom/v2',
+		},
+		{
+			checklist_slug: checklistSlug,
+			launchpad_context: 'sites-dashboard',
+		}
+	);
+}

--- a/client/dashboard/data/site.ts
+++ b/client/dashboard/data/site.ts
@@ -38,6 +38,7 @@ export const SITE_OPTIONS = [
 	'is_wpforteams_site',
 	'p2_hub_blog_id',
 	'site_creation_flow',
+	'site_intent',
 	'software_version',
 	'updated_at',
 	'wpcom_production_blog_id',
@@ -69,6 +70,7 @@ export interface SiteOptions {
 	is_wpforteams_site?: boolean;
 	p2_hub_blog_id?: number;
 	site_creation_flow?: string;
+	site_intent?: string;
 	software_version: string;
 	updated_at?: string;
 	wpcom_production_blog_id?: number;

--- a/client/dashboard/sites/overview-card/index.tsx
+++ b/client/dashboard/sites/overview-card/index.tsx
@@ -75,7 +75,7 @@ export default function OverviewCard( {
 					{ link && ! progress && (
 						<Icon className="dashboard-overview-card__link-icon" icon={ chevronRight } />
 					) }
-					{ externalLink && (
+					{ externalLink && ! progress && (
 						<span
 							className="dashboard-overview-card__link-icon components-external-link__icon"
 							aria-label={

--- a/client/dashboard/sites/overview/visibility-card.tsx
+++ b/client/dashboard/sites/overview/visibility-card.tsx
@@ -1,5 +1,7 @@
+import { useQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import { lockOutline, published } from '@wordpress/icons';
+import { siteLaunchpadQuery } from '../../app/queries/site-launchpad';
 import { launch } from '../../components/icons';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import OverviewCard from '../overview-card';
@@ -18,12 +20,35 @@ function getVisibilityURL( site: Site ) {
 	return `/sites/${ site.slug }/settings/site-visibility`;
 }
 
-function VisibilityCardUnlaunched() {
-	const isSetupComplete = true;
+function getLaunchpadChecklistSlug( site: Site ) {
+	const intent = site.options?.site_intent;
+	if ( ! intent ) {
+		return 'legacy-site-setup';
+	}
+
+	const flow = site.options?.site_creation_flow ?? '';
+	const isHostedSite = [ 'host-site', 'new-hosted-site', 'import-hosted-site' ].includes( flow );
+
+	if ( isHostedSite && ! site?.is_wpcom_atomic ) {
+		return 'legacy-site-setup';
+	}
+
+	return intent;
+}
+
+function VisibilityCardUnlaunched( { site }: { site: Site } ) {
+	const { data: launchpad } = useQuery(
+		siteLaunchpadQuery( site.ID, getLaunchpadChecklistSlug( site ) )
+	);
+
+	const tasks = launchpad?.checklist ?? [];
+	const numberOfTasks = tasks.length;
+	const completedTasks = tasks.filter( ( task ) => task.completed ).length;
+	const isLaunchpadCompleted = completedTasks && completedTasks === numberOfTasks;
 	let heading = __( 'Coming soon' );
 	let description = __( 'Finish setting up your site' );
 
-	if ( isSetupComplete ) {
+	if ( isLaunchpadCompleted ) {
 		heading = __( 'Launch site' );
 		description = __( 'Ready to go public?' );
 	}
@@ -34,11 +59,12 @@ function VisibilityCardUnlaunched() {
 			icon={ launch }
 			heading={ heading }
 			description={ description }
+			externalLink={ `/home/${ site.slug }` }
 			progress={ {
-				value: 5,
-				max: 5,
-				label: '5/5',
-				variant: 'success',
+				value: completedTasks,
+				max: numberOfTasks,
+				label: `${ completedTasks }/${ numberOfTasks }`,
+				...( isLaunchpadCompleted && { variant: 'success' } ),
 			} }
 		/>
 	);
@@ -50,7 +76,11 @@ function VisibilityCardComingSoon( { site }: { site: Site } ) {
 			{ ...CARD_PROPS }
 			icon={ launch }
 			heading={ __( 'Coming soon' ) }
-			description={ __( 'Ready to go public?' ) }
+			description={
+				site.is_wpcom_staging_site
+					? __( 'Visitors will see a coming soon page' )
+					: __( 'Ready to go public?' )
+			}
 			link={ getVisibilityURL( site ) }
 		/>
 	);
@@ -87,7 +117,7 @@ function VisibilityCardPublic( { site }: { site: Site } ) {
 
 export default function VisibilityCard( { site }: { site: Site } ) {
 	if ( site.launch_status === 'unlaunched' ) {
-		return <VisibilityCardUnlaunched />;
+		return <VisibilityCardUnlaunched site={ site } />;
 	}
 
 	if ( site.is_coming_soon ) {

--- a/client/dashboard/sites/overview/visibility-card.tsx
+++ b/client/dashboard/sites/overview/visibility-card.tsx
@@ -45,21 +45,22 @@ function VisibilityCardUnlaunched( { site }: { site: Site } ) {
 	const numberOfTasks = tasks.length;
 	const completedTasks = tasks.filter( ( task ) => task.completed ).length;
 	const isLaunchpadCompleted = completedTasks && completedTasks === numberOfTasks;
-	let heading = __( 'Coming soon' );
-	let description = __( 'Finish setting up your site' );
-
-	if ( isLaunchpadCompleted ) {
-		heading = __( 'Launch site' );
-		description = __( 'Ready to go public?' );
-	}
 
 	return (
 		<OverviewCard
 			{ ...CARD_PROPS }
 			icon={ launch }
-			heading={ heading }
-			description={ description }
-			externalLink={ `/home/${ site.slug }` }
+			{ ...( isLaunchpadCompleted
+				? {
+						heading: __( 'Launch site' ),
+						description: __( 'Ready to go public?' ),
+						link: getVisibilityURL( site ),
+				  }
+				: {
+						heading: __( 'Coming soon' ),
+						description: __( 'Finish setting up your site' ),
+						externalLink: `/home/${ site.slug }`,
+				  } ) }
 			progress={ {
 				value: completedTasks,
 				max: numberOfTasks,


### PR DESCRIPTION
Ref DOTDASH-125

## Proposed Changes

This PR implements the launchpad progress circular bar in the visibility card. We only show this for unlaunched sites.
<img width="351" height="160" alt="SCR-20250723-nvqg" src="https://github.com/user-attachments/assets/5c341dac-b5fd-4f67-bfd9-3d5672a28501" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Site Overview v2 development.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Select any unlaunched site
* Ensure that the launchpad progress is the same as the one in My Home

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
