### PR TITLE
Hosting Dashboard: Add remaining WAF components to the security settings

### DIFF
--- a/client/dashboard/app/queries/site-jetpack-module.ts
+++ b/client/dashboard/app/queries/site-jetpack-module.ts
@@ -23,7 +23,7 @@ export const siteJetpackModuleMutation = ( siteId: number ) =>
 				: deactivateJetpackModule( siteId, module );
 		},
 		onSuccess: ( newData: unknown, variables: { module: string; value: boolean } ) => {
-			queryClient.setQueryData( siteJetpackModulesQuery( siteId ).queryKey, ( oldData ) => {
+			queryClient.setQueryData( siteJetpackModulesQuery( siteId ).queryKey, ( oldData = [] ) => {
 				if ( variables.value ) {
 					return [ ...oldData, variables.module ];
 				}

--- a/client/dashboard/app/queries/site-jetpack-module.ts
+++ b/client/dashboard/app/queries/site-jetpack-module.ts
@@ -1,3 +1,4 @@
+import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import {
 	activateJetpackModule,
 	deactivateJetpackModule,
@@ -7,27 +8,29 @@ import { queryClient } from '../query-client';
 import { siteQueryFilter } from './site';
 import { sitesQuery } from './sites';
 
-export const siteJetpackModulesQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'jetpack_modules' ],
-	queryFn: () => fetchJetpackModules( siteId ),
-} );
+export const siteJetpackModulesQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'jetpack_modules' ],
+		queryFn: () => fetchJetpackModules( siteId ),
+	} );
 
-export const siteJetpackModuleMutation = ( siteId: number ) => ( {
-	mutationFn: ( variables: { module: string; value: boolean } ) => {
-		const { module, value } = variables;
-		return value
-			? activateJetpackModule( siteId, module )
-			: deactivateJetpackModule( siteId, module );
-	},
-	onSuccess: ( newData: unknown, variables: { module: string; value: boolean } ) => {
-		queryClient.setQueryData( siteJetpackModulesQuery( siteId ).queryKey, ( oldData: string[] ) => {
-			if ( variables.value ) {
-				return [ ...oldData, variables.module ];
-			}
-			return oldData.filter( ( module ) => module !== variables.module );
-		} );
-		queryClient.invalidateQueries( { queryKey: siteJetpackModulesQuery( siteId ).queryKey } );
-		queryClient.invalidateQueries( siteQueryFilter( siteId ) );
-		queryClient.invalidateQueries( { queryKey: sitesQuery().queryKey } );
-	},
-} );
+export const siteJetpackModuleMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( variables: { module: string; value: boolean } ) => {
+			const { module, value } = variables;
+			return value
+				? activateJetpackModule( siteId, module )
+				: deactivateJetpackModule( siteId, module );
+		},
+		onSuccess: ( newData: unknown, variables: { module: string; value: boolean } ) => {
+			queryClient.setQueryData( siteJetpackModulesQuery( siteId ).queryKey, ( oldData ) => {
+				if ( variables.value ) {
+					return [ ...oldData, variables.module ];
+				}
+				return oldData.filter( ( module ) => module !== variables.module );
+			} );
+			queryClient.invalidateQueries( { queryKey: siteJetpackModulesQuery( siteId ).queryKey } );
+			queryClient.invalidateQueries( siteQueryFilter( siteId ) );
+			queryClient.invalidateQueries( { queryKey: sitesQuery().queryKey } );
+		},
+	} );

--- a/client/dashboard/app/queries/site-jetpack-settings.ts
+++ b/client/dashboard/app/queries/site-jetpack-settings.ts
@@ -1,0 +1,25 @@
+import { fetchJetpackSettings, updateJetpackSettings } from '../../data/site-jetpack-settings';
+import { queryClient } from '../query-client';
+import { siteQueryFilter } from './site';
+import { siteSettingsQuery } from './site-settings';
+import type { SiteSettings } from '../../data/site-settings';
+
+export const siteJetpackSettingsQuery = ( siteId: number ) => ( {
+	queryKey: [ 'site', siteId, 'settings' ],
+	queryFn: () => fetchJetpackSettings( siteId ),
+} );
+
+export const siteJetpackSettingsMutation = ( siteId: number ) => ( {
+	mutationFn: ( settings: Partial< SiteSettings > ) => updateJetpackSettings( siteId, settings ),
+	onSuccess: ( newData: unknown, newSettings: Partial< SiteSettings > ) => {
+		queryClient.setQueryData(
+			siteJetpackSettingsQuery( siteId ).queryKey,
+			( oldData: SiteSettings ) => ( {
+				...oldData,
+				...newSettings,
+			} )
+		);
+		queryClient.invalidateQueries( siteSettingsQuery( siteId ) );
+		queryClient.invalidateQueries( siteQueryFilter( siteId ) );
+	},
+} );

--- a/client/dashboard/app/queries/site-jetpack-settings.ts
+++ b/client/dashboard/app/queries/site-jetpack-settings.ts
@@ -1,11 +1,10 @@
 import { fetchJetpackSettings, updateJetpackSettings } from '../../data/site-jetpack-settings';
 import { queryClient } from '../query-client';
 import { siteQueryFilter } from './site';
