### PR TITLE
Revert "Revert "Clean up deprecation and otherwise problematic warnings from scan dashboard""

### DIFF
--- a/client/components/jetpack/scan-threats/index.tsx
+++ b/client/components/jetpack/scan-threats/index.tsx
@@ -124,9 +124,13 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 		triggerScanRun( site.ID )( dispatch );
 	}, [ dispatch, site ] );
 
-	const allFixableThreats = threats.filter(
-		( threat ): threat is FixableThreat =>
-			threat.fixable !== false && threat.fixerStatus !== 'in_progress'
+	const allFixableThreats = React.useMemo(
+		() =>
+			threats.filter(
+				( threat ): threat is FixableThreat =>
+					threat.fixable !== false && threat.fixerStatus !== 'in_progress'
+			),
+		[ threats ]
 	);
 	const hasFixableThreats = !! allFixableThreats.length;
 
@@ -185,15 +189,24 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 		[ updatingThreats ]
 	);
 
-	const maxSeverity = threats.reduce( ( max, threat ) => Math.max( max, threat.severity ), 0 );
-	const countMap = {
-		low: threats.filter( ( threat ) => threat.severity < 3 ).length,
-		high: threats.filter( ( threat ) => threat.severity >= 3 ).length,
-	};
-	const countMapFixable = {
-		low: allFixableThreats.filter( ( threat ) => threat.severity < 3 ).length,
-		high: allFixableThreats.filter( ( threat ) => threat.severity >= 3 ).length,
-	};
+	const maxSeverity = React.useMemo(
+		() => threats.reduce( ( max, threat ) => Math.max( max, threat.severity ), 0 ),
+		[ threats ]
+	);
+	const countMap = React.useMemo(
+		() => ( {
+			low: threats.filter( ( threat ) => threat.severity < 3 ).length,
+			high: threats.filter( ( threat ) => threat.severity >= 3 ).length,
+		} ),
+		[ threats ]
+	);
+	const countMapFixable = React.useMemo(
+		() => ( {
+			low: allFixableThreats.filter( ( threat ) => threat.severity < 3 ).length,
+			high: allFixableThreats.filter( ( threat ) => threat.severity >= 3 ).length,
+		} ),
+		[ allFixableThreats ]
+	);
 
 	const headerSummary = getThreatCountMessage(
 		countMap.high,
@@ -216,10 +229,17 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 		securityIcon = 'okay';
 	}
 
