### PR TITLE
Login/Signup: update Woo styling

### DIFF
--- a/client/assets/stylesheets/_wp-base-styles-overrides.scss
+++ b/client/assets/stylesheets/_wp-base-styles-overrides.scss
@@ -10,30 +10,6 @@
 		--wp-admin-theme-color: var(--color-gray);
 	}
 
-	/* Woo */
-	.woo.is-woo-passwordless & {
-		&[type='text'],
-		&[type='password'] {
-			/* stylelint-disable-next-line scales/radii */
-			border-radius: 8px;
-			font-size: 1rem;
-			height: 48px;
-			padding: 8px 16px;
-
-			&:not(:focus, :disabled) {
-				border-color: var(--studio-gray-30);
-			}
-
-			&:focus {
-				border-width: 1.5px;
-			}
-
-			&:not(.is-error, .is-valid) {
-				--wp-admin-theme-color: var(--woo-purple-50);
-			}
-		}
-	}
-
 	/* Akismet */
 	.is-akismet &:not(.is-error, .is-valid) {
 		--wp-admin-theme-color: var(--color-akismet);

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -124,18 +124,7 @@
 			--wp-components-color-accent: var(--woo-purple-60);
 		}
 
-		&.is-primary,
-		&.is-secondary,
-		// Used for social auth buttons
-		&.a8c-components-wp-button {
-			border-radius: 8px; /* stylelint-disable-line scales/radii */
-		}
-
 		&.is-primary {
-			&:focus:not(:disabled, [aria-disabled="true"]) {
-				box-shadow: 0 0 0 2px var(--wp-components-color-accent);
-			}
-
 			&:disabled,
 			&[aria-disabled="true"] {
 				--wp-components-color-accent: var(--studio-gray-5);
@@ -145,30 +134,6 @@
 				.components-spinner {
 					--wp-components-color-accent: var(--woo-purple-40);
 				}
-			}
-
-			&.is-busy:has(.components-spinner) {
-				background-image: unset;
-			}
-
-			.components-spinner {
-				margin-top: 0;
-			}
-		}
-
-		&.is-secondary:not(:focus) {
-			box-shadow: inset 0 0 0 2px var(--wp-components-color-accent), 0 0 0 currentColor;
-		}
-
-		// Used for social auth buttons
-		&.a8c-components-wp-button:not(:focus) {
-			box-shadow: inset 0 0 0 2px $gray-300, 0 0 0 currentColor;
-		}
-
-		&.is-secondary,
-		&.a8c-components-wp-button {
-			&:focus:not(:disabled, [aria-disabled="true"]) {
-				box-shadow: inset 0 0 0 1px var(--wp-components-color-background, #fff), 0 0 0 2px var(--wp-components-color-accent);
 			}
 		}
 	}

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -564,7 +564,6 @@ class Login extends Component {
 			socialConnect,
 			twoStepNonce,
 			twoFactorAuthType,
-			twoFactorEnabled,
 		} = this.props;
 
 		return (
@@ -589,7 +588,6 @@ class Login extends Component {
 						socialConnect={ socialConnect }
 						twoStepNonce={ twoStepNonce }
 						twoFactorAuthType={ twoFactorAuthType }
-						twoFactorEnabled={ twoFactorEnabled }
 					/>
 				) }
 

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -419,14 +419,6 @@ export class LoginForm extends Component {
 	}
 
 	renderUsernameorEmailLabel() {
-		if ( this.props.isWoo ) {
-			return this.props.translate( 'Your email or username' );
-		}
-
-		if ( this.props.isWoo ) {
-			return this.props.translate( 'Your email address or username' );
-		}
-
 		if ( this.props.currentQuery?.username_only === 'true' ) {
 			return this.props.translate( 'Your username' );
 		}

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -431,7 +431,7 @@ export class LoginForm extends Component {
 			// text above the form. We therefore need to clarity the must use WordPress.com credentials.
 			<>
 				<span className="screen-reader-text">
-					{ this.props.translate( 'WordPress.com Email address or username' ) }
+					{ this.props.translate( 'WordPress.com email address or username' ) }
 				</span>
 				{ showLabel && (
 					<span aria-hidden="true">{ this.props.translate( 'Email address or username' ) }</span>

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -371,22 +371,18 @@ export class LoginForm extends Component {
 	};
 
 	getLoginButtonText = () => {
-		const { translate, isWoo, isWooJPC, loginButtonText, isJetpack } = this.props;
+		const { translate, isWoo, loginButtonText, isJetpack } = this.props;
 
 		if ( loginButtonText ) {
 			return loginButtonText;
 		}
 
 		if ( this.isUsernameOrEmailView() ) {
-			if ( isJetpack ) {
+			if ( isJetpack && ! isWoo ) {
 				return translate( 'Continue with email' );
 			}
 
 			return translate( 'Continue' );
-		}
-
-		if ( isWoo && ! isWooJPC ) {
-			return translate( 'Get started' );
 		}
 
 		return translate( 'Log In' );
@@ -423,9 +419,13 @@ export class LoginForm extends Component {
 			return this.props.translate( 'Your username' );
 		}
 
-		return this.isPasswordView() ? (
-			this.renderChangeUsername()
-		) : (
+		if ( this.isPasswordView() ) {
+			return this.renderChangeUsername();
+		}
+
+		const showLabel = ! this.props.isJetpack || this.props.isWoo;
+
+		return (
 			// Since the input receives focus on page load, screen reader users don't have any context
 			// for what credentials to use. Unlike other users, they won't have seen the informative
 			// text above the form. We therefore need to clarity the must use WordPress.com credentials.
@@ -433,7 +433,7 @@ export class LoginForm extends Component {
 				<span className="screen-reader-text">
 					{ this.props.translate( 'WordPress.com Email address or username' ) }
 				</span>
-				{ ! this.props.isJetpack && (
+				{ showLabel && (
 					<span aria-hidden="true">{ this.props.translate( 'Email address or username' ) }</span>
 				) }
 			</>

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -104,22 +104,10 @@ $breakpoint-mobile: 660px;
 	$woo-form-whitespace: 60px;
 	$woo-form-whitespace-660: 20px;
 	$woo-form-divider-border: 1px solid #e6e6e6;
-	$gray-60: #50575e;
+	$gray-60: #000;
 	$gray-50: #646970;
 	$woo-sfpro-display-font:  "SF Pro Display", -apple-system, system-ui, sans-serif;
 	$woo-sfpro-text-font:  "SF Pro Text", -apple-system, system-ui, sans-serif;
-
-	background: #fff;
-	min-height: 100%;
-
-	&.layout.is-section-login {
-		min-height: 100%;
-		padding-bottom: 0;
-	}
-
-	.masterbar__woo-link {
-		line-height: 32px;
-	}
 
 	input[type="text"].form-text-input,
 	input[type="email"].form-text-input,
@@ -200,10 +188,6 @@ $breakpoint-mobile: 660px;
 			background-color: var(--studio-gray-0);
 			color: var(--studio-gray-20);
 		}
-	}
-
-	button {
-		background-color: initial;
 	}
 
 	.login__form-user-exists-notice.calypso-notice {
@@ -557,15 +541,6 @@ $breakpoint-mobile: 660px;
 		padding: 0 0 8px;
 	}
 
-	.logged-out-form label.form-label,
-	.login__form-userdata label.form-label {
-		font-weight: normal;
-		font-size: $woo-font-size-base;
-		line-height: 20px;
-		color: $woo-label-color;
-		margin-bottom: 8px;
-	}
-
 	.login__form-password {
 		margin-top: 8px;
 	}
@@ -573,23 +548,6 @@ $breakpoint-mobile: 660px;
 	.auth-form__separator::before,
 	.auth-form__separator::after {
 		border-block-start: $woo-form-divider-border;
-	}
-
-	.auth-form__separator + .auth-form__social.card {
-		clip-path: unset; // unset the rule applied in ./client/blocks/authentication/form-divider/style.scss
-		max-width: 100%;
-	}
-
-	.auth-form__social,
-	.two-factor-authentication__actions {
-		background: initial;
-		padding-top: 40px;
-		padding-bottom: 40px;
-		text-align: center;
-
-		@media (max-width: $break-mobile) {
-			padding-top: 28px;
-		}
 	}
 
 	.login__two-factor-footer {
@@ -1160,44 +1118,6 @@ $breakpoint-mobile: 660px;
 			max-width: 327px;
 			display: flex;
 			flex-direction: column;
-		}
-
-		.login form.is-woo-passwordless {
-			@media (max-width: $break-medium) {
-				flex-direction: column;
-			}
-
-			.card.login__form {
-				padding: 0;
-				display: flex;
-				flex-direction: column;
-				justify-content: center;
-				width: 100%;
-				margin: 0;
-
-				~ .auth-form__social.card {
-					width: 100%;
-					max-width: $max-width;
-					margin: 0;
-				}
-			}
-
-			.auth-form__separator {
-				@media screen and (min-width: $break-medium) {
-					margin-block: 0;
-				}
-			}
-		}
-
-		label.form-label,
-		.logged-out-form label.form-label,
-		.magic-login__form label.form-label {
-			color: var(--studio-gray-100);
-			font-size: 1rem;
-			font-style: normal;
-			font-weight: 600;
-			line-height: 24px;
-			margin-bottom: 10px;
 		}
 
 		.wp-login__login-block-footer {

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -104,7 +104,7 @@ $breakpoint-mobile: 660px;
 	$woo-form-whitespace: 60px;
 	$woo-form-whitespace-660: 20px;
 	$woo-form-divider-border: 1px solid #e6e6e6;
-	$gray-60: #000;
+	$gray-60: #50575e;
 	$gray-50: #646970;
 	$woo-sfpro-display-font:  "SF Pro Display", -apple-system, system-ui, sans-serif;
 	$woo-sfpro-text-font:  "SF Pro Text", -apple-system, system-ui, sans-serif;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -670,12 +670,6 @@ $breakpoint-mobile: 660px;
 	}
 
 	&.is-woocommerce-core-profiler-flow {
-		background: #fff;
-
-		* {
-			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-		}
-
 		.wp-login__container,
 		.step-wrapper {
 			@media (max-width: $break-mobile) {
@@ -737,14 +731,6 @@ $breakpoint-mobile: 660px;
 			@media (max-width: $break-mobile) {
 				width: auto;
 			}
-		}
-
-		.login__form-userdata label.form-label,
-		.logged-out-form label.form-label {
-			font-weight: 500;
-			text-transform: uppercase;
-			font-size: rem(11px);
-			color: $gray-900;
 		}
 
 		.jetpack-connect__action-disclaimer .button.is-primary,
@@ -846,10 +832,6 @@ $breakpoint-mobile: 660px;
 
 		.wp-login__container .is-jetpack .auth-form__social,
 		.signup-form .auth-form__social {
-			padding-left: 0;
-			padding-right: 0;
-			padding-top: 40px;
-
 			button.social-buttons__button.button {
 				width: 100%;
 				border: 1px solid var(--studio-gray-50, #646970);
@@ -1437,16 +1419,9 @@ $breakpoint-mobile: 660px;
 
 	// Core Profiler + Passwordless
 	&.is-woocommerce-core-profiler-flow.is-woo-passwordless {
-		* {
-			font-family: $woo-sfpro-text-font;
-			font-weight: 400;
-		}
-
 		h3,
 		h1.formatted-header__title,
 		h1.magic-login__form-header {
-			font-family: $woo-sfpro-display-font;
-			font-weight: 500;
 			margin-bottom: 15px;
 		}
 

--- a/client/login/wp-login/components/heading-logo.tsx
+++ b/client/login/wp-login/components/heading-logo.tsx
@@ -53,8 +53,8 @@ const HeadingLogo = ( { isFromAkismet, isJetpack }: Props ) => {
 				icon={ WooLogo }
 				classes="masterbar__woo-client-logo"
 				width="128"
-				height="48"
-				viewBox="0 0 64 24"
+				height="40"
+				viewBox="0 0 60 24"
 			/>
 		);
 	} else if ( isJetpack ) {

--- a/client/login/wp-login/gravatar/grav-powered-login-block-header.tsx
+++ b/client/login/wp-login/gravatar/grav-powered-login-block-header.tsx
@@ -29,7 +29,6 @@ const GravPoweredLoginBlockHeader = ( {
 	socialConnect,
 	twoStepNonce,
 	twoFactorAuthType,
-	twoFactorEnabled,
 }: Props ) => {
 	const translate = useTranslate();
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
@@ -42,7 +41,6 @@ const GravPoweredLoginBlockHeader = ( {
 		linkingSocialService,
 		action,
 		oauth2Client,
-		twoFactorEnabled,
 		currentQuery,
 		translate,
 		twoStepNonce,

--- a/client/login/wp-login/hooks/get-header-text.tsx
+++ b/client/login/wp-login/hooks/get-header-text.tsx
@@ -17,7 +17,6 @@ interface Props {
 	linkingSocialService: string;
 	action: string;
 	oauth2Client: ReturnType< typeof getOAuth2Client >;
-	twoFactorEnabled: boolean;
 	currentQuery: ReturnType< typeof getCurrentQueryArguments >;
 	translate: ( arg0: string, arg1?: object ) => TranslateResult;
 	isJetpack?: boolean;
@@ -48,7 +47,6 @@ export function getHeaderText( {
 	isFromAkismet,
 	isFromAutomatticForAgenciesPlugin,
 	isGravPoweredClient,
-	twoFactorEnabled,
 	currentQuery,
 	translate,
 	twoStepNonce,
@@ -67,10 +65,18 @@ export function getHeaderText( {
 			clientName = 'Jetpack Cloud';
 		} else if ( isJetpack ) {
 			clientName = 'Jetpack';
-		} else if ( isWCCOM || isWooJPC ) {
+		} else if ( isWCCOM ) {
 			clientName = 'Woo';
 		} else if ( isVIPOAuth2Client( oauth2Client ) ) {
 			clientName = 'VIP';
+		}
+
+		/**
+		 * Override WooJPC. It's technically a Jetpack client, but we want to show "Woo" instead of "Jetpack".
+		 * This conditionoverrides the clientName set in the above if/elseif statement.
+		 */
+		if ( isWooJPC ) {
+			clientName = 'Woo';
 		}
 
 		headerText = clientName
@@ -130,12 +136,6 @@ export function getHeaderText( {
 			headerText = translate( 'Login to %(clientTitle)s', {
 				args: { clientTitle: oauth2Client.title },
 			} );
-		}
-	} else if ( isWooJPC ) {
-		if ( twoFactorEnabled ) {
-			headerText = translate( 'Authenticate your login' );
-		} else {
-			headerText = translate( 'Log in to your account' );
 		}
 	}
 

--- a/client/login/wp-login/hooks/get-header-text.tsx
+++ b/client/login/wp-login/hooks/get-header-text.tsx
@@ -73,7 +73,7 @@ export function getHeaderText( {
 
 		/**
 		 * Override WooJPC. It's technically a Jetpack client, but we want to show "Woo" instead of "Jetpack".
-		 * This conditionoverrides the clientName set in the above if/elseif statement.
+		 * This condition overrides the clientName set in the above if/elseif statement.
 		 */
 		if ( isWooJPC ) {
 			clientName = 'Woo';

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -107,7 +107,6 @@ export class Login extends Component {
 			'isFromAkismet',
 			'isFromAutomatticForAgenciesPlugin',
 			'isGravPoweredClient',
-			'twoFactorEnabled',
 			'currentQuery',
 			'translate',
 		];
@@ -284,7 +283,6 @@ export class Login extends Component {
 			isFromAkismet,
 			isFromAutomatticForAgenciesPlugin,
 			isGravPoweredClient,
-			twoFactorEnabled,
 			currentQuery,
 			translate,
 		} = this.props;
@@ -306,7 +304,6 @@ export class Login extends Component {
 			isFromAkismet,
 			isFromAutomatticForAgenciesPlugin,
 			isGravPoweredClient,
-			twoFactorEnabled,
 			currentQuery,
 			translate,
 		} );

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -52,7 +52,11 @@ $image-height: 47px;
 	}
 	/* End: Blaze Pro OAuth client font styles for login page */
 
-	/* Start: Jetpack font styles for login page */
+	/*
+	* Start: Jetpack font styles for login page
+	*
+	* If we're on a Woo page, we don't want to apply the Jetpack font styles, as Woo brings in its own font styles.
+	*/
 	&.is-jetpack-login:not(.is-woo-passwordless) {
 		.wp-login__heading-text {
 			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -53,7 +53,7 @@ $image-height: 47px;
 	/* End: Blaze Pro OAuth client font styles for login page */
 
 	/* Start: Jetpack font styles for login page */
-	&.is-jetpack-login {
+	&.is-jetpack-login:not(.is-woo-passwordless) {
 		.wp-login__heading-text {
 			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif
 		}


### PR DESCRIPTION
Fixes DOTCOM-13849
P2: pfrEX1-1sh-p2

## Proposed Changes

* Remove many Woo customizations in terms of paddings, margin, font style changes. Only update title font and colors.
* Update all login titles. Both WCCOM and WooJPC should say "Log in to Woo with WordPress.com". 
* Update Woo logo size to be 104px

## Why are these changes being made?

* With this P2 (pfrEX1-1sh-p2) from the design, we should make the necessary changes to Woo login pages to improve looks.

## Testing Instructions

* Visit [WCCOM login](http://calypso.localhost:3000/log-in?client_id=50916&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Dbabd2834d29179c7104bba84668042e1f8a4c310f62299dd24992cf002dbda31%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%3Dnux%26calypso_env%3Dproduction%26from-calypso%3D1) and [sign-up](http://calypso.localhost:3000/start/wpcc/oauth2-user?oauth2_client_id=50916&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Dbabd2834d29179c7104bba84668042e1f8a4c310f62299dd24992cf002dbda31%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%3Dnux%26calypso_env%3Dproduction%26from-calypso%3D1)
* Visit [WooJPC](http://calypso.localhost:3000/log-in/jetpack?redirect_to=http%3A%2F%2Fcalypso.localhost%3A3000%2Fjetpack%2Fconnect%2Fauthorize%3Fclient_id%3D245657653%26redirect_uri%3Dhttps%253A%252F%252Ftotal-sable-millipede.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fhandler%253Djetpack-connection-webhooks%2526action%253Dauthorize%2526_wpnonce%253De1fd5da4a3%2526redirect%253Dhttps%25253A%25252F%25252Ftotal-sable-millipede.jurassic.ninja%25252Fwp-admin%25252Fadmin.php%25253Fpage%25253Dwc-admin%26state%3D1%26scope%3Dadministrator%253Acebfe5edc3805525128c6b79ecbbee7e%26user_email%3Dcem.unalan%2540a8c.com%26user_login%3Draicem%26jp_version%3D14.8-a.5%26secret%3DpQONgKUOSZeSEJYXRLeQCGAxBpFRyFF1%26blogname%3DTotal%2520Sable%2520Millipede%26site_url%3Dhttps%253A%252F%252Ftotal-sable-millipede.jurassic.ninja%26home_url%3Dhttps%253A%252F%252Ftotal-sable-millipede.jurassic.ninja%26site_icon%3D%26site_lang%3Den_US%26site_created%3D2025-06-18%252015%253A02%253A22%26allow_site_connection%3D1%26calypso_env%3Dproduction%26source%3D%26_as%3Dwp-cli%26locale%3Den%26from%3Dwoocommerce-core-profiler%26plugin_name%3D%26color_scheme%3Dfresh%26_ui%3D11140294%26_ut%3Dwpcom%253Auser_id%26purchase_nonce%3D5ispUNoV%26_wp_nonce%3D1c5e04be2f%26redirect_after_auth%3Dhttps%253A%252F%252Ftotal-sable-millipede.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin%26site%3Dhttps%253A%252F%252Ftotal-sable-millipede.jurassic.ninja&from=woocommerce-core-profiler) login and [sign-up](http://calypso.localhost:3000/jetpack/connect/authorize?client_id=245657653&redirect_uri=https%3A%2F%2Ftotal-sable-millipede.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fhandler%3Djetpack-connection-webhooks%26action%3Dauthorize%26_wpnonce%3De1fd5da4a3%26redirect%3Dhttps%253A%252F%252Ftotal-sable-millipede.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin&state=1&scope=administrator%3Acebfe5edc3805525128c6b79ecbbee7e&user_email=cem.unalan%40a8c.com&user_login=raicem&jp_version=14.8-a.5&secret=pQONgKUOSZeSEJYXRLeQCGAxBpFRyFF1&blogname=Total%20Sable%20Millipede&site_url=https%3A%2F%2Ftotal-sable-millipede.jurassic.ninja&home_url=https%3A%2F%2Ftotal-sable-millipede.jurassic.ninja&site_icon=&site_lang=en_US&site_created=2025-06-18%2015%3A02%3A22&allow_site_connection=1&calypso_env=production&source=&_as=wp-cli&locale=en&from=woocommerce-core-profiler&plugin_name=&color_scheme=fresh&_ui=11140294&_ut=wpcom%3Auser_id&purchase_nonce=5ispUNoV&_wp_nonce=1c5e04be2f&redirect_after_auth=https%3A%2F%2Ftotal-sable-millipede.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-admin&site=https%3A%2F%2Ftotal-sable-millipede.jurassic.ninja)
    * Bonus: login with two factor auth enabled
* Visit [WooDNA login](https://wordpress.com/jetpack/connect/authorize?client_id=246264896&redirect_uri=https%3A%2F%2Fspeedily-net-pilot.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fhandler%3Djetpack-connection-webhooks%26action%3Dauthorize%26_wpnonce%3D3c621acaca%26redirect%3Dhttps%253A%252F%252Fspeedily-net-pilot.jurassic.ninja%252Fwp-admin%252Fplugins.php%253Fplugin_status%253Dall%2526paged%253D1%2526s&state=1&scope=administrator%3Aab2a50f6f685a4e260ac5dc2c989ba66&user_email=cem.unalan%40a8c.com&user_login=raicem&jp_version=14.8&secret=B18GR6Jlp2MnfaL1p9k6MRrhNU9ibPlU&blogname=Speedily+Net+Pilot&site_url=https%3A%2F%2Fspeedily-net-pilot.jurassic.ninja&home_url=https%3A%2F%2Fspeedily-net-pilot.jurassic.ninja&site_icon&site_lang=en_US&site_created=2025-07-08+10%3A26%3A50&allow_site_connection=1&calypso_env&source&_as=wp-cli&from=woocommerce-services&_ui=11140294&_ut=wpcom%3Auser_id&purchase_nonce=cr3PxtYO&woodna_service_name=WooCommerce+Tax+%28Formerly+WooCommerce+Shipping+%26+Tax%29&woodna_help_url=https%3A%2F%2Fwoocommerce.com%2Fdocument%2Fwoocommerce-shipping-and-tax%2F&_wp_nonce=bd530adf67&redirect_after_auth=https%3A%2F%2Fspeedily-net-pilot.jurassic.ninja%2Fwp-admin%2Fplugins.php%3Fplugin_status%3Dall%26paged%3D1%26s&site=https%3A%2F%2Fspeedily-net-pilot.jurassic.ninja)
* Visit other [Oauth](https://linear.app/a8c/issue/DOTCOM-13220/login-make-the-two-columnwhite-layout-the-default-across-all-contexts) clients

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?P2