### PR TITLE
Staging Sites Redesign: Add tooltip explaining database sync implications in the Sync modal

### DIFF
--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -476,7 +476,7 @@ export default function SyncModal( {
 						/>
 						<Tooltip
 							text={ __(
-								'Overwrite the site database, including any posts, pages, products, or orders.'
+								'Selecting this option will overwrite the site database, including any posts, pages, products, or orders.'
 							) }
 						>
 							<Icon icon={ error } style={ { fill: 'var(--studio-orange-50)' } } />

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -474,7 +474,13 @@ export default function SyncModal( {
 							checked={ shouldDisableGranularSync || sqlNode?.checkState === 'checked' }
 							onChange={ handleDatabaseCheckboxChange }
 						/>
-						<Icon icon={ error } style={ { fill: 'var(--studio-orange-50)' } } />
+						<Tooltip
+							text={ __(
+								'Overwrite the site database, including any posts, pages, products, or orders.'
+							) }
+						>
+							<Icon icon={ error } style={ { fill: 'var(--studio-orange-50)' } } />
+						</Tooltip>
 					</HStack>
 					<VStack spacing={ 7 }>
 						<HStack alignment="left" spacing={ 1 }>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTCOM-14025

## Proposed Changes

* add tooltip explaining database sync implications in the Sync modal

<img width="2800" height="1988" alt="Markup on 2025-07-30 at 10:30:52" src="https://github.com/user-attachments/assets/e472765e-148d-4cf7-8c33-50b917c4ffe1" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* DOTCOM-14025

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start` (or use Calypso Live link).
2. Head over to a staging site, click the `Sync` dropdown button and pick any of the two options.
3. Once the Sync modal opens, hover over the `⚠️` icon by the `Database tables` checkbox and observe the tooltip.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
