### PR TITLE
Reaader: Show/Hide button based on the subscriptions

### DIFF
--- a/client/blocks/reader-feed-header/follow.jsx
+++ b/client/blocks/reader-feed-header/follow.jsx
@@ -117,11 +117,13 @@ export default function ReaderFeedHeaderFollow( props ) {
 								</div>
 							) }
 						</div>
-						<RecommendButton
-							isLoading={ isRequestingRecommendedBlogs }
-							isRecommended={ isRecommended }
-							onClick={ toggleRecommended }
-						/>
+						{ ( following || isRecommended ) && (
+							<RecommendButton
+								isLoading={ isRequestingRecommendedBlogs }
+								isRecommended={ isRecommended }
+								onClick={ toggleRecommended }
+							/>
+						) }
 					</div>
 				) }
 			</div>


### PR DESCRIPTION
Closes CML-698

## Proposed Changes
* Hide the recommend button by default
* Once you subscribe, reveal it
* If you recommend and then unsubscribe, still show both buttons


## Testing Instructions
1. Go to /reader/feeds/151999939
2. Using Calypso, go to any feed page from your reader (e.g., /reader/feeds/151999939) that you are not subscribed to.
3. Check that you can’t see the Recommend button.
4. Click the Subscribe button.
5. Check that you can now see the Recommend button.
6. Click the Recommend button.
7. Unsubscribe from the feed (click the Subscribed button).
8. Check that you can still see the Recommend button.
9. Click the Recommend button again to remove the recommendation.
10. Check that the Recommend button is no longer visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
