### PR TITLE
Stats: Fix TS errors for Line Chart

### DIFF
--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -1,4 +1,4 @@
-import { LineChart, ThemeProvider, jetpackTheme } from '@automattic/charts';
+import { LineChart, ThemeProvider, jetpackTheme, EventHandlerParams } from '@automattic/charts';
 import { DataPointDate } from '@automattic/charts/src/types';
 import { formatNumber } from '@automattic/number-formatters';
 import clsx from 'clsx';
@@ -174,7 +174,7 @@ function StatsLineChart( {
 	);
 
 	const onPointerUp = useCallback(
-		( { datum }: { datum: DataPointDate } ) => {
+		( { datum }: EventHandlerParams< DataPointDate > ) => {
 			if ( datum && datum.date ) {
 				onClick && onClick( { data: { period: moment( datum.date ).format( DATE_FORMAT ) } } );
 			}
@@ -193,9 +193,7 @@ function StatsLineChart( {
 						withGradientFill
 						height={ height }
 						curveType={ curveType }
-						// TODO: figure out the right type for onPointerDown
-						// eslint-disable-next-line @typescript-eslint/no-explicit-any
-						onPointerUp={ onPointerUp as any }
+						onPointerUp={ onPointerUp }
 						margin={ {
 							left: 20,
 							top: 20,

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -1,5 +1,10 @@
-import { LineChart, ThemeProvider, jetpackTheme, EventHandlerParams } from '@automattic/charts';
-import { DataPointDate } from '@automattic/charts/src/types';
+import {
+	LineChart,
+	ThemeProvider,
+	jetpackTheme,
+	EventHandlerParams,
+	DataPointDate,
+} from '@automattic/charts';
 import { formatNumber } from '@automattic/number-formatters';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -2,8 +2,8 @@ import {
 	LineChart,
 	ThemeProvider,
 	jetpackTheme,
-	EventHandlerParams,
-	DataPointDate,
+	type EventHandlerParams,
+	type DataPointDate,
 } from '@automattic/charts';
 import { formatNumber } from '@automattic/number-formatters';
 import clsx from 'clsx';

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
 		"@automattic/calypso-products": "workspace:^",
 		"@automattic/calypso-razorpay": "workspace:^",
 		"@automattic/calypso-router": "workspace:^",
-		"@automattic/charts": "^0.11.4",
+		"@automattic/charts": "^0.23.1",
 		"@automattic/color-studio": "^4.1.0",
 		"@automattic/command-palette": "workspace:^",
 		"@automattic/components": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -754,31 +754,37 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/charts@npm:^0.11.4":
-  version: 0.11.4
-  resolution: "@automattic/charts@npm:0.11.4"
+"@automattic/charts@npm:^0.23.1":
+  version: 0.23.1
+  resolution: "@automattic/charts@npm:0.23.1"
   dependencies:
-    "@babel/runtime": "npm:7.26.10"
-    "@react-spring/web": "npm:9.7.3"
+    "@automattic/number-formatters": "npm:^1.0.10"
+    "@babel/runtime": "npm:7.27.6"
+    "@react-spring/web": "npm:9.7.5"
+    "@visx/annotation": "npm:^3.12.0"
     "@visx/axis": "npm:^3.12.0"
-    "@visx/curve": "npm:3.12.0"
-    "@visx/event": "npm:^3.8.0"
-    "@visx/gradient": "npm:3.12.0"
+    "@visx/curve": "npm:^3.12.0"
+    "@visx/event": "npm:^3.12.0"
+    "@visx/gradient": "npm:^3.12.0"
     "@visx/grid": "npm:^3.12.0"
     "@visx/group": "npm:^3.12.0"
     "@visx/legend": "npm:^3.12.0"
-    "@visx/responsive": "npm:3.12.0"
+    "@visx/pattern": "npm:^3.12.0"
+    "@visx/responsive": "npm:^3.12.0"
     "@visx/scale": "npm:^3.12.0"
     "@visx/shape": "npm:^3.12.0"
-    "@visx/text": "npm:3.12.0"
-    "@visx/tooltip": "npm:^3.8.0"
-    "@visx/xychart": "npm:3.12.0"
+    "@visx/text": "npm:^3.12.0"
+    "@visx/tooltip": "npm:^3.12.0"
+    "@visx/xychart": "npm:^3.12.0"
     clsx: "npm:2.1.1"
+    date-fns: "npm:^4.1.0"
+    deepmerge: "npm:4.3.1"
+    gridicons: "npm:3.4.2"
     tslib: "npm:2.5.0"
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-  checksum: 523787f199979c2c5af458eae078f2f1809b7a9a41913531161e905a39a56f6833c3b998bfe314619e199f6ed3b39b5b04b40d1cd5230f82009da33280059876
+  checksum: b8557f87b40306506902e4e32cbb879effc90d6fe6f84f2873bdf8a19d566825b6aac48721e8109a1db11a957111c712bee507b94bf490960888cff9c498dd0b
   languageName: node
   linkType: hard
 
@@ -1685,6 +1691,17 @@ __metadata:
     debug: "npm:^4.4.0"
     tslib: "npm:^2.5.0"
   checksum: eb3823c04ea85d6bbdc786ba33501c2b07c6e8f9ff15d45027859b59f25a666dd739c33a2aee6b71034f3eddb326678c71bf3855732c6857ab40b64fcaae67dd
+  languageName: node
+  linkType: hard
+
+"@automattic/number-formatters@npm:^1.0.10":
+  version: 1.0.10
+  resolution: "@automattic/number-formatters@npm:1.0.10"
+  dependencies:
+    "@wordpress/date": "npm:^5.19.0"
+    debug: "npm:^4.4.0"
+    tslib: "npm:^2.5.0"
+  checksum: 60c9f8463d646c912df1a5a1df42d3eb772a878c78f00c628215312e79c35019076b75b9e207a12cb7e05ff0497b86fabda34ec1dd5fdd70b9a971e0b9cb1493
   languageName: node
   linkType: hard
 
@@ -4115,12 +4132,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:7.26.10":
-  version: 7.26.10
-  resolution: "@babel/runtime@npm:7.26.10"
-  dependencies:
-    regenerator-runtime: "npm:^0.14.0"
-  checksum: 6dc6d88c7908f505c4f7770fb4677dfa61f68f659b943c2be1f2a99cb6680343462867abf2d49822adc435932919b36c77ac60125793e719ea8745f2073d3745
+"@babel/runtime@npm:7.27.6":
+  version: 7.27.6
+  resolution: "@babel/runtime@npm:7.27.6"
+  checksum: 89726be83f356f511dcdb74d3ea4d873a5f0cf0017d4530cb53aa27380c01ca102d573eff8b8b77815e624b1f8c24e7f0311834ad4fb632c90a770fda00bd4c8
   languageName: node
   linkType: hard
 
@@ -7934,7 +7949,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-spring/core@npm:~9.7.3":
+"@react-spring/core@npm:~9.7.3, @react-spring/core@npm:~9.7.5":
   version: 9.7.5
   resolution: "@react-spring/core@npm:9.7.5"
   dependencies:
@@ -7973,7 +7988,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-spring/web@npm:9.7.3, @react-spring/web@npm:^9.4.5":
+"@react-spring/web@npm:9.7.5":
+  version: 9.7.5
+  resolution: "@react-spring/web@npm:9.7.5"
+  dependencies:
+    "@react-spring/animated": "npm:~9.7.5"
+    "@react-spring/core": "npm:~9.7.5"
+    "@react-spring/shared": "npm:~9.7.5"
+    "@react-spring/types": "npm:~9.7.5"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: bcd1e052e1b16341a12a19bf4515f153ca09d1fa86ff7752a5d02d7c4db58e8baf80e6283e64411f1e388c65340dce2254b013083426806b5dbae38bd151e53e
+  languageName: node
+  linkType: hard
+
+"@react-spring/web@npm:^9.4.5":
   version: 9.7.3
   resolution: "@react-spring/web@npm:9.7.3"
   dependencies:
@@ -10979,7 +11009,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@visx/annotation@npm:3.12.0":
+"@visx/annotation@npm:3.12.0, @visx/annotation@npm:^3.12.0":
   version: 3.12.0
   resolution: "@visx/annotation@npm:3.12.0"
   dependencies:
@@ -11028,7 +11058,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@visx/curve@npm:3.12.0":
+"@visx/curve@npm:3.12.0, @visx/curve@npm:^3.12.0":
   version: 3.12.0
   resolution: "@visx/curve@npm:3.12.0"
   dependencies:
@@ -11052,7 +11082,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@visx/event@npm:3.12.0, @visx/event@npm:^3.8.0":
+"@visx/event@npm:3.12.0, @visx/event@npm:^3.12.0":
   version: 3.12.0
   resolution: "@visx/event@npm:3.12.0"
   dependencies:
@@ -11078,7 +11108,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@visx/gradient@npm:3.12.0":
+"@visx/gradient@npm:^3.12.0":
   version: 3.12.0
   resolution: "@visx/gradient@npm:3.12.0"
   dependencies:
@@ -11136,6 +11166,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@visx/pattern@npm:^3.12.0":
+  version: 3.12.0
+  resolution: "@visx/pattern@npm:3.12.0"
+  dependencies:
+    "@types/react": "npm:*"
+    classnames: "npm:^2.3.1"
+    prop-types: "npm:^15.5.10"
+  peerDependencies:
+    react: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
+  checksum: 1c4f982e0752e03fdfb07419be67c8720be57df28eab183e0dd590826ab915bab2287225fbe9709952449fbee7ee1a4c5c80afd3d97e2b9e5cf4037d40f3d669
+  languageName: node
+  linkType: hard
+
 "@visx/point@npm:3.12.0":
   version: 3.12.0
   resolution: "@visx/point@npm:3.12.0"
@@ -11161,7 +11204,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@visx/responsive@npm:3.12.0":
+"@visx/responsive@npm:3.12.0, @visx/responsive@npm:^3.12.0":
   version: 3.12.0
   resolution: "@visx/responsive@npm:3.12.0"
   dependencies:
@@ -11206,7 +11249,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@visx/text@npm:3.12.0":
+"@visx/text@npm:3.12.0, @visx/text@npm:^3.12.0":
   version: 3.12.0
   resolution: "@visx/text@npm:3.12.0"
   dependencies:
@@ -11222,7 +11265,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@visx/tooltip@npm:3.12.0, @visx/tooltip@npm:^3.8.0":
+"@visx/tooltip@npm:3.12.0, @visx/tooltip@npm:^3.12.0":
   version: 3.12.0
   resolution: "@visx/tooltip@npm:3.12.0"
   dependencies:
@@ -11280,7 +11323,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@visx/xychart@npm:3.12.0":
+"@visx/xychart@npm:^3.12.0":
   version: 3.12.0
   resolution: "@visx/xychart@npm:3.12.0"
   dependencies:
@@ -17699,7 +17742,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deepmerge@npm:^4.2.2, deepmerge@npm:^4.3.0, deepmerge@npm:^4.3.1":
+"deepmerge@npm:4.3.1, deepmerge@npm:^4.2.2, deepmerge@npm:^4.3.0, deepmerge@npm:^4.3.1":
   version: 4.3.1
   resolution: "deepmerge@npm:4.3.1"
   checksum: e53481aaf1aa2c4082b5342be6b6d8ad9dfe387bc92ce197a66dea08bd4265904a087e75e464f14d1347cf2ac8afe1e4c16b266e0561cc5df29382d3c5f80044
@@ -21494,7 +21537,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gridicons@npm:^3.4.2":
+"gridicons@npm:3.4.2, gridicons@npm:^3.4.2":
   version: 3.4.2
   resolution: "gridicons@npm:3.4.2"
   dependencies:
@@ -37909,7 +37952,7 @@ __metadata:
     "@automattic/calypso-razorpay": "workspace:^"
     "@automattic/calypso-router": "workspace:^"
     "@automattic/calypso-storybook": "workspace:^"
-    "@automattic/charts": "npm:^0.11.4"
+    "@automattic/charts": "npm:^0.23.1"
     "@automattic/color-studio": "npm:^4.1.0"
     "@automattic/command-palette": "workspace:^"
     "@automattic/components": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1683,18 +1683,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/number-formatters@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "@automattic/number-formatters@npm:1.0.2"
-  dependencies:
-    "@wordpress/date": "npm:^5.19.0"
-    debug: "npm:^4.4.0"
-    tslib: "npm:^2.5.0"
-  checksum: eb3823c04ea85d6bbdc786ba33501c2b07c6e8f9ff15d45027859b59f25a666dd739c33a2aee6b71034f3eddb326678c71bf3855732c6857ab40b64fcaae67dd
-  languageName: node
-  linkType: hard
-
-"@automattic/number-formatters@npm:^1.0.10":
+"@automattic/number-formatters@npm:^1.0.1, @automattic/number-formatters@npm:^1.0.10":
   version: 1.0.10
   resolution: "@automattic/number-formatters@npm:1.0.10"
   dependencies:
@@ -4132,17 +4121,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:7.27.6":
+"@babel/runtime@npm:7.27.6, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.25.9, @babel/runtime@npm:^7.27.1, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.9.2":
   version: 7.27.6
   resolution: "@babel/runtime@npm:7.27.6"
   checksum: 89726be83f356f511dcdb74d3ea4d873a5f0cf0017d4530cb53aa27380c01ca102d573eff8b8b77815e624b1f8c24e7f0311834ad4fb632c90a770fda00bd4c8
-  languageName: node
-  linkType: hard
-
-"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.25.9, @babel/runtime@npm:^7.27.1, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.9.2":
-  version: 7.27.1
-  resolution: "@babel/runtime@npm:7.27.1"
-  checksum: 530a7332f86ac5a7442250456823a930906911d895c0b743bf1852efc88a20a016ed4cd26d442d0ca40ae6d5448111e02a08dd638a4f1064b47d080e2875dc05
   languageName: node
   linkType: hard
 
@@ -7937,7 +7919,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-spring/animated@npm:~9.7.3, @react-spring/animated@npm:~9.7.5":
+"@react-spring/animated@npm:~9.7.5":
   version: 9.7.5
   resolution: "@react-spring/animated@npm:9.7.5"
   dependencies:
@@ -7949,7 +7931,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-spring/core@npm:~9.7.3, @react-spring/core@npm:~9.7.5":
+"@react-spring/core@npm:~9.7.5":
   version: 9.7.5
   resolution: "@react-spring/core@npm:9.7.5"
   dependencies:
@@ -7969,7 +7951,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-spring/shared@npm:~9.7.3, @react-spring/shared@npm:~9.7.5":
+"@react-spring/shared@npm:~9.7.5":
   version: 9.7.5
   resolution: "@react-spring/shared@npm:9.7.5"
   dependencies:
@@ -7981,14 +7963,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-spring/types@npm:~9.7.3, @react-spring/types@npm:~9.7.5":
+"@react-spring/types@npm:~9.7.5":
   version: 9.7.5
   resolution: "@react-spring/types@npm:9.7.5"
   checksum: 85c05121853cacb64f7cf63a4855e9044635e1231f70371cd7b8c78bc10be6f4dd7c68f592f92a2607e8bb68051540989b4677a2ccb525dba937f5cd95dc8bc1
   languageName: node
   linkType: hard
 
-"@react-spring/web@npm:9.7.5":
+"@react-spring/web@npm:9.7.5, @react-spring/web@npm:^9.4.5":
   version: 9.7.5
   resolution: "@react-spring/web@npm:9.7.5"
   dependencies:
@@ -8000,21 +7982,6 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: bcd1e052e1b16341a12a19bf4515f153ca09d1fa86ff7752a5d02d7c4db58e8baf80e6283e64411f1e388c65340dce2254b013083426806b5dbae38bd151e53e
-  languageName: node
-  linkType: hard
-
-"@react-spring/web@npm:^9.4.5":
-  version: 9.7.3
-  resolution: "@react-spring/web@npm:9.7.3"
-  dependencies:
-    "@react-spring/animated": "npm:~9.7.3"
-    "@react-spring/core": "npm:~9.7.3"
-    "@react-spring/shared": "npm:~9.7.3"
-    "@react-spring/types": "npm:~9.7.3"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: a5b4847a2921a29a3e8ce569f4951abeb268b6e8eb230f8c49d98709216b2b3a23ba1e58628c51c9eaa0bd20d83f9d7b8f8f03df98215e933de4c66c39e17fe1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [CHARTS-9: Line Charts: fix TS error for `onPointerDown` and other errors](https://linear.app/a8c/issue/CHARTS-9/line-charts-fix-ts-error-for-onpointerdown-and-other-errors)

## Proposed Changes

* Fixes TS errors in Stats Line Chart by importing new types from the `@automattic/charts` package

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We were ignoring TS errors in the Stats Line Chart implementation
* Upgrading the charts library also provides significant new capability and bug fixes

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Regression test any stats line charts

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
