### PR TITLE
Connect Refresh (Signup): Backbone for unification and Woo migration

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1063,9 +1063,12 @@ class SignupForm extends Component {
 			);
 		}
 
+		const isUnifiedCreateAccount = this.props.isWoo;
 		const isGravatar = this.props.isGravatar;
 		const emailErrorMessage = this.getErrorMessagesWithLogin( 'email' );
-		const showSeparator = ! config.isEnabled( 'desktop' ) && this.isHorizontal();
+		const showSeparator =
+			isUnifiedCreateAccount ||
+			( 'wpcc' !== this.props.flowName && ! config.isEnabled( 'desktop' ) && this.isHorizontal() );
 
 		if (
 			( this.props.isPasswordless && ( 'wpcc' !== this.props.flowName || this.props.isWoo ) ) ||

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { FormInputValidation, FormLabel } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { Spinner, TextControl } from '@wordpress/components';
+import { Spinner } from '@wordpress/components';
 import clsx from 'clsx';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
@@ -776,84 +776,6 @@ class SignupForm extends Component {
 		} );
 	};
 
-	renderWooCommerce() {
-		return (
-			<div className="signup-form__woocommerce-inputs-wrapper">
-				<TextControl
-					label={ this.props.translate( 'Your email address' ) }
-					disabled={
-						this.state.submitting || !! this.props.disabled || !! this.props.disableEmailInput
-					}
-					id="email"
-					name="email"
-					type="email"
-					value={ formState.getFieldValue( this.state.form, 'email' ) }
-					onBlur={ this.handleBlur }
-					onChange={ ( value ) => {
-						this.formStateController.handleFieldChange( {
-							name: 'email',
-							value,
-						} );
-					} }
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-				/>
-				{ this.emailDisableExplanation() }
-
-				{ formState.isFieldInvalid( this.state.form, 'email' ) && (
-					<FormInputValidation isError text={ this.getErrorMessagesWithLogin( 'email' ) } />
-				) }
-
-				{ this.props.displayUsernameInput && (
-					<>
-						<TextControl
-							label={ this.props.translate( 'Choose a username' ) }
-							disabled={ this.state.submitting || this.props.disabled }
-							id="username"
-							name="username"
-							value={ formState.getFieldValue( this.state.form, 'username' ) }
-							onBlur={ this.handleBlur }
-							onChange={ ( value ) => {
-								this.formStateController.handleFieldChange( {
-									name: 'username',
-									value,
-								} );
-							} }
-							__next40pxDefaultSize
-							__nextHasNoMarginBottom
-						/>
-
-						{ formState.isFieldInvalid( this.state.form, 'username' ) && (
-							<FormInputValidation isError text={ this.getErrorMessagesWithLogin( 'username' ) } />
-						) }
-					</>
-				) }
-
-				<TextControl
-					label={ this.props.translate( 'Choose a password' ) }
-					disabled={ this.state.submitting || this.props.disabled }
-					id="password"
-					name="password"
-					type="password"
-					value={ formState.getFieldValue( this.state.form, 'password' ) }
-					onBlur={ this.handleBlur }
-					onChange={ ( value ) => {
-						this.formStateController.handleFieldChange( {
-							name: 'password',
-							value,
-						} );
-					} }
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-				/>
-
-				{ this.passwordValidationExplanation() }
-
-				{ this.props.formFooter || this.formFooter() }
-			</div>
-		);
-	}
-
 	handleTosClick = () => {
 		recordTracksEvent( 'calypso_signup_tos_link_click' );
 	};
@@ -1086,6 +1008,7 @@ class SignupForm extends Component {
 			return null;
 		}
 
