### PR TITLE
Add flow_name for domain registration products in cart

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/hundred-year-domain/hundred-year-domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/hundred-year-domain/hundred-year-domain.ts
@@ -48,7 +48,7 @@ const HundredYearDomainFlow: Flow = {
 			const submittedDomainCartItem = domainRegistration( {
 				productSlug: productSlug as string,
 				domain: domainName as string,
-				extra: { is_hundred_year_domain: true },
+				extra: { is_hundred_year_domain: true, flow_name: HUNDRED_YEAR_DOMAIN_FLOW },
 				volume: 100,
 			} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -131,6 +131,7 @@ const DomainsStep: Step< {
 			const domainCartItem = domainRegistration( {
 				domain: suggestion.domain_name,
 				productSlug: suggestion.product_slug || '',
+				extra: { flow_name: flow },
 			} );
 			dispatch( submitDomainStepSelection( suggestion, getAnalyticsSection() ) );
 

--- a/client/me/domain-upsell/index.jsx
+++ b/client/me/domain-upsell/index.jsx
@@ -162,6 +162,9 @@ export function RenderDomainUpsell( {
 				domainRegistration( {
 					productSlug: domainSuggestionProductSlug,
 					domain: domainSuggestionName,
+					extra: {
+						flow_name: 'domain-upsell',
+					},
 				} ),
 			] );
 		} catch {

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -166,6 +166,9 @@ export function RenderDomainUpsell( {
 				domainRegistration( {
 					productSlug: domainSuggestionProductSlug,
 					domain: domainSuggestionName,
+					extra: {
+						flow_name: 'domain-upsell',
+					},
 				} ),
 			] );
 		} catch {

--- a/client/my-sites/customer-home/cards/tasks/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/domain-upsell/index.jsx
@@ -133,6 +133,9 @@ export function RenderDomainUpsell( { isFreePlan, isMonthlyPlan, searchTerm, sit
 				domainRegistration( {
 					productSlug: domainSuggestionProductSlug,
 					domain: domainSuggestionName,
+					extra: {
+						flow_name: 'domain-upsell',
+					},
 				} ),
 			] );
 		} catch {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -713,7 +713,7 @@ class RenderDomainsStepComponent extends Component {
 		let registration = domainRegistration( {
 			domain,
 			productSlug,
-			extra: { privacy_available: supportsPrivacy },
+			extra: { privacy_available: supportsPrivacy, flow_name: this.props.flowName },
 		} );
 
 		if ( supportsPrivacy ) {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -518,6 +518,7 @@ class RenderDomainsStepComponent extends Component {
 				productSlug: suggestion.product_slug,
 				extra: {
 					is_gravatar_domain: true,
+					flow_name: this.props.flowName,
 				},
 			} );
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -153,7 +153,11 @@ class RenderDomainsStepComponent extends Component {
 		) {
 			this.skipRender = true;
 			const productSlug = getDomainProductSlug( domain );
-			const domainItem = domainRegistration( { productSlug, domain } );
+			const domainItem = domainRegistration( {
+				productSlug,
+				domain,
+				extra: { flow_name: props.flowName },
+			} );
 			const domainCart = shouldUseMultipleDomainsInCart( props.flowName )
 				? getDomainsInCart( this.props.cart )
 				: {};
@@ -479,6 +483,7 @@ class RenderDomainsStepComponent extends Component {
 			? domainRegistration( {
 					domain: suggestion.domain_name,
 					productSlug: suggestion.product_slug,
+					extra: { flow_name: this.props.flowName },
 			  } )
 			: undefined;
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -972,6 +972,7 @@ class RenderDomainsStepComponent extends Component {
 			domainItem = domainRegistration( {
 				domain: selectedDomain?.domain_name || selectedDomain?.meta,
 				productSlug: selectedDomain?.product_slug,
+				extra: { flow_name: this.props.flowName },
 			} );
 		}
 

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -174,7 +174,11 @@ class SiteOrDomain extends Component {
 		const domain = this.getDomainName();
 		const domainCart = this.getDomainCart();
 		const productSlug = getDomainProductSlug( domain );
-		const domainItem = domainRegistration( { productSlug, domain } );
+		const domainItem = domainRegistration( {
+			productSlug,
+			domain,
+			extra: { flow_name: this.props.flowName },
+		} );
 		const siteUrl = domain;
 
 		this.props.submitSignupStep(

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -957,6 +957,7 @@ export interface RequestCartProductExtra extends ResponseCartProductExtra {
 	headstart_theme?: string;
 	feature_slug?: string;
 	is_hundred_year_domain?: boolean;
+	flow_name?: string;
 
 	/**
 	 * A way to signal intent to the back end when included as an extra with

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -957,6 +957,10 @@ export interface RequestCartProductExtra extends ResponseCartProductExtra {
 	headstart_theme?: string;
 	feature_slug?: string;
 	is_hundred_year_domain?: boolean;
+
+	/**
+	 * Tracks the flow from which a domain registration originated.
+	 */
 	flow_name?: string;
 
 	/**


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/DOMENG-56/add-flow-name-property-in-domain-registration-products

## Proposed Changes
This PR adds `flow_name` property in the `extra` array for domain registration products, when they are added to cart.

## Why are these changes being made?
We want to track the flow name in the `wpcom_register_domain` Tracks event (which is triggered in the backend after every successfully domain registration).

## Testing Instructions
Verify that the property is successfully added when the cart is created. Test a couple of flows, `onboarding` and `domain-only` should be enough.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
