### PR TITLE
Sites Overview v2: Implement Jetpack Plan card

### DIFF
--- a/client/dashboard/data/constants.ts
+++ b/client/dashboard/data/constants.ts
@@ -17,16 +17,29 @@ export enum DotcomPlans {
 export enum DotcomFeatures {
 	ATOMIC = 'atomic',
 	BACKUPS = 'backups',
-	SCAN = 'scan',
 	SUBSCRIPTION_GIFTING = 'subscription-gifting',
 	COPY_SITE = 'copy-site',
 	LEGACY_CONTACT = 'legacy-contact',
 	LOCKED_MODE = 'locked-mode',
+	SCAN = 'scan',
 	SECURITY_SETTINGS = 'security-settings',
 	SFTP = 'sftp',
 	SSH = 'ssh',
 	SITE_PREVIEW_LINKS = 'site-preview-links',
 	STAGING_SITES = 'staging-sites',
+}
+
+// Features that are used to identify the paid product.
+export enum JetpackFeatures {
+	ANTISPAM = 'antispam',
+	BACKUPS = 'backups',
+	CLOUD_CRITICAL_CSS = 'cloud-critical-css',
+	MONITOR = 'monitor',
+	SCAN = 'scan',
+	SOCIAL_ENHANCED_PUBLISHING = 'social-enhanced-publishing',
+	STATS = 'stats-paid',
+	SEARCH = 'search',
+	VIDEOPRESS = 'videopress',
 }
 
 // Features that needs Atomic or self-hosted infrastructure,
@@ -47,6 +60,6 @@ export enum HostingFeatures {
 }
 
 export enum JetpackModules {
-	STATS = 'stats',
 	MONITOR = 'monitor',
+	STATS = 'stats',
 }

--- a/client/dashboard/data/constants.ts
+++ b/client/dashboard/data/constants.ts
@@ -30,6 +30,7 @@ export enum DotcomFeatures {
 }
 
 // Features that are used to identify the paid product.
+// Feature slug extracted from https://github.com/Automattic/jetpack/tree/trunk/projects/packages/my-jetpack/src/products.
 export enum JetpackFeatures {
 	ANTISPAM = 'antispam',
 	BACKUPS = 'backups',
@@ -40,6 +41,11 @@ export enum JetpackFeatures {
 	STATS = 'stats-paid',
 	SEARCH = 'search',
 	VIDEOPRESS = 'videopress',
+}
+
+export enum JetpackModules {
+	MONITOR = 'monitor',
+	STATS = 'stats',
 }
 
 // Features that needs Atomic or self-hosted infrastructure,
@@ -57,9 +63,4 @@ export enum HostingFeatures {
 	SSH = DotcomFeatures.SSH,
 	STAGING_SITE = DotcomFeatures.STAGING_SITES,
 	STATIC_FILE_404 = DotcomFeatures.SFTP,
-}
-
-export enum JetpackModules {
-	MONITOR = 'monitor',
-	STATS = 'stats',
 }

--- a/client/dashboard/data/site-purchases.ts
+++ b/client/dashboard/data/site-purchases.ts
@@ -5,6 +5,7 @@ export interface Purchase {
 	active: boolean;
 	expiry_message: string;
 	is_cancelable: boolean;
+	partner_name: string;
 	product_slug: string;
 	user_id: string;
 }

--- a/client/dashboard/sites/fields.tsx
+++ b/client/dashboard/sites/fields.tsx
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import TimeSince from '../components/time-since';
 import { getSiteDisplayName } from '../utils/site-name';
+import { getSitePlanDisplayName } from '../utils/site-plan';
 import { getSiteProviderName, DEFAULT_PROVIDER_NAME } from '../utils/site-provider';
 import { STATUS_LABELS, getSiteStatus } from '../utils/site-status';
 import { getSiteDisplayUrl } from '../utils/site-url';
@@ -56,7 +57,7 @@ export const DEFAULT_FIELDS: Field< Site >[] = [
 	{
 		id: 'plan',
 		label: __( 'Plan' ),
-		getValue: ( { item } ) => item.plan?.product_name_short ?? '',
+		getValue: ( { item } ) => getSitePlanDisplayName( item ) ?? '',
 		render: ( { item } ) => <Plan site={ item } />,
 	},
 	{

--- a/client/dashboard/sites/overview-card/style.scss
+++ b/client/dashboard/sites/overview-card/style.scss
@@ -79,12 +79,15 @@
 }
 
 .dashboard-overview-card__link {
-	display: flex;
 	text-decoration: none;
-	flex-grow: 1;
 
-	.dashboard-overview-card__content {
-		flex: 1;
+	&:only-child {
+	    display: flex;
+	    flex-grow: 1;
+
+	    .dashboard-overview-card__content {
+	    	flex: 1;
+	    }
 	}
 
 	&:hover {

--- a/client/dashboard/sites/overview-plan-card/index.tsx
+++ b/client/dashboard/sites/overview-plan-card/index.tsx
@@ -1,21 +1,105 @@
+import { JetpackLogo } from '@automattic/components/src/logos/jetpack-logo';
 import { useQuery } from '@tanstack/react-query';
-import { __experimentalVStack as VStack } from '@wordpress/components';
+import {
+	__experimentalGrid as Grid,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	Icon,
+	Tooltip,
+} from '@wordpress/components';
 import { cloneElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
-import { wordpress } from '@wordpress/icons';
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	chartBar,
+	cloud,
+	megaphone,
+	next,
+	removeBug,
+	shield,
+	search,
+	video,
+	wordpress,
+} from '@wordpress/icons';
 import filesize from 'filesize';
 import { siteMediaStorageQuery } from '../../app/queries/site-media-storage';
 import { siteMetricsQuery } from '../../app/queries/site-metrics';
 import { siteCurrentPlanQuery } from '../../app/queries/site-plans';
 import { sitePurchaseQuery } from '../../app/queries/site-purchases';
 import { Stat } from '../../components/stat';
-import { DotcomPlans } from '../../data/constants';
+import { DotcomPlans, JetpackFeatures } from '../../data/constants';
+import { hasPlanFeature } from '../../utils/site-features';
+import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { getSiteDisplayUrl } from '../../utils/site-url';
 import OverviewCard from '../overview-card';
-import type { Site, Plan, Purchase } from '../../data/types';
+import type { Site, Purchase } from '../../data/types';
+
+import './style.scss';
 
 const MINIMUM_DISPLAYED_USAGE = 2.5;
 const ALERT_PERCENT = 80;
+
+const JETPACK_PRODUCTS = [
+	{
+		// See: https://github.com/Automattic/jetpack/blob/46e8a181299c296ac8e108daa2f2c6f9761a2d82/projects/packages/my-jetpack/src/products/class-stats.php#L82
+		id: JetpackFeatures.STATS,
+		icon: chartBar,
+		label: __( 'Stats' ),
+		description: __( 'Clear, concise, and actionable analysis of your site performance.' ),
+	},
+	{
+		// See: https://github.com/Automattic/jetpack/blob/46e8a181299c296ac8e108daa2f2c6f9761a2d82/projects/packages/my-jetpack/src/products/class-backup.php#L80
+		id: JetpackFeatures.BACKUPS,
+		icon: cloud,
+		label: __( 'VaultPress Backup' ),
+		description: __(
+			'Real-time backups save every change, and one-click restores get you back online quickly.'
+		),
+	},
+	{
+		// See: https://github.com/Automattic/jetpack/blob/46e8a181299c296ac8e108daa2f2c6f9761a2d82/projects/packages/my-jetpack/src/products/class-social.php#L78
+		id: JetpackFeatures.SOCIAL_ENHANCED_PUBLISHING,
+		icon: megaphone,
+		label: __( 'Social' ),
+		description: __(
+			'Auto‑share your posts to social networks and track engagement in one place.'
+		),
+	},
+	{
+		// See: https://github.com/Automattic/jetpack/blob/46e8a181299c296ac8e108daa2f2c6f9761a2d82/projects/packages/my-jetpack/src/products/class-boost.php#L87
+		id: JetpackFeatures.CLOUD_CRITICAL_CSS,
+		icon: next,
+		label: __( 'Boost' ),
+		description: __( 'Improves your site speed and performance.' ),
+	},
+	{
+		// See: https://github.com/Automattic/jetpack/blob/46e8a181299c296ac8e108daa2f2c6f9761a2d82/projects/packages/my-jetpack/src/products/class-anti-spam.php#L51
+		id: JetpackFeatures.ANTISPAM,
+		icon: removeBug,
+		label: __( 'Akismet Anti-spam' ),
+		description: __( 'Automatically clear spam from comments and forms.' ),
+	},
+	{
+		// See: https://github.com/Automattic/jetpack/blob/46e8a181299c296ac8e108daa2f2c6f9761a2d82/projects/packages/my-jetpack/src/products/class-search.php#L94
+		id: JetpackFeatures.SEARCH,
+		icon: search,
+		label: __( 'Search' ),
+		description: __( 'Instantly deliver the most relevant results to your visitors.' ),
+	},
+	{
+		// See: https://github.com/Automattic/jetpack/blob/46e8a181299c296ac8e108daa2f2c6f9761a2d82/projects/packages/my-jetpack/src/products/class-scan.php#L46
+		id: JetpackFeatures.SCAN,
+		icon: shield,
+		label: __( 'Scan' ),
+		description: __( 'Guard against malware and bad actors 24/7.' ),
+	},
+	{
+		// See: https://github.com/Automattic/jetpack/blob/46e8a181299c296ac8e108daa2f2c6f9761a2d82/projects/packages/my-jetpack/src/products/class-videopress.php#L88
+		id: JetpackFeatures.VIDEOPRESS,
+		icon: video,
+		label: __( 'VideoPress' ),
+		description: __( 'Powerful and flexible video hosting.' ),
+	},
+];
 
 function getCurrentMonthRangeTimestamps() {
 	const now = new Date();
@@ -33,15 +117,89 @@ function getCurrentMonthRangeTimestamps() {
 	};
 }
 
-export default function PlanCard( { site }: { site: Site } ) {
-	const { data: plan, isLoading: isLoadingPlan } = useQuery( siteCurrentPlanQuery( site.ID ) );
-	const { data: purchase, isLoading: isLoadingPurchase } = useQuery( {
-		...sitePurchaseQuery( site.ID, plan?.id ?? '' ),
-		enabled: !! plan?.id,
-	} );
+function getJetpackProductsDescription( products: typeof JETPACK_PRODUCTS ) {
+	if ( products.length === JETPACK_PRODUCTS.length ) {
+		return __( 'The full Jetpack suite with everything you need to grow your business.' );
+	}
+
+	if ( products.length === 0 ) {
+		return __( 'Enhance your site with Jetpack security, performance, and growth tools.' );
+	}
+
+	if ( products.length === 1 ) {
+		return products[ 0 ].description;
+	}
+
+	return `${ products.map( ( product ) => product.label ).join( ', ' ) }.`;
+}
+
+function getJetpackProducts( site: Site ) {
+	return JETPACK_PRODUCTS.filter( ( product ) =>
+		hasPlanFeature( site, product.id as JetpackFeatures )
+	);
+}
+
+function JetpackPlanCard( {
+	site,
+	purchase,
+	isLoading,
+}: {
+	site: Site;
+	purchase?: Purchase;
+	isLoading: boolean;
+} ) {
+	const products = getJetpackProducts( site );
+	const hasProducts = products.length > 0;
+	const productsToDisplay = hasProducts ? products : JETPACK_PRODUCTS;
+	const isPlanFreeAndHasProducts = site.plan?.is_free && hasProducts;
+
+	return (
+		<OverviewCard
+			title={ __( 'Subscriptions' ) }
+			icon={ <JetpackLogo /> }
+			heading={ isPlanFreeAndHasProducts ? __( 'Jetpack' ) : site.plan?.product_name_short }
+			description={ getCardDescription( site, purchase ) }
+			externalLink={ `https://cloud.jetpack.com/purchases/subscriptions/${ site.slug }` }
+			tracksId="plan"
+			isLoading={ isLoading }
+			bottom={
+				<VStack spacing={ 3 }>
+					<Grid
+						className="jetpack-plan-card__icons"
+						columns={ 4 }
+						rows={ Math.ceil( productsToDisplay.length / 4 ) }
+						gap={ 2 }
+					>
+						{ productsToDisplay.map( ( product ) => (
+							<Tooltip key={ product.id } text={ product.label } placement="top">
+								<div tabIndex={ -1 }>
+									<Icon icon={ product.icon } />
+								</div>
+							</Tooltip>
+						) ) }
+					</Grid>
+					<Text variant="muted" lineHeight="16px" size={ 12 }>
+						{ getJetpackProductsDescription( products ) }
+					</Text>
+				</VStack>
+			}
+		/>
+	);
+}
+
+function WpcomPlanCard( {
+	site,
+	purchase,
+	isLoading,
+}: {
+	site: Site;
+	purchase?: Purchase;
+	isLoading: boolean;
+} ) {
 	const { data: mediaStorage, isLoading: isLoadingMediaStorage } = useQuery(
 		siteMediaStorageQuery( site.ID )
 	);
+
 	const { startInSeconds, endInSeconds } = getCurrentMonthRangeTimestamps();
 	const { data: bandwidth, isLoading: isLoadingBandwidth } = useQuery( {
 		...siteMetricsQuery( site.ID, {
@@ -94,11 +252,9 @@ export default function PlanCard( { site }: { site: Site } ) {
 			title={ __( 'Plan' ) }
 			icon={ icon }
 			heading={ site.plan?.product_name_short }
-			description={ getCardDescription( plan, purchase ) }
+			description={ getCardDescription( site, purchase ) }
 			tracksId="plan"
-			isLoading={
-				isLoadingPlan || isLoadingPurchase || isLoadingMediaStorage || isLoadingBandwidth
-			}
+			isLoading={ isLoading || isLoadingMediaStorage || isLoadingBandwidth }
 			link={ site.plan?.is_free ? undefined : '/v2/me/billing/active-subscriptions' }
 			bottom={
 				<VStack spacing={ 4 }>
@@ -131,10 +287,54 @@ export default function PlanCard( { site }: { site: Site } ) {
 	);
 }
 
-function getCardDescription( plan?: Plan, purchase?: Purchase ) {
-	if ( plan?.product_slug === DotcomPlans.FREE_PLAN ) {
+export default function PlanCard( { site }: { site: Site } ) {
+	const { data: plan, isLoading: isLoadingPlan } = useQuery( siteCurrentPlanQuery( site.ID ) );
+	const { data: purchase, isLoading: isLoadingPurchase } = useQuery( {
+		...sitePurchaseQuery( site.ID, plan?.id ?? '' ),
+		enabled: !! plan?.id,
+	} );
+
+	if ( isSelfHostedJetpackConnected( site ) ) {
+		return (
+			<JetpackPlanCard
+				site={ site }
+				purchase={ purchase }
+				isLoading={ isLoadingPlan || isLoadingPurchase }
+			/>
+		);
+	}
+
+	return (
+		<WpcomPlanCard
+			site={ site }
+			purchase={ purchase }
+			isLoading={ isLoadingPlan || isLoadingPurchase }
+		/>
+	);
+}
+
+function getCardDescription( site: Site, purchase?: Purchase ) {
+	if ( site.plan?.product_slug === DotcomPlans.FREE_PLAN ) {
 		return __( 'Upgrade to access all hosting features.' );
 	}
 
-	return purchase?.expiry_message;
+	if ( site.plan?.product_slug === DotcomPlans.JETPACK_FREE ) {
+		return getJetpackProducts( site ).length > 0
+			? __( 'Manage subscriptions.' )
+			: __( 'Upgrade to access more Jetpack tools.' );
+	}
+
+	if ( purchase?.expiry_message ) {
+		return purchase.expiry_message;
+	}
+
+	if ( purchase?.partner_name ) {
+		return sprintf(
+			/* translators: %s: the partner name, e.g.: "Jetpack" */
+			__( 'Managed by %s.' ),
+			purchase.partner_name
+		);
+	}
+
+	return undefined;
 }

--- a/client/dashboard/sites/overview-plan-card/index.tsx
+++ b/client/dashboard/sites/overview-plan-card/index.tsx
@@ -9,25 +9,19 @@ import {
 } from '@wordpress/components';
 import { cloneElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import {
-	chartBar,
-	cloud,
-	megaphone,
-	next,
-	removeBug,
-	shield,
-	search,
-	video,
-	wordpress,
-} from '@wordpress/icons';
+import { wordpress } from '@wordpress/icons';
 import filesize from 'filesize';
 import { siteMediaStorageQuery } from '../../app/queries/site-media-storage';
 import { siteMetricsQuery } from '../../app/queries/site-metrics';
 import { siteCurrentPlanQuery } from '../../app/queries/site-plans';
 import { sitePurchaseQuery } from '../../app/queries/site-purchases';
 import { Stat } from '../../components/stat';
-import { DotcomPlans, JetpackFeatures } from '../../data/constants';
-import { hasPlanFeature } from '../../utils/site-features';
+import { DotcomPlans } from '../../data/constants';
+import {
+	getJetpackProductsForSite,
+	getSitePlanDisplayName,
+	JETPACK_PRODUCTS,
+} from '../../utils/site-plan';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { getSiteDisplayUrl } from '../../utils/site-url';
 import OverviewCard from '../overview-card';
@@ -37,69 +31,6 @@ import './style.scss';
 
 const MINIMUM_DISPLAYED_USAGE = 2.5;
 const ALERT_PERCENT = 80;
-
-const JETPACK_PRODUCTS = [
-	{
-		// See: https://github.com/Automattic/jetpack/blob/46e8a181299c296ac8e108daa2f2c6f9761a2d82/projects/packages/my-jetpack/src/products/class-stats.php#L82
-		id: JetpackFeatures.STATS,
-		icon: chartBar,
-		label: __( 'Stats' ),
-		description: __( 'Clear, concise, and actionable analysis of your site performance.' ),
-	},
-	{
-		// See: https://github.com/Automattic/jetpack/blob/46e8a181299c296ac8e108daa2f2c6f9761a2d82/projects/packages/my-jetpack/src/products/class-backup.php#L80
-		id: JetpackFeatures.BACKUPS,
-		icon: cloud,
-		label: __( 'VaultPress Backup' ),
-		description: __(
-			'Real-time backups save every change, and one-click restores get you back online quickly.'
-		),
-	},
-	{
-		// See: https://github.com/Automattic/jetpack/blob/46e8a181299c296ac8e108daa2f2c6f9761a2d82/projects/packages/my-jetpack/src/products/class-social.php#L78
-		id: JetpackFeatures.SOCIAL_ENHANCED_PUBLISHING,
-		icon: megaphone,
-		label: __( 'Social' ),
-		description: __(
-			'Auto‑share your posts to social networks and track engagement in one place.'
-		),
-	},
-	{
-		// See: https://github.com/Automattic/jetpack/blob/46e8a181299c296ac8e108daa2f2c6f9761a2d82/projects/packages/my-jetpack/src/products/class-boost.php#L87
-		id: JetpackFeatures.CLOUD_CRITICAL_CSS,
-		icon: next,
-		label: __( 'Boost' ),
-		description: __( 'Improves your site speed and performance.' ),
-	},
-	{
-		// See: https://github.com/Automattic/jetpack/blob/46e8a181299c296ac8e108daa2f2c6f9761a2d82/projects/packages/my-jetpack/src/products/class-anti-spam.php#L51
-		id: JetpackFeatures.ANTISPAM,
-		icon: removeBug,
-		label: __( 'Akismet Anti-spam' ),
-		description: __( 'Automatically clear spam from comments and forms.' ),
-	},
-	{
-		// See: https://github.com/Automattic/jetpack/blob/46e8a181299c296ac8e108daa2f2c6f9761a2d82/projects/packages/my-jetpack/src/products/class-search.php#L94
-		id: JetpackFeatures.SEARCH,
-		icon: search,
-		label: __( 'Search' ),
-		description: __( 'Instantly deliver the most relevant results to your visitors.' ),
-	},
-	{
-		// See: https://github.com/Automattic/jetpack/blob/46e8a181299c296ac8e108daa2f2c6f9761a2d82/projects/packages/my-jetpack/src/products/class-scan.php#L46
-		id: JetpackFeatures.SCAN,
-		icon: shield,
-		label: __( 'Scan' ),
-		description: __( 'Guard against malware and bad actors 24/7.' ),
-	},
-	{
-		// See: https://github.com/Automattic/jetpack/blob/46e8a181299c296ac8e108daa2f2c6f9761a2d82/projects/packages/my-jetpack/src/products/class-videopress.php#L88
-		id: JetpackFeatures.VIDEOPRESS,
-		icon: video,
-		label: __( 'VideoPress' ),
-		description: __( 'Powerful and flexible video hosting.' ),
-	},
-];
 
 function getCurrentMonthRangeTimestamps() {
 	const now = new Date();
@@ -133,26 +64,6 @@ function getJetpackProductsDescription( products: typeof JETPACK_PRODUCTS ) {
 	return `${ products.map( ( product ) => product.label ).join( ', ' ) }.`;
 }
 
-function getJetpackProducts( site: Site ) {
-	return JETPACK_PRODUCTS.filter( ( product ) =>
-		hasPlanFeature( site, product.id as JetpackFeatures )
-	);
-}
-
-function getJetpackHeading( site: Site ) {
-	if ( site.plan?.product_slug === DotcomPlans.JETPACK_FREE ) {
-		const products = getJetpackProducts( site );
-		if ( products.length === 1 ) {
-			return products[ 0 ].label;
-		}
-		if ( products.length > 1 ) {
-			return __( 'Jetpack' );
-		}
-	}
-
-	return site.plan?.product_name;
-}
-
 function JetpackPlanCard( {
 	site,
 	purchase,
@@ -162,14 +73,14 @@ function JetpackPlanCard( {
 	purchase?: Purchase;
 	isLoading: boolean;
 } ) {
-	const products = getJetpackProducts( site );
+	const products = getJetpackProductsForSite( site );
 	const productsToDisplay = products.length > 0 ? products : JETPACK_PRODUCTS;
 
 	return (
 		<OverviewCard
 			title={ __( 'Subscriptions' ) }
 			icon={ <JetpackLogo /> }
-			heading={ getJetpackHeading( site ) }
+			heading={ getSitePlanDisplayName( site ) }
 			description={ getCardDescription( site, purchase ) }
 			externalLink={ `https://cloud.jetpack.com/purchases/subscriptions/${ site.slug }` }
 			tracksId="plan"
@@ -263,7 +174,7 @@ function WpcomPlanCard( {
 		<OverviewCard
 			title={ __( 'Plan' ) }
 			icon={ icon }
-			heading={ site.plan?.product_name_short }
+			heading={ getSitePlanDisplayName( site ) }
 			description={ getCardDescription( site, purchase ) }
 			tracksId="plan"
 			isLoading={ isLoading || isLoadingMediaStorage || isLoadingBandwidth }
@@ -331,7 +242,7 @@ function getCardDescription( site: Site, purchase?: Purchase ) {
 	}
 
 	if ( site.plan?.product_slug === DotcomPlans.JETPACK_FREE ) {
-		return getJetpackProducts( site ).length > 0
+		return getJetpackProductsForSite( site ).length > 0
 			? __( 'Manage subscriptions.' )
 			: __( 'Upgrade to access more Jetpack tools.' );
 	}

--- a/client/dashboard/sites/overview-plan-card/index.tsx
+++ b/client/dashboard/sites/overview-plan-card/index.tsx
@@ -139,6 +139,20 @@ function getJetpackProducts( site: Site ) {
 	);
 }
 
+function getJetpackHeading( site: Site ) {
+	if ( site.plan?.product_slug === DotcomPlans.JETPACK_FREE ) {
+		const products = getJetpackProducts( site );
+		if ( products.length === 1 ) {
+			return products[ 0 ].label;
+		}
+		if ( products.length > 1 ) {
+			return __( 'Jetpack' );
+		}
+	}
+
+	return site.plan?.product_name;
+}
+
 function JetpackPlanCard( {
 	site,
 	purchase,
@@ -149,15 +163,13 @@ function JetpackPlanCard( {
 	isLoading: boolean;
 } ) {
 	const products = getJetpackProducts( site );
-	const hasProducts = products.length > 0;
-	const productsToDisplay = hasProducts ? products : JETPACK_PRODUCTS;
-	const isPlanFreeAndHasProducts = site.plan?.is_free && hasProducts;
+	const productsToDisplay = products.length > 0 ? products : JETPACK_PRODUCTS;
 
 	return (
 		<OverviewCard
 			title={ __( 'Subscriptions' ) }
 			icon={ <JetpackLogo /> }
-			heading={ isPlanFreeAndHasProducts ? __( 'Jetpack' ) : site.plan?.product_name_short }
+			heading={ getJetpackHeading( site ) }
 			description={ getCardDescription( site, purchase ) }
 			externalLink={ `https://cloud.jetpack.com/purchases/subscriptions/${ site.slug }` }
 			tracksId="plan"

--- a/client/dashboard/sites/overview-plan-card/style.scss
+++ b/client/dashboard/sites/overview-plan-card/style.scss
@@ -1,0 +1,17 @@
+.jetpack-plan-card__icons {
+	align-self: flex-start;
+
+	> div {
+		align-items: center;
+		background-color: #102f14;
+		display: flex;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		border-radius: 4px;
+
+		svg {
+			fill: #66db64;
+		}
+	}
+}

--- a/client/dashboard/sites/overview-plan-card/style.scss
+++ b/client/dashboard/sites/overview-plan-card/style.scss
@@ -1,3 +1,5 @@
+@import '@wordpress/base-styles/variables';
+
 .jetpack-plan-card__icons {
 	align-self: flex-start;
 
@@ -8,7 +10,7 @@
 		justify-content: center;
 		width: 32px;
 		height: 32px;
-		border-radius: 4px;
+		border-radius: $radius-medium;
 
 		svg {
 			fill: #66db64;

--- a/client/dashboard/sites/settings-caching/index.tsx
+++ b/client/dashboard/sites/settings-caching/index.tsx
@@ -30,6 +30,7 @@ import Notice from '../../components/notice';
 import PageLayout from '../../components/page-layout';
 import { HostingFeatures } from '../../data/constants';
 import { hasHostingFeature, hasPlanFeature } from '../../utils/site-features';
+import { getSitePlanDisplayName } from '../../utils/site-plan';
 import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callout';
 import SettingsPageHeader from '../settings-page-header';
 import { isEdgeCacheAvailable as getIsEdgeCacheAvailable } from './utils';
@@ -311,7 +312,7 @@ export default function CachingSettings( { siteSlug }: { siteSlug: string } ) {
 					__(
 						'Caching is managed for you on the %s plan. The cache is cleared automatically as you make changes to your site. <link>Learn more</link>'
 					),
-					site?.plan?.product_name_short
+					getSitePlanDisplayName( site )
 				),
 				{
 					link: <InlineSupportLink supportContext="hosting-edge-cache" />,

--- a/client/dashboard/sites/settings-php/index.tsx
+++ b/client/dashboard/sites/settings-php/index.tsx
@@ -18,6 +18,7 @@ import PageLayout from '../../components/page-layout';
 import RequiredSelect from '../../components/required-select';
 import { HostingFeatures } from '../../data/constants';
 import { hasHostingFeature, hasPlanFeature } from '../../utils/site-features';
+import { getSitePlanDisplayName } from '../../utils/site-plan';
 import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callout';
 import SettingsPageHeader from '../settings-page-header';
 import type { Field } from '@wordpress/dataviews';
@@ -79,7 +80,7 @@ export default function PHPVersionSettings( { siteSlug }: { siteSlug: string } )
 		: sprintf(
 				/* translators: %s: plan name. Eg. 'Personal' */
 				__( 'Sites on the %s plan run on our recommended PHP version.' ),
-				site?.plan?.product_name_short
+				getSitePlanDisplayName( site )
 		  );
 
 	return (

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -24,6 +24,7 @@ import TimeSince from '../../components/time-since';
 import { DotcomFeatures, HostingFeatures, JetpackModules } from '../../data/constants';
 import { isAtomicTransferInProgress } from '../../utils/site-atomic-transfers';
 import { hasHostingFeature, hasJetpackModule, hasPlanFeature } from '../../utils/site-features';
+import { getSitePlanDisplayName } from '../../utils/site-plan';
 import { getSiteStatus, getSiteStatusLabel } from '../../utils/site-status';
 import { isSelfHostedJetpackConnected, isP2 } from '../../utils/site-types';
 import { canManageSite } from '../features';
@@ -407,6 +408,7 @@ export function Status( { site }: { site: Site } ) {
 }
 
 export function Plan( { site }: { site: Site } ) {
+	const planName = getSitePlanDisplayName( site );
 	if ( site.is_wpcom_staging_site ) {
 		// translator: this is the label of a staging site.
 		return __( 'Staging' );
@@ -419,7 +421,7 @@ export function Plan( { site }: { site: Site } ) {
 		return (
 			<HStack spacing={ 1 } expanded={ false } justify="flex-start">
 				<JetpackLogo size={ 16 } />
-				<span>{ site.plan?.product_name_short }</span>
+				<span>{ planName }</span>
 			</HStack>
 		);
 	}
@@ -431,7 +433,7 @@ export function Plan( { site }: { site: Site } ) {
 					{ sprintf(
 						/* translators: %s: plan name */
 						__( '%s-expired' ),
-						site.plan?.product_name_short
+						planName
 					) }
 				</Text>
 				<PlanRenewNag site={ site } source="plan" />
@@ -439,5 +441,5 @@ export function Plan( { site }: { site: Site } ) {
 		);
 	}
 
-	return site.plan?.product_name_short;
+	return planName;
 }

--- a/client/dashboard/utils/site-features.ts
+++ b/client/dashboard/utils/site-features.ts
@@ -1,8 +1,13 @@
-import { DotcomFeatures, HostingFeatures, JetpackModules } from '../data/constants';
+import {
+	DotcomFeatures,
+	HostingFeatures,
+	JetpackFeatures,
+	JetpackModules,
+} from '../data/constants';
 import type { Site } from '../data/types';
 
 // Returns whether the plan supports a specific feature.
-export function hasPlanFeature( site: Site, feature: `${ DotcomFeatures }` ) {
+export function hasPlanFeature( site: Site, feature: `${ DotcomFeatures | JetpackFeatures }` ) {
 	if ( ! site.plan ) {
 		return false;
 	}

--- a/client/dashboard/utils/site-plan.ts
+++ b/client/dashboard/utils/site-plan.ts
@@ -1,0 +1,89 @@
+import { __ } from '@wordpress/i18n';
+import {
+	chartBar,
+	cloud,
+	megaphone,
+	next,
+	removeBug,
+	search,
+	shield,
+	video,
+} from '@wordpress/icons';
+import { DotcomPlans, JetpackFeatures } from '../data/constants';
+import { hasPlanFeature } from '../utils/site-features';
+import type { Site } from '../data/types';
+
+export const JETPACK_PRODUCTS = [
+	{
+		id: JetpackFeatures.STATS,
+		icon: chartBar,
+		label: __( 'Stats' ),
+		description: __( 'Clear, concise, and actionable analysis of your site performance.' ),
+	},
+	{
+		id: JetpackFeatures.BACKUPS,
+		icon: cloud,
+		label: __( 'VaultPress Backup' ),
+		description: __(
+			'Real-time backups save every change, and one-click restores get you back online quickly.'
+		),
+	},
+	{
+		id: JetpackFeatures.SOCIAL_ENHANCED_PUBLISHING,
+		icon: megaphone,
+		label: __( 'Social' ),
+		description: __(
+			'Auto‑share your posts to social networks and track engagement in one place.'
+		),
+	},
+	{
+		id: JetpackFeatures.CLOUD_CRITICAL_CSS,
+		icon: next,
+		label: __( 'Boost' ),
+		description: __( 'Improves your site speed and performance.' ),
+	},
+	{
+		id: JetpackFeatures.ANTISPAM,
+		icon: removeBug,
+		label: __( 'Akismet Anti-spam' ),
+		description: __( 'Automatically clear spam from comments and forms.' ),
+	},
+	{
+		id: JetpackFeatures.SEARCH,
+		icon: search,
+		label: __( 'Search' ),
+		description: __( 'Instantly deliver the most relevant results to your visitors.' ),
+	},
+	{
+		id: JetpackFeatures.SCAN,
+		icon: shield,
+		label: __( 'Scan' ),
+		description: __( 'Guard against malware and bad actors 24/7.' ),
+	},
+	{
+		id: JetpackFeatures.VIDEOPRESS,
+		icon: video,
+		label: __( 'VideoPress' ),
+		description: __( 'Powerful and flexible video hosting.' ),
+	},
+];
+
+export function getJetpackProductsForSite( site: Site ) {
+	return JETPACK_PRODUCTS.filter( ( product ) =>
+		hasPlanFeature( site, product.id as JetpackFeatures )
+	);
+}
+
+export function getSitePlanDisplayName( site: Site ) {
+	if ( site.plan?.product_slug === DotcomPlans.JETPACK_FREE ) {
+		const products = getJetpackProductsForSite( site );
+		if ( products.length === 1 ) {
+			return products[ 0 ].label;
+		}
+		if ( products.length > 1 ) {
+			return __( 'Jetpack' );
+		}
+	}
+
+	return site.plan?.product_name || site.plan?.product_name_short || '';
+}

--- a/client/dashboard/utils/site-plan.ts
+++ b/client/dashboard/utils/site-plan.ts
@@ -45,7 +45,7 @@ export const JETPACK_PRODUCTS = [
 	{
 		id: JetpackFeatures.ANTISPAM,
 		icon: removeBug,
-		label: __( 'Jetpack Akismet Anti-spam' ),
+		label: __( 'Akismet Anti-spam' ),
 		description: __( 'Automatically clear spam from comments and forms.' ),
 	},
 	{

--- a/client/dashboard/utils/site-plan.ts
+++ b/client/dashboard/utils/site-plan.ts
@@ -17,13 +17,13 @@ export const JETPACK_PRODUCTS = [
 	{
 		id: JetpackFeatures.STATS,
 		icon: chartBar,
-		label: __( 'Stats' ),
+		label: __( 'Jetpack Stats' ),
 		description: __( 'Clear, concise, and actionable analysis of your site performance.' ),
 	},
 	{
 		id: JetpackFeatures.BACKUPS,
 		icon: cloud,
-		label: __( 'VaultPress Backup' ),
+		label: __( 'Jetpack VaultPress Backup' ),
 		description: __(
 			'Real-time backups save every change, and one-click restores get you back online quickly.'
 		),
@@ -31,7 +31,7 @@ export const JETPACK_PRODUCTS = [
 	{
 		id: JetpackFeatures.SOCIAL_ENHANCED_PUBLISHING,
 		icon: megaphone,
-		label: __( 'Social' ),
+		label: __( 'Jetpack Social' ),
 		description: __(
 			'Auto‑share your posts to social networks and track engagement in one place.'
 		),
@@ -39,31 +39,31 @@ export const JETPACK_PRODUCTS = [
 	{
 		id: JetpackFeatures.CLOUD_CRITICAL_CSS,
 		icon: next,
-		label: __( 'Boost' ),
+		label: __( 'Jetpack Boost' ),
 		description: __( 'Improves your site speed and performance.' ),
 	},
 	{
 		id: JetpackFeatures.ANTISPAM,
 		icon: removeBug,
-		label: __( 'Akismet Anti-spam' ),
+		label: __( 'Jetpack Akismet Anti-spam' ),
 		description: __( 'Automatically clear spam from comments and forms.' ),
 	},
 	{
 		id: JetpackFeatures.SEARCH,
 		icon: search,
-		label: __( 'Search' ),
+		label: __( 'Jetpack Search' ),
 		description: __( 'Instantly deliver the most relevant results to your visitors.' ),
 	},
 	{
 		id: JetpackFeatures.SCAN,
 		icon: shield,
-		label: __( 'Scan' ),
+		label: __( 'Jetpack Scan' ),
 		description: __( 'Guard against malware and bad actors 24/7.' ),
 	},
 	{
 		id: JetpackFeatures.VIDEOPRESS,
 		icon: video,
-		label: __( 'VideoPress' ),
+		label: __( 'Jetpack VideoPress' ),
 		description: __( 'Powerful and flexible video hosting.' ),
 	},
 ];

--- a/packages/components/src/logos/jetpack-logo/index.tsx
+++ b/packages/components/src/logos/jetpack-logo/index.tsx
@@ -89,7 +89,10 @@ export const JetpackLogo = ( {
 	if ( 24 === size ) {
 		return (
 			<svg className={ classes } height="24" width="24" viewBox="0 0 24 24" { ...props }>
-				<path d="M12,2C6.5,2,2,6.5,2,12s4.5,10,10,10s10-4.5,10-10S17.5,2,12,2z M11,14H6l5-10V14z M13,20V10h5L13,20z" />
+				<path
+					d="M12,2C6.5,2,2,6.5,2,12s4.5,10,10,10s10-4.5,10-10S17.5,2,12,2z M11,14H6l5-10V14z M13,20V10h5L13,20z"
+					{ ...( ! monochrome ? { fill: COLOR_JETPACK } : {} ) }
+				/>
 			</svg>
 		);
 	}


### PR DESCRIPTION
Ref DOTDASH-118

## Proposed Changes

This PR implements the Plan card for self-hosted sites. The bottom section changes according to the number of paid modules the site has. Pressable card will be handled separatedly.

<img width="1145" height="476" alt="SCR-20250730-qqbw" src="https://github.com/user-attachments/assets/cf88b848-ecf1-4651-aebe-1b2c66eeb106" />

For Free plan, I'm proposing the following but needs design input from @matt-west (Matt said LGTM)

<img width="351" height="342" alt="SCR-20250730-qqjd" src="https://github.com/user-attachments/assets/77892fb4-6eeb-48b2-b60a-578b39aa85d1" />

> [!NOTE] 
> I replaced CRM with Stats for now, as CRM is not a Jetpack module that requires Jetpack connection and thus doesn't seem to show up in the active modules list. We can address this later if needed.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Select any self-hosted site, and ensure that the Plan card is as described above
* Use JN to create sites with different Jetpack modules
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
