### PR TITLE
Add bandwidth calcualtion to plan card

### DIFF
--- a/client/dashboard/app/queries/site-metrics.ts
+++ b/client/dashboard/app/queries/site-metrics.ts
@@ -1,0 +1,11 @@
+import { queryOptions } from '@tanstack/react-query';
+import {
+	fetchSiteHostingMetrics,
+	type SiteHostingMetricsParams,
+} from '../../data/site-hosting-metrics';
+
+export const siteMetricsQuery = ( siteId: number, params: SiteHostingMetricsParams ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'metrics', params ],
+		queryFn: () => fetchSiteHostingMetrics( siteId, params ),
+	} );

--- a/client/dashboard/data/site-hosting-metrics.ts
+++ b/client/dashboard/data/site-hosting-metrics.ts
@@ -1,0 +1,61 @@
+import wpcom from 'calypso/lib/wp';
+
+export interface SiteHostingMetrics {
+	message?: string;
+	data: {
+		_meta?: SiteHostingMetricsMetaData;
+		periods: SiteHostingMetricsPeriodData[];
+	};
+}
+
+export interface SiteHostingMetricsPeriodData {
+	timestamp: number;
+	dimension: { [ key: string ]: number };
+}
+
+export interface SiteHostingMetricsMetaData {
+	start: number;
+	end: number;
+	resolution: number;
+	metric: string;
+	dimension: string;
+	took: number;
+}
+
+export type SiteHostingMetricsDimension =
+	| 'http_version'
+	| 'http_verb'
+	| 'http_host'
+	| 'http_status'
+	| 'page_renderer'
+	| 'page_is_cached'
+	| 'wp_admin_ajax_action'
+	| 'visitor_asn'
+	| 'visitor_country_code'
+	| 'visitor_is_crawler';
+
+export type SiteHostingMetricType =
+	| 'requests_persec'
+	| 'response_bytes_persec'
+	| 'response_bytes_average'
+	| 'response_time_average';
+
+export interface SiteHostingMetricsParams {
+	start: number;
+	end: number;
+	metric?: SiteHostingMetricType;
+	dimension?: SiteHostingMetricsDimension;
+}
+
+export async function fetchSiteHostingMetrics(
+	siteId: number,
+	params: SiteHostingMetricsParams
+): Promise< SiteHostingMetrics > {
+	return wpcom.req.get(
+		{
+			path: `/sites/${ siteId }/hosting/metrics`,
+			apiNamespace: 'wpcom/v2',
+		},
+		params
+	);
+}

