### PR TITLE
Detect errors in data layer and handle them when routing

### DIFF
--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -4,6 +4,7 @@ import {
 	createRootRoute,
 	redirect,
 	createLazyRoute,
+	lazyRouteComponent,
 } from '@tanstack/react-router';
 import { HostingFeatures } from '../data/constants';
 import { fetchTwoStep } from '../data/me';
@@ -110,6 +111,7 @@ const siteRoute = createRoute( {
 			await queryClient.ensureQueryData( siteByIdQuery( otherEnvironmentSiteId ) );
 		}
 	},
+	errorComponent: lazyRouteComponent( () => import( '../sites/site/error' ) ),
 } ).lazy( () =>
 	import( '../sites/site' ).then( ( d ) =>
 		createLazyRoute( 'site' )( {

--- a/client/dashboard/data/error.ts
+++ b/client/dashboard/data/error.ts
@@ -1,0 +1,13 @@
+export class DashboardDataError extends Error {
+	constructor(
+		public code: string,
+		cause?: unknown
+	) {
+		const message = cause instanceof Error ? cause.message : `Error: ${ cause }`;
+		super( message, { cause } );
+		this.name = 'DashboardDataError';
+
+		// Fix prototype chain (important for instanceof to work reliably)
+		Object.setPrototypeOf( this, new.target.prototype );
+	}
+}

--- a/client/dashboard/data/error.ts
+++ b/client/dashboard/data/error.ts
@@ -11,3 +11,21 @@ export class DashboardDataError extends Error {
 		Object.setPrototypeOf( this, new.target.prototype );
 	}
 }
+
+interface WPError extends Error {
+	status: number;
+	statusCode: number;
+	error?: string;
+	[ key: string ]: unknown;
+}
+
+export function isWpError( error: unknown ): error is WPError {
+	return (
+		error instanceof Error &&
+		'status' in error &&
+		typeof error.status === 'number' &&
+		'statusCode' in error &&
+		typeof error.statusCode === 'number' &&
+		( 'error' in error ? typeof error.error === 'string' : true )
+	);
+}

--- a/client/dashboard/data/site.ts
+++ b/client/dashboard/data/site.ts
@@ -1,4 +1,5 @@
 import wpcom from 'calypso/lib/wp';
+import { DashboardDataError } from './error';
 
 export const SITE_FIELDS = [
 	'ID',
@@ -112,10 +113,17 @@ export interface Site {
 }
 
 export async function fetchSite( siteIdOrSlug: number | string ): Promise< Site > {
-	return await wpcom.req.get(
-		{ path: `/sites/${ siteIdOrSlug }` },
-		{ fields: JOINED_SITE_FIELDS, options: JOINED_SITE_OPTIONS }
-	);
+	try {
+		return await wpcom.req.get(
+			{ path: `/sites/${ siteIdOrSlug }` },
+			{ fields: JOINED_SITE_FIELDS, options: JOINED_SITE_OPTIONS }
+		);
+	} catch ( error ) {
+		if ( error instanceof Error && error.message.includes( '[-32710]' ) ) {
+			throw new DashboardDataError( 'inaccessible_jetpack', error );
+		}
+		throw error;
+	}
 }
 
 export async function deleteSite( siteId: number ) {

--- a/client/dashboard/data/site.ts
+++ b/client/dashboard/data/site.ts
@@ -1,5 +1,5 @@
 import wpcom from 'calypso/lib/wp';
-import { DashboardDataError } from './error';
+import { isWpError, DashboardDataError } from './error';
 
 export const SITE_FIELDS = [
 	'ID',
@@ -119,7 +119,7 @@ export async function fetchSite( siteIdOrSlug: number | string ): Promise< Site 
 			{ fields: JOINED_SITE_FIELDS, options: JOINED_SITE_OPTIONS }
 		);
 	} catch ( error ) {
-		if ( error instanceof Error && error.message.includes( '[-32710]' ) ) {
+		if ( isWpError( error ) && error.error === 'parse_error' ) {
 			throw new DashboardDataError( 'inaccessible_jetpack', error );
 		}
 		throw error;

--- a/client/dashboard/sites/site/error.tsx
+++ b/client/dashboard/sites/site/error.tsx
@@ -1,16 +1,11 @@
-import { useQueryClient } from '@tanstack/react-query';
 import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import UnknownError from '../../app/500';
-import { siteBySlugQuery } from '../../app/queries/site';
-import { sitesQuery } from '../../app/queries/sites';
 import { siteRoute } from '../../app/router';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';
 import { DashboardDataError } from '../../data/error';
-import { getSiteDisplayName } from '../../utils/site-name';
-import type { Site } from '../../data/types';
 
 export default function Error( { error }: { error: Error } ) {
 	switch ( error instanceof DashboardDataError && error.code ) {
@@ -23,19 +18,12 @@ export default function Error( { error }: { error: Error } ) {
 
 function InaccessibleJetpackError( { error }: { error: Error } ) {
 	const { siteSlug } = siteRoute.useParams();
-	const queryClient = useQueryClient();
-
-	let site = queryClient.getQueryData< Site >( siteBySlugQuery( siteSlug ).queryKey );
-	if ( ! site ) {
-		const allSites = queryClient.getQueryData< Site[] >( sitesQuery().queryKey );
-		site = allSites?.find( ( s ) => s.slug === siteSlug );
-	}
 
 	return (
 		<PageLayout
 			header={
 				<PageHeader
-					title={ site ? getSiteDisplayName( site ) : siteSlug }
+					title={ siteSlug }
 					description={ __( 'Your Jetpack site can not be reached at this time.' ) }
 					actions={
 						<RouterLinkButton to="/sites" variant="primary" __next40pxDefaultSize>

--- a/client/dashboard/sites/site/error.tsx
+++ b/client/dashboard/sites/site/error.tsx
@@ -1,0 +1,54 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { Notice } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import UnknownError from '../../app/500';
+import { siteBySlugQuery } from '../../app/queries/site';
+import { sitesQuery } from '../../app/queries/sites';
+import { siteRoute } from '../../app/router';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import RouterLinkButton from '../../components/router-link-button';
+import { DashboardDataError } from '../../data/error';
+import { getSiteDisplayName } from '../../utils/site-name';
+import type { Site } from '../../data/types';
+
+export default function Error( { error }: { error: Error } ) {
+	switch ( error instanceof DashboardDataError && error.code ) {
+		case 'inaccessible_jetpack':
+			return <InaccessibleJetpackError error={ error } />;
+		default:
+			return <UnknownError error={ error } />;
+	}
+}
+
+function InaccessibleJetpackError( { error }: { error: Error } ) {
+	const { siteSlug } = siteRoute.useParams();
+	const queryClient = useQueryClient();
+
+	let site = queryClient.getQueryData< Site >( siteBySlugQuery( siteSlug ).queryKey );
+	if ( ! site ) {
+		const allSites = queryClient.getQueryData< Site[] >( sitesQuery().queryKey );
+		site = allSites?.find( ( s ) => s.slug === siteSlug );
+	}
+
+	return (
+		<PageLayout
+			header={
+				<PageHeader
+					title={ site ? getSiteDisplayName( site ) : siteSlug }
+					description={ __( 'Your Jetpack site can not be reached at this time.' ) }
+					actions={
+						<RouterLinkButton to="/sites" variant="primary" __next40pxDefaultSize>
+							{ __( 'Go to Sites' ) }
+						</RouterLinkButton>
+					}
+				/>
+			}
+			notices={
+				<Notice status="error" isDismissible={ false }>
+					{ error.message }
+				</Notice>
+			}
+		></PageLayout>
+	);
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

More generally, this PR suggests an error handling strategy.
- Detect errors in the data layer
- Handle those errors in the UI, it could be
  - router
  - suspense boundary
  - error boundary

It seems like React has moved in the direction of propagating errors through the component tree using exceptions. So perhaps we just embrace that.

More specifically, this detects and show a specific error UI when we detect the case of a Jurassic Ninja site being missing

<img width="2334" height="888" alt="CleanShot 2025-07-25 at 16 57 40@2x" src="https://github.com/user-attachments/assets/eeae0e57-5377-4567-a3c7-ee77ddfbff03" />

## Why make this change?

I think of the "500" error page as a last resort. It gives the user a way to recover (by navigating to `/sites`) but we should actually handle expected error cases with something else.

Most errors probably won't propagate all the way up to such a high level in the router. But this same exception throwing strategy should work for more localised `<ErrorBoundary>` components too.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Hopefully you have an old Jurassic Ninja site that has been cleaned up.
Navigate to `/v2/sites/old.jurassic.ninja`
You should not see the "500" error page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
