### PR TITLE
Update several `FormLabel`s to sentence case

### DIFF
--- a/client/components/domains/registrant-extra-info/fr-form.tsx
+++ b/client/components/domains/registrant-extra-info/fr-form.tsx
@@ -255,7 +255,7 @@ class RegistrantExtraInfoFrForm extends PureComponent< FormProps & LocalizeProps
 			<div>
 				<FormFieldset>
 					<FormLabel className="registrant-extra-info__organization" htmlFor="organization">
-						{ translate( 'Organization Name' ) }
+						{ translate( 'Organization name' ) }
 					</FormLabel>
 					<FormTextInput
 						id="organization"
@@ -272,7 +272,7 @@ class RegistrantExtraInfoFrForm extends PureComponent< FormProps & LocalizeProps
 
 				<FormFieldset>
 					<FormLabel htmlFor="registrantVatId" optional>
-						{ translate( 'VAT Number' ) }
+						{ translate( 'VAT number' ) }
 					</FormLabel>
 					<FormTextInput
 						id="registrantVatId"
@@ -289,7 +289,7 @@ class RegistrantExtraInfoFrForm extends PureComponent< FormProps & LocalizeProps
 
 				<FormFieldset>
 					<FormLabel htmlFor="sirenSiret" optional>
-						{ translate( 'SIREN or SIRET Number' ) }
+						{ translate( 'SIREN or SIRET number' ) }
 					</FormLabel>
 					<FormTextInput
 						id="sirenSiret"
@@ -310,7 +310,7 @@ class RegistrantExtraInfoFrForm extends PureComponent< FormProps & LocalizeProps
 
 				<FormFieldset>
 					<FormLabel htmlFor="trademarkNumber" optional>
-						{ translate( 'EU Trademark Number' ) }
+						{ translate( 'EU trademark number' ) }
 					</FormLabel>
 					<FormTextInput
 						id="trademarkNumber"

--- a/client/components/domains/registrant-extra-info/uk-form.tsx
+++ b/client/components/domains/registrant-extra-info/uk-form.tsx
@@ -111,7 +111,7 @@ export class RegistrantExtraInfoUkForm extends PureComponent< FormProps & Locali
 			<div>
 				<FormFieldset>
 					<FormLabel className="registrant-extra-info__trading-name" htmlFor="trading-name">
-						{ translate( 'Trading Name' ) }
+						{ translate( 'Trading name' ) }
 					</FormLabel>
 					<FormTextInput
 						id="trading-name"
@@ -147,7 +147,7 @@ export class RegistrantExtraInfoUkForm extends PureComponent< FormProps & Locali
 						className="registrant-extra-info__registration-number"
 						htmlFor="registration-number"
 					>
-						{ translate( 'Registration Number' ) }
+						{ translate( 'Registration number' ) }
 					</FormLabel>
 					<FormTextInput
 						id="registration-number"

