### PR TITLE
Domains: Add notice to inform users that the org field will be the legal domain owner

### DIFF
--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -4,6 +4,7 @@ import {
 	tryToGuessPostalCodeFormat,
 	getCountryPostalCodeSupport,
 } from '@automattic/wpcom-checkout';
+import { Notice } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { get, kebabCase, pick, includes, isEqual, isEmpty, camelCase } from 'lodash';
@@ -384,18 +385,22 @@ export class ContactDetailsFormFields extends Component {
 						{
 							label: translate( 'Organization' ),
 							text: labelTexts.organization || translate( '+ Add organization name' ),
-							description: translate(
-								'If provided, the organization name will be considered the legal domain owner and made public. You can hide it using {{a}}privacy protection{{/a}}.',
-								{
-									components: {
-										a: (
-											<InlineSupportLink
-												supportContext="domain-registrations-and-privacy"
-												showIcon={ false }
-											/>
-										),
-									},
-								}
+							description: (
+								<Notice status="info" isDismissible={ false }>
+									{ translate(
+										'If provided, the organization name will be considered the legal domain owner and made public. You can hide it using {{a}}privacy protection{{/a}}.',
+										{
+											components: {
+												a: (
+													<InlineSupportLink
+														supportContext="domain-registrations-and-privacy"
+														showIcon={ false }
+													/>
+												),
+											},
+										}
+									) }
+								</Notice>
 							),
 						},
 						{

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -387,7 +387,7 @@ export class ContactDetailsFormFields extends Component {
 							text: labelTexts.organization || translate( '+ Add organization name' ),
 							placeholder: translate( 'Organization (optional)' ),
 							description: (
-								<Notice status="info" isDismissible={ false }>
+								<Notice status="warning" isDismissible={ false }>
 									{ translate(
 										'By completing the organization field, you agree that the listed organization will be considered the legal domain owner and that this information will be publicly visible. You can choose to hide it using {{a}}privacy protection{{/a}}.',
 										{

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -385,6 +385,7 @@ export class ContactDetailsFormFields extends Component {
 						{
 							label: translate( 'Organization' ),
 							text: labelTexts.organization || translate( '+ Add organization name' ),
+							placeholder: translate( 'Organization (optional)' ),
 							description: (
 								<Notice status="info" isDismissible={ false }>
 									{ translate(

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -383,6 +383,9 @@ export class ContactDetailsFormFields extends Component {
 						{
 							label: translate( 'Organization' ),
 							text: labelTexts.organization || translate( '+ Add organization name' ),
+							description: translate(
+								'The organization, if filled, will be made public and considered the legal domain owner'
+							),
 						},
 						{
 							needsChildRef: true,

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -15,6 +15,7 @@ import FormButton from 'calypso/components/forms/form-button';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormPhoneMediaInput from 'calypso/components/forms/form-phone-media-input';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import { countries } from 'calypso/components/phone-input/data';
 import { toIcannFormat } from 'calypso/components/phone-input/phone-number';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -384,7 +385,17 @@ export class ContactDetailsFormFields extends Component {
 							label: translate( 'Organization' ),
 							text: labelTexts.organization || translate( '+ Add organization name' ),
 							description: translate(
-								'The organization, if filled, will be made public and considered the legal domain owner'
+								'If provided, the organization name will be considered the legal domain owner and made public. You can hide it using {{a}}privacy protection{{/a}}.',
+								{
+									components: {
+										a: (
+											<InlineSupportLink
+												supportContext="domain-registrations-and-privacy"
+												showIcon={ false }
+											/>
+										),
+									},
+								}
 							),
 						},
 						{

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -389,7 +389,7 @@ export class ContactDetailsFormFields extends Component {
 							description: (
 								<Notice status="info" isDismissible={ false }>
 									{ translate(
-										'If provided, the organization name will be considered the legal domain owner and made public. You can hide it using {{a}}privacy protection{{/a}}.',
+										'By completing the organization field, you agree that the listed organization will be considered the legal domain owner and that this information will be publicly visible. You can choose to hide it using {{a}}privacy protection{{/a}}.',
 										{
 											components: {
 												a: (

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
@@ -362,7 +362,7 @@ export class ManagedContactDetailsFormFields extends Component<
 						toggled={ this.props.contactDetails.organization || isOrganizationFieldRequired }
 						placeholder={ translate( 'Organization (optional)' ) }
 						description={
-							<Notice status="info" isDismissible={ false }>
+							<Notice status="warning" isDismissible={ false }>
 								{ translate(
 									'By completing the organization field, you agree that the listed organization will be considered the legal domain owner and that this information will be publicly visible. You can choose to hide it using {{a}}privacy protection{{/a}}.',
 									{

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
@@ -364,7 +364,7 @@ export class ManagedContactDetailsFormFields extends Component<
 						description={
 							<Notice status="info" isDismissible={ false }>
 								{ translate(
-									'If provided, the organization name will be considered the legal domain owner and made public. You can hide it using {{a}}privacy protection{{/a}}.',
+									'By completing the organization field, you agree that the listed organization will be considered the legal domain owner and that this information will be publicly visible. You can choose to hide it using {{a}}privacy protection{{/a}}.',
 									{
 										components: {
 											a: (

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
@@ -4,6 +4,7 @@ import {
 	getCountryTaxRequirements,
 	CountryListItem,
 } from '@automattic/wpcom-checkout';
+import { Notice } from '@wordpress/components';
 import debugFactory from 'debug';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { camelCase, deburr } from 'lodash';
@@ -359,19 +360,23 @@ export class ManagedContactDetailsFormFields extends Component<
 						name="organization"
 						text={ translate( '+ Add organization name' ) }
 						toggled={ this.props.contactDetails.organization || isOrganizationFieldRequired }
-						description={ translate(
-							'If provided, the organization name will be considered the legal domain owner and made public. You can hide it using {{a}}privacy protection{{/a}}.',
-							{
-								components: {
-									a: (
-										<InlineSupportLink
-											supportContext="domain-registrations-and-privacy"
-											showIcon={ false }
-										/>
-									),
-								},
-							}
-						) }
+						description={
+							<Notice status="info" isDismissible={ false }>
+								{ translate(
+									'If provided, the organization name will be considered the legal domain owner and made public. You can hide it using {{a}}privacy protection{{/a}}.',
+									{
+										components: {
+											a: (
+												<InlineSupportLink
+													supportContext="domain-registrations-and-privacy"
+													showIcon={ false }
+												/>
+											),
+										},
+									}
+								) }
+							</Notice>
+						}
 					/>
 				</div>
 

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
@@ -360,6 +360,7 @@ export class ManagedContactDetailsFormFields extends Component<
 						name="organization"
 						text={ translate( '+ Add organization name' ) }
 						toggled={ this.props.contactDetails.organization || isOrganizationFieldRequired }
+						placeholder={ translate( 'Organization (optional)' ) }
 						description={
 							<Notice status="info" isDismissible={ false }>
 								{ translate(

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
@@ -358,6 +358,9 @@ export class ManagedContactDetailsFormFields extends Component<
 						name="organization"
 						text={ translate( '+ Add organization name' ) }
 						toggled={ this.props.contactDetails.organization || isOrganizationFieldRequired }
+						description={ translate(
+							'The organization, if filled, will be made public and considered the legal domain owner'
+						) }
 					/>
 				</div>
 

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
@@ -12,6 +12,7 @@ import { connect } from 'react-redux';
 import QueryDomainCountries from 'calypso/components/data/query-countries/domains';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormPhoneMediaInput from 'calypso/components/forms/form-phone-media-input';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import { countries } from 'calypso/components/phone-input/data';
 import { toIcannFormat } from 'calypso/components/phone-input/phone-number';
 import CountrySelectMenu from 'calypso/my-sites/checkout/src/components/country-select-menu';
@@ -359,7 +360,17 @@ export class ManagedContactDetailsFormFields extends Component<
 						text={ translate( '+ Add organization name' ) }
 						toggled={ this.props.contactDetails.organization || isOrganizationFieldRequired }
 						description={ translate(
-							'The organization, if filled, will be made public and considered the legal domain owner'
+							'If provided, the organization name will be considered the legal domain owner and made public. You can hide it using {{a}}privacy protection{{/a}}.',
+							{
+								components: {
+									a: (
+										<InlineSupportLink
+											supportContext="domain-registrations-and-privacy"
+											showIcon={ false }
+										/>
+									),
+								},
+							}
 						) }
 					/>
 				</div>

--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -116,6 +116,10 @@
 			}
 		}
 	}
+
+	.contact-details-form-fields__field.organization .form-setting-explanation {
+		font-style: normal;
+	}
 }
 
 .contact-details-form-fields__contact-details {

--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -116,10 +116,6 @@
 			}
 		}
 	}
-
-	.contact-details-form-fields__field.organization .form-setting-explanation {
-		font-style: normal;
-	}
 }
 
 .contact-details-form-fields__contact-details {

--- a/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
+++ b/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
@@ -80,7 +80,26 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
         <p
           class="form-setting-explanation"
         >
-          If provided, the organization name will be considered the legal domain owner and made public. You can hide it using {{a}}privacy protection{{/a}}.
+          <div
+            class="components-notice is-info"
+          >
+            <div
+              class="components-visually-hidden css-161q9d5-PolymorphicDiv e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="VisuallyHidden"
+              style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+            >
+              Information notice
+            </div>
+            <div
+              class="components-notice__content"
+            >
+              If provided, the organization name will be considered the legal domain owner and made public. You can hide it using {{a}}privacy protection{{/a}}.
+              <div
+                class="components-notice__actions"
+              />
+            </div>
+          </div>
         </p>
       </div>
     </div>

--- a/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
+++ b/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
@@ -77,6 +77,11 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
           type="text"
           value="Il pagliaccio del comune"
         />
+        <p
+          class="form-setting-explanation"
+        >
+          If provided, the organization name will be considered the legal domain owner and made public. You can hide it using {{a}}privacy protection{{/a}}.
+        </p>
       </div>
     </div>
     <div

--- a/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
+++ b/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
@@ -73,7 +73,7 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
           class="form-text-input"
           id="organization"
           name="organization"
-          placeholder="Organization"
+          placeholder="Organization (optional)"
           type="text"
           value="Il pagliaccio del comune"
         />
@@ -81,7 +81,7 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
           class="form-setting-explanation"
         >
           <div
-            class="components-notice is-info"
+            class="components-notice is-warning"
           >
             <div
               class="components-visually-hidden css-161q9d5-PolymorphicDiv e19lxcc00"
@@ -89,12 +89,12 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
               data-wp-component="VisuallyHidden"
               style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
             >
-              Information notice
+              Warning notice
             </div>
             <div
               class="components-notice__content"
             >
-              If provided, the organization name will be considered the legal domain owner and made public. You can hide it using {{a}}privacy protection{{/a}}.
+              By completing the organization field, you agree that the listed organization will be considered the legal domain owner and that this information will be publicly visible. You can choose to hide it using {{a}}privacy protection{{/a}}.
               <div
                 class="components-notice__actions"
               />


### PR DESCRIPTION
> [!NOTE]
> This PR will be merged on August 21, 2025, when RDP takes effect.

Related to: [DOTOBRD-184](https://linear.app/a8c/issue/DOTOBRD-184/)

## Proposed Changes

This PR adds a notice below the organization field in the contact information form. That notice explains that, if that field is populated, it will be made public and considered the legal domain owner. It also notes that the organization name can be hidden by using privacy protection.

### Screenshots

| | Desktop | Mobile |
| --- | --- | --- |
| Edit contact info | <img width="707" height="284" alt="Screenshot 2025-08-14 at 09 53 07" src="https://github.com/user-attachments/assets/46fde2dc-2f14-43db-aa5e-099260f591ca" /> | <img width="353" height="503" alt="Screenshot 2025-08-14 at 09 53 21" src="https://github.com/user-attachments/assets/4219c251-c689-4226-9493-6da4f2a9e0aa" /> |
| Checkout | <img width="626" height="355" alt="Screenshot 2025-08-14 at 09 53 54" src="https://github.com/user-attachments/assets/6c486daf-3a9b-4117-831e-a711674b22d8" /> | <img width="353" height="608" alt="Screenshot 2025-08-14 at 09 54 21" src="https://github.com/user-attachments/assets/a9890124-2eee-4155-91ca-3d7d0501b7a9" /> |

Clicking the privacy protection link opens the domain privacy support doc:

<img width="435" height="819" alt="Screenshot 2025-08-04 at 19 14 36" src="https://github.com/user-attachments/assets/c00cd15a-e414-4659-90cd-37e2bcac5d2a" />

## Why are these changes being made?

This is a requirement of the new RDP policy that will take effect in August 21, 2025. The policy states that if the organization field is filled, it will be considered the domain owner and will be public and treated as non-personal data.

See pet6gk-2kA-p2 for more context. 

## Testing Instructions

- Build this branch locally or open the live Calypso link
- Select a test domain in your account and go to the contact info editing page
- Ensure the organization explanation is shown below the organization input field
- Now search for a domain, add it to the cart and reach the checkout page
- Ensure the organization explanation is shown in that form too

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?