### PR TITLE
Domains: Add notice to inform users that the org field will be the legal domain owner

### DIFF
--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -20,7 +20,7 @@ import { toIcannFormat } from 'calypso/components/phone-input/phone-number';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import formState from 'calypso/lib/form-state';
 import NoticeErrorMessage from 'calypso/my-sites/checkout/checkout/notice-error-message';
-import { CountrySelect, Input, HiddenInput } from 'calypso/my-sites/domains/components/form';
+import { CountrySelect, Input, OrganizationField } from 'calypso/my-sites/domains/components/form';
 import { getCountryStates } from 'calypso/state/country-states/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
 import getCountries from 'calypso/state/selectors/get-countries';
@@ -372,13 +372,28 @@ export class ContactDetailsFormFields extends Component {
 			: false;
 
 	renderContactDetailsFields() {
-		const { translate, needsFax, hasCountryStates } = this.props;
+		const { translate, needsFax, hasCountryStates, labelTexts } = this.props;
 		const countryCode = this.getCountryCode();
 		const arePostalCodesSupported = this.getCountryPostalCodeSupport( countryCode );
 
 		return (
 			<div className="contact-details-form-fields__contact-details">
-				<div className="contact-details-form-fields__row">{ this.renderOrganizationField() }</div>
+				<div className="contact-details-form-fields__row">
+					{ this.createField(
+						'organization',
+						OrganizationField,
+						{
+							label: translate( 'Organization' ),
+							text: labelTexts.organization || translate( '+ Add organization name' ),
+							placeholder: translate( 'Organization (optional)' ),
+							onToggle: () => this.setState( { organizationFieldIsVisible: true } ),
+						},
+						{
+							needsChildRef: true,
+							customErrorMessage: this.props.contactDetailsErrors?.organization,
+						}
+					) }
+				</div>
 
 				<div className="contact-details-form-fields__row">
 					{ this.renderContactEmailInputWithCheckbox() }
@@ -447,36 +462,6 @@ export class ContactDetailsFormFields extends Component {
 		this.props.onUpdateWpcomEmailCheckboxChange( value );
 		this.setState( { updateWpcomEmail: value } );
 	};
-
-	renderOrganizationField() {
-		const { translate, labelTexts } = this.props;
-
-		return (
-			<div className="organization-field-container">
-				{ this.createField(
-					'organization',
-					HiddenInput,
-					{
-						label: translate( 'Organization' ),
-						text: labelTexts.organization || translate( '+ Add organization name' ),
-						placeholder: translate( 'Organization (optional)' ),
-						onToggle: () => this.setState( { organizationFieldIsVisible: true } ),
-					},
-					{
-						needsChildRef: true,
-						customErrorMessage: this.props.contactDetailsErrors?.organization,
-					}
-				) }
-				{ this.state.organizationFieldIsVisible && (
-					<span>
-						{ translate(
-							'The organization, if filled, will be made public and considered the legal domain owner'
-						) }
-					</span>
-				) }
-			</div>
-		);
-	}
 
 	renderContactEmailInputWithCheckbox() {
 		const emailInputFieldProps = this.getFieldProps( 'email', {

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -105,6 +105,7 @@ export class ContactDetailsFormFields extends Component {
 			form: null,
 			submissionCount: 0,
 			updateWpcomEmail: false,
+			organizationFieldIsVisible: false,
 		};
 
 		this.inputRefs = {};
@@ -128,7 +129,8 @@ export class ContactDetailsFormFields extends Component {
 			nextProps.needsFax !== this.props.needsFax ||
 			nextProps.disableSubmitButton !== this.props.disableSubmitButton ||
 			nextProps.needsOnlyGoogleAppsDetails !== this.props.needsOnlyGoogleAppsDetails ||
-			nextState.updateWpcomEmail !== this.state.updateWpcomEmail
+			nextState.updateWpcomEmail !== this.state.updateWpcomEmail ||
+			nextState.organizationFieldIsVisible !== this.state.organizationFieldIsVisible
 		);
 	}
 
@@ -370,26 +372,13 @@ export class ContactDetailsFormFields extends Component {
 			: false;
 
 	renderContactDetailsFields() {
-		const { translate, needsFax, hasCountryStates, labelTexts } = this.props;
+		const { translate, needsFax, hasCountryStates } = this.props;
 		const countryCode = this.getCountryCode();
 		const arePostalCodesSupported = this.getCountryPostalCodeSupport( countryCode );
 
 		return (
 			<div className="contact-details-form-fields__contact-details">
-				<div className="contact-details-form-fields__row">
-					{ this.createField(
-						'organization',
-						HiddenInput,
-						{
-							label: translate( 'Organization' ),
-							text: labelTexts.organization || translate( '+ Add organization name' ),
-						},
-						{
-							needsChildRef: true,
-							customErrorMessage: this.props.contactDetailsErrors?.organization,
-						}
-					) }
-				</div>
+				<div className="contact-details-form-fields__row">{ this.renderOrganizationField() }</div>
 
 				<div className="contact-details-form-fields__row">
 					{ this.renderContactEmailInputWithCheckbox() }
@@ -458,6 +447,36 @@ export class ContactDetailsFormFields extends Component {
 		this.props.onUpdateWpcomEmailCheckboxChange( value );
 		this.setState( { updateWpcomEmail: value } );
 	};
+
+	renderOrganizationField() {
+		const { translate, labelTexts } = this.props;
+
+		return (
+			<div className="organization-field-container">
+				{ this.createField(
+					'organization',
+					HiddenInput,
+					{
+						label: translate( 'Organization' ),
+						text: labelTexts.organization || translate( '+ Add organization name' ),
+						placeholder: translate( 'Organization (optional)' ),
+						onToggle: () => this.setState( { organizationFieldIsVisible: true } ),
+					},
+					{
+						needsChildRef: true,
+						customErrorMessage: this.props.contactDetailsErrors?.organization,
+					}
+				) }
+				{ this.state.organizationFieldIsVisible && (
+					<span>
+						{ translate(
+							'The organization, if filled, will be made public and considered the legal domain owner'
+						) }
+					</span>
+				) }
+			</div>
+		);
+	}
 
 	renderContactEmailInputWithCheckbox() {
 		const emailInputFieldProps = this.getFieldProps( 'email', {

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -105,7 +105,6 @@ export class ContactDetailsFormFields extends Component {
 			form: null,
 			submissionCount: 0,
 			updateWpcomEmail: false,
-			organizationFieldIsVisible: false,
 		};
 
 		this.inputRefs = {};
@@ -129,8 +128,7 @@ export class ContactDetailsFormFields extends Component {
 			nextProps.needsFax !== this.props.needsFax ||
 			nextProps.disableSubmitButton !== this.props.disableSubmitButton ||
 			nextProps.needsOnlyGoogleAppsDetails !== this.props.needsOnlyGoogleAppsDetails ||
-			nextState.updateWpcomEmail !== this.state.updateWpcomEmail ||
-			nextState.organizationFieldIsVisible !== this.state.organizationFieldIsVisible
+			nextState.updateWpcomEmail !== this.state.updateWpcomEmail
 		);
 	}
 
@@ -387,7 +385,6 @@ export class ContactDetailsFormFields extends Component {
 							text: labelTexts.organization || translate( '+ Add organization name' ),
 							placeholder: translate( 'Organization (optional)' ),
 							toggled: formState.getFieldValue( this.state.form, 'organization' ),
-							onToggle: () => this.setState( { organizationFieldIsVisible: true } ),
 						},
 						{
 							needsChildRef: true,

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -386,6 +386,7 @@ export class ContactDetailsFormFields extends Component {
 							label: translate( 'Organization' ),
 							text: labelTexts.organization || translate( '+ Add organization name' ),
 							placeholder: translate( 'Organization (optional)' ),
+							toggled: formState.getFieldValue( this.state.form, 'organization' ),
 							onToggle: () => this.setState( { organizationFieldIsVisible: true } ),
 						},
 						{

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
@@ -19,7 +19,7 @@ import {
 	prepareDomainContactDetails,
 	convertDomainContactDetailsToManagedContactDetails,
 } from 'calypso/my-sites/checkout/src/types/wpcom-store-state';
-import { Input, HiddenInput } from 'calypso/my-sites/domains/components/form';
+import { Input, OrganizationField } from 'calypso/my-sites/domains/components/form';
 import { getCountryStates } from 'calypso/state/country-states/selectors';
 import {
 	getCurrentUserEmail,
@@ -345,7 +345,7 @@ export class ManagedContactDetailsFormFields extends Component<
 		return (
 			<div className="contact-details-form-fields__contact-details">
 				<div className="contact-details-form-fields__row">
-					<HiddenInput
+					<OrganizationField
 						label={ this.props.translate( 'Organization' ) }
 						labelClass="contact-details-form-fields__label"
 						additionalClasses="contact-details-form-fields__field"

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
@@ -357,6 +357,7 @@ export class ManagedContactDetailsFormFields extends Component<
 						value={ this.props.contactDetails.organization }
 						name="organization"
 						text={ translate( '+ Add organization name' ) }
+						placeholder={ translate( 'Organization (optional)' ) }
 						toggled={ this.props.contactDetails.organization || isOrganizationFieldRequired }
 					/>
 				</div>

--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -116,6 +116,16 @@
 			}
 		}
 	}
+
+	.organization-field-container {
+		flex-grow: 1;
+
+		span {
+			display: block;
+			font-size: $font-body-small;
+			margin-top: 0.5em;
+		}
+	}
 }
 
 .contact-details-form-fields__contact-details {

--- a/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
+++ b/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
@@ -58,25 +58,29 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
       class="contact-details-form-fields__row"
     >
       <div
-        class="contact-details-form-fields__field organization contact-details-form-fields__label"
+        class="organization-field-container"
       >
-        <label
-          class="form-label"
-          for="organization"
+        <div
+          class="contact-details-form-fields__field organization contact-details-form-fields__label"
         >
-          Organization
-        </label>
-        <input
-          aria-describedby="validation-field-organization"
-          aria-invalid="false"
-          autocomplete="on"
-          class="form-text-input"
-          id="organization"
-          name="organization"
-          placeholder="Organization"
-          type="text"
-          value="Il pagliaccio del comune"
-        />
+          <label
+            class="form-label"
+            for="organization"
+          >
+            Organization
+          </label>
+          <input
+            aria-describedby="validation-field-organization"
+            aria-invalid="false"
+            autocomplete="on"
+            class="form-text-input"
+            id="organization"
+            name="organization"
+            placeholder="Organization (optional)"
+            type="text"
+            value="Il pagliaccio del comune"
+          />
+        </div>
       </div>
     </div>
     <div

--- a/client/my-sites/domains/components/form/hidden-input.jsx
+++ b/client/my-sites/domains/components/form/hidden-input.jsx
@@ -37,6 +37,7 @@ export class HiddenInput extends PureComponent {
 			},
 			() => {
 				this.inputField && this.inputField.focus();
+				this.props.onToggle && this.props.onToggle();
 			}
 		);
 	};

--- a/client/my-sites/domains/components/form/index.jsx
+++ b/client/my-sites/domains/components/form/index.jsx
@@ -1,7 +1,8 @@
 import CountrySelect from './country-select';
 import HiddenInput from './hidden-input';
 import Input from './input';
+import OrganizationField from './organization-field';
 import Select from './select';
 import StateSelect from './state-select';
 
-export { CountrySelect, HiddenInput, Input, StateSelect, Select };
+export { CountrySelect, HiddenInput, Input, OrganizationField, StateSelect, Select };

--- a/client/my-sites/domains/components/form/organization-field.jsx
+++ b/client/my-sites/domains/components/form/organization-field.jsx
@@ -1,0 +1,35 @@
+import { localize } from 'i18n-calypso';
+import { PureComponent } from 'react';
+import HiddenInput from './hidden-input';
+
+export class OrganizationField extends PureComponent {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			isToggled: false,
+		};
+	}
+
+	handleToggle = () => {
+		this.setState( { isToggled: true } );
+	};
+
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<div className="organization-field-container">
+				<HiddenInput { ...this.props } onToggle={ this.handleToggle } />
+				{ this.state.isToggled && (
+					<span>
+						{ translate(
+							'The organization, if filled, will be made public and considered the legal domain owner'
+						) }
+					</span>
+				) }
+			</div>
+		);
+	}
+}
+
+export default localize( OrganizationField );

--- a/client/my-sites/domains/components/form/organization-field.jsx
+++ b/client/my-sites/domains/components/form/organization-field.jsx
@@ -6,21 +6,22 @@ export class OrganizationField extends PureComponent {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			isToggled: false,
+			toggled: props.toggled,
 		};
 	}
 
 	handleToggle = () => {
-		this.setState( { isToggled: true } );
+		this.setState( { toggled: true } );
 	};
 
 	render() {
 		const { translate } = this.props;
+		const shouldShowExplanation = this.state.toggled || this.props.value;
 
 		return (
 			<div className="organization-field-container">
 				<HiddenInput { ...this.props } onToggle={ this.handleToggle } />
-				{ this.state.isToggled && (
+				{ shouldShowExplanation && (
 					<span>
 						{ translate(
 							'The organization, if filled, will be made public and considered the legal domain owner'


### PR DESCRIPTION
Related to: [DOTOBRD-184](https://linear.app/a8c/issue/DOTOBRD-184/)

## Proposed Changes

This PR adds a notice below the organization field in the contact information editing form explaining that, if that field is populated, it will be made public and considered the legal domain owner.

Internally, this PR adds a new `OrganizationField` domain form component and added a `onToggle` callback to `HiddenInput`.

### Screenshots

| | Desktop | Mobile |
| --- | --- | --- |
| Edit contact info | <img width="718" height="342" alt="Screenshot 2025-07-25 at 15 34 25" src="https://github.com/user-attachments/assets/d67ccd3f-d794-49a8-bcf8-9a4fe2cc1f71" /> | <img width="349" height="413" alt="Screenshot 2025-07-25 at 16 57 28" src="https://github.com/user-attachments/assets/8d6b5014-d007-4524-81b4-8c0b033c5e55" /> |
| Checkout | <img width="644" height="389" alt="Screenshot 2025-07-25 at 16 19 27" src="https://github.com/user-attachments/assets/4fa4d59a-15a5-4063-a26e-910d06e7d391" /> | <img width="356" height="528" alt="Screenshot 2025-07-25 at 16 21 31" src="https://github.com/user-attachments/assets/a8e79b78-75b9-4d6a-9d87-0d68f61d30dc" /> |

## Why are these changes being made?

This is a requirement of the new RDP policy that will take effect in August 21, 2025. See pet6gk-2kA-p2 for more context. 

## Testing Instructions

- Build this branch locally or open the live Calypso link
- Select a test domain in your account and go to the contact info editing page
- Ensure the organization explanation is shown below the organization input field
- Now search for a domain, add it to the cart and reach the checkout page
- Ensure the organization explanation is shown in that form too

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?