### PR TITLE
A4A > Referrals: Handle BD referral commissions

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/hooks/test/use-get-consolidated-payout-data.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/test/use-get-consolidated-payout-data.ts
@@ -99,7 +99,14 @@ describe( 'useGetConsolidatedPayoutData', () => {
 		expect( mockGetEstimatedCommission ).toHaveBeenCalledWith(
 			mockReferrals,
 			mockProducts,
-			mockActivityWindow
+			mockActivityWindow,
+			false // use current quarter
+		);
+		expect( mockGetEstimatedCommission ).toHaveBeenCalledWith(
+			mockReferrals,
+			mockProducts,
+			mockActivityWindow,
+			true // use previous quarter
 		);
 		expect( result.current.previousQuarterExpectedCommission ).toBe( 50 );
 	} );
@@ -112,7 +119,14 @@ describe( 'useGetConsolidatedPayoutData', () => {
 		expect( mockGetEstimatedCommission ).toHaveBeenCalledWith(
 			mockReferrals,
 			mockProducts,
-			mockActivityWindow
+			mockActivityWindow,
+			false // use current quarter
+		);
+		expect( mockGetEstimatedCommission ).toHaveBeenCalledWith(
+			mockReferrals,
+			mockProducts,
+			mockActivityWindow,
+			true // use previous quarter
 		);
 		expect( result.current.currentQuarterExpectedCommission ).toBe( 50 );
 	} );
@@ -210,12 +224,14 @@ describe( 'useGetConsolidatedPayoutData', () => {
 		expect( mockGetEstimatedCommission ).toHaveBeenCalledWith(
 			referralsWithRevokedPurchase,
 			mockProducts,
-			previousQuarterWindow
+			currentQuarterWindow,
+			false // use current quarter
 		);
 		expect( mockGetEstimatedCommission ).toHaveBeenCalledWith(
 			referralsWithRevokedPurchase,
 			mockProducts,
-			currentQuarterWindow
+			previousQuarterWindow,
+			true // use previous quarter
 		);
 		expect( result.current.previousQuarterExpectedCommission ).toBe( 75 );
 		expect( result.current.currentQuarterExpectedCommission ).toBe( 50 );

--- a/client/a8c-for-agencies/sections/referrals/hooks/use-get-consolidated-payout-data.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-get-consolidated-payout-data.ts
@@ -15,39 +15,19 @@ export default function useGetConsolidatedPayoutData(
 		const currentDate = new Date();
 		const productsArray = products || [];
 
-		// For current quarter: use getEstimatedCommission which handles API + legacy data
-		const currentQuarterCommissions = getEstimatedCommission(
-			referrals,
-			productsArray,
-			getCurrentCycleActivityWindow( currentDate )
-		);
-
-		// For previous quarter: we need to handle API data separately since getEstimatedCommission
-		// only handles current quarter API data
-		const previousQuarterApiCommissions = referrals.reduce( ( acc, referral ) => {
-			return (
-				acc +
-				referral.purchases.reduce( ( purchaseAcc, purchase ) => {
-					return purchaseAcc + ( purchase.commissions?.estimated_commission_previous_quarter ?? 0 );
-				}, 0 )
-			);
-		}, 0 );
-
-		// For previous quarter legacy calculations, we need to create a modified version
-		// that uses previous quarter activity window but doesn't use current quarter API data
-		const previousQuarterLegacyCommissions = getEstimatedCommission(
-			referrals.map( ( referral ) => ( {
-				...referral,
-				purchases: referral.purchases.filter( ( purchase ) => ! purchase.commissions ),
-			} ) ),
-			productsArray,
-			getNextPayoutDateActivityWindow( currentDate )
-		);
-
 		return {
-			previousQuarterExpectedCommission:
-				previousQuarterApiCommissions + previousQuarterLegacyCommissions,
-			currentQuarterExpectedCommission: currentQuarterCommissions,
+			previousQuarterExpectedCommission: getEstimatedCommission(
+				referrals,
+				productsArray,
+				getNextPayoutDateActivityWindow( currentDate ),
+				true // use previous quarter
+			),
+			currentQuarterExpectedCommission: getEstimatedCommission(
+				referrals,
+				productsArray,
+				getCurrentCycleActivityWindow( currentDate ),
+				false // use current quarter
+			),
 		};
 	}, [ referrals, products ] );
 

--- a/client/a8c-for-agencies/sections/referrals/hooks/use-get-consolidated-payout-data.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-get-consolidated-payout-data.ts
@@ -15,17 +15,39 @@ export default function useGetConsolidatedPayoutData(
 		const currentDate = new Date();
 		const productsArray = products || [];
 
+		// For current quarter: use getEstimatedCommission which handles API + legacy data
+		const currentQuarterCommissions = getEstimatedCommission(
+			referrals,
+			productsArray,
+			getCurrentCycleActivityWindow( currentDate )
+		);
+
+		// For previous quarter: we need to handle API data separately since getEstimatedCommission
+		// only handles current quarter API data
+		const previousQuarterApiCommissions = referrals.reduce( ( acc, referral ) => {
+			return (
+				acc +
+				referral.purchases.reduce( ( purchaseAcc, purchase ) => {
+					return purchaseAcc + ( purchase.commissions?.estimated_commission_previous_quarter ?? 0 );
+				}, 0 )
+			);
+		}, 0 );
+
+		// For previous quarter legacy calculations, we need to create a modified version
+		// that uses previous quarter activity window but doesn't use current quarter API data
+		const previousQuarterLegacyCommissions = getEstimatedCommission(
+			referrals.map( ( referral ) => ( {
+				...referral,
+				purchases: referral.purchases.filter( ( purchase ) => ! purchase.commissions ),
+			} ) ),
+			productsArray,
+			getNextPayoutDateActivityWindow( currentDate )
+		);
+
 		return {
-			previousQuarterExpectedCommission: getEstimatedCommission(
-				referrals,
-				productsArray,
-				getNextPayoutDateActivityWindow( currentDate )
-			),
-			currentQuarterExpectedCommission: getEstimatedCommission(
-				referrals,
-				productsArray,
-				getCurrentCycleActivityWindow( currentDate )
-			),
+			previousQuarterExpectedCommission:
+				previousQuarterApiCommissions + previousQuarterLegacyCommissions,
+			currentQuarterExpectedCommission: currentQuarterCommissions,
 		};
 	}, [ referrals, products ] );
 