--- a/client/dashboard/sites/overview-plan-card/index.tsx
+++ b/client/dashboard/sites/overview-plan-card/index.tsx
@@ -115,9 +115,11 @@ export default function PlanCard( { site }: { site: Site } ) {
 						density="high"
 						strapline={ __( 'Bandwidth' ) }
 						metric={
-							bandwidth && site.is_wpcom_atomic ? filesize( bandwidth, { round: 1 } ) : 'Unlimited'
+							bandwidth && site.is_wpcom_atomic
+								? filesize( bandwidth, { round: 1 } )
+								: __( 'Unlimited' )
 						}
-						description={ site.is_wpcom_atomic ? 'Unlimited' : undefined }
+						description={ site.is_wpcom_atomic ? __( 'Unlimited' ) : undefined }
 						progressValue={ 100 }
 						progressColor="alert-green"
 					/>

--- a/client/dashboard/sites/overview-plan-card/index.tsx
+++ b/client/dashboard/sites/overview-plan-card/index.tsx
@@ -5,15 +5,33 @@ import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 import filesize from 'filesize';
 import { siteMediaStorageQuery } from '../../app/queries/site-media-storage';
+import { siteMetricsQuery } from '../../app/queries/site-metrics';
 import { siteCurrentPlanQuery } from '../../app/queries/site-plans';
 import { sitePurchaseQuery } from '../../app/queries/site-purchases';
 import { Stat } from '../../components/stat';
 import { DotcomPlans } from '../../data/constants';
+import { getSiteDisplayUrl } from '../../utils/site-url';
 import OverviewCard from '../overview-card';
 import type { Site, Plan, Purchase } from '../../data/types';
 
 const MINIMUM_DISPLAYED_USAGE = 2.5;
 const ALERT_PERCENT = 80;
+
+function getCurrentMonthRangeTimestamps() {
+	const now = new Date();
+	const firstDayOfMonth = new Date( now.getFullYear(), now.getMonth(), 1 );
+	const startInSeconds = Math.floor( firstDayOfMonth.getTime() / 1000 );
+
+	const today = new Date();
+	today.setMinutes( 59 );
+	today.setSeconds( 59 );
+	const endInSeconds = Math.floor( today.getTime() / 1000 );
+
+	return {
+		startInSeconds,
+		endInSeconds,
+	};
+}
 
 export default function PlanCard( { site }: { site: Site } ) {
 	const { data: plan, isLoading: isLoadingPlan } = useQuery( siteCurrentPlanQuery( site.ID ) );
@@ -24,6 +42,29 @@ export default function PlanCard( { site }: { site: Site } ) {
 	const { data: mediaStorage, isLoading: isLoadingMediaStorage } = useQuery(
 		siteMediaStorageQuery( site.ID )
 	);
+	const { startInSeconds, endInSeconds } = getCurrentMonthRangeTimestamps();
+	const { data: bandwidth, isLoading: isLoadingBandwidth } = useQuery( {
+		...siteMetricsQuery( site.ID, {
+			start: startInSeconds,
+			end: endInSeconds,
+			metric: 'response_bytes_persec',
+		} ),
+		enabled: !! site.is_wpcom_atomic,
+		select: ( data ) => {
+			if ( ! data ) {
+				return data;
+			}
+			const domain = getSiteDisplayUrl( site );
+			return data.data.periods.reduce(
+				( acc, curr ) => acc + ( curr.dimension[ domain ] || 0 ),
+				0
+			);
+		},
+
+		// Don't update until page is refreshed
+		meta: { persist: false },
+		staleTime: Infinity,
+	} );
 
 	const storageUsagePercent = ! mediaStorage
 		? 0
@@ -55,7 +96,9 @@ export default function PlanCard( { site }: { site: Site } ) {
 			heading={ site.plan?.product_name_short }
 			description={ getCardDescription( plan, purchase ) }
 			tracksId="plan"
-			isLoading={ isLoadingPlan || isLoadingPurchase || isLoadingMediaStorage }
+			isLoading={
+				isLoadingPlan || isLoadingPurchase || isLoadingMediaStorage || isLoadingBandwidth
+			}
 			link={ site.plan?.is_free ? undefined : '/v2/me/billing/active-subscriptions' }
 			bottom={
 				<VStack spacing={ 4 }>
@@ -71,8 +114,10 @@ export default function PlanCard( { site }: { site: Site } ) {
 					<Stat
 						density="high"
 						strapline={ __( 'Bandwidth' ) }
-						metric="7.2 GB"
-						description="Unlimited"
+						metric={
+							bandwidth && site.is_wpcom_atomic ? filesize( bandwidth, { round: 1 } ) : 'Unlimited'
+						}
+						description={ site.is_wpcom_atomic ? 'Unlimited' : undefined }
 						progressValue={ 100 }
 						progressColor="alert-green"
 					/>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-114

## Proposed Changes

- Fetches bandwidth stats from `/site/:id/hosting/metrics`
- Display in plans card
- Simple sites (which do not support hosting metrics) display "Unlimited")

The "bandwidth" stat is actually the total number of response bytes that have been served by the site over the last calendar month. This reproduces the same behaviour that's in the v1 dashboard.

**An atomic site**

<img width="1484" height="944" alt="CleanShot 2025-07-28 at 17 00 12@2x" src="https://github.com/user-attachments/assets/4f77370b-ac52-4417-9120-d77c8ffab3ca" />

**A simple site**

<img width="1458" height="850" alt="CleanShot 2025-07-28 at 17 00 43@2x" src="https://github.com/user-attachments/assets/ceba06fa-a7f1-48c0-837c-d5fcc40413b8" />


Note: This PR does not implement
- Nice loading
- Self-hosted Jetpack (it should show the JP-specific overview page right?)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test a simple and atomic site. Confirm the bandwidth numbers match what is in the v1 dashboard.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
