### PR TITLE
Domain Search Retrofitting: Restricted domains should show renewal price

### DIFF
--- a/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
+++ b/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
@@ -1,12 +1,14 @@
 import {
 	DomainSuggestion,
 	DomainSuggestionBadge,
+	DomainSuggestionCTA,
 	DomainSuggestionPrice,
 } from '@automattic/domain-search';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
 import { HUNDRED_YEAR_DOMAIN_FLOW, isHundredYearPlanFlow } from '@automattic/onboarding';
 import { HTTPS_SSL } from '@automattic/urls';
+import { envelope } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import { get, includes } from 'lodash';
 import PropTypes from 'prop-types';
@@ -408,23 +410,20 @@ class DomainRegistrationSuggestion extends Component {
 					notice={ notice }
 					domain={ domainName }
 					tld={ tld.join( '.' ) }
-					disabled
+					cta={
+						<DomainSuggestionCTA.Primary
+							href="https://wordpress.com/help/contact"
+							label={ translate( 'Interested in this domain? Contact support' ) }
+							icon={ envelope }
+						>
+							{ translate( 'Contact support' ) }
+						</DomainSuggestionCTA.Primary>
+					}
 					price={
 						<DomainSuggestionPrice
 							salePrice={ productSaleCost }
 							price={ productCost }
 							renewPrice={ renewCost }
-							subText={ translate( 'Interested in this domain? {{a}}Contact support{{/a}}', {
-								components: {
-									a: (
-										<a
-											href="https://wordpress.com/help/contact"
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									),
-								},
-							} ) }
 						/>
 					}
 				/>

--- a/client/components/domain-search-v2/domain-search-results/index.jsx
+++ b/client/components/domain-search-v2/domain-search-results/index.jsx
@@ -3,9 +3,11 @@ import {
 	DomainSuggestionsList,
 	DomainSuggestion,
 	DomainSuggestionBadge,
+	DomainSuggestionCTA,
 } from '@automattic/domain-search';
 import { formatCurrency } from '@automattic/number-formatters';
 import { __experimentalVStack as VStack } from '@wordpress/components';
+import { envelope } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import { get, times } from 'lodash';
 import PropTypes from 'prop-types';
@@ -119,23 +121,20 @@ class DomainSearchResults extends Component {
 					badges={ badges }
 					domain={ domainName }
 					tld={ tld.join( '.' ) }
-					disabled
+					cta={
+						<DomainSuggestionCTA.Primary
+							href="https://wordpress.com/help/contact"
+							label={ translate( 'Interested in this domain? Contact support' ) }
+							icon={ envelope }
+						>
+							{ translate( 'Contact support' ) }
+						</DomainSuggestionCTA.Primary>
+					}
 					price={
 						<DomainSuggestionPrice
 							salePrice={ productSaleCost }
 							price={ premiumDomain.cost }
 							renewPrice={ premiumDomain.renew_cost }
-							subText={ translate( 'Interested in this domain? {{a}}Contact support{{/a}}', {
-								components: {
-									a: (
-										<a
-											href="https://wordpress.com/help/contact"
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									),
-								},
-							} ) }
 						/>
 					}
 				/>

--- a/client/components/domain-search-v2/domain-search-results/index.jsx
+++ b/client/components/domain-search-v2/domain-search-results/index.jsx
@@ -13,6 +13,7 @@ import { get, times } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import { parseMatchReasons } from 'calypso/components/domain-search-v2/domain-registration-suggestion/utility';
 import { isDomainMappingFree, isNextDomainFree } from 'calypso/lib/cart-values/cart-items';
 import { isSubdomain } from 'calypso/lib/domains';
 import { domainAvailability } from 'calypso/lib/domains/constants';
@@ -116,11 +117,20 @@ class DomainSearchResults extends Component {
 
 			badges.push( <PremiumBadge key="premium" restrictedPremium /> );
 
+			const suggestion = this.props.suggestions.find(
+				( s ) => s.domain_name === lastDomainSearched
+			);
+
 			return (
-				<DomainSuggestion
+				<DomainSuggestion.Featured
 					badges={ badges }
 					domain={ domainName }
 					tld={ tld.join( '.' ) }
+					matchReasons={
+						this.props.hideMatchReasons
+							? undefined
+							: parseMatchReasons( lastDomainSearched, suggestion.match_reasons )
+					}
 					cta={
 						<DomainSuggestionCTA.Primary
 							href="https://wordpress.com/help/contact"

--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -1819,7 +1819,7 @@ class RegisterDomainStep extends Component {
 				unavailableDomains={ this.state.unavailableDomains }
 				onSkip={ this.props.onSkip }
 				showSkipButton={ this.props.showSkipButton }
-				hideMatchReasons={ this.props.hideMatchReasons ?? this.props.isOnboarding }
+				hideMatchReasons={ this.props.hideMatchReasons }
 				domainAndPlanUpsellFlow={ this.props.domainAndPlanUpsellFlow }
 				useProvidedProductsList={ this.props.useProvidedProductsList }
 				isCartPendingUpdateDomain={ this.props.isCartPendingUpdateDomain }

--- a/packages/domain-search/src/components/domain-suggestion-cta/continue.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-cta/continue.tsx
@@ -16,7 +16,7 @@ export const DomainSuggestionContinueCTA = ( {
 	const listContext = useDomainSuggestionContainerContext();
 
 	if ( ! listContext ) {
-		throw new Error( 'DomainSuggestionCTA.AddToCart must be used within a DomainSuggestionsList' );
+		throw new Error( 'DomainSuggestionContinueCTA must be used within a DomainSuggestionsList' );
 	}
 
 	return (

--- a/packages/domain-search/src/components/domain-suggestion-cta/continue.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-cta/continue.tsx
@@ -1,0 +1,36 @@
+import { Button } from '@wordpress/components';
+import { arrowRight } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import { useDomainSuggestionContainerContext } from '../../hooks/use-domain-suggestion-container';
+import { useDomainSearch } from '../domain-search';
+
+export const DomainSuggestionContinueCTA = ( {
+	disabled,
+	onClick,
+}: {
+	disabled: boolean;
+	onClick: () => void;
+} ) => {
+	const { cart } = useDomainSearch();
+	const { __ } = useI18n();
+	const listContext = useDomainSuggestionContainerContext();
+
+	if ( ! listContext ) {
+		throw new Error( 'DomainSuggestionCTA.AddToCart must be used within a DomainSuggestionsList' );
+	}
+
+	return (
+		<Button
+			isPressed
+			aria-pressed="mixed"
+			__next40pxDefaultSize
+			icon={ arrowRight }
+			className="domain-suggestion-cta domain-suggestion-cta--continue"
+			onClick={ onClick }
+			label={ __( 'Continue' ) }
+			disabled={ disabled || cart.isBusy }
+		>
+			{ listContext.isFeatured ? __( 'Continue' ) : undefined }
+		</Button>
+	);
+};

--- a/packages/domain-search/src/components/domain-suggestion-cta/error.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-cta/error.tsx
@@ -1,0 +1,42 @@
+import { Button, Tooltip } from '@wordpress/components';
+import { warning } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import clsx from 'clsx';
+import { useDomainSuggestionContainerContext } from '../../hooks/use-domain-suggestion-container';
+
+export const DomainSuggestionErrorCTA = ( {
+	errorMessage,
+	callback,
+}: {
+	errorMessage: string;
+	callback: () => void;
+} ) => {
+	const { __ } = useI18n();
+	const listContext = useDomainSuggestionContainerContext();
+
+	if ( ! listContext ) {
+		throw new Error( 'DomainSuggestionCTA.AddToCart must be used within a DomainSuggestionsList' );
+	}
+
+	return (
+		<div className="domain-suggestion-cta-error">
+			<Tooltip
+				delay={ 0 }
+				text={ errorMessage }
+				placement="top"
+				className="domain-suggestion-cta-error__tooltip"
+			>
+				<Button
+					className={ clsx( 'domain-suggestion-cta', 'domain-suggestion-cta--error' ) }
+					isDestructive
+					variant="primary"
+					__next40pxDefaultSize
+					onClick={ callback }
+					icon={ warning }
+				>
+					{ listContext.isFeatured ? __( 'Add to Cart' ) : undefined }
+				</Button>
+			</Tooltip>
+		</div>
+	);
+};

--- a/packages/domain-search/src/components/domain-suggestion-cta/error.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-cta/error.tsx
@@ -15,7 +15,7 @@ export const DomainSuggestionErrorCTA = ( {
 	const listContext = useDomainSuggestionContainerContext();
 
 	if ( ! listContext ) {
-		throw new Error( 'DomainSuggestionCTA.AddToCart must be used within a DomainSuggestionsList' );
+		throw new Error( 'DomainSuggestionErrorCTA must be used within a DomainSuggestionsList' );
 	}
 
 	return (

--- a/packages/domain-search/src/components/domain-suggestion-cta/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-cta/index.tsx
@@ -1,29 +1,18 @@
-import { Button, Tooltip } from '@wordpress/components';
-import { arrowRight, warning } from '@wordpress/icons';
-import { useI18n } from '@wordpress/react-i18n';
-import { clsx } from 'clsx';
 import { useFocusedCartAction } from '../../hooks/use-focused-cart-action';
 import { useDomainSearch } from '../domain-search';
-import { shoppingCartIcon } from './shopping-cart-icon';
+import { DomainSuggestionContinueCTA } from './continue';
+import { DomainSuggestionErrorCTA } from './error';
+import { DomainSuggestionPrimaryCTA } from './primary';
 
 import './style.scss';
 
 export interface DomainSuggestionCTAProps {
-	variant?: 'primary' | 'secondary';
-	compact?: boolean;
 	uuid: string;
 	onClick?( action: 'add-to-cart' | 'continue' ): void;
 	disabled?: boolean;
 }
 
-export const DomainSuggestionCTA = ( {
-	variant = 'secondary',
-	compact,
-	uuid,
-	onClick,
-	disabled,
-}: DomainSuggestionCTAProps ) => {
-	const { __ } = useI18n();
+const DomainSuggestionCTA = ( { uuid, onClick, disabled }: DomainSuggestionCTAProps ) => {
 	const { cart, onContinue } = useDomainSearch();
 	const { isBusy, errorMessage, callback } = useFocusedCartAction( () => {
 		onClick?.( 'add-to-cart' );
@@ -39,57 +28,26 @@ export const DomainSuggestionCTA = ( {
 		};
 
 		return (
-			<Button
-				isPressed
-				aria-pressed="mixed"
-				__next40pxDefaultSize
-				icon={ arrowRight }
-				className="domain-suggestion-cta domain-suggestion-cta--continue"
-				onClick={ handleContinueClick }
-				label={ __( 'Continue' ) }
+			<DomainSuggestionContinueCTA
 				disabled={ disabled || cart.isBusy }
-			>
-				{ compact ? undefined : __( 'Continue' ) }
-			</Button>
+				onClick={ handleContinueClick }
+			/>
 		);
 	}
 
 	if ( errorMessage ) {
-		return (
-			<div className="domain-suggestion-cta-error">
-				<Tooltip
-					delay={ 0 }
-					text={ errorMessage }
-					placement="top"
-					className="domain-suggestion-cta-error__tooltip"
-				>
-					<Button
-						className={ clsx( 'domain-suggestion-cta', 'domain-suggestion-cta--error' ) }
-						isDestructive
-						variant="primary"
-						__next40pxDefaultSize
-						onClick={ callback }
-						icon={ warning }
-					>
-						{ compact ? undefined : __( 'Add to Cart' ) }
-					</Button>
-				</Tooltip>
-			</div>
-		);
+		return <DomainSuggestionErrorCTA errorMessage={ errorMessage } callback={ callback } />;
 	}
 
 	return (
-		<Button
-			className="domain-suggestion-cta"
-			variant={ variant }
-			__next40pxDefaultSize
-			icon={ shoppingCartIcon }
+		<DomainSuggestionPrimaryCTA
 			onClick={ callback }
-			label={ __( 'Add to Cart' ) }
 			disabled={ disabled || cart.isBusy }
 			isBusy={ isBusy }
-		>
-			{ compact ? undefined : __( 'Add to Cart' ) }
-		</Button>
+		/>
 	);
 };
+
+DomainSuggestionCTA.Primary = DomainSuggestionPrimaryCTA;
+
+export { DomainSuggestionCTA };

--- a/packages/domain-search/src/components/domain-suggestion-cta/primary.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-cta/primary.tsx
@@ -1,0 +1,45 @@
+import { Button } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
+import { useDomainSuggestionContainerContext } from '../../hooks/use-domain-suggestion-container';
+import { shoppingCartIcon } from './shopping-cart-icon';
+
+export const DomainSuggestionPrimaryCTA = ( {
+	onClick,
+	href,
+	disabled,
+	isBusy,
+	label,
+	icon,
+	children,
+}: {
+	onClick?: () => void;
+	href?: string;
+	disabled: boolean;
+	isBusy: boolean;
+	label?: string;
+	icon?: React.ReactElement;
+	children?: React.ReactNode;
+} ) => {
+	const { __ } = useI18n();
+	const listContext = useDomainSuggestionContainerContext();
+
+	if ( ! listContext ) {
+		throw new Error( 'DomainSuggestionCTA.Primary must be used within a DomainSuggestionsList' );
+	}
+
+	return (
+		<Button
+			className="domain-suggestion-cta"
+			variant={ listContext.isFeatured ? 'primary' : 'secondary' }
+			__next40pxDefaultSize
+			icon={ icon ?? shoppingCartIcon }
+			onClick={ onClick }
+			href={ href }
+			label={ label ?? __( 'Add to Cart' ) }
+			disabled={ disabled }
+			isBusy={ isBusy }
+		>
+			{ listContext.isFeatured ? children ?? __( 'Add to Cart' ) : undefined }
+		</Button>
+	);
+};

--- a/packages/domain-search/src/components/domain-suggestion-cta/primary.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-cta/primary.tsx
@@ -24,7 +24,7 @@ export const DomainSuggestionPrimaryCTA = ( {
 	const listContext = useDomainSuggestionContainerContext();
 
 	if ( ! listContext ) {
-		throw new Error( 'DomainSuggestionCTA.Primary must be used within a DomainSuggestionsList' );
+		throw new Error( 'DomainSuggestionPrimaryCTA must be used within a DomainSuggestionsList' );
 	}
 
 	return (

--- a/packages/domain-search/src/components/domain-suggestion-cta/test/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-cta/test/index.tsx
@@ -78,7 +78,7 @@ describe( 'DomainSuggestionCTA', () => {
 	it( 'should not show Add to Cart text when compact prop is true', () => {
 		render(
 			<DomainSearch cart={ buildDomainSearchCart() } onContinue={ jest.fn() }>
-				<DomainSuggestionCTA uuid="1" compact />
+				<DomainSuggestionCTA uuid="1" />
 			</DomainSearch>
 		);
 
@@ -95,7 +95,7 @@ describe( 'DomainSuggestionCTA', () => {
 				} ) }
 				onContinue={ jest.fn() }
 			>
-				<DomainSuggestionCTA uuid="1" compact />
+				<DomainSuggestionCTA uuid="1" />
 			</DomainSearch>
 		);
 

--- a/packages/domain-search/src/components/domain-suggestion-cta/test/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-cta/test/index.tsx
@@ -1,14 +1,18 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DomainSuggestionCTA } from '..';
+import { DomainSuggestionContainerContext } from '../../../hooks/use-domain-suggestion-container';
 import { buildDomain, buildDomainSearchCart } from '../../../test-helpers/factories';
 import { DomainSearch } from '../../domain-search';
+import { DomainSuggestionsList } from '../../domain-suggestions-list';
 
 describe( 'DomainSuggestionCTA', () => {
 	it( 'should render Add to Cart button when domain is not in cart', () => {
 		render(
 			<DomainSearch cart={ buildDomainSearchCart() } onContinue={ jest.fn() }>
-				<DomainSuggestionCTA uuid="1" />
+				<DomainSuggestionsList>
+					<DomainSuggestionCTA uuid="1" />
+				</DomainSuggestionsList>
 			</DomainSearch>
 		);
 
@@ -25,7 +29,9 @@ describe( 'DomainSuggestionCTA', () => {
 				} ) }
 				onContinue={ jest.fn() }
 			>
-				<DomainSuggestionCTA uuid="1" />
+				<DomainSuggestionsList>
+					<DomainSuggestionCTA uuid="1" />
+				</DomainSuggestionsList>
 			</DomainSearch>
 		);
 
@@ -44,7 +50,9 @@ describe( 'DomainSuggestionCTA', () => {
 				} ) }
 				onContinue={ jest.fn() }
 			>
-				<DomainSuggestionCTA uuid="1" />
+				<DomainSuggestionsList>
+					<DomainSuggestionCTA uuid="1" />
+				</DomainSuggestionsList>
 			</DomainSearch>
 		);
 
@@ -65,7 +73,9 @@ describe( 'DomainSuggestionCTA', () => {
 				} ) }
 				onContinue={ onContinue }
 			>
-				<DomainSuggestionCTA uuid="1" />
+				<DomainSuggestionsList>
+					<DomainSuggestionCTA uuid="1" />
+				</DomainSuggestionsList>
 			</DomainSearch>
 		);
 
@@ -75,41 +85,15 @@ describe( 'DomainSuggestionCTA', () => {
 		expect( onContinue ).toHaveBeenCalled();
 	} );
 
-	it( 'should not show Add to Cart text when compact prop is true', () => {
-		render(
-			<DomainSearch cart={ buildDomainSearchCart() } onContinue={ jest.fn() }>
-				<DomainSuggestionCTA uuid="1" />
-			</DomainSearch>
-		);
-
-		const button = screen.getByRole( 'button', { name: 'Add to Cart' } );
-		expect( button ).toHaveTextContent( '' );
-	} );
-
-	it( 'should not show Continue text when compact prop is true', () => {
-		render(
-			<DomainSearch
-				cart={ buildDomainSearchCart( {
-					items: [ buildDomain( { uuid: '1' } ) ],
-					hasItem: ( uuid ) => uuid === '1',
-				} ) }
-				onContinue={ jest.fn() }
-			>
-				<DomainSuggestionCTA uuid="1" />
-			</DomainSearch>
-		);
-
-		const button = screen.getByRole( 'button', { name: 'Continue' } );
-		expect( button ).toHaveTextContent( '' );
-	} );
-
 	it( 'should call onClick with add-to-cart when Add to Cart is clicked', async () => {
 		const user = userEvent.setup();
 		const onClick = jest.fn();
 
 		render(
 			<DomainSearch cart={ buildDomainSearchCart() } onContinue={ jest.fn() }>
-				<DomainSuggestionCTA uuid="1" onClick={ onClick } />
+				<DomainSuggestionsList>
+					<DomainSuggestionCTA uuid="1" onClick={ onClick } />
+				</DomainSuggestionsList>
 			</DomainSearch>
 		);
 
@@ -130,12 +114,86 @@ describe( 'DomainSuggestionCTA', () => {
 				} ) }
 				onContinue={ jest.fn() }
 			>
-				<DomainSuggestionCTA uuid="1" onClick={ onClick } />
+				<DomainSuggestionsList>
+					<DomainSuggestionCTA uuid="1" onClick={ onClick } />
+				</DomainSuggestionsList>
 			</DomainSearch>
 		);
 
 		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 
 		expect( onClick ).toHaveBeenCalledWith( 'continue' );
+	} );
+
+	describe( 'when rendering within a list', () => {
+		it( 'should not show Add to Cart text', () => {
+			render(
+				<DomainSearch cart={ buildDomainSearchCart() } onContinue={ jest.fn() }>
+					<DomainSuggestionsList>
+						<DomainSuggestionCTA uuid="1" />
+					</DomainSuggestionsList>
+				</DomainSearch>
+			);
+
+			const button = screen.getByRole( 'button', { name: 'Add to Cart' } );
+			expect( button ).toHaveTextContent( '' );
+		} );
+
+		it( 'should not show Continue text', () => {
+			render(
+				<DomainSearch
+					cart={ buildDomainSearchCart( {
+						items: [ buildDomain( { uuid: '1' } ) ],
+						hasItem: ( uuid ) => uuid === '1',
+					} ) }
+					onContinue={ jest.fn() }
+				>
+					<DomainSuggestionsList>
+						<DomainSuggestionCTA uuid="1" />
+					</DomainSuggestionsList>
+				</DomainSearch>
+			);
+
+			const button = screen.getByRole( 'button', { name: 'Continue' } );
+			expect( button ).toHaveTextContent( '' );
+		} );
+	} );
+
+	describe( 'when rendered as a featured suggestion', () => {
+		it( 'should show Add to Cart text', () => {
+			render(
+				<DomainSearch cart={ buildDomainSearchCart() } onContinue={ jest.fn() }>
+					<DomainSuggestionContainerContext.Provider
+						value={ { activeQuery: 'large', isFeatured: true } }
+					>
+						<DomainSuggestionCTA uuid="1" />
+					</DomainSuggestionContainerContext.Provider>
+				</DomainSearch>
+			);
+
+			const button = screen.getByRole( 'button', { name: 'Add to Cart' } );
+			expect( button ).toHaveTextContent( 'Add to Cart' );
+		} );
+
+		it( 'should show Continue text', () => {
+			render(
+				<DomainSearch
+					cart={ buildDomainSearchCart( {
+						items: [ buildDomain( { uuid: '1' } ) ],
+						hasItem: ( uuid ) => uuid === '1',
+					} ) }
+					onContinue={ jest.fn() }
+				>
+					<DomainSuggestionContainerContext.Provider
+						value={ { activeQuery: 'large', isFeatured: true } }
+					>
+						<DomainSuggestionCTA uuid="1" />
+					</DomainSuggestionContainerContext.Provider>
+				</DomainSearch>
+			);
+
+			const button = screen.getByRole( 'button', { name: 'Continue' } );
+			expect( button ).toHaveTextContent( 'Continue' );
+		} );
 	} );
 } );

--- a/packages/domain-search/src/components/domain-suggestion-price/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-price/index.tsx
@@ -6,7 +6,6 @@ import {
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useDomainSuggestionContainerContext } from '../../hooks/use-domain-suggestion-container';
-import type { ReactNode } from 'react';
 
 import './style.scss';
 
@@ -14,14 +13,12 @@ interface DomainSuggestionPriceProps {
 	salePrice?: string;
 	price: string;
 	renewPrice?: string;
-	subText?: ReactNode;
 }
 
 export const DomainSuggestionPrice = ( {
 	salePrice,
 	price,
 	renewPrice,
-	subText: subTextProp,
 }: DomainSuggestionPriceProps ) => {
 	const { __ } = useI18n();
 	const containerContext = useDomainSuggestionContainerContext();
@@ -44,10 +41,6 @@ export const DomainSuggestionPrice = ( {
 	const priceSize = getPriceSize();
 
 	const getSubText = () => {
-		if ( subTextProp ) {
-			return subTextProp;
-		}
-
 		if ( ! renewPrice ) {
 			return null;
 		}

--- a/packages/domain-search/src/components/domain-suggestion-price/test/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-price/test/index.tsx
@@ -59,15 +59,4 @@ describe( 'DomainSuggestionPrice', () => {
 		expect( screen.queryByText( '/year' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'For first year. $15/year renewal.' ) ).toBeInTheDocument();
 	} );
-
-	it( 'renders the price with a custom sub text', () => {
-		render(
-			<DomainSuggestionsList>
-				<DomainSuggestionPrice price="$15" renewPrice="$20" subText="Here's a different sub text" />
-			</DomainSuggestionsList>
-		);
-
-		expect( screen.queryByText( 'For first year. $20/year renewal.' ) ).not.toBeInTheDocument();
-		expect( screen.getByText( "Here's a different sub text" ) ).toBeInTheDocument();
-	} );
 } );

--- a/packages/domain-search/src/components/domain-suggestion/featured.tsx
+++ b/packages/domain-search/src/components/domain-suggestion/featured.tsx
@@ -41,18 +41,12 @@ const Featured = ( {
 				activeQuery,
 				alignment: ! matchReasons ? 'left' : undefined,
 				priceSize: activeQuery === 'large' ? 20 : 18,
+				isFeatured: true,
 			} ) as const,
 		[ activeQuery, matchReasons ]
 	);
 
-	const cta = (
-		<DomainSuggestionCTA
-			onClick={ onClick }
-			disabled={ disabled }
-			uuid={ uuid }
-			variant="primary"
-		/>
-	);
+	const cta = <DomainSuggestionCTA onClick={ onClick } disabled={ disabled } uuid={ uuid } />;
 
 	const title = (
 		<Text size={ activeQuery === 'large' ? 32 : 24 } style={ { wordBreak: 'break-all' } }>

--- a/packages/domain-search/src/components/domain-suggestion/featured.tsx
+++ b/packages/domain-search/src/components/domain-suggestion/featured.tsx
@@ -20,6 +20,7 @@ type DomainSuggestionFeaturedProps = {
 	badges?: React.ReactNode;
 	price: React.ReactNode;
 	isHighlighted?: boolean;
+	cta?: React.ReactNode;
 } & Pick< ComponentProps< typeof DomainSuggestionCTA >, 'onClick' | 'disabled' >;
 
 const Featured = ( {
@@ -32,6 +33,7 @@ const Featured = ( {
 	isHighlighted,
 	onClick,
 	disabled,
+	cta,
 }: DomainSuggestionFeaturedProps ) => {
 	const { containerRef, activeQuery } = useDomainSuggestionContainer();
 
@@ -45,8 +47,6 @@ const Featured = ( {
 			} ) as const,
 		[ activeQuery, matchReasons ]
 	);
-
-	const cta = <DomainSuggestionCTA onClick={ onClick } disabled={ disabled } uuid={ uuid } />;
 
 	const title = (
 		<Text size={ activeQuery === 'large' ? 32 : 24 } style={ { wordBreak: 'break-all' } }>
@@ -74,7 +74,9 @@ const Featured = ( {
 				title={ title }
 				matchReasonsList={ matchReasonsList }
 				price={ price }
-				cta={ cta }
+				cta={
+					cta ?? <DomainSuggestionCTA onClick={ onClick } disabled={ disabled } uuid={ uuid } />
+				}
 			/>
 		</DomainSuggestionContainerContext.Provider>
 	);

--- a/packages/domain-search/src/components/domain-suggestion/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion/index.tsx
@@ -19,6 +19,7 @@ type DomainSuggestionProps = {
 	price: React.ReactNode;
 	badges?: React.ReactNode;
 	notice?: React.ReactNode;
+	cta?: React.ReactNode;
 } & Pick< ComponentProps< typeof DomainSuggestionCTA >, 'onClick' | 'disabled' >;
 
 const DomainSuggestionComponent = ( {
@@ -30,6 +31,7 @@ const DomainSuggestionComponent = ( {
 	notice,
 	onClick,
 	disabled,
+	cta,
 }: DomainSuggestionProps ) => {
 	const listContext = useDomainSuggestionContainerContext();
 
@@ -72,10 +74,6 @@ const DomainSuggestionComponent = ( {
 		</span>
 	);
 
-	const cta = (
-		<DomainSuggestionCTA onClick={ onClick } compact uuid={ uuid } disabled={ disabled } />
-	);
-
 	const domainNameElement =
 		activeQuery === 'large' ? (
 			<HStack alignment="left" spacing={ 3 }>
@@ -86,7 +84,13 @@ const DomainSuggestionComponent = ( {
 			domainName
 		);
 
-	return <SuggestionSkeleton domainName={ domainNameElement } price={ price } cta={ cta } />;
+	return (
+		<SuggestionSkeleton
+			domainName={ domainNameElement }
+			price={ price }
+			cta={ cta ?? <DomainSuggestionCTA onClick={ onClick } uuid={ uuid } disabled={ disabled } /> }
+		/>
+	);
 };
 
 export const DomainSuggestion = ( props: DomainSuggestionProps ) => {

--- a/packages/domain-search/src/hooks/use-domain-suggestion-container.ts
+++ b/packages/domain-search/src/hooks/use-domain-suggestion-container.ts
@@ -14,6 +14,7 @@ interface DomainSuggestionContainerContextValue {
 	activeQuery: 'small' | 'large';
 	alignment?: 'left' | 'right';
 	priceSize?: number;
+	isFeatured?: boolean;
 }
 
 export const DomainSuggestionContainerContext = createContext<

--- a/packages/domain-search/src/index.ts
+++ b/packages/domain-search/src/index.ts
@@ -8,6 +8,7 @@ export { DomainSuggestionsList } from './components/domain-suggestions-list';
 export { DomainSuggestion } from './components/domain-suggestion';
 export { DomainSuggestionBadge } from './components/domain-suggestion-badge';
 export { DomainSuggestionPrice } from './components/domain-suggestion-price';
+export { DomainSuggestionCTA } from './components/domain-suggestion-cta';
 export { DomainSuggestionLoadMore } from './components/domain-suggestion-load-more';
 export { DomainSuggestionFilterReset } from './components/domain-suggestion-filter-reset';
 export * as DomainSearchControls from './components/domain-search-controls';


### PR DESCRIPTION
Closes DOMAINS-1559.

## Proposed Changes

We should show the contact support button for restricted premium domains, both as regular and featured suggestions. This PR does exactly that.

### Screenshots

#### Featured

<img width="1158" height="441" alt="featured-desktop" src="https://github.com/user-attachments/assets/0fa09f79-7e48-44f0-9d24-21ff7dacce57" />

<img width="470" height="372" alt="featured-mobile" src="https://github.com/user-attachments/assets/9a6f818b-cc5a-4fbc-a919-8e10ac3b72a6" />



#### Regular


<img width="1153" height="104" alt="regular-desktop" src="https://github.com/user-attachments/assets/a48e8287-c91a-4eff-b21c-51cd5e1f3a4b" />

<img width="475" height="119" alt="regular-mobile" src="https://github.com/user-attachments/assets/aa6c29b5-2341-4ab1-9c66-5895c3896f9e" />
