### PR TITLE
Domain Search Retrofitting: Add some extra padding to the DomainsMiniCart to prevent elements overlapping with it

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1690,6 +1690,7 @@ class RenderDomainsStepComponent extends Component {
 					}
 					heading={ <Step.Heading text={ headerText } subText={ fallbackSubHeaderText } /> }
 					className="domains__step-content domains__step-content-domain-step"
+					noBottomPadding={ shouldUseDomainSearchV2 }
 				>
 					{ mainContent }
 					{ sideContent }

--- a/packages/domain-search/src/components/domain-search/style.scss
+++ b/packages/domain-search/src/components/domain-search/style.scss
@@ -10,4 +10,5 @@
 	--domain-search-warning-badge-background-color: #f9edb4;
 	--domain-search-success-badge-border-color: #b8e5be;
 	--domain-search-success-badge-background-color: #d1eed5;
+	--domain-search-mini-cart-height: 80px;
 }

--- a/packages/domain-search/src/components/domain-suggestion-load-more/style.scss
+++ b/packages/domain-search/src/components/domain-suggestion-load-more/style.scss
@@ -2,7 +2,8 @@
 
 .domain-suggestion-load-more__btn {
 	&.is-secondary {
-		color: var(--domain-search-secondary-action-color);
+		color: var( --domain-search-secondary-action-color );
 		box-shadow: inset 0 0 0 1px #{$gray-300};
+		background: $white;
 	}
 }

