### PR TITLE
Help Center: Increase search field font size to prevent autozoom

### DIFF
--- a/packages/help-center/src/components/help-center-search.scss
+++ b/packages/help-center/src/components/help-center-search.scss
@@ -20,7 +20,7 @@
 			border: 1px;
 
 			input.search__input {
-				font-size: $font-body-small;
+				font-size: $font-body;
 				min-height: 40px;
 			}
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-14012/increase-help-center-search-field-font-size-to-prevent-safari-autozoom