### PR TITLE
E2E: Robustify tests that use pattern insertion

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
@@ -9,7 +9,9 @@ const selectors = {
 	closeBlockInserterButton:
 		'button[aria-label="Close Block Inserter"], button[aria-label="Close block inserter"]',
 	blockSearchInput: `${ sidebarParentSelector } input[type="search"]`,
-	patternResultItem: ( name: string ) => `${ sidebarParentSelector } div[aria-label="${ name }"]`,
+	patternExactResultItem: ( name: string ) =>
+		`${ sidebarParentSelector } div[aria-label="${ name }"]`,
+	patternResultItem: ( name: string ) => `${ sidebarParentSelector } div[aria-label*="${ name }"]`,
 };
 
 /**
@@ -59,27 +61,34 @@ export class EditorSidebarBlockInserterComponent {
 	}
 
 	/**
-	 * Selects the maching result from the block inserter.
+	 * Selects the matching result from the block inserter.
 	 *
 	 * By default, this method considers only the Block-type results
 	 * (including Resuable blocks).
 	 * In order to select from Pattern-type results, set the `type`
 	 * optional flag in the parameter to `'pattern'`.
 	 *
-	 * Where mulltiple matches exist (eg. due to partial matching), the first result will be chosen.
+	 * Where multiple matches exist (eg. due to partial matching), the first result will be chosen.
 	 */
 	async selectBlockInserterResult(
 		name: string,
 		{
 			type = 'block',
 			blockFallBackName = '',
-		}: { type?: 'block' | 'pattern'; blockFallBackName?: string } = {}
+			exactMatch = true,
+		}: { type?: 'block' | 'pattern'; blockFallBackName?: string; exactMatch?: boolean } = {}
 	): Promise< Locator > {
 		const editorParent = await this.editor.parent();
 		let locator;
 
 		if ( type === 'pattern' ) {
-			locator = editorParent.locator( selectors.patternResultItem( name ) ).first();
+			locator = editorParent
+				.locator(
+					exactMatch
+						? selectors.patternExactResultItem( name )
+						: selectors.patternResultItem( name )
+				)
+				.first();
 		} else {
 			const optionName = blockFallBackName
 				? new RegExp( `(${ name }|${ blockFallBackName })` )

--- a/packages/calypso-e2e/src/lib/pages/shared-types/editor-types.ts
+++ b/packages/calypso-e2e/src/lib/pages/shared-types/editor-types.ts
@@ -5,6 +5,6 @@ export interface BlockInserter {
 	searchBlockInserter( blockName: string ): Promise< void >;
 	selectBlockInserterResult(
 		name: string,
-		options?: { type?: 'block' | 'pattern'; blockFallBackName?: string }
+		options?: { type?: 'block' | 'pattern'; blockFallBackName?: string; exactMatch?: boolean }
 	): Promise< Locator >;
 }

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -75,8 +75,8 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Page Flow' ), function () 
 			await modalSelector.waitFor( { timeout: 3 * 1000 } );
 			selectedPatternLocator = await modalSelector.getByRole( 'option' ).first();
 		} catch ( e ) {
-			// Probably doesn't exist. Let's add the pattern from the sidebar.
-			selectedPatternLocator = await editorPage.addPatternFromSidebar( 'About 1' );
+			// Probably doesn't exist. Let's add the first pattern that starts with "About" from the sidebar.
+			selectedPatternLocator = await editorPage.addPatternFromSidebar( 'About', false );
 		}
 
 		pageTemplateFirstTextContent =

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -67,10 +67,11 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	describe( 'Patterns', function () {
-		const patternName = 'About 1';
+		const patternName = 'About';
 
+		// Adds first pattern that matches `patternName` (not an exact match).
 		it( `Add ${ patternName } pattern`, async function () {
-			await editorPage.addPatternFromSidebar( patternName );
+			await editorPage.addPatternFromSidebar( patternName, false );
 		} );
 	} );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

There are two tests that insert arbitrary patterns as part of their flow. The pattern that was used previously was deleted. In #104913 I did a quick fix to ensure E2E tests kept running, and this PR is a follow-on to make the test more robust.

In particular, I've passed an `exactMatch` param through a chain of functions so we can use a pattern name (e.g. "About" in these tests) to select a pattern based on partial match. The default `exactMatch` value is `true` so as to match the original behavior anywhere else it's called.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

These should continue to pass with this branch:
```
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION="wp-beta" TEST_ON_ATOMIC="true" VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/editor/editor__post-basic-flow.ts"
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION="wp-beta" TEST_ON_ATOMIC="true" VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/editor/editor__page-basic-flow.ts"
```

To test regressions:
1. They should fail if `exactMatch` is set to `true` in both tests.
2. They should pass if `exactMatch` is set to `true` and "About 12" is used as the pattern name.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?