### PR TITLE
A4A: Add missing purchase_type query parse on Marketplace hosting page.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -45,6 +45,8 @@ export const marketplaceProductsContext: Callback = ( context, next ) => {
 };
 
 export const marketplaceHostingContext: Callback = ( context, next ) => {
+	const { purchase_type } = context.query;
+
 	if ( ! context.params.section ) {
 		const currentAgency = getActiveAgency( context.store.getState() );
 		page.redirect(
@@ -58,11 +60,13 @@ export const marketplaceHostingContext: Callback = ( context, next ) => {
 
 	const section = getValidHostingSection( context.params.section );
 
+	const purchaseType = purchase_type === 'referral' ? 'referral' : undefined;
+
 	context.secondary = <MarketplaceSidebar path={ context.path } />;
 	context.primary = (
 		<>
 			<PageViewTracker title="Marketplace > Hosting" path={ context.path } />
-			<HostingOverview section={ section } />
+			<HostingOverview section={ section } defaultMarketplaceType={ purchaseType } />
 		</>
 	);
 	next();

--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -18,8 +18,11 @@ import DownloadProducts from './primary/download-products';
 import ProductsOverview from './products-overview';
 import ReferEnterpriseHosting from './refer-enterprise-hosting';
 
-export const marketplaceContext: Callback = () => {
-	page.redirect( A4A_MARKETPLACE_HOSTING_LINK );
+export const marketplaceContext: Callback = ( context ) => {
+	const { purchase_type } = context.query;
+	const purchaseType = purchase_type === 'referral' ? 'referral' : undefined;
+	const purchaseTypeURLQuery = purchaseType ? `?purchase_type=${ purchaseType }` : '';
+	page.redirect( A4A_MARKETPLACE_HOSTING_LINK + purchaseTypeURLQuery );
 };
 
 export const marketplaceProductsContext: Callback = ( context, next ) => {
@@ -46,21 +49,23 @@ export const marketplaceProductsContext: Callback = ( context, next ) => {
 
 export const marketplaceHostingContext: Callback = ( context, next ) => {
 	const { purchase_type } = context.query;
+	const purchaseType = purchase_type === 'referral' ? 'referral' : undefined;
 
 	if ( ! context.params.section ) {
 		const currentAgency = getActiveAgency( context.store.getState() );
+
+		const purchaseTypeURLQuery = purchaseType ? `?purchase_type=${ purchaseType }` : '';
+
 		page.redirect(
 			// If the agency is managing less than 5 sites, then we make wpcom as default section.
-			currentAgency?.signup_meta?.number_sites === '1-5'
+			( currentAgency?.signup_meta?.number_sites === '1-5'
 				? A4A_MARKETPLACE_HOSTING_WPCOM_LINK
-				: A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK
+				: A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK ) + purchaseTypeURLQuery
 		);
 		return;
 	}
 
 	const section = getValidHostingSection( context.params.section );
-
-	const purchaseType = purchase_type === 'referral' ? 'referral' : undefined;
 
 	context.secondary = <MarketplaceSidebar path={ context.path } />;
 	context.primary = (


### PR DESCRIPTION
The marketplace hosting page lacks support for `purchase_type`, which is available on the Products page.  This PR adds the missing handler.
 
Closes https://linear.app/a8c/issue/A4A-1374/link-to-marketplace-with-referral-mode-for-onboarding-emails

## Proposed Changes

* Parse purchase_type query parameter and pass as the marketplace type.

## Why are these changes being made?

* This is needed to allow referral flow via email activation.

## Testing Instructions

* Use the A4A live link and navigate to `/marketplace?purchase_type=referral`
* Confirm that the referral toggle is enabled by default.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
