### PR TITLE
Reader: Add  useFeedRecommendationsQuery hook to centralize the fetching logic

### DIFF
--- a/client/components/gravatar-with-hovercards/recommended-blogs/index.jsx
+++ b/client/components/gravatar-with-hovercards/recommended-blogs/index.jsx
@@ -1,25 +1,17 @@
 import page from '@automattic/calypso-router';
 import { useTranslate } from 'i18n-calypso';
 import { shuffle } from 'lodash';
-import { useEffect } from 'react';
-import { useSelector, useDispatch } from 'calypso/state';
-import { requestUserRecommendedBlogs } from 'calypso/state/reader/lists/actions';
-import { getUserRecommendedBlogs } from 'calypso/state/reader/lists/selectors';
+import { useFeedRecommendationsQuery } from 'calypso/data/reader/use-feed-recommendations-query';
 import RecommendedBlogItem from './item';
 
 function RecommendedBlogs( { userLogin, closeCard } ) {
 	const translate = useTranslate();
-	const dispatch = useDispatch();
-	const recommendedBlogs = useSelector( ( state ) => getUserRecommendedBlogs( state, userLogin ) );
+	const { data: recommendedBlogs } = useFeedRecommendationsQuery( userLogin, {
+		enabled: !! userLogin,
+	} );
+
 	const recommendedBlogsPath = `/reader/users/${ userLogin }/recommended-blogs`;
-
 	const shouldShowRecommendedBlogs = recommendedBlogs?.length && userLogin;
-
-	useEffect( () => {
-		if ( ! recommendedBlogs && userLogin ) {
-			dispatch( requestUserRecommendedBlogs( userLogin ) );
-		}
-	}, [ userLogin, recommendedBlogs, dispatch ] );
 
 	const handleViewAllClick = ( e ) => {
 		e.preventDefault();

--- a/client/components/gravatar-with-hovercards/recommended-blogs/item.jsx
+++ b/client/components/gravatar-with-hovercards/recommended-blogs/item.jsx
@@ -6,25 +6,8 @@ import ReaderFollowButton from 'calypso/reader/follow-button';
 import { useSelector } from 'calypso/state';
 import { getSite } from 'calypso/state/reader/sites/selectors';
 
-// A blog from a list may have either a site or feed object, and the data is structured in different
-// property names. This function normalizes the data to a consistent format.
-const getBlogData = ( blog ) => {
-	if ( blog.meta?.data?.site ) {
-		const { name, feed_URL: feedUrl, ID: siteId, icon } = blog.meta.data.site;
-		return {
-			image: icon?.img || icon?.ico,
-			name,
-			feedUrl,
-			siteId,
-			feedId: blog.feed_ID,
-		};
-	}
-	const { image, name, feed_URL: feedUrl, blog_ID: siteId } = blog.meta?.data?.feed || {};
-	return { image, name, feedUrl, siteId, feedId: blog.feed_ID };
-};
-
 function RecommendedBlogItem( { blog, classPrefix, compact = false, onLinkClick = () => {} } ) {
-	const { image, name, feedUrl, siteId, feedId } = getBlogData( blog );
+	const { image, name, feedUrl, siteId, feedId } = blog;
 
 	const site = useSelector( ( state ) => getSite( state, siteId ) );
 	const siteIcon = site?.icon?.img || site?.icon?.ico || image;

--- a/client/data/reader/use-feed-recommendations-query/index.tsx
+++ b/client/data/reader/use-feed-recommendations-query/index.tsx
@@ -69,7 +69,15 @@ const normalizeFeedRecommendation = ( blog: APIFeedRecommendation ): FeedRecomme
 	};
 };
 
-export const useFeedRecommendationsQuery = ( userLogin?: string, options?: QueryOptions ) => {
+/**
+ * Hook to fetch and manage user recommended blogs.
+ * 
+ * @param userLogin - The user login to fetch recommendations for
+ * @param options - Optional configuration
+ * @param options.enabled - Whether the query should be enabled (default: true)
+ * @returns Object containing loading state, data, and success status
+ */
+export const useFeedRecommendationsQuery = (userLogin?: string, options?: QueryOptions) => {
 	const { enabled = true } = options || {};
 	const dispatch = useDispatch();
 	const hasRequested = useSelector( ( state ) =>

--- a/client/data/reader/use-feed-recommendations-query/index.tsx
+++ b/client/data/reader/use-feed-recommendations-query/index.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useMemo } from 'react';
+import { useDispatch, useSelector } from 'calypso/state';
+import { requestUserRecommendedBlogs } from 'calypso/state/reader/lists/actions';
+import {
+	getUserRecommendedBlogs,
+	hasRequestedUserRecommendedBlogs,
+	isRequestingUserRecommendedBlogs,
+} from 'calypso/state/reader/lists/selectors';
+
+interface QueryOptions {
+	enabled?: boolean;
+}
+
+interface APIFeedRecommendation {
+	meta: {
+		data: {
+			site?: {
+				name: string;
+				feed_URL: string;
+				ID: string;
+				icon: {
+					img?: string;
+					ico?: string;
+				};
+				description: string;
+			};
+			feed?: {
+				image: string;
+				name: string;
+				feed_URL: string;
+				blog_ID: string;
+			};
+		};
+	};
+	feed_ID: string;
+}
+
+export interface FeedRecommendation {
+	ID: string;
+	image?: string;
+	name?: string;
+	feedUrl?: string;
+	siteId?: string;
+	feedId: string;
+}
+
+// A blog from a list may have either a site or feed object, and the data is structured in different
+// property names. This function normalizes the data to a consistent format.
+const normalizeFeedRecommendation = ( blog: APIFeedRecommendation ): FeedRecommendation => {
+	if ( blog.meta?.data?.site ) {
+		const { name, feed_URL: feedUrl, ID: siteId, icon } = blog.meta.data.site;
+		return {
+			ID: blog.meta.data.site.ID,
+			image: icon?.img || icon?.ico,
+			name,
+			feedUrl,
+			siteId,
+			feedId: blog.feed_ID,
+		};
+	}
+	const { image, name, feed_URL: feedUrl, blog_ID: siteId } = blog.meta?.data?.feed || {};
+	return {
+		ID: blog.meta?.data?.feed?.blog_ID || '',
+		image,
+		name,
+		feedUrl,
+		siteId,
+		feedId: blog.feed_ID,
+	};
+};
+
+export const useFeedRecommendationsQuery = ( userLogin?: string, options?: QueryOptions ) => {
+	const { enabled = true } = options || {};
+	const dispatch = useDispatch();
+	const hasRequested = useSelector( ( state ) =>
+		hasRequestedUserRecommendedBlogs( state, userLogin || '' )
+	);
+
+	const isRequesting = useSelector( ( state ) =>
+		isRequestingUserRecommendedBlogs( state, userLogin || '' )
+	);
+
+	const recommendedBlogs = useSelector( ( state ) =>
+		getUserRecommendedBlogs( state, userLogin || '' )
+	);
+
+	useEffect( () => {
+		if ( ! recommendedBlogs && userLogin && ! hasRequested && enabled ) {
+			dispatch( requestUserRecommendedBlogs( userLogin ) );
+		}
+	}, [ userLogin, recommendedBlogs, dispatch, hasRequested, enabled ] );
+
+	const feedRecommendations = useMemo< FeedRecommendation[] >(
+		() => recommendedBlogs?.map?.( normalizeFeedRecommendation ),
+		[ recommendedBlogs ]
+	);
+
+	return {
+		isLoading: isRequesting,
+		data: feedRecommendations ?? [],
+		isSuccess: ! isRequesting && hasRequested,
+	};
+};

--- a/client/data/reader/use-feed-recommendations-query/index.tsx
+++ b/client/data/reader/use-feed-recommendations-query/index.tsx
@@ -71,13 +71,12 @@ const normalizeFeedRecommendation = ( blog: APIFeedRecommendation ): FeedRecomme
 
 /**
  * Hook to fetch and manage user recommended blogs.
- * 
  * @param userLogin - The user login to fetch recommendations for
  * @param options - Optional configuration
  * @param options.enabled - Whether the query should be enabled (default: true)
  * @returns Object containing loading state, data, and success status
  */
-export const useFeedRecommendationsQuery = (userLogin?: string, options?: QueryOptions) => {
+export const useFeedRecommendationsQuery = ( userLogin?: string, options?: QueryOptions ) => {
 	const { enabled = true } = options || {};
 	const dispatch = useDispatch();
 	const hasRequested = useSelector( ( state ) =>

--- a/client/data/reader/use-feed-recommendations-query/test/index.test.ts
+++ b/client/data/reader/use-feed-recommendations-query/test/index.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { useFeedRecommendationsQuery } from 'calypso/data/reader/use-feed-recommendations-query';
+import { requestUserRecommendedBlogs } from 'calypso/state/reader/lists/actions';
+import {
+	getUserRecommendedBlogs,
+	hasRequestedUserRecommendedBlogs,
+	isRequestingUserRecommendedBlogs,
+} from 'calypso/state/reader/lists/selectors';
+import { type AppState } from 'calypso/types';
+
+jest.mock( 'calypso/state', () => ( {
+	useSelector: ( selector: ( state: AppState ) => any ) => selector( {} as AppState ),
+	useDispatch: () => jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state/reader/lists/selectors', () => ( {
+	getUserRecommendedBlogs: jest.fn(),
+	isRequestingUserRecommendedBlogs: jest.fn(),
+	hasRequestedUserRecommendedBlogs: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state/reader/lists/actions', () => ( {
+	requestUserRecommendedBlogs: jest.fn(),
+} ) );
+
+describe( 'useFeedRecommendationsQuery', () => {
+	beforeEach( () => {
+		jest.resetAllMocks();
+	} );
+
+	it( 'returns an empty array when no recommended blogs are found', () => {
+		const { result } = renderHook( () => useFeedRecommendationsQuery( 'test' ) );
+		expect( result.current.data ).toEqual( [] );
+	} );
+
+	it( 'returns the correct data when recommended blogs are found', () => {
+		jest.mocked( getUserRecommendedBlogs ).mockReturnValue( [
+			{
+				ID: '1',
+				name: 'Test Blog 1',
+				feedId: '1',
+			},
+		] );
+		const { result } = renderHook( () => useFeedRecommendationsQuery( 'test' ) );
+		expect( result.current.data ).toHaveLength( 1 );
+	} );
+
+	it( 'returns loading state when recommended blogs are being requested', () => {
+		jest.mocked( isRequestingUserRecommendedBlogs ).mockReturnValue( true );
+		const { result } = renderHook( () => useFeedRecommendationsQuery( 'test' ) );
+
+		expect( result.current.isLoading ).toBe( true );
+	} );
+
+	it( 'requests recommended blogs when not available and not yet requested', async () => {
+		const requestUserRecommendedBlogsMock = jest.fn();
+
+		jest
+			.mocked( requestUserRecommendedBlogs )
+			.mockImplementation( requestUserRecommendedBlogsMock );
+
+		jest.mocked( hasRequestedUserRecommendedBlogs ).mockReturnValue( false );
+
+		renderHook( () => useFeedRecommendationsQuery( 'test' ) );
+
+		expect( requestUserRecommendedBlogsMock ).toHaveBeenCalled();
+	} );
+
+	it( 'does not request recommended blogs when not available and already requested', async () => {
+		const requestUserRecommendedBlogsMock = jest.fn();
+
+		jest
+			.mocked( requestUserRecommendedBlogs )
+			.mockImplementation( requestUserRecommendedBlogsMock );
+
+		jest.mocked( hasRequestedUserRecommendedBlogs ).mockReturnValue( true );
+
+		renderHook( () => useFeedRecommendationsQuery( 'test' ) );
+
+		expect( requestUserRecommendedBlogsMock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not request recommended blogs when it is disabled', async () => {
+		const requestUserRecommendedBlogsMock = jest.fn();
+		jest.mocked( hasRequestedUserRecommendedBlogs ).mockReturnValue( false );
+
+		jest
+			.mocked( requestUserRecommendedBlogs )
+			.mockImplementation( requestUserRecommendedBlogsMock );
+
+		renderHook( () => useFeedRecommendationsQuery( 'test', { enabled: false } ) );
+
+		expect( requestUserRecommendedBlogsMock ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/reader/user-profile/views/recommended-blogs.tsx
+++ b/client/reader/user-profile/views/recommended-blogs.tsx
@@ -1,18 +1,12 @@
 import { LoadingPlaceholder } from '@automattic/components';
 import { siteLogo, Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
 import EmptyContent from 'calypso/components/empty-content';
 import RecommendedBlogItem from 'calypso/components/gravatar-with-hovercards/recommended-blogs/item';
+import { useFeedRecommendationsQuery } from 'calypso/data/reader/use-feed-recommendations-query';
 import { UserData } from 'calypso/lib/user/user';
-import { useSelector, useDispatch } from 'calypso/state';
+import { useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import { requestUserRecommendedBlogs } from 'calypso/state/reader/lists/actions';
-import {
-	isRequestingUserRecommendedBlogs,
-	hasRequestedUserRecommendedBlogs,
-	getUserRecommendedBlogs,
-} from 'calypso/state/reader/lists/selectors';
 
 interface UserRecommendedBlogsProps {
 	user: UserData;
@@ -20,27 +14,14 @@ interface UserRecommendedBlogsProps {
 
 const UserRecommendedBlogs = ( { user }: UserRecommendedBlogsProps ): JSX.Element | null => {
 	const { user_login: userLogin } = user;
-	const dispatch = useDispatch();
 	const translate = useTranslate();
-	const isRequesting = useSelector( ( state ) =>
-		isRequestingUserRecommendedBlogs( state, userLogin || '' )
-	);
-	const hasRequested = useSelector( ( state ) =>
-		hasRequestedUserRecommendedBlogs( state, userLogin || '' )
-	);
-	const isExpectingRequest = isRequesting || ! hasRequested;
-	const recommendedBlogs = useSelector( ( state ) =>
-		getUserRecommendedBlogs( state, userLogin || '' )
-	);
+
+	const { data: recommendedBlogs, isLoading } = useFeedRecommendationsQuery( userLogin, {
+		enabled: !! userLogin,
+	} );
+
 	const currentUser = useSelector( getCurrentUser );
-
-	useEffect( () => {
-		if ( ! recommendedBlogs && userLogin && ! hasRequested ) {
-			dispatch( requestUserRecommendedBlogs( userLogin ) );
-		}
-	}, [ userLogin, recommendedBlogs, dispatch, hasRequested ] );
-
-	if ( ! recommendedBlogs?.length && isExpectingRequest ) {
+	if ( isLoading ) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/client/reader/user-profile/views/test/recommended-blogs.tsx
+++ b/client/reader/user-profile/views/test/recommended-blogs.tsx
@@ -1,9 +1,11 @@
 /**
  * @jest-environment jsdom
  */
-
 import { render, screen } from '@testing-library/react';
-import React from 'react';
+import {
+	FeedRecommendation,
+	useFeedRecommendationsQuery,
+} from 'calypso/data/reader/use-feed-recommendations-query';
 import { UserData } from 'calypso/lib/user/user';
 import UserRecommendedBlogs from '../recommended-blogs';
 
@@ -15,13 +17,7 @@ jest.mock(
 	'calypso/components/gravatar-with-hovercards/recommended-blogs/item',
 	() =>
 		( { blog, classPrefix }: { blog: { ID: number; name: string }; classPrefix: string } ) => (
-			<li
-				data-testid="recommended-blog-item"
-				data-blog-id={ blog.ID }
-				data-class-prefix={ classPrefix }
-			>
-				{ blog.name }
-			</li>
+			<li data-class-prefix={ classPrefix }>{ blog.name }</li>
 		)
 );
 
@@ -35,18 +31,8 @@ jest.mock( 'calypso/state', () => ( {
 	useDispatch: jest.fn(),
 } ) );
 
-jest.mock( 'calypso/state/reader/lists/actions', () => ( {
-	requestUserRecommendedBlogs: jest.fn(),
-} ) );
-
-jest.mock( 'calypso/state/reader/lists/selectors', () => ( {
-	isRequestingUserRecommendedBlogs: jest.fn(),
-	hasRequestedUserRecommendedBlogs: jest.fn(),
-	getUserRecommendedBlogs: jest.fn(),
-} ) );
-
-jest.mock( 'i18n-calypso', () => ( {
-	useTranslate: () => ( text: string ) => text,
+jest.mock( 'calypso/data/reader/use-feed-recommendations-query', () => ( {
+	useFeedRecommendationsQuery: jest.fn(),
 } ) );
 
 describe( 'UserRecommendedBlogs', () => {
@@ -58,66 +44,19 @@ describe( 'UserRecommendedBlogs', () => {
 	};
 
 	const mockDispatch = jest.fn();
-	const mockGetUserRecommendedBlogs = jest.requireMock(
-		'calypso/state/reader/lists/selectors'
-	).getUserRecommendedBlogs;
-	const mockIsRequestingUserRecommendedBlogs = jest.requireMock(
-		'calypso/state/reader/lists/selectors'
-	).isRequestingUserRecommendedBlogs;
-	const mockHasRequestedUserRecommendedBlogs = jest.requireMock(
-		'calypso/state/reader/lists/selectors'
-	).hasRequestedUserRecommendedBlogs;
-	const { useSelector, useDispatch } = jest.requireMock( 'calypso/state' );
+	const { useDispatch } = jest.requireMock( 'calypso/state' );
 
 	beforeEach( () => {
 		jest.clearAllMocks();
 		useDispatch.mockReturnValue( mockDispatch );
-		useSelector.mockImplementation( ( selector: ( state: unknown ) => unknown ) => {
-			// Mock the selector calls based on the selector function
-			if ( selector.toString().includes( 'isRequestingUserRecommendedBlogs' ) ) {
-				return mockIsRequestingUserRecommendedBlogs();
-			}
-			if ( selector.toString().includes( 'hasRequestedUserRecommendedBlogs' ) ) {
-				return mockHasRequestedUserRecommendedBlogs();
-			}
-			if ( selector.toString().includes( 'getUserRecommendedBlogs' ) ) {
-				return mockGetUserRecommendedBlogs();
-			}
-			return undefined;
-		} );
-		mockIsRequestingUserRecommendedBlogs.mockReturnValue( false );
-		mockHasRequestedUserRecommendedBlogs.mockReturnValue( true );
-		mockGetUserRecommendedBlogs.mockReturnValue( [] );
 	} );
 
 	test( 'should render LoadingPlaceholder when no recommended blogs and still expecting request', () => {
-		mockGetUserRecommendedBlogs.mockReturnValue( null );
-		mockIsRequestingUserRecommendedBlogs.mockReturnValue( true );
-		mockHasRequestedUserRecommendedBlogs.mockReturnValue( false );
-
-		render( <UserRecommendedBlogs user={ defaultUser } /> );
-
-		const loadingPlaceholder = screen.getByTestId( 'loading-placeholder' );
-		expect( loadingPlaceholder ).toBeInTheDocument();
-		expect( loadingPlaceholder ).toHaveTextContent( 'Loading...' );
-	} );
-
-	test( 'should render LoadingPlaceholder when recommended blogs array is empty and still expecting request', () => {
-		mockGetUserRecommendedBlogs.mockReturnValue( [] );
-		mockIsRequestingUserRecommendedBlogs.mockReturnValue( true );
-		mockHasRequestedUserRecommendedBlogs.mockReturnValue( false );
-
-		render( <UserRecommendedBlogs user={ defaultUser } /> );
-
-		const loadingPlaceholder = screen.getByTestId( 'loading-placeholder' );
-		expect( loadingPlaceholder ).toBeInTheDocument();
-		expect( loadingPlaceholder ).toHaveTextContent( 'Loading...' );
-	} );
-
-	test( 'should render LoadingPlaceholder when no recommended blogs and not yet requested', () => {
-		mockGetUserRecommendedBlogs.mockReturnValue( null );
-		mockIsRequestingUserRecommendedBlogs.mockReturnValue( false );
-		mockHasRequestedUserRecommendedBlogs.mockReturnValue( false );
+		jest.mocked( useFeedRecommendationsQuery ).mockReturnValue( {
+			data: [],
+			isLoading: true,
+			isSuccess: false,
+		} );
 
 		render( <UserRecommendedBlogs user={ defaultUser } /> );
 
@@ -127,21 +66,11 @@ describe( 'UserRecommendedBlogs', () => {
 	} );
 
 	test( 'should render EmptyContent when no recommended blogs and request has completed', () => {
-		mockGetUserRecommendedBlogs.mockReturnValue( null );
-		mockIsRequestingUserRecommendedBlogs.mockReturnValue( false );
-		mockHasRequestedUserRecommendedBlogs.mockReturnValue( true );
-
-		render( <UserRecommendedBlogs user={ defaultUser } /> );
-
-		const emptyContent = screen.getByTestId( 'empty-content' );
-		expect( emptyContent ).toBeInTheDocument();
-		expect( emptyContent ).toHaveTextContent( 'No blogs have been recommended yet.' );
-	} );
-
-	test( 'should render EmptyContent when recommended blogs array is empty and request has completed', () => {
-		mockGetUserRecommendedBlogs.mockReturnValue( [] );
-		mockIsRequestingUserRecommendedBlogs.mockReturnValue( false );
-		mockHasRequestedUserRecommendedBlogs.mockReturnValue( true );
+		jest.mocked( useFeedRecommendationsQuery ).mockReturnValue( {
+			data: [],
+			isLoading: false,
+			isSuccess: true,
+		} );
 
 		render( <UserRecommendedBlogs user={ defaultUser } /> );
 
@@ -153,46 +82,26 @@ describe( 'UserRecommendedBlogs', () => {
 	test( 'should render recommended blogs when available', () => {
 		const mockRecommendedBlogs = [
 			{
-				ID: 1,
+				ID: '1',
 				name: 'Test Blog 1',
-				URL: 'https://testblog1.com',
+				feedId: '1',
 			},
 			{
-				ID: 2,
+				ID: '2',
 				name: 'Test Blog 2',
-				URL: 'https://testblog2.com',
+				feedId: '2',
 			},
-		];
+		] as FeedRecommendation[];
 
-		mockGetUserRecommendedBlogs.mockReturnValue( mockRecommendedBlogs );
-
-		render( <UserRecommendedBlogs user={ defaultUser } /> );
-
-		// Container should be present
-		const container = screen.getByRole( 'list' );
-		expect( container ).toHaveClass( 'user-profile__recommended-blogs-list' );
-
-		// Blog items should be rendered
-		const blogItems = screen.getAllByTestId( 'recommended-blog-item' );
-		expect( blogItems ).toHaveLength( 2 );
-
-		// Blog names should be displayed
-		expect( screen.getByText( 'Test Blog 1' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Test Blog 2' ) ).toBeInTheDocument();
-
-		// Blog items should have correct props
-		expect( blogItems[ 0 ] ).toHaveAttribute( 'data-blog-id', '1' );
-		expect( blogItems[ 0 ] ).toHaveAttribute( 'data-class-prefix', 'user-profile' );
-		expect( blogItems[ 1 ] ).toHaveAttribute( 'data-blog-id', '2' );
-		expect( blogItems[ 1 ] ).toHaveAttribute( 'data-class-prefix', 'user-profile' );
-	} );
-
-	test( 'should request recommended blogs when not available and not yet requested', () => {
-		mockGetUserRecommendedBlogs.mockReturnValue( null );
-		mockHasRequestedUserRecommendedBlogs.mockReturnValue( false );
+		jest.mocked( useFeedRecommendationsQuery ).mockReturnValue( {
+			data: mockRecommendedBlogs,
+			isLoading: false,
+			isSuccess: true,
+		} );
 
 		render( <UserRecommendedBlogs user={ defaultUser } /> );
 
-		expect( mockDispatch ).toHaveBeenCalled();
+		expect( screen.getByText( 'Test Blog 1' ) ).toBeVisible();
+		expect( screen.getByText( 'Test Blog 2' ) ).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of CML-612

## Proposed Changes
* Add `useFeedRecommendationsQuery` hook to manage the feed recommendation list loading
* Refactor components that requires this data to use the new hook

> [!NOTE]
>  I extracted this change from the branch I am working on to show the recommended lists in more places. 
 

## Why are these changes being made?
Nowadays, to retrieve the recommended feed list, we need to pay attention to details such as subscribing to the store, checking if the list has been fetched, and fetching it only when needed. It requires managing multiple disconnected code
* We are going to have more and more components that need to fetch the recommendation list


## Testing Instructions
* Check if we are still showing a list of recommended sites on the user profile `/reader/users/jeherve/recommended-blogs`
* Check if the gravar hover is still displaying a list of recommended items [Image 1]
<img width="1534" height="1526" alt="CleanShot 2025-07-25 at 13 47 39@2x" src="https://github.com/user-attachments/assets/39bab892-1904-438f-b568-b714a2da06be" /> (Mouse over an user avatar) [Image 2]

<img width="1974" height="1808" alt="CleanShot 2025-07-25 at 13 48 15@2x" src="https://github.com/user-attachments/assets/5438af53-1859-49ff-bb11-73f6fede6451" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
