### PR TITLE
A4A: Show BD purchase details in agency referral dashboard

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/product-details.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/product-details.tsx
@@ -11,7 +11,14 @@ type Props = {
 const ProductDetails = ( { purchase, data, isFetching }: Props ) => {
 	const product = data?.find( ( product ) => product.product_id === purchase.product_id );
 
-	return isFetching ? <TextPlaceholder /> : product?.name;
+	if ( isFetching ) {
+		return <TextPlaceholder />;
+	}
+
+	// Use product_name from subscription if available, otherwise fall back to product name from data
+	const productName = purchase.subscription?.product_name || product?.name;
+
+	return productName;
 };
 
 export default ProductDetails;

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/referral-products.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/referral-products.tsx
@@ -1,9 +1,12 @@
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import type { ReferralPurchase } from '../../types';
-const getProductName = ( productId: number, data: APIProductFamilyProduct[] ) => {
-	const product = data.find( ( product ) => product.product_id === productId );
-	return product?.name;
+
+const getProductName = ( purchase: ReferralPurchase, data: APIProductFamilyProduct[] ) => {
+	const product = data.find( ( product ) => product.product_id === purchase.product_id );
+
+	// Use product_name from subscription if available, otherwise fall back to product name from data
+	return purchase.subscription?.product_name || product?.name;
 };
 
 export default function ReferralProducts( {
@@ -20,9 +23,7 @@ export default function ReferralProducts( {
 	}
 	return (
 		<div>
-			{ products
-				.map( ( product ) => getProductName( product.product_id, productsData ) )
-				.join( ', ' ) }
+			{ products.map( ( product ) => getProductName( product, productsData ) ).join( ', ' ) }
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/total-amount.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/total-amount.tsx
@@ -21,7 +21,6 @@ const TotalAmount = ( { purchase, data, isFetching }: Props ) => {
 	}
 
 	// Use purchase_price from subscription if available, otherwise fall back to product amount
-	// This follows the same pattern as the client subscriptions implementation
 	let amount = product?.amount;
 	let currency = 'USD';
 	let interval = 'month';

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/total-amount.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/total-amount.tsx
@@ -21,7 +21,7 @@ const TotalAmount = ( { purchase, data, isFetching }: Props ) => {
 	}
 
 	// Use purchase_price from subscription if available, otherwise fall back to product amount
-	let amount = product?.amount;
+	let amount = Number( product?.amount );
 	let currency = 'USD';
 	let interval = 'month';
 
@@ -35,7 +35,7 @@ const TotalAmount = ( { purchase, data, isFetching }: Props ) => {
 		return <Gridicon icon="minus" />;
 	}
 
-	const formatted = formatCurrency( Number( amount ), currency );
+	const formatted = formatCurrency( amount, currency );
 
 	return interval === 'year'
 		? /* translators: %(total)s is the price of the subscription per year */

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/total-amount.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/total-amount.tsx
@@ -20,13 +20,33 @@ const TotalAmount = ( { purchase, data, isFetching }: Props ) => {
 		return <TextPlaceholder />;
 	}
 
-	return product?.amount ? (
-		translate( '%(total)s/mo', {
-			args: { total: formatCurrency( Number( product.amount ?? 0 ), product.currency ?? 'USD' ) },
-		} )
-	) : (
-		<Gridicon icon="minus" />
-	);
+	// Use purchase_price from subscription if available, otherwise fall back to product amount
+	// This follows the same pattern as the client subscriptions implementation
+	let amount = product?.amount;
+	let currency = 'USD';
+	let interval = 'month';
+
+	if ( purchase.subscription?.purchase_price ) {
+		amount = purchase.subscription.purchase_price;
+		currency = purchase.subscription.purchase_currency;
+		interval = purchase.subscription.billing_interval_unit;
+	}
+
+	if ( ! amount ) {
+		return <Gridicon icon="minus" />;
+	}
+
+	const formatted = formatCurrency( Number( amount ), currency );
+
+	return interval === 'year'
+		? /* translators: %(total)s is the price of the subscription per year */
+		  translate( '%(total)s/yr', {
+				args: { total: formatted },
+		  } )
+		: /* translators: %(total)s is the price of the subscription per month */
+		  translate( '%(total)s/mo', {
+				args: { total: formatted },
+		  } );
 };
 
 export default TotalAmount;

--- a/client/a8c-for-agencies/sections/referrals/types.ts
+++ b/client/a8c-for-agencies/sections/referrals/types.ts
@@ -11,9 +11,8 @@ interface ReferralPurchaseAPIResponse {
 	site_assigned: string;
 	subscription?: {
 		product_name: string;
-		purchase_price: string;
+		purchase_price: number;
 		purchase_currency: string;
-		commissionable_amount: string;
 		billing_interval_unit: string;
 	};
 }

--- a/client/a8c-for-agencies/sections/referrals/types.ts
+++ b/client/a8c-for-agencies/sections/referrals/types.ts
@@ -9,6 +9,13 @@ interface ReferralPurchaseAPIResponse {
 		revoked_at: string | null;
 	};
 	site_assigned: string;
+	subscription?: {
+		product_name: string;
+		purchase_price: string;
+		purchase_currency: string;
+		purchase_price_usd: string;
+		billing_interval_unit: string;
+	};
 }
 export interface ReferralPurchase extends ReferralPurchaseAPIResponse {
 	status: string;

--- a/client/a8c-for-agencies/sections/referrals/types.ts
+++ b/client/a8c-for-agencies/sections/referrals/types.ts
@@ -13,7 +13,7 @@ interface ReferralPurchaseAPIResponse {
 		product_name: string;
 		purchase_price: string;
 		purchase_currency: string;
-		purchase_price_usd: string;
+		commissionable_amount: string;
 		billing_interval_unit: string;
 	};
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Linear issue: https://linear.app/a8c/issue/A4A-1322/agency-referrals-should-show-correct-product-and-price-details
Backend PR: 188671-ghe-Automattic/wpcom

## Proposed Changes

* If purchase details exist in the referral purchase then use that for product name and price. Otherwise fall back on existing product family data.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To show accurate referral purchase details to the agency

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test with this backend PR: 188671-ghe-Automattic/wpcom.
* Send some referrals to a client and complete the purchases as the client in the new  `/v2` checkout (see 188433-ghe-Automattic/wpcom for instructions).
  * After creating the user account for the client, change their currency to a non-USD currency in store admin, if it was USD.
    <img width="1513" height="645" alt="Screenshot 2025-07-23 at 4 48 15 PM" src="https://github.com/user-attachments/assets/0b09de89-d723-49ea-a213-c41ede165293" />

  * Try purchasing products with different billing intervals (monthly and yearly)
* As the agency, visit `/referrals/dashboard`
* Click the `>` for the client to view the referrals.
* Under the "Referrals" tab you should see the product names shown correctly
<img width="1680" height="566" alt="Screenshot 2025-07-23 at 4 41 16 PM" src="https://github.com/user-attachments/assets/e43420ce-ef6c-453c-b789-a7dc443c88fe" />

* Under the "Purchases" tab you should see the product names, and prices shown correctly. The prices should reflect the correct currency and billing interval.
<img width="1684" height="667" alt="Screenshot 2025-07-23 at 4 41 29 PM" src="https://github.com/user-attachments/assets/6998ed18-478e-4e79-8240-9f1335a9e1e5" />

* Check another client that has not made purchases using the new BD checkout.
* Product details should continue to display just as before, with prices always shown in USD and per month.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?