### PR TITLE
Stats: Update Calypso links with wp-admin links

### DIFF
--- a/client/my-sites/customer-home/cards/features/stats/index.jsx
+++ b/client/my-sites/customer-home/cards/features/stats/index.jsx
@@ -14,11 +14,7 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import { preventWidows } from 'calypso/lib/formatting';
 import { buildChartData } from 'calypso/my-sites/stats/stats-chart-tabs/utility';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
-import {
-	getSiteAdminUrl,
-	getSiteOption,
-	isAdminInterfaceWPAdmin,
-} from 'calypso/state/sites/selectors';
+import { getSiteAdminUrl, getSiteOption } from 'calypso/state/sites/selectors';
 import { requestChartCounts } from 'calypso/state/stats/chart-tabs/actions';
 import { getCountRecords, getLoadingTabs } from 'calypso/state/stats/chart-tabs/selectors';
 import {
@@ -26,7 +22,7 @@ import {
 	getTopPostAndPage,
 	isRequestingSiteStatsForQuery,
 } from 'calypso/state/stats/lists/selectors';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
@@ -40,12 +36,10 @@ export const StatsV2 = ( {
 	insightsQuery,
 	isLoading,
 	isSiteUnlaunched,
-	adminInterfaceIsWPAdmin,
 	mostPopularDay,
 	mostPopularTime,
 	siteCreatedAt,
 	siteId,
-	siteSlug,
 	siteAdminUrl,
 	topPage,
 	topPost,
@@ -170,14 +164,7 @@ export const StatsV2 = ( {
 							) }
 						</div>
 						<div className="stats__all">
-							<a
-								href={
-									adminInterfaceIsWPAdmin
-										? `${ siteAdminUrl }admin.php?page=stats`
-										: `/stats/day/${ siteSlug }`
-								}
-								className="stats__all-link"
-							>
+							<a href={ `${ siteAdminUrl }admin.php?page=stats` } className="stats__all-link">
 								{ translate( 'See all stats' ) }
 							</a>
 						</div>
@@ -290,10 +277,8 @@ const isLoadingStats = ( state, siteId, chartQuery, insightsQuery, topPostsQuery
 
 const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
-	const siteSlug = getSelectedSiteSlug( state );
 	const siteAdminUrl = getSiteAdminUrl( state, siteId );
 	const isSiteUnlaunched = isUnlaunchedSite( state, siteId );
-	const adminInterfaceIsWPAdmin = isAdminInterfaceWPAdmin( state, siteId );
 	const siteCreatedAt = getSiteOption( state, siteId, 'created_at' );
 
 	const { chartQuery, insightsQuery, topPostsQuery, visitsQuery } = getStatsQueries(
@@ -321,10 +306,8 @@ const mapStateToProps = ( state ) => {
 		insightsQuery,
 		isLoading: canShowStatsData ? statsData.chartData.length !== chartQuery.quantity : isLoading,
 		isSiteUnlaunched,
-		adminInterfaceIsWPAdmin,
 		siteCreatedAt,
 		siteId,
-		siteSlug,
 		siteAdminUrl,
 		topPostsQuery,
 		visitsQuery,

--- a/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
@@ -12,6 +12,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
 import { find } from 'lodash';
 import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
 import googleIllustration from 'calypso/assets/images/illustrations/google-analytics-logo.svg';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
@@ -26,6 +27,7 @@ import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-t
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { requestSiteSettings } from 'calypso/state/site-settings/actions';
+import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import FormAnalyticsStores from '../form-analytics-stores';
 
 import './style.scss';
@@ -66,6 +68,12 @@ const GoogleAnalyticsJetpackForm = ( {
 	const wooCommerceActive = wooCommercePlugin ? wooCommercePlugin.sites[ siteId ].active : false;
 	const dispatch = useDispatch();
 	const trackTracksEvent = ( name, props ) => dispatch( recordTracksEvent( name, props ) );
+
+	const statsUrl = useSelector( ( state ) =>
+		site.options?.is_wpcom_atomic
+			? getSiteAdminUrl( state, siteId, 'admin.php?page=stats' )
+			: '/stats/' + site.domain
+	);
 
 	useEffect( () => {
 		// Show the form if GA module is active, or it's been removed but GA is activated via the Legacy Plugin.
@@ -214,7 +222,7 @@ const GoogleAnalyticsJetpackForm = ( {
 										'normally show slightly different totals for your visits, views, etc.',
 									{
 										components: {
-											a: <a href={ '/stats/' + site.domain } />,
+											a: <a href={ statsUrl } />,
 										},
 									}
 								) }

--- a/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
@@ -12,12 +12,14 @@ import {
 } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
 import googleIllustration from 'calypso/assets/images/illustrations/google-analytics-logo.svg';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { PanelCard, PanelCardHeading } from 'calypso/components/panel';
+import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
 
 import './style.scss';
 
@@ -38,12 +40,17 @@ const GoogleAnalyticsSimpleForm = ( {
 	setDisplayForm,
 	showUpgradeNudge,
 	site,
+	siteId,
 	translate,
 } ) => {
 	const nudgeTitle = translate(
 		'Connect your site to Google Analytics in seconds with the %(premiumPlanName)s plan',
 		{ args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() } }
 	);
+	const wpAdminUrl = useSelector( ( state ) =>
+		getSiteAdminUrl( state, siteId, 'admin.php?page=stats' )
+	);
+
 	useEffect( () => {
 		if ( fields?.wga?.code ) {
 			setDisplayForm( true );
@@ -138,7 +145,7 @@ const GoogleAnalyticsSimpleForm = ( {
 										'normally show slightly different totals for your visits, views, etc.',
 									{
 										components: {
-											a: <a href={ '/stats/' + site.domain } />,
+											a: <a href={ wpAdminUrl } />,
 										},
 									}
 								) }

--- a/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
@@ -47,7 +47,7 @@ const GoogleAnalyticsSimpleForm = ( {
 		'Connect your site to Google Analytics in seconds with the %(premiumPlanName)s plan',
 		{ args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() } }
 	);
-	const wpAdminUrl = useSelector( ( state ) =>
+	const statsUrl = useSelector( ( state ) =>
 		getSiteAdminUrl( state, siteId, 'admin.php?page=stats' )
 	);
 
@@ -145,7 +145,7 @@ const GoogleAnalyticsSimpleForm = ( {
 										'normally show slightly different totals for your visits, views, etc.',
 									{
 										components: {
-											a: <a href={ wpAdminUrl } />,
+											a: <a href={ statsUrl } />,
 										},
 									}
 								) }

--- a/client/sites/components/plan-stats/plan-site-visits.tsx
+++ b/client/sites/components/plan-stats/plan-site-visits.tsx
@@ -11,12 +11,7 @@ import { activateModule } from 'calypso/state/jetpack/modules/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isActivatingJetpackModule from 'calypso/state/selectors/is-activating-jetpack-module';
 import { requestSite } from 'calypso/state/sites/actions';
-import {
-	getSiteAdminUrl,
-	getSiteSlug,
-	isAdminInterfaceWPAdmin,
-	isJetpackModuleActive,
-} from 'calypso/state/sites/selectors';
+import { getSiteAdminUrl, isJetpackModuleActive } from 'calypso/state/sites/selectors';
 
 interface PlanSiteVisitsProps {
 	siteId: number;
@@ -31,7 +26,6 @@ type VisitResponse = number | 'loading' | 'disabled' | 'error';
 export function PlanSiteVisits( { siteId }: PlanSiteVisitsProps ) {
 	const dispatch = useDispatch();
 	const [ visitsResponse, setVisitsResponse ] = useState< VisitResponse >( 'loading' );
-	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const canViewStat = useSelector( ( state ) => canCurrentUser( state, siteId, 'publish_posts' ) );
 
 	const translate = useTranslate();
@@ -86,11 +80,7 @@ export function PlanSiteVisits( { siteId }: PlanSiteVisitsProps ) {
 		fetchVisits();
 	}, [ fetchVisits, hasModuleActive ] );
 
-	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
-
-	const adminInterfaceIsWPAdmin = useSelector( ( state ) =>
-		isAdminInterfaceWPAdmin( state, siteId )
-	);
+	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) ) as string;
 
 	if ( ! canViewStat ) {
 		return null;
@@ -182,10 +172,9 @@ export function PlanSiteVisits( { siteId }: PlanSiteVisitsProps ) {
 			);
 		}
 
-		const statsPageUrl =
-			adminInterfaceIsWPAdmin && siteAdminUrl
-				? `${ untrailingslashit( siteAdminUrl ) }/admin.php?page=stats#!/stats/month/${ siteId }`
-				: `/stats/month/${ siteSlug }`;
+		const statsPageUrl = `${ untrailingslashit(
+			siteAdminUrl
+		) }/admin.php?page=stats#!/stats/month/${ siteId }`;
 
 		return (
 			<a

--- a/client/state/selectors/get-stats-url.ts
+++ b/client/state/selectors/get-stats-url.ts
@@ -1,11 +1,6 @@
-import { getSiteAdminUrl, getSiteSlug, isAdminInterfaceWPAdmin } from '../sites/selectors';
+import { getSiteAdminUrl } from '../sites/selectors';
 import type { AppState } from 'calypso/types';
 
 export default function getStatsUrl( state: AppState, siteId?: number | null ) {
-	if ( ! isAdminInterfaceWPAdmin( state, siteId ) ) {
-		const siteSlug = getSiteSlug( state, siteId );
-		return `/stats/${ siteSlug }`;
-	}
-
 	return getSiteAdminUrl( state, siteId, 'admin.php?page=stats' );
 }

--- a/packages/command-palette/src/commands.tsx
+++ b/packages/command-palette/src/commands.tsx
@@ -676,12 +676,7 @@ export function useCommands() {
 						__i18n_text_domain__
 					),
 				].join( KEYWORD_SEPARATOR ),
-				callback: ( params ) =>
-					commandNavigation(
-						siteUsesWpAdminInterface( params.site )
-							? '/wp-admin/admin.php?page=stats'
-							: '/stats/:site'
-					)( params ),
+				callback: commandNavigation( '/wp-admin/admin.php?page=stats' ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to open Jetpack Stats', __i18n_text_domain__ ),
 				icon: statsIcon,

--- a/packages/data-stores/src/contextual-help/admin-sections.ts
+++ b/packages/data-stores/src/contextual-help/admin-sections.ts
@@ -127,7 +127,7 @@ export function generateAdminSections(
 		},
 		{
 			title: __( "View my site's latest stats" ),
-			link: `/stats/day/${ siteSlug }`,
+			link: `https://${ siteSlug }/wp-admin/admin.php?page=stats`,
 			synonyms: [ 'analytics' ],
 			icon: 'stats-alt',
 		},


### PR DESCRIPTION
Fixes DOTCOM-13872

## Proposed Changes

Now that wp-admin Jetpack Stats is available on all WP.com sites, we no longer need to point to Calypso Stats. This PR updates all the links below so they go to wp-admin Jetpack Stats.

**Hosting/Tools -> Marketing -> Traffic** 

<img width="1280" height="951" alt="Screenshot 2025-07-25 at 14 04 08" src="https://github.com/user-attachments/assets/fda711d5-c49e-4501-8b53-c067b06c714a" />

**Command palette**

<img width="664" height="185" alt="Screenshot 2025-07-25 at 14 25 11" src="https://github.com/user-attachments/assets/c008b8ad-fec5-4299-8151-05d18ffcedbe" />

**My Home**

<img width="1728" height="959" alt="Screenshot 2025-07-25 at 15 22 31" src="https://github.com/user-attachments/assets/4ce9d817-200a-406b-8b97-c39f8d9a3dd3" />

**Hosting dashboard**

<img width="1728" height="956" alt="Screenshot 2025-07-25 at 15 28 15" src="https://github.com/user-attachments/assets/302df395-9cdd-4347-b511-0f4ad3d1cd1c" />

**Help Center**

<img width="437" height="799" alt="Screenshot 2025-07-25 at 15 38 49" src="https://github.com/user-attachments/assets/f08cd37d-918c-47b9-ae0d-8d84f8498f68" />


## Why are these changes being made?

Because we don't want to use Calypso for site admin screens.

## Testing Instructions

- Use the Calypso live link below
- Switch to a site with the default admin interface active. You'll need a Premium plan at least to test the link in the Google Analytics section
- Check the Stats links listed above
- Make sure they all link to wp-admin Jetpack Stats

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
