### PR TITLE
Domain Search Retrofitting: Make sure all Stepper flows have consistent designs

### DIFF
--- a/client/components/domain-search-v2/free-domain-for-a-year-promo/style.scss
+++ b/client/components/domain-search-v2/free-domain-for-a-year-promo/style.scss
@@ -8,6 +8,7 @@
 
 .free-domain-for-a-year-promo__image {
 	width: 140px;
+	height: 84px;
 	user-select: none;
 	flex-shrink: 0;
 }

--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -609,7 +609,9 @@ class RegisterDomainStep extends Component {
 		const notices = this.renderGeneralNotices();
 
 		const showFreeDomainPromo =
-			this.props.isPlanSelectionAvailableInFlow || this.props.showFreeDomainPromo;
+			this.props.showFreeDomainPromo === false
+				? false
+				: this.props.isPlanSelectionAvailableInFlow || this.props.showFreeDomainPromo;
 
 		const showHelperTerm =
 			this.state.helperTermSubmitted || ( this.state.hasSubmitted && ! this.state.lastQuery );

--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -1754,6 +1754,14 @@ class RegisterDomainStep extends Component {
 		return this.goToUseYourDomainStep;
 	};
 
+	getUseYourDomainHandler = () => {
+		if ( this.props.flowName === 'new-hosted-site' ) {
+			return null;
+		}
+
+		return this.props.handleClickUseYourDomain ?? this.useYourDomainFunction();
+	};
+
 	renderSearchResults() {
 		const {
 			exactMatchDomain,
@@ -1786,7 +1794,7 @@ class RegisterDomainStep extends Component {
 				onAddMapping={ onAddMapping }
 				onClickMapping={ this.goToMapDomainStep }
 				onAddTransfer={ this.props.onAddTransfer }
-				onClickUseYourDomain={ this.props.handleClickUseYourDomain ?? this.useYourDomainFunction() }
+				onClickUseYourDomain={ this.getUseYourDomainHandler() }
 				tracksButtonClickSource="exact-match-top"
 				suggestions={ suggestions }
 				premiumDomains={ premiumDomains }

--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -16,6 +16,7 @@ import {
 	HUNDRED_YEAR_PLAN_FLOW,
 	isHundredYearDomainFlow,
 	isDomainForGravatarFlow,
+	NEW_HOSTED_SITE_FLOW,
 } from '@automattic/onboarding';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import {
@@ -1755,7 +1756,7 @@ class RegisterDomainStep extends Component {
 	};
 
 	getUseYourDomainHandler = () => {
-		if ( this.props.flowName === 'new-hosted-site' ) {
+		if ( [ NEW_HOSTED_SITE_FLOW, AI_SITE_BUILDER_FLOW ].includes( this.props.flowName ) ) {
 			return null;
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -189,28 +189,30 @@ button {
 		}
 	}
 
-	// While we don't standardize all Calypso interfaces, we need to override this for onboarding flows #79851
-	.components-button.is-primary {
-		border-radius: 4px;
-		font-size: 0.875rem;
-		font-weight: 500;
-		justify-content: center;
+	&:not(:has(.wpcom-domain-search-v2)) {
+		// While we don't standardize all Calypso interfaces, we need to override this for onboarding flows #79851
+		.components-button.is-primary {
+			border-radius: 4px;
+			font-size: 0.875rem;
+			font-weight: 500;
+			justify-content: center;
 
-		&[disabled],
-		&:disabled,
-		&.disabled {
-			color: #fff;
-			background-color: var(--studio-wordpress-blue-20);
-			border-color: var(--studio-wordpress-blue-20);
+			&[disabled],
+			&:disabled,
+			&.disabled {
+				color: #fff;
+				background-color: var(--studio-wordpress-blue-20);
+				border-color: var(--studio-wordpress-blue-20);
+			}
 		}
-	}
 
-	.components-button.is-link {
-		color: var(--color-accent);
+		.components-button.is-link {
+			color: var(--color-accent);
 
-		&:hover:not(:disabled):not(.disabled),
-		&:focus:not(:disabled):not(.disabled) {
-			color: var(--color-neutral-70);
+			&:hover:not(:disabled):not(.disabled),
+			&:focus:not(:disabled):not(.disabled) {
+				color: var(--color-neutral-70);
+			}
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -120,7 +120,7 @@ button {
 			&.courses,
 			&.site-picker,
 			&.new-or-existing-site,
-			&.domains:not(.copy-site):not(.onboarding) {
+			&.domains:not(.copy-site):not(.ai-site-builder):not(.domain-upsell):not(.onboarding):not(.newsletter):not(.readymade-template):not(.reblogging):not(.start-writing) {
 				margin-top: -60px;
 			}
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -7,6 +7,7 @@ import {
 	NEWSLETTER_FLOW,
 	READYMADE_TEMPLATE_FLOW,
 	REBLOGGING_FLOW,
+	START_WRITING_FLOW,
 } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { isEmpty } from 'lodash';
@@ -121,7 +122,9 @@ export function DomainFormControl( {
 
 	if (
 		isDomainSearchV2Enabled &&
-		[ NEWSLETTER_FLOW, READYMADE_TEMPLATE_FLOW, REBLOGGING_FLOW ].includes( flow ?? '' )
+		[ NEWSLETTER_FLOW, READYMADE_TEMPLATE_FLOW, REBLOGGING_FLOW, START_WRITING_FLOW ].includes(
+			flow ?? ''
+		)
 	) {
 		includeWordPressDotCom = true;
 		showSkipButton = true;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -4,6 +4,7 @@ import {
 	HUNDRED_YEAR_DOMAIN_FLOW,
 	HUNDRED_YEAR_PLAN_FLOW,
 	isDomainUpsellFlow,
+	NEWSLETTER_FLOW,
 } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { isEmpty } from 'lodash';
@@ -113,6 +114,11 @@ export function DomainFormControl( {
 	}
 
 	if ( isDomainSearchV2Enabled && flow === COPY_SITE_FLOW ) {
+		showSkipButton = true;
+	}
+
+	if ( isDomainSearchV2Enabled && flow === NEWSLETTER_FLOW ) {
+		includeWordPressDotCom = true;
 		showSkipButton = true;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -258,6 +258,9 @@ export function DomainFormControl( {
 					// RegisterDomainStepComponentV2 props below
 					onContinue={ onContinue }
 					shouldRenderUseYourDomain
+					showFreeDomainPromo={
+						! [ HUNDRED_YEAR_DOMAIN_FLOW, HUNDRED_YEAR_PLAN_FLOW ].includes( flow ?? '' )
+					}
 				/>
 			</CalypsoShoppingCartProvider>
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -1,4 +1,5 @@
 import {
+	COPY_SITE_FLOW,
 	DOMAIN_UPSELL_FLOW,
 	HUNDRED_YEAR_DOMAIN_FLOW,
 	HUNDRED_YEAR_PLAN_FLOW,
@@ -57,6 +58,8 @@ export function DomainFormControl( {
 	isCartPendingUpdate,
 	isCartPendingUpdateDomain,
 }: DomainFormControlProps ) {
+	const [ , isDomainSearchV2Enabled ] = useDomainSearchV2( flow ?? '' );
+
 	const selectedSite = useSelector( getSelectedSite );
 	const productsList = useSelector( getAvailableProductsList );
 
@@ -107,6 +110,10 @@ export function DomainFormControl( {
 	if ( flow === HUNDRED_YEAR_DOMAIN_FLOW ) {
 		includeWordPressDotCom = false;
 		shouldQuerySubdomains = false;
+	}
+
+	if ( isDomainSearchV2Enabled && flow === COPY_SITE_FLOW ) {
+		showSkipButton = true;
 	}
 
 	const domainsWithPlansOnly = true;
@@ -180,8 +187,6 @@ export function DomainFormControl( {
 		);
 	};
 
-	const [ , isDomainSearchV2Enabled ] = useDomainSearchV2( flow ?? '' );
-
 	const renderDomainForm = () => {
 		let initialState: DomainForm = {};
 		if ( domainForm ) {
@@ -252,6 +257,7 @@ export function DomainFormControl( {
 					} ) }
 					// RegisterDomainStepComponentV2 props below
 					onContinue={ onContinue }
+					shouldRenderUseYourDomain
 				/>
 			</CalypsoShoppingCartProvider>
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -6,6 +6,7 @@ import {
 	isDomainUpsellFlow,
 	NEWSLETTER_FLOW,
 	READYMADE_TEMPLATE_FLOW,
+	REBLOGGING_FLOW,
 } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { isEmpty } from 'lodash';
@@ -120,7 +121,7 @@ export function DomainFormControl( {
 
 	if (
 		isDomainSearchV2Enabled &&
-		[ NEWSLETTER_FLOW, READYMADE_TEMPLATE_FLOW ].includes( flow ?? '' )
+		[ NEWSLETTER_FLOW, READYMADE_TEMPLATE_FLOW, REBLOGGING_FLOW ].includes( flow ?? '' )
 	) {
 		includeWordPressDotCom = true;
 		showSkipButton = true;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -5,6 +5,7 @@ import {
 	HUNDRED_YEAR_PLAN_FLOW,
 	isDomainUpsellFlow,
 	NEWSLETTER_FLOW,
+	READYMADE_TEMPLATE_FLOW,
 } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { isEmpty } from 'lodash';
@@ -117,7 +118,10 @@ export function DomainFormControl( {
 		showSkipButton = true;
 	}
 
-	if ( isDomainSearchV2Enabled && flow === NEWSLETTER_FLOW ) {
+	if (
+		isDomainSearchV2Enabled &&
+		[ NEWSLETTER_FLOW, READYMADE_TEMPLATE_FLOW ].includes( flow ?? '' )
+	) {
 		includeWordPressDotCom = true;
 		showSkipButton = true;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -54,6 +54,7 @@ const DomainsStep: Step< {
 		  }
 		| undefined;
 } > = function DomainsStep( { navigation, flow } ) {
+	const [ , shouldUseDomainSearchV2 ] = useDomainSearchV2( flow );
 	const { setHideFreePlan, setDomainCartItem, setDomain } = useDispatch( ONBOARD_STORE );
 	const { __ } = useI18n();
 
@@ -194,18 +195,18 @@ const DomainsStep: Step< {
 				);
 			case COPY_SITE_FLOW:
 				return __( 'Make your copied site unique with a custom domain all of its own.' );
-			case DOMAIN_UPSELL_FLOW:
-				return __( 'Enter some descriptive keywords to get started.' );
 			case HUNDRED_YEAR_PLAN_FLOW:
 			case HUNDRED_YEAR_DOMAIN_FLOW:
 				return __( 'Secure your 100-Year domain and start building your legacy.' );
 			default:
-				return createInterpolateElement(
-					__(
-						'Help your site stand out with a custom domain. Not sure yet? <span>Decide later</span>.'
-					),
-					decideLaterComponent
-				);
+				return shouldUseDomainSearchV2
+					? __( 'Make it yours with a .com, .blog, or one of 350+ domain options.' )
+					: createInterpolateElement(
+							__(
+								'Help your site stand out with a custom domain. Not sure yet? <span>Decide later</span>.'
+							),
+							decideLaterComponent
+					  );
 		}
 	};
 
@@ -220,6 +221,10 @@ const DomainsStep: Step< {
 
 		if ( [ HUNDRED_YEAR_PLAN_FLOW, HUNDRED_YEAR_DOMAIN_FLOW ].includes( flow ) ) {
 			return __( 'Find the perfect domain' );
+		}
+
+		if ( shouldUseDomainSearchV2 ) {
+			return __( 'Claim your space on the web' );
 		}
 
 		return __( 'Choose a domain' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -2,6 +2,57 @@
 @import '@automattic/onboarding/styles/mixins';
 @import '../hundred-year-plan-step-wrapper/mixins';
 
+.copy-site,
+.newsletter,
+.readymade-template,
+.reblogging,
+.start-writing,
+.domain-upsell {
+	&.domains.step-container {
+		&:has( .wpcom-domain-search-v2 ) {
+			padding: 0 16px;
+			margin: 0 auto;
+			box-sizing: content-box;
+
+			@include break-small {
+				padding: 0 24px;
+			}
+		}
+
+		.use-my-domain__page-heading {
+			padding-left: 24px;
+			padding-right: 24px;
+			text-align: center;
+		}
+
+		.use-my-domain,
+		.connect-domain-step,
+		.domain-transfer-or-connect__content {
+			background: transparent;
+			box-shadow: none;
+
+			.form-text-input {
+				height: 100%;
+			}
+
+			@include break-mobile {
+				padding-left: 0;
+				padding-right: 0;
+			}
+		}
+	}
+}
+
+.hundred-year-plan-step-wrapper__step-container:has( .wpcom-domain-search-v2 ) {
+	width: 100%;
+
+	.domains__content {
+		padding: 0 16px;
+		margin: 0 auto;
+		max-width: 780px;
+	}
+}
+
 .domain-search-legacy--stepper {
 	.domains {
 		.step-container {

--- a/client/my-sites/domains/domain-search/style.scss
+++ b/client/my-sites/domains/domain-search/style.scss
@@ -2,6 +2,15 @@
 // domain search
 
 .domain-search-legacy--my-sites {
+	&:not(.is-domain-plan-package-flow) .site-domains-add-page {
+		.domains__domain-cart-foldable-card {
+			@include break-medium {
+				width: calc( 100% - var( --sidebar-width-min ) );
+				left: var( --sidebar-width-min );
+			}
+		}
+	}
+
 	.site-domains-add-page {
 		.already-own-a-domain {
 			display: none;
@@ -195,11 +204,6 @@
 			z-index: 99;
 			padding-bottom: 0 !important;
 			box-shadow: 0 -3px 10px 0 rgba( 0, 0, 0, 0.12 );
-
-			@include break-medium {
-				width: calc( 100% - var( --sidebar-width-min ) );
-				left: var( --sidebar-width-min );
-			}
 
 			.foldable-card__main {
 				max-width: 100%;

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1323,15 +1323,11 @@ class RenderDomainsStepComponent extends Component {
 			return '';
 		}
 
-		if ( shouldUseDomainSearchV2 ) {
-			return translate( 'Make it yours with a .com, .blog, or one of 350+ domain options.' );
-		}
-
 		if ( isAllDomains ) {
 			return translate( 'Find the domain that defines you' );
 		}
 
-		if ( isNewHostedSiteCreationFlow( flowName ) ) {
+		if ( isNewHostedSiteCreationFlow( flowName ) && ! shouldUseDomainSearchV2 ) {
 			return translate(
 				'Help your site stand out with a custom domain. Not sure yet? {{decideLater}}Decide later{{/decideLater}}.',
 				{
@@ -1365,6 +1361,10 @@ class RenderDomainsStepComponent extends Component {
 		}
 
 		if ( ! stepSectionName ) {
+			if ( shouldUseDomainSearchV2 ) {
+				return translate( 'Make it yours with a .com, .blog, or one of 350+ domain options.' );
+			}
+
 			return translate( 'Enter some descriptive keywords to get started.' );
 		}
 
@@ -1387,16 +1387,16 @@ class RenderDomainsStepComponent extends Component {
 			return '';
 		}
 
-		if ( shouldUseDomainSearchV2 ) {
-			return translate( 'Claim your space on the web' );
-		}
-
 		if ( headerText ) {
 			return headerText;
 		}
 
 		if ( isAllDomains ) {
 			return translate( 'Your next big idea starts here' );
+		}
+
+		if ( shouldUseDomainSearchV2 ) {
+			return translate( 'Claim your space on the web' );
 		}
 
 		if ( shouldUseMultipleDomainsInCart( flowName ) ) {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1532,6 +1532,16 @@ class RenderDomainsStepComponent extends Component {
 		);
 	}
 
+	shouldRenderStickyNavigation() {
+		if ( this.props.shouldUseDomainSearchV2 ) {
+			return false;
+		}
+
+		if ( shouldUseMultipleDomainsInCart( this.props.flowName ) ) {
+			return false;
+		}
+	}
+
 	render() {
 		if ( this.skipRender ) {
 			return null;
@@ -1752,7 +1762,7 @@ class RenderDomainsStepComponent extends Component {
 				goToNextStep={ this.handleSkip }
 				align="center"
 				isWideLayout
-				isSticky={ ! shouldUseDomainSearchV2 }
+				isSticky={ this.shouldRenderStickyNavigation() }
 				customizedActionButtons={ useDomainIOwnLink }
 			/>
 		);

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -13,6 +13,7 @@ import {
 	NEW_HOSTED_SITE_FLOW,
 	DOMAIN_FOR_GRAVATAR_FLOW,
 	isDomainForGravatarFlow,
+	AI_SITE_BUILDER_FLOW,
 } from '@automattic/onboarding';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { Button } from '@wordpress/components';
@@ -693,6 +694,7 @@ class RenderDomainsStepComponent extends Component {
 			DOMAIN_FOR_GRAVATAR_FLOW,
 			'onboarding-with-email',
 			NEW_HOSTED_SITE_FLOW,
+			AI_SITE_BUILDER_FLOW,
 		].includes( flowName );
 	};
 
@@ -1711,7 +1713,9 @@ class RenderDomainsStepComponent extends Component {
 						/>
 					}
 					backLabelText={ backLabelText }
-					hideSkip
+					hideSkip={ ! shouldUseDomainSearchV2 || AI_SITE_BUILDER_FLOW !== flowName }
+					skipLabelText={ translate( 'Decide later' ) }
+					onSkip={ () => this.handleSkip( undefined, true ) }
 					align="center"
 					isWideLayout
 					goBack={ goBack }

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -34,21 +34,22 @@ body:has( .wpcom-domain-search-v2 ) {
 		height: 60px;
 	}
 
-	.step-wrapper__content {
-		padding: 0 16px 32px 16px;
+	.step-wrapper {
+		padding-inline: 16px;
 
 		@include break-small {
 			padding-inline: 24px;
 		}
+	}
 
-		.domains-mini-cart__content {
-			padding-inline: 16px;
-			max-width: 1040px;
-
-			@include break-small {
-				padding-inline: 24px;
-			}
+	.domains-mini-cart {
+		@include break-small {
+			padding-inline: 24px;
 		}
+	}
+
+	.domains-mini-cart__content {
+		max-width: 1040px;
 	}
 
 	.step-wrapper__navigation-link {
@@ -82,23 +83,9 @@ body:has( .wpcom-domain-search-v2 ) {
 		}
 
 		.domains-mini-cart {
-			display: flex;
-			justify-content: center;
-			padding-inline: 1rem;
-			box-sizing: border-box;
-
-			@include break-small {
-				padding-inline: 24px;
-			}
-
 			@include break-large {
 				padding-inline: 32px;
 			}
-		}
-
-		.domains-mini-cart__content {
-			max-width: 1040px;
-			padding: 1rem 0;
 		}
 	}
 

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -34,6 +34,7 @@ body:has( .wpcom-domain-search-v2 ) {
 		height: 60px;
 	}
 
+	.step-route.domains:has( .step-container ),
 	.step-wrapper {
 		padding-inline: 16px;
 

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -98,13 +98,13 @@ body:has( .wpcom-domain-search-v2 ) {
 				padding-inline: 32px;
 			}
 		}
-	}
 
-	&:not( .is-domain-plan-package-flow ):has( .site-domains-add-page ) {
-		.domains-mini-cart {
-			@include break-medium {
-				width: calc( 100% - var( --sidebar-width-min ) );
-				left: var( --sidebar-width-min );
+		&:not( .is-domain-plan-package-flow ) {
+			.domains-mini-cart__container {
+				@include break-medium {
+					width: calc( 100% - var( --sidebar-width-min ) );
+					left: var( --sidebar-width-min );
+				}
 			}
 		}
 	}

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -117,12 +117,6 @@ body.domain-search-legacy--unified {
 	}
 
 	.signup__step.is-domains {
-		.action-buttons.step-wrapper__navigation {
-			@media ( max-width: $break-mobile ) {
-				display: none;
-			}
-		}
-
 		.async-load__placeholder {
 			margin: 12px;
 		}

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -52,6 +52,16 @@ body:has( .wpcom-domain-search-v2 ) {
 		max-width: 1040px;
 	}
 
+	&:has( .step-container-v2 ) {
+		.domains-mini-cart {
+			padding-inline: var( --step-container-v2-content-inline-padding );
+		}
+
+		.domains-mini-cart__content {
+			max-width: var( --step-container-v2-content-row-max-width );
+		}
+	}
+
 	.step-wrapper__navigation-link {
 		color: #1d2327;
 	}

--- a/packages/domain-search/src/components/domains-mini-cart/index.tsx
+++ b/packages/domain-search/src/components/domains-mini-cart/index.tsx
@@ -11,8 +11,6 @@ import { DomainsMiniCartSummary } from './summary';
 
 import './style.scss';
 
-const AnimatedCard = motion( Card );
-
 const animation = {
 	initial: {
 		y: '100%',
@@ -21,7 +19,7 @@ const animation = {
 	},
 	animateIn: {
 		y: 0,
-		display: 'block',
+		display: 'flex',
 		opacity: 1,
 	},
 	animateOut: {
@@ -37,21 +35,23 @@ const DomainsMiniCart = ( { className }: { className?: string } ) => {
 	const shouldDisplayMiniCart = cart.items.length > 0 && ! isFullCartOpen;
 
 	return (
-		<AnimatedCard
+		<motion.div
+			className={ clsx( 'domains-mini-cart__container', className ) }
 			initial={ animation.initial }
 			animate={ shouldDisplayMiniCart ? animation.animateIn : animation.animateOut }
 			transition={ { type: 'tween', duration: 0.25 } }
-			className={ clsx( 'domains-mini-cart', className ) }
-			isRounded={ false }
-			elevation={ 2 }
 		>
-			<div className="domains-mini-cart__content">
-				<HStack spacing={ 2 }>
-					<DomainsMiniCartSummary />
-					<DomainsMiniCartActions />
-				</HStack>
-			</div>
-		</AnimatedCard>
+			<Card isRounded={ false } elevation={ 2 } style={ { width: '100%' } }>
+				<div className="domains-mini-cart">
+					<div className="domains-mini-cart__content">
+						<HStack spacing={ 2 }>
+							<DomainsMiniCartSummary />
+							<DomainsMiniCartActions />
+						</HStack>
+					</div>
+				</div>
+			</Card>
+		</motion.div>
 	);
 };
 

--- a/packages/domain-search/src/components/domains-mini-cart/style.scss
+++ b/packages/domain-search/src/components/domains-mini-cart/style.scss
@@ -1,17 +1,23 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
-.domains-mini-cart {
+.domains-mini-cart__container {
 	position: fixed !important;
 	left: 0;
 	right: 0;
 	bottom: 0;
 }
 
+.domains-mini-cart {
+	justify-content: center;
+	padding-inline: 1rem;
+	display: flex;
+	box-sizing: border-box;
+}
+
 .domains-mini-cart__content {
 	box-sizing: border-box;
-	margin: 0 auto;
-	padding: 1rem;
+	padding-block: 1rem;
 	width: 100%;
 	max-width: 64rem;
 }

--- a/packages/onboarding/src/step-container-v2/components/ContentRow/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/ContentRow/style.scss
@@ -13,7 +13,11 @@
 			( var( --columns ) - 1 ) * var( --step-container-v2-content-column-gap )
 		);
 
-		max-width: calc( var( --total-gap-width ) + var( --total-column-width ) );
+		--step-container-v2-content-row-max-width: calc(
+			var( --total-gap-width ) + var( --total-column-width )
+		);
+
+		max-width: var( --step-container-v2-content-row-max-width );
 	}
 
 	&.stretched {


### PR DESCRIPTION
Closes DOMAINS-1404.

## Proposed Changes

Same as https://github.com/Automattic/wp-calypso/pull/104895, but for the `/setup/*` flows.

## Testing Instructions

Verify that, in all flows, you can perform the same actions as in production (transfer, skip.)

Verify that the page has proper margins, paddings, and the cart and results are aligned in all viewports.

**Also, verify that turning the feature flag off yields the same results as production.**

The flows are listed in Linear. Check the flows for the following tickets:
- DOMAINS-1403
- DOMAINS-1404
- DOMAINS-1405