--- a/client/components/forms/docs/example.jsx
+++ b/client/components/forms/docs/example.jsx
@@ -192,7 +192,7 @@ class FormFields extends PureComponent {
 					</FormFieldset>
 
 					<FormFieldset>
-						<FormLabel htmlFor="username">Disabled Form Text Input</FormLabel>
+						<FormLabel htmlFor="username">Disabled form text input</FormLabel>
 						<FormTextInput
 							id="username"
 							name="username"
@@ -202,7 +202,7 @@ class FormFields extends PureComponent {
 					</FormFieldset>
 
 					<FormFieldset>
-						<FormLabel htmlFor="username">Form Text Input</FormLabel>
+						<FormLabel htmlFor="username">Form text input</FormLabel>
 						<FormTextInput id="username" name="username" placeholder="Placeholder text..." />
 						<FormSettingExplanation>
 							This is an explanation of FormTextInput.
@@ -210,7 +210,7 @@ class FormFields extends PureComponent {
 					</FormFieldset>
 
 					<FormFieldset>
-						<FormLabel htmlFor="text_valid">Form Text Input</FormLabel>
+						<FormLabel htmlFor="text_valid">Form text input</FormLabel>
 						<FormTextInput
 							autoCapitalize="off"
 							autoComplete="off"
@@ -224,7 +224,7 @@ class FormFields extends PureComponent {
 					</FormFieldset>
 
 					<FormFieldset>
-						<FormLabel htmlFor="text_invalid">Form Text Input</FormLabel>
+						<FormLabel htmlFor="text_invalid">Form text input</FormLabel>
 						<FormTextInput
 							autoCapitalize="off"
 							autoComplete="off"
@@ -238,7 +238,7 @@ class FormFields extends PureComponent {
 					</FormFieldset>
 
 					<FormFieldset>
-						<FormLabel htmlFor="text_with_affixes">Form Text Input With Action</FormLabel>
+						<FormLabel htmlFor="text_with_affixes">Form text input with action</FormLabel>
 						<FormTextInputWithAction
 							placeholder="Enter a name for your site"
 							action="Continue"
@@ -251,7 +251,7 @@ class FormFields extends PureComponent {
 					</FormFieldset>
 
 					<FormFieldset>
-						<FormLabel htmlFor="text_with_affixes">Form Text Input With Affixes</FormLabel>
+						<FormLabel htmlFor="text_with_affixes">Form text input with affixes</FormLabel>
 						<FormTextInputWithAffixes
 							id="text_with_affixes"
 							placeholder="Placeholder text..."
@@ -261,7 +261,7 @@ class FormFields extends PureComponent {
 					</FormFieldset>
 
 					<FormFieldset>
-						<FormLabel htmlFor="select">Form Select</FormLabel>
+						<FormLabel htmlFor="select">Form select</FormLabel>
 						<FormSelect id="select">
 							<option>1</option>
 							<option>2</option>
@@ -278,7 +278,7 @@ class FormFields extends PureComponent {
 					</FormFieldset>
 
 					<FormFieldset>
-						<FormLabel htmlFor="password">Form Password Input</FormLabel>
+						<FormLabel htmlFor="password">Form password input</FormLabel>
 						<FormPasswordInput id="password" name="password" />
 					</FormFieldset>
 
@@ -301,7 +301,7 @@ class FormFields extends PureComponent {
 					<FormSectionHeading>Form Section Heading</FormSectionHeading>
 
 					<FormFieldset>
-						<FormLabel htmlFor="country_code">Form Country Select</FormLabel>
+						<FormLabel htmlFor="country_code">Form country select</FormLabel>
 						<QuerySmsCountries />
 						<FormCountrySelect
 							name="country_code"
@@ -311,7 +311,7 @@ class FormFields extends PureComponent {
 					</FormFieldset>
 
 					<FormFieldset>
-						<FormLabel htmlFor="us_state">Form US State Select</FormLabel>
+						<FormLabel htmlFor="us_state">Form US state select</FormLabel>
 						<FormStateSelector name="us_state" id="us_state" />
 					</FormFieldset>
 
@@ -365,12 +365,12 @@ class FormFields extends PureComponent {
 					</FormFieldset>
 
 					<FormFieldset>
-						<FormLabel htmlFor="telInput">Form Tel Input</FormLabel>
+						<FormLabel htmlFor="telInput">Form tel input</FormLabel>
 						<FormTelInput name="telInput" id="telInput" placeholder="Placeholder text..." />
 					</FormFieldset>
 
 					<FormFieldset>
-						<FormLabel htmlFor="telInput_valid">Form Tel Input</FormLabel>
+						<FormLabel htmlFor="telInput_valid">Form tel input</FormLabel>
 						<FormTelInput
 							name="telInput"
 							id="telInput_valid"
@@ -381,7 +381,7 @@ class FormFields extends PureComponent {
 					</FormFieldset>
 
 					<FormFieldset>
-						<FormLabel htmlFor="telInput_error">Form Tel Input</FormLabel>
+						<FormLabel htmlFor="telInput_error">Form tel input</FormLabel>
 						<FormTelInput
 							name="telInput"
 							id="telInput_error"
@@ -392,7 +392,7 @@ class FormFields extends PureComponent {
 					</FormFieldset>
 
 					<FormFieldset>
-						<FormLabel>Form Phone Input</FormLabel>
+						<FormLabel>Form phone input</FormLabel>
 						<FormPhoneInput
 							initialCountryCode="US"
 							initialPhoneNumber="8772733049"
@@ -401,7 +401,7 @@ class FormFields extends PureComponent {
 					</FormFieldset>
 
 					<FormFieldset>
-						<FormLabel>Form Media Phone Input</FormLabel>
+						<FormLabel>Form media phone input</FormLabel>
 						<PhoneInput
 							value={ {
 								phoneNumber: this.state.phoneInput.value,
@@ -413,7 +413,7 @@ class FormFields extends PureComponent {
 					</FormFieldset>
 
 					<FormFieldset>
-						<FormLabel htmlFor="currency_input">Form Currency Input</FormLabel>
+						<FormLabel htmlFor="currency_input">Form currency input</FormLabel>
 						<FormCurrencyInput
 							name="currency_input"
 							id="currency_input"
@@ -423,7 +423,7 @@ class FormFields extends PureComponent {
 					</FormFieldset>
 
 					<FormFieldset>
-						<FormLabel htmlFor="currency_input_valid">Form Currency Input</FormLabel>
+						<FormLabel htmlFor="currency_input_valid">Form currency input</FormLabel>
 						<FormCurrencyInput
 							name="currency_input"
 							id="currency_input_valid"
@@ -435,7 +435,7 @@ class FormFields extends PureComponent {
 					</FormFieldset>
 
 					<FormFieldset>
-						<FormLabel htmlFor="currency_input_error">Form Currency Input</FormLabel>
+						<FormLabel htmlFor="currency_input_error">Form currency input</FormLabel>
 						<FormCurrencyInput
 							name="currency_input"
 							id="currency_input_error"
@@ -447,7 +447,7 @@ class FormFields extends PureComponent {
 					</FormFieldset>
 
 					<FormFieldset>
-						<FormLabel htmlFor="currency_input_editable">Editable Form Currency Input</FormLabel>
+						<FormLabel htmlFor="currency_input_editable">Editable form currency input</FormLabel>
 						<FormCurrencyInput
 							name="currency_input_editable"
 							id="currency_input_editable"
@@ -462,7 +462,7 @@ class FormFields extends PureComponent {
 
 					<FormFieldset>
 						<FormLabel htmlFor="currency_input_editable">
-							Editable Form Currency Input (customized list)
+							Editable form currency input (customized list)
 						</FormLabel>
 						<FormCurrencyInput
 							name="currency_input_editable"
@@ -477,12 +477,12 @@ class FormFields extends PureComponent {
 					</FormFieldset>
 
 					<FormFieldset>
-						<FormLabel htmlFor="textarea">Form Textarea</FormLabel>
+						<FormLabel htmlFor="textarea">Form textarea</FormLabel>
 						<FormTextarea name="textarea" id="textarea" placeholder="Placeholder text..." />
 					</FormFieldset>
 
 					<FormFieldset>
-						<FormLabel htmlFor="textarea_valid">Form Textarea</FormLabel>
+						<FormLabel htmlFor="textarea_valid">Form textarea</FormLabel>
 						<FormTextarea
 							name="textarea"
 							id="textarea_valid"
@@ -493,7 +493,7 @@ class FormFields extends PureComponent {
 					</FormFieldset>
 
 					<FormFieldset>
-						<FormLabel htmlFor="textarea_error">Form Textarea</FormLabel>
+						<FormLabel htmlFor="textarea_error">Form textarea</FormLabel>
 						<FormTextarea
 							name="textarea"
 							id="textarea_error"

--- a/client/components/jetpack/server-credentials-form/index.jsx
+++ b/client/components/jetpack/server-credentials-form/index.jsx
@@ -38,7 +38,7 @@ const ServerCredentialsForm = ( {
 	return (
 		<div className="server-credentials-form">
 			<FormFieldset>
-				<FormLabel htmlFor="protocol-type">{ translate( 'Credential Type' ) }</FormLabel>
+				<FormLabel htmlFor="protocol-type">{ translate( 'Credential type' ) }</FormLabel>
 				<FormSelect
 					name="protocol"
 					id="protocol-type"
@@ -54,7 +54,7 @@ const ServerCredentialsForm = ( {
 			<div className="server-credentials-form__row">
 				<FormFieldset className="server-credentials-form__server-address">
 					<FormLabel htmlFor="host-address">
-						{ labels.host || translate( 'Server Address' ) }
+						{ labels.host || translate( 'Server address' ) }
 					</FormLabel>
 					<FormTextInput
 						name="host"
@@ -69,7 +69,7 @@ const ServerCredentialsForm = ( {
 				</FormFieldset>
 
 				<FormFieldset className="server-credentials-form__port-number">
-					<FormLabel htmlFor="server-port">{ labels.port || translate( 'Port Number' ) }</FormLabel>
+					<FormLabel htmlFor="server-port">{ labels.port || translate( 'Port number' ) }</FormLabel>
 					<FormTextInput
 						name="port"
 						id="server-port"
@@ -138,7 +138,7 @@ const ServerCredentialsForm = ( {
 			</FormFieldset>
 
 			<FormFieldset className="server-credentials-form__kpri">
-				<FormLabel htmlFor="private-key">{ labels.kpri || translate( 'Private Key' ) }</FormLabel>
+				<FormLabel htmlFor="private-key">{ labels.kpri || translate( 'Private key' ) }</FormLabel>
 				<FormTextArea
 					name="kpri"
 					id="private-key"

--- a/client/components/line-chart/docs/example.js
+++ b/client/components/line-chart/docs/example.js
@@ -103,7 +103,7 @@ export default class LineChartExample extends Component {
 				{ this.state.showDataControls && (
 					<div>
 						<FormLabel>
-							Data Min
+							Data min
 							<FormTextInput
 								type="number"
 								value={ this.state.dataMin }
@@ -113,7 +113,7 @@ export default class LineChartExample extends Component {
 						</FormLabel>
 
 						<FormLabel>
-							Data Max
+							Data max
 							<FormTextInput
 								type="number"
 								value={ this.state.dataMax }
@@ -123,7 +123,7 @@ export default class LineChartExample extends Component {
 						</FormLabel>
 
 						<FormLabel>
-							Series Length
+							Series length
 							<FormTextInput
 								type="number"
 								value={ this.state.seriesLength }
@@ -138,7 +138,7 @@ export default class LineChartExample extends Component {
 									checked={ this.state.fillArea }
 									onChange={ this.toggleFillArea }
 								/>
-								Fill Area
+								Fill area
 							</FormLabel>
 						</div>
 					</div>

--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -159,7 +159,7 @@ export class RewindCredentialsForm extends Component {
 					</div>
 				) }
 				<FormFieldset>
-					<FormLabel htmlFor="protocol-type">{ translate( 'Credential Type' ) }</FormLabel>
+					<FormLabel htmlFor="protocol-type">{ translate( 'Credential type' ) }</FormLabel>
 					<FormSelect
 						name="protocol"
 						id="protocol-type"
@@ -175,7 +175,7 @@ export class RewindCredentialsForm extends Component {
 				<div className="rewind-credentials-form__row">
 					<FormFieldset className="rewind-credentials-form__server-address">
 						<FormLabel htmlFor="host-address">
-							{ labels.host || translate( 'Server Address' ) }
+							{ labels.host || translate( 'Server address' ) }
 						</FormLabel>
 						<FormTextInput
 							name="host"
@@ -191,7 +191,7 @@ export class RewindCredentialsForm extends Component {
 
 					<FormFieldset className="rewind-credentials-form__port-number">
 						<FormLabel htmlFor="server-port">
-							{ labels.port || translate( 'Port Number' ) }
+							{ labels.port || translate( 'Port number' ) }
 						</FormLabel>
 						<FormTextInput
 							name="port"

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -614,7 +614,7 @@ export class JetpackAuthorize extends Component {
 		const { authorizeError } = this.props.authorizationData;
 		return (
 			<div className="jetpack-connect__error-details">
-				<FormLabel>{ this.props.translate( 'Error Details' ) }</FormLabel>
+				<FormLabel>{ this.props.translate( 'Error details' ) }</FormLabel>
 				<FormSettingExplanation>{ authorizeError.message }</FormSettingExplanation>
 			</div>
 		);

--- a/client/login/magic-login/request-login-code.jsx
+++ b/client/login/magic-login/request-login-code.jsx
@@ -135,7 +135,7 @@ const RequestLoginCode = ( {
 				) }
 
 				<FormLabel htmlFor="usernameOrEmail">
-					{ translate( 'Email Address or Username' ) }
+					{ translate( 'Email address or username' ) }
 				</FormLabel>
 				<FormFieldset className="magic-login__email-fields">
 					<FormTextInput

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -257,7 +257,7 @@ class RequestLoginEmailForm extends Component {
 
 		const formLabel = customFormLabel
 			? this.props.translate( 'Email address or username' )
-			: this.props.translate( 'Email Address or Username' );
+			: this.props.translate( 'Email address or username' );
 
 		const onSubmit = onSubmitEmail
 			? ( e ) => onSubmitEmail( this.getUsernameOrEmailFromState(), e )

--- a/client/me/concierge/book/info-step.js
+++ b/client/me/concierge/book/info-step.js
@@ -130,7 +130,7 @@ class InfoStep extends Component {
 
 				<CompactCard>
 					<FormFieldset>
-						<FormLabel htmlFor="firstname">{ translate( 'First Name' ) }</FormLabel>
+						<FormLabel htmlFor="firstname">{ translate( 'First name' ) }</FormLabel>
 						<FormTextInput
 							name="firstname"
 							placeholder={ translate( 'What may we call you?' ) }
@@ -139,7 +139,7 @@ class InfoStep extends Component {
 						/>
 					</FormFieldset>
 					<FormFieldset>
-						<FormLabel htmlFor="lastname">{ translate( 'Last Name' ) }</FormLabel>
+						<FormLabel htmlFor="lastname">{ translate( 'Last name' ) }</FormLabel>
 						<FormTextInput
 							name="lastname"
 							placeholder={ translate( 'Optionally, please tell us your last name.' ) }

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -742,7 +742,7 @@ function ReceiptLabels( { hideDetailsOnPrint }: { hideDetailsOnPrint?: boolean }
 	return (
 		<div className={ clsx( { 'receipt__no-print': hideDetailsOnPrint } ) }>
 			<FormLabel htmlFor="billing-history__billing-details-textarea">
-				{ translate( 'Billing Details' ) }
+				{ translate( 'Billing details' ) }
 			</FormLabel>
 			<div
 				className="billing-history__billing-details-description"

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -187,7 +187,7 @@ class ReauthRequired extends Component {
 
 				<form onSubmit={ this.submitForm }>
 					<FormFieldset>
-						<FormLabel htmlFor="code">{ this.props.translate( 'Verification Code' ) }</FormLabel>
+						<FormLabel htmlFor="code">{ this.props.translate( 'Verification code' ) }</FormLabel>
 						<FormVerificationCodeInput
 							autoFocus
 							id="code"

--- a/client/me/security-2fa-backup-codes-prompt/index.jsx
+++ b/client/me/security-2fa-backup-codes-prompt/index.jsx
@@ -126,7 +126,7 @@ class Security2faBackupCodesPrompt extends Component {
 			<form className="security-2fa-backup-codes-prompt" onSubmit={ this.onVerify }>
 				<FormFieldset>
 					<FormLabel htmlFor="backup-code-entry">
-						{ this.props.translate( 'Type a Backup Code to Verify' ) }
+						{ this.props.translate( 'Type a backup code to verify' ) }
 					</FormLabel>
 
 					<FormVerificationCodeInput

--- a/client/me/security-2fa-code-prompt/index.jsx
+++ b/client/me/security-2fa-code-prompt/index.jsx
@@ -188,7 +188,7 @@ class Security2faCodePrompt extends Component {
 			<form className="security-2fa-code-prompt" onSubmit={ this.onSubmit }>
 				<FormFieldset>
 					<FormLabel htmlFor="verification-code">
-						{ this.props.translate( 'Verification Code' ) }
+						{ this.props.translate( 'Verification code' ) }
 					</FormLabel>
 
 					<FormVerificationCodeInput

--- a/client/me/security-ssh-key/add-ssh-key-form.tsx
+++ b/client/me/security-ssh-key/add-ssh-key-form.tsx
@@ -58,7 +58,7 @@ export const AddSSHKeyForm = ( { addSSHKey, isAdding, saveText }: AddSSHKeyFormP
 			} }
 		>
 			<FormFieldset>
-				<FormLabel htmlFor={ PUBLIC_SSH_KEY_INPUT_ID }>{ __( 'SSH Public Key' ) }</FormLabel>
+				<FormLabel htmlFor={ PUBLIC_SSH_KEY_INPUT_ID }>{ __( 'SSH public key' ) }</FormLabel>
 				<TextareaAutosize
 					required
 					id={ PUBLIC_SSH_KEY_INPUT_ID }

--- a/client/me/security-ssh-key/update-ssh-key-form.tsx
+++ b/client/me/security-ssh-key/update-ssh-key-form.tsx
@@ -77,7 +77,7 @@ export const UpdateSSHKeyForm = ( {
 			} }
 		>
 			<FormFieldset>
-				<FormLabel>{ __( 'Current SSH Public Key' ) }</FormLabel>
+				<FormLabel>{ __( 'Current SSH public key' ) }</FormLabel>
 				<SSHKeyCard.Root>
 					<SSHKeyCard.Details>
 						<SSHKeyCard.KeyName>
@@ -87,7 +87,7 @@ export const UpdateSSHKeyForm = ( {
 					</SSHKeyCard.Details>
 				</SSHKeyCard.Root>
 				<NewSSHFormFieldContainer>
-					<FormLabel htmlFor={ PUBLIC_SSH_KEY_INPUT_ID }>{ __( 'New SSH Public Key' ) }</FormLabel>
+					<FormLabel htmlFor={ PUBLIC_SSH_KEY_INPUT_ID }>{ __( 'New SSH public key' ) }</FormLabel>
 					<TextareaAutosize
 						required
 						id={ PUBLIC_SSH_KEY_INPUT_ID }

--- a/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
@@ -37,27 +37,27 @@ const ActivityLogConfirmDialog = ( {
 					</p>
 					<FormLabel>
 						<FormCheckbox name="themes" onChange={ onSettingsChange } defaultChecked />
-						{ __( 'WordPress Themes' ) }
+						{ __( 'WordPress themes' ) }
 					</FormLabel>
 					<FormLabel>
 						<FormCheckbox name="plugins" onChange={ onSettingsChange } defaultChecked />
-						{ __( 'WordPress Plugins' ) }
+						{ __( 'WordPress plugins' ) }
 					</FormLabel>
 					<FormLabel>
 						<FormCheckbox name="uploads" onChange={ onSettingsChange } defaultChecked />
-						{ __( 'Media Uploads' ) }
+						{ __( 'Media uploads' ) }
 					</FormLabel>
 					<FormLabel>
 						<FormCheckbox name="roots" onChange={ onSettingsChange } defaultChecked />
-						{ __( 'WordPress Root (includes wp-config.php and any non-WordPress files)' ) }
+						{ __( 'WordPress root (includes wp-config.php and any non-WordPress files)' ) }
 					</FormLabel>
 					<FormLabel>
 						<FormCheckbox name="contents" onChange={ onSettingsChange } defaultChecked />
-						{ __( 'WP-Content Directory (excluding themes, plugins, and uploads)' ) }
+						{ __( 'WP-Content directory (excluding themes, plugins, and uploads)' ) }
 					</FormLabel>
 					<FormLabel>
 						<FormCheckbox name="sqls" onChange={ onSettingsChange } defaultChecked />
-						{ __( 'Site Database (SQL)' ) }
+						{ __( 'Site database (SQL)' ) }
 					</FormLabel>
 				</div>
 

--- a/client/my-sites/comments/comment/comment-html-editor/add-image-dialog.jsx
+++ b/client/my-sites/comments/comment/comment-html-editor/add-image-dialog.jsx
@@ -74,7 +74,7 @@ export class AddImageDialog extends Component {
 					<FormTextInput name="image_title" onChange={ this.setImageTitle } value={ imageTitle } />
 				</FormFieldset>
 				<FormFieldset>
-					<FormLabel htmlFor="image_alt">{ translate( 'Alt Text' ) }</FormLabel>
+					<FormLabel htmlFor="image_alt">{ translate( 'Alt text' ) }</FormLabel>
 					<FormTextInput name="image_alt" onChange={ this.setImageAlt } value={ imageAlt } />
 				</FormFieldset>
 			</Dialog>

--- a/client/my-sites/comments/comment/comment-html-editor/add-link-dialog.jsx
+++ b/client/my-sites/comments/comment/comment-html-editor/add-link-dialog.jsx
@@ -102,7 +102,7 @@ export class AddLinkDialog extends Component {
 					<FormTextInput name="link_url" onChange={ this.setLinkUrl } value={ linkUrl } />
 				</FormFieldset>
 				<FormFieldset>
-					<FormLabel htmlFor="link_text">{ translate( 'Link Text' ) }</FormLabel>
+					<FormLabel htmlFor="link_text">{ translate( 'Link text' ) }</FormLabel>
 					<FormTextInput name="link_text" onChange={ this.setLinkText } value={ linkText } />
 				</FormFieldset>
 				<FormFieldset>

--- a/client/my-sites/domains/domain-management/dns/a-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/a-record.jsx
@@ -53,11 +53,11 @@ class ARecord extends Component {
 						value={ fieldValues.name }
 						suffix={ '.' + selectedDomainName }
 					/>
-					{ ! isNameValid && <FormInputValidation text={ translate( 'Invalid Name' ) } isError /> }
+					{ ! isNameValid && <FormInputValidation text={ translate( 'Invalid name' ) } isError /> }
 				</FormFieldset>
 
 				<FormFieldset>
-					<FormLabel>{ translate( 'Points To' ) }</FormLabel>
+					<FormLabel>{ translate( 'Points to' ) }</FormLabel>
 					<FormTextInput
 						name="data"
 						isError={ ! isDataValid }

--- a/client/my-sites/domains/domain-management/dns/alias-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/alias-record.jsx
@@ -23,7 +23,7 @@ class AliasRecord extends Component {
 		return (
 			<div className={ classes }>
 				<FormFieldset>
-					<FormLabel>{ translate( 'Alias Of (Points To)' ) }</FormLabel>
+					<FormLabel>{ translate( 'Alias of (points to)' ) }</FormLabel>
 					<FormTextInput
 						name="data"
 						isError={ ! isDataValid }
@@ -32,7 +32,7 @@ class AliasRecord extends Component {
 						placeholder={ translate( 'e.g. %(example)s', { args: { example: 'example.com' } } ) }
 					/>
 					{ ! isDataValid && (
-						<FormInputValidation text={ translate( 'Invalid Target Host' ) } isError />
+						<FormInputValidation text={ translate( 'Invalid target host' ) } isError />
 					) }
 				</FormFieldset>
 

--- a/client/my-sites/domains/domain-management/dns/caa-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/caa-record.jsx
@@ -47,7 +47,7 @@ class CaaRecord extends Component {
 						value={ fieldValues.name }
 						suffix={ '.' + selectedDomainName }
 					/>
-					{ ! isNameValid && <FormInputValidation text={ translate( 'Invalid Name' ) } isError /> }
+					{ ! isNameValid && <FormInputValidation text={ translate( 'Invalid name' ) } isError /> }
 				</FormFieldset>
 
 				<FormFieldset>

--- a/client/my-sites/domains/domain-management/dns/cname-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/cname-record.jsx
@@ -37,11 +37,11 @@ class CnameRecord extends Component {
 						value={ fieldValues.name }
 						suffix={ '.' + selectedDomainName }
 					/>
-					{ ! isNameValid && <FormInputValidation text={ translate( 'Invalid Name' ) } isError /> }
+					{ ! isNameValid && <FormInputValidation text={ translate( 'Invalid name' ) } isError /> }
 				</FormFieldset>
 
 				<FormFieldset>
-					<FormLabel>{ translate( 'Alias Of (Points To)' ) }</FormLabel>
+					<FormLabel>{ translate( 'Alias of (points to)' ) }</FormLabel>
 					<FormTextInput
 						name="data"
 						isError={ ! isDataValid }
@@ -50,7 +50,7 @@ class CnameRecord extends Component {
 						placeholder={ translate( 'e.g. %(example)s', { args: { example: 'example.com' } } ) }
 					/>
 					{ ! isDataValid && (
-						<FormInputValidation text={ translate( 'Invalid Target Host' ) } isError />
+						<FormInputValidation text={ translate( 'Invalid target host' ) } isError />
 					) }
 				</FormFieldset>
 

--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -337,7 +337,7 @@ class DnsAddNew extends React.Component {
 		return (
 			<form className="dns__form">
 				<FormFieldset>
-					<FormLabel>{ translate( 'Type', { context: 'DNS Record' } ) }</FormLabel>
+					<FormLabel>{ translate( 'Type', { context: 'DNS record' } ) }</FormLabel>
 					<FormSelect
 						className="dns__add-new-select-type"
 						onChange={ this.changeType }

--- a/client/my-sites/domains/domain-management/dns/email-provider.jsx
+++ b/client/my-sites/domains/domain-management/dns/email-provider.jsx
@@ -80,7 +80,7 @@ class EmailProvider extends Component {
 						placeholder={ placeholder }
 					/>
 					{ token && ! isDataValid && (
-						<FormInputValidation text={ translate( 'Invalid Token' ) } isError />
+						<FormInputValidation text={ translate( 'Invalid token' ) } isError />
 					) }
 				</FormFieldset>
 				<div>

--- a/client/my-sites/domains/domain-management/dns/mx-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/mx-record.jsx
@@ -39,7 +39,7 @@ class MxRecord extends Component {
 						value={ fieldValues.name }
 						suffix={ '.' + selectedDomainName }
 					/>
-					{ ! isNameValid && <FormInputValidation text={ translate( 'Invalid Name' ) } isError /> }
+					{ ! isNameValid && <FormInputValidation text={ translate( 'Invalid name' ) } isError /> }
 				</FormFieldset>
 
 				<FormFieldset>
@@ -54,7 +54,7 @@ class MxRecord extends Component {
 						} ) }
 					/>
 					{ ! isDataValid && (
-						<FormInputValidation text={ translate( 'Invalid Mail Server' ) } isError />
+						<FormInputValidation text={ translate( 'Invalid mail server' ) } isError />
 					) }
 					<FormSettingExplanation>
 						{ translate(
@@ -82,7 +82,7 @@ class MxRecord extends Component {
 						value={ fieldValues.aux }
 					/>
 					{ ! isAuxValid && (
-						<FormInputValidation text={ translate( 'Invalid Priority' ) } isError />
+						<FormInputValidation text={ translate( 'Invalid priority' ) } isError />
 					) }
 				</FormFieldset>
 

--- a/client/my-sites/domains/domain-management/dns/ns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/ns-record.jsx
@@ -46,7 +46,7 @@ class NsRecord extends Component {
 						value={ fieldValues.name }
 						suffix={ '.' + selectedDomainName }
 					/>
-					{ ! isNameValid && <FormInputValidation text={ translate( 'Invalid Name' ) } isError /> }
+					{ ! isNameValid && <FormInputValidation text={ translate( 'Invalid name' ) } isError /> }
 				</FormFieldset>
 
 				<FormFieldset>
@@ -59,7 +59,7 @@ class NsRecord extends Component {
 							args: { example: 'ns1.example.com' },
 						} ) }
 					/>
-					{ ! isDataValid && <FormInputValidation text={ translate( 'Invalid Host' ) } isError /> }
+					{ ! isDataValid && <FormInputValidation text={ translate( 'Invalid host' ) } isError /> }
 				</FormFieldset>
 
 				<FormFieldset>

--- a/client/my-sites/domains/domain-management/dns/srv-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/srv-record.jsx
@@ -50,7 +50,7 @@ class SrvRecord extends Component {
 						value={ name }
 						suffix={ '.' + selectedDomainName }
 					/>
-					{ ! isNameValid && <FormInputValidation text={ translate( 'Invalid Name' ) } isError /> }
+					{ ! isNameValid && <FormInputValidation text={ translate( 'Invalid name' ) } isError /> }
 				</FormFieldset>
 
 				<FormFieldset>
@@ -63,7 +63,7 @@ class SrvRecord extends Component {
 						placeholder={ translate( 'e.g. %(example)s', { args: { example: 'sip' } } ) }
 					/>
 					{ ! isServiceValid && (
-						<FormInputValidation text={ translate( 'Invalid Service' ) } isError />
+						<FormInputValidation text={ translate( 'Invalid service' ) } isError />
 					) }
 				</FormFieldset>
 
@@ -79,7 +79,7 @@ class SrvRecord extends Component {
 					<FormLabel>{ translate( 'Priority', { context: 'Dns Record' } ) }</FormLabel>
 					<FormTextInput name="aux" isError={ ! isAuxValid } onChange={ onChange } value={ aux } />
 					{ ! isAuxValid && (
-						<FormInputValidation text={ translate( 'Invalid Priority' ) } isError />
+						<FormInputValidation text={ translate( 'Invalid priority' ) } isError />
 					) }
 				</FormFieldset>
 
@@ -92,12 +92,12 @@ class SrvRecord extends Component {
 						value={ weight }
 					/>
 					{ ! isWeightValid && (
-						<FormInputValidation text={ translate( 'Invalid Weight' ) } isError />
+						<FormInputValidation text={ translate( 'Invalid weight' ) } isError />
 					) }
 				</FormFieldset>
 
 				<FormFieldset>
-					<FormLabel>{ translate( 'Target Host', { context: 'Dns Record' } ) }</FormLabel>
+					<FormLabel>{ translate( 'Target host', { context: 'Dns Record' } ) }</FormLabel>
 					<FormTextInput
 						name="target"
 						isError={ ! isTargetValid }
@@ -108,12 +108,12 @@ class SrvRecord extends Component {
 						} ) }
 					/>
 					{ ! isTargetValid && (
-						<FormInputValidation text={ translate( 'Invalid Target Host' ) } isError />
+						<FormInputValidation text={ translate( 'Invalid target host' ) } isError />
 					) }
 				</FormFieldset>
 
 				<FormFieldset>
-					<FormLabel>{ translate( 'Target Port', { context: 'Dns Record' } ) }</FormLabel>
+					<FormLabel>{ translate( 'Target port', { context: 'Dns Record' } ) }</FormLabel>
 					<FormTextInput
 						name="port"
 						isError={ ! isPortValid }
@@ -122,7 +122,7 @@ class SrvRecord extends Component {
 						placeholder={ translate( 'e.g. %(example)s', { args: { example: '5060' } } ) }
 					/>
 					{ ! isPortValid && (
-						<FormInputValidation text={ translate( 'Invalid Target Port' ) } isError />
+						<FormInputValidation text={ translate( 'Invalid target port' ) } isError />
 					) }
 				</FormFieldset>
 

--- a/client/my-sites/domains/domain-management/dns/txt-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/txt-record.jsx
@@ -53,7 +53,7 @@ class TxtRecord extends Component {
 						value={ fieldValues.name }
 						suffix={ '.' + selectedDomainName }
 					/>
-					{ ! isNameValid && <FormInputValidation text={ translate( 'Invalid Name' ) } isError /> }
+					{ ! isNameValid && <FormInputValidation text={ translate( 'Invalid name' ) } isError /> }
 				</FormFieldset>
 
 				<FormFieldset>
@@ -67,7 +67,7 @@ class TxtRecord extends Component {
 						} ) }
 					/>
 					{ hasNonAsciiData && (
-						<FormInputValidation text={ translate( 'TXT Record has non-ASCII data' ) } isWarning />
+						<FormInputValidation text={ translate( 'TXT record has non-ASCII data' ) } isWarning />
 					) }
 					{ ! isDataValid && validationError && (
 						<FormInputValidation text={ validationError } isError />

--- a/client/my-sites/domains/domain-management/site-redirect/index.jsx
+++ b/client/my-sites/domains/domain-management/site-redirect/index.jsx
@@ -225,6 +225,7 @@ const recordUpdateSiteRedirectClick = ( domainName, location, success ) =>
 		} )
 	);
 
+// eslint-disable-next-line react/display-name
 const withLocationAsKey = createHigherOrderComponent( ( Wrapped ) => ( props ) => {
 	const selectedSite = useSelector( getSelectedSite );
 	const location = useSelector( ( state ) =>

--- a/client/my-sites/domains/domain-management/site-redirect/index.jsx
+++ b/client/my-sites/domains/domain-management/site-redirect/index.jsx
@@ -127,7 +127,7 @@ class SiteRedirect extends Component {
 					<Card className={ classes }>
 						<form>
 							<FormFieldset>
-								<FormLabel htmlFor="site-redirect__input">{ translate( 'Redirect To' ) }</FormLabel>
+								<FormLabel htmlFor="site-redirect__input">{ translate( 'Redirect to' ) }</FormLabel>
 
 								<FormTextInputWithAffixes
 									disabled={ isFetching || isUpdating }

--- a/client/my-sites/earn/ads/form-settings.tsx
+++ b/client/my-sites/earn/ads/form-settings.tsx
@@ -286,7 +286,7 @@ const AdsFormSettings = () => {
 	function paymentOptions() {
 		return (
 			<FormFieldset>
-				<FormLabel htmlFor="paypal">{ translate( 'PayPal E-mail Address' ) }</FormLabel>
+				<FormLabel htmlFor="paypal">{ translate( 'PayPal email address' ) }</FormLabel>
 				<FormTextInput
 					name="paypal"
 					id="paypal-earn-input"
@@ -388,7 +388,7 @@ const AdsFormSettings = () => {
 				{ settings.ccpa_enabled && (
 					<div className="ads__child-settings">
 						<FormFieldset>
-							<FormLabel>{ translate( 'Do Not Sell Link' ) }</FormLabel>
+							<FormLabel>{ translate( 'Do Not Sell link' ) }</FormLabel>
 							<span>
 								{ translate(
 									'If you enable targeted advertising in all US states you are required to place a "Do Not Sell or Share My Personal Information" link on every page of your site where targeted advertising will appear. You can use the {{a}}Do Not Sell Link Widget{{/a}}, or the {{code}}[privacy-do-not-sell-link]{{/code}} shortcode to automatically place this link on your site. Note: the link will always display to logged in administrators regardless of geolocation.',
@@ -409,7 +409,7 @@ const AdsFormSettings = () => {
 
 						<FormFieldset>
 							<FormLabel htmlFor="ccpa-privacy-policy-url">
-								{ translate( 'Privacy Policy URL' ) }
+								{ translate( 'Privacy policy URL' ) }
 							</FormLabel>
 							<FormTextInput
 								name="ccpa_privacy_policy_url"

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -393,7 +393,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 					<>
 						<FormFieldset className="memberships__dialog-sections-price">
 							<div className="memberships__dialog-sections-price-field-container">
-								<FormLabel htmlFor="currency_monthly">{ translate( 'Monthly Price' ) }</FormLabel>
+								<FormLabel htmlFor="currency_monthly">{ translate( 'Monthly price' ) }</FormLabel>
 								<FormCurrencyInput
 									name="currency_monthly"
 									id="currency_monthly"
@@ -407,7 +407,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 								/>
 							</div>
 							<div className="memberships__dialog-sections-price-field-container">
-								<FormLabel htmlFor="currency_annual">{ translate( 'Annual Price' ) }</FormLabel>
+								<FormLabel htmlFor="currency_annual">{ translate( 'Annual price' ) }</FormLabel>
 								<FormCurrencyInput
 									name="currency_annual"
 									id="currency_annual"

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -235,7 +235,7 @@ class EditUserForm extends Component {
 				returnField = (
 					<FormFieldset key={ fieldKeys.firstName }>
 						<FormLabel htmlFor={ fieldKeys.firstName }>
-							{ this.props.translate( 'First Name', {
+							{ this.props.translate( 'First name', {
 								context: 'Text that is displayed in a label of a form.',
 							} ) }
 						</FormLabel>
@@ -254,7 +254,7 @@ class EditUserForm extends Component {
 				returnField = (
 					<FormFieldset key={ fieldKeys.lastName }>
 						<FormLabel htmlFor={ fieldKeys.lastName }>
-							{ this.props.translate( 'Last Name', {
+							{ this.props.translate( 'Last name', {
 								context: 'Text that is displayed in a label of a form.',
 							} ) }
 						</FormLabel>
@@ -273,7 +273,7 @@ class EditUserForm extends Component {
 				returnField = (
 					<FormFieldset key={ fieldKeys.name }>
 						<FormLabel htmlFor={ fieldKeys.name }>
-							{ this.props.translate( 'Public Display Name', {
+							{ this.props.translate( 'Public display name', {
 								context: 'Text that is displayed in a label of a form.',
 							} ) }
 						</FormLabel>

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -345,6 +345,7 @@ class EditUserForm extends Component {
 }
 
 const withExternalContributors = createHigherOrderComponent(
+	// eslint-disable-next-line react/display-name
 	( Wrapped ) => ( props ) => {
 		const { siteId, user } = props;
 		const {

--- a/client/my-sites/people/team-invite/invite-form.tsx
+++ b/client/my-sites/people/team-invite/invite-form.tsx
@@ -190,7 +190,7 @@ function InviteForm( props: Props ) {
 			{ [ ...Array( tokenControlNum ) ].map( ( v, i ) => (
 				<FormFieldset key={ i }>
 					{ ! i && (
-						<FormLabel htmlFor={ `token-${ i }` }>{ translate( 'Email or Username' ) }</FormLabel>
+						<FormLabel htmlFor={ `token-${ i }` }>{ translate( 'Email or username' ) }</FormLabel>
 					) }
 					<div className="form-field-wrapper">
 						<FormTextInput

--- a/client/my-sites/site-settings/comment-display-settings/index.jsx
+++ b/client/my-sites/site-settings/comment-display-settings/index.jsx
@@ -87,7 +87,7 @@ class CommentDisplaySettings extends Component {
 				</div>
 				<div className="comment-display-settings__module-setting is-indented">
 					<FormLabel htmlFor="jetpack_comment_form_color_scheme">
-						{ translate( 'Color Scheme' ) }
+						{ translate( 'Color scheme' ) }
 					</FormLabel>
 					<FormSelect
 						name="jetpack_comment_form_color_scheme"

--- a/client/my-sites/site-settings/date-time-format/date-format-option.jsx
+++ b/client/my-sites/site-settings/date-time-format/date-format-option.jsx
@@ -17,7 +17,7 @@ export const DateFormatOption = ( {
 	translate,
 } ) => (
 	<FormFieldset>
-		<FormLabel>{ translate( 'Date Format' ) }</FormLabel>
+		<FormLabel>{ translate( 'Date format' ) }</FormLabel>
 		{ getDefaultDateFormats().map( ( format ) => (
 			<FormLabel key={ format }>
 				<FormRadio

--- a/client/my-sites/site-settings/date-time-format/time-format-option.jsx
+++ b/client/my-sites/site-settings/date-time-format/time-format-option.jsx
@@ -18,7 +18,7 @@ export const TimeFormatOption = ( {
 	translate,
 } ) => (
 	<FormFieldset>
-		<FormLabel>{ translate( 'Time Format' ) }</FormLabel>
+		<FormLabel>{ translate( 'Time format' ) }</FormLabel>
 		{ getDefaultTimeFormats().map( ( format ) => (
 			<FormLabel key={ format }>
 				<FormRadio

--- a/client/my-sites/site-settings/media-settings-writing.jsx
+++ b/client/my-sites/site-settings/media-settings-writing.jsx
@@ -79,7 +79,7 @@ class MediaSettingsWriting extends Component {
 								label={ translate( 'Show photo metadata in carousel, when available' ) }
 							/>
 							<FormLabel className={ labelClassName } htmlFor="carousel_background_color">
-								{ translate( 'Background Color' ) }
+								{ translate( 'Background color' ) }
 							</FormLabel>
 							<FormSelect
 								name="carousel_background_color"

--- a/client/my-sites/site-settings/podcast-cover-image-setting/index.jsx
+++ b/client/my-sites/site-settings/podcast-cover-image-setting/index.jsx
@@ -264,7 +264,7 @@ class PodcastCoverImageSetting extends PureComponent {
 
 		return (
 			<FormFieldset className="podcast-cover-image-setting">
-				<FormLabel>{ translate( 'Cover Image' ) }</FormLabel>
+				<FormLabel>{ translate( 'Cover image' ) }</FormLabel>
 				{ this.renderCoverPreview() }
 				{ this.renderChangeButton() }
 				{ this.renderRemoveButton() }

--- a/client/my-sites/site-settings/podcasting-details/feed-url.jsx
+++ b/client/my-sites/site-settings/podcasting-details/feed-url.jsx
@@ -15,7 +15,7 @@ function PodcastFeedUrl( { feedUrl, translate } ) {
 
 	return (
 		<FormFieldset>
-			<FormLabel>{ translate( 'RSS Feed' ) }</FormLabel>
+			<FormLabel>{ translate( 'RSS feed' ) }</FormLabel>
 			<ClipboardButtonInput value={ feedUrl } />
 			<FormSettingExplanation>
 				{ translate(

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -66,7 +66,7 @@ class PodcastingDetails extends Component {
 
 		return (
 			<FormFieldset>
-				<FormLabel htmlFor="podcasting_explicit">{ translate( 'Explicit Content' ) }</FormLabel>
+				<FormLabel htmlFor="podcasting_explicit">{ translate( 'Explicit content' ) }</FormLabel>
 				<FormSelect
 					id="podcasting_explicit"
 					name="podcasting_explicit"
@@ -154,7 +154,7 @@ class PodcastingDetails extends Component {
 
 		return (
 			<FormFieldset>
-				<FormLabel htmlFor="podcasting_category_1">{ translate( 'Podcast Topics' ) }</FormLabel>
+				<FormLabel htmlFor="podcasting_category_1">{ translate( 'Podcast topics' ) }</FormLabel>
 				<FormSettingExplanation>
 					{ translate(
 						'Choose how your podcast should be categorized within Apple Podcasts and other podcasting services.'
@@ -276,7 +276,7 @@ class PodcastingDetails extends Component {
 							</Button>
 						</div>
 					) }
-					<FormLabel>{ translate( 'Podcast Category' ) }</FormLabel>
+					<FormLabel>{ translate( 'Podcast category' ) }</FormLabel>
 					<FormSettingExplanation>
 						{ translate(
 							'Posts published in this category will be included in your podcast feed.'

--- a/client/my-sites/site-settings/reading-site-settings/RelatedPostsSetting.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/RelatedPostsSetting.tsx
@@ -29,7 +29,7 @@ export const RelatedPostsSetting = ( {
 	return (
 		<>
 			<FormLabel id="related-posts-settings" className="increase-margin-bottom-fix">
-				{ translate( 'Related Posts' ) }
+				{ translate( 'Related posts' ) }
 			</FormLabel>
 			<RelatedPostsFormFieldset
 				fields={ fields }

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -393,7 +393,7 @@ export class SiteSettingsFormSEO extends Component {
 										) }
 									</p>
 									<FormLabel htmlFor="advanced_seo_front_page_description">
-										{ translate( 'Front Page Meta Description' ) }
+										{ translate( 'Front page meta description' ) }
 									</FormLabel>
 									<CountedTextarea
 										name="advanced_seo_front_page_description"

--- a/client/my-sites/site-settings/spam-filtering-settings.jsx
+++ b/client/my-sites/site-settings/spam-filtering-settings.jsx
@@ -111,7 +111,7 @@ const SpamFilteringSettings = ( {
 						text={ translate( 'Removes spam from comments and contact forms.' ) }
 						link="https://jetpack.com/features/security/spam-filtering/"
 					/>
-					<FormLabel htmlFor="wordpress_api_key">{ translate( 'Your API Key' ) }</FormLabel>
+					<FormLabel htmlFor="wordpress_api_key">{ translate( 'Your API key' ) }</FormLabel>
 					<FormTextInput
 						name="wordpress_api_key"
 						className={ className }

--- a/client/reader/list-manage/list-form.jsx
+++ b/client/reader/list-manage/list-form.jsx
@@ -71,7 +71,7 @@ export default function ListForm( { isCreateForm, isSubmissionDisabled, list = {
 	return (
 		<Card>
 			<FormFieldset>
-				<FormLabel htmlFor="list-name">{ translate( 'Name (Required)' ) }</FormLabel>
+				<FormLabel htmlFor="list-name">{ translate( 'Name (required)' ) }</FormLabel>
 				<FormTextInput
 					data-key="title"
 					id="list-name"

--- a/client/sites/settings/server/server-configuration-form.tsx
+++ b/client/sites/settings/server/server-configuration-form.tsx
@@ -228,7 +228,7 @@ export default function ServerConfigurationForm( { disabled }: ServerConfigurati
 
 		return (
 			<FormFieldset>
-				<FormLabel>{ translate( 'Primary Data Center' ) }</FormLabel>
+				<FormLabel>{ translate( 'Primary data center' ) }</FormLabel>
 				<FormTextInput
 					className="web-server-settings-card__data-center-input"
 					value={ displayValue }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-12843

## Proposed Changes

* Update dozens of `FormLabel`s from title case to sentence case.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the capitalization consistency of the platform.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Smoke test Calypso, but generally speaking a code check is enough.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
