### PR TITLE
Staging site: Allow full sync when there are no backups and add latest backup info

### DIFF
--- a/client/components/jetpack/daily-backup-status/use-get-display-date.js
+++ b/client/components/jetpack/daily-backup-status/use-get-display-date.js
@@ -6,6 +6,16 @@ import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 
+/**
+ * Custom hook that returns a function to format dates with site-specific timezone offset.
+ * The returned function formats dates differently based on whether they occur today,
+ * this year, or in previous years, and can optionally prefix with "Latest:" text.
+ * @param {number|null} [selectedSiteId] - The site ID to use for timezone calculations.
+ *                                              If null, uses the currently selected site.
+ * @returns {Function} A date formatting function that accepts:
+ *                     - dateTime: Date string or moment object to format
+ *                     - withLatest: Boolean to include "Latest:" prefix (default: true)
+ */
 export default function useGetDisplayDate( selectedSiteId = null ) {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -495,7 +495,7 @@ export default function SyncModal( {
 									? createInterpolateElement( __( 'Backup contents from: <date />' ), {
 											date: <span>{ displayBackupDate }</span>,
 									  } )
-									: __( 'There are no backups' ) }{ ' ' }
+									: __( 'There are no backups.' ) }{ ' ' }
 								<ExternalLink
 									href={ `/backup/${ sourceSiteSlug }` }
 									children={ __( 'Backup now' ) }

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -15,6 +15,7 @@ import { createInterpolateElement, useState, useCallback, useEffect } from '@wor
 import { __, isRTL } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
+import useGetDisplayDate from 'calypso/components/jetpack/daily-backup-status/use-get-display-date';
 import InlineSupportLink from 'calypso/dashboard/components/inline-support-link';
 import { SectionHeader } from 'calypso/dashboard/components/section-header';
 import SiteEnvironmentBadge, {
@@ -196,12 +197,15 @@ export default function SyncModal( {
 	const stagingSiteTitle = useSelector( ( state ) => getSiteTitle( state, stagingSiteId ) ) || '';
 
 	const targetSiteSlug = targetEnvironment === 'production' ? productionSiteSlug : stagingSiteSlug;
+	const sourceSiteSlug = sourceEnvironment === 'staging' ? stagingSiteSlug : productionSiteSlug;
 
 	const sourceSiteTitle = sourceEnvironment === 'staging' ? stagingSiteTitle : productionSiteTitle;
 	const targetSiteTitle =
 		targetEnvironment === 'production' ? productionSiteTitle : stagingSiteTitle;
 
 	const querySiteId = sourceEnvironment === 'staging' ? stagingSiteId : productionSiteId;
+
+	const getDisplayDate = useGetDisplayDate( querySiteId );
 
 	const browserCheckList = useSelector( ( state ) =>
 		getBackupBrowserCheckList( state, querySiteId )
@@ -366,6 +370,10 @@ export default function SyncModal( {
 		( showDomainConfirmation && domainConfirmation !== productionSiteSlug ) ||
 		( browserCheckList.totalItems === 0 && browserCheckList.includeList.length === 0 );
 
+	const displayBackupDate = lastKnownBackupAttempt
+		? getDisplayDate( lastKnownBackupAttempt.activityTs, false )
+		: null;
+
 	return (
 		<Modal
 			title={ syncConfig[ environment ].title }
@@ -481,6 +489,19 @@ export default function SyncModal( {
 								/>
 							</VStack>
 						) }
+						<HStack alignment="left" spacing={ 1 }>
+							<Text color="var(--studio-gray-40)">
+								{ displayBackupDate
+									? createInterpolateElement( __( 'Backup contents from: <date />' ), {
+											date: <span>{ displayBackupDate }</span>,
+									  } )
+									: __( 'There are no backups' ) }{ ' ' }
+								<ExternalLink
+									href={ `/backup/${ sourceSiteSlug }` }
+									children={ __( 'Backup now' ) }
+								/>
+							</Text>
+						</HStack>
 					</VStack>
 				</div>
 				<HStack className="staging-site-card__footer">

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -492,7 +492,7 @@ export default function SyncModal( {
 						<HStack alignment="left" spacing={ 1 }>
 							<Text color="var(--studio-gray-40)">
 								{ displayBackupDate
-									? createInterpolateElement( __( 'Backup contents from: <date />' ), {
+									? createInterpolateElement( __( 'Backup contents from: <date />.' ), {
 											date: <span>{ displayBackupDate }</span>,
 									  } )
 									: __( 'There are no backups.' ) }{ ' ' }

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -11,7 +11,7 @@ import {
 	SelectControl,
 	Notice,
 } from '@wordpress/components';
-import { createInterpolateElement, useState, useCallback } from '@wordpress/element';
+import { createInterpolateElement, useState, useCallback, useEffect } from '@wordpress/element';
 import { __, isRTL } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
@@ -37,6 +37,7 @@ import type { FileBrowserConfig } from 'calypso/my-sites/backup/backup-contents-
 
 import './style.scss';
 
+const ROOT_PATH = '/';
 const WP_CONFIG_PATH = '/wp-config.php';
 const WP_CONTENT_PATH = '/wp-content';
 const SQL_PATH = '/sql';
@@ -280,10 +281,24 @@ export default function SyncModal( {
 	} );
 	const rewindId = lastKnownBackupAttempt?.rewindId;
 
+	const shouldDisableGranularSync = ! lastKnownBackupAttempt;
+
+	useEffect( () => {
+		if ( shouldDisableGranularSync ) {
+			dispatch( setNodeCheckState( querySiteId, ROOT_PATH, 'checked' ) );
+			dispatch( setNodeCheckState( querySiteId, WP_CONTENT_PATH, 'checked' ) );
+			dispatch( setNodeCheckState( querySiteId, WP_CONFIG_PATH, 'checked' ) );
+			dispatch( setNodeCheckState( querySiteId, SQL_PATH, 'checked' ) );
+		}
+	}, [ dispatch, querySiteId, shouldDisableGranularSync ] );
+
 	const handleConfirm = () => {
 		let include_paths = browserCheckList.includeList.map( ( item ) => item.id ).join( ',' );
 		let exclude_paths = browserCheckList.excludeList.map( ( item ) => item.id ).join( ',' );
-		if ( filesAndFoldersNodesCheckState === 'checked' && sqlNode?.checkState === 'checked' ) {
+		if (
+			shouldDisableGranularSync ||
+			( filesAndFoldersNodesCheckState === 'checked' && sqlNode?.checkState === 'checked' )
+		) {
 			// Sync everything
 			include_paths = '';
 			exclude_paths = '';
@@ -349,7 +364,7 @@ export default function SyncModal( {
 
 	const isButtonDisabled =
 		( showDomainConfirmation && domainConfirmation !== productionSiteSlug ) ||
-		! browserCheckList.totalItems;
+		( browserCheckList.totalItems === 0 && browserCheckList.includeList.length === 0 );
 
 	return (
 		<Modal
@@ -384,13 +399,15 @@ export default function SyncModal( {
 						<CheckboxControl
 							__nextHasNoMarginBottom
 							label={ __( 'Files and folders' ) }
-							checked={ filesAndFoldersNodesCheckState === 'checked' }
+							disabled={ shouldDisableGranularSync }
+							checked={ shouldDisableGranularSync || filesAndFoldersNodesCheckState === 'checked' }
 							indeterminate={ filesAndFoldersNodesCheckState === 'mixed' }
 							onChange={ onCheckboxChange }
 						/>
 						<SelectControl
 							value={ isFileBrowserVisible ? 'true' : 'false' }
 							variant="minimal"
+							disabled={ shouldDisableGranularSync }
 							options={ [
 								{
 									label: __( 'All files and folders' ),
@@ -423,7 +440,8 @@ export default function SyncModal( {
 						<CheckboxControl
 							__nextHasNoMarginBottom
 							label={ __( 'Database tables' ) }
-							checked={ sqlNode?.checkState === 'checked' }
+							disabled={ shouldDisableGranularSync }
+							checked={ shouldDisableGranularSync || sqlNode?.checkState === 'checked' }
 							onChange={ handleDatabaseCheckboxChange }
 						/>
 					</div>

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -10,6 +10,7 @@ import {
 	CheckboxControl,
 	SelectControl,
 	Notice,
+	Tooltip,
 } from '@wordpress/components';
 import {
 	createInterpolateElement,
@@ -406,36 +407,46 @@ export default function SyncModal( {
 				<SectionHeader level={ 3 } title={ syncConfig.syncSelectionHeading } />
 
 				<div className="staging-site-card">
-					<HStack spacing={ 2 } justify="space-between" alignment="center">
-						<CheckboxControl
-							__nextHasNoMarginBottom
-							label={ __( 'Files and folders' ) }
-							disabled={ shouldDisableGranularSync }
-							checked={ shouldDisableGranularSync || filesAndFoldersNodesCheckState === 'checked' }
-							indeterminate={ filesAndFoldersNodesCheckState === 'mixed' }
-							onChange={ onCheckboxChange }
-						/>
-						<SelectControl
-							value={ isFileBrowserVisible ? 'true' : 'false' }
-							variant="minimal"
-							disabled={ shouldDisableGranularSync }
-							options={ [
-								{
-									label: __( 'All files and folders' ),
-									value: 'false',
-								},
-								{
-									label: __( 'Specific files and folders' ),
-									value: 'true',
-								},
-							] }
-							onChange={ handleExpanderChange }
-							__next40pxDefaultSize
-							__nextHasNoMarginBottom
-							aria-label={ __( 'Select files and folders to sync' ) }
-						/>
-					</HStack>
-
+					<Tooltip
+						text={
+							shouldDisableGranularSync
+								? __( 'Selective Sync will be enabled automatically once your backup is complete.' )
+								: ''
+						}
+					>
+						<HStack spacing={ 2 } justify="space-between" alignment="center">
+							<CheckboxControl
+								__nextHasNoMarginBottom
+								label={ __( 'Files and folders' ) }
+								disabled={ shouldDisableGranularSync }
+								checked={
+									shouldDisableGranularSync || filesAndFoldersNodesCheckState === 'checked'
+								}
+								indeterminate={ filesAndFoldersNodesCheckState === 'mixed' }
+								onChange={ onCheckboxChange }
+							/>
+							<SelectControl
+								style={ shouldDisableGranularSync ? { backgroundColor: 'white' } : {} }
+								value={ isFileBrowserVisible ? 'true' : 'false' }
+								variant="minimal"
+								disabled={ shouldDisableGranularSync }
+								options={ [
+									{
+										label: __( 'All files and folders' ),
+										value: 'false',
+									},
+									{
+										label: __( 'Specific files and folders' ),
+										value: 'true',
+									},
+								] }
+								onChange={ handleExpanderChange }
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+								aria-label={ __( 'Select files and folders to sync' ) }
+							/>
+						</HStack>
+					</Tooltip>
 					{ /*
 					 * Keep the FileBrowser component rendered (using a CSS 'hidden' class instead of conditional rendering)
 					 * to ensure its child nodes initialize properly and can be selected by default.


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTDEV-190

## Proposed Changes

* Add a message indicating the date of the latest backup being used in the file tree or `There are no backups` 
* When there are no backups, only full sync can be done, so all checkboxes are checked and disabled.

|Before | After with no backups| After with backups|No backups with tooltip
|-------|------|------|---
| <img width="1900" height="1760" alt="CleanShot 2025-07-24 at 15 39 24@2x" src="https://github.com/user-attachments/assets/a46e964c-5438-41ee-b266-32c2fc686cc2" />|  <img width="1900" height="1760" alt="CleanShot 2025-07-24 at 15 39 00@2x" src="https://github.com/user-attachments/assets/ac3d65d2-4ddd-494e-b0ac-6e9a4891c767" />| <img width="1900" height="1760" alt="CleanShot 2025-07-24 at 15 36 58@2x" src="https://github.com/user-attachments/assets/d3475a96-6cbe-41fa-88b5-8d7e112b24c9" />|<img width="1508" height="1504" alt="CleanShot 2025-07-25 at 17 01 11@2x" src="https://github.com/user-attachments/assets/31e8e867-cbe9-4bb0-a3fe-68911a63693b" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To notify the user about the backup being used for synchronization

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this changes and run Calypso locally
* On a site without Staging site, add a staging site and once it is added
* Select `Sync` dropdown and select `Pull from Staging`
* Check the checkboxes are disabled and marked
* Add your domain name, and check that the `Pull` button is accessible
* Check that the message indicating that there are no backups is displayed and the design looks similar to the screenshot in the task, listed here p1753177938431569/1753172946.699619-slack-C04GESRBWKW
* Click on `Backup now` link and check it navigates to the backup page of the site being synced _from_
- Perform a backup of the staging site or navigate to a Production site with a Staging site that has backups
- Select `Sync` dropdown and select `Pull from Staging`
- Check that the message indicates the date of the latest Staging backup
- Check that the granular sync works as expected, so you can synchronize specific files, folders and the database.

- On a site with

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?