--- a/packages/domain-search/src/components/domains-mini-cart/index.tsx
+++ b/packages/domain-search/src/components/domains-mini-cart/index.tsx
@@ -32,26 +32,29 @@ const animation = {
 const DomainsMiniCart = ( { className }: { className?: string } ) => {
 	const { cart, isFullCartOpen } = useDomainSearch();
 
-	const shouldDisplayMiniCart = cart.items.length > 0 && ! isFullCartOpen;
+	const isMiniCartOpen = cart.items.length > 0 && ! isFullCartOpen;
 
 	return (
-		<motion.div
-			className={ clsx( 'domains-mini-cart__container', className ) }
-			initial={ animation.initial }
-			animate={ shouldDisplayMiniCart ? animation.animateIn : animation.animateOut }
-			transition={ { type: 'tween', duration: 0.25 } }
-		>
-			<Card isRounded={ false } elevation={ 2 } style={ { width: '100%' } }>
-				<div className="domains-mini-cart">
-					<div className="domains-mini-cart__content">
-						<HStack spacing={ 2 }>
-							<DomainsMiniCartSummary />
-							<DomainsMiniCartActions />
-						</HStack>
+		<>
+			<div className="domains-mini-cart__cushion" />
+			<motion.div
+				className={ clsx( 'domains-mini-cart__container', className ) }
+				initial={ animation.initial }
+				animate={ isMiniCartOpen ? animation.animateIn : animation.animateOut }
+				transition={ { type: 'tween', duration: 0.25 } }
+			>
+				<Card isRounded={ false } elevation={ 2 } style={ { width: '100%' } }>
+					<div className="domains-mini-cart">
+						<div className="domains-mini-cart__content">
+							<HStack spacing={ 2 }>
+								<DomainsMiniCartSummary />
+								<DomainsMiniCartActions />
+							</HStack>
+						</div>
 					</div>
-				</div>
-			</Card>
-		</motion.div>
+				</Card>
+			</motion.div>
+		</>
 	);
 };
 

--- a/packages/domain-search/src/components/domains-mini-cart/style.scss
+++ b/packages/domain-search/src/components/domains-mini-cart/style.scss
@@ -1,23 +1,30 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
+.domains-mini-cart__cushion {
+	margin-top: 36px;
+	height: var( --domain-search-mini-cart-height );
+}
+
 .domains-mini-cart__container {
 	position: fixed !important;
 	left: 0;
 	right: 0;
 	bottom: 0;
+	height: var( --domain-search-mini-cart-height );
 }
 
 .domains-mini-cart {
 	justify-content: center;
+	align-items: center;
 	padding-inline: 1rem;
 	display: flex;
 	box-sizing: border-box;
+	height: 100%;
 }
 
 .domains-mini-cart__content {
 	box-sizing: border-box;
-	padding-block: 1rem;
 	width: 100%;
 	max-width: 64rem;
 }

--- a/packages/onboarding/src/step-container-v2/components/ContentWrapper/ContentWrapper.tsx
+++ b/packages/onboarding/src/step-container-v2/components/ContentWrapper/ContentWrapper.tsx
@@ -8,17 +8,20 @@ export const ContentWrapper = ( {
 	centerAligned,
 	axisDirection = 'vertical',
 	noTopPadding = false,
+	noBottomPadding = false,
 }: {
 	children: ReactNode;
 	centerAligned?: boolean;
 	axisDirection?: 'vertical' | 'horizontal';
 	noTopPadding?: boolean;
+	noBottomPadding?: boolean;
 } ) => {
 	return (
 		<div
 			className={ clsx( 'step-container-v2__content-wrapper', `axis-${ axisDirection }`, {
 				'center-aligned': centerAligned,
 				'no-top-padding': noTopPadding,
+				'no-bottom-padding': noBottomPadding,
 			} ) }
 		>
 			{ children }

--- a/packages/onboarding/src/step-container-v2/components/ContentWrapper/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/ContentWrapper/style.scss
@@ -24,6 +24,10 @@
 		padding-top: 0;
 	}
 
+	&.no-bottom-padding {
+		padding-bottom: 0;
+	}
+
 	--step-container-v2-content-max-width: 1344px;
 
 	max-width: calc(

--- a/packages/onboarding/src/step-container-v2/wireframes/TwoColumnLayout/TwoColumnLayout.tsx
+++ b/packages/onboarding/src/step-container-v2/wireframes/TwoColumnLayout/TwoColumnLayout.tsx
@@ -17,6 +17,7 @@ interface TwoColumnLayoutProps {
 	stickyBottomBar?: ContentProp;
 	firstColumnWidth: number;
 	secondColumnWidth: number;
+	noBottomPadding?: boolean;
 }
 
 export const TwoColumnLayout = ( {
@@ -28,6 +29,7 @@ export const TwoColumnLayout = ( {
 	className,
 	footer,
 	stickyBottomBar,
+	noBottomPadding = false,
 }: TwoColumnLayoutProps ) => {
 	const getChildFlexGrow = ( index: number ) => {
 		switch ( index ) {
@@ -59,7 +61,7 @@ export const TwoColumnLayout = ( {
 				return (
 					<>
 						<TopBarRenderer topBar={ topBar } />
-						<ContentWrapper>
+						<ContentWrapper noBottomPadding={ noBottomPadding }>
 							{ heading && <ContentRow columns={ 6 }>{ heading }</ContentRow> }
 							<ContentRow
 								columns={ 10 }


### PR DESCRIPTION
This is a second take on #104922 which I think works better as it's isolated within the same component so the padding is only shown when the `DomainsMiniCart` is displayed

Here's how that looks when you scroll down to the bottom:

| before | after |
| --- | --- |
| <img width="1212" height="432" alt="Screenshot 2025-07-25 at 14 07 53" src="https://github.com/user-attachments/assets/8a1fa9fd-2248-4132-a5a6-28541e302d93" /> | <img width="1220" height="481" alt="new" src="https://github.com/user-attachments/assets/2abf5046-f04d-47ee-a488-7c09ba24b774" /> |
| <img width="1181" height="505" alt="Screenshot 2025-07-25 at 14 08 05" src="https://github.com/user-attachments/assets/3cefd8e9-ad2c-47a5-b8ea-11df63efeb31" /> | <img width="1198" height="528" alt="Screenshot 2025-07-25 at 14 08 27" src="https://github.com/user-attachments/assets/ee05eddb-b53c-45c9-9f8e-27808515e41e" /> |


Part of https://linear.app/a8c/issue/DOMAINS-1561/show-more-result-button-is-not-reachable-when-the-mini-cart-is



## Proposed Changes

* Add new padding div in the DomainsMiniCart so that other elements would not overlap with it

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The "Show more results" button overlaps with the DomainMiniCart and is not visible if there is a domain in the cart

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