-	const highSeverityThreats = threats
-		.filter( ( threat ) => threat.severity >= 3 )
-		.sort( ( a, b ) => b.severity - a.severity );
-	const lowSeverityThreats = threats.filter( ( threat ) => threat.severity < 3 );
+	const highSeverityThreats = React.useMemo(
+		() =>
+			threats
+				.filter( ( threat ) => threat.severity >= 3 )
+				.sort( ( a, b ) => b.severity - a.severity ),
+		[ threats ]
+	);
+	const lowSeverityThreats = React.useMemo(
+		() => threats.filter( ( threat ) => threat.severity < 3 ),
+		[ threats ]
+	);
 
 	return (
 		<>

--- a/client/components/jetpack/security-icon/index.tsx
+++ b/client/components/jetpack/security-icon/index.tsx
@@ -7,12 +7,12 @@ import infoIcon from './images/security-info.svg';
 import okayIcon from './images/security-okay.svg';
 
 interface Props {
-	icon: string;
+	icon?: string;
 	className?: string;
 }
 
 function SecurityIcon( props: Props ) {
-	const { icon, className } = props;
+	const { icon = 'success', className } = props;
 
 	let iconPath;
 	switch ( icon ) {
@@ -46,9 +46,5 @@ function SecurityIcon( props: Props ) {
 		/>
 	);
 }
-
-SecurityIcon.defaultProps = {
-	icon: 'success',
-};
 
 export default SecurityIcon;

--- a/client/components/jetpack/threat-history-list/index.tsx
+++ b/client/components/jetpack/threat-history-list/index.tsx
@@ -5,6 +5,7 @@ import { useCallback, useMemo, useState } from 'react';
 import * as React from 'react';
 import QueryJetpackScanHistory from 'calypso/components/data/query-jetpack-scan-history';
 import QueryJetpackScanThreatCounts from 'calypso/components/data/query-jetpack-scan-threat-counts';
+import { Threat } from 'calypso/components/jetpack/threat-item/types';
 import ThreatListHeader from 'calypso/components/jetpack/threat-list-header';
 import Pagination from 'calypso/components/pagination';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -80,7 +81,7 @@ const ThreatHistoryList: React.FC< ThreatHistoryListProps > = ( { filter } ) => 
 		isRequestingJetpackScanHistory( state, siteId )
 	);
 
-	const threats = useSelector( ( state ) => getSiteScanHistory( state, siteId ) );
+	const threats = useSelector( ( state ) => getSiteScanHistory( state, siteId ) as Threat[] );
 	const [ currentPage, setCurrentPage ] = useState( 1 );
 	const showPagination = ! isRequestingThreatCounts && filteredThreatCount > THREATS_PER_PAGE;
 

--- a/client/components/section-nav/tabs.jsx
+++ b/client/components/section-nav/tabs.jsx
@@ -7,7 +7,6 @@ import { createRef, Children, cloneElement, Component } from 'react';
 import ReactDom from 'react-dom';
 import TranslatableString from 'calypso/components/translatable/proptype';
 import afterLayoutFlush from 'calypso/lib/after-layout-flush';
-
 import './tabs.scss';
 
 /**

--- a/client/lib/jetpack/use-threats.ts
+++ b/client/lib/jetpack/use-threats.ts
@@ -12,7 +12,21 @@ import getSiteScanUpdatingThreats from 'calypso/state/selectors/get-site-scan-up
 
 export const useThreats = ( siteId: number ) => {
 	const [ selectedThreat, setSelectedThreat ] = useState< Threat >();
-	const updatingThreats = useSelector( ( state ) => getSiteScanUpdatingThreats( state, siteId ) );
+	const updatingThreats = useSelector(
+		( state ) => {
+			return getSiteScanUpdatingThreats( state, siteId );
+		},
+		( a, b ) => {
+			// Compare arrays by reference first, then by contents
+			if ( a === b ) {
+				return true;
+			}
+			if ( ! a || ! b || a.length !== b.length ) {
+				return false;
+			}
+			return a.every( ( val, idx ) => val === b[ idx ] );
+		}
+	);
 	const dispatch = useDispatch();
 
 	const updateThreat = useCallback(

--- a/client/state/selectors/get-site-scan-history.js
+++ b/client/state/selectors/get-site-scan-history.js
@@ -1,3 +1,4 @@
+import { createSelector } from '@automattic/state-utils';
 import { get } from 'lodash';
 
 import 'calypso/state/data-layer/wpcom/sites/scan';
@@ -9,6 +10,7 @@ import 'calypso/state/data-layer/wpcom/sites/scan';
  * @param  {number}   siteId   The ID of the site we're querying
  * @returns {import('calypso/components/jetpack/threat-item/types').Threat[]} Array of threats found
  */
-export default function getSiteScanHistory( state, siteId ) {
-	return get( state, [ 'jetpackScan', 'history', 'data', siteId, 'threats' ], [] );
-}
+export default createSelector(
+	( state, siteId ) => get( state, [ 'jetpackScan', 'history', 'data', siteId, 'threats' ], [] ),
+	( state, siteId ) => [ state.jetpackScan?.history?.data?.[ siteId ]?.threats ]
+);

--- a/client/state/selectors/get-site-scan-threat-counts.ts
+++ b/client/state/selectors/get-site-scan-threat-counts.ts
@@ -1,3 +1,4 @@
+import { createSelector } from '@automattic/state-utils';
 import { AppState } from 'calypso/types';
 
 import 'calypso/state/data-layer/wpcom/sites/scan';
@@ -25,9 +26,9 @@ const NO_INFO: JetpackScanThreatCounts = {};
  * @param  {number}   siteId   		The ID of the site we're querying
  * @returns {JetpackScanThreatCounts} Threat counts, by status
  */
-export default function getSiteScanThreatCounts(
-	state: AppState,
-	siteId: number
-): JetpackScanThreatCounts {
-	return state.jetpackScan.threatCounts.data?.[ siteId ] || NO_INFO;
-}
+export default createSelector(
+	( state: AppState, siteId: number ): JetpackScanThreatCounts => {
+		return state.jetpackScan.threatCounts.data?.[ siteId ] || NO_INFO;
+	},
+	( state: AppState, siteId: number ) => [ state.jetpackScan?.threatCounts?.data?.[ siteId ] ]
+);

--- a/client/state/selectors/is-requesting-jetpack-scan-history.js
+++ b/client/state/selectors/is-requesting-jetpack-scan-history.js
@@ -1,3 +1,4 @@
+import { createSelector } from '@automattic/state-utils';
 import { get } from 'lodash';
 
 import 'calypso/state/data-layer/wpcom/sites/scan/history';
@@ -9,6 +10,8 @@ import 'calypso/state/data-layer/wpcom/sites/scan/history';
  * @param  {number}   siteId   The ID of the site we're querying
  * @returns {?boolean}          Whether the connection data is being requested
  */
-export default function isRequestingJetpackScanHistory( state, siteId ) {
-	return get( state.jetpackScan.history.requestStatus, [ siteId ], false ) === 'pending';
-}
+export default createSelector(
+	( state, siteId ) =>
+		get( state.jetpackScan.history.requestStatus, [ siteId ], false ) === 'pending',
+	( state, siteId ) => [ state.jetpackScan?.history?.requestStatus?.[ siteId ] ]
+);

--- a/client/state/selectors/is-requesting-jetpack-scan-threat-counts.js
+++ b/client/state/selectors/is-requesting-jetpack-scan-threat-counts.js
@@ -1,3 +1,5 @@
+import { createSelector } from '@automattic/state-utils';
+
 import 'calypso/state/data-layer/wpcom/sites/scan/threat-counts';
 
 /**
@@ -7,6 +9,7 @@ import 'calypso/state/data-layer/wpcom/sites/scan/threat-counts';
  * @param  {number}   siteId   The ID of the site we're querying
  * @returns {?boolean}          Whether the connection data is being requested
  */
-export default function isRequestingJetpackScanThreatCounts( state, siteId ) {
-	return state.jetpackScan.threatCounts.requestStatus?.[ siteId ] === 'pending';
-}
+export default createSelector(
+	( state, siteId ) => state.jetpackScan.threatCounts.requestStatus?.[ siteId ] === 'pending',
+	( state, siteId ) => [ state.jetpackScan?.threatCounts?.requestStatus?.[ siteId ] ]
+);


### PR DESCRIPTION
Reverts Automattic/wp-calypso#104886 - the issue with the tests was totally unrelated to this PR, so no actual need to revert it in the first place.