### PR TITLE
Domain Search Retrofit: Fix FQDN rendering

### DIFF
--- a/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
+++ b/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
@@ -372,7 +372,8 @@ class DomainRegistrationSuggestion extends Component {
 		if (
 			! Array.isArray( this.props.suggestion.match_reasons ) ||
 			hideMatchReasons ||
-			! isFeatured
+			! isFeatured ||
+			! this.isExactMatch()
 		) {
 			return null;
 		}

--- a/packages/domain-search/src/components/domain-suggestion/featured.skeleton.tsx
+++ b/packages/domain-search/src/components/domain-suggestion/featured.skeleton.tsx
@@ -28,8 +28,12 @@ export const FeaturedSkeleton = forwardRef< HTMLDivElement, SkeletonProps >( ( p
 				return (
 					<VStack spacing={ 3 } className="domain-suggestion-featured__content">
 						{ badges }
-						<HStack spacing={ 6 }>
-							<VStack spacing={ 3 } alignment="left">
+						<HStack spacing={ 6 } style={ { alignItems: 'flex-start', height: '100%' } }>
+							<VStack
+								spacing={ 3 }
+								alignment="left"
+								style={ { alignSelf: 'stretch', justifyContent: 'flex-start' } }
+							>
 								{ title }
 								{ matchReasonsList }
 							</VStack>


### PR DESCRIPTION
## Proposed Changes

Featured elements with match reasons were getting some weird rendering patterns:

<img width="1192" height="453" alt="image" src="https://github.com/user-attachments/assets/729735fe-4d33-4fb2-8810-9ac1ba9876a1" />


This PR make it so only FQDN renders the match reasons list:

<img width="1182" height="239" alt="image" src="https://github.com/user-attachments/assets/3e4e9cb2-768d-4cf8-a344-fa5f5a6d573f" />

We will certainly revisit this the next week.