### PR TITLE
Help Center: persist the help center minmized state

### DIFF
--- a/apps/help-center/help-center-gutenberg.js
+++ b/apps/help-center/help-center-gutenberg.js
@@ -41,7 +41,10 @@ function HelpCenterContent() {
 		return () => clearTimeout( timeout );
 	}, [] );
 
-	const closeCallback = useCallback( () => setShowHelpCenter( false ), [ setShowHelpCenter ] );
+	const closeCallback = useCallback(
+		() => setShowHelpCenter( false, undefined, undefined, true ),
+		[ setShowHelpCenter ]
+	);
 
 	const sidebarActionsContainer = document.querySelector( '.edit-site-site-hub__actions' );
 

--- a/apps/help-center/help-center-wp-admin.js
+++ b/apps/help-center/help-center-wp-admin.js
@@ -61,7 +61,10 @@ function AdminHelpCenterContent() {
 		}
 	}, [ unreadCount, button ] );
 
-	const closeCallback = useCallback( () => setShowHelpCenter( false ), [ setShowHelpCenter ] );
+	const closeCallback = useCallback(
+		() => setShowHelpCenter( false, undefined, undefined, true ),
+		[ setShowHelpCenter ]
+	);
 
 	const handleToggleHelpCenter = () => {
 		recordTracksEvent( `calypso_inlinehelp_${ show ? 'close' : 'show' }`, {

--- a/client/components/help-center/help-center-app.tsx
+++ b/client/components/help-center/help-center-app.tsx
@@ -20,7 +20,7 @@ const HelpCenterApp = ( props: HelpCenterAppProps ) => {
 	const { setShowHelpCenter } = useDispatch( HELP_CENTER_STORE );
 
 	const handleClose = useCallback( () => {
-		setShowHelpCenter( false );
+		setShowHelpCenter( false, undefined, undefined, true );
 	}, [ setShowHelpCenter ] );
 
 	return (

--- a/client/layout/help-center-loader.tsx
+++ b/client/layout/help-center-loader.tsx
@@ -25,7 +25,7 @@ export default function HelpCenterLoader( { sectionName, loadHelpCenter, current
 	const { setShowHelpCenter } = useDispatch( HELP_CENTER_STORE );
 	const isDesktop = useBreakpoint( '>782px' );
 	const handleClose = useCallback( () => {
-		setShowHelpCenter( false );
+		setShowHelpCenter( false, undefined, undefined, true );
 	}, [ setShowHelpCenter ] );
 
 	const locale = useLocale();

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -158,11 +158,18 @@ export const setHelpCenterOptions = ( options: HelpCenterOptions ) => ( {
 export const setShowHelpCenter = function* (
 	show: boolean,
 	allowPremiumSupport = false,
-	options: HelpCenterShowOptions = { hideBackButton: false, contextTerm: '' }
+	options: HelpCenterShowOptions = { hideBackButton: false, contextTerm: '' },
+	/**
+	 * When the Help Center is minimized and someone clicks the (?) toggle button, we should maximize it.
+	 * But this means ignoring the `show=false` value the button will send. The problem is we'll also ignore the `show=false` when the close (x) buttons is clicked too.
+	 * `forceClose` listens to the show value always. Which the (x) button sets to true.
+	 */
+	forceClose = false
 ): Generator< unknown, { type: 'HELP_CENTER_SET_SHOW'; show: boolean }, unknown > {
 	let isMinimized = ( select( STORE_KEY ) as HelpCenterSelect ).getIsMinimized();
 
-	if ( ! show && isMinimized ) {
+	// Opening or closing the Help Center should reset the minimized state.
+	if ( ! show && ! forceClose && isMinimized ) {
 		yield setIsMinimized( false );
 		isMinimized = false;
 
@@ -178,7 +185,7 @@ export const setShowHelpCenter = function* (
 
 	if ( ! show ) {
 		yield setNavigateToRoute( undefined );
-		// Reset the local navigation history when closing the help center
+		// Reset the local navigation history when closing the help center.
 		yield setHelpCenterRouterHistory( undefined );
 	} else {
 		yield setShowMessagingWidget( false );

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -277,7 +277,6 @@ export type HelpCenterAction =
 			| typeof setUserDeclaredSite
 			| typeof setUserDeclaredSiteUrl
 			| typeof setUnreadCount
-			| typeof setIsMinimized
 			| typeof setHelpCenterRouterHistory
 			| typeof setIsChatLoaded
 			| typeof setAreSoundNotificationsEnabled
@@ -289,4 +288,5 @@ export type HelpCenterAction =
 			| typeof setAllowPremiumSupport
 			| typeof setHelpCenterOptions
 	  >
-	| GeneratorReturnType< typeof setShowHelpCenter >;
+	| GeneratorReturnType< typeof setShowHelpCenter >
+	| GeneratorReturnType< typeof setIsMinimized >;

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -15,6 +15,45 @@ import type {
 import type { SupportInteraction } from '@automattic/odie-client/src/types';
 import type { Location } from 'history';
 
+/**
+ * Save the open state of the help center to the remote user preferences.
+ * @param isShown - Whether the help center is shown.
+ * @param isMinimized - Whether the help center is minimized.
+ */
+export const saveOpenState = ( isShown: boolean | undefined, isMinimized: boolean | undefined ) => {
+	const saveState: Record< string, boolean | null > = {};
+
+	if ( typeof isShown === 'boolean' ) {
+		saveState.help_center_open = isShown;
+		if ( ! isShown ) {
+			// Delete the remote version of the navigation history when closing the help center
+			saveState.help_center_router_history = null;
+		}
+	}
+
+	if ( typeof isMinimized === 'boolean' ) {
+		saveState.help_center_minimized = isMinimized;
+	}
+
+	if ( canAccessWpcomApis() ) {
+		// Use the promise version to do that action without waiting for the result.
+		wpcomRequestPromise( {
+			path: '/me/preferences',
+			apiNamespace: 'wpcom/v2',
+			method: 'PUT',
+			body: { calypso_preferences: saveState },
+		} ).catch( () => {} );
+	} else {
+		// Use the promise version to do that action without waiting for the result.
+		apiFetchPromise( {
+			global: true,
+			path: '/help-center/open-state',
+			method: 'PUT',
+			data: saveState,
+		} as APIFetchOptions ).catch( () => {} );
+	}
+};
+
 export function setCurrentSupportInteraction( supportInteraction: SupportInteraction ) {
 	return {
 		type: 'HELP_CENTER_SET_CURRENT_SUPPORT_INTERACTION',
@@ -55,11 +94,13 @@ export const setOdieBotNameSlug = ( odieBotNameSlug: string ) =>
 		odieBotNameSlug,
 	} ) as const;
 
-export const setIsMinimized = ( minimized: boolean ) =>
-	( {
+export const setIsMinimized = function* ( minimized: boolean ) {
+	yield saveOpenState( undefined, minimized );
+	return {
 		type: 'HELP_CENTER_SET_MINIMIZED',
 		minimized,
-	} ) as const;
+	} as const;
+};
 
 export const setIsChatLoaded = ( isChatLoaded: boolean ) =>
 	( {
@@ -119,10 +160,11 @@ export const setShowHelpCenter = function* (
 	allowPremiumSupport = false,
 	options: HelpCenterShowOptions = { hideBackButton: false, contextTerm: '' }
 ): Generator< unknown, { type: 'HELP_CENTER_SET_SHOW'; show: boolean }, unknown > {
-	const isMinimized = ( select( STORE_KEY ) as HelpCenterSelect ).getIsMinimized();
+	let isMinimized = ( select( STORE_KEY ) as HelpCenterSelect ).getIsMinimized();
 
 	if ( ! show && isMinimized ) {
 		yield setIsMinimized( false );
+		isMinimized = false;
 
 		return {
 			type: 'HELP_CENTER_SET_SHOW',
@@ -131,32 +173,7 @@ export const setShowHelpCenter = function* (
 	}
 
 	if ( ! isE2ETest() ) {
-		if ( canAccessWpcomApis() ) {
-			// Use the promise version to do that action without waiting for the result.
-			wpcomRequestPromise( {
-				path: '/me/preferences',
-				apiNamespace: 'wpcom/v2',
-				method: 'PUT',
-				body: {
-					calypso_preferences: {
-						help_center_open: show,
-						// Delete the remote version of the navigation history when closing the help center
-						...( ! show ? { help_center_router_history: null } : {} ),
-					},
-				},
-			} ).catch( () => {} );
-		} else {
-			// Use the promise version to do that action without waiting for the result.
-			apiFetchPromise( {
-				global: true,
-				path: '/help-center/open-state',
-				method: 'PUT',
-				data: {
-					help_center_open: show, // Delete the remote version of the navigation history when closing the help center
-					...( ! show ? { help_center_router_history: null } : {} ),
-				},
-			} as APIFetchOptions ).catch( () => {} );
-		}
+		saveOpenState( show, isMinimized );
 	}
 
 	if ( ! show ) {

--- a/packages/data-stores/src/help-center/resolvers.ts
+++ b/packages/data-stores/src/help-center/resolvers.ts
@@ -1,7 +1,7 @@
 import { apiFetch } from '@wordpress/data-controls';
 import { canAccessWpcomApis } from 'wpcom-proxy-request';
 import { wpcomRequest } from '../wpcom-request-controls';
-import { setHelpCenterRouterHistory } from './actions';
+import { setHelpCenterRouterHistory, setIsMinimized } from './actions';
 import type { APIFetchOptions } from './types';
 import type { Location } from 'history';
 
@@ -9,6 +9,7 @@ export function* isHelpCenterShown() {
 	try {
 		const preferences: {
 			help_center_open: boolean;
+			help_center_minimized: boolean;
 			help_center_router_history: {
 				entries: Location[];
 				index: number;
@@ -26,6 +27,8 @@ export function* isHelpCenterShown() {
 		if ( preferences.help_center_router_history ) {
 			yield setHelpCenterRouterHistory( preferences.help_center_router_history );
 		}
+
+		yield setIsMinimized( preferences.help_center_minimized );
 
 		// We only want to auto-open, we don't want to auto-close (and potentially overrule the user's action).
 		if ( preferences.help_center_open ) {


### PR DESCRIPTION
Fixes: https://linear.app/a8c/issue/DOTCOM-14019/help-center-persist-the-minimized-state-along-the-open-state
Fixes: https://linear.app/a8c/issue/DOTCOM-14023/closing-the-help-center-when-its-minimized-maximizes-it

## Proposed Changes

Persist the Help Center minimized state along the open state.

## Why are these changes being made?
Because the open state is persisted and the minimized state is not, if you minimize the Help Center and refresh the page, it pops back maximized. 

## Testing Instructions

1. Open the Help Center.
2. Minimize it.
3. Refresh the page.
4. The Help Center should remain as is, open but minimized.

### Maximization issue

Currently in production, if you close the Help Center using the X button when it's minimized, it will be maximized.

1. Open the HC.
2. Minimize it.
3. Close it by clicking the X. 
4. It should close.
5. Open it.
6. Minimize it.
7. Click the (?).
8. It should maximize.

### Regression
1. Open the Help Center
9. Refresh while it's maximized.
10. Should remain maximized.

---

1. Close it.
2. Refresh.
3. Should remain closed.
