### PR TITLE
Site overview v2: fix domains card list view

### DIFF
--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -21,7 +21,17 @@ const textOverflowStyles = {
 
 const IneligibleIndicator = () => <Text color="#CCCCCC">-</Text>;
 
-const DomainName = ( { domain, site, value }: { domain: Domain; site?: Site; value: string } ) => {
+const DomainName = ( {
+	domain,
+	site,
+	value,
+	showPrimaryDomainBadge,
+}: {
+	domain: Domain;
+	site?: Site;
+	value: string;
+	showPrimaryDomainBadge?: boolean;
+} ) => {
 	const siteSlug = site?.slug ?? domain.site_slug;
 	const domainManagementUrl = site
 		? `${ window.location.origin }/overview/site-domain/domain/${ domain.domain }/${ siteSlug }`
@@ -29,9 +39,9 @@ const DomainName = ( { domain, site, value }: { domain: Domain; site?: Site; val
 
 	return (
 		<Link to={ domainManagementUrl } disabled={ domain.type === DomainTypes.WPCOM }>
-			<HStack alignment="center" spacing={ 1 }>
+			<HStack spacing={ 1 }>
 				<span style={ textOverflowStyles }>{ value }</span>
-				{ domain.primary_domain && (
+				{ showPrimaryDomainBadge && domain.primary_domain && (
 					<span style={ { flexShrink: 0 } }>
 						<Badge>{ __( 'Primary' ) }</Badge>
 					</span>
@@ -103,19 +113,36 @@ const DomainExpiry = ( {
 	);
 };
 
-export const useFields = ( { site }: { site?: Site } = {} ) => {
+export const useFields = ( {
+	site,
+	showPrimaryDomainBadge = true,
+}: {
+	site?: Site;
+	showPrimaryDomainBadge?: boolean;
+} = {} ) => {
 	const fields: Field< Domain >[] = useMemo(
 		() => [
 			{
 				id: 'domain',
-				label: __( 'Domains' ),
+				label: __( 'Domain' ),
 				enableHiding: false,
 				enableSorting: true,
 				enableGlobalSearch: true,
 				getValue: ( { item }: { item: Domain } ) => item.domain,
 				render: ( { field, item } ) => (
-					<DomainName domain={ item } site={ site } value={ field.getValue( { item } ) } />
+					<DomainName
+						domain={ item }
+						site={ site }
+						value={ field.getValue( { item } ) }
+						showPrimaryDomainBadge={ showPrimaryDomainBadge }
+					/>
 				),
+			},
+			{
+				id: 'is_primary_domain',
+				getValue: ( { item }: { item: Domain } ) => item.primary_domain,
+				render: ( { field, item } ) =>
+					field.getValue( { item } ) ? <Text>{ __( 'Primary' ) }</Text> : null,
 			},
 			{
 				id: 'type',
@@ -169,7 +196,7 @@ export const useFields = ( { site }: { site?: Site } = {} ) => {
 				},
 			},
 		],
-		[ site ]
+		[ site, showPrimaryDomainBadge ]
 	);
 
 	return fields;

--- a/client/dashboard/sites/overview-domains-card/index.tsx
+++ b/client/dashboard/sites/overview-domains-card/index.tsx
@@ -32,7 +32,10 @@ const SiteDomainDataViews = ( {
 		site,
 		showPrimaryDomainBadge: type === 'table',
 	} );
-	const [ viewBeforeMergingType, setView ] = useState< DomainsView >( DEFAULT_VIEW );
+	const [ initialView, setView ] = useState< DomainsView >( {
+		...DEFAULT_VIEW,
+		type,
+	} );
 
 	const handleChangeView = ( nextView: View ) => {
 		if ( nextView.type === 'grid' ) {
@@ -43,11 +46,11 @@ const SiteDomainDataViews = ( {
 
 	const view = useMemo(
 		() => ( {
-			...viewBeforeMergingType,
+			...initialView,
 			type,
 			fields: [ ...( type === 'list' ? [ 'is_primary_domain' ] : [] ), 'expiry' ],
 		} ),
-		[ viewBeforeMergingType, type ]
+		[ initialView, type ]
 	);
 
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( domains, view, fields );

--- a/client/dashboard/sites/overview-domains-card/index.tsx
+++ b/client/dashboard/sites/overview-domains-card/index.tsx
@@ -1,9 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 import { Button, Card, CardHeader, CardBody } from '@wordpress/components';
-import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { DataViews, filterSortAndPaginate, View } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { useState, useEffect } from 'react';
+import { useState, useMemo } from 'react';
 import { siteDomainsQuery } from '../../app/queries/site-domains';
 import { siteCurrentPlanQuery } from '../../app/queries/site-plans';
 import { SectionHeader } from '../../components/section-header';
@@ -32,22 +32,25 @@ const SiteDomainDataViews = ( {
 		site,
 		showPrimaryDomainBadge: type === 'table',
 	} );
-	const [ view, setView ] = useState< DomainsView >( {
-		...DEFAULT_VIEW,
-		type,
-	} );
+	const [ viewBeforeMergingType, setView ] = useState< DomainsView >( DEFAULT_VIEW );
+
+	const handleChangeView = ( nextView: View ) => {
+		if ( nextView.type === 'grid' ) {
+			return;
+		}
+		setView( nextView );
+	};
+
+	const view = useMemo(
+		() => ( {
+			...viewBeforeMergingType,
+			type,
+			fields: [ ...( type === 'list' ? [ 'is_primary_domain' ] : [] ), 'expiry' ],
+		} ),
+		[ viewBeforeMergingType, type ]
+	);
 
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( domains, view, fields );
-
-	useEffect( () => {
-		if ( type ) {
-			setView( ( currentView ) => ( {
-				...currentView,
-				type,
-				fields: [ ...( type === 'list' ? [ 'is_primary_domain' ] : [] ), 'expiry' ],
-			} ) );
-		}
-	}, [ type ] );
 
 	return (
 		<Card>
@@ -88,7 +91,7 @@ const SiteDomainDataViews = ( {
 				<DataViews< SiteDomain >
 					data={ filteredData || [] }
 					fields={ fields }
-					onChangeView={ ( nextView ) => setView( () => nextView as DomainsView ) }
+					onChangeView={ handleChangeView }
 					view={ view }
 					actions={ actions }
 					paginationInfo={ paginationInfo }

--- a/client/dashboard/sites/overview-domains-card/index.tsx
+++ b/client/dashboard/sites/overview-domains-card/index.tsx
@@ -28,10 +28,12 @@ const SiteDomainDataViews = ( {
 	domains: SiteDomain[];
 	type?: DomainsView[ 'type' ];
 } ) => {
-	const fields = useFields( { site } );
+	const fields = useFields( {
+		site,
+		showPrimaryDomainBadge: type === 'table',
+	} );
 	const [ view, setView ] = useState< DomainsView >( {
 		...DEFAULT_VIEW,
-		fields: [ 'expiry' ],
 		type,
 	} );
 
@@ -39,7 +41,11 @@ const SiteDomainDataViews = ( {
 
 	useEffect( () => {
 		if ( type ) {
-			setView( ( currentView ) => ( { ...currentView, type } ) );
+			setView( ( currentView ) => ( {
+				...currentView,
+				type,
+				fields: [ ...( type === 'list' ? [ 'is_primary_domain' ] : [] ), 'expiry' ],
+			} ) );
 		}
 	}, [ type ] );
 
@@ -85,10 +91,8 @@ const SiteDomainDataViews = ( {
 					onChangeView={ ( nextView ) => setView( () => nextView as DomainsView ) }
 					view={ view }
 					actions={ actions }
-					search={ false }
 					paginationInfo={ paginationInfo }
 					getItemId={ getDomainId }
-					isLoading={ false }
 					defaultLayouts={ DEFAULT_LAYOUTS }
 				>
 					<>


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/104804

## Proposed Changes

This PR fixes the `list` view layout on Domains card as per Figma.

|Before|After|
|-|-|
|<img width="528" height="247" alt="image" src="https://github.com/user-attachments/assets/f641e4ee-703c-47b7-8a1b-5d37d8a12085" />|<img width="533" height="248" alt="image" src="https://github.com/user-attachments/assets/50d2dc26-0ef7-4943-b5a3-0b4a971564ea" />|


## Out of Scope

- The `Primary` green text color. The badge itself is still gray due to the component limitation. We can fix it along with the badge color.

## Testing Instructions

1. Go to /v2/sites on a site with custom primary domain
2. Verify the card displays in table view.
3. Resize your browser to the mobile viewport.
4. Verify the card displays in list view as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