-import { siteSettingsQuery } from './site-settings';
 import type { SiteSettings } from '../../data/site-settings';
 
 export const siteJetpackSettingsQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'settings' ],
+	queryKey: [ 'site', siteId, 'jetpackSettings' ],
 	queryFn: () => fetchJetpackSettings( siteId ),
 } );
 
@@ -19,7 +18,6 @@ export const siteJetpackSettingsMutation = ( siteId: number ) => ( {
 				...newSettings,
 			} )
 		);
-		queryClient.invalidateQueries( siteSettingsQuery( siteId ) );
 		queryClient.invalidateQueries( siteQueryFilter( siteId ) );
 	},
 } );

--- a/client/dashboard/app/queries/site-jetpack-settings.ts
+++ b/client/dashboard/app/queries/site-jetpack-settings.ts
@@ -1,23 +1,23 @@
+import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { fetchJetpackSettings, updateJetpackSettings } from '../../data/site-jetpack-settings';
 import { queryClient } from '../query-client';
 import { siteQueryFilter } from './site';
 import type { SiteSettings } from '../../data/site-settings';
 
-export const siteJetpackSettingsQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'jetpack-settings' ],
-	queryFn: () => fetchJetpackSettings( siteId ),
-} );
+export const siteJetpackSettingsQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'jetpack-settings' ],
+		queryFn: () => fetchJetpackSettings( siteId ),
+	} );
 
-export const siteJetpackSettingsMutation = ( siteId: number ) => ( {
-	mutationFn: ( settings: Partial< SiteSettings > ) => updateJetpackSettings( siteId, settings ),
-	onSuccess: ( newData: unknown, newSettings: Partial< SiteSettings > ) => {
-		queryClient.setQueryData(
-			siteJetpackSettingsQuery( siteId ).queryKey,
-			( oldData: SiteSettings ) => ( {
+export const siteJetpackSettingsMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( settings: Partial< SiteSettings > ) => updateJetpackSettings( siteId, settings ),
+		onSuccess: ( newData: unknown, newSettings: Partial< SiteSettings > ) => {
+			queryClient.setQueryData( siteJetpackSettingsQuery( siteId ).queryKey, ( oldData ) => ( {
 				...oldData,
 				...newSettings,
-			} )
-		);
-		queryClient.invalidateQueries( siteQueryFilter( siteId ) );
-	},
-} );
+			} ) );
+			queryClient.invalidateQueries( siteQueryFilter( siteId ) );
+		},
+	} );

--- a/client/dashboard/app/queries/site-jetpack-settings.ts
+++ b/client/dashboard/app/queries/site-jetpack-settings.ts
@@ -4,7 +4,7 @@ import { siteQueryFilter } from './site';
 import type { SiteSettings } from '../../data/site-settings';
 
 export const siteJetpackSettingsQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'jetpackSettings' ],
+	queryKey: [ 'site', siteId, 'jetpack-settings' ],
 	queryFn: () => fetchJetpackSettings( siteId ),
 } );
 

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -25,6 +25,7 @@ import { siteEdgeCacheStatusQuery } from './queries/site-cache';
 import { siteDefensiveModeSettingsQuery } from './queries/site-defensive-mode';
 import { siteDomainsQuery } from './queries/site-domains';
 import { siteJetpackModulesQuery } from './queries/site-jetpack-module';
+import { siteJetpackSettingsQuery } from './queries/site-jetpack-settings';
 import { sitePHPVersionQuery } from './queries/site-php-version';
 import { siteCurrentPlanQuery } from './queries/site-plans';
 import { sitePreviewLinksQuery } from './queries/site-preview-links';
