### PR TITLE
Connect Refresh: one-login-footer

### DIFF
--- a/client/layout/masterbar/blaze-pro.scss
+++ b/client/layout/masterbar/blaze-pro.scss
@@ -503,19 +503,6 @@ body.is-section-signup {
 	.wp-login__main.main:has(.login form.is-blaze-pro) {
 		max-width: unset;
 	}
-
-	.wp-login__container {
-		.wp-login__login-block-footer {
-			text-align: center;
-		}
-
-		.login__lost-password-link {
-			font-family: $sfProText;
-			font-size: rem(18px);
-			font-weight: 500;
-			line-height: 24px;
-		}
-	}
 }
 
 // Hacks for Continue-as-a-user for Sign Up (but user is already logged in)

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1102,21 +1102,6 @@ $breakpoint-mobile: 660px;
 			flex-direction: column;
 		}
 
-		.wp-login__login-block-footer {
-			@media (max-width: $break-mobile) {
-				max-width: $max-width;
-				margin-bottom: 40px;
-			}
-
-			.auth-form__social-buttons-tos {
-				margin: 24px 0 0 0;
-
-				@media (max-width: $break-medium) {
-					max-width: $max-width;
-				}
-			}
-		}
-
 		.signup-form {
 			input[type="email"].form-text-input {
 				margin-bottom: 0;

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -29,6 +29,7 @@ import {
 import { login } from 'calypso/lib/paths';
 import getToSAcceptancePayload from 'calypso/lib/tos-acceptance-tracking';
 import wpcom from 'calypso/lib/wp';
+import OneLoginFooter from 'calypso/login/wp-login/components/one-login-footer';
 import OneLoginLayout from 'calypso/login/wp-login/components/one-login-layout';
 import {
 	recordTracksEventWithClientId as recordTracksEvent,
@@ -327,15 +328,17 @@ class MagicLogin extends Component {
 
 		return (
 			<>
-				<div className="wp-login__login-block-footer">
-					<a
-						className="magic-login__footer-link"
-						href={ login( loginParameters ) }
-						onClick={ this.onClickEnterPasswordInstead }
-					>
-						{ linkBack }
-					</a>
-				</div>
+				<OneLoginFooter
+					loginLink={
+						<a
+							className="one-login__footer-link"
+							href={ login( loginParameters ) }
+							onClick={ this.onClickEnterPasswordInstead }
+						>
+							{ linkBack }
+						</a>
+					}
+				/>
 				{ ! oauth2Client && (
 					<AppPromo
 						title={ translate( 'Stay logged in with the Jetpack Mobile App' ) }

--- a/client/login/wp-login/components/one-login-footer.scss
+++ b/client/login/wp-login/components/one-login-footer.scss
@@ -1,0 +1,20 @@
+.one-login__footer {
+    display: flex;
+    flex-direction: column;
+    align-self: center;
+    gap: 1em;
+
+    .one-login__footer-link {
+        font-size: $font-body-small;
+        display: inline-flex;
+        align-items: center;
+        align-self: center;
+        gap: 0.1em;
+    }
+
+    .one-login__footer-link a,
+    a.one-login__footer-link {
+        color: var(--studio-gray-90, #1d2327);
+        font-weight: 500;
+    }
+}

--- a/client/login/wp-login/components/one-login-footer.tsx
+++ b/client/login/wp-login/components/one-login-footer.tsx
@@ -6,8 +6,17 @@ import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selector
 import './one-login-footer.scss';
 
 interface OneLoginFooterProps {
+	/**
+	 * when `isLoginView` is true, this is the "lost password" link
+	 */
 	lostPasswordLink?: JSX.Element;
+	/**
+	 * when `isLoginView` is false, this is the "back to login" link
+	 */
 	loginLink?: string;
+	/**
+	 * when true, this is the footer for the main login screen
+	 */
 	isLoginView?: boolean;
 }
 

--- a/client/login/wp-login/components/one-login-footer.tsx
+++ b/client/login/wp-login/components/one-login-footer.tsx
@@ -3,8 +3,9 @@ import { useSelector } from 'react-redux';
 import LoggedOutFormBackLink from 'calypso/components/logged-out-form/back-link';
 import { isVIPOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import './one-login-footer.scss';
 
-interface LoginFooterProps {
+interface OneLoginFooterProps {
 	lostPasswordLink: JSX.Element;
 	loginLink: string;
 	isLoginView?: boolean;
@@ -14,24 +15,20 @@ const recordBackToWpcomLinkClick = () => {
 	recordTracksEvent( 'calypso_login_back_to_wpcom_link_click' );
 };
 
-const LoginBlockFooter = ( { lostPasswordLink, isLoginView, loginLink }: LoginFooterProps ) => {
+const OneLoginFooter = ( { lostPasswordLink, loginLink, isLoginView }: OneLoginFooterProps ) => {
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
 	const isVIPClient = isVIPOAuth2Client( oauth2Client );
 
-	if ( ! lostPasswordLink ) {
-		return null;
-	}
-
 	if ( isLoginView ) {
 		return (
-			<div className="wp-login__login-block-footer">
+			<div className="one-login__footer">
 				{ lostPasswordLink }
 				{ isVIPClient && (
 					<LoggedOutFormBackLink
 						classes={ {
 							'logged-out-form__link-item': false,
 							'logged-out-form__back-link': false,
-							'wp-login__login-block-footer-back-link': true,
+							'one-login__footer-link': true,
 						} }
 						oauth2Client={ oauth2Client }
 						recordClick={ recordBackToWpcomLinkClick }
@@ -41,7 +38,7 @@ const LoginBlockFooter = ( { lostPasswordLink, isLoginView, loginLink }: LoginFo
 		);
 	}
 
-	return <div className="wp-login__login-block-footer">{ loginLink }</div>;
+	return <div className="one-login__footer">{ loginLink }</div>;
 };
 
-export default LoginBlockFooter;
+export default OneLoginFooter;

--- a/client/login/wp-login/components/one-login-footer.tsx
+++ b/client/login/wp-login/components/one-login-footer.tsx
@@ -6,8 +6,8 @@ import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selector
 import './one-login-footer.scss';
 
 interface OneLoginFooterProps {
-	lostPasswordLink: JSX.Element;
-	loginLink: string;
+	lostPasswordLink?: JSX.Element;
+	loginLink?: string;
 	isLoginView?: boolean;
 }
 

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -41,10 +41,10 @@ import getIsWoo from 'calypso/state/selectors/get-is-woo';
 import isWooJPCFlow from 'calypso/state/selectors/is-woo-jpc-flow';
 import { withEnhancers } from 'calypso/state/utils';
 import { LoginContext } from '../login-context';
+import OneLoginFooter from './components/one-login-footer';
 import OneLoginLayout from './components/one-login-layout';
 import GravPoweredLoginBlockFooter from './gravatar/grav-powered-login-block-footer';
 import getHeadingSubText from './hooks/get-heading-subtext';
-import LoginBlockFooter from './login-block-footer';
 
 import './style.scss';
 
@@ -160,7 +160,7 @@ export class Login extends Component {
 
 		return (
 			<a
-				className="login__lost-password-link"
+				className="one-login__footer-link"
 				href="/"
 				onClick={ ( event ) => {
 					event.preventDefault();
@@ -187,7 +187,7 @@ export class Login extends Component {
 	getLoginLink() {
 		return (
 			<a
-				className="wp-login__login-block-footer-back-link"
+				className="one-login__footer-link"
 				href="/"
 				onClick={ ( event ) => {
 					event.preventDefault();
@@ -254,7 +254,7 @@ export class Login extends Component {
 					isGravPoweredLoginPage ? (
 						<GravPoweredLoginBlockFooter />
 					) : (
-						<LoginBlockFooter
+						<OneLoginFooter
 							isLoginView={ isLoginView }
 							lostPasswordLink={ this.getLostPasswordLink() }
 							loginLink={ this.getLoginLink() }

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -375,31 +375,6 @@ $image-height: 47px;
 		}
 	}
 
-	.wp-login__login-block-footer {
-		display: flex;
-		flex-direction: column;
-		align-self: center;
-		gap: 1em;
-
-		.magic-login__footer-link,
-		.login__lost-password-link,
-		.wp-login__login-block-footer-back-link {
-			font-size: $font-body-small;
-			display: inline-flex;
-			align-items: center;
-			align-self: center;
-			gap: 0.1em;
-		}
-
-		.login__lost-password-link,
-		.magic-login__footer-link,
-		.wp-login__login-block-footer-back-link a,
-		a.wp-login__login-block-footer-back-link {
-			color: var(--studio-gray-90, #1d2327);
-			font-weight: 500;
-		}
-	}
-
 	&:not(.is-mobile) .layout__primary {
 		margin-top: 0;
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13832/login-pass-login-footer-into-oneloginlayout-component-for-alignment

## Proposed Changes

* Removes unnecessary overrides to the Login footer that should be unified
* Cleans up CSS classes to reduce specificity in the type of links rendered in the footer
* Cleans up components and usage to a `OneLoginFooter` component

This doesn't address https://linear.app/a8c/issue/DOTCOM-13832/login-pass-login-footer-into-oneloginlayout-component-for-alignment fully, which seeks to centralise the footer into the `OneLoginLayout` component. But we at least have a `OneLoginFooter` component now that we can work with on top.

### Media

| Main | Lost Password | Magic Login |
|--------|--------|--------|
| <img width="782" height="621" alt="Screenshot 2025-07-24 at 12 39 53 PM" src="https://github.com/user-attachments/assets/c768409d-a9d7-4455-a316-23142e889f4f" /> | <img width="709" height="519" alt="Screenshot 2025-07-24 at 12 39 59 PM" src="https://github.com/user-attachments/assets/228b5923-51e5-4d9a-bf36-3321dec8d48a" /> | <img width="646" height="551" alt="Screenshot 2025-07-24 at 12 40 07 PM" src="https://github.com/user-attachments/assets/1d218bff-ad7e-4a1c-9294-08161bcad077" /> |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13832/login-pass-login-footer-into-oneloginlayout-component-for-alignment

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to various [Login screens](https://linear.app/a8c/project/login-and-signup-unify-design-and-layout-16a857e58712/overview) (and Gravatar) and confirm the footer renders correctly with correct links
* Confirm both main Login, Lost-Password, and Magic-Login screens

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
