### PR TITLE
Staging Sites Redesign: Improve backup message copy and move it close to the file tree

### DIFF
--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -455,6 +455,22 @@ export default function SyncModal( {
 							siteId={ querySiteId }
 							fileBrowserConfig={ fileBrowserConfig }
 						/>
+						<HStack alignment="left" spacing={ 1 }>
+							<Text color="var(--studio-gray-40)">
+								{ displayBackupDate
+									? createInterpolateElement(
+											__( 'Listing files from the latest backup: <date />.' ),
+											{
+												date: <span>{ displayBackupDate }</span>,
+											}
+									  )
+									: __( 'There are no backups.' ) }{ ' ' }
+								<ExternalLink
+									href={ `/backup/${ sourceSiteSlug }` }
+									children={ __( 'Create fresh backup now' ) }
+								/>
+							</Text>
+						</HStack>
 					</div>
 					<HStack
 						alignment="left"
@@ -477,19 +493,6 @@ export default function SyncModal( {
 						<Icon icon={ error } style={ { fill: 'var(--studio-orange-50)' } } />
 					</HStack>
 					<VStack spacing={ 7 }>
-						<HStack alignment="left" spacing={ 1 }>
-							<Text color="var(--studio-gray-40)">
-								{ displayBackupDate
-									? createInterpolateElement( __( 'Backup contents from: <date />.' ), {
-											date: <span>{ displayBackupDate }</span>,
-									  } )
-									: __( 'There are no backups.' ) }{ ' ' }
-								<ExternalLink
-									href={ `/backup/${ sourceSiteSlug }` }
-									children={ __( 'Backup now' ) }
-								/>
-							</Text>
-						</HStack>
 						{ showWooCommerceWarning && (
 							<Notice status="warning" isDismissible={ false }>
 								<Text as="p" weight="bold" style={ { lineHeight: '24px' } }>

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -6,6 +6,7 @@ import {
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
+	// eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
 	__experimentalInputControl as InputControl,
 	CheckboxControl,
 	SelectControl,

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -22,7 +22,6 @@ import {
 import { __, isRTL } from '@wordpress/i18n';
 import { error, chevronRight, chevronLeft } from '@wordpress/icons';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
-import useGetDisplayDate from 'calypso/components/jetpack/daily-backup-status/use-get-display-date';
 import InlineSupportLink from 'calypso/dashboard/components/inline-support-link';
 import { SectionHeader } from 'calypso/dashboard/components/section-header';
 import SiteEnvironmentBadge, {
@@ -57,6 +56,7 @@ const fileBrowserConfig: FileBrowserConfig = {
 	alwaysInclude: [ 'wp-config.php' ],
 	showHeaderButtons: false,
 	showFileCard: false,
+	showBackupTime: true,
 };
 
 const DirectionArrow = () => {
@@ -204,15 +204,12 @@ export default function SyncModal( {
 	const stagingSiteTitle = useSelector( ( state ) => getSiteTitle( state, stagingSiteId ) ) || '';
 
 	const targetSiteSlug = targetEnvironment === 'production' ? productionSiteSlug : stagingSiteSlug;
-	const sourceSiteSlug = sourceEnvironment === 'staging' ? stagingSiteSlug : productionSiteSlug;
 
 	const sourceSiteTitle = sourceEnvironment === 'staging' ? stagingSiteTitle : productionSiteTitle;
 	const targetSiteTitle =
 		targetEnvironment === 'production' ? productionSiteTitle : stagingSiteTitle;
 
 	const querySiteId = sourceEnvironment === 'staging' ? stagingSiteId : productionSiteId;
-
-	const getDisplayDate = useGetDisplayDate( querySiteId );
 
 	const browserCheckList = useSelector( ( state ) =>
 		getBackupBrowserCheckList( state, querySiteId )
@@ -372,10 +369,6 @@ export default function SyncModal( {
 		( showDomainConfirmation && domainConfirmation !== productionSiteSlug ) ||
 		( browserCheckList.totalItems === 0 && browserCheckList.includeList.length === 0 );
 
-	const displayBackupDate = lastKnownBackupAttempt
-		? getDisplayDate( lastKnownBackupAttempt.activityTs, false )
-		: null;
-
 	return (
 		<Modal
 			title={ syncConfig[ environment ].title }
@@ -455,22 +448,6 @@ export default function SyncModal( {
 							siteId={ querySiteId }
 							fileBrowserConfig={ fileBrowserConfig }
 						/>
-						<HStack alignment="left" spacing={ 1 }>
-							<Text color="var(--studio-gray-40)" style={ { marginInlineStart: '14px' } }>
-								{ displayBackupDate
-									? createInterpolateElement(
-											__( 'Listing files from the latest backup: <date />.' ),
-											{
-												date: <span>{ displayBackupDate }</span>,
-											}
-									  )
-									: __( 'There are no backups.' ) }{ ' ' }
-								<ExternalLink
-									href={ `/backup/${ sourceSiteSlug }` }
-									children={ __( 'Create fresh backup now' ) }
-								/>
-							</Text>
-						</HStack>
 					</div>
 					<HStack
 						alignment="left"

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -456,7 +456,7 @@ export default function SyncModal( {
 							fileBrowserConfig={ fileBrowserConfig }
 						/>
 						<HStack alignment="left" spacing={ 1 }>
-							<Text color="var(--studio-gray-40)">
+							<Text color="var(--studio-gray-40)" style={ { marginInlineStart: '14px' } }>
 								{ displayBackupDate
 									? createInterpolateElement(
 											__( 'Listing files from the latest backup: <date />.' ),


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTCOM-14034

## Proposed Changes

* improve backup message copy and move it to the top of the file tree

| Before | After |
|--------|--------|
| <img width="4092" height="3580" alt="Markup on 2025-07-29 at 11:36:33" src="https://github.com/user-attachments/assets/6224cb7b-981b-4d29-8e98-6a782af1d074" /> | <img width="2732" height="2476" alt="Markup on 2025-07-30 at 10:17:21" src="https://github.com/user-attachments/assets/68276320-f18d-417c-b0d2-56f6721d73ef" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* DOTCOM-14034: The goal is to make the message more helpful and relevant.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start` (or use the Calypso Live link below).
2. Head over to a staging site (or a production site with staging site) and click the `Sync` button / dropdown. Select any of the two options.
3. Once the modal opens, select `Specific files and folders` from the dropdown in it.
4. Observe the new copy and its placement right above the file tree (as can be seen in the _After_ screenshot above).
5. There should be no regressions in the FileBrowser component used in `http://calypso.localhost:3000/backup/{site-slug}`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
