### PR TITLE
Site list: move default plan field last

### DIFF
--- a/client/dashboard/sites/views.ts
+++ b/client/dashboard/sites/views.ts
@@ -21,7 +21,7 @@ export const DEFAULT_LAYOUTS: SupportedLayouts = {
 
 const DEFAULT_LAYOUT_FIELDS: SupportedLayouts = {
 	table: {
-		fields: [ 'plan', 'status', 'visitors', 'subscribers_count' ],
+		fields: [ 'status', 'visitors', 'subscribers_count', 'plan' ],
 	},
 	grid: {
 		fields: [ 'status' ],


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/pull/104880#discussion_r2225113850

## Proposed Changes

Before

<img width="938" height="122" alt="image" src="https://github.com/user-attachments/assets/362cc500-9e99-4b42-8332-d3ac4b7692df" />

After

<img width="1005" height="120" alt="image" src="https://github.com/user-attachments/assets/55bba3d1-a614-4bc1-8d74-8bab95e8f167" />



## Testing Instructions

Go to /sites and verify the columns.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