--- a/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts
@@ -19,7 +19,7 @@ export const getEstimatedCommission = (
 	products: APIProductFamilyProduct[],
 	activityWindow: { start: Date; finish: Date }
 ) => {
-	const { totalCommissionsFromSubscriptions, otherCommissionsInCents } = referrals.reduce(
+	const { bdCommissions, legacyCommissionsInCents } = referrals.reduce(
 		( acc, referral ) => {
 			if ( ! referral?.purchases?.length ) {
 				return acc;
@@ -35,29 +35,21 @@ export const getEstimatedCommission = (
 					continue;
 				}
 
-				// Get commission percentage for the product (common for both subscription and license)
-				const commissionPercentage = getProductCommissionPercentage( product.family_slug );
-
-				// Day the license was issued
-				const issuedDate = new Date( purchase.license.issued_at );
-				// Set hours to 0 to compare from start of the day
-				issuedDate.setHours( 0, 0, 0, 0 );
-
-				if ( purchase.subscription ) {
-					// FIXME: We will need to find a better way to handle this
-					if (
-						issuedDate.getTime() < activityWindow.start.getTime() ||
-						issuedDate.getTime() > activityWindow.finish.getTime()
-					) {
-						continue;
-					}
-
-					const totalPrice = Number( purchase.subscription.commissionable_amount ) ?? 0;
-
-					// Add commission to subscription total (in dollars)
-					acc.totalCommissionsFromSubscriptions += totalPrice * commissionPercentage;
+				if ( purchase.commissions ) {
+					// As of Aug 2025, new client purchases will use BD for purchases
+					// In this case the estimated commission has already been calculated on the backend
+					// and we just need to add it to the total commission
+					acc.bdCommissions += purchase.commissions.estimated_commission_current_quarter ?? 0;
 				} else {
+					// Legacy approach, but we need to keep it to continue working with old data
+					// Calculate commission using the license data
 					// Day the license was revoked if present
+					// Day the license was issued
+
+					const issuedDate = new Date( purchase.license.issued_at );
+					// Set hours to 0 to compare from start of the day
+					issuedDate.setHours( 0, 0, 0, 0 );
+
 					const revokedAt = purchase.license.revoked_at
 						? new Date( purchase.license.revoked_at )
 						: null;
@@ -80,20 +72,28 @@ export const getEstimatedCommission = (
 
 					const dailyPrice = getDailyPrice( product, purchase.quantity );
 
+					// Get commission percentage for the product (common for both subscription and license)
+					const commissionPercentage = getProductCommissionPercentage( product.family_slug );
+
 					// Add commission to the total commission (in cents)
-					acc.otherCommissionsInCents += dailyPrice * totalDays * commissionPercentage;
+					acc.legacyCommissionsInCents += dailyPrice * totalDays * commissionPercentage;
 				}
 			}
 			return acc;
 		},
-		{ totalCommissionsFromSubscriptions: 0, otherCommissionsInCents: 0 }
+		{ bdCommissions: 0, legacyCommissionsInCents: 0 }
 	);
+
+	// eslint-disable-next-line no-console
+	console.log( 'Commission calculation summary:', {
+		bdCommissions,
+		legacyCommissionsInCents,
+		totalCommission: bdCommissions + legacyCommissionsInCents / 100,
+	} );
 
 	// Convert commission from cents to dollars,
 	// add subscriptions commission and round to 2 decimal places
-	const totalCommission = Number(
-		( totalCommissionsFromSubscriptions + otherCommissionsInCents / 100 ).toFixed( 2 )
-	);
+	const totalCommission = Number( ( bdCommissions + legacyCommissionsInCents / 100 ).toFixed( 2 ) );
 
 	return totalCommission;
 };

--- a/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts
@@ -19,60 +19,87 @@ export const getEstimatedCommission = (
 	products: APIProductFamilyProduct[],
 	activityWindow: { start: Date; finish: Date }
 ) => {
-	const totalCommissionInCents = referrals.reduce( ( acc, referral ) => {
-		if ( ! referral?.purchases?.length ) {
+	const { totalCommissionsFromSubscriptions, otherCommissionsInCents } = referrals.reduce(
+		( acc, referral ) => {
+			if ( ! referral?.purchases?.length ) {
+				return acc;
+			}
+			for ( const purchase of referral.purchases ) {
+				// We go over 'active' and 'cancelled' subscriptions
+				if ( ! purchase || purchase.status === 'pending' || purchase.status === 'error' ) {
+					continue;
+				}
+				// Find corresponding product for price
+				const product = products.find( ( product ) => purchase.product_id === product.product_id );
+				if ( ! product ) {
+					continue;
+				}
+
+				// Get commission percentage for the product (common for both subscription and license)
+				const commissionPercentage = getProductCommissionPercentage( product.family_slug );
+
+				// Day the license was issued
+				const issuedDate = new Date( purchase.license.issued_at );
+				// Set hours to 0 to compare from start of the day
+				issuedDate.setHours( 0, 0, 0, 0 );
+
+				if ( purchase.subscription ) {
+					if ( purchase.subscription.status !== 'active' ) {
+						continue;
+					}
+
+					// Skip if subscription started outside the activity window
+					if (
+						issuedDate.getTime() < activityWindow.start.getTime() ||
+						issuedDate.getTime() > activityWindow.finish.getTime()
+					) {
+						continue;
+					}
+
+					// FIXME: We will only consider USD price. This is just for testing
+					const totalPrice =
+						purchase.subscription.purchase_price_usd ?? purchase.subscription.purchase_price;
+
+					// Add commission to subscription total (in dollars)
+					acc.totalCommissionsFromSubscriptions += totalPrice * commissionPercentage;
+				} else {
+					// Day the license was revoked if present
+					const revokedAt = purchase.license.revoked_at
+						? new Date( purchase.license.revoked_at )
+						: null;
+
+					// Start date is the latest of the license issued date and activity window start
+					const start = Math.max( issuedDate.getTime(), activityWindow.start.getTime() );
+					// Finish date is the earliest of the license revoked date and activity window finish
+					const finish = Math.min(
+						revokedAt ? revokedAt.getTime() : Infinity,
+						activityWindow.finish.getTime()
+					);
+
+					// Total days is the difference between finish and start dates in days
+					// We add 1 to include end-to-end days
+					const totalDays = Math.floor( ( finish - start ) / ( 1000 * 60 * 60 * 24 ) ) + 1;
+
+					if ( totalDays < 1 ) {
+						continue;
+					}
+
+					const dailyPrice = getDailyPrice( product, purchase.quantity );
+
+					// Add commission to the total commission (in cents)
+					acc.otherCommissionsInCents += dailyPrice * totalDays * commissionPercentage;
+				}
+			}
 			return acc;
-		}
-		for ( const purchase of referral.purchases ) {
-			// We go over 'active' and 'cancelled' subscriptions
-			if ( ! purchase || purchase.status === 'pending' || purchase.status === 'error' ) {
-				continue;
-			}
-			// Find corresponding product for price
-			const product = products.find( ( product ) => purchase.product_id === product.product_id );
-			if ( ! product ) {
-				continue;
-			}
+		},
+		{ totalCommissionsFromSubscriptions: 0, otherCommissionsInCents: 0 }
+	);
 
-			// Day the license was issued
-			const issuedDate = new Date( purchase.license.issued_at );
-			// Set hours to 0 to compare from start of the day
-			issuedDate.setHours( 0, 0, 0, 0 );
-
-			// Day the license was revoked if present
-			const revokedAt = purchase.license.revoked_at
-				? new Date( purchase.license.revoked_at )
-				: null;
-
-			// Start date is the latest of the license issued date and activity window start
-			const start = Math.max( issuedDate.getTime(), activityWindow.start.getTime() );
-			// Finish date is the earliest of the license revoked date and activity window finish
-			const finish = Math.min(
-				revokedAt ? revokedAt.getTime() : Infinity,
-				activityWindow.finish.getTime()
-			);
-
-			// Total days is the difference between finish and start dates in days
-			// We add 1 to include end-to-end days
-			const totalDays = Math.floor( ( finish - start ) / ( 1000 * 60 * 60 * 24 ) ) + 1;
-
-			if ( totalDays < 1 ) {
-				continue;
-			}
-
-			const dailyPrice = getDailyPrice( product, purchase.quantity );
-
-			// Get commission percentage for the product
-			const commissionPercentage = getProductCommissionPercentage( product.family_slug );
-
-			// Calculate commission for the day
-			acc += dailyPrice * totalDays * commissionPercentage;
-		}
-		return acc;
-	}, 0 );
-
-	// Convert commission to dollars and round
-	const totalCommission = Number( ( totalCommissionInCents / 100 ).toFixed( 2 ) );
+	// Convert commission from cents to dollars,
+	// add subscriptions commission and round to 2 decimal places
+	const totalCommission = Number(
+		( totalCommissionsFromSubscriptions + otherCommissionsInCents / 100 ).toFixed( 2 )
+	);
 
 	return totalCommission;
 };

--- a/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts
@@ -44,11 +44,7 @@ export const getEstimatedCommission = (
 				issuedDate.setHours( 0, 0, 0, 0 );
 
 				if ( purchase.subscription ) {
-					if ( purchase.subscription.status !== 'active' ) {
-						continue;
-					}
-
-					// Skip if subscription started outside the activity window
+					// FIXME: We will need to find a better way to handle this
 					if (
 						issuedDate.getTime() < activityWindow.start.getTime() ||
 						issuedDate.getTime() > activityWindow.finish.getTime()
@@ -56,9 +52,7 @@ export const getEstimatedCommission = (
 						continue;
 					}
 
-					// FIXME: We will only consider USD price. This is just for testing
-					const totalPrice =
-						purchase.subscription.purchase_price_usd ?? purchase.subscription.purchase_price;
+					const totalPrice = Number( purchase.subscription.commissionable_amount ) ?? 0;
 
 					// Add commission to subscription total (in dollars)
 					acc.totalCommissionsFromSubscriptions += totalPrice * commissionPercentage;

--- a/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts
@@ -17,7 +17,8 @@ export const getDailyPrice = ( product: APIProductFamilyProduct, quantity: numbe
 export const getEstimatedCommission = (
 	referrals: Referral[],
 	products: APIProductFamilyProduct[],
-	activityWindow: { start: Date; finish: Date }
+	activityWindow: { start: Date; finish: Date },
+	usePreviousQuarter: boolean = false
 ) => {
 	const { bdCommissions, legacyCommissionsInCents } = referrals.reduce(
 		( acc, referral ) => {
@@ -39,7 +40,10 @@ export const getEstimatedCommission = (
 					// As of Aug 2025, new client purchases will use BD for purchases
 					// In this case the estimated commission has already been calculated on the backend
 					// and we just need to add it to the total commission
-					acc.bdCommissions += purchase.commissions.estimated_commission_current_quarter ?? 0;
+					const commissionAmount = usePreviousQuarter
+						? purchase.commissions.estimated_commission_previous_quarter ?? 0
+						: purchase.commissions.estimated_commission_current_quarter ?? 0;
+					acc.bdCommissions += commissionAmount;
 				} else {
 					// Legacy approach, but we need to keep it to continue working with old data
 					// Calculate commission using the license data
@@ -83,13 +87,6 @@ export const getEstimatedCommission = (
 		},
 		{ bdCommissions: 0, legacyCommissionsInCents: 0 }
 	);
-
-	// eslint-disable-next-line no-console
-	console.log( 'Commission calculation summary:', {
-		bdCommissions,
-		legacyCommissionsInCents,
-		totalCommission: bdCommissions + legacyCommissionsInCents / 100,
-	} );
 
 	// Convert commission from cents to dollars,
 	// add subscriptions commission and round to 2 decimal places

--- a/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts
@@ -30,12 +30,6 @@ export const getEstimatedCommission = (
 				if ( ! purchase || purchase.status === 'pending' || purchase.status === 'error' ) {
 					continue;
 				}
-				// Find corresponding product for price
-				const product = products.find( ( product ) => purchase.product_id === product.product_id );
-				if ( ! product ) {
-					continue;
-				}
-
 				if ( purchase.commissions ) {
 					// As of Aug 2025, new client purchases will use BD for purchases
 					// In this case the estimated commission has already been calculated on the backend
@@ -47,13 +41,21 @@ export const getEstimatedCommission = (
 				} else {
 					// Legacy approach, but we need to keep it to continue working with old data
 					// Calculate commission using the license data
-					// Day the license was revoked if present
-					// Day the license was issued
 
+					// For legacy calculations, we need to find the corresponding product
+					const product = products.find(
+						( product ) => purchase.product_id === product.product_id
+					);
+					if ( ! product ) {
+						continue;
+					}
+
+					// Day the license was issued
 					const issuedDate = new Date( purchase.license.issued_at );
 					// Set hours to 0 to compare from start of the day
 					issuedDate.setHours( 0, 0, 0, 0 );
 
+					// Day the license was revoked if present
 					const revokedAt = purchase.license.revoked_at
 						? new Date( purchase.license.revoked_at )
 						: null;

--- a/client/a8c-for-agencies/sections/referrals/lib/test/get-estimated-commission.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/test/get-estimated-commission.ts
@@ -244,6 +244,7 @@ describe( 'get-estimated-commission', () => {
 		it( 'uses API commissions data when available', () => {
 			const referrals: Referral[] = [
 				{
+					client: { id: 1, email: 'test@example.com' },
 					purchaseStatuses: [ 'active' ],
 					referralStatuses: [ 'active' ],
 					purchases: [
@@ -263,6 +264,7 @@ describe( 'get-estimated-commission', () => {
 					],
 				} as never,
 				{
+					client: { id: 2, email: 'test2@example.com' },
 					purchaseStatuses: [ 'active' ],
 					referralStatuses: [ 'active' ],
 					purchases: [
@@ -284,14 +286,20 @@ describe( 'get-estimated-commission', () => {
 			];
 
 			// Should use the sum of current quarter commissions from API
-			expect( getEstimatedCommission( referrals, [ mockProduct ], mockActivityWindow ) ).toBe(
-				350
+			expect(
+				getEstimatedCommission( referrals, [ mockProduct ], mockActivityWindow, false )
+			).toBe( 350 );
+
+			// Should use the sum of previous quarter commissions from API
+			expect( getEstimatedCommission( referrals, [ mockProduct ], mockActivityWindow, true ) ).toBe(
+				175
 			);
 		} );
 
 		it( 'combines API commissions with calculated commissions', () => {
 			const referrals: Referral[] = [
 				{
+					client: { id: 1, email: 'test@example.com' },
 					purchaseStatuses: [ 'active' ],
 					referralStatuses: [ 'active' ],
 					purchases: [
@@ -311,6 +319,7 @@ describe( 'get-estimated-commission', () => {
 					],
 				} as never,
 				{
+					client: { id: 2, email: 'test2@example.com' },
 					purchaseStatuses: [ 'active' ],
 					referralStatuses: [ 'active' ],
 					purchases: [
@@ -329,8 +338,13 @@ describe( 'get-estimated-commission', () => {
 			];
 
 			// Should combine API commissions (150) + calculated commissions (15.5) = 165.5
-			expect( getEstimatedCommission( referrals, [ mockProduct ], mockActivityWindow ) ).toBe(
-				165.5
+			expect(
+				getEstimatedCommission( referrals, [ mockProduct ], mockActivityWindow, false )
+			).toBe( 165.5 );
+
+			// Should combine API commissions (75) + calculated commissions (15.5) = 90.5
+			expect( getEstimatedCommission( referrals, [ mockProduct ], mockActivityWindow, true ) ).toBe(
+				90.5
 			);
 		} );
 

--- a/client/a8c-for-agencies/sections/referrals/lib/test/get-estimated-commission.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/test/get-estimated-commission.ts
@@ -240,5 +240,138 @@ describe( 'get-estimated-commission', () => {
 				13.95
 			);
 		} );
+
+		it( 'uses API commissions data when available', () => {
+			const referrals: Referral[] = [
+				{
+					purchaseStatuses: [ 'active' ],
+					referralStatuses: [ 'active' ],
+					purchases: [
+						{
+							product_id: 1,
+							status: 'active',
+							quantity: 1,
+							license: {
+								issued_at: '2024-03-01T00:00:00Z',
+								revoked_at: null,
+							},
+							commissions: {
+								estimated_commission_current_quarter: 150,
+								estimated_commission_previous_quarter: 75,
+							},
+						},
+					],
+				} as never,
+				{
+					purchaseStatuses: [ 'active' ],
+					referralStatuses: [ 'active' ],
+					purchases: [
+						{
+							product_id: 1,
+							status: 'active',
+							quantity: 1,
+							license: {
+								issued_at: '2024-03-01T00:00:00Z',
+								revoked_at: null,
+							},
+							commissions: {
+								estimated_commission_current_quarter: 200,
+								estimated_commission_previous_quarter: 100,
+							},
+						},
+					],
+				} as never,
+			];
+
+			// Should use the sum of current quarter commissions from API
+			expect( getEstimatedCommission( referrals, [ mockProduct ], mockActivityWindow ) ).toBe(
+				350
+			);
+		} );
+
+		it( 'combines API commissions with calculated commissions', () => {
+			const referrals: Referral[] = [
+				{
+					purchaseStatuses: [ 'active' ],
+					referralStatuses: [ 'active' ],
+					purchases: [
+						{
+							product_id: 1,
+							status: 'active',
+							quantity: 1,
+							license: {
+								issued_at: '2024-03-01T00:00:00Z',
+								revoked_at: null,
+							},
+							commissions: {
+								estimated_commission_current_quarter: 150,
+								estimated_commission_previous_quarter: 75,
+							},
+						},
+					],
+				} as never,
+				{
+					purchaseStatuses: [ 'active' ],
+					referralStatuses: [ 'active' ],
+					purchases: [
+						{
+							product_id: 1,
+							status: 'active',
+							quantity: 1,
+							license: {
+								issued_at: '2024-03-01T00:00:00Z',
+								revoked_at: null,
+							},
+							// Missing commissions data - will be calculated
+						},
+					],
+				} as never,
+			];
+
+			// Should combine API commissions (150) + calculated commissions (15.5) = 165.5
+			expect( getEstimatedCommission( referrals, [ mockProduct ], mockActivityWindow ) ).toBe(
+				165.5
+			);
+		} );
+
+		it( 'falls back to calculation when no referrals have commissions data', () => {
+			const referrals: Referral[] = [
+				{
+					purchaseStatuses: [ 'active' ],
+					referralStatuses: [ 'active' ],
+					purchases: [
+						{
+							product_id: 1,
+							status: 'active',
+							quantity: 1,
+							license: {
+								issued_at: '2024-03-01T00:00:00Z',
+								revoked_at: null,
+							},
+						},
+					],
+				} as never,
+				{
+					purchaseStatuses: [ 'active' ],
+					referralStatuses: [ 'active' ],
+					purchases: [
+						{
+							product_id: 1,
+							status: 'active',
+							quantity: 1,
+							license: {
+								issued_at: '2024-03-01T00:00:00Z',
+								revoked_at: null,
+							},
+						},
+					],
+				} as never,
+			];
+
+			// Should fall back to calculation method
+			// 31 days * $100 daily price * 50% commission * 2 referrals = 3100 cents
+			// Convert to dollars by dividing by 100
+			expect( getEstimatedCommission( referrals, [ mockProduct ], mockActivityWindow ) ).toBe( 31 );
+		} );
 	} );
 } );

--- a/client/a8c-for-agencies/sections/referrals/types.ts
+++ b/client/a8c-for-agencies/sections/referrals/types.ts
@@ -15,6 +15,10 @@ interface ReferralPurchaseAPIResponse {
 		purchase_currency: string;
 		billing_interval_unit: string;
 	};
+	commissions?: {
+		estimated_commission_current_quarter: number;
+		estimated_commission_previous_quarter: number;
+	};
 }
 export interface ReferralPurchase extends ReferralPurchaseAPIResponse {
 	status: string;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Linear issue: https://linear.app/a8c/issue/A4A-1327/incorporate-bd-purchases-into-estimated-commission-payout

## Proposed Changes

* Use the new purchase commissions property returned from the referrals endpoint if it exists for a referral. If it doesn't exist continue to use the old commission calculation logic. Totals should combine referral from both sources.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To show accurate commissions estimates to agencies whose clients purchase using the new BD-powered checkout.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test with this backend PR and do the few setup steps mentioned there: 188937-ghe-Automattic/wpcom/files
* It's easiest to test using a new agency and new clients. That way manually calculating amounts will be easier. But it depends how many clients and referrals your agency has.
* Send some referrals of different products to a client and complete the purchases as the client in the new  `/v2` checkout (see 188433-ghe-Automattic/wpcom for how to use v2).
* As the agency, visit `/referrals/dashboard`
* Check the commission estimates in a few different place and make sure they add up correctly.
  * Products should use a 50% commission rate and hosting should use a 20% commission rate.
* Places to check:
  * On the dashboard, the "Estimate Commissions" column adds up to the "Estimated earnings in current quarter"
  <img width="1883" height="789" alt="Screenshot 2025-07-29 at 11 20 22 AM" src="https://github.com/user-attachments/assets/63bbd774-ff70-4d7a-af1c-90c1636f7f88" />

  * Select a client that has BD purchases and check the "Purchases" tab. Calculate the expected commission and make sure it matches the amount on the "Commissions" tab.
  <img width="1872" height="817" alt="Screenshot 2025-07-28 at 6 29 36 PM" src="https://github.com/user-attachments/assets/270a8e80-dbaa-4924-aff6-a018e04372bd" />
  <img width="1872" height="410" alt="Screenshot 2025-07-28 at 6 58 25 PM" src="https://github.com/user-attachments/assets/fa0f249f-c677-485a-9a04-0d30108a41a9" />

* Check a client that has only used the old (non-v2) checkout. The amounts shown should be the same as on production.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?