### PR TITLE
Staging Sites Redesign: hide sync dropdown when staging site is deleted

### DIFF
--- a/client/sites/components/site-preview-pane/preview-pane-header-buttons.tsx
+++ b/client/sites/components/site-preview-pane/preview-pane-header-buttons.tsx
@@ -1,11 +1,14 @@
 import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
+import { useQuery } from '@tanstack/react-query';
 import { useMergeRefs } from '@wordpress/compose';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useRef, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { GuidedTourStep } from 'calypso/components/guided-tour/step';
+import { isDeletingStagingSiteQuery } from 'calypso/dashboard/app/queries/site-staging-sites';
+import { queryClient } from 'calypso/dashboard/app/query-client';
 import SyncDropdown from 'calypso/dashboard/sites/staging-site-sync-dropdown';
 import { useCheckSyncStatus } from 'calypso/sites/staging-site/hooks/use-site-sync-status';
 import { useDispatch } from 'calypso/state';
@@ -46,8 +49,16 @@ const PreviewPaneHeaderButtons = ( { focusRef, itemData }: Props ) => {
 		getIsStagingSiteInTransition( state, itemData.blogId ?? 0 )
 	);
 
+	const { data: isStagingSiteDeletionInProgress } = useQuery(
+		isDeletingStagingSiteQuery( itemData.blogId ?? 0 ),
+		queryClient
+	);
+
 	const shouldShowSyncDropdown = Boolean(
-		stagingSitesRedesign && ( isStagingSite || hasStagingSite ) && ! isStagingSiteInTransition
+		stagingSitesRedesign &&
+			( isStagingSite || hasStagingSite ) &&
+			! isStagingSiteInTransition &&
+			! isStagingSiteDeletionInProgress
 	);
 
 	const productionSiteId = isStagingSite

--- a/client/sites/components/site-preview-pane/preview-pane-header-buttons.tsx
+++ b/client/sites/components/site-preview-pane/preview-pane-header-buttons.tsx
@@ -4,21 +4,18 @@ import { useQuery } from '@tanstack/react-query';
 import { useMergeRefs } from '@wordpress/compose';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import { useRef, useEffect } from 'react';
+import { useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { GuidedTourStep } from 'calypso/components/guided-tour/step';
 import { isDeletingStagingSiteQuery } from 'calypso/dashboard/app/queries/site-staging-sites';
 import { queryClient } from 'calypso/dashboard/app/query-client';
 import SyncDropdown from 'calypso/dashboard/sites/staging-site-sync-dropdown';
 import { useCheckSyncStatus } from 'calypso/sites/staging-site/hooks/use-site-sync-status';
-import { useDispatch } from 'calypso/state';
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import hasWpcomStagingSite from 'calypso/state/selectors/has-wpcom-staging-site';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import { useSiteAdminInterfaceData } from 'calypso/state/sites/hooks';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getIsStagingSiteInTransition } from 'calypso/state/staging-site/selectors';
-import { SiteSyncStatus } from 'calypso/state/sync/constants';
 import type { ItemData } from 'calypso/layout/hosting-dashboard/item-view/types';
 
 import './preview-pane-header-buttons.scss';
@@ -32,8 +29,6 @@ const PreviewPaneHeaderButtons = ( { focusRef, itemData }: Props ) => {
 	const adminButtonRef = useRef< HTMLButtonElement | null >( null );
 	const { adminLabel, adminUrl } = useSiteAdminInterfaceData( itemData.blogId );
 	const { __ } = useI18n();
-	const dispatch = useDispatch();
-	const previousSyncInProgress = useRef< boolean >( false );
 
 	const stagingSitesRedesign = config.isEnabled( 'hosting/staging-sites-redesign' );
 
@@ -71,19 +66,7 @@ const PreviewPaneHeaderButtons = ( { focusRef, itemData }: Props ) => {
 
 	const environment = isStagingSite ? 'staging' : 'production';
 
-	const { resetSyncStatus, isSyncInProgress, status } = useCheckSyncStatus( productionSiteId );
-
-	useEffect( () => {
-		if ( previousSyncInProgress.current && ! isSyncInProgress ) {
-			if ( status === SiteSyncStatus.COMPLETED ) {
-				dispatch( successNotice( __( 'Synchronization completed successfully.' ) ) );
-			} else if ( status === SiteSyncStatus.FAILED || status === SiteSyncStatus.ALLOW_RETRY ) {
-				dispatch( errorNotice( __( 'Synchronization failed. Please try again.' ) ) );
-			}
-		}
-
-		previousSyncInProgress.current = isSyncInProgress;
-	}, [ isSyncInProgress, status, dispatch, __ ] );
+	const { resetSyncStatus, isSyncInProgress } = useCheckSyncStatus( productionSiteId );
 
 	return (
 		<>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves [DOTDEV-221 Staging Sites Redesign: hide sync dropdown when staging site is deleted](https://linear.app/a8c/issue/DOTDEV-221/staging-sites-redesign-hide-sync-dropdown-when-staging-site-is-deleted)

## Proposed Changes

* Reuse the query used to hide the tabs when the deletion is in progress
* Hide the sync dropdown when the deletion is in progress

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The sync dropdown shouldn't be shown while deleting the staging site

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this change and open Calypso in your local environment, that will enable the flag `hosting/staging-sites-redesign`
* Create a staging site or open a site that already has an staging site. [More info here](https://developer.wordpress.com/docs/developer-tools/staging-sites/)
* Navigate to the Staging site settings, and click on the "Delete staging site" button
* Click the Delete button on the modal that appears
* Check that while the delete banner is shown, the sync dropdown is also hidden

Starting the deletion:

https://github.com/user-attachments/assets/49cbd378-1cf5-40ef-ab64-0b124d0aa6cf


When the site is reverted:

https://github.com/user-attachments/assets/477b07f1-6821-4434-bf2f-09a74102e5c7