### PR TITLE
Help Center: Navigate Calypso links using SPA navigation

### DIFF
--- a/client/components/navigation-header/navigation-header.tsx
+++ b/client/components/navigation-header/navigation-header.tsx
@@ -1,8 +1,8 @@
 import page from '@automattic/calypso-router';
+import { isSameOrigin } from '@automattic/calypso-url';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import { ReactNode } from 'react';
-import { isSameOrigin } from 'calypso/lib/navigate';
 import { popCurrentScreenFromHistory } from 'calypso/my-sites/stats/hooks/use-stats-navigation-history';
 import './navigation-header.scss';
 

--- a/client/lib/navigate/index.ts
+++ b/client/lib/navigate/index.ts
@@ -1,12 +1,7 @@
 import page from '@automattic/calypso-router';
+import { isSameOrigin } from '@automattic/calypso-url';
 import { logmeinUrl } from 'calypso/lib/logmein';
 import scrollToAnchor from 'calypso/lib/scroll-to-anchor';
-
-// Using page() for cross origin navigations would throw a `History.pushState` exception
-// about creating state object with a cross-origin URL.
-export function isSameOrigin( path: string ): boolean {
-	return new URL( path, window.location.href ).origin === window.location.origin;
-}
 
 // Check if the current path is within Calypso's scope.
 // For example, the path "/home" is within Calypso's scope.

--- a/packages/calypso-url/src/index.ts
+++ b/packages/calypso-url/src/index.ts
@@ -3,3 +3,4 @@ export { default as format } from './format';
 export { getUrlParts, getUrlFromParts } from './url-parts';
 export { safeImageUrl } from './safe-image-url';
 export { getCalypsoUrl } from './get-calypso-url';
+export { isSameOrigin } from './is-same-origin';

--- a/packages/calypso-url/src/is-same-origin.ts
+++ b/packages/calypso-url/src/is-same-origin.ts
@@ -1,0 +1,9 @@
+/**
+ * Check if a URL is on the same origin as the current page.
+ *
+ * @param path - The URL to check.
+ * @returns True if the URL is on the same origin as the current page, false otherwise.
+ */
+export function isSameOrigin( path: string ): boolean {
+	return new URL( path, window.location.href ).origin === window.location.origin;
+}

--- a/packages/help-center/src/hooks/use-content-filter.ts
+++ b/packages/help-center/src/hooks/use-content-filter.ts
@@ -110,13 +110,8 @@ export const useContentFilter = ( node: HTMLDivElement | null ) => {
 						return;
 					}
 
-					// Support sites add `target="_blank"` to Calypso links. We should remove that in context of Calypso.
+					// Support sites add `target="_blank"` to Calypso links. We should remove that in the context of Calypso.
 					if ( isSameOrigin( href ) ) {
-						element.removeAttribute( 'target' );
-						return;
-					}
-
-					if ( href.includes( 'https://wordpress.com' ) ) {
 						element.removeAttribute( 'target' );
 						return;
 					}

--- a/packages/help-center/src/hooks/use-content-filter.ts
+++ b/packages/help-center/src/hooks/use-content-filter.ts
@@ -1,3 +1,4 @@
+import { isSameOrigin } from '@automattic/calypso-url';
 import { isThisASupportArticleLink } from '@automattic/urls';
 import { useEffect, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -19,7 +20,6 @@ export const useContentFilter = ( node: HTMLDivElement | null ) => {
 				pattern: 'a[href*="wordpress.com"], a[href^="/"]',
 				action: ( element: HTMLAnchorElement ) => {
 					const href = element.getAttribute( 'href' ) as string;
-
 					if ( ! href.startsWith( '/' ) && ! isThisASupportArticleLink( href ) ) {
 						return;
 					}
@@ -107,6 +107,17 @@ export const useContentFilter = ( node: HTMLDivElement | null ) => {
 
 					// Skip support articles
 					if ( href && isThisASupportArticleLink( href ) ) {
+						return;
+					}
+
+					// Support sites add `target="_blank"` to Calypso links. We should remove that in context of Calypso.
+					if ( isSameOrigin( href ) ) {
+						element.removeAttribute( 'target' );
+						return;
+					}
+
+					if ( href.includes( 'https://wordpress.com' ) ) {
+						element.removeAttribute( 'target' );
 						return;
 					}
 

--- a/packages/help-center/src/hooks/use-content-filter.ts
+++ b/packages/help-center/src/hooks/use-content-filter.ts
@@ -110,7 +110,8 @@ export const useContentFilter = ( node: HTMLDivElement | null ) => {
 						return;
 					}
 
-					// Support sites add `target="_blank"` to Calypso links. We should remove that in the context of Calypso.
+					// Support sites add `target="_blank"` to Calypso links.
+					// We should remove that in the context of Calypso.
 					if ( isSameOrigin( href ) ) {
 						element.removeAttribute( 'target' );
 						return;


### PR DESCRIPTION

Fixes: https://linear.app/a8c/issue/DOTCOM-14038/help-center-use-spa-navigation-when-opening-calypso-links

## Proposed Changes
Opening Calypso links in the Help Center opens a new tab. Because they come from support sites with target=blank. But that's super wasteful in Calypso because everything is loaded and doing a SPA navigation is much faster.

This removes the target value of the URL of the link has the same origin as the current URL. So this will only apply in Calypso and not wp-admin.


## Why are these changes being made?
Performance and to make resolving [this issue ](https://linear.app/a8c/issue/DOTCOM-14011/minimize-the-help-center-when-a-dashboard-link-is-opened-on-mobile)easier.

## Testing Instructions

This has to be tested locally.

1. Checkout this branch.
2. Run `yarn start-mock-wordpress-com` and follow the instructions.
3. Open the Help Center from my home.
4. Search for billing history.
5. Click "billing history" in "to access your billing history for plans…".
6. The billing history page should open quickly in the same tab.