+		// TODO clk should just redirect to the login page?
 		if ( this.props.currentUser && ! this.props.disableContinueAsUser ) {
 			return (
 				<ContinueAsUser
@@ -1121,6 +1044,7 @@ class SignupForm extends Component {
 
 		const logInUrl = this.getLoginLink();
 
+		// TODO clk Akismet
 		if ( this.props.isSocialFirst ) {
 			return (
 				<SignupFormSocialFirst
@@ -1169,6 +1093,7 @@ class SignupForm extends Component {
 					};
 			}
 
+			// TODO clk woo
 			return (
 				<div
 					className={ clsx( 'signup-form', this.props.className, {
@@ -1176,32 +1101,56 @@ class SignupForm extends Component {
 					} ) }
 				>
 					{ this.getNotice() }
-					<PasswordlessSignupForm
-						stepName={ this.props.stepName }
-						flowName={ this.props.flowName }
-						goToNextStep={ this.props.goToNextStep }
-						renderTerms={ this.termsOfServiceLink }
-						disableTosText={ this.props.disableTosText }
-						submitForm={ this.handlePasswordlessSubmit }
-						logInUrl={ logInUrl }
-						disabled={ this.props.disabled }
-						disableSubmitButton={ this.props.disableSubmitButton || emailErrorMessage }
-						queryArgs={ this.props.queryArgs }
-						userEmail={ this.getEmailValue() }
-						labelText={ this.props.labelText }
-						onInputBlur={ this.handleBlur }
-						onInputChange={ this.handleChangeEvent }
-						onCreateAccountError={ this.handleCreateAccountError }
-						onCreateAccountSuccess={ this.props.handleCreateAccountSuccess }
-						{ ...formProps }
-					>
-						{ emailErrorMessage && (
-							<ValidationFieldset errorMessages={ [ emailErrorMessage ] }></ValidationFieldset>
-						) }
-					</PasswordlessSignupForm>
-
+					{ isGravatar && (
+						<PasswordlessSignupForm
+							stepName={ this.props.stepName }
+							flowName={ this.props.flowName }
+							goToNextStep={ this.props.goToNextStep }
+							renderTerms={ this.termsOfServiceLink }
+							disableTosText={ this.props.disableTosText }
+							submitForm={ this.handlePasswordlessSubmit }
+							logInUrl={ logInUrl }
+							disabled={ this.props.disabled }
+							disableSubmitButton={ this.props.disableSubmitButton || emailErrorMessage }
+							queryArgs={ this.props.queryArgs }
+							userEmail={ this.getEmailValue() }
+							labelText={ this.props.labelText }
+							onInputBlur={ this.handleBlur }
+							onInputChange={ this.handleChangeEvent }
+							onCreateAccountError={ this.handleCreateAccountError }
+							onCreateAccountSuccess={ this.props.handleCreateAccountSuccess }
+							{ ...formProps }
+						>
+							{ emailErrorMessage && (
+								<ValidationFieldset errorMessages={ [ emailErrorMessage ] }></ValidationFieldset>
+							) }
+						</PasswordlessSignupForm>
+					) }
 					{ ! isGravatar && (
 						<>
+							<PasswordlessSignupForm
+								stepName={ this.props.stepName }
+								flowName={ this.props.flowName }
+								goToNextStep={ this.props.goToNextStep }
+								renderTerms={ this.termsOfServiceLink }
+								disableTosText={ this.props.disableTosText }
+								submitForm={ this.handlePasswordlessSubmit }
+								logInUrl={ logInUrl }
+								disabled={ this.props.disabled }
+								disableSubmitButton={ this.props.disableSubmitButton || emailErrorMessage }
+								queryArgs={ this.props.queryArgs }
+								userEmail={ this.getEmailValue() }
+								labelText={ this.props.labelText }
+								onInputBlur={ this.handleBlur }
+								onInputChange={ this.handleChangeEvent }
+								onCreateAccountError={ this.handleCreateAccountError }
+								onCreateAccountSuccess={ this.props.handleCreateAccountSuccess }
+								{ ...formProps }
+							>
+								{ emailErrorMessage && (
+									<ValidationFieldset errorMessages={ [ emailErrorMessage ] }></ValidationFieldset>
+								) }
+							</PasswordlessSignupForm>
 							{ showSeparator && <FormDivider /> }
 							{ this.props.isSocialSignupEnabled && (
 								<SocialSignupForm
@@ -1226,13 +1175,10 @@ class SignupForm extends Component {
 			>
 				<LoggedOutForm onSubmit={ this.handleSubmit } noValidate>
 					{ this.getNotice() }
-
 					{ this.props.formHeader && (
 						<header className="signup-form__header">{ this.props.formHeader }</header>
 					) }
-
 					{ this.formFields() }
-
 					{ this.props.formFooter || this.formFooter() }
 				</LoggedOutForm>
 

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1065,8 +1065,7 @@ class SignupForm extends Component {
 
 		const isGravatar = this.props.isGravatar;
 		const emailErrorMessage = this.getErrorMessagesWithLogin( 'email' );
-		const showSeparator =
-			'wpcc' !== this.props.flowName && ! config.isEnabled( 'desktop' ) && this.isHorizontal();
+		const showSeparator = ! config.isEnabled( 'desktop' ) && this.isHorizontal();
 
 		if (
 			( this.props.isPasswordless && ( 'wpcc' !== this.props.flowName || this.props.isWoo ) ) ||

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -98,6 +98,8 @@ class SocialSignupForm extends Component {
 			setCurrentStep,
 		} = this.props;
 
+		const isUnifiedCreateAccount = isWoo;
+
 		return (
 			<Card
 				className={ clsx( 'auth-form__social', 'is-signup', {
@@ -131,9 +133,8 @@ class SocialSignupForm extends Component {
 							<UsernameOrEmailButton onClick={ () => setCurrentStep( 'email' ) } />
 						) }
 					</div>
-					{ ! isWoo && ! disableTosText && <SocialToS /> }
+					{ ! isUnifiedCreateAccount && ! disableTosText && <SocialToS /> }
 				</div>
-				{ isWoo && ! disableTosText && <SocialToS /> }
 			</Card>
 		);
 	}

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -63,7 +63,7 @@
 		width: 100%;
 		// Below is the same as .card.logged-out-form
 		margin: 0 auto 16px;
-		max-width: 360px;
+		// max-width: 360px;
 		padding: 16px;
 	}
 

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -59,6 +59,14 @@
 	padding: 16px;
 	box-sizing: border-box;
 
+	.is-unified-create-account & {
+		width: 100%;
+		// Below is the same as .card.logged-out-form
+		margin: 0 auto 16px;
+		max-width: 360px;
+		padding: 16px;
+	}
+
 	p {
 		font-size: $font-body-small;
 		color: var(--color-text-inverted);

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -119,6 +119,8 @@ const LayoutLoggedOut = ( {
 			currentRoute?.startsWith( '/start/do-it-for-me/' ) ) &&
 		userAllowedToHelpCenter;
 
+	const isUnifiedCreateAccount = sectionName === 'signup' && isWoo;
+
 	const classes = {
 		[ 'is-group-' + sectionGroup ]: sectionGroup,
 		[ 'is-section-' + sectionName ]: sectionName,
@@ -144,6 +146,7 @@ const LayoutLoggedOut = ( {
 		woo: isWoo,
 		'feature-flag-woocommerce-core-profiler-passwordless-auth': true,
 		'jetpack-cloud': isJetpackCloudOAuth2Client( oauth2Client ),
+		'is-unified-create-account': isUnifiedCreateAccount,
 	};
 
 	let masterbar = null;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -109,7 +109,7 @@ $breakpoint-mobile: 660px;
 	$woo-sfpro-display-font:  "SF Pro Display", -apple-system, system-ui, sans-serif;
 	$woo-sfpro-text-font:  "SF Pro Text", -apple-system, system-ui, sans-serif;
 
-	input.form-text-input, 
+	input.form-text-input,
 	textarea.form-text-input {
 		&:focus,
 		&:hover {
@@ -822,8 +822,8 @@ $breakpoint-mobile: 660px;
 		}
 
 		h1,
-		.signup-form__woo-wrapper, 
-		.wp-login__heading-text {
+		.signup-form__woo-wrapper,
+		.wp-login__one-login-layout-heading-text {
 			color: var(--studio-gray-100);
 			font-family: var(--woo-font-family-header);
 			font-feature-settings: "ss01" on, "salt" on;
@@ -837,7 +837,7 @@ $breakpoint-mobile: 660px;
 		}
 
 		h1,
-		h3:not(.wp-login__heading-subtext) {
+		h3:not(.wp-login__one-login-layout-heading-subtext) {
 			color: var(--studio-gray-100);
 			text-align: center;
 			font-size: 2.25rem;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -952,8 +952,6 @@ $breakpoint-mobile: 660px;
 		}
 
 		div.auth-form__separator {
-			max-width: $max-width;
-
 			&::before,
 			&::after {
 				border-block-start-color: #e0e0e1;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -339,8 +339,6 @@ $breakpoint-mobile: 660px;
 	&:not(.is-section-login) {
 		.card {
 			box-shadow: none;
-			padding-left: 0;
-			padding-right: 0;
 			background-color: initial;
 		}
 	}
@@ -943,7 +941,6 @@ $breakpoint-mobile: 660px;
 			width: 100%;
 			margin: 0 auto;
 			padding: 0;
-			max-width: 327px;
 			display: flex;
 			flex-direction: column;
 		}
@@ -951,11 +948,6 @@ $breakpoint-mobile: 660px;
 		.signup-form {
 			input[type="email"].form-text-input {
 				margin-bottom: 0;
-			}
-
-			.signup-form__passwordless-form-wrapper .logged-out-form__footer {
-				padding: 0;
-				margin: 24px 0 0 0;
 			}
 		}
 

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -1260,7 +1260,7 @@ class MagicLogin extends Component {
 			),
 		} );
 
-		return <p className="magic-login__tos wp-login__tos">{ tosText }</p>;
+		return <p className="magic-login__tos wp-login__one-login-layout-tos">{ tosText }</p>;
 	};
 
 	handlePublicTokenReceived = ( publicToken ) => {

--- a/client/login/wp-login/components/heading-logo.tsx
+++ b/client/login/wp-login/components/heading-logo.tsx
@@ -73,7 +73,7 @@ const HeadingLogo = ( { isFromAkismet, isJetpack }: Props ) => {
 		logo = <img src={ gravatarLogo } alt="Gravatar Logo" />;
 	}
 
-	return logo ? <div className="wp-login__heading-logo">{ logo }</div> : null;
+	return logo ? <div className="wp-login__one-login-layout-heading-logo">{ logo }</div> : null;
 };
 
 export default HeadingLogo;

--- a/client/login/wp-login/components/one-login-layout.scss
+++ b/client/login/wp-login/components/one-login-layout.scss
@@ -6,8 +6,51 @@
 	gap: 2em;
 }
 
-.wp-login__header {
+.wp-login__one-login-layout-heading {
 	color: var( --color-neutral-100 );
 	font-size: $font-body;
 	text-align: center;
+}
+
+.wp-login__one-login-layout-heading-logo {
+	margin-bottom: 16px;
+
+	> img {
+		width: 64px;
+		height: 64px;
+	}
+}
+
+.wp-login__one-login-layout-tos {
+	a {
+		color: var(--color-text);
+		text-decoration: underline;
+	}
+}
+
+.wp-login__one-login-layout-heading-subtext-wrapper {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+.wp-login__one-login-layout-heading-subtext {
+	text-wrap: balance;
+	color: var(--studio-gray-50, #646970);
+	margin-block: 0.5rem 0;
+	font-size: $font-body;
+
+	a {
+		color: var(--studio-gray-50, #646970);
+		text-decoration: underline;
+	}
+
+	&.is-secondary {
+		font-size: $font-body-extra-small;
+		color: var(--studio-gray-30);
+
+		a {
+			color: var(--studio-gray-30);
+		}
+	}
 }

--- a/client/login/wp-login/components/one-login-layout.scss
+++ b/client/login/wp-login/components/one-login-layout.scss
@@ -1,0 +1,13 @@
+.wp-login__one-login-layout-content-wrapper {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 2em;
+}
+
+.wp-login__header {
+	color: var( --color-neutral-100 );
+	font-size: $font-body;
+	text-align: center;
+}

--- a/client/login/wp-login/components/one-login-layout.scss
+++ b/client/login/wp-login/components/one-login-layout.scss
@@ -54,3 +54,7 @@
 		}
 	}
 }
+
+.wp-login__one-login-layout-content-wrapper .login__body--continue-as-user {
+	max-width: 540px;
+}

--- a/client/login/wp-login/components/one-login-layout.tsx
+++ b/client/login/wp-login/components/one-login-layout.tsx
@@ -10,6 +10,7 @@ import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selector
 import { getCurrentQueryArguments } from 'calypso/state/selectors/get-current-query-arguments';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import HeadingLogo from './heading-logo';
+import './one-login-layout.scss';
 
 interface OneLoginLayoutProps {
 	isJetpack: boolean;
@@ -19,6 +20,8 @@ interface OneLoginLayoutProps {
 	 * `signupUrl` prop should merge with `getSignupLinkComponent` logic in `/client/block/login/index.js`, so we have a single source for this logic.
 	 */
 	signupUrl?: string;
+	isSectionSignup?: boolean;
+	loginUrl?: string;
 }
 
 const OneLoginLayout = ( {
@@ -26,6 +29,8 @@ const OneLoginLayout = ( {
 	isFromAkismet,
 	children,
 	signupUrl: signupUrlProp,
+	isSectionSignup,
+	loginUrl,
 }: OneLoginLayoutProps ) => {
 	const translate = useTranslate();
 	const locale = useSelector( getCurrentUserLocale );
@@ -58,10 +63,27 @@ const OneLoginLayout = ( {
 		);
 	};
 
+	const LoginLink = () => {
+		if ( ! loginUrl ) {
+			return null;
+		}
+
+		return (
+			<Step.LinkButton href={ loginUrl } key="login-link" rel="external">
+				{ translate( 'Log in' ) }
+			</Step.LinkButton>
+		);
+	};
+
 	return (
 		<Step.CenteredColumnLayout
 			columnWidth={ 6 }
-			topBar={ <Step.TopBar rightElement={ <SignUpLink /> } compactLogo="always" /> }
+			topBar={
+				<Step.TopBar
+					rightElement={ isSectionSignup ? <LoginLink /> : <SignUpLink /> }
+					compactLogo="always"
+				/>
+			}
 			verticalAlign="center"
 		>
 			<div className="wp-login__one-login-layout-content-wrapper">

--- a/client/login/wp-login/components/one-login-layout.tsx
+++ b/client/login/wp-login/components/one-login-layout.tsx
@@ -87,13 +87,15 @@ const OneLoginLayout = ( {
 			verticalAlign="center"
 		>
 			<div className="wp-login__one-login-layout-content-wrapper">
-				<div className="wp-login__header">
+				<div className="wp-login__one-login-layout-heading">
 					<HeadingLogo isFromAkismet={ isFromAkismet } isJetpack={ isJetpack } />
-					<Step.Heading text={ <div className="wp-login__heading-text">{ headingText }</div> } />
-					<div className="wp-login__heading-subtext-wrapper">
-						<h2 className="wp-login__heading-subtext">{ subHeadingText }</h2>
+					<Step.Heading
+						text={ <div className="wp-login__one-login-layout-heading-text">{ headingText }</div> }
+					/>
+					<div className="wp-login__one-login-layout-heading-subtext-wrapper">
+						<h2 className="wp-login__one-login-layout-heading-subtext">{ subHeadingText }</h2>
 						{ subHeadingTextSecondary && (
-							<h3 className="wp-login__heading-subtext is-secondary">
+							<h3 className="wp-login__one-login-layout-heading-subtext is-secondary">
 								{ subHeadingTextSecondary }
 							</h3>
 						) }

--- a/client/login/wp-login/hooks/get-heading-subtext.tsx
+++ b/client/login/wp-login/hooks/get-heading-subtext.tsx
@@ -24,7 +24,7 @@ const getHeadingSubText = ( {
 	}
 
 	const tos = (
-		<span className="wp-login__tos">
+		<span className="wp-login__one-login-layout-tos">
 			{ translate(
 				'Just a little reminder that by continuing with any of the options below, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and {{privacyLink}}Privacy Policy{{/privacyLink}}.',
 				{

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -116,26 +116,8 @@ $image-height: 47px;
 	}
 }
 
-.wp-login__header {
-	color: var( --color-neutral-100 );
-	font-size: $font-body;
-	text-align: center;
-
-	body.is-section-signup & {
-		color: var(--color-text-inverted);
-	}
-}
-
 .wp-login__main {
 	width: 100%;
-}
-
-.wp-login__one-login-layout-content-wrapper {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	gap: 2em;
 }
 
 .wp-login__site-return-link {

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -36,14 +36,14 @@ $image-height: 47px;
 			font-family: Inter, -apple-system, system-ui, blinkmacsystemfont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 		}
 
-		.wp-login__heading-text {
+		.wp-login__one-login-layout-heading-text {
 			font-family: Inter, -apple-system, system-ui, blinkmacsystemfont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 			font-size: 2rem;
 			font-weight: 700;
 			line-height: 40px;
 		}
 
-		.wp-login__heading-subtext {
+		.wp-login__one-login-layout-heading-subtext {
 			font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 			font-size: rem(18px);
 			font-weight: 500;
@@ -58,7 +58,7 @@ $image-height: 47px;
 	* If we're on a Woo page, we don't want to apply the Jetpack font styles, as Woo brings in its own font styles.
 	*/
 	&.is-jetpack-login:not(.is-woo-passwordless) {
-		.wp-login__heading-text {
+		.wp-login__one-login-layout-heading-text {
 			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif
 		}
 	}
@@ -66,54 +66,11 @@ $image-height: 47px;
 
 	/* Start: Jetpack Cloud font styles for login page */
 	&.jetpack-cloud {
-		.wp-login__heading-text {
+		.wp-login__one-login-layout-heading-text {
 			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif
 		}
 	}
 	/* End: Jetpack Cloud font styles for login page */
-}
-
-.wp-login__heading-logo {
-	margin-bottom: 16px;
-
-	> img {
-		width: 64px;
-		height: 64px;
-	}
-}
-
-.wp-login__tos {
-	a {
-		color: var(--color-text);
-		text-decoration: underline;
-	}
-}
-
-.wp-login__heading-subtext-wrapper {
-	display: flex;
-	flex-direction: column;
-	gap: 0.5rem;
-}
-
-.wp-login__heading-subtext {
-	text-wrap: balance;
-	color: var(--studio-gray-50, #646970);
-	margin-block: 0.5rem 0;
-	font-size: $font-body;
-
-	a {
-		color: var(--studio-gray-50, #646970);
-		text-decoration: underline;
-	}
-
-	&.is-secondary {
-		font-size: $font-body-extra-small;
-		color: var(--studio-gray-30);
-
-		a {
-			color: var(--studio-gray-30);
-		}
-	}
 }
 
 .wp-login__main {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -60,6 +60,7 @@ import {
 } from 'calypso/state/current-user/selectors';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
+import getIsWoo from 'calypso/state/selectors/get-is-woo';
 import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
@@ -778,7 +779,10 @@ class Signup extends Component {
 			...flowStepProps,
 		};
 		const stepKey = this.state.shouldShowLoadingScreen ? 'processing' : stepName;
-		const shouldRenderLocaleSuggestions = 0 === this.getPositionInFlow() && ! this.props.isLoggedIn;
+		const isUnifiedCreateAccount =
+			0 === this.getPositionInFlow() && ! this.props.isLoggedIn && this.props.isWoo;
+		const shouldRenderLocaleSuggestions =
+			0 === this.getPositionInFlow() && ! this.props.isLoggedIn && ! isUnifiedCreateAccount;
 
 		let propsForCurrentStep = propsFromConfig;
 		if ( this.props.isManageSiteFlow ) {
@@ -942,6 +946,7 @@ export default connect(
 			isGravatar: isGravatarOAuth2Client( oauth2Client ),
 			wccomFrom: getWccomFrom( state ),
 			hostingFlow,
+			isWoo: getIsWoo( state ),
 		};
 	},
 	{

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -765,7 +765,7 @@ class Signup extends Component {
 		);
 	}
 
-	renderCurrentStep() {
+	renderCurrentStep( isUnifiedCreateAccount ) {
 		const { stepName, flowName } = this.props;
 
 		const flow = flows.getFlow( flowName, this.props.isLoggedIn );
@@ -779,8 +779,6 @@ class Signup extends Component {
 			...flowStepProps,
 		};
 		const stepKey = this.state.shouldShowLoadingScreen ? 'processing' : stepName;
-		const isUnifiedCreateAccount =
-			0 === this.getPositionInFlow() && ! this.props.isLoggedIn && this.props.isWoo;
 		const shouldRenderLocaleSuggestions =
 			0 === this.getPositionInFlow() && ! this.props.isLoggedIn && ! isUnifiedCreateAccount;
 
@@ -872,7 +870,9 @@ class Signup extends Component {
 			return this.props.siteId && waitToRenderReturnValue;
 		}
 
-		const showPageHeader = ! this.props.isGravatar;
+		const isUnifiedCreateAccount =
+			0 === this.getPositionInFlow() && ! this.props.isLoggedIn && this.props.isWoo;
+		const showPageHeader = ! this.props.isGravatar && ! isUnifiedCreateAccount;
 		const isGravatarDomain = isDomainForGravatarFlow( this.props.flowName );
 
 		return (
@@ -898,7 +898,7 @@ class Signup extends Component {
 							logoComponent={ isGravatarDomain ? <GravatarTextLogo /> : undefined }
 						/>
 					) }
-					<div className="signup__steps">{ this.renderCurrentStep() }</div>
+					<div className="signup__steps">{ this.renderCurrentStep( isUnifiedCreateAccount ) }</div>
 					{ this.state.bearerToken && (
 						<WpcomLoginForm
 							authorization={ 'Bearer ' + this.state.bearerToken }

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -520,7 +520,7 @@ export class UserStep extends Component {
 
 			return (
 				<span className={ clsx( 'signup-form__woo-wrapper' ) }>
-					{ translate( 'Create an account' ) }
+					{ translate( 'Create an account with WordPress.com' ) }
 				</span>
 			);
 		}

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -14,6 +14,7 @@ import { connect } from 'react-redux';
 import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
 import SignupForm from 'calypso/blocks/signup-form';
 import JetpackLogo from 'calypso/components/jetpack-logo';
+import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import WooCommerceConnectCartHeader from 'calypso/components/woocommerce-connect-cart-header';
 import WPCloudLogo from 'calypso/components/wp-cloud-logo';
 import { initGoogleRecaptcha, recordGoogleRecaptchaAction } from 'calypso/lib/analytics/recaptcha';
@@ -53,7 +54,6 @@ import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
 import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
 import { getSuggestedUsername } from 'calypso/state/signup/optional-dependencies/selectors';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
-
 import './style.scss';
 
 // Wrapper component to set headers in login context
@@ -596,7 +596,7 @@ export class UserStep extends Component {
 	}
 
 	renderSignupForm() {
-		const { oauth2Client, isWCCOM, isWoo } = this.props;
+		const { oauth2Client, isWCCOM, isWoo, isUnifiedCreateAccount } = this.props;
 		const isPasswordless =
 			isMobile() ||
 			this.props.isPasswordless ||
@@ -647,6 +647,9 @@ export class UserStep extends Component {
 					isSocialFirst={ this.props.isSocialFirst }
 					labelText={ isWoo ? this.props.translate( 'Your email' ) : null }
 				/>
+				{ isUnifiedCreateAccount && (
+					<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
+				) }
 				<div id="g-recaptcha"></div>
 			</>
 		);

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -9,7 +9,7 @@ import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { get, isEmpty, omit } from 'lodash';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
 import SignupForm from 'calypso/blocks/signup-form';
@@ -27,6 +27,8 @@ import {
 	isPartnerPortalOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
+import LoginContextProvider, { useLoginContext } from 'calypso/login/login-context';
+import OneLoginLayout from 'calypso/login/wp-login/components/one-login-layout';
 import flows from 'calypso/signup/config/flows';
 import GravatarStepWrapper from 'calypso/signup/gravatar-step-wrapper';
 import StepWrapper from 'calypso/signup/step-wrapper';
@@ -53,6 +55,20 @@ import { getSuggestedUsername } from 'calypso/state/signup/optional-dependencies
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 
 import './style.scss';
+
+// Wrapper component to set headers in login context
+const LoginContextWrapper = ( { children, headerText, subHeaderText } ) => {
+	const { setHeaders } = useLoginContext();
+
+	React.useEffect( () => {
+		setHeaders( {
+			heading: headerText,
+			subHeading: subHeaderText,
+		} );
+	}, [ setHeaders, headerText, subHeaderText ] );
+
+	return children;
+};
 
 function getRedirectToAfterLoginUrl( {
 	oauth2Signup,
@@ -694,6 +710,26 @@ export class UserStep extends Component {
 			return null;
 		}
 
+		if ( this.props.isUnifiedCreateAccount ) {
+			return (
+				<LoginContextProvider>
+					<LoginContextWrapper
+						headerText={ this.getHeaderText() }
+						subHeaderText={ this.getSubHeaderText() }
+					>
+						<OneLoginLayout
+							isJetpack={ false }
+							isFromAkismet={ false }
+							isSectionSignup
+							loginUrl={ this.getLoginUrl() }
+						>
+							{ this.renderSignupForm() }
+						</OneLoginLayout>
+					</LoginContextWrapper>
+				</LoginContextProvider>
+			);
+		}
+
 		// TODO: decouple hideBack flag from the flow name.
 		return (
 			<StepWrapper
@@ -714,17 +750,20 @@ export class UserStep extends Component {
 const ConnectedUser = connect(
 	( state ) => {
 		const oauth2Client = getCurrentOAuth2Client( state );
+		const isWoo = getIsWoo( state );
+		const isUnifiedCreateAccount = isWoo;
 
 		return {
 			oauth2Client: oauth2Client,
 			suggestedUsername: getSuggestedUsername( state ),
 			wccomFrom: getWccomFrom( state ),
 			isWCCOM: getIsWCCOM( state ),
-			isWoo: getIsWoo( state ),
+			isWoo,
 			isBlazePro: getIsBlazePro( state ),
 			from: get( getCurrentQueryArguments( state ), 'from' ),
 			userLoggedIn: isUserLoggedIn( state ),
 			isOnboardingAffiliateFlow: getIsOnboardingAffiliateFlow( state ),
+			isUnifiedCreateAccount,
 		};
 	},
 	{

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -30,6 +30,7 @@ import {
 import { login } from 'calypso/lib/paths';
 import LoginContextProvider, { useLoginContext } from 'calypso/login/login-context';
 import OneLoginLayout from 'calypso/login/wp-login/components/one-login-layout';
+import getHeadingSubText from 'calypso/login/wp-login/hooks/get-heading-subtext';
 import flows from 'calypso/signup/config/flows';
 import GravatarStepWrapper from 'calypso/signup/gravatar-step-wrapper';
 import StepWrapper from 'calypso/signup/step-wrapper';
@@ -51,6 +52,7 @@ import getIsBlazePro from 'calypso/state/selectors/get-is-blaze-pro';
 import getIsWCCOM from 'calypso/state/selectors/get-is-wccom';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
 import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
+import isWooJPCFlow from 'calypso/state/selectors/is-woo-jpc-flow';
 import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
 import { getSuggestedUsername } from 'calypso/state/signup/optional-dependencies/selectors';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
@@ -63,7 +65,8 @@ const LoginContextWrapper = ( { children, headerText, subHeaderText } ) => {
 	React.useEffect( () => {
 		setHeaders( {
 			heading: headerText,
-			subHeading: subHeaderText,
+			subHeading: subHeaderText?.primary,
+			subHeadingSecondary: subHeaderText?.secondary,
 		} );
 	}, [ setHeaders, headerText, subHeaderText ] );
 
@@ -718,7 +721,12 @@ export class UserStep extends Component {
 				<LoginContextProvider>
 					<LoginContextWrapper
 						headerText={ this.getHeaderText() }
-						subHeaderText={ this.getSubHeaderText() }
+						subHeaderText={ getHeadingSubText( {
+							isSocialFirst: true,
+							twoFactorAuthType: false,
+							translate: this.props.translate,
+							isWooJPC: this.props.isWooJPC,
+						} ) }
 					>
 						<OneLoginLayout
 							isJetpack={ false }
@@ -762,6 +770,7 @@ const ConnectedUser = connect(
 			wccomFrom: getWccomFrom( state ),
 			isWCCOM: getIsWCCOM( state ),
 			isWoo,
+			isWooJPC: isWooJPCFlow( state ),
 			isBlazePro: getIsBlazePro( state ),
 			from: get( getCurrentQueryArguments( state ), 'from' ),
 			userLoggedIn: isUserLoggedIn( state ),

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -40,6 +40,18 @@ body.is-section-signup {
 		padding: 0;
 	}
 
+	.is-unified-create-account {
+		.locale-suggestions {
+			margin: 0;
+		}
+
+		.locale-suggestions__notice {
+			&.calypso-notice.is-compact.is-light.is-info {
+				margin: 0;
+			}
+		}
+	}
+
 	// Hide the masterbar for realz
 	&.has-no-masterbar .masterbar {
 		display: none;

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -55,11 +55,32 @@ body.is-section-signup {
 			max-width: 400px;
 		}
 
-		.logged-out-form {
+		.card.logged-out-form {
+			padding: 0;
 			.form-fieldset {
 				margin-bottom: 0;
 			}
 		}
+
+		.auth-form__social {
+			margin: 0;
+			padding-top: 0;
+			padding-bottom: 0;
+
+		}
+
+		.auth-form__separator {
+			margin: 0 auto;
+			max-width: 360px;
+			.auth-form__separator-text {
+				padding: 0 24px;
+			}
+		}
+
+		.signup-form.is-horizontal {
+			gap: 1em;
+		}
+
 	}
 
 	// Hide the masterbar for realz

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -32,8 +32,12 @@ body.is-section-signup {
 
 	// Adjust the padding as we no longer
 	// show the masterbar.
-	.layout__content {
+	.layout:not(.is-unified-create-account) .layout__content {
 		padding: 48px 0 0;
+	}
+
+	.is-unified-create-account .layout__content {
+		padding: 0;
 	}
 
 	// Hide the masterbar for realz

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -50,6 +50,16 @@ body.is-section-signup {
 				margin: 0;
 			}
 		}
+
+		.signup-form {
+			max-width: 400px;
+		}
+
+		.logged-out-form {
+			.form-fieldset {
+				margin-bottom: 0;
+			}
+		}
 	}
 
 	// Hide the masterbar for realz

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -36,11 +36,11 @@ body.is-section-signup {
 		padding: 48px 0 0;
 	}
 
-	.is-unified-create-account .layout__content {
-		padding: 0;
-	}
+	.layout.is-unified-create-account {
+		.layout__content {
+			padding: 0;
+		}
 
-	.is-unified-create-account {
 		.locale-suggestions {
 			margin: 0;
 		}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13218/signup-update-and-unify-the-account-creation-screens
Fixes https://linear.app/a8c/issue/DOTCOM-13980/signup-woo-update-create-an-account-screen

## Proposed Changes

- We bring together the unified Login layouts into the Signup (create account) screens so we can unify those equally.
- We use Woo (all variants) as the foremost use-case, on top of which we can migrate the rest
- We focus only on OAuth2 clients, which are served from Start
- There are some intermediate steps we take here, which we'll resolve as we go - such as using Login components into Signup, or the flag `isUnifiedCreateAccount`

## Media

- The goal (this is for WooJPC):

<img width="700" height="1224" alt="image" src="https://github.com/user-attachments/assets/0eb82740-cc67-4a7c-a88d-d50b8fb1278f" />

- Woo (not WooJPC):

| Before | After |
|--------|--------|
| <img width="500" alt="Screenshot 2025-07-30 at 9 06 18 PM" src="https://github.com/user-attachments/assets/cefff3eb-3141-456f-acef-1c2e38677034" /> | <img width="500" alt="Screenshot 2025-07-30 at 1 04 02 PM" src="https://github.com/user-attachments/assets/605b104d-58d8-494c-b787-956f412465ed" /> |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13218/signup-update-and-unify-the-account-creation-screens
Fixes https://linear.app/a8c/issue/DOTCOM-13980/signup-woo-update-create-an-account-screen

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [Woo and WooJPC Signup (create account)](https://linear.app/a8c/issue/DOTCOM-13218/signup-update-and-unify-the-account-creation-screens) screens and verify - through Login screen, click on "Create an account" at the top. 
  * Beyond design, confirm the back/forth works correctly
  * Ensure the flow itself redirects correctly
* Go to Gravatar, enter "create account" flow, and verify no changes
* Go to other OAUth2 client and the default WP Signup and verify no changes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
