### PR TITLE
OverviewCard hover state needs to fully cover the click target

### DIFF
--- a/client/dashboard/sites/overview-card/style.scss
+++ b/client/dashboard/sites/overview-card/style.scss
@@ -9,6 +9,9 @@
 
 	.components-card__body {
 		padding: 0;
+		height: 100%;
+		display: flex;
+		flex-direction: column;
 	}
 }
 
@@ -70,6 +73,7 @@
 .dashboard-overview-card__link {
 	display: flex;
 	text-decoration: none;
+	flex-grow: 1;
 
 	.dashboard-overview-card__content {
 		flex: 1;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Follow up to https://github.com/Automattic/wp-calypso/pull/104877

## Proposed Changes

The `OverviewCard` hover state is only as high as the card content. But it should always cover the entire clickable region.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

https://github.com/Automattic/wp-calypso/pull/104877 grew the plans card height by 0.5px and it introduced this ghosty hover state on the other cards.

<img width="813" height="376" alt="CleanShot 2025-07-24 at 14 51 47" src="https://github.com/user-attachments/assets/7623cf16-ea55-48a6-b2ef-b931c6dc414d" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Try hovering over the `OverviewCard`s at various screen widths.
Also, artificially increase the height of the plans card by adding more text. The other `OverviewCard`s will grow, and should their hover states.

https://github.com/user-attachments/assets/8eb59b6f-6d19-498c-8d04-b686ba30bdd1


https://github.com/user-attachments/assets/c879e202-5296-4d88-aa5e-27175a32b6c5



https://github.com/user-attachments/assets/6bb24598-8c9e-4cf7-8e30-8f5739a37299


https://github.com/user-attachments/assets/d8efe441-bc46-481f-9c7b-cc439f4faf22




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
