### PR TITLE
Jetpack Search purchase flow: Allow 'enter' key form submission during purchase flow

### DIFF
--- a/client/components/suggestion-search/index.jsx
+++ b/client/components/suggestion-search/index.jsx
@@ -15,9 +15,6 @@ class SuggestionSearch extends Component {
 		placeholder: PropTypes.string,
 		onChange: PropTypes.func,
 		onSelect: PropTypes.func,
-		onSubmit: PropTypes.func,
-		isSubmitDisabled: PropTypes.bool,
-		isSubmitBusy: PropTypes.bool,
 		suggestions: PropTypes.arrayOf(
 			PropTypes.shape( {
 				label: PropTypes.string.isRequired,
@@ -37,9 +34,6 @@ class SuggestionSearch extends Component {
 		placeholder: '',
 		onChange: noop,
 		onSelect: noop,
-		onSubmit: noop,
-		isSubmitDisabled: false,
-		isSubmitBusy: false,
 		suggestions: [],
 		value: '',
 		autoFocus: false,
@@ -60,9 +54,7 @@ class SuggestionSearch extends Component {
 		}
 	}
 
-	setSuggestionsRef = ( ref ) => {
-		this.suggestionsRef = ref;
-	};
+	setSuggestionsRef = ( ref ) => ( this.suggestionsRef = ref );
 
 	hideSuggestions = () => this.setState( { query: '' } );
 
@@ -74,29 +66,17 @@ class SuggestionSearch extends Component {
 	};
 
 	handleSuggestionKeyDown = ( event ) => {
-		const { onSubmit, isSubmitDisabled, isSubmitBusy } = this.props;
-		const hasSuggestions = this.getSuggestions().length > 0;
-		const isEnter = event.key === 'Enter';
-
-		if ( isEnter ) {
+		if ( this.suggestionsRef.props.suggestions.length > 0 && event.key === 'Enter' ) {
 			event.preventDefault();
-
-			if ( hasSuggestions ) {
-				event.stopPropagation();
-				this.suggestionsRef.handleKeyEvent( event );
-			} else if ( onSubmit && ! isSubmitDisabled && ! isSubmitBusy ) {
-				onSubmit();
-			}
-		} else if ( hasSuggestions ) {
-			this.suggestionsRef.handleKeyEvent( event );
 		}
+
+		this.suggestionsRef.handleKeyEvent( event );
 	};
 
 	handleSuggestionMouseDown = ( suggestion, suggestionIndex ) => {
 		this.updateInputValue( suggestion.label );
 		this.hideSuggestions();
 		this.props.onChange( suggestion.label, true );
-		this.props.onSelect( suggestion );
 		const { railcar } = this.props;
 		if ( railcar ) {
 			const { action, id } = railcar;
@@ -113,6 +93,15 @@ class SuggestionSearch extends Component {
 		}
 
 		return this.props.suggestions;
+	}
+
+	getSuggestionLabel( suggestionPosition ) {
+		return this.suggestionsRef.props.suggestions[ suggestionPosition ].label;
+	}
+
+	updateFieldFromSuggestion( newValue ) {
+		this.updateInputValue( newValue );
+		this.props.onChange( newValue, true );
 	}
 
 	onSuggestionItemMount = ( { index, suggestionIndex } ) => {

--- a/client/components/suggestion-search/index.jsx
+++ b/client/components/suggestion-search/index.jsx
@@ -15,6 +15,9 @@ class SuggestionSearch extends Component {
 		placeholder: PropTypes.string,
 		onChange: PropTypes.func,
 		onSelect: PropTypes.func,
+		onSubmit: PropTypes.func,
+		isSubmitDisabled: PropTypes.bool,
+		isSubmitBusy: PropTypes.bool,
 		suggestions: PropTypes.arrayOf(
 			PropTypes.shape( {
 				label: PropTypes.string.isRequired,
@@ -34,6 +37,9 @@ class SuggestionSearch extends Component {
 		placeholder: '',
 		onChange: noop,
 		onSelect: noop,
+		onSubmit: noop,
+		isSubmitDisabled: false,
+		isSubmitBusy: false,
 		suggestions: [],
 		value: '',
 		autoFocus: false,
@@ -54,7 +60,9 @@ class SuggestionSearch extends Component {
 		}
 	}
 
-	setSuggestionsRef = ( ref ) => ( this.suggestionsRef = ref );
+	setSuggestionsRef = ( ref ) => {
+		this.suggestionsRef = ref;
+	};
 
 	hideSuggestions = () => this.setState( { query: '' } );
 
@@ -66,17 +74,29 @@ class SuggestionSearch extends Component {
 	};
 
 	handleSuggestionKeyDown = ( event ) => {
-		if ( this.suggestionsRef.props.suggestions.length > 0 && event.key === 'Enter' ) {
-			event.preventDefault();
-		}
+		const { onSubmit, isSubmitDisabled, isSubmitBusy } = this.props;
+		const hasSuggestions = this.getSuggestions().length > 0;
+		const isEnter = event.key === 'Enter';
 
-		this.suggestionsRef.handleKeyEvent( event );
+		if ( isEnter ) {
+			event.preventDefault();
+
+			if ( hasSuggestions ) {
+				event.stopPropagation();
+				this.suggestionsRef.handleKeyEvent( event );
+			} else if ( onSubmit && ! isSubmitDisabled && ! isSubmitBusy ) {
+				onSubmit();
+			}
+		} else if ( hasSuggestions ) {
+			this.suggestionsRef.handleKeyEvent( event );
+		}
 	};
 
 	handleSuggestionMouseDown = ( suggestion, suggestionIndex ) => {
 		this.updateInputValue( suggestion.label );
 		this.hideSuggestions();
 		this.props.onChange( suggestion.label, true );
+		this.props.onSelect( suggestion );
 		const { railcar } = this.props;
 		if ( railcar ) {
 			const { action, id } = railcar;
@@ -93,15 +113,6 @@ class SuggestionSearch extends Component {
 		}
 
 		return this.props.suggestions;
-	}
-
-	getSuggestionLabel( suggestionPosition ) {
-		return this.suggestionsRef.props.suggestions[ suggestionPosition ].label;
-	}
-
-	updateFieldFromSuggestion( newValue ) {
-		this.updateInputValue( newValue );
-		this.props.onChange( newValue, true );
 	}
 
 	onSuggestionItemMount = ( { index, suggestionIndex } ) => {

--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -203,10 +203,6 @@ class JetpackConnectSiteUrlInput extends Component {
 							id="siteSelection"
 							placeholder="Type your site"
 							onChange={ this.handleChange }
-							onSelect={ this.props.onSelect }
-							onSubmit={ this.handleFormSubmit }
-							isSubmitDisabled={ this.isFormSubmitDisabled() }
-							isSubmitBusy={ this.isFormSubmitBusy() }
 							suggestions={ candidateSites }
 							value={ url }
 						/>

--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -198,7 +198,7 @@ class JetpackConnectSiteUrlInput extends Component {
 							onChange={ this.handleChange }
 							disabled={ isBusy }
 							placeholder="https://yourjetpack.blog"
-							onKeyUp={ this.handleKeyPress }
+							onKeyDown={ this.handleKeyPress }
 							value={ url }
 						/>
 					) }
@@ -207,6 +207,10 @@ class JetpackConnectSiteUrlInput extends Component {
 							id="siteSelection"
 							placeholder="Type your site"
 							onChange={ this.handleChange }
+							onSelect={ this.props.onSelect }
+							onSubmit={ this.handleFormSubmit }
+							isSubmitDisabled={ this.isFormSubmitDisabled() }
+							isSubmitBusy={ this.isFormSubmitBusy() }
 							suggestions={ candidateSites }
 							value={ url }
 						/>

--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -63,9 +63,16 @@ class JetpackConnectSiteUrlInput extends Component {
 		window.removeEventListener( 'beforeunload', this.beforeUnloadHandler );
 	}
 
-	handleKeyPress = ( event ) => {
-		if ( 13 === event.keyCode && ! this.isFormSubmitDisabled() && ! this.isFormSubmitBusy() ) {
-			this.handleFormSubmit();
+	handleFormSubmit = ( event ) => {
+		if ( event ) {
+			event.preventDefault();
+		}
+		const { onSubmit } = this.props;
+
+		const isFormValid = this.validateForm();
+
+		if ( isFormValid ) {
+			onSubmit();
 		}
 	};
 
@@ -119,16 +126,6 @@ class JetpackConnectSiteUrlInput extends Component {
 
 		return true;
 	}
-
-	handleFormSubmit = () => {
-		const { onSubmit } = this.props;
-
-		const isFormValid = this.validateForm();
-
-		if ( isFormValid ) {
-			onSubmit();
-		}
-	};
 
 	handleChange = ( event ) => {
 		const { onChange } = this.props;
@@ -185,7 +182,7 @@ class JetpackConnectSiteUrlInput extends Component {
 		const isBusy = this.isFormSubmitBusy();
 
 		return (
-			<div>
+			<form onSubmit={ this.handleFormSubmit }>
 				<FormLabel htmlFor="siteUrl">{ translate( 'Site address' ) }</FormLabel>
 				<div className="jetpack-connect__site-address-container">
 					<Gridicon className="jetpack-connect__site-address-icon" size={ 24 } icon="domains" />
@@ -198,7 +195,6 @@ class JetpackConnectSiteUrlInput extends Component {
 							onChange={ this.handleChange }
 							disabled={ isBusy }
 							placeholder="https://yourjetpack.blog"
-							onKeyDown={ this.handleKeyPress }
 							value={ url }
 						/>
 					) }
@@ -220,16 +216,16 @@ class JetpackConnectSiteUrlInput extends Component {
 				<Card className="jetpack-connect__connect-button-card">
 					{ this.renderTermsOfServiceLink() }
 					<Button
+						type="submit"
 						className="jetpack-connect__connect-button"
 						primary
 						disabled={ isDisabled && ! isBusy }
 						busy={ isBusy }
-						onClick={ this.handleFormSubmit }
 					>
 						{ this.renderButtonLabel() }
 					</Button>
 				</Card>
-			</div>
+			</form>
 		);
 	}
 }


### PR DESCRIPTION
## Proposed Changes

Addresses #54344

This PR enables the use of the `Enter` key to submit the form at `/purchase-product/jetpack_search/monthly`.

> [!NOTE]  
> Because `components/suggestion-search/index.jsx` is modified, this change also impacts any form that uses this component, meaning that `Enter` key submission would not be limited to only the form shown through the `/purchase-product/jetpack_search/monthly` flow. I looked into limiting the change to the one form, but if `Enter` key submission is a UX/QoL concern for the Jetpack Search purchase flow, then I would expect it to be a concern for similar flows elsewhere, and so we wouldn't want to limit this change.

## Why are these changes being made?

This addresses a UX/QoL concern. As a user, I would expect to be able to press `Enter` twice when going through this purchase flow — once to select my site from the Site Search field and again to submit the form itself via the `Get Search` button. Right now, pressing `Enter` to select my site prevents `Enter` being used again to submit the form.

## Testing Instructions

* Ensure you're testing with an account that has a Jetpack-connected site, but no Search plan purchased.
* Navigate to `/purchase-product/jetpack_search/monthly` and begin to type your site's URL
* Press `Enter` to select the suggested site
* Press `Enter` again to submit the Jetpack Search `Get Search` form
* Upon pressing enter you should expect to be taken to the billing area to enter your purchase details
* Try the same flow again using mouse clicks, and a combination of mouse clicks and `enter` key presses

- Confirm no unexpected behaviour at the other paths impacted by this change:
  - `/purchase-product/jetpack_search`
  - `/purchase-product/jetpack_search/monthly`
  - `/purchase-product/wpcom_search`
  - `/purchase-product/wpcom_search/monthly`

- Confirm Jetpack connection flow is not impacted, including:
  - `/jetpack/connect/`
  - `/jetpack/connect/search`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
