### PR TITLE
Unified onborading flow: Use dedicated label for the checkout coupon and hide the coupon field

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -33,7 +33,10 @@ import {
 	isStreamlinedPriceCheckoutTreatment,
 } from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import { useSelector } from 'calypso/state';
-import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
+import {
+	getIsOnboardingAffiliateFlow,
+	getIsOnboardingUnifiedFlow,
+} from 'calypso/state/signup/flow/selectors';
 import useCartKey from '../../use-cart-key';
 import { getAffiliateCouponLabel } from '../../utils';
 import { CheckIcon } from './check-icon';
@@ -475,6 +478,7 @@ export function CouponCostOverride( {
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
 	const isOnboardingAffiliateFlow = useSelector( getIsOnboardingAffiliateFlow );
+	const isOnboardingUnifiedFlow = useSelector( getIsOnboardingUnifiedFlow );
 	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
 
 	if ( ! responseCart.coupon || ! responseCart.coupon_savings_total_integer ) {
@@ -486,8 +490,8 @@ export function CouponCostOverride( {
 		args: { couponCode: responseCart.coupon },
 	} );
 
-	const label = isOnboardingAffiliateFlow ? getAffiliateCouponLabel() : couponLabel;
-
+	const label =
+		isOnboardingAffiliateFlow || isOnboardingUnifiedFlow ? getAffiliateCouponLabel() : couponLabel;
 	return (
 		<CostOverridesListStyle
 			isStreamlinedPrice={ isStreamlinedPriceCheckoutTreatment(

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -14,7 +14,10 @@ import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/selectors';
-import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
+import {
+	getIsOnboardingAffiliateFlow,
+	getIsOnboardingUnifiedFlow,
+} from 'calypso/state/signup/flow/selectors';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 import Coupon from './coupon';
 import { WPOrderReviewLineItems, WPOrderReviewSection } from './wp-order-review-line-items';
@@ -201,6 +204,7 @@ export function CouponFieldArea( {
 	const translate = useTranslate();
 	const { setCouponFieldValue } = couponFieldStateProps;
 	const isOnboardingAffiliateFlow = useSelector( getIsOnboardingAffiliateFlow );
+	const isOnboardingUnifiedFlow = useSelector( getIsOnboardingUnifiedFlow );
 
 	useEffect( () => {
 		if ( couponStatus === 'applied' ) {
@@ -209,7 +213,12 @@ export function CouponFieldArea( {
 		}
 	}, [ couponStatus, setCouponFieldValue ] );
 
-	if ( isPurchaseFree || couponStatus === 'applied' || isOnboardingAffiliateFlow ) {
+	if (
+		isPurchaseFree ||
+		couponStatus === 'applied' ||
+		isOnboardingAffiliateFlow ||
+		isOnboardingUnifiedFlow
+	) {
 		return null;
 	}
 

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -32,7 +32,10 @@ import {
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
+import {
+	getIsOnboardingAffiliateFlow,
+	getIsOnboardingUnifiedFlow,
+} from 'calypso/state/signup/flow/selectors';
 import { getAffiliateCouponLabel } from '../../utils';
 import { AkismetProQuantityDropDown } from './akismet-pro-quantity-dropdown';
 import { ItemVariationPicker } from './item-variation-picker';
@@ -103,12 +106,14 @@ export function WPOrderReviewLineItems( {
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	const couponLineItem = getCouponLineItemFromCart( responseCart );
 	const isOnboardingAffiliateFlow = useSelector( getIsOnboardingAffiliateFlow );
+	const isOnboardingUnifiedFlow = useSelector( getIsOnboardingUnifiedFlow );
 	const [ restorableProducts ] = useRestorableProducts();
 
 	if ( couponLineItem ) {
-		couponLineItem.label = isOnboardingAffiliateFlow
-			? getAffiliateCouponLabel()
-			: couponLineItem.label;
+		couponLineItem.label =
+			isOnboardingAffiliateFlow || isOnboardingUnifiedFlow
+				? getAffiliateCouponLabel()
+				: couponLineItem.label;
 	}
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;

--- a/client/state/signup/flow/selectors.js
+++ b/client/state/signup/flow/selectors.js
@@ -17,6 +17,23 @@ export function getExcludedSteps( state ) {
 	return get( state, 'signup.flow.excludedSteps', [] );
 }
 
+export const getIsOnboardingUnifiedFlow = ( state, source = undefined ) => {
+	const currentRoute = getCurrentRoute( state );
+	const queryArgs = getCurrentQueryArguments( state );
+
+	if ( currentRoute ) {
+		const flowFromURL = getFlowFromURL( currentRoute );
+		const isOnboardingUnifiedFlow = flowFromURL === ONBOARDING_UNIFIED_FLOW;
+		if ( isOnboardingUnifiedFlow && source ) {
+			return queryArgs?.source === source;
+		}
+
+		return isOnboardingUnifiedFlow;
+	}
+
+	return false;
+};
+
 export const getIsOnboardingAffiliateFlow = ( state ) => {
 	const currentFlowName = getCurrentFlowName( state );
 
@@ -28,15 +45,7 @@ export const getIsOnboardingAffiliateFlow = ( state ) => {
 	// Check if it's the new onboarding-unified flow with source=affiliate
 	// Use Redux state instead of direct window access
 	if ( currentFlowName === '' ) {
-		const currentRoute = getCurrentRoute( state );
-		const queryArgs = getCurrentQueryArguments( state );
-
-		if ( currentRoute ) {
-			const flowFromURL = getFlowFromURL( currentRoute );
-			if ( flowFromURL === ONBOARDING_UNIFIED_FLOW ) {
-				return queryArgs?.source === 'affiliate';
-			}
-		}
+		return getIsOnboardingUnifiedFlow( state, 'affiliate' );
 	}
 
 	return false;

--- a/client/state/signup/flow/test/selectors.js
+++ b/client/state/signup/flow/test/selectors.js
@@ -1,4 +1,8 @@
-import { getCurrentFlowName, getIsOnboardingAffiliateFlow } from '../selectors';
+import {
+	getCurrentFlowName,
+	getIsOnboardingAffiliateFlow,
+	getIsOnboardingUnifiedFlow,
+} from '../selectors';
 
 describe( 'getCurrentFlowName()', () => {
 	test( 'should return the current flow', () => {
@@ -68,5 +72,87 @@ describe( 'getIsOnboardingAffiliateFlow()', () => {
 
 	test( 'should return false when state has no signup data', () => {
 		expect( getIsOnboardingAffiliateFlow( {} ) ).toBe( false );
+	} );
+} );
+
+describe( 'getIsOnboardingUnifiedFlow()', () => {
+	test( 'should return true for onboarding-unified flow without source parameter', () => {
+		const state = {
+			route: {
+				path: {
+					current: '/setup/onboarding-unified',
+				},
+				query: {
+					current: {},
+				},
+			},
+		};
+
+		expect( getIsOnboardingUnifiedFlow( state ) ).toBe( true );
+	} );
+
+	test( 'should return true for onboarding-unified flow with matching source', () => {
+		const state = {
+			route: {
+				path: {
+					current: '/setup/onboarding-unified',
+				},
+				query: {
+					current: {
+						source: 'pm',
+					},
+				},
+			},
+		};
+
+		expect( getIsOnboardingUnifiedFlow( state, 'pm' ) ).toBe( true );
+	} );
+
+	test( 'should return false for onboarding-unified flow with non-matching source', () => {
+		const state = {
+			route: {
+				path: {
+					current: '/setup/onboarding-unified',
+				},
+				query: {
+					current: {
+						source: 'pm',
+					},
+				},
+			},
+		};
+
+		expect( getIsOnboardingUnifiedFlow( state, 'other-source' ) ).toBe( false );
+	} );
+
+	test( 'should return false for non-onboarding-unified flow', () => {
+		const state = {
+			route: {
+				path: {
+					current: '/setup/other-flow',
+				},
+				query: {
+					current: {},
+				},
+			},
+		};
+
+		expect( getIsOnboardingUnifiedFlow( state ) ).toBe( false );
+	} );
+
+	test( 'should return false when there is no current route', () => {
+		const state = {
+			route: {
+				path: {
+					current: null,
+				},
+			},
+		};
+
+		expect( getIsOnboardingUnifiedFlow( state ) ).toBe( false );
+	} );
+
+	test( 'should return false when state has no route data', () => {
+		expect( getIsOnboardingUnifiedFlow( {} ) ).toBe( false );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/project/unify-and-optimize-onboarding-flows-for-paid-media-and-affiliates-97581f74500d/overview

## Proposed Changes

* on the `onboarding-unified`, show the same label for the applied coupon as in the `onboarding-affiliate` flow 
* on the `onboarding-unified`, hide the coupon field as in the `onboarding-affiliate` flow

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is a follow-up to https://github.com/Automattic/wp-calypso/pull/104731 and applies the same coupon approach the affiliate onboarding has to the unified onboarding flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Coupon applied
* Go to `/setup/onboarding-unified/plans?coupon={COUPON_CODE}`
* Select a plan
* The coupon label should match the `affiliate` version on checkout, if a valid coupon is applied

| Before | After |
|--------|--------|
| <img width="1372" height="578" alt="Screenshot 2025-07-23 at 10 33 46" src="https://github.com/user-attachments/assets/0549ec06-234d-4c2f-b8c3-e9fc45dc3c5e" /> | <img width="1361" height="568" alt="Screenshot 2025-07-23 at 10 33 29" src="https://github.com/user-attachments/assets/c409b877-0096-40f8-9d6f-e18d42584364" /> |

#### No Coupon
* Go to `/setup/onboarding-unified/plans
* Select a plan
* The coupon field should not be visible

| Before | After |
|--------|--------|
| <img width="1306" height="349" alt="Screenshot 2025-07-23 at 10 36 12" src="https://github.com/user-attachments/assets/8fddc0e6-8eef-4bff-84fc-3e52c9b7db3b" /> | <img width="1328" height="405" alt="Screenshot 2025-07-23 at 10 37 42" src="https://github.com/user-attachments/assets/3222fa9d-0aac-4553-9c74-e10349e45f4f" /> | 



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
