### PR TITLE
Purchases: Make sure field values will not include "undefined"

### DIFF
--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -145,13 +145,13 @@ export function getPurchasesFieldDefinitions( {
 				return (
 					getDisplayName( item ) +
 					' ' +
-					purchaseType( item ) +
+					( purchaseType( item ) || '' ) +
 					' ' +
 					item.siteName +
 					' ' +
 					( item.siteSlug || item.domain ) +
 					' ' +
-					site?.URL
+					( site?.URL ?? '' )
 				);
 			},
 			render: ( { item }: { item: Purchases.Purchase } ) => {
@@ -196,7 +196,7 @@ export function getPurchasesFieldDefinitions( {
 			getValue: ( { item }: { item: Purchases.Purchase } ) => {
 				// Render a bunch of things to make this easily searchable.
 				const site = sites.find( ( site ) => site.ID === item.siteId );
-				return item.siteName + ' ' + item.domain + ' ' + site?.URL;
+				return item.siteName + ' ' + ( item.siteSlug || item.domain ) + ' ' + ( site?.URL ?? '' );
 			},
 			render: ( { item }: { item: Purchases.Purchase } ) => {
 				return (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/CHE-239/active-subscriptions-and-billing-history-fields-need-to-opt-out-of

## Proposed Changes

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/104954 which fixed some filtering regressions in the DataViews used for the list of active subscriptions.

In this PR we make sure that the values of each field cannot include the string `undefined` or `null`. This will not have any major practical effect since these fields have filtering disabled now but it should be done regardless. Those values can be used for many things.

See the discussion that revealed this bug in Slack: p1753779715908529/1753733071.278209-slack-C02ECE3ML

## Testing Instructions

TypeScript should be sufficient here.