### PR TITLE
Domain Search Retrofit: Enable it in production

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -8,6 +8,7 @@ import { useState, useEffect } from 'react';
 import { isSimplifiedOnboarding } from 'calypso/landing/stepper/hooks/use-simplified-onboarding';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { addSurvicate } from 'calypso/lib/analytics/survicate';
+import { useIsDomainSearchV2Enabled } from 'calypso/lib/domains/use-domain-search-v2';
 import { pathToUrl } from 'calypso/lib/url';
 import {
 	persistSignupDestination,
@@ -28,7 +29,12 @@ import { recordStepNavigation } from '../../internals/analytics/record-step-navi
 import { usePurchasePlanNotification } from '../../internals/hooks/use-purchase-plan-notification';
 import { STEPS } from '../../internals/steps';
 import { ProcessingResult } from '../../internals/steps-repository/processing-step/constants';
-import type { FlowV2, ProvidedDependencies, SubmitHandler } from '../../internals/types';
+import {
+	AssertConditionState,
+	type FlowV2,
+	type ProvidedDependencies,
+	type SubmitHandler,
+} from '../../internals/types';
 
 const clearUseMyDomainsQueryParams = ( currentStepSlug: string | undefined ) => {
 	const isDomainsStep = currentStepSlug === 'domains';
@@ -289,6 +295,13 @@ const onboarding: FlowV2< typeof initialize > = {
 		};
 
 		return { submit };
+	},
+	useAssertConditions() {
+		const [ isLoading ] = useIsDomainSearchV2Enabled( this.name );
+
+		return {
+			state: isLoading ? AssertConditionState.CHECKING : AssertConditionState.SUCCESS,
+		};
 	},
 	useSideEffect( currentStepSlug ) {
 		const reduxDispatch = useReduxDispatch();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -21,7 +21,7 @@ import SideExplainer from 'calypso/components/domains/side-explainer';
 import UseMyDomain from 'calypso/components/domains/use-my-domain';
 import { getDomainSuggestionSearch, getFixedDomainSearch } from 'calypso/lib/domains';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
-import { useDomainSearchV2 } from 'calypso/lib/domains/use-domain-search-v2';
+import { useIsDomainSearchV2Enabled } from 'calypso/lib/domains/use-domain-search-v2';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import {
 	retrieveSignupDestination,
@@ -62,7 +62,7 @@ export function DomainFormControl( {
 	isCartPendingUpdate,
 	isCartPendingUpdateDomain,
 }: DomainFormControlProps ) {
-	const [ , isDomainSearchV2Enabled ] = useDomainSearchV2( flow ?? '' );
+	const [ , isDomainSearchV2Enabled ] = useIsDomainSearchV2Enabled( flow ?? '' );
 
 	const selectedSite = useSelector( getSelectedSite );
 	const productsList = useSelector( getAvailableProductsList );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -21,7 +21,7 @@ import {
 	domainMapping,
 	domainTransfer,
 } from 'calypso/lib/cart-values/cart-items';
-import { useDomainSearchV2 } from 'calypso/lib/domains/use-domain-search-v2';
+import { useIsDomainSearchV2Enabled } from 'calypso/lib/domains/use-domain-search-v2';
 import { useDispatch as useReduxDispatch } from 'calypso/state';
 import {
 	composeAnalytics,
@@ -54,7 +54,7 @@ const DomainsStep: Step< {
 		  }
 		| undefined;
 } > = function DomainsStep( { navigation, flow } ) {
-	const [ , shouldUseDomainSearchV2 ] = useDomainSearchV2( flow );
+	const [ , shouldUseDomainSearchV2 ] = useIsDomainSearchV2Enabled( flow );
 	const { setHideFreePlan, setDomainCartItem, setDomain } = useDispatch( ONBOARD_STORE );
 	const { __ } = useI18n();
 
@@ -367,7 +367,7 @@ const DomainsStep: Step< {
 };
 
 const StyleWrappedDomainsStep: typeof DomainsStep = ( props ) => {
-	const [ isLoading, shouldUseDomainSearchV2 ] = useDomainSearchV2( props.flow );
+	const [ isLoading, shouldUseDomainSearchV2 ] = useIsDomainSearchV2Enabled( props.flow );
 
 	if ( isLoading ) {
 		// TODO: Add a loading state to indicate that the experiment is loading.

--- a/client/lib/domains/use-domain-search-v2.ts
+++ b/client/lib/domains/use-domain-search-v2.ts
@@ -10,7 +10,7 @@ const EXPERIMENT_NAME = 'domains-ui-redesign';
  * This hook is used to determine if the domain search redesign is enabled for a given flow.
  * It should NOT be used within components, only at top level pages.
  */
-export const useDomainSearchV2 = ( flowName: string ) => {
+export const useIsDomainSearchV2Enabled = ( flowName: string ) => {
 	const [ isLoading, experimentAssignment ] = useExperiment( EXPERIMENT_NAME, {
 		isEligible: flowName === ONBOARDING_FLOW,
 	} );

--- a/client/lib/domains/use-domain-search-v2.ts
+++ b/client/lib/domains/use-domain-search-v2.ts
@@ -1,27 +1,31 @@
 import config from '@automattic/calypso-config';
-import { useEffect, useState } from 'react';
+import { ONBOARDING_FLOW } from '@automattic/onboarding';
+import { useExperiment } from 'calypso/lib/explat';
+
+const isDomainSearchV2Enabled = config.isEnabled( 'domains/ui-redesign' );
+
+const EXPERIMENT_NAME = 'domains-ui-redesign';
 
 /**
  * This hook is used to determine if the domain search redesign is enabled for a given flow.
  * It should NOT be used within components, only at top level pages.
  */
 export const useDomainSearchV2 = ( flowName: string ) => {
-	const isDomainSearchV2Enabled = config.isEnabled( 'domains/ui-redesign' );
-	const [ isLoading, setIsLoading ] = useState( true );
+	const [ isLoading, experimentAssignment ] = useExperiment( EXPERIMENT_NAME, {
+		isEligible: flowName === ONBOARDING_FLOW,
+	} );
 
-	/**
-	 * Introduce an artificial delay to simulate the loading state of the experiment.
-	 */
-	useEffect( () => {
-		const interval = setInterval( () => {
-			setIsLoading( false );
-		}, 750 );
+	if ( flowName === ONBOARDING_FLOW ) {
+		/**
+		 * If the user is not eligible, we'll treat them as if they were in the
+		 * holdout/control group so we can provide the existing experience.
+		 *
+		 * This fallback is necessary because experimentAssignment returns null when the user
+		 * is not eligible, and we're using this hook within steps that are used by other flows.
+		 */
+		const variationName = experimentAssignment?.variationName ?? 'control';
 
-		return () => clearInterval( interval );
-	}, [] );
-
-	if ( flowName === 'onboarding' && isDomainSearchV2Enabled ) {
-		return [ isLoading, isDomainSearchV2Enabled ];
+		return [ isLoading, variationName === 'treatment' ];
 	}
 
 	return [ false, isDomainSearchV2Enabled ];

--- a/client/lib/domains/use-domain-search-v2.ts
+++ b/client/lib/domains/use-domain-search-v2.ts
@@ -4,7 +4,7 @@ import { useExperiment } from 'calypso/lib/explat';
 
 const isDomainSearchV2Enabled = config.isEnabled( 'domains/ui-redesign' );
 
-const EXPERIMENT_NAME = 'domains-ui-redesign';
+const EXPERIMENT_NAME = 'calypso_signup_onboarding_domain_search_redesign_202507';
 
 /**
  * This hook is used to determine if the domain search redesign is enabled for a given flow.

--- a/client/lib/domains/use-domain-search-v2.ts
+++ b/client/lib/domains/use-domain-search-v2.ts
@@ -4,7 +4,7 @@ import { useExperiment } from 'calypso/lib/explat';
 
 const isDomainSearchV2Enabled = config.isEnabled( 'domains/ui-redesign' );
 
-const EXPERIMENT_NAME = 'calypso_signup_onboarding_domain_search_redesign_202507';
+const EXPERIMENT_NAME = 'calypso_signup_onboarding_domain_search_redesign_202508';
 
 /**
  * This hook is used to determine if the domain search redesign is enabled for a given flow.

--- a/client/my-sites/domains/domain-search/index.tsx
+++ b/client/my-sites/domains/domain-search/index.tsx
@@ -22,7 +22,7 @@ import {
 	domainRegistration,
 	ObjectWithProducts,
 } from 'calypso/lib/cart-values/cart-items';
-import { useDomainSearchV2 } from 'calypso/lib/domains/use-domain-search-v2';
+import { useIsDomainSearchV2Enabled } from 'calypso/lib/domains/use-domain-search-v2';
 import { isExternal } from 'calypso/lib/url';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import DomainAndPlanPackageNavigation from 'calypso/my-sites/domains/components/domain-and-plan-package/navigation';
@@ -496,7 +496,7 @@ class DomainSearch extends Component< DomainSearchProps > {
 }
 
 const StyleWrappedDomainSearch = ( props: DomainSearchProps ) => {
-	const [ isLoading, shouldUseDomainSearchV2 ] = useDomainSearchV2( 'domains/add' );
+	const [ isLoading, shouldUseDomainSearchV2 ] = useIsDomainSearchV2Enabled( 'domains/add' );
 
 	if ( isLoading ) {
 		return null;

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -61,7 +61,7 @@ import {
 	getFixedDomainSearch,
 } from 'calypso/lib/domains';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
-import { useDomainSearchV2 } from 'calypso/lib/domains/use-domain-search-v2';
+import { useIsDomainSearchV2Enabled } from 'calypso/lib/domains/use-domain-search-v2';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
@@ -1785,7 +1785,7 @@ class RenderDomainsStepComponent extends Component {
 }
 
 const StyleWrappedDomainsStepComponent = ( props ) => {
-	const [ isLoading, shouldUseDomainSearchV2 ] = useDomainSearchV2( props.flowName );
+	const [ isLoading, shouldUseDomainSearchV2 ] = useIsDomainSearchV2Enabled( props.flowName );
 
 	if ( isLoading ) {
 		if ( shouldUseStepContainerV2( props.flowName ) ) {

--- a/config/development.json
+++ b/config/development.json
@@ -64,7 +64,7 @@
 		"dev/store-sandbox-helper": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
-		"domains/ui-redesign": false,
+		"domains/ui-redesign": true,
 		"email-accounts/enabled": true,
 		"global-styles/on-personal-plan": false,
 		"google-drive": true,

--- a/config/production.json
+++ b/config/production.json
@@ -42,7 +42,7 @@
 		"dashboard/v2/backport/site-settings": true,
 		"dashboard/v2/backport/sites-list": true,
 		"dashboard/v2/security-settings": false,
-		"domains/ui-redesign": false,
+		"domains/ui-redesign": true,
 		"global-styles/on-personal-plan": false,
 		"google-my-business": true,
 		"help": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -42,6 +42,7 @@
 		"dashboard/v2/security-settings": false,
 		"dev/preferences-helper": true,
 		"dev/store-sandbox-helper": true,
+		"domains/ui-redesign": true,
 		"global-styles/on-personal-plan": false,
 		"google-my-business": true,
 		"help": true,

--- a/config/test.json
+++ b/config/test.json
@@ -38,6 +38,7 @@
 		"current-site/notice": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
+		"domains/ui-redesign": true,
 		"global-styles/on-personal-plan": false,
 		"google-my-business": false,
 		"help": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -46,7 +46,7 @@
 		"dev/store-sandbox-helper": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
-		"domains/ui-redesign": true,
+		"domains/ui-redesign": false,
 		"email-accounts/enabled": true,
 		"cookie-banner": true,
 		"google-my-business": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -46,7 +46,7 @@
 		"dev/store-sandbox-helper": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
-		"domains/ui-redesign": false,
+		"domains/ui-redesign": true,
 		"email-accounts/enabled": true,
 		"cookie-banner": true,
 		"google-my-business": true,


### PR DESCRIPTION
Closes DOMAINS-1416.
Explat experiment: 22299-explat-experiment

## Proposed Changes

Enables the retrofitted version in `/setup/onboarding` behind an experiment, and make it the default experience in all other flows.

## Testing Instructions

Verify the experience is the default in `/start/domain`, `/setup/newsletter` and behind the experiment in `/setup/onboarding`.