### PR TITLE
Handling the status of creating staging site is in progress

### DIFF
--- a/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
@@ -55,7 +55,7 @@ export default function HeaderStagingSiteButton( {
 	} );
 
 	const stagingSiteId = useMemo( () => {
-		return stagingSites?.length ? stagingSites[ 0 ].id : undefined;
+		return stagingSites?.length ? stagingSites[ 0 ].id : null;
 	}, [ stagingSites ] );
 	const transferStatus = useCheckStagingSiteStatus( stagingSiteId );
 

--- a/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
@@ -40,7 +40,8 @@ export default function HeaderStagingSiteButton( {
 	const { __ } = useI18n();
 	const queryClient = useQueryClient();
 	const site = useSelector( getSelectedSite );
-	const stagingSiteStatus = useSelector( ( state ) => getStagingSiteStatus( state, siteId ) );
+	const stagingSiteStatus =
+		useSelector( ( state ) => getStagingSiteStatus( state, siteId ) ) ?? StagingSiteStatus.UNSET;
 	const isCreatingStagingSite = [
 		StagingSiteStatus.INITIATE_TRANSFERRING,
 		StagingSiteStatus.TRANSFERRING,

--- a/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
@@ -4,8 +4,9 @@ import { Button } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useAddStagingSiteMutation } from 'calypso/sites/staging-site/hooks/use-add-staging-site';
+import { useCheckStagingSiteStatus } from 'calypso/sites/staging-site/hooks/use-check-staging-site-status';
 import { USE_STAGING_SITE_LOCK_QUERY_KEY } from 'calypso/sites/staging-site/hooks/use-get-lock-query';
 import { useHasValidQuotaQuery } from 'calypso/sites/staging-site/hooks/use-has-valid-quota';
 import { useStagingSite } from 'calypso/sites/staging-site/hooks/use-staging-site';
@@ -48,6 +49,11 @@ export default function HeaderStagingSiteButton( {
 		enabled: ! hideEnvDataInHeader && isAtomic,
 	} );
 
+	const stagingSiteId = useMemo( () => {
+		return stagingSites?.length ? stagingSites[ 0 ].id : undefined;
+	}, [ stagingSites ] );
+	const transferStatus = useCheckStagingSiteStatus( stagingSiteId as number, true );
+
 	const removeAllNotices = useCallback( () => {
 		dispatch( removeNotice( 'staging-site-add-success' ) );
 		dispatch( removeNotice( stagingSiteAddFailureNoticeId ) );
@@ -85,7 +91,10 @@ export default function HeaderStagingSiteButton( {
 		}
 	);
 
-	const showAddStagingButton = stagingSites.length === 0 && isAtomic && ! isStagingSite;
+	const showAddStagingButton =
+		isAtomic &&
+		! isStagingSite &&
+		( stagingSites.length === 0 || transferStatus !== StagingSiteStatus.COMPLETE );
 
 	const onAddClick = useCallback( () => {
 		dispatch( setStagingSiteStatus( siteId, StagingSiteStatus.INITIATE_TRANSFERRING ) );
@@ -113,7 +122,10 @@ export default function HeaderStagingSiteButton( {
 		disabledReason = __(
 			'Your available storage space is lower than 50%, which is insufficient for creating a staging site.'
 		);
-	} else if ( isLoadingAddStagingSite ) {
+	} else if (
+		isLoadingAddStagingSite ||
+		! [ StagingSiteStatus.COMPLETE, null ].includes( transferStatus )
+	) {
 		disabledReason = __( 'Adding staging site…' );
 	}
 

--- a/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
@@ -4,7 +4,8 @@ import { Button } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useEffect } from 'react';
+import { USE_SITE_EXCERPTS_QUERY_KEY } from 'calypso/data/sites/use-site-excerpts-query';
 import { useAddStagingSiteMutation } from 'calypso/sites/staging-site/hooks/use-add-staging-site';
 import { useCheckStagingSiteStatus } from 'calypso/sites/staging-site/hooks/use-check-staging-site-status';
 import { USE_STAGING_SITE_LOCK_QUERY_KEY } from 'calypso/sites/staging-site/hooks/use-get-lock-query';
@@ -13,10 +14,14 @@ import { useStagingSite } from 'calypso/sites/staging-site/hooks/use-staging-sit
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
-import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
+import { transferStates } from 'calypso/state/automated-transfer/constants';
+import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import { setStagingSiteStatus } from 'calypso/state/staging-site/actions';
 import { StagingSiteStatus } from 'calypso/state/staging-site/constants';
+import { getStagingSiteStatus } from 'calypso/state/staging-site/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+const stagingSiteAddSuccessNoticeId = 'staging-site-add-success';
 
 interface HeaderStagingSiteButtonProps {
 	siteId: number;
@@ -52,7 +57,24 @@ export default function HeaderStagingSiteButton( {
 	const stagingSiteId = useMemo( () => {
 		return stagingSites?.length ? stagingSites[ 0 ].id : undefined;
 	}, [ stagingSites ] );
-	const transferStatus = useCheckStagingSiteStatus( stagingSiteId as number, true );
+	const transferStatus = useCheckStagingSiteStatus( stagingSiteId );
+
+	useEffect( () => {
+		if ( transferStatus === transferStates.COMPLETE ) {
+			dispatch( setStagingSiteStatus( siteId, StagingSiteStatus.COMPLETE ) );
+		}
+	}, [ dispatch, siteId, transferStatus ] );
+
+	const stagingSiteStatus = useSelector( ( state ) => getStagingSiteStatus( state, siteId ) );
+
+	useEffect( () => {
+		if ( stagingSiteStatus === StagingSiteStatus.COMPLETE ) {
+			queryClient.invalidateQueries( { queryKey: [ USE_SITE_EXCERPTS_QUERY_KEY ] } );
+			dispatch(
+				successNotice( __( 'Staging site added.' ), { id: stagingSiteAddSuccessNoticeId } )
+			);
+		}
+	}, [ __, dispatch, queryClient, siteId, stagingSiteStatus ] );
 
 	const removeAllNotices = useCallback( () => {
 		dispatch( removeNotice( 'staging-site-add-success' ) );
@@ -122,9 +144,11 @@ export default function HeaderStagingSiteButton( {
 		disabledReason = __(
 			'Your available storage space is lower than 50%, which is insufficient for creating a staging site.'
 		);
+	} else if ( transferStatus === transferStates.RELOCATING_REVERT ) {
+		disabledReason = __( 'We are deleting your staging site.' );
 	} else if (
 		isLoadingAddStagingSite ||
-		! [ StagingSiteStatus.COMPLETE, null ].includes( transferStatus )
+		( transferStatus !== null && transferStatus !== StagingSiteStatus.COMPLETE )
 	) {
 		disabledReason = __( 'Adding staging site…' );
 	}

--- a/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
@@ -18,7 +18,7 @@ import { transferStates } from 'calypso/state/automated-transfer/constants';
 import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import { setStagingSiteStatus } from 'calypso/state/staging-site/actions';
 import { StagingSiteStatus } from 'calypso/state/staging-site/constants';
-import { getStagingSiteStatus } from 'calypso/state/staging-site/selectors';
+import { getStagingSiteStatus } from 'calypso/state/staging-site/selectors/get-staging-site-status';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 const stagingSiteAddSuccessNoticeId = 'staging-site-add-success';
@@ -40,6 +40,11 @@ export default function HeaderStagingSiteButton( {
 	const { __ } = useI18n();
 	const queryClient = useQueryClient();
 	const site = useSelector( getSelectedSite );
+	const stagingSiteStatus = useSelector( ( state ) => getStagingSiteStatus( state, siteId ) );
+	const isCreatingStagingSite = [
+		StagingSiteStatus.INITIATE_TRANSFERRING,
+		StagingSiteStatus.TRANSFERRING,
+	].includes( stagingSiteStatus );
 	const isA4ADevSite = site?.is_a4a_dev_site || false;
 	const {
 		data: hasValidQuota,
@@ -60,21 +65,14 @@ export default function HeaderStagingSiteButton( {
 	const transferStatus = useCheckStagingSiteStatus( stagingSiteId );
 
 	useEffect( () => {
-		if ( transferStatus === transferStates.COMPLETE ) {
+		if ( isCreatingStagingSite && transferStatus === transferStates.COMPLETE ) {
 			dispatch( setStagingSiteStatus( siteId, StagingSiteStatus.COMPLETE ) );
-		}
-	}, [ dispatch, siteId, transferStatus ] );
-
-	const stagingSiteStatus = useSelector( ( state ) => getStagingSiteStatus( state, siteId ) );
-
-	useEffect( () => {
-		if ( stagingSiteStatus === StagingSiteStatus.COMPLETE ) {
 			queryClient.invalidateQueries( { queryKey: [ USE_SITE_EXCERPTS_QUERY_KEY ] } );
 			dispatch(
 				successNotice( __( 'Staging site added.' ), { id: stagingSiteAddSuccessNoticeId } )
 			);
 		}
-	}, [ __, dispatch, queryClient, siteId, stagingSiteStatus ] );
+	}, [ __, dispatch, queryClient, siteId, transferStatus, isCreatingStagingSite ] );
 
 	const removeAllNotices = useCallback( () => {
 		dispatch( removeNotice( 'staging-site-add-success' ) );
@@ -116,7 +114,8 @@ export default function HeaderStagingSiteButton( {
 	const showAddStagingButton =
 		isAtomic &&
 		! isStagingSite &&
-		( stagingSites.length === 0 || transferStatus !== StagingSiteStatus.COMPLETE );
+		( stagingSites.length === 0 ||
+			( transferStatus !== StagingSiteStatus.COMPLETE && ! isCreatingStagingSite ) );
 
 	const onAddClick = useCallback( () => {
 		dispatch( setStagingSiteStatus( siteId, StagingSiteStatus.INITIATE_TRANSFERRING ) );
@@ -146,10 +145,7 @@ export default function HeaderStagingSiteButton( {
 		);
 	} else if ( transferStatus === transferStates.RELOCATING_REVERT ) {
 		disabledReason = __( 'We are deleting your staging site.' );
-	} else if (
-		isLoadingAddStagingSite ||
-		( transferStatus !== null && transferStatus !== StagingSiteStatus.COMPLETE )
-	) {
+	} else if ( isLoadingAddStagingSite || isCreatingStagingSite ) {
 		disabledReason = __( 'Adding staging site…' );
 	}
 

--- a/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
@@ -112,10 +112,7 @@ export default function HeaderStagingSiteButton( {
 	);
 
 	const showAddStagingButton =
-		isAtomic &&
-		! isStagingSite &&
-		( stagingSites.length === 0 ||
-			( transferStatus !== StagingSiteStatus.COMPLETE && ! isCreatingStagingSite ) );
+		isAtomic && ! isStagingSite && ( stagingSites.length === 0 || isCreatingStagingSite );
 
 	const onAddClick = useCallback( () => {
 		dispatch( setStagingSiteStatus( siteId, StagingSiteStatus.INITIATE_TRANSFERRING ) );

--- a/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
@@ -85,8 +85,7 @@ export default function HeaderStagingSiteButton( {
 		}
 	);
 
-	const showAddStagingButton =
-		stagingSites.length === 0 && isAtomic && ! isStagingSite && ! isLoadingAddStagingSite;
+	const showAddStagingButton = stagingSites.length === 0 && isAtomic && ! isStagingSite;
 
 	const onAddClick = useCallback( () => {
 		dispatch( setStagingSiteStatus( siteId, StagingSiteStatus.INITIATE_TRANSFERRING ) );
@@ -114,6 +113,8 @@ export default function HeaderStagingSiteButton( {
 		disabledReason = __(
 			'Your available storage space is lower than 50%, which is insufficient for creating a staging site.'
 		);
+	} else if ( isLoadingAddStagingSite ) {
+		disabledReason = __( 'Adding staging site…' );
 	}
 
 	return (

--- a/client/sites/staging-site/components/staging-site-card/index.js
+++ b/client/sites/staging-site/components/staging-site-card/index.js
@@ -185,7 +185,10 @@ export const StagingSiteCard = ( {
 	} );
 
 	useEffect( () => {
-		if ( stagingSiteStatus === StagingSiteStatus.COMPLETE ) {
+		if (
+			stagingSiteStatus === StagingSiteStatus.COMPLETE &&
+			! isEnabled( 'hosting/staging-sites-redesign' )
+		) {
 			queryClient.invalidateQueries( [ USE_SITE_EXCERPTS_QUERY_KEY ] );
 			dispatch( setStagingSiteStatus( siteId, StagingSiteStatus.NONE ) );
 			dispatch(

--- a/client/sites/staging-site/hooks/use-check-staging-site-status.ts
+++ b/client/sites/staging-site/hooks/use-check-staging-site-status.ts
@@ -6,7 +6,7 @@ import {
 	isFetchingAutomatedTransferStatus,
 } from 'calypso/state/automated-transfer/selectors';
 
-export const useCheckStagingSiteStatus = ( siteId?: number, isEnabled: boolean = true ) => {
+export const useCheckStagingSiteStatus = ( siteId: number | null, isEnabled: boolean = true ) => {
 	const dispatch = useDispatch();
 	const [ isAutomatedTransferFetched, setIsAutomatedTransferFetched ] = useState( false );
 

--- a/client/sites/staging-site/hooks/use-check-staging-site-status.ts
+++ b/client/sites/staging-site/hooks/use-check-staging-site-status.ts
@@ -6,7 +6,7 @@ import {
 	isFetchingAutomatedTransferStatus,
 } from 'calypso/state/automated-transfer/selectors';
 
-export const useCheckStagingSiteStatus = ( siteId: number, isEnabled: boolean ) => {
+export const useCheckStagingSiteStatus = ( siteId?: number, isEnabled: boolean = true ) => {
 	const dispatch = useDispatch();
 	const [ isAutomatedTransferFetched, setIsAutomatedTransferFetched ] = useState( false );
 

--- a/client/state/automated-transfer/selectors/get-automated-transfer-status.ts
+++ b/client/state/automated-transfer/selectors/get-automated-transfer-status.ts
@@ -14,7 +14,7 @@ export const getStatusData = ( state: AppState ): string | null => state?.status
  * Returns status info for transfer
  * @param {Object} state global app state
  * @param {number} siteId requested site for transfer info
- * @returns {string|null} status if available else `null`
+ * @returns {string|null|undefined} status if available else `null`
  */
-export const getAutomatedTransferStatus = ( state: AppState, siteId: number | null ) =>
+export const getAutomatedTransferStatus = ( state: AppState, siteId: number | null | undefined ) =>
 	getStatusData( getAutomatedTransfer( state, siteId ) );

--- a/client/state/automated-transfer/selectors/get-automated-transfer-status.ts
+++ b/client/state/automated-transfer/selectors/get-automated-transfer-status.ts
@@ -14,7 +14,7 @@ export const getStatusData = ( state: AppState ): string | null => state?.status
  * Returns status info for transfer
  * @param {Object} state global app state
  * @param {number} siteId requested site for transfer info
- * @returns {string|null|undefined} status if available else `null`
+ * @returns {string|null} status if available else `null`
  */
-export const getAutomatedTransferStatus = ( state: AppState, siteId: number | null | undefined ) =>
+export const getAutomatedTransferStatus = ( state: AppState, siteId: number | null ) =>
 	getStatusData( getAutomatedTransfer( state, siteId ) );

--- a/client/state/automated-transfer/selectors/is-fetching-automated-transfer-status.js
+++ b/client/state/automated-transfer/selectors/is-fetching-automated-transfer-status.js
@@ -6,7 +6,7 @@ import 'calypso/state/automated-transfer/init';
 /**
  * Returns whether we are already fetching the Automated Transfer status for given siteId.
  * @param {Object} state global app state
- * @param {?number} siteId requested site for transfer info
+ * @param {(number|undefined)} siteId requested site for transfer info
  * @returns {?boolean} whether we are fetching transfer status for given siteId
  */
 export default ( state, siteId ) => {

--- a/client/state/automated-transfer/selectors/is-fetching-automated-transfer-status.js
+++ b/client/state/automated-transfer/selectors/is-fetching-automated-transfer-status.js
@@ -6,8 +6,8 @@ import 'calypso/state/automated-transfer/init';
 /**
  * Returns whether we are already fetching the Automated Transfer status for given siteId.
  * @param {Object} state global app state
- * @param {(number|undefined)} siteId requested site for transfer info
- * @returns {?boolean} whether we are fetching transfer status for given siteId
+ * @param {(number|null)} siteId requested site for transfer info
+ * @returns {boolean|null} whether we are fetching transfer status for given siteId
  */
 export default ( state, siteId ) => {
 	if ( ! siteId ) {


### PR DESCRIPTION
Fixes DOTDEV-214
Fixes DOTDEV-187

## Proposed Changes
With this PR, when users clicks on "Add staging site" button we disable it and render tooltip with information on why it's disabled. Also, we enable it as soon as creation is finished.

## Testing Instructions
1. Open `/sites`
2. Select a site or create a new one
3. Click on `Add staging site` in the header
4. Assert that the button is immediately disabled and on mouseover you see the tooltip<br /><img width="1032" height="176" alt="Screenshot 2025-07-23 at 21 32 27" src="https://github.com/user-attachments/assets/0924c9dc-a3ce-46e0-ba4a-edd8141c6045" />
5. Wait till it's finished and assert that the button is enabled

