### PR TITLE
Disable domain warning on calypso sidebar

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -47,7 +47,7 @@
 		"checkout/razorpay": true,
 		"comments/filters-in-posts": true,
 		"cookie-banner": false,
-		"current-site/domain-warning": true,
+		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-settings": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -23,7 +23,7 @@
 		"checkout/google-pay": true,
 		"checkout/razorpay": false,
 		"cookie-banner": true,
-		"current-site/domain-warning": true,
+		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dashboard/v2": false,
 		"dashboard/v2/backport/site-settings": true,

--- a/config/production.json
+++ b/config/production.json
@@ -36,7 +36,7 @@
 		"checkout/google-pay": true,
 		"checkout/razorpay": false,
 		"cookie-banner": true,
-		"current-site/domain-warning": true,
+		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dashboard/v2/backport/site-settings": true,
 		"dashboard/v2/backport/sites-list": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -34,7 +34,7 @@
 		"checkout/google-pay": true,
 		"checkout/razorpay": false,
 		"cookie-banner": false,
-		"current-site/domain-warning": true,
+		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dashboard/v2/backport/site-settings": true,
 		"dashboard/v2/backport/sites-list": true,

--- a/config/test.json
+++ b/config/test.json
@@ -34,7 +34,7 @@
 		"checkout/google-pay": true,
 		"checkout/razorpay": true,
 		"cookie-banner": false,
-		"current-site/domain-warning": true,
+		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -32,7 +32,7 @@
 		"checkout/google-pay": true,
 		"checkout/checkout-version": true,
 		"checkout/razorpay": false,
-		"current-site/domain-warning": true,
+		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-settings": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to [DOTEMAL-45](https://linear.app/a8c/issue/DOTEMAL-45/domain-warning-on-the-calypso-sidebar-seem-broken)

<img width="806" height="389" alt="image" src="https://github.com/user-attachments/assets/b283b27e-f4e8-4506-9c38-6a37b6ea0c66" />


## Proposed Changes

* We're disabling these warnings until we get a better design feedback on them

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Currently, these errors seem messy

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
