### PR TITLE
Domain Search Retrofitting: Make sure Start flows have consistent designs and behavior

### DIFF
--- a/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
+++ b/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
@@ -464,7 +464,6 @@ const mapStateToProps = ( state, props ) => {
 	const productsList = props.products ?? getProductsList( state );
 	const currentUserCurrencyCode =
 		props.suggestion.currency_code || getCurrentUserCurrencyCode( state );
-	const stripZeros = props.showStrikedOutPrice ? true : false;
 	const isPremium = props.premiumDomain?.is_premium || props.suggestion?.is_premium;
 	const flowName = getCurrentFlowName( state );
 
@@ -477,26 +476,26 @@ const mapStateToProps = ( state, props ) => {
 		renewCost = props.premiumDomain?.renew_cost;
 		if ( props.premiumDomain?.sale_cost ) {
 			productSaleCost = formatCurrency( props.premiumDomain?.sale_cost, currentUserCurrencyCode, {
-				stripZeros,
+				stripZeros: true,
 			} );
 		}
 	} else if ( HUNDRED_YEAR_DOMAIN_FLOW === flowName ) {
 		productCost = props.suggestion.cost;
 		renewCost = props.suggestion.renew_cost;
 	} else {
-		productCost = getDomainPrice( productSlug, productsList, currentUserCurrencyCode, stripZeros );
+		productCost = getDomainPrice( productSlug, productsList, currentUserCurrencyCode, true );
 		// Renew cost is the same as the product cost for non-premium domains
 		renewCost = productCost;
 		productSaleCost = getDomainSalePrice(
 			productSlug,
 			productsList,
 			currentUserCurrencyCode,
-			stripZeros
+			true
 		);
 	}
 
 	return {
-		zeroCost: formatCurrency( 0, currentUserCurrencyCode, { stripZeros } ),
+		zeroCost: formatCurrency( 0, currentUserCurrencyCode, { stripZeros: true } ),
 		showHstsNotice: isHstsRequired( productSlug, productsList ),
 		showDotGayNotice: isDotGayNoticeRequired( productSlug, productsList ),
 		productCost,

--- a/client/components/domain-search-v2/domain-search-results/index.jsx
+++ b/client/components/domain-search-v2/domain-search-results/index.jsx
@@ -99,7 +99,7 @@ class DomainSearchResults extends Component {
 
 			if ( premiumDomain.sale_cost ) {
 				productSaleCost = formatCurrency( premiumDomain.sale_cost, currentUserCurrencyCode, {
-					stripZeros: this.props.showStrikedOutPrice,
+					stripZeros: true,
 				} );
 
 				const saleBadgeText = translate( 'Sale', {

--- a/client/components/domain-search-v2/free-domain-for-a-year-promo/index.tsx
+++ b/client/components/domain-search-v2/free-domain-for-a-year-promo/index.tsx
@@ -15,7 +15,7 @@ import './style.scss';
 export const FreeDomainForAYearPromo = ( { textOnly = false } ) => {
 	const { ref, activeQuery } = useContainerQuery( {
 		small: 0,
-		large: 480,
+		large: 600,
 	} );
 
 	const { __ } = useI18n();

--- a/client/components/domain-search-v2/free-domain-for-a-year-promo/index.tsx
+++ b/client/components/domain-search-v2/free-domain-for-a-year-promo/index.tsx
@@ -40,11 +40,7 @@ export const FreeDomainForAYearPromo = ( { textOnly = false } ) => {
 	);
 
 	return (
-		<Card
-			ref={ ref }
-			size={ activeQuery === 'large' ? 'medium' : 'small' }
-			className="free-domain-for-a-year-promo"
-		>
+		<Card ref={ ref } size="small" className="free-domain-for-a-year-promo">
 			<CardBody className="free-domain-for-a-year-promo__body">
 				<HStack spacing={ 6 } alignment="left">
 					{ activeQuery === 'large' && (

--- a/client/components/domain-search-v2/free-domain-for-a-year-promo/style.scss
+++ b/client/components/domain-search-v2/free-domain-for-a-year-promo/style.scss
@@ -7,6 +7,7 @@
 }
 
 .free-domain-for-a-year-promo__image {
+	width: 140px;
 	user-select: none;
 	flex-shrink: 0;
 }

--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -472,10 +472,12 @@ class RegisterDomainStep extends Component {
 	}
 
 	getCart = () => {
-		const { cart, onAddDomain, onRemoveDomain } = this.props;
+		const { cart, onRemoveDomain } = this.props;
 		const searchResults = this.state.searchResults || [];
 
-		const domainsInCart = getDomainsInCart( cart );
+		const domainsInCart = ! shouldUseMultipleDomainsInCart( this.props.flowName )
+			? []
+			: getDomainsInCart( cart );
 
 		const total = formatCurrency(
 			domainsInCart.reduce( ( acc, item ) => acc + item.item_subtotal_integer, 0 ),
@@ -487,7 +489,7 @@ class RegisterDomainStep extends Component {
 		);
 
 		return {
-			isBusy: this.props.isMiniCartContinueButtonBusy,
+			isBusy: !! this.state.pendingCheckSuggestion || this.props.isMiniCartContinueButtonBusy,
 			errorMessage: this.props.replaceDomainFailedMessage,
 			items: domainsInCart.map( ( domain ) => {
 				const [ domainName, ...tld ] = domain.meta.split( '.' );
@@ -526,10 +528,10 @@ class RegisterDomainStep extends Component {
 
 				const suggestion = searchResults[ suggestionPosition ];
 
-				return onAddDomain( suggestion, suggestionPosition, false );
+				return this.onAddDomain( suggestion, suggestionPosition, false );
 			},
 			onRemoveItem: ( itemUuid ) => {
-				const domainInCart = cart.products.find( ( product ) => product.cart_item_id === itemUuid );
+				const domainInCart = domainsInCart.find( ( product ) => product.cart_item_id === itemUuid );
 
 				if ( ! domainInCart ) {
 					return;
@@ -538,7 +540,7 @@ class RegisterDomainStep extends Component {
 				return onRemoveDomain( domainInCart );
 			},
 			hasItem: ( domain_name ) => {
-				return cart.products.some( ( item ) => item.meta === domain_name );
+				return domainsInCart.some( ( item ) => item.meta === domain_name );
 			},
 		};
 	};
@@ -1691,7 +1693,9 @@ class RegisterDomainStep extends Component {
 
 			this.setState( { pendingCheckSuggestion: suggestion } );
 			const promise = this.preCheckDomainAvailability( domain )
-				.catch( () => [] )
+				.catch( () => {
+					this.setState( { pendingCheckSuggestion: null } );
+				} )
 				.then( ( { status, trademarkClaimsNoticeInfo } ) => {
 					this.setState( { pendingCheckSuggestion: null } );
 					this.props.recordDomainAddAvailabilityPreCheck(

--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -475,9 +475,7 @@ class RegisterDomainStep extends Component {
 		const { cart, onRemoveDomain } = this.props;
 		const searchResults = this.state.searchResults || [];
 
-		const domainsInCart = ! shouldUseMultipleDomainsInCart( this.props.flowName )
-			? []
-			: getDomainsInCart( cart );
+		const domainsInCart = this.getDomainsInCart();
 
 		const total = formatCurrency(
 			domainsInCart.reduce( ( acc, item ) => acc + item.item_subtotal_integer, 0 ),
@@ -892,8 +890,14 @@ class RegisterDomainStep extends Component {
 		);
 	}
 
+	getDomainsInCart = () => {
+		return ! shouldUseMultipleDomainsInCart( this.props.flowName )
+			? []
+			: getDomainsInCart( this.props.cart );
+	};
+
 	isInInitialState = () => {
-		const domainsInCart = getDomainsInCart( this.props.cart );
+		const domainsInCart = this.getDomainsInCart();
 
 		return (
 			! Array.isArray( this.state.searchResults ) &&

--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -581,7 +581,11 @@ class RegisterDomainStep extends Component {
 	}
 
 	renderAlreadyOwnADomainButton() {
-		const { handleClickUseYourDomain } = this.props;
+		const { handleClickUseYourDomain, shouldRenderUseYourDomain } = this.props;
+
+		if ( ! shouldRenderUseYourDomain ) {
+			return null;
+		}
 
 		return (
 			<div className="wpcom-domain-search-v2__sticky-bottom">

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -198,6 +198,7 @@ export function generateFlows( {
 			description: 'Checkout without user account or site. Read more https://wp.me/pau2Xa-1hW',
 			lastModified: '2020-06-26',
 			showRecaptcha: true,
+			hideProgressIndicator: true,
 		},
 		{
 			name: 'rewind-setup',

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -303,6 +303,7 @@ export function generateFlows( {
 			destination: getLaunchDestination,
 			description: 'A flow to launch a private site.',
 			providesDependenciesInQuery: [ 'siteSlug' ],
+			hideProgressIndicator: true,
 			lastModified: '2019-11-22',
 			get pageTitle() {
 				return translate( 'Launch your site' );

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1299,8 +1299,31 @@ class RenderDomainsStepComponent extends Component {
 		);
 	};
 
+	getSkipStepButton() {
+		const { shouldUseDomainSearchV2, flowName, translate } = this.props;
+
+		if ( ! shouldUseDomainSearchV2 || ! isNewHostedSiteCreationFlow( flowName ) ) {
+			return null;
+		}
+
+		return (
+			<Step.LinkButton onClick={ () => this.handleSkip( undefined, true ) }>
+				{ translate( 'Decide later' ) }
+			</Step.LinkButton>
+		);
+	}
+
 	getSubHeaderText() {
-		const { isAllDomains, stepSectionName, flowName, translate } = this.props;
+		const { isAllDomains, stepSectionName, flowName, translate, shouldUseDomainSearchV2 } =
+			this.props;
+
+		if ( 'use-your-domain' === stepSectionName ) {
+			return '';
+		}
+
+		if ( shouldUseDomainSearchV2 ) {
+			return translate( 'Make it yours with a .com, .blog, or one of 350+ domain options.' );
+		}
 
 		if ( isAllDomains ) {
 			return translate( 'Find the domain that defines you' );
@@ -1343,20 +1366,27 @@ class RenderDomainsStepComponent extends Component {
 			return translate( 'Enter some descriptive keywords to get started.' );
 		}
 
-		if ( 'use-your-domain' === stepSectionName ) {
-			return '';
-		}
-
 		return 'transfer' === stepSectionName || 'mapping' === stepSectionName
 			? translate( 'Use a domain you already own with your new WordPress.com site.' )
 			: translate( "Enter your site's name or some keywords that describe it to get started." );
 	}
 
 	getHeaderText() {
-		const { headerText, isAllDomains, stepSectionName, translate, flowName } = this.props;
+		const {
+			headerText,
+			isAllDomains,
+			stepSectionName,
+			translate,
+			flowName,
+			shouldUseDomainSearchV2,
+		} = this.props;
 
 		if ( stepSectionName === 'use-your-domain' ) {
 			return '';
+		}
+
+		if ( shouldUseDomainSearchV2 ) {
+			return translate( 'Claim your space on the web' );
 		}
 
 		if ( headerText ) {
@@ -1602,7 +1632,12 @@ class RenderDomainsStepComponent extends Component {
 				<Step.TwoColumnLayout
 					firstColumnWidth={ 7 }
 					secondColumnWidth={ 3 }
-					topBar={ <Step.TopBar leftElement={ ! hideBack && backButton } /> }
+					topBar={
+						<Step.TopBar
+							leftElement={ ! hideBack && backButton }
+							rightElement={ this.getSkipStepButton() }
+						/>
+					}
 					heading={ <Step.Heading text={ headerText } subText={ fallbackSubHeaderText } /> }
 					className="domains__step-content domains__step-content-domain-step"
 				>

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1508,6 +1508,7 @@ class RenderDomainsStepComponent extends Component {
 			previousStepName,
 			useStepperWrapper,
 			goBack,
+			shouldUseDomainSearchV2,
 		} = this.props;
 		const siteUrl = this.props.selectedSite?.URL;
 		const siteSlug = this.props.queryObject?.siteSlug;
@@ -1708,6 +1709,7 @@ class RenderDomainsStepComponent extends Component {
 				goToNextStep={ this.handleSkip }
 				align="center"
 				isWideLayout
+				isSticky={ ! shouldUseDomainSearchV2 }
 			/>
 		);
 	}

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -15,6 +15,7 @@ import {
 	isDomainForGravatarFlow,
 } from '@automattic/onboarding';
 import { withShoppingCart } from '@automattic/shopping-cart';
+import { Button } from '@wordpress/components';
 import { getQueryArg } from '@wordpress/url';
 import { withViewportMatch } from '@wordpress/viewport';
 import clsx from 'clsx';
@@ -1244,6 +1245,7 @@ class RenderDomainsStepComponent extends Component {
 				onRemoveDomain={ ( cartItem ) => this.removeDomainClickHandler( cartItem )() }
 				showFreeDomainPromo={ ! this.shouldHideDomainExplainer() }
 				isMiniCartContinueButtonBusy={ this.state.isMiniCartContinueButtonBusy }
+				shouldRenderUseYourDomain={ ! this.shouldHideUseYourDomain() }
 			/>
 		);
 	};
@@ -1493,6 +1495,41 @@ class RenderDomainsStepComponent extends Component {
 		return url.split( '?' )[ 0 ];
 	}
 
+	getUseDomainIOwnLink() {
+		const { shouldUseDomainSearchV2, translate, stepSectionName, step, isSmallScreen, flowName } =
+			this.props;
+
+		const hasSearchedDomains = Array.isArray( step?.domainForm?.searchResults );
+
+		if (
+			! shouldUseDomainSearchV2 ||
+			stepSectionName === 'use-your-domain' ||
+			this.shouldHideUseYourDomain() ||
+			! isSmallScreen ||
+			! hasSearchedDomains
+		) {
+			return null;
+		}
+
+		if ( shouldUseStepContainerV2( flowName ) ) {
+			return (
+				<Step.LinkButton onClick={ this.handleUseYourDomainClick }>
+					{ translate( 'Use a domain I already own' ) }
+				</Step.LinkButton>
+			);
+		}
+
+		return (
+			<Button
+				className="step-wrapper__navigation-link forward"
+				onClick={ this.handleUseYourDomainClick }
+				variant="link"
+			>
+				<span>{ translate( 'Use a domain I already own' ) }</span>
+			</Button>
+		);
+	}
+
 	render() {
 		if ( this.skipRender ) {
 			return null;
@@ -1636,7 +1673,7 @@ class RenderDomainsStepComponent extends Component {
 					topBar={
 						<Step.TopBar
 							leftElement={ ! hideBack && backButton }
-							rightElement={ this.getSkipStepButton() }
+							rightElement={ this.getUseDomainIOwnLink() ?? this.getSkipStepButton() }
 						/>
 					}
 					heading={ <Step.Heading text={ headerText } subText={ fallbackSubHeaderText } /> }
@@ -1683,6 +1720,8 @@ class RenderDomainsStepComponent extends Component {
 			);
 		}
 
+		const useDomainIOwnLink = this.getUseDomainIOwnLink();
+
 		return (
 			<AsyncLoad
 				require="calypso/signup/step-wrapper"
@@ -1710,6 +1749,7 @@ class RenderDomainsStepComponent extends Component {
 				align="center"
 				isWideLayout
 				isSticky={ ! shouldUseDomainSearchV2 }
+				customizedActionButtons={ useDomainIOwnLink }
 			/>
 		);
 	}
@@ -1740,9 +1780,10 @@ const StyleWrappedDomainsStepComponent = ( props ) => {
 	);
 };
 
-export const RenderDomainsStep = withViewportMatch( { isDesktop: '>= large' } )(
-	StyleWrappedDomainsStepComponent
-);
+export const RenderDomainsStep = withViewportMatch( {
+	isSmallScreen: '>= small',
+	isDesktop: '>= large',
+} )( StyleWrappedDomainsStepComponent );
 
 export const submitDomainStepSelection = ( suggestion, section ) => {
 	let domainType = 'domain_reg';

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1124,6 +1124,16 @@ class RenderDomainsStepComponent extends Component {
 		);
 	};
 
+	showSkipButton = () => {
+		const { showSkipButton, shouldUseDomainSearchV2 } = this.props;
+
+		if ( showSkipButton || ! shouldUseDomainSearchV2 ) {
+			return showSkipButton;
+		}
+
+		return ! this.shouldHideDomainExplainer();
+	};
+
 	domainForm = () => {
 		const initialState = this.props.step?.domainForm ?? {};
 
@@ -1207,7 +1217,6 @@ class RenderDomainsStepComponent extends Component {
 				} ) }
 				deemphasiseTlds={ this.props.flowName === 'ecommerce' ? [ 'blog' ] : [] }
 				selectedSite={ this.props.selectedSite }
-				showSkipButton={ this.props.showSkipButton }
 				onSkip={ this.handleSkip }
 				hideFreePlan={ this.handleSkip }
 				forceHideFreeDomainExplainerAndStrikeoutUi={
@@ -1230,11 +1239,10 @@ class RenderDomainsStepComponent extends Component {
 				handleClickUseYourDomain={ this.handleUseYourDomainClick }
 				showAlreadyOwnADomain={ this.props.showAlreadyOwnADomain }
 				// RegisterDomainStepComponentV2 props below
+				showSkipButton={ this.showSkipButton() }
 				onContinue={ this.goToNext }
 				onRemoveDomain={ ( cartItem ) => this.removeDomainClickHandler( cartItem )() }
-				showFreeDomainPromo={
-					! this.shouldHideDomainExplainer() || this.shouldDisplayDomainOnlyExplainer()
-				}
+				showFreeDomainPromo={ ! this.shouldHideDomainExplainer() }
 				isMiniCartContinueButtonBusy={ this.state.isMiniCartContinueButtonBusy }
 			/>
 		);

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -23,6 +23,20 @@
 	}
 }
 
+body:has( .wpcom-domain-search-v2 ) {
+	.step-wrapper__navigation.action-buttons {
+		height: 60px;
+	}
+
+	.step-wrapper__content {
+		padding: 0 16px 32px 16px;
+
+		@include break-small {
+			padding-inline: 24px;
+		}
+	}
+}
+
 body.domain-search-legacy--unified {
 	.domains__step-section-wrapper {
 		margin: 0 auto;

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -2,29 +2,35 @@
 @import '@wordpress/base-styles/mixins';
 @import '@wordpress/base-styles/variables';
 
-.is-section-stepper .domains__step-content,
-.is-section-signup .domains__step-content {
-	& .use-my-domain__page-heading {
-		padding-left: 24px;
-		padding-right: 24px;
-		text-align: center;
+.is-section-stepper,
+.is-section-signup {
+	.step-wrapper__navigation.action-buttons.no-sticky {
+		height: 60px;
 	}
 
-	& .use-my-domain,
-	& .connect-domain-step,
-	& .domain-transfer-or-connect__content {
-		background: transparent;
-		box-shadow: none;
+	.domains__step-content {
+		& .use-my-domain__page-heading {
+			padding-left: 24px;
+			padding-right: 24px;
+			text-align: center;
+		}
 
-		@include break-mobile {
-			padding-left: 0;
-			padding-right: 0;
+		& .use-my-domain,
+		& .connect-domain-step,
+		& .domain-transfer-or-connect__content {
+			background: transparent;
+			box-shadow: none;
+
+			@include break-mobile {
+				padding-left: 0;
+				padding-right: 0;
+			}
 		}
 	}
 }
 
 body:has( .wpcom-domain-search-v2 ) {
-	.step-wrapper__navigation.action-buttons {
+	.step-wrapper__navigation.action-buttons.no-sticky {
 		height: 60px;
 	}
 
@@ -34,6 +40,10 @@ body:has( .wpcom-domain-search-v2 ) {
 		@include break-small {
 			padding-inline: 24px;
 		}
+	}
+
+	.step-wrapper__navigation-link {
+		color: #1d2327;
 	}
 }
 

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -40,6 +40,15 @@ body:has( .wpcom-domain-search-v2 ) {
 		@include break-small {
 			padding-inline: 24px;
 		}
+
+		.domains-mini-cart__content {
+			padding-inline: 16px;
+			max-width: 1040px;
+
+			@include break-small {
+				padding-inline: 24px;
+			}
+		}
 	}
 
 	.step-wrapper__navigation-link {

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -2,6 +2,27 @@
 @import '@wordpress/base-styles/mixins';
 @import '@wordpress/base-styles/variables';
 
+.is-section-stepper .domains__step-content,
+.is-section-signup .domains__step-content {
+	& .use-my-domain__page-heading {
+		padding-left: 24px;
+		padding-right: 24px;
+		text-align: center;
+	}
+
+	& .use-my-domain,
+	& .connect-domain-step,
+	& .domain-transfer-or-connect__content {
+		background: transparent;
+		box-shadow: none;
+
+		@include break-mobile {
+			padding-left: 0;
+			padding-right: 0;
+		}
+	}
+}
+
 body.domain-search-legacy--unified {
 	.domains__step-section-wrapper {
 		margin: 0 auto;
@@ -23,24 +44,6 @@ body.domain-search-legacy--unified {
 	&.is-section-stepper .domains__step-content,
 	.is-section-signup .domains__step-content {
 		margin-bottom: 50px;
-
-		& .use-my-domain__page-heading {
-			padding-left: 24px;
-			padding-right: 24px;
-			text-align: center;
-		}
-
-		& .use-my-domain,
-		& .connect-domain-step,
-		& .domain-transfer-or-connect__content {
-			background: transparent;
-			box-shadow: none;
-
-			@include break-mobile {
-				padding-left: 0;
-				padding-right: 0;
-			}
-		}
 
 		&.domains__step-content-domain-step {
 			margin-bottom: 20px;
@@ -455,10 +458,6 @@ body.domain-search-legacy--unified {
 
 			.search-component .search-component__icon-navigation {
 				padding: 0 7px;
-			}
-
-			.use-my-domain__page-heading {
-				text-align: center;
 			}
 		}
 

--- a/packages/components/src/summary-button/index.tsx
+++ b/packages/components/src/summary-button/index.tsx
@@ -51,7 +51,7 @@ function UnforwardedSummaryButton(
 			ref={ ref }
 			href={ href }
 			onClick={ onClick }
-			className={ clsx( 'summary-button', `has-density-${ density }` ) }
+			className={ clsx( 'summary-button', `has-density-${ density }`, props.className ) }
 			disabled={ disabled }
 			accessibleWhenDisabled
 		>

--- a/packages/components/src/summary-button/types.ts
+++ b/packages/components/src/summary-button/types.ts
@@ -73,4 +73,8 @@ export interface SummaryButtonProps {
 	 * @default false
 	 */
 	disabled?: boolean;
+	/**
+	 * Optional class name to be applied to the component.
+	 */
+	className?: string;
 }

--- a/packages/domain-search/.eslintrc.js
+++ b/packages/domain-search/.eslintrc.js
@@ -1,0 +1,15 @@
+module.exports = {
+	rules: {
+		'no-restricted-imports': [
+			'error',
+			{
+				patterns: [
+					{
+						group: [ 'client/**/*', 'calypso/**/*' ],
+						message: 'Calypso imports are not allowed in this package',
+					},
+				],
+			},
+		],
+	},
+};

--- a/packages/domain-search/src/components/domain-search-already-own-domain-cta/index.tsx
+++ b/packages/domain-search/src/components/domain-search-already-own-domain-cta/index.tsx
@@ -2,6 +2,8 @@ import { SummaryButton } from '@automattic/components';
 import { globe, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 
+import './style.scss';
+
 interface Props {
 	onClick: () => void;
 }
@@ -11,6 +13,7 @@ export const DomainSearchAlreadyOwnDomainCTA = ( { onClick }: Props ) => {
 
 	return (
 		<SummaryButton
+			className="domain-search-already-own-domain-cta"
 			title={ __( 'Already have a domain?' ) }
 			description={ __( 'Connect a domain you already own to WordPress.com.' ) }
 			decoration={ <Icon icon={ globe } /> }

--- a/packages/domain-search/src/components/domain-search-already-own-domain-cta/style.scss
+++ b/packages/domain-search/src/components/domain-search-already-own-domain-cta/style.scss
@@ -1,0 +1,5 @@
+.domain-search-already-own-domain-cta {
+	.summary-button-description {
+		text-align: left;
+	}
+}


### PR DESCRIPTION
Closes DOMAINS-1405.

## Proposed Changes

Apply design changes to all `/start/*` flows that contains domains steps to make them closer to the Figma designs (aiyAvhP2AQTQllMWHw99OI-fi).

It also fixes some quirks from the new version, like the 'Already own a domain' button always showing up despite not being possible for the flow.

## Testing Instructions

Go through the flows specified in the Linear task and make sure that the designs aren't broken (i.e., they all have the same edge padding, the cart content and page content are aligned.)

Verify you can perform all actions (add to cart, continue, go to checkout and see the domains there, use your domain, skip the step) compared to production.

Finally, verify that this PR's version with the feature flag turned off, which should match progression, is also working (i.e., there are no regressions.) If you're too lazy to restart the server, just hardcode [this line](https://github.com/Automattic/wp-calypso/blob/trunk/client/lib/domains/use-domain-search-v2.ts#L9) as `false`. 😛 