### PR TITLE
Stats: show more emails on summary page

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -488,6 +488,7 @@ export function emailStats( context, next ) {
 }
 
 export function emailSummary( context, next ) {
+	const MAX_ITEM_COUNT = 30; // The backend support only up to 30 items.
 	const givenSiteId = context.params.site;
 
 	const selectedSite = getSite( context.store.getState(), givenSiteId );
@@ -509,7 +510,11 @@ export function emailSummary( context, next ) {
 	const date = moment().locale( 'en' );
 
 	context.primary = (
-		<StatsEmailSummary period={ rangeOfPeriod( activeFilter.period, date ) } context={ context } />
+		<StatsEmailSummary
+			period={ rangeOfPeriod( activeFilter.period, date ) }
+			context={ context }
+			query={ { quantity: MAX_ITEM_COUNT } }
+		/>
 	);
 
 	next();


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Show more (30 is the max allowed from the backend) items

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Show more emails on the summary page as it used to do

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Jetpack Stats on a website that has more than 10 emails sent e.g. `http://calypso.localhost:3000/stats/subscribers/emails/en.blog.wordpress.com`
* Ensure Emails modules shows 10 emails
* Click `View all`
* Ensure it shows more than 10 items (max is 30) Emails

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
