### PR TITLE
Dashboard Overview: `<Stat>` description position depends on progress bar visibility

### DIFF
--- a/client/dashboard/components/stat/index.stories.tsx
+++ b/client/dashboard/components/stat/index.stories.tsx
@@ -10,13 +10,21 @@ const meta: Meta< typeof Stat > = {
 export default meta;
 type Story = StoryObj< typeof Stat >;
 
-export const Default: Story = {
+export const WithProgress: Story = {
+	args: {
+		density: 'low',
+		strapline: 'Storage',
+		metric: '1.3 GB',
+		description: '5 GB',
+		progressValue: ( 100 * 1.3 ) / 5,
+	},
+};
+
+export const NoProgress: Story = {
 	args: {
 		density: 'low',
 		strapline: 'Views',
 		metric: '1.3 M',
 		description: '33% left',
-		descriptionAlignment: 'start',
-		progressValue: 15,
 	},
 };

--- a/client/dashboard/components/stat/index.tsx
+++ b/client/dashboard/components/stat/index.tsx
@@ -2,24 +2,52 @@ import { __experimentalHStack as HStack, ProgressBar } from '@wordpress/componen
 import './style.scss';
 
 interface StatProps {
+	/**
+	 * Determines how much vertical space the stat should take up.
+	 */
 	density?: 'low' | 'high';
+
+	/**
+	 * When progressValue is undefined, this is a short description presented
+	 * beside the metric. Otherwise, it describes the maximum value of the metric.
+	 */
 	description?: string;
-	descriptionAlignment?: 'start' | 'end';
+
+	/**
+	 * The main value to display. Remember to include units.
+	 */
 	metric: string;
+
+	/**
+	 * The color of the progress bar. If none is provided the admin theme colour
+	 * will be used.
+	 */
 	progressColor?: 'alert-yellow' | 'alert-red' | 'alert-green';
+
+	/**
+	 * Accessible label for the progress bar.
+	 */
 	progressLabel?: string;
+
+	/**
+	 * The value of the progress bar as a percentage. If this is undefined, no
+	 * progress bar will be displayed.
+	 */
 	progressValue?: number;
+
+	/**
+	 * A short heading for the metric.
+	 */
 	strapline?: string;
 }
 
 export function Stat( {
 	density = 'low',
 	description,
-	descriptionAlignment = 'start',
 	metric,
 	progressColor,
-	progressLabel,
 	progressValue,
+	progressLabel = `${ progressValue }%`,
 	strapline,
 }: StatProps ) {
 	return (
@@ -28,7 +56,7 @@ export function Stat( {
 			<HStack
 				alignment="baseline"
 				spacing={ 2 }
-				justify={ descriptionAlignment === 'start' ? 'start' : 'space-between' }
+				justify={ progressValue === undefined ? 'start' : 'space-between' }
 			>
 				<div className="dashboard-stat__metric">{ metric }</div>
 				{ description && <div className="dashboard-stat__description">{ description }</div> }
@@ -37,7 +65,7 @@ export function Stat( {
 				<ProgressBar
 					className={ `dashboard-stat__progress-bar dashboard-stat__progress-bar--${ progressColor }` }
 					value={ progressValue }
-					aria-label={ progressLabel ?? `${ progressValue }%` }
+					aria-label={ progressLabel }
 				/>
 			) }
 		</div>

--- a/client/dashboard/sites/overview-plan-card/index.tsx
+++ b/client/dashboard/sites/overview-plan-card/index.tsx
@@ -64,7 +64,6 @@ export default function PlanCard( { site }: { site: Site } ) {
 						strapline={ __( 'Storage' ) }
 						metric={ filesize( mediaStorage?.storage_used_bytes ?? 0, { round: 0 } ) }
 						description={ filesize( mediaStorage?.max_storage_bytes ?? 0, { round: 0 } ) }
-						descriptionAlignment="end"
 						progressValue={ progressBarValue }
 						progressColor={ storageWarningColor }
 						progressLabel={ `${ storageUsagePercent }%` }
@@ -74,7 +73,6 @@ export default function PlanCard( { site }: { site: Site } ) {
 						strapline={ __( 'Bandwidth' ) }
 						metric="7.2 GB"
 						description="Unlimited"
-						descriptionAlignment="end"
 						progressValue={ 100 }
 						progressColor="alert-green"
 					/>


### PR DESCRIPTION
The description text is right aligned when there is a progress bar, otherwise it is left aligned.

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-114

## Proposed Changes

When a `<Stat>` has a progress bar, the `description` is right-aligned. When it has no progress bar, it is left-aligned.

<img width="2060" height="2522" alt="CleanShot 2025-07-28 at 10 52 11@2x" src="https://github.com/user-attachments/assets/15f73c24-c1bf-408d-923b-693f3d2b9ac7" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

As discussed here https://github.com/Automattic/wp-calypso/pull/104877#discussion_r2230938628

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Should be no change to the storage and bandwidth stats on the overview page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
