### PR TITLE
Purchase Management: Disable filtering for non-filterable columns

### DIFF
--- a/client/me/purchases/billing-history/field-definitions.tsx
+++ b/client/me/purchases/billing-history/field-definitions.tsx
@@ -1,4 +1,4 @@
-import { type Operator } from '@wordpress/dataviews';
+import { type Fields, type Operator } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { capitalPDangit } from 'calypso/lib/formatting';
 import { isInternalA4AAgencyDomain } from 'calypso/me/purchases/utils';
@@ -116,13 +116,12 @@ export function getFieldDefinitions(
 	transactions: BillingTransaction[] | null,
 	translate: ReturnType< typeof useTranslate >,
 	getReceiptUrlFor: ( receiptId: string ) => string
-) {
-	return {
-		date: {
+): Fields< BillingTransaction > {
+	return [
+		{
 			id: 'date',
 			label: translate( 'Date' ),
 			type: 'text' as const,
-			width: '15%',
 			elements: getUniqueMonths( transactions ?? [] ),
 			enableGlobalSearch: true,
 			enableSorting: true,
@@ -137,11 +136,10 @@ export function getFieldDefinitions(
 				return <time>{ formatDisplayDate( new Date( item.date ) ) }</time>;
 			},
 		},
-		service: {
+		{
 			id: 'service',
 			label: translate( 'App' ),
 			type: 'text' as const,
-			width: '45%',
 			elements: getUniqueServices( transactions ?? [] ),
 			enableGlobalSearch: true,
 			enableSorting: true,
@@ -169,11 +167,10 @@ export function getFieldDefinitions(
 				return capitalPDangit( transactionItem.variation );
 			},
 		},
-		type: {
+		{
 			id: 'type',
 			label: translate( 'Type' ),
 			type: 'text' as const,
-			width: '20%',
 			elements: getUniqueTransactionTypes( transactions ?? [] ),
 			enableGlobalSearch: true,
 			enableSorting: true,
@@ -190,11 +187,10 @@ export function getFieldDefinitions(
 				return transactionItem.type;
 			},
 		},
-		amount: {
+		{
 			id: 'amount',
 			label: translate( 'Amount' ),
 			type: 'text' as const,
-			width: '20%',
 			enableGlobalSearch: true,
 			enableSorting: true,
 			enableHiding: false,
@@ -206,5 +202,5 @@ export function getFieldDefinitions(
 				return <TransactionAmount transaction={ item } />;
 			},
 		},
-	};
+	];
 }

--- a/client/me/purchases/billing-history/field-definitions.tsx
+++ b/client/me/purchases/billing-history/field-definitions.tsx
@@ -198,9 +198,7 @@ export function getFieldDefinitions(
 			enableGlobalSearch: true,
 			enableSorting: true,
 			enableHiding: false,
-			filterBy: {
-				operators: [ 'is' as Operator ],
-			},
+			filterBy: false,
 			getValue: ( { item }: { item: BillingTransaction } ) => {
 				return item.amount_integer;
 			},

--- a/client/me/purchases/billing-history/hooks/use-field-definitions.ts
+++ b/client/me/purchases/billing-history/hooks/use-field-definitions.ts
@@ -10,7 +10,6 @@ export function useFieldDefinitions(
 	const translate = useTranslate();
 
 	return useMemo( () => {
-		const fieldDefinitions = getFieldDefinitions( transactions, translate, getReceiptUrlFor );
-		return Object.values( fieldDefinitions );
+		return getFieldDefinitions( transactions, translate, getReceiptUrlFor );
 	}, [ transactions, translate, getReceiptUrlFor ] );
 }

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -113,7 +113,7 @@ export function getPurchasesFieldDefinitions( {
 						label: `${ site.name } (${ site.domain })`,
 				  } ) )
 				: undefined,
-			filterBy: shouldAllowSiteFiltering ? { operators: [ 'isAny' ] } : undefined,
+			filterBy: shouldAllowSiteFiltering ? { operators: [ 'isAny' ] } : false,
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
 				// getValue must return a string because the DataViews search feature calls `trim()` on it.
 				return String( item.siteId );

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -139,6 +139,7 @@ export function getPurchasesFieldDefinitions( {
 			enableGlobalSearch: true,
 			enableSorting: true,
 			enableHiding: false,
+			filterBy: false,
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
 				// Render a bunch of things to make this easily searchable.
 				const site = sites.find( ( site ) => site.ID === item.siteId );
@@ -192,6 +193,7 @@ export function getPurchasesFieldDefinitions( {
 			enableGlobalSearch: true,
 			enableSorting: true,
 			enableHiding: false,
+			filterBy: false,
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
 				// Render a bunch of things to make this easily searchable.
 				const site = sites.find( ( site ) => site.ID === item.siteId );
@@ -291,6 +293,7 @@ export function getPurchasesFieldDefinitions( {
 			enableGlobalSearch: true,
 			enableSorting: true,
 			enableHiding: false,
+			filterBy: false,
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
 				if ( isExpired( item ) ) {
 					// Prefix expired items with a z so they sort to the end of the list.
@@ -312,6 +315,7 @@ export function getPurchasesFieldDefinitions( {
 			enableGlobalSearch: true,
 			enableSorting: true,
 			enableHiding: false,
+			filterBy: false,
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
 				// This should not be possible. Investigating a bug:
 				// https://linear.app/a8c/issue/SHILL-901/
@@ -381,6 +385,7 @@ export function getMembershipsFieldDefinitions( {
 			enableGlobalSearch: true,
 			enableSorting: false,
 			enableHiding: false,
+			filterBy: false,
 			getValue: ( { item }: { item: MembershipSubscription } ) => {
 				return item.site_id + ' ' + item.site_title + ' ' + item.site_url;
 			},
@@ -403,6 +408,7 @@ export function getMembershipsFieldDefinitions( {
 			enableGlobalSearch: true,
 			enableSorting: true,
 			enableHiding: false,
+			filterBy: false,
 			getValue: ( { item }: { item: MembershipSubscription } ) => {
 				return item.title + ' ' + item.site_title + ' ' + item.site_url;
 			},
@@ -434,6 +440,7 @@ export function getMembershipsFieldDefinitions( {
 			enableGlobalSearch: true,
 			enableSorting: true,
 			enableHiding: false,
+			filterBy: false,
 			getValue: ( { item }: { item: MembershipSubscription } ) => {
 				return item.title + ' ' + item.site_title + ' ' + item.site_url;
 			},
@@ -454,6 +461,7 @@ export function getMembershipsFieldDefinitions( {
 			enableGlobalSearch: true,
 			enableSorting: false,
 			enableHiding: false,
+			filterBy: false,
 			getValue: ( { item }: { item: MembershipSubscription } ) => {
 				return item.end_date ?? '';
 			},

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -97,6 +97,8 @@ export function getPurchasesFieldDefinitions( {
 		return getManagePurchaseUrlFor( siteUrl, subscriptionId );
 	};
 
+	// No point in having a filter if there's only one site.
+	const shouldAllowSiteFiltering = sites.length > 1;
 	const fields: Fields< Purchases.Purchase > = [
 		{
 			id: 'site',
@@ -105,16 +107,13 @@ export function getPurchasesFieldDefinitions( {
 			enableGlobalSearch: true,
 			enableSorting: true,
 			enableHiding: false,
-			elements: ( () => {
-				if ( sites.length < 2 ) {
-					// No point in having a filter if there's only one site.
-					return undefined;
-				}
-				return sites.map( ( site ) => {
-					return { value: String( site.ID ), label: `${ site.name } (${ site.domain })` };
-				} );
-			} )(),
-			filterBy: { operators: [ 'isAny' ] },
+			elements: shouldAllowSiteFiltering
+				? sites.map( ( site ) => ( {
+						value: String( site.ID ),
+						label: `${ site.name } (${ site.domain })`,
+				  } ) )
+				: undefined,
+			filterBy: shouldAllowSiteFiltering ? { operators: [ 'isAny' ] } : undefined,
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
 				// getValue must return a string because the DataViews search feature calls `trim()` on it.
 				return String( item.siteId );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CHE-239/active-subscriptions-and-billing-history-fields-need-to-opt-out-of

## Proposed Changes

This PR explicitly opts-out of filtering for fields which are not designed to be filtered (they have no `elements` property) in the active subscriptions list and the billing history list DataViews.

Before             |  After
:-------------------------:|:-------------------------:
<img width="415" height="432" alt="Screenshot 2025-07-28 at 5 09 47 PM" src="https://github.com/user-attachments/assets/473d4289-d181-41ae-8525-2dcd22d6897a" /> |  <img width="410" height="270" alt="Screenshot 2025-07-28 at 5 08 19 PM" src="https://github.com/user-attachments/assets/cd86d81c-ecb9-4da6-8180-645176bae560" />
<img width="403" height="316" alt="Screenshot 2025-07-28 at 5 09 56 PM" src="https://github.com/user-attachments/assets/0b67aa7a-befe-4f05-94ae-8697a307d945" /> | <img width="402" height="201" alt="Screenshot 2025-07-28 at 5 09 09 PM" src="https://github.com/user-attachments/assets/c2eeee5f-976c-4259-8a71-57f1a58abb50" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

A recent change to `@wordpress/dataviews` made filtering of a Field opt-out instead of opt-in ([see changelog for 5.0 here](https://github.com/WordPress/gutenberg/blob/911beccf1d73d8ce00f9111fe128588959a550c5/packages/dataviews/CHANGELOG.md#500-2025-07-23)). This created weird broken UX for fields which are not designed to be filtered.

Example:

<img width="447" height="319" alt="Screenshot 2025-07-28 at 4 49 29 PM" src="https://github.com/user-attachments/assets/3abf537e-e43c-4c0e-9dac-13beacb8bfc4" />


## Testing Instructions

- Visit `/me/purchases` and click the filter icon next to the search field.
- Verify that you only see "Expiring soon", "Site" (if you have more than 1 site), and "Type".
- Visit `/me/purchases/billing-history` and click the filter icon next to the search field.
- Verify that you only see "App", "Date", and "Type".
