### PR TITLE
Domain Search Retrofitting: Adjust initial search bar

### DIFF
--- a/client/components/domain-search-v2/domain-search-input/index.tsx
+++ b/client/components/domain-search-v2/domain-search-input/index.tsx
@@ -28,9 +28,11 @@ interface DomainSearchInputProps {
 	minLength?: number;
 	maxLength?: number;
 	placeholderAnimation?: boolean;
+	disableAutoSearch?: boolean;
 	onBlur?: ( event: React.FocusEvent< HTMLInputElement > ) => void;
 	onSearch?: ( value: string ) => void;
 	onSearchChange?: ( value: string ) => void;
+	onKeyDown?: ( event: React.KeyboardEvent< HTMLInputElement > ) => void;
 }
 
 const PLACEHOLDER_PHRASES = [
@@ -48,6 +50,7 @@ const DomainSearchInput = function DomainSearchInput( {
 	describedBy,
 	dir,
 	defaultValue,
+	disableAutoSearch,
 	value: controlledValue,
 	inputLabel,
 	minLength,
@@ -65,14 +68,14 @@ const DomainSearchInput = function DomainSearchInput( {
 	const { placeholder } = useTypedPlaceholder( PLACEHOLDER_PHRASES, pausePlaceholderAnimation );
 
 	const doSearch = useMemo( () => {
-		if ( ! onSearch ) {
+		if ( ! onSearch || disableAutoSearch ) {
 			return;
 		}
 		if ( ! delaySearch ) {
 			return onSearch;
 		}
 		return debounce( onSearch, delayTimeout );
-	}, [ onSearch, delayTimeout, delaySearch ] );
+	}, [ onSearch, delayTimeout, delaySearch, disableAutoSearch ] );
 
 	useUpdateEffect( () => {
 		if ( doSearch ) {
@@ -96,6 +99,13 @@ const DomainSearchInput = function DomainSearchInput( {
 		handleChange( '' );
 	};
 
+	const handleKeyDown = ( event: React.KeyboardEvent< HTMLInputElement > ) => {
+		if ( event.key === 'Enter' && onSearch ) {
+			event.preventDefault();
+			onSearch( controlledValue ?? '' );
+		}
+	};
+
 	const searchControlLabel = inputLabel || _x( 'Search', 'search label', 'domain-search' );
 
 	return (
@@ -112,6 +122,7 @@ const DomainSearchInput = function DomainSearchInput( {
 			maxLength={ maxLength ?? 253 }
 			dir={ dir ?? 'ltr' }
 			aria-describedby={ describedBy ?? '' }
+			onKeyDown={ handleKeyDown }
 		/>
 	);
 };

--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -774,6 +774,7 @@ class RegisterDomainStep extends Component {
 			onSearch: this.onSearch,
 			onSearchChange: this.onSearchChange,
 			ref: this.bindSearchCardReference,
+			disableAutoSearch: this.isInInitialState(),
 			isOnboarding: this.props.isOnboarding,
 			placeholderAnimation: ! this.state.searchResults,
 			childrenBeforeCloseButton:
@@ -1096,7 +1097,7 @@ class RegisterDomainStep extends Component {
 		}
 
 		const cleanedQuery = getDomainSuggestionSearch( searchQuery, MIN_QUERY_LENGTH );
-		const loadingResults = Boolean( cleanedQuery );
+		const loadingResults = this.isInInitialState() ? false : Boolean( cleanedQuery );
 		const isInitialQueryActive = ! searchQuery || searchQuery === this.props.suggestion;
 
 		this.setState(
@@ -1728,11 +1729,13 @@ class RegisterDomainStep extends Component {
 	};
 
 	onHelperTermClick = ( term ) => {
-		this.setState( {
-			lastQuery: term,
-			helperTermSubmitted: true,
-			loadingResults: true,
-		} );
+		this.setState(
+			{
+				lastQuery: term,
+				helperTermSubmitted: true,
+			},
+			() => this.onSearch( term )
+		);
 	};
 
 	useYourDomainFunction = () => {

--- a/packages/domain-search/src/components/domain-search-controls/input.tsx
+++ b/packages/domain-search/src/components/domain-search-controls/input.tsx
@@ -10,6 +10,7 @@ export const DomainSearchControlsInput = ( {
 	onReset,
 	autoFocus,
 	onBlur,
+	onKeyDown,
 	minLength,
 	maxLength,
 	dir,
@@ -22,6 +23,7 @@ export const DomainSearchControlsInput = ( {
 	onReset: () => void;
 	autoFocus: boolean;
 	onBlur: ( event: React.FocusEvent< HTMLInputElement > ) => void;
+	onKeyDown: ( event: React.KeyboardEvent< HTMLInputElement > ) => void;
 	minLength: number;
 	maxLength: number;
 	dir: 'ltr' | 'rtl';
@@ -42,6 +44,7 @@ export const DomainSearchControlsInput = ( {
 			// eslint-disable-next-line jsx-a11y/no-autofocus
 			autoFocus={ autoFocus }
 			onBlur={ onBlur }
+			onKeyDown={ onKeyDown }
 			minLength={ minLength }
 			maxLength={ maxLength }
 			dir={ dir }

--- a/packages/domain-search/src/index.stories.tsx
+++ b/packages/domain-search/src/index.stories.tsx
@@ -65,6 +65,7 @@ function DomainSearchEmptyState( { onSearch }: { onSearch( query: string ): void
 						dir="ltr"
 						aria-describedby="domain-search-description"
 						onBlur={ () => {} }
+						onKeyDown={ () => {} }
 					/>
 					<Button __next40pxDefaultSize type="submit" variant="primary">
 						Search domains
@@ -115,6 +116,7 @@ function DomainSearchResults( { initialQuery }: { initialQuery: string } ) {
 							dir="ltr"
 							aria-describedby="domain-search-description"
 							onBlur={ () => {} }
+							onKeyDown={ () => {} }
 						/>
 						<DomainSearchControls.FilterButton count={ 3 } onClick={ () => {} } />
 					</HStack>


### PR DESCRIPTION
Part of DOMAINS-1564/initial-empty-state-make-sure-that-search-input-triggers-search-on

## Proposed Changes

* Adjust the search bar to its initial state by disabling search by typing, and allow it only when the user presses the Enter or Submit button.

## Why are these changes being made?

* DOMAINS-1564/initial-empty-state-make-sure-that-search-input-triggers-search-on

## Testing Instructions

* Make sure you have `domains/ui-redesign` feature flag
* Go to `/setup/onboarding/domains`
* Enter anything the search bar
* Check if search runs on enter

https://github.com/user-attachments/assets/512bc96b-ea6f-41d0-90dd-18815cc43cdb

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
