### PR TITLE
A4A: Fix missing BD product name in client cancel modal

### DIFF
--- a/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
@@ -5,7 +5,8 @@ import { A4AConfirmationDialog } from 'calypso/a8c-for-agencies/components/a4a-c
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import useCancelClientSubscription from 'calypso/a8c-for-agencies/data/client/use-cancel-client-subscription';
 import useFetchClientProducts from 'calypso/a8c-for-agencies/data/client/use-fetch-client-products';
-import { useDispatch } from 'calypso/state';
+import { useSelector, useDispatch } from 'calypso/state';
+import { getUserBillingType } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { Subscription } from '../types';
@@ -22,6 +23,7 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 	const [ isVisible, setIsVisible ] = useState( false );
 
 	const { data: products, isFetching: isFetchingProductInfo } = useFetchClientProducts( false );
+	const isBillingTypeBD = useSelector( getUserBillingType ) === 'billingdragon';
 
 	const { mutate: cancelSubscription, isPending } = useCancelClientSubscription( {
 		onSuccess: () => {
@@ -52,7 +54,9 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 	};
 
 	const productName =
-		products?.find( ( product ) => product.product_id === subscription.product_id )?.name ?? '';
+		isBillingTypeBD && subscription.subscription?.product_name
+			? subscription.subscription.product_name
+			: products?.find( ( product ) => product.product_id === subscription.product_id )?.name ?? '';
 
 	return (
 		<>


### PR DESCRIPTION
Linear issue: https://linear.app/a8c/issue/A4A-1361/fix-missing-product-name-on-client-cancel-modal

## Proposed Changes

- Fix missing product name in client cancel subscription confirmation dialog for monthly BillingDragon subscriptions
- Add logic to use `subscription.subscription?.product_name` when billing type is 'billingdragon'
- Fall back to existing product lookup logic for non-BillingDragon subscriptions

## Why are these changes being made?

The cancel subscription confirmation dialog was not displaying the product name for BillingDragon subscriptions because it was only looking up the product name from the products list using `product_id`. However, for BillingDragon subscriptions, the product name is available directly in `subscription.subscription?.product_name`. This change ensures that users see the correct product name in the confirmation dialog regardless of the billing type.

## Testing Instructions

### Before Testing
- For a client with a BD subscription, visit `/client/subscriptions`
  - See 188433-ghe-Automattic/wpcom for how tp purchase using BD (v2 checkout)
- Click on "Cancel the subscription" and make sure the product name shows in the modal

<img width="1879" height="1006" alt="Screenshot 2025-07-29 at 1 09 40 PM" src="https://github.com/user-attachments/assets/8321b966-0c70-4c05-97b0-d696c73db355" />
<img width="1892" height="965" alt="Screenshot 2025-07-29 at 1 09 31 PM" src="https://github.com/user-attachments/assets/4d66facc-8629-4357-9445-6fda28d7dced" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?