### PR TITLE
Staging sites sync: Add a danger icon for database sync and update Woo warning

### DIFF
--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -494,7 +494,7 @@ export default function SyncModal( {
 						</HStack>
 						{ showWooCommerceWarning && (
 							<Notice status="warning" isDismissible={ false }>
-								<Text as="p" weight="bold" style={ { marginBottom: '8px' } }>
+								<Text as="p" weight="bold" style={ { lineHeight: '24px' } }>
 									{ __( 'Warning! WooCommerce data will be overwritten.' ) }
 								</Text>
 								{ createInterpolateElement(

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -20,7 +20,7 @@ import {
 	useEffect,
 } from '@wordpress/element';
 import { __, isRTL } from '@wordpress/i18n';
-import { chevronRight, chevronLeft } from '@wordpress/icons';
+import { error, chevronRight, chevronLeft } from '@wordpress/icons';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import useGetDisplayDate from 'calypso/components/jetpack/daily-backup-status/use-get-display-date';
 import InlineSupportLink from 'calypso/dashboard/components/inline-support-link';
@@ -458,7 +458,17 @@ export default function SyncModal( {
 							fileBrowserConfig={ fileBrowserConfig }
 						/>
 					</div>
-					<div className="database-item">
+					<HStack
+						alignment="left"
+						spacing={ 2 }
+						style={ {
+							borderTop: '1px solid var(--wp-components-color-gray-300, #ddd)',
+							borderBottom: '1px solid var(--wp-components-color-gray-300, #ddd)',
+							padding: '16px 0',
+							marginTop: '8px',
+							marginBottom: '20px',
+						} }
+					>
 						<CheckboxControl
 							__nextHasNoMarginBottom
 							label={ __( 'Database tables' ) }
@@ -466,7 +476,8 @@ export default function SyncModal( {
 							checked={ shouldDisableGranularSync || sqlNode?.checkState === 'checked' }
 							onChange={ handleDatabaseCheckboxChange }
 						/>
-					</div>
+						<Icon icon={ error } style={ { fill: 'var(--studio-orange-50)' } } />
+					</HStack>
 					<VStack spacing={ 7 }>
 						{ showWooCommerceWarning && (
 							<Notice status="warning" isDismissible={ false }>

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -479,6 +479,19 @@ export default function SyncModal( {
 						<Icon icon={ error } style={ { fill: 'var(--studio-orange-50)' } } />
 					</HStack>
 					<VStack spacing={ 7 }>
+						<HStack alignment="left" spacing={ 1 }>
+							<Text color="var(--studio-gray-40)">
+								{ displayBackupDate
+									? createInterpolateElement( __( 'Backup contents from: <date />.' ), {
+											date: <span>{ displayBackupDate }</span>,
+									  } )
+									: __( 'There are no backups.' ) }{ ' ' }
+								<ExternalLink
+									href={ `/backup/${ sourceSiteSlug }` }
+									children={ __( 'Backup now' ) }
+								/>
+							</Text>
+						</HStack>
 						{ showWooCommerceWarning && (
 							<Notice status="warning" isDismissible={ false }>
 								<Text as="p" weight="bold" style={ { marginBottom: '8px' } }>
@@ -486,7 +499,7 @@ export default function SyncModal( {
 								</Text>
 								{ createInterpolateElement(
 									__(
-										'This site has WooCommerce installed. We do not recommend syncing or pushing data from a staging site to live production news sites or sites that use eCommerce plugins, such as WooCommerce, without proper planning and testing. Keep in mind that data on the destination site could have newer transactions, such as customers and orders, and would be lost when overwritten by the staging site’s data. <a>Learn more</a>'
+										'This site has WooCommerce installed. We do not recommend syncing or pushing data from a staging site to live production news sites or sites that use eCommerce plugins. <a>Learn more</a>'
 									),
 									{
 										a: (
@@ -514,19 +527,6 @@ export default function SyncModal( {
 								/>
 							</VStack>
 						) }
-						<HStack alignment="left" spacing={ 1 }>
-							<Text color="var(--studio-gray-40)">
-								{ displayBackupDate
-									? createInterpolateElement( __( 'Backup contents from: <date />.' ), {
-											date: <span>{ displayBackupDate }</span>,
-									  } )
-									: __( 'There are no backups.' ) }{ ' ' }
-								<ExternalLink
-									href={ `/backup/${ sourceSiteSlug }` }
-									children={ __( 'Backup now' ) }
-								/>
-							</Text>
-						</HStack>
 					</VStack>
 				</div>
 				<HStack className="staging-site-card__footer">

--- a/client/sites/staging-site/components/staging-site-sync-modal/style.scss
+++ b/client/sites/staging-site/components/staging-site-sync-modal/style.scss
@@ -12,14 +12,6 @@
 		display: none;
 	}
 
-	.database-item {
-		border-top: 1px solid var(--wp-components-color-gray-300, #ddd);
-		border-bottom: 1px solid var(--wp-components-color-gray-300, #ddd);
-		padding: 16px 0;
-		margin-top: 8px;
-		margin-bottom: 20px
-	}
-
 	&__back-button.components-button.is-link {
 		color: #000;
 		padding: 12px 0;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTCOM-14006

Figma design ASqz3fW9Go9m5bHL2XiuUR-fi-1594_69989


|Before | After|
|-------|------|
| <img width="1482" height="1692" alt="CleanShot 2025-07-25 at 18 42 36@2x" src="https://github.com/user-attachments/assets/1ec9b2e2-1e11-4037-ac65-650a7a11a5c9" />| <img width="1484" height="1692" alt="CleanShot 2025-07-25 at 18 42 55@2x" src="https://github.com/user-attachments/assets/33233536-a0a0-4ae7-bcbe-7939b840cd96" />|

## Proposed Changes

* Change the wording in the Woo warning
* Add a danger icon to the Database tables checkbox
* Move backup contents message above the warnings just below the database checkbox

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To match latest design

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply these changes and open Calypso locally
* Create a staging site to a Production site that has WooCommerce installed and active
* On the top right, select Sync dropdown and `Pull fro Staging`
* Check that the Database tables row contains a danger icon as per design
* Check the database checkbox
* Check that the Woo warning is displayed and has the wording included in the design
* Check the domain confirmation is displayed as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?