### PR TITLE
Enable FEATURE_ADVANCED_FORM_FEATURES_JP only on paid plans

### DIFF
--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -621,7 +621,6 @@ const getPlanFreeDetails = (): IncompleteWPcomPlan => ( {
 			FEATURE_STATS_JP,
 			FEATURE_SPAM_JP,
 			FEATURE_CONTACT_FORM_JP,
-			FEATURE_ADVANCED_FORM_FEATURES_JP,
 			FEATURE_SITE_ACTIVITY_LOG_JP,
 			FEATURE_UNLTD_SOCIAL_MEDIA_JP,
 			FEATURE_ES_SEARCH_JP,
@@ -840,6 +839,9 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		return isGlobalStylesOnPersonalEnabled()
 			? [ ...baseFeatures, FEATURE_STYLE_CUSTOMIZATION ]
 			: baseFeatures;
+	},
+	get2023PlanComparisonJetpackFeatureOverride: () => {
+		return [ FEATURE_ADVANCED_FORM_FEATURES_JP ];
 	},
 	getStorageFeature: () => FEATURE_6GB_STORAGE,
 	getPlanComparisonFeatureLabels: () => {
@@ -1461,6 +1463,7 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 			FEATURE_PAYPAL_JP,
 			FEATURE_UPLOAD_VIDEO,
 			isEnabled( 'stats/paid-wpcom-v3' ) ? FEATURE_STATS_COMMERCIAL : FEATURE_STATS_PAID,
+			FEATURE_ADVANCED_FORM_FEATURES_JP,
 		];
 	},
 	// Features not displayed but used for checking plan abilities
@@ -1650,6 +1653,7 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 			FEATURE_UPTIME_MONITOR_JP,
 			FEATURE_PLUGIN_AUTOUPDATE_JP,
 			FEATURE_SEO_JP,
+			FEATURE_ADVANCED_FORM_FEATURES_JP,
 		];
 	},
 	getPlanComparisonFeatureLabels: () => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # M4R73CH-1014

## Proposed Changes

* Enables FEATURE_ADVANCED_FORM_FEATURES_JP only for paid plans. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As a follow-up to https://github.com/Automattic/wp-calypso/pull/104784, this PR fixes a bug where the new Advanced Form Features was showing as enabled for all plans, including Free, which shouldn't be the case. This PR manually enables FEATURE_ADVANCED_FORM_FEATURES_JP for only paid plans.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch and visit a test site at http://calypso.localhost:3000/plans/[siteaddress]
* View the plans grid. There should be no changes.
* Click the Compare plans button to view the comparison grid.
* You should now see that Advanced form features should be available on the personal and up plans. 

**Before:**
<img width="1198" height="511" alt="Screenshot 2025-07-24 at 8 35 31 PM" src="https://github.com/user-attachments/assets/11b2fbc7-3efb-4d97-b42b-89786b7ff2f6" />

**After:**
<img width="1207" height="415" alt="Screenshot 2025-07-24 at 8 34 13 PM" src="https://github.com/user-attachments/assets/883bc5b4-8c2e-400f-a799-d8e3115cbb93" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
