### PR TITLE
Domain Search Retrofitting: Match the initial search domain position with the design

### DIFF
--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -388,15 +388,8 @@ class RegisterDomainStep extends Component {
 		this.props.recordSearchFormView( this.props.analyticsSection, this.props.flowName );
 	}
 
-	componentDidUpdate( prevProps, prevState ) {
-		// Check if isInInitialState would return a different value
-		const wasInitialState = ! prevState.lastQuery && ! prevState.searchResults;
-		const isInitialState = this.isInInitialState();
-
-		if ( wasInitialState !== isInitialState ) {
-			this.updateParentClass();
-		}
-
+	componentDidUpdate( prevProps ) {
+		this.updateParentClass();
 		this.checkForBloggerPlan();
 
 		if (

--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -361,6 +361,8 @@ class RegisterDomainStep extends Component {
 	}
 
 	componentDidMount() {
+		this.updateParentClass();
+
 		const storedQuery = globalThis?.sessionStorage?.getItem( SESSION_STORAGE_QUERY_KEY );
 		let query = this.state.lastQuery || storedQuery;
 
@@ -386,7 +388,15 @@ class RegisterDomainStep extends Component {
 		this.props.recordSearchFormView( this.props.analyticsSection, this.props.flowName );
 	}
 
-	componentDidUpdate( prevProps ) {
+	componentDidUpdate( prevProps, prevState ) {
+		// Check if isInInitialState would return a different value
+		const wasInitialState = ! prevState.lastQuery && ! prevState.searchResults;
+		const isInitialState = this.isInInitialState();
+
+		if ( wasInitialState !== isInitialState ) {
+			this.updateParentClass();
+		}
+
 		this.checkForBloggerPlan();
 
 		if (
@@ -594,6 +604,18 @@ class RegisterDomainStep extends Component {
 				/>
 			</div>
 		);
+	}
+
+	updateParentClass() {
+		// Find the parent element with the step-container-v2__content-wrapper class
+		const parentElement = document.querySelector( '.step-container-v2__content-wrapper' );
+		if ( parentElement ) {
+			if ( this.isInInitialState() ) {
+				parentElement.classList.add( 'is-initial-state' );
+			} else {
+				parentElement.classList.remove( 'is-initial-state' );
+			}
+		}
 	}
 
 	render() {

--- a/client/components/domain-search-v2/register-domain-step/style.scss
+++ b/client/components/domain-search-v2/register-domain-step/style.scss
@@ -1,6 +1,19 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
+// Style for parent wrapper when in initial state
+.step-container-v2__content-wrapper.is-initial-state {
+	margin-top: 0;
+
+	@include break-small {
+		margin-top: 6rem;
+	}
+
+	@include break-medium {
+		margin-top: 9rem;
+	}
+}
+
 .wpcom-domain-search-v2 {
 
 	&.initial-state {


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/DOMAINS-1565/initial-empty-state-make-sure-that-the-search-has-a-position-matching

## Proposed Changes

While the current solution modifies the parent component's classes directly from the child component (via `document.querySelector`), I acknowledge that this isn't ideal from a component encapsulation perspective. However, this solution was implemented without modifying the stepper framework itself.

- Added state class to the stepper wrapper component
- Apply styles to match the Figma design


https://github.com/user-attachments/assets/a3cb2d2a-f99d-4a56-b1d1-459d5993c4c4



## Why are these changes being made?

https://linear.app/a8c/issue/DOMAINS-1565/initial-empty-state-make-sure-that-the-search-has-a-position-matching

## Testing Instructions

* Make sure you have domains/ui-redesign feature flag
* Go to `/setup/onboarding/domains`
* Check the initial position of the Domain Search 

<img width="1728" height="986" alt="Screenshot 2025-07-24 at 17 17 41" src="https://github.com/user-attachments/assets/e8112f88-efbb-4d42-8dbb-cd8a10e0a877" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
