### PR TITLE
Login: update font sizes to match WordPress design system

### DIFF
--- a/client/login/wp-login/components/one-login-layout.scss
+++ b/client/login/wp-login/components/one-login-layout.scss
@@ -12,6 +12,21 @@
 	text-align: center;
 }
 
+/**
+ * By default, all headings get .wp-brand-font class and it applies a 40px font size. That size should only be used
+ * for Recoleta font. Any other heading, should be 32px. This rule achieves this affect.
+
+ * TODO: to clean up this code, we should apply .wp-brand-font selectively, only when we use Recoleta.
+ */
+.is-jetpack-login,
+.jetpack-cloud,
+.woo,
+.is-blaze-pro {
+	.wp-login__one-login-layout-heading-text {
+		font-size: 2rem;
+	}
+}
+
 .wp-login__one-login-layout-heading-logo {
 	margin-bottom: 16px;
 
@@ -43,7 +58,7 @@
 	text-wrap: balance;
 	color: var( --studio-gray-50, #646970 );
 	margin-block: 0.5rem 0;
-	font-size: $font-body;
+	font-size: rem( 15px );
 
 	a {
 		color: var( --studio-gray-50, #646970 );
@@ -51,7 +66,7 @@
 	}
 
 	&.is-secondary {
-		font-size: $font-body-extra-small;
+		font-size: rem( 13px );
 		color: var( --studio-gray-30 );
 
 		a {

--- a/packages/onboarding/src/step-container-v2/components/Heading/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/Heading/style.scss
@@ -18,7 +18,7 @@
 
 		&:not( .small ) {
 			@include break-large {
-				font-size: 2.75rem;
+				font-size: rem( 40px );
 				line-height: 1.15;
 			}
 		}


### PR DESCRIPTION
https://linear.app/a8c/issue/DSGCOM-148

## Proposed Changes

* Update font sizes in login flows to better match [WordPress Design System](https://www.figma.com/design/b5bhplFGxDj4VLYrKeWYHY/WordPress-Design-System--Community-?node-id=13482-72792&p=f&t=rTBieO3E8yIlayi5-0).

<img width="1003" height="662" alt="image" src="https://github.com/user-attachments/assets/289fee72-d1d8-4545-aa05-8ac0990ba9c5" />

## Testing Instructions

* Load any login and signup page that uses Recoleta font: [WordPress.com](http://calypso.localhost:3000/log-in), [Studio](http://calypso.localhost:3000/log-in?client_id=95109&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dtoken%26client_id%3D95109%26redirect_uri%3Dwpcom-local-dev%253A%252F%252Fauth%26scope%3Dglobal%26client_source%26jetpack-code%26jetpack-user-id%3D0%26action%3Doauth2-login%26from-calypso%3D1), [Akismet](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fr-login.wordpress.com%2Fremote-login.php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet.com%252Faccount%252F&signup_url=%2Fstart%2Faccount%2Fuser-social%3Fredirect_to%3Dhttps%253A%252F%252Fr-login.wordpress.com%252Fremote-login.php%253Faction%253Dlink%2526back%253Dhttps%25253A%25252F%25252Fakismet.com%25252Faccount%25252F), [CrowdSignal](http://calypso.localhost:3000/log-in?client_id=978&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3Df5da55616562ed1b1ef36c8e88328853efcc0167150831e59437c3330ec11509%26redirect_uri%3Dhttps%253A%252F%252Fapp.crowdsignal.com%252Fconnect%253Fsource%253Dlogin%2526action%253Drequest_access_token%26wpcom_connect%3D1%26from-calypso%3D1) and [VIP](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fstate%3Dd01a004590fc4017316cef309b1e213de0cf6c1fd4b68d3152d9f9acbf9c%26scope%3Dauth%26response_type%3Dcode%26approval_prompt%3Dauto%26redirect_uri%3Dhttps%253A%252F%252Fid.wpvip.com%252Fwp-json%252Foauth%252Fv1%252Fcallback%252Fwpcom%26client_id%3D76596%26from-calypso%3D1&client_id=76596&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D76596%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%253Fstate%253Dd01a004590fc4017316cef309b1e213de0cf6c1fd4b68d3152d9f9acbf9c%2526scope%253Dauth%2526response_type%253Dcode%2526approval_prompt%253Dauto%2526redirect_uri%253Dhttps%25253A%25252F%25252Fid.wpvip.com%25252Fwp-json%25252Foauth%25252Fv1%25252Fcallback%25252Fwpcom%2526client_id%253D76596%2526from-calypso%253D1). Confirm they now have 40px font size.
* Load any other login and signup page that _doesn't_ use Recoleta. [WCCOM](http://calypso.localhost:3000/log-in?client_id=50916&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Dbabd2834d29179c7104bba84668042e1f8a4c310f62299dd24992cf002dbda31%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%3Dnux%26calypso_env%3Dproduction%26from-calypso%3D1), [Jetpack](http://calypso.localhost:3000/log-in/jetpack), [Jetpack Cloud](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D69040%26redirect_uri%3Dhttps%253A%252F%252Fcloud.jetpack.com%252Fconnect%252Foauth%252Ftoken%253Fnext%253D%25252F%26scope%3Dglobal%26blog_id%3D0%26from-calypso%3D1&client_id=69040&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D69040%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%253Fresponse_type%253Dtoken%2526client_id%253D69040%2526redirect_uri%253Dhttps%25253A%25252F%25252Fcloud.jetpack.com%25252Fconnect%25252Foauth%25252Ftoken%25253Fnext%25253D%2525252F%2526scope%253Dglobal%2526blog_id%253D0%2526from-calypso%253D1), [WooJPC](http://calypso.localhost:3000/start/account/user-social?redirect_to=%2Fjetpack%2Fconnect%2Fauthorize%3Fclient_id%3D245657653%26redirect_uri%3Dhttps%253A%252F%252Ftotal-sable-millipede.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fhandler%253Djetpack-connection-webhooks%2526action%253Dauthorize%2526_wpnonce%253De1fd5da4a3%2526redirect%253Dhttps%25253A%25252F%25252Ftotal-sable-millipede.jurassic.ninja%25252Fwp-admin%25252Fadmin.php%25253Fpage%25253Dwc-admin%26state%3D1%26scope%3Dadministrator%253Acebfe5edc3805525128c6b79ecbbee7e%26user_email%3Dcem.unalan%2540a8c.com%26user_login%3Draicem%26jp_version%3D14.8-a.5%26secret%3DpQONgKUOSZeSEJYXRLeQCGAxBpFRyFF1%26blogname%3DTotal%2BSable%2BMillipede%26site_url%3Dhttps%253A%252F%252Ftotal-sable-millipede.jurassic.ninja%26home_url%3Dhttps%253A%252F%252Ftotal-sable-millipede.jurassic.ninja%26site_icon%3D%26site_lang%3Den_US%26site_created%3D2025-06-18%2B15%253A02%253A22%26allow_site_connection%3D1%26calypso_env%3Dproduction%26source%3D%26_as%3Dwp-cli%26locale%3Den%26from%3Dwoocommerce-core-profiler%26plugin_name%3D%26color_scheme%3Dfresh%26_ui%3D11140294%26_ut%3Dwpcom%253Auser_id%26purchase_nonce%3D5ispUNoV%26_wp_nonce%3D1c5e04be2f%26redirect_after_auth%3Dhttps%253A%252F%252Ftotal-sable-millipede.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin%26site%3Dhttps%253A%252F%252Ftotal-sable-millipede.jurassic.ninja%26auth_approved%3Dtrue&from=woocommerce-core-profiler). Confirm heading is 32px, subheading is 15px, TOS text is 13px.
* Visit Gravatar [login](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D4a5153e30a28e2ef24ca7e599abd80f3969340cd1f88327c1f5d2fbc88593fa1%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1&client_id=1854) and [signup](http://calypso.localhost:3000/log-in/link?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D4a5153e30a28e2ef24ca7e599abd80f3969340cd1f88327c1f5d2fbc88593fa1%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1&client_id=1854&gravatar_from=signup), confirm it works as usual.
* Please test around this issue.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
