### PR TITLE
Disabled unused test and modify another to avoid checking a screen that doesn't exist anymore

### DIFF
--- a/test/e2e/specs/onboarding/onboarding__focused-launchpad.ts
+++ b/test/e2e/specs/onboarding/onboarding__focused-launchpad.ts
@@ -21,7 +21,8 @@ import { apiDeleteSite } from '../shared';
 
 declare const browser: Browser;
 
-describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
+// We might want to re-enable this test for CIAB, so leaving here until EOY.
+describe.skip( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 	let page: Page;
 	let newSiteDetails: NewSiteResponse;
 	let siteCreatedFlag = false;

--- a/test/e2e/specs/plans/plans__signup-business.ts
+++ b/test/e2e/specs/plans/plans__signup-business.ts
@@ -6,7 +6,6 @@ import {
 	DataHelper,
 	BrowserManager,
 	SignupPickPlanPage,
-	StartSiteFlow,
 	SidebarComponent,
 	RestAPIClient,
 	CartCheckoutPage,
@@ -71,12 +70,6 @@ describe(
 
 			it( 'Make purchase', async function () {
 				await cartCheckoutPage.purchase( { timeout: 75 * 1000 } );
-			} );
-
-			it( 'Skip Onboarding', async function () {
-				await page.waitForURL( /setup\/site-setup\/goals/ );
-				const startSiteFlow = new StartSiteFlow( page );
-				await startSiteFlow.clickButton( 'Skip to dashboard' );
 			} );
 
 			it( 'See Home', async function () {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

We want to avoid "flaky tests", which usually stand for tests that weren't given enough love. 

- The onboarding one will be disabled as we plan to reuse this feature in CIAB. If by EOY we don't use. I'll remove the entire feature and these tests.
- The other was outdated with the /setup/goals removal


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This test is failing since the feature was disabled, and it was muted until now.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure e2e-prerelease tests pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
