### PR TITLE
Domain Search Retrofit: Fix domain and TLD word wrapping

### DIFF
--- a/client/components/domain-search-v2/domain-skip-suggestion/index.skeleton.tsx
+++ b/client/components/domain-search-v2/domain-skip-suggestion/index.skeleton.tsx
@@ -1,3 +1,4 @@
+import { useDomainSuggestionContainer } from '@automattic/domain-search';
 import { Card, CardBody } from '@wordpress/components';
 
 interface Props {
@@ -7,8 +8,14 @@ interface Props {
 }
 
 export const DomainSkipSkeleton = ( { title, subtitle, right }: Props ) => {
+	const { containerRef, activeQuery } = useDomainSuggestionContainer();
+
 	return (
-		<Card className="subdomain-skip-suggestion">
+		<Card
+			className="subdomain-skip-suggestion"
+			ref={ containerRef }
+			size={ activeQuery === 'large' ? 'medium' : 'small' }
+		>
 			<CardBody>
 				<div className="subdomain-skip-suggestion__content">
 					{ title }

--- a/client/components/domain-search-v2/domain-skip-suggestion/index.tsx
+++ b/client/components/domain-search-v2/domain-skip-suggestion/index.tsx
@@ -28,14 +28,14 @@ const DomainSkipSuggestion = ( { domain, onSkip }: Props ) => {
 				</Heading>
 			}
 			subtitle={
-				<Text>
+				<Text style={ { wordBreak: 'break-all' } }>
 					{ translate( '%(subdomain)s{{strong}}.%(domainName)s{{/strong}} is included', {
 						args: {
 							subdomain: subdomain,
 							domainName: tlds.join( '.' ),
 						},
 						components: {
-							strong: <strong />,
+							strong: <strong style={ { whiteSpace: 'nowrap' } } />,
 						},
 					} ) }
 				</Text>

--- a/client/components/domain-search-v2/domain-skip-suggestion/index.tsx
+++ b/client/components/domain-search-v2/domain-skip-suggestion/index.tsx
@@ -28,16 +28,20 @@ const DomainSkipSuggestion = ( { domain, onSkip }: Props ) => {
 				</Heading>
 			}
 			subtitle={
-				<Text style={ { wordBreak: 'break-all' } }>
-					{ translate( '%(subdomain)s{{strong}}.%(domainName)s{{/strong}} is included', {
-						args: {
-							subdomain: subdomain,
-							domainName: tlds.join( '.' ),
-						},
-						components: {
-							strong: <strong style={ { whiteSpace: 'nowrap' } } />,
-						},
-					} ) }
+				<Text>
+					{ translate(
+						'{{domain}}%(subdomain)s{{strong}}.%(domainName)s{{/strong}}{{/domain}} is included',
+						{
+							args: {
+								subdomain: subdomain,
+								domainName: tlds.join( '.' ),
+							},
+							components: {
+								domain: <span style={ { wordBreak: 'break-all' } } />,
+								strong: <strong style={ { whiteSpace: 'nowrap' } } />,
+							},
+						}
+					) }
 				</Text>
 			}
 			right={

--- a/client/components/domain-search-v2/domain-skip-suggestion/style.scss
+++ b/client/components/domain-search-v2/domain-skip-suggestion/style.scss
@@ -6,11 +6,7 @@
 		flex-direction: row;
 		justify-content: space-between;
 		align-items: center;
-		gap: 0.5rem;
-
-		@media ( max-width: $break-mobile ) {
-			padding: 1rem;
-		}
+		gap: 1rem;
 	}
 
 	.subdomain-skip-suggestion__content {

--- a/client/components/domain-search-v2/free-domain-for-a-year-promo/index.tsx
+++ b/client/components/domain-search-v2/free-domain-for-a-year-promo/index.tsx
@@ -1,4 +1,4 @@
-import { useContainerQuery } from '@automattic/domain-search';
+import { useDomainSuggestionContainer } from '@automattic/domain-search';
 import {
 	Card,
 	CardBody,
@@ -13,10 +13,7 @@ import freeDomainForAYearPromoImage from './graphic.svg';
 import './style.scss';
 
 export const FreeDomainForAYearPromo = ( { textOnly = false } ) => {
-	const { ref, activeQuery } = useContainerQuery( {
-		small: 0,
-		large: 600,
-	} );
+	const { containerRef, activeQuery } = useDomainSuggestionContainer();
 
 	const { __ } = useI18n();
 
@@ -40,7 +37,7 @@ export const FreeDomainForAYearPromo = ( { textOnly = false } ) => {
 	);
 
 	return (
-		<Card ref={ ref } size="small" className="free-domain-for-a-year-promo">
+		<Card ref={ containerRef } size="small" className="free-domain-for-a-year-promo">
 			<CardBody className="free-domain-for-a-year-promo__body">
 				<HStack spacing={ 6 } alignment="left">
 					{ activeQuery === 'large' && (

--- a/packages/domain-search/src/components/domain-suggestion/featured.tsx
+++ b/packages/domain-search/src/components/domain-suggestion/featured.tsx
@@ -50,7 +50,8 @@ const Featured = ( {
 
 	const title = (
 		<Text size={ activeQuery === 'large' ? 32 : 24 } style={ { wordBreak: 'break-all' } }>
-			{ domain }.{ tld }
+			{ domain }
+			<span style={ { whiteSpace: 'nowrap' } }>.{ tld }</span>
 		</Text>
 	);
 

--- a/packages/domain-search/src/components/domain-suggestion/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion/index.tsx
@@ -60,7 +60,7 @@ const DomainSuggestionComponent = ( {
 					} }
 				>
 					{ domain }
-					<Text size="inherit" weight={ 500 }>
+					<Text size="inherit" weight={ 500 } style={ { whiteSpace: 'nowrap' } }>
 						.{ tld }
 					</Text>
 				</span>

--- a/packages/domain-search/src/components/domain-suggestion/unavailable.tsx
+++ b/packages/domain-search/src/components/domain-suggestion/unavailable.tsx
@@ -42,13 +42,17 @@ const UnavailableComponent = ( {
 
 	const reasonText = useMemo( () => {
 		const styledTld = (
-			<Text size="inherit" weight={ 500 }>
+			<Text size="inherit" weight={ 500 } style={ { whiteSpace: 'nowrap' } }>
 				.{ tld }
 			</Text>
 		);
 
 		const styledDomain = (
-			<Text size="inherit" aria-label={ `${ domain }.${ tld }` }>
+			<Text
+				size="inherit"
+				aria-label={ `${ domain }.${ tld }` }
+				style={ { wordBreak: 'break-all' } }
+			>
 				{ domain }
 				{ styledTld }
 			</Text>

--- a/packages/domain-search/src/components/domains-full-cart-items/item.tsx
+++ b/packages/domain-search/src/components/domains-full-cart-items/item.tsx
@@ -26,9 +26,13 @@ export const DomainsFullCartItem = ( { domain }: { domain: SelectedDomain } ) =>
 				<VStack spacing={ 4 }>
 					<HStack alignment="top" justify="space-between" spacing={ 6 }>
 						<VStack spacing={ 2 } alignment="left">
-							<Text size="medium" aria-label={ `${ domain.domain }.${ domain.tld }` }>
+							<Text
+								size="medium"
+								aria-label={ `${ domain.domain }.${ domain.tld }` }
+								style={ { wordBreak: 'break-all' } }
+							>
 								{ domain.domain }
-								<Text size="inherit" weight={ 500 }>
+								<Text size="inherit" weight={ 500 } style={ { whiteSpace: 'nowrap' } }>
 									.{ domain.tld }
 								</Text>
 							</Text>

--- a/packages/domain-search/src/components/domains-full-cart/style.scss
+++ b/packages/domain-search/src/components/domains-full-cart/style.scss
@@ -12,7 +12,7 @@
 
 	@include break-small {
 		left: initial;
-		max-width: 22.25rem;
+		max-width: 26.5rem;
 	}
 }
 

--- a/packages/domain-search/src/index.ts
+++ b/packages/domain-search/src/index.ts
@@ -13,5 +13,5 @@ export { DomainSuggestionLoadMore } from './components/domain-suggestion-load-mo
 export { DomainSuggestionFilterReset } from './components/domain-suggestion-filter-reset';
 export * as DomainSearchControls from './components/domain-search-controls';
 
-export { useContainerQuery } from './hooks/use-container-query';
+export { useDomainSuggestionContainer } from './hooks/use-domain-suggestion-container';
 export { useTypedPlaceholder } from './hooks/use-typed-placeholder';


### PR DESCRIPTION
Closes DOMAINS-1568. Closes DOMAINS-1569.

## Proposed Changes

| Search | Cart |
| --- | --- |
| <img width="343" height="742" alt="Screenshot at Jul 28 15-35-08" src="https://github.com/user-attachments/assets/9d36bd0c-25a2-4a88-b68c-dbe834e5f79d" /> | <img width="465" height="584" alt="Screenshot at Jul 28 15-35-45" src="https://github.com/user-attachments/assets/b93a3679-2b42-4df7-8e43-77a312cfbe8d" /> |


## Testing Instructions

Search for very long domain names and add them to the cart. Verify that the TLD doesn't break in the middle and that the full domain respects the element boundaries (i.e., they don't overflow their container.)