@@ -463,7 +464,10 @@ const siteSettingsWebApplicationFirewallRoute = createRoute( {
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		if ( hasHostingFeature( site, HostingFeatures.SECURITY_SETTINGS ) ) {
-			await queryClient.ensureQueryData( siteJetpackModulesQuery( site.ID ) );
+			await Promise.all( [
+				queryClient.ensureQueryData( siteJetpackModulesQuery( site.ID ) ),
+				queryClient.ensureQueryData( siteJetpackSettingsQuery( site.ID ) ),
+			] );
 		}
 	},
 } ).lazy( () =>

--- a/client/dashboard/data/constants.ts
+++ b/client/dashboard/data/constants.ts
@@ -45,7 +45,9 @@ export enum JetpackFeatures {
 
 export enum JetpackModules {
 	MONITOR = 'monitor',
+	PROTECT = 'protect',
 	STATS = 'stats',
+	WAF = 'waf',
 }
 
 // Features that needs Atomic or self-hosted infrastructure,

--- a/client/dashboard/data/site-jetpack-modules.ts
+++ b/client/dashboard/data/site-jetpack-modules.ts
@@ -1,6 +1,6 @@
 import wpcom from 'calypso/lib/wp';
 
-export async function fetchJetpackModules( siteId: number ) {
+export async function fetchJetpackModules( siteId: number ): Promise< string[] > {
 	const { data } = await wpcom.req.get( `/jetpack-blogs/${ siteId }/rest-api/`, {
 		path: '/jetpack/v4/module/all/',
 	} );

--- a/client/dashboard/data/site-jetpack-settings.ts
+++ b/client/dashboard/data/site-jetpack-settings.ts
@@ -1,0 +1,18 @@
+import wpcom from 'calypso/lib/wp';
+import { SiteSettings } from './site-settings';
+
+// This request returns roughly the same data as fetchSiteSettings
+export async function fetchJetpackSettings( siteId: number ) {
+	const { settings } = await wpcom.req.get( `/jetpack-blogs/${ siteId }/rest-api/`, {
+		path: '/jetpack/v4/settings/',
+	} );
+	return settings;
+}
+
+export async function updateJetpackSettings( siteId: number, settings: Partial< SiteSettings > ) {
+	return wpcom.req.post( `/jetpack-blogs/${ siteId }/rest-api/`, {
+		path: '/jetpack/v4/settings/',
+		body: JSON.stringify( settings ),
+		json: true,
+	} );
+}

--- a/client/dashboard/data/site-jetpack-settings.ts
+++ b/client/dashboard/data/site-jetpack-settings.ts
@@ -3,10 +3,10 @@ import { SiteSettings } from './site-settings';
 
 // This request returns roughly the same data as fetchSiteSettings
 export async function fetchJetpackSettings( siteId: number ): Promise< Partial< SiteSettings > > {
-	const { settings } = await wpcom.req.get( `/jetpack-blogs/${ siteId }/rest-api/`, {
+	const { data } = await wpcom.req.get( `/jetpack-blogs/${ siteId }/rest-api/`, {
 		path: '/jetpack/v4/settings/',
 	} );
-	return settings;
+	return data;
 }
 
 export async function updateJetpackSettings( siteId: number, settings: Partial< SiteSettings > ) {

--- a/client/dashboard/data/site-jetpack-settings.ts
+++ b/client/dashboard/data/site-jetpack-settings.ts
@@ -2,7 +2,7 @@ import wpcom from 'calypso/lib/wp';
 import { SiteSettings } from './site-settings';
 
 // This request returns roughly the same data as fetchSiteSettings
-export async function fetchJetpackSettings( siteId: number ) {
+export async function fetchJetpackSettings( siteId: number ): Promise< Partial< SiteSettings > > {
 	const { settings } = await wpcom.req.get( `/jetpack-blogs/${ siteId }/rest-api/`, {
 		path: '/jetpack/v4/settings/',
 	} );

--- a/client/dashboard/data/site-jetpack-settings.ts
+++ b/client/dashboard/data/site-jetpack-settings.ts
@@ -12,7 +12,6 @@ export async function fetchJetpackSettings( siteId: number ): Promise< Partial< 
 export async function updateJetpackSettings( siteId: number, settings: Partial< SiteSettings > ) {
 	return wpcom.req.post( `/jetpack-blogs/${ siteId }/rest-api/`, {
 		path: '/jetpack/v4/settings/',
-		body: JSON.stringify( settings ),
-		json: true,
+		body: settings,
 	} );
 }

--- a/client/dashboard/data/site-settings.ts
+++ b/client/dashboard/data/site-settings.ts
@@ -16,6 +16,8 @@ export interface SiteSettings {
 	wpcom_locked_mode?: boolean;
 	jetpack_waf_ip_allow_list_enabled?: boolean;
 	jetpack_waf_ip_allow_list?: string;
+	jetpack_waf_ip_block_list_enabled?: boolean;
+	jetpack_waf_ip_block_list?: string;
 }
 
 export async function fetchSiteSettings( siteId: number ): Promise< SiteSettings > {

--- a/client/dashboard/data/site-settings.ts
+++ b/client/dashboard/data/site-settings.ts
@@ -14,6 +14,8 @@ export interface SiteSettings {
 	wpcom_performance_report_url?: string;
 	wpcom_legacy_contact?: string;
 	wpcom_locked_mode?: boolean;
+	jetpack_waf_ip_allow_list_enabled?: boolean;
+	jetpack_waf_ip_allow_list?: string;
 }
 
 export async function fetchSiteSettings( siteId: number ): Promise< SiteSettings > {

--- a/client/dashboard/data/site-settings.ts
+++ b/client/dashboard/data/site-settings.ts
@@ -14,6 +14,8 @@ export interface SiteSettings {
 	wpcom_performance_report_url?: string;
 	wpcom_legacy_contact?: string;
 	wpcom_locked_mode?: boolean;
+	jetpack_waf_automatic_rules?: boolean;
+	jetpack_waf_automatic_rules_last_updated_timestamp?: number;
 	jetpack_waf_ip_allow_list_enabled?: boolean;
 	jetpack_waf_ip_allow_list?: string;
 	jetpack_waf_ip_block_list_enabled?: boolean;

--- a/client/dashboard/sites/settings-web-application-firewall/allow-list-form.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/allow-list-form.tsx
@@ -4,12 +4,14 @@ import {
 	CardBody,
 	TextareaControl,
 	__experimentalHStack as HStack,
+	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	Button,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
-import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import {
@@ -89,6 +91,8 @@ export default function AllowListForm( { site }: { site: Site } ) {
 		formData.jetpack_waf_ip_allow_list !== currentList;
 	const { isPending } = mutation;
 
+	const ipAddress = window?.app?.clientIp || __( 'Unknown' );
+
 	return (
 		<Card>
 			<CardBody>
@@ -109,6 +113,16 @@ export default function AllowListForm( { site }: { site: Site } ) {
 								setFormData( ( data ) => ( { ...data, ...edits } ) );
 							} }
 						/>
+						<Text>
+							{ createInterpolateElement(
+								sprintf(
+									/* translators: %s: IP address */
+									__( 'Your current IP address is: <strong>%s</strong>' ),
+									ipAddress
+								),
+								{ strong: <strong /> }
+							) }
+						</Text>
 						<HStack justify="flex-start">
 							<Button
 								variant="primary"

--- a/client/dashboard/sites/settings-web-application-firewall/allow-list-form.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/allow-list-form.tsx
@@ -1,0 +1,127 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import {
+	Card,
+	CardBody,
+	TextareaControl,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Button,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { DataForm } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useState } from 'react';
+import {
+	siteJetpackSettingsQuery,
+	siteJetpackSettingsMutation,
+} from '../../app/queries/site-jetpack-settings';
+import { SectionHeader } from '../../components/section-header';
+import type { SiteSettings } from '../../data/site-settings';
+import type { Site } from '../../data/types';
+import type { Field } from '@wordpress/dataviews';
+
+const fields: Field< SiteSettings >[] = [
+	{
+		id: 'jetpack_waf_ip_allow_list_enabled',
+		label: __( 'Enable allowing specific IP addresses' ),
+		Edit: 'checkbox',
+	},
+	{
+		id: 'jetpack_waf_ip_allow_list',
+		label: __( 'Allowed IP addresses' ),
+		type: 'text',
+		Edit: ( { field, onChange, data, hideLabelFromVision } ) => {
+			const { id, getValue } = field;
+			return (
+				<TextareaControl
+					__nextHasNoMarginBottom
+					disabled={ ! data.jetpack_waf_ip_allow_list_enabled }
+					// eslint-disable-next-line @wordpress/i18n-hyphenated-range
+					help={ __(
+						'IPv4 and IPv6 are acceptable. To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100'
+					) }
+					label={ hideLabelFromVision ? '' : field.label }
+					onChange={ ( value ) => onChange( { [ id ]: value } ) }
+					rows={ 4 }
+					value={ getValue( { item: data } ) || '' }
+				/>
+			);
+		},
+	},
+];
+
+const form = {
+	type: 'regular' as const,
+	fields: [ 'jetpack_waf_ip_allow_list_enabled', 'jetpack_waf_ip_allow_list' ],
+};
+
+export default function AllowListForm( { site }: { site: Site } ) {
+	const { data: jetpackSettings } = useQuery( siteJetpackSettingsQuery( site.ID ) );
+	const mutation = useMutation( siteJetpackSettingsMutation( site.ID ) );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const currentEnabled = jetpackSettings?.jetpack_waf_ip_allow_list_enabled ?? false;
+	const currentList = jetpackSettings?.jetpack_waf_ip_allow_list ?? '';
+
+	const [ formData, setFormData ] = useState< SiteSettings >( {
+		jetpack_waf_ip_allow_list_enabled: currentEnabled,
+		jetpack_waf_ip_allow_list: currentList,
+	} );
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		mutation.mutate(
+			{ ...formData },
+			{
+				onSuccess: () => {
+					createSuccessNotice( __( 'Allowed IP addresses saved.' ), { type: 'snackbar' } );
+				},
+				onError: () => {
+					createErrorNotice( __( 'Failed to save allowed IP addresses.' ), { type: 'snackbar' } );
+				},
+			}
+		);
+	};
+
+	const isDirty =
+		formData.jetpack_waf_ip_allow_list_enabled !== currentEnabled ||
+		formData.jetpack_waf_ip_allow_list !== currentList;
+	const { isPending } = mutation;
+
+	return (
+		<Card>
+			<CardBody>
+				<form onSubmit={ handleSubmit }>
+					<VStack spacing={ 4 }>
+						<SectionHeader
+							title={ __( 'Always allow specific IP addresses' ) }
+							description={ __(
+								"IP addresses added to this list will never be blocked by Jetpack's security features."
+							) }
+							level={ 3 }
+						/>
+						<DataForm< SiteSettings >
+							data={ formData }
+							fields={ fields }
+							form={ form }
+							onChange={ ( edits: Partial< SiteSettings > ) => {
+								setFormData( ( data ) => ( { ...data, ...edits } ) );
+							} }
+						/>
+						<HStack justify="flex-start">
+							<Button
+								variant="primary"
+								type="submit"
+								isBusy={ isPending }
+								disabled={ isPending || ! isDirty }
+							>
+								{ __( 'Save' ) }
+							</Button>
+						</HStack>
+					</VStack>
+				</form>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/sites/settings-web-application-firewall/allow-list-form.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/allow-list-form.tsx
@@ -101,7 +101,7 @@ export default function AllowListForm( { site }: { site: Site } ) {
 						<SectionHeader
 							title={ __( 'Always allow specific IP addresses' ) }
 							description={ __(
-								"IP addresses added to this list will never be blocked by Jetpack's security features."
+								'IP addresses added to this list will never be blocked by Jetpack’s security features.'
 							) }
 							level={ 3 }
 						/>

--- a/client/dashboard/sites/settings-web-application-firewall/automatic-rules-form.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/automatic-rules-form.tsx
@@ -1,0 +1,127 @@
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import {
+	Card,
+	CardBody,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Button,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { DataForm } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useState } from 'react';
+import { siteJetpackModulesQuery } from '../../app/queries/site-jetpack-module';
+import {
+	siteJetpackSettingsQuery,
+	siteJetpackSettingsMutation,
+} from '../../app/queries/site-jetpack-settings';
+import { SectionHeader } from '../../components/section-header';
+import { HostingFeatures } from '../../data/constants';
+import { hasHostingFeature } from '../../utils/site-features';
+import { isSelfHostedJetpackConnected } from '../../utils/site-types';
+import type { SiteSettings } from '../../data/site-settings';
+import type { Site } from '../../data/types';
+import type { Field } from '@wordpress/dataviews';
+
+const fields: Field< SiteSettings >[] = [
+	{
+		id: 'jetpack_waf_automatic_rules',
+		label: __( 'Enable automatic firewall protection' ),
+		Edit: 'checkbox',
+	},
+];
+
+const form = {
+	type: 'regular' as const,
+	fields: [ 'jetpack_waf_automatic_rules' ],
+};
+
+export default function AutomaticRulesForm( { site }: { site: Site } ) {
+	const { data: jetpackModules } = useSuspenseQuery( siteJetpackModulesQuery( site.ID ) );
+	const { data: jetpackSettings } = useSuspenseQuery( siteJetpackSettingsQuery( site.ID ) );
+	const mutation = useMutation( siteJetpackSettingsMutation( site.ID ) );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	// The WAF module is only supported on self-hosted Jetpack sites, and not supported on VIP
+	const isFirewallModuleSupported =
+		jetpackModules?.includes( 'waf' ) && isSelfHostedJetpackConnected( site ) && ! site.is_vip;
+
+	const canUseAutomaticRules =
+		hasHostingFeature( site, HostingFeatures.SCAN ) ||
+		!! jetpackSettings?.jetpack_waf_automatic_rules_last_updated_timestamp;
+
+	const currentEnabled = jetpackSettings?.jetpack_waf_automatic_rules ?? false;
+
+	const [ formData, setFormData ] = useState< SiteSettings >( {
+		jetpack_waf_automatic_rules: currentEnabled,
+	} );
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		mutation.mutate(
+			{ ...formData },
+			{
+				onSuccess: () => {
+					createSuccessNotice(
+						formData.jetpack_waf_automatic_rules
+							? __( 'Automatic firewall protection enabled.' )
+							: __( 'Automatic firewall protection disabled.' ),
+						{ type: 'snackbar' }
+					);
+				},
+				onError: () => {
+					createErrorNotice(
+						formData.jetpack_waf_automatic_rules
+							? __( 'Failed to enable automatic firewall protection.' )
+							: __( 'Failed to disable automatic firewall protection.' ),
+						{ type: 'snackbar' }
+					);
+				},
+			}
+		);
+	};
+
+	const isDirty = formData.jetpack_waf_ip_block_list_enabled !== currentEnabled;
+	const { isPending } = mutation;
+
+	if ( ! isFirewallModuleSupported || ! canUseAutomaticRules ) {
+		return null;
+	}
+
+	return (
+		<Card>
+			<CardBody>
+				<form onSubmit={ handleSubmit }>
+					<VStack spacing={ 4 }>
+						<SectionHeader
+							title={ __( 'Automatic firewall protection' ) }
+							description={ __(
+								"Block untrusted traffic sources by scanning every request made to your site. Jetpack's advanced security rules are automatically kept up-to-date to protect your site from the latest threats."
+							) }
+							level={ 3 }
+						/>
+						<DataForm< SiteSettings >
+							data={ formData }
+							fields={ fields }
+							form={ form }
+							onChange={ ( edits: Partial< SiteSettings > ) => {
+								setFormData( ( data ) => ( { ...data, ...edits } ) );
+							} }
+						/>
+						<HStack justify="flex-start">
+							<Button
+								variant="primary"
+								type="submit"
+								isBusy={ isPending }
+								disabled={ isPending || ! isDirty }
+							>
+								{ __( 'Save' ) }
+							</Button>
+						</HStack>
+					</VStack>
+				</form>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/sites/settings-web-application-firewall/automatic-rules-form.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/automatic-rules-form.tsx
@@ -11,14 +11,13 @@ import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
-import { siteJetpackModulesQuery } from '../../app/queries/site-jetpack-module';
 import {
 	siteJetpackSettingsQuery,
 	siteJetpackSettingsMutation,
 } from '../../app/queries/site-jetpack-settings';
 import { SectionHeader } from '../../components/section-header';
-import { HostingFeatures } from '../../data/constants';
-import { hasHostingFeature } from '../../utils/site-features';
+import { HostingFeatures, JetpackModules } from '../../data/constants';
+import { hasHostingFeature, hasJetpackModule } from '../../utils/site-features';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import type { SiteSettings } from '../../data/site-settings';
 import type { Site } from '../../data/types';
@@ -38,14 +37,15 @@ const form = {
 };
 
 export default function AutomaticRulesForm( { site }: { site: Site } ) {
-	const { data: jetpackModules } = useSuspenseQuery( siteJetpackModulesQuery( site.ID ) );
 	const { data: jetpackSettings } = useSuspenseQuery( siteJetpackSettingsQuery( site.ID ) );
 	const mutation = useMutation( siteJetpackSettingsMutation( site.ID ) );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
 	// The WAF module is only supported on self-hosted Jetpack sites, and not supported on VIP
 	const isFirewallModuleSupported =
-		jetpackModules?.includes( 'waf' ) && isSelfHostedJetpackConnected( site ) && ! site.is_vip;
+		hasJetpackModule( site, JetpackModules.WAF ) &&
+		isSelfHostedJetpackConnected( site ) &&
+		! site.is_vip;
 
 	const canUseAutomaticRules =
 		hasHostingFeature( site, HostingFeatures.SCAN ) ||

--- a/client/dashboard/sites/settings-web-application-firewall/automatic-rules-form.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/automatic-rules-form.tsx
@@ -82,7 +82,7 @@ export default function AutomaticRulesForm( { site }: { site: Site } ) {
 		);
 	};
 
-	const isDirty = formData.jetpack_waf_ip_block_list_enabled !== currentEnabled;
+	const isDirty = formData.jetpack_waf_automatic_rules !== currentEnabled;
 	const { isPending } = mutation;
 
 	if ( ! isFirewallModuleSupported || ! canUseAutomaticRules ) {

--- a/client/dashboard/sites/settings-web-application-firewall/automatic-rules-form.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/automatic-rules-form.tsx
@@ -97,7 +97,7 @@ export default function AutomaticRulesForm( { site }: { site: Site } ) {
 						<SectionHeader
 							title={ __( 'Automatic firewall protection' ) }
 							description={ __(
-								"Block untrusted traffic sources by scanning every request made to your site. Jetpack's advanced security rules are automatically kept up-to-date to protect your site from the latest threats."
+								'Block untrusted traffic sources by scanning every request made to your site. Jetpack’s advanced security rules are automatically kept up-to-date to protect your site from the latest threats.'
 							) }
 							level={ 3 }
 						/>

--- a/client/dashboard/sites/settings-web-application-firewall/block-list-form.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/block-list-form.tsx
@@ -12,12 +12,13 @@ import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
-import { siteJetpackModulesQuery } from '../../app/queries/site-jetpack-module';
 import {
 	siteJetpackSettingsQuery,
 	siteJetpackSettingsMutation,
 } from '../../app/queries/site-jetpack-settings';
 import { SectionHeader } from '../../components/section-header';
+import { JetpackModules } from '../../data/constants';
+import { hasJetpackModule } from '../../utils/site-features';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import type { SiteSettings } from '../../data/site-settings';
 import type { Site } from '../../data/types';
@@ -59,14 +60,15 @@ const form = {
 };
 
 export default function BlockListForm( { site }: { site: Site } ) {
-	const { data: jetpackModules } = useSuspenseQuery( siteJetpackModulesQuery( site.ID ) );
 	const { data: jetpackSettings } = useSuspenseQuery( siteJetpackSettingsQuery( site.ID ) );
 	const mutation = useMutation( siteJetpackSettingsMutation( site.ID ) );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
 	// The WAF module is only supported on self-hosted Jetpack sites, and not supported on VIP
 	const isFirewallModuleSupported =
-		jetpackModules?.includes( 'waf' ) && isSelfHostedJetpackConnected( site ) && ! site.is_vip;
+		hasJetpackModule( site, JetpackModules.WAF ) &&
+		isSelfHostedJetpackConnected( site ) &&
+		! site.is_vip;
 
 	const currentEnabled = jetpackSettings?.jetpack_waf_ip_block_list_enabled ?? false;
 	const currentList = jetpackSettings?.jetpack_waf_ip_block_list ?? '';

--- a/client/dashboard/sites/settings-web-application-firewall/block-list-form.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/block-list-form.tsx
@@ -12,31 +12,33 @@ import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
+import { siteJetpackModulesQuery } from '../../app/queries/site-jetpack-module';
 import {
 	siteJetpackSettingsQuery,
 	siteJetpackSettingsMutation,
 } from '../../app/queries/site-jetpack-settings';
 import { SectionHeader } from '../../components/section-header';
+import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import type { SiteSettings } from '../../data/site-settings';
 import type { Site } from '../../data/types';
 import type { Field } from '@wordpress/dataviews';
 
 const fields: Field< SiteSettings >[] = [
 	{
-		id: 'jetpack_waf_ip_allow_list_enabled',
-		label: __( 'Enable allowing specific IP addresses' ),
+		id: 'jetpack_waf_ip_block_list_enabled',
+		label: __( 'Enable blocking specific IP addresses' ),
 		Edit: 'checkbox',
 	},
 	{
-		id: 'jetpack_waf_ip_allow_list',
-		label: __( 'Allowed IP addresses' ),
+		id: 'jetpack_waf_ip_block_list',
+		label: __( 'Blocked IP addresses' ),
 		type: 'text',
 		Edit: ( { field, onChange, data, hideLabelFromVision } ) => {
 			const { id, getValue } = field;
 			return (
 				<TextareaControl
 					__nextHasNoMarginBottom
-					disabled={ ! data.jetpack_waf_ip_allow_list_enabled }
+					disabled={ ! data.jetpack_waf_ip_block_list_enabled }
 					// eslint-disable-next-line @wordpress/i18n-hyphenated-range
 					help={ __(
 						'IPv4 and IPv6 are acceptable. To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100'
@@ -53,20 +55,25 @@ const fields: Field< SiteSettings >[] = [
 
 const form = {
 	type: 'regular' as const,
-	fields: [ 'jetpack_waf_ip_allow_list_enabled', 'jetpack_waf_ip_allow_list' ],
+	fields: [ 'jetpack_waf_ip_block_list_enabled', 'jetpack_waf_ip_block_list' ],
 };
 
-export default function AllowListForm( { site }: { site: Site } ) {
+export default function BlockListForm( { site }: { site: Site } ) {
+	const { data: jetpackModules } = useSuspenseQuery( siteJetpackModulesQuery( site.ID ) );
 	const { data: jetpackSettings } = useSuspenseQuery( siteJetpackSettingsQuery( site.ID ) );
 	const mutation = useMutation( siteJetpackSettingsMutation( site.ID ) );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
-	const currentEnabled = jetpackSettings?.jetpack_waf_ip_allow_list_enabled ?? false;
-	const currentList = jetpackSettings?.jetpack_waf_ip_allow_list ?? '';
+	// The WAF module is only supported on self-hosted Jetpack sites, and not supported on VIP
+	const isFirewallModuleSupported =
+		jetpackModules?.includes( 'waf' ) && isSelfHostedJetpackConnected( site ) && ! site.is_vip;
+
+	const currentEnabled = jetpackSettings?.jetpack_waf_ip_block_list_enabled ?? false;
+	const currentList = jetpackSettings?.jetpack_waf_ip_block_list ?? '';
 
 	const [ formData, setFormData ] = useState< SiteSettings >( {
-		jetpack_waf_ip_allow_list_enabled: currentEnabled,
-		jetpack_waf_ip_allow_list: currentList,
+		jetpack_waf_ip_block_list_enabled: currentEnabled,
+		jetpack_waf_ip_block_list: currentList,
 	} );
 
 	const handleSubmit = ( e: React.FormEvent ) => {
@@ -75,19 +82,23 @@ export default function AllowListForm( { site }: { site: Site } ) {
 			{ ...formData },
 			{
 				onSuccess: () => {
-					createSuccessNotice( __( 'Allowed IP addresses saved.' ), { type: 'snackbar' } );
+					createSuccessNotice( __( 'Blocked IP addresses saved.' ), { type: 'snackbar' } );
 				},
 				onError: () => {
-					createErrorNotice( __( 'Failed to save allowed IP addresses.' ), { type: 'snackbar' } );
+					createErrorNotice( __( 'Failed to save blocked IP addresses.' ), { type: 'snackbar' } );
 				},
 			}
 		);
 	};
 
 	const isDirty =
-		formData.jetpack_waf_ip_allow_list_enabled !== currentEnabled ||
-		formData.jetpack_waf_ip_allow_list !== currentList;
+		formData.jetpack_waf_ip_block_list_enabled !== currentEnabled ||
+		formData.jetpack_waf_ip_block_list !== currentList;
 	const { isPending } = mutation;
+
+	if ( ! isFirewallModuleSupported ) {
+		return null;
+	}
 
 	return (
 		<Card>
@@ -95,9 +106,9 @@ export default function AllowListForm( { site }: { site: Site } ) {
 				<form onSubmit={ handleSubmit }>
 					<VStack spacing={ 4 }>
 						<SectionHeader
-							title={ __( 'Always allow specific IP addresses' ) }
+							title={ __( 'Block specific IP addresses' ) }
 							description={ __(
-								"IP addresses added to this list will never be blocked by Jetpack's security features."
+								'IP addresses added to this list will be blocked from accessing your site.'
 							) }
 							level={ 3 }
 						/>

--- a/client/dashboard/sites/settings-web-application-firewall/index.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/index.tsx
@@ -9,6 +9,7 @@ import PageLayout from '../../components/page-layout';
 import { HostingFeatures } from '../../data/constants';
 import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callout';
 import SettingsPageHeader from '../settings-page-header';
+import AllowListForm from './allow-list-form';
 import ProtectForm from './protect-form';
 
 export default function WebApplicationFirewallSettings( { siteSlug }: { siteSlug: string } ) {
@@ -46,7 +47,7 @@ export default function WebApplicationFirewallSettings( { siteSlug }: { siteSlug
 
 				{ /* JP WAF Module's Block List */ }
 
-				{ /* Allow List */ }
+				<AllowListForm site={ site } />
 			</HostingFeatureGatedWithCallout>
 		</PageLayout>
 	);

--- a/client/dashboard/sites/settings-web-application-firewall/index.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/index.tsx
@@ -10,6 +10,7 @@ import { HostingFeatures } from '../../data/constants';
 import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callout';
 import SettingsPageHeader from '../settings-page-header';
 import AllowListForm from './allow-list-form';
+import AutomaticRulesForm from './automatic-rules-form';
 import BlockListForm from './block-list-form';
 import ProtectForm from './protect-form';
 
@@ -42,7 +43,7 @@ export default function WebApplicationFirewallSettings( { siteSlug }: { siteSlug
 				feature={ HostingFeatures.SECURITY_SETTINGS }
 				tracksFeatureId="settings-security"
 			>
-				{ /* JP WAF Module */ }
+				<AutomaticRulesForm site={ site } />
 
 				<ProtectForm site={ site } />
 

--- a/client/dashboard/sites/settings-web-application-firewall/index.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/index.tsx
@@ -10,6 +10,7 @@ import { HostingFeatures } from '../../data/constants';
 import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callout';
 import SettingsPageHeader from '../settings-page-header';
 import AllowListForm from './allow-list-form';
+import BlockListForm from './block-list-form';
 import ProtectForm from './protect-form';
 
 export default function WebApplicationFirewallSettings( { siteSlug }: { siteSlug: string } ) {
@@ -45,7 +46,7 @@ export default function WebApplicationFirewallSettings( { siteSlug }: { siteSlug
 
 				<ProtectForm site={ site } />
 
-				{ /* JP WAF Module's Block List */ }
+				<BlockListForm site={ site } />
 
 				<AllowListForm site={ site } />
 			</HostingFeatureGatedWithCallout>

--- a/client/dashboard/sites/settings-web-application-firewall/protect-form.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/protect-form.tsx
@@ -16,6 +16,7 @@ import {
 	siteJetpackModuleMutation,
 } from '../../app/queries/site-jetpack-module';
 import { SectionHeader } from '../../components/section-header';
+import { JetpackModules } from '../../data/constants';
 import type { Site } from '../../data/types';
 
 const fields = [
@@ -36,7 +37,7 @@ export default function ProtectForm( { site }: { site: Site } ) {
 	const mutation = useMutation( siteJetpackModuleMutation( site.ID ) );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
-	const currentProtect = jetpackModules?.includes( 'protect' ) ?? false;
+	const currentProtect = jetpackModules?.includes( JetpackModules.PROTECT ) ?? false;
 
 	const [ formData, setFormData ] = useState< { protect: boolean } >( {
 		protect: currentProtect,

--- a/client/types.ts
+++ b/client/types.ts
@@ -133,6 +133,7 @@ declare global {
 		COMMIT_SHA: string; // Added by an inline script in <head> via SSR context + webpack.
 		app?: {
 			isDebug?: boolean;
+			clientIp?: string;
 		};
 		__REDUX_DEVTOOLS_EXTENSION__?: () => void;
 	}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-14036

Follow up to #104909

## Proposed Changes

* Add the remaining Web Application Firewall components to the new Hosting Dashboard's security settings.
* Create a new data layer to update Jetpack settings that cannot be updated through the site settings layer.
  * Note: fetching Jetpack settings returns (roughly) the same list as site settings. For most intents and purposes, they are exactly the same.

<img height="500" alt="Screenshot 2025-07-29 at 18 08 33" src="https://github.com/user-attachments/assets/e2d21fd1-13a3-4da5-ad7d-ef7703023b31" />


### Notes about each component

* Block list of IP addresses
  * Only available on non-VIP, self-hosted, connected sites.
* Automatic firewall rules
  * Only available on non-VIP, self-hosted, connected sites, with the Scan feature.
  * On Calypso (/settings/security), this is upsold in place. I oped to just hide the component as (AFAICS) there are no "small" upsells, just the big callout.
  * The feature is also upsold from Jetpack -> Settings -> Security.
* Allow list of IP addresses
  * The Calypso version also has a button to insert the current IP address. The design omit it, and so did I.
  * FWIW, I think it's unnecessary, but I don't have any strong opinions.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Security Settings are used to address possible issues on the Jetpack/Dotcom connection. The screen has been hidden as part of the Untangling work, but it's still accessible via direct link (/settings/security/:SITE) — and recommended by HEs when necessary.

For further details, refer to the issue: [DOTCOM-13963](https://linear.app/a8c/issue/DOTCOM-13963).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Note: these changes are still behind feature flag, only enabled locally and on wpcalypso.

* Navigate to the Hosting Dashboard's site settings at `/sites/settings/v2/:SITE` (or `/v2/sites/:SITE/settings`).
* Open Web Application Firewall (WAF).
* Test all the forms, keeping in mind that they have different requirements:
  * Simple sites
    * Only get an upsell.
  * Atomic sites
    * Brute force protection (introduced in #104909)
    * IP address allow list
  * Self-hosted Jetpack
    * Brute force protection (introduced in #104909)
    * IP address block list
    * IP address allow list
  * Self-hosted Jetpack with Jetpack Scan
    * Automatic firewall
    * Brute force protection (introduced in #104909)
    * IP address block list
    * IP address allow list

The easiest way to test everything is via Jurassic Ninja, creating a site with a daily JP Scan license issued, and then connecting it to Dotcom.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
