### PR TITLE
Domain Search Retrofitting: Allow skipping the purchase

### DIFF
--- a/client/components/domain-search-v2/domain-search-results/index.jsx
+++ b/client/components/domain-search-v2/domain-search-results/index.jsx
@@ -277,7 +277,7 @@ class DomainSearchResults extends Component {
 
 		if ( ! this.props.isLoadingSuggestions && this.props.suggestions ) {
 			const subdomainSuggestion = suggestions.find(
-				( suggestion ) => suggestion.isSubDomainSuggestion
+				( suggestion ) => suggestion.isSubDomainSuggestion || suggestion.is_free
 			);
 			const regularSuggestions = suggestions.filter(
 				( suggestion ) =>
@@ -353,9 +353,10 @@ class DomainSearchResults extends Component {
 				);
 			} );
 
-			domainSkipSuggestion = showSkipButton && subdomainSuggestion && (
+			domainSkipSuggestion = showSkipButton && (
 				<DomainSkipSuggestion
-					domain={ subdomainSuggestion.domain_name }
+					selectedSite={ this.props.selectedSite }
+					subdomainSuggestion={ subdomainSuggestion }
 					onSkip={ this.props.onSkip }
 				/>
 			);

--- a/client/components/domain-search-v2/domain-skip-suggestion/index.tsx
+++ b/client/components/domain-search-v2/domain-skip-suggestion/index.tsx
@@ -11,14 +11,59 @@ import { DomainSkipSkeleton } from './index.skeleton';
 import './style.scss';
 
 interface Props {
-	domain: string;
-	onSkip: () => void;
+	selectedSite?: { URL: string };
+	subdomainSuggestion?: { domain_name: string };
 }
 
-const DomainSkipSuggestion = ( { domain, onSkip }: Props ) => {
+const DomainSkipSuggestion = ( { selectedSite, subdomainSuggestion }: Props ) => {
 	const translate = useTranslate();
-	const { cart } = useDomainSearch();
-	const [ subdomain, ...tlds ] = domain.split( '.' );
+	const { cart, onContinue } = useDomainSearch();
+
+	if ( selectedSite ) {
+		const [ subdomain, ...tlds ] = new URL( selectedSite.URL ).hostname.split( '.' ) ?? [];
+
+		return (
+			<DomainSkipSkeleton
+				title={
+					<Heading level="4" weight="normal">
+						{ translate( 'Current address' ) }
+					</Heading>
+				}
+				subtitle={
+					<Text>
+						{ translate(
+							'Keep %(subdomain)s{{strong}}.%(domainName)s{{/strong}} as your site address',
+							{
+								args: {
+									subdomain: subdomain,
+									domainName: tlds.join( '.' ),
+								},
+								components: {
+									strong: <strong />,
+								},
+							}
+						) }
+					</Text>
+				}
+				right={
+					<Button
+						className="subdomain-skip-suggestion__btn"
+						variant="secondary"
+						onClick={ onContinue }
+						disabled={ cart.isBusy }
+					>
+						{ translate( 'Skip purchase' ) }
+					</Button>
+				}
+			/>
+		);
+	}
+
+	if ( ! subdomainSuggestion ) {
+		throw new Error( 'No selected site but no suggestion was passed.' );
+	}
+
+	const [ subdomain, ...tlds ] = subdomainSuggestion.domain_name.split( '.' ) ?? [];
 
 	return (
 		<DomainSkipSkeleton
@@ -44,7 +89,9 @@ const DomainSkipSuggestion = ( { domain, onSkip }: Props ) => {
 				<Button
 					className="subdomain-skip-suggestion__btn"
 					variant="secondary"
-					onClick={ onSkip }
+					onClick={ () => {
+						cart.onAddItem( subdomainSuggestion.domain_name );
+					} }
 					disabled={ cart.isBusy }
 				>
 					{ translate( 'Skip purchase' ) }

--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -517,6 +517,16 @@ class RegisterDomainStep extends Component {
 			} ),
 			total,
 			onAddItem: ( domain_name ) => {
+				const subdomainPosition = this.state.subdomainSearchResults.findIndex(
+					( subdomain ) => subdomain.domain_name === domain_name
+				);
+
+				if ( subdomainPosition !== -1 ) {
+					const subdomain = this.state.subdomainSearchResults[ subdomainPosition ];
+
+					return this.onAddDomain( subdomain, subdomainPosition, false );
+				}
+
 				const suggestionPosition = searchResults.findIndex(
 					( result ) => result.domain_name === domain_name
 				);

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -300,6 +300,13 @@ class RenderDomainsStepComponent extends Component {
 
 		await this.props.saveSignupStep( stepData );
 
+		if ( this.props.shouldUseDomainSearchV2 && suggestion?.isSubDomainSuggestion ) {
+			this.setState( { isMiniCartContinueButtonBusy: true } );
+			await this.props.saveSignupStep( stepData );
+			await this.submitWithDomain( { signupDomainOrigin, position, suggestion } );
+			return;
+		}
+
 		if (
 			shouldUseMultipleDomainsInCart( this.props.flowName ) &&
 			suggestion?.isSubDomainSuggestion


### PR DESCRIPTION
Closes DOMAINS-1552.

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
