### PR TITLE
Domain Search Retrofitting: Make sure the in-Calypso experience has consistent designs and behavior

### DIFF
--- a/client/components/domain-search-v2/register-domain-step/style.scss
+++ b/client/components/domain-search-v2/register-domain-step/style.scss
@@ -2,7 +2,6 @@
 @import '@wordpress/base-styles/mixins';
 
 .wpcom-domain-search-v2 {
-
 	&.initial-state {
 		max-width: 800px;
 		margin-inline: auto;
@@ -41,7 +40,7 @@
 
 	.wpcom-domain-search-v2__sticky-bottom {
 		position: fixed;
-		z-index: z-index('root', '.sticky-panel.is-sticky .sticky-panel__content');
+		z-index: z-index( 'root', '.sticky-panel.is-sticky .sticky-panel__content' );
 		display: flex;
 		justify-content: center;
 		left: 1rem;
@@ -57,5 +56,9 @@
 		.summary-button {
 			width: auto;
 		}
+	}
+
+	.register-domain-step__domains-quickfilter-group {
+		padding-bottom: 0;
 	}
 }

--- a/client/my-sites/domains/style.scss
+++ b/client/my-sites/domains/style.scss
@@ -1,6 +1,46 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
+.is-section-domains.is-domain-plan-package-flow {
+	background: var( --color-body-background );
+
+	.domains__header {
+		display: block;
+
+		h1 {
+			font-family: $brand-serif;
+			font-size: $font-headline-small;
+		}
+
+		p {
+			font-size: $font-body;
+			color: var( --color-text-subtle );
+			text-align: center;
+			padding: 0 10px;
+			max-width: $break-small;
+			margin-inline: auto;
+		}
+
+		.domains__header-decide-later {
+			color: var( --studio-gray-90 );
+			font-weight: 500;
+			padding-left: 5px;
+			text-decoration: underline;
+		}
+	}
+
+	@include break-small {
+		.domains__header {
+			h1 {
+				font-size: $font-headline-medium;
+			}
+			p {
+				padding: 0 80px;
+			}
+		}
+	}
+}
+
 .domain-search-legacy--my-sites {
 	.domains__header {
 		display: flex;
@@ -9,46 +49,6 @@
 
 		@include breakpoint-deprecated( '<660px' ) {
 			align-items: center;
-		}
-	}
-
-	&.is-section-domains.is-domain-plan-package-flow {
-		background: var( --color-body-background );
-
-		.domains__header {
-			display: block;
-
-			h1 {
-				font-family: $brand-serif;
-				font-size: $font-headline-small;
-			}
-
-			p {
-				font-size: $font-body;
-				color: var( --color-text-subtle );
-				text-align: center;
-				padding: 0 10px;
-				max-width: $break-small;
-				margin-inline: auto;
-			}
-
-			.domains__header-decide-later {
-				color: var( --studio-gray-90 );
-				font-weight: 500;
-				padding-left: 5px;
-				text-decoration: underline;
-			}
-		}
-
-		@include break-small {
-			.domains__header {
-				h1 {
-					font-size: $font-headline-medium;
-				}
-				p {
-					padding: 0 80px;
-				}
-			}
 		}
 	}
 }

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -81,28 +81,26 @@ body:has( .wpcom-domain-search-v2 ) {
 			}
 		}
 
-		.domains-mini-cart {
-			.domains-mini-cart__content {
-				padding-inline: 16px;
-				max-width: 1040px;
+		.domains-mini-cart__content {
+			padding-inline: 16px;
+			max-width: 1040px;
 
-				@include break-small {
-					padding-inline: 24px;
-				}
+			@include break-small {
+				padding-inline: 24px;
+			}
 
-				@include break-large {
-					padding-inline: 32px;
-				}
+			@include break-large {
+				padding-inline: 32px;
+			}
 
-				@include break-xlarge {
-					padding-inline: 0;
-				}
+			@include break-xlarge {
+				padding-inline: 0;
 			}
 		}
 	}
 
 	&:not( .is-domain-plan-package-flow ):has( .site-domains-add-page ) {
-		.domains-mini-cart__content {
+		.domains-mini-cart {
 			@include break-medium {
 				width: calc( 100% - var( --sidebar-width-min ) );
 				left: var( --sidebar-width-min );

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -81,9 +81,11 @@ body:has( .wpcom-domain-search-v2 ) {
 			}
 		}
 
-		.domains-mini-cart__content {
-			padding-inline: 16px;
-			max-width: 1040px;
+		.domains-mini-cart {
+			display: flex;
+			justify-content: center;
+			padding-inline: 1rem;
+			box-sizing: border-box;
 
 			@include break-small {
 				padding-inline: 24px;
@@ -92,10 +94,11 @@ body:has( .wpcom-domain-search-v2 ) {
 			@include break-large {
 				padding-inline: 32px;
 			}
+		}
 
-			@include break-xlarge {
-				padding-inline: 0;
-			}
+		.domains-mini-cart__content {
+			max-width: 1040px;
+			padding: 1rem 0;
 		}
 	}
 

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -54,6 +54,61 @@ body:has( .wpcom-domain-search-v2 ) {
 	.step-wrapper__navigation-link {
 		color: #1d2327;
 	}
+
+	&:has( .site-domains-add-page ) {
+		.domain-search__go-back {
+			color: var( --studio-gray-50 );
+			font-size: 0.875rem;
+			line-height: 17px;
+			text-decoration: none;
+			margin-bottom: 18px;
+		}
+
+		@media ( max-width: #{$break-small} ) {
+			.layout__content {
+				padding-inline: 16px !important;
+			}
+
+			.new-domains-redirection-notice-upsell__banner {
+				margin-bottom: 24px;
+			}
+		}
+
+		@media ( max-width: #{$break-medium} ) {
+			.formatted-header {
+				margin-top: 0;
+				margin-left: 0;
+			}
+		}
+
+		.domains-mini-cart {
+			.domains-mini-cart__content {
+				padding-inline: 16px;
+				max-width: 1040px;
+
+				@include break-small {
+					padding-inline: 24px;
+				}
+
+				@include break-large {
+					padding-inline: 32px;
+				}
+
+				@include break-xlarge {
+					padding-inline: 0;
+				}
+			}
+		}
+	}
+
+	&:not( .is-domain-plan-package-flow ):has( .site-domains-add-page ) {
+		.domains-mini-cart__content {
+			@include break-medium {
+				width: calc( 100% - var( --sidebar-width-min ) );
+				left: var( --sidebar-width-min );
+			}
+		}
+	}
 }
 
 body.domain-search-legacy--unified {

--- a/client/signup/steps/domains/utils.js
+++ b/client/signup/steps/domains/utils.js
@@ -37,6 +37,7 @@ export function shouldUseMultipleDomainsInCart( flowName ) {
 	const enabledFlows = [
 		'domain',
 		'onboarding',
+		'domains',
 		'domains/add',
 		EXAMPLE_FLOW,
 		NEW_HOSTED_SITE_FLOW,


### PR DESCRIPTION
Closes DOMAINS-1403.

## Proposed Changes

Same as https://github.com/Automattic/wp-calypso/pull/104895, but for the /domains/add/:siteId flow.

## Testing Instructions

Verify that, in `/domains/add/:siteId` and `/domains/add/:siteId?domainAndPlanPackage=true`, you can perform the same actions as in production (transfer, skip.) Also, verify that turning the feature flag off yields the same results as production.

Verify that the page has proper margins, paddings, and the cart and results are aligned in all viewports.
