### PR TITLE
Sync modal: Show domain confirmation always when syncing Staging to Prod

### DIFF
--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -366,9 +366,7 @@ export default function SyncModal( {
 	const showWooCommerceWarning =
 		isSiteWooStore && targetEnvironment === 'production' && sqlNode?.checkState === 'checked';
 
-	const showDomainConfirmation =
-		targetEnvironment === 'production' &&
-		( browserCheckList.totalItems > 0 || browserCheckList.includeList.length > 0 );
+	const showDomainConfirmation = targetEnvironment === 'production';
 
 	const isButtonDisabled =
 		( showDomainConfirmation && domainConfirmation !== productionSiteSlug ) ||


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTCOM-14026

## Proposed Changes

* Show domain confirmation input always when syncing Staging to Production

|Before | After|
|-------|------|
| <img width="1548" height="1568" alt="CleanShot 2025-07-28 at 18 23 30@2x" src="https://github.com/user-attachments/assets/3e79f937-7bce-4ea8-9208-8edc771dae50" />|<img width="1548" height="1568" alt="CleanShot 2025-07-28 at 18 23 46@2x" src="https://github.com/user-attachments/assets/26f1cd79-2f41-47de-a5d3-1669aee6a167" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To action some feedback here https://github.com/Automattic/wp-calypso/pull/104857#issuecomment-3127773977, the confirmation should be displayed always, regardless of the checkboxes ticked

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this changes and navigate to Calypso locally
* Navigate to a site that has a Staging site or add a staging site to an existing site.
* On the production site, select the `Sync` dropdown on the top-right and then, `Pull from Staging`
* Check that the domain confirmation input is displayed even if all the checkboxes are unselected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
