### PR TITLE
Always show the "Show more results" button in the domain suggestions even if the mini cart is visible

### DIFF
--- a/client/components/domain-search-v2/domain-cart/style.scss
+++ b/client/components/domain-search-v2/domain-cart/style.scss
@@ -2,3 +2,7 @@
 .domains-search-v2__full-cart {
 	z-index: z-index( 'root', '.drawer' );
 }
+
+.domains-search-v2__mini-cart {
+	height: var( --domain-search-mini-cart-height );
+}

--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -673,7 +673,7 @@ class RegisterDomainStep extends Component {
 				cart={ this.getCart() }
 				className="wpcom-domain-search-v2"
 			>
-				<VStack spacing={ 8 }>
+				<VStack spacing={ 8 } className="wpcom-domain-search-v2__content">
 					<VStack spacing={ 4 }>
 						{ this.renderSearchControls() }
 						{ isDomainAndPlanPackageFlow && this.renderQuickFilters() }

--- a/client/components/domain-search-v2/register-domain-step/style.scss
+++ b/client/components/domain-search-v2/register-domain-step/style.scss
@@ -1,7 +1,10 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
+
 .wpcom-domain-search-v2 {
+	--domain-search-mini-cart-height: 80px;
+	margin-bottom: var( --domain-search-mini-cart-height );
 
 	&.initial-state {
 		max-width: 800px;


### PR DESCRIPTION
When the mini-cart is visible the "Show more results" button overlaps with it and customers can't click on it.

Here's how that looks when you scroll down to the bottom:

| before | after |
| --- | --- |
| <img width="1212" height="432" alt="Screenshot 2025-07-25 at 14 07 53" src="https://github.com/user-attachments/assets/8a1fa9fd-2248-4132-a5a6-28541e302d93" /> | <img width="1220" height="565" alt="Screenshot 2025-07-25 at 14 08 18" src="https://github.com/user-attachments/assets/f49993a8-c680-4df5-a057-1aa286222434" /> |
| <img width="1181" height="505" alt="Screenshot 2025-07-25 at 14 08 05" src="https://github.com/user-attachments/assets/3cefd8e9-ad2c-47a5-b8ea-11df63efeb31" /> | <img width="1198" height="528" alt="Screenshot 2025-07-25 at 14 08 27" src="https://github.com/user-attachments/assets/ee05eddb-b53c-45c9-9f8e-27808515e41e" /> |


Part of https://linear.app/a8c/issue/DOMAINS-1561/show-more-result-button-is-not-reachable-when-the-mini-cart-is

## Proposed Changes

* Set fixed margin-bottom for the container of domain results so that the "Show more results" button would not overlap with the mini-cart


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The Show More button was not accessible

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup/onboarding
* Search for some domains, then add one in the cart
* Verify that the "Show more results" button at the bottom is visible and can be clicked

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
