### PR TITLE
Domain Search Retrofitting: Increase speed of typing and reduce time between phrases

### DIFF
--- a/packages/domain-search/src/hooks/use-typed-placeholder.ts
+++ b/packages/domain-search/src/hooks/use-typed-placeholder.ts
@@ -15,8 +15,8 @@ export const useTypedPlaceholder = ( phrases: string[], pauseAnimation = false )
 	const phraseIndexRef = useRef( 0 );
 	const timeoutIdRef = useRef< ReturnType< typeof setTimeout > >();
 
-	const timeBetweenChars = 70;
-	const timeBetweenPhrases = 2000;
+	const timeBetweenChars = 60;
+	const timeBetweenPhrases = 1500;
 
 	// Control animation state
 	useEffect( () => {


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/DOMAINS-1573/domain-search-animation-increase-the-speed-of-animated-typing

## Proposed Changes

* Increase speed of typing and reduce time between phrases

## Why are these changes being made?

https://linear.app/a8c/issue/DOMAINS-1573/domain-search-animation-increase-the-speed-of-animated-typing

## Testing Instructions

* Go to `/setup/onboarding/domains?flags=domains%2Fui-redesign`
* Check the speed of the placeholder animated typing

https://github.com/user-attachments/assets/bdf6faec-3a28-42aa-a3ca-df2234f3c6bd

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
