### PR TITLE
Hosting dashboard: Wrap query objects in queryOptions/mutationOptions

### DIFF
--- a/client/dashboard/app/queries/domains.ts
+++ b/client/dashboard/app/queries/domains.ts
@@ -1,15 +1,18 @@
+import { queryOptions } from '@tanstack/react-query';
 import { fetchDomains, fetchDomainSuggestions } from '../../data/domains';
 import type { DomainSuggestionQuery } from '../../data/types';
 
-export const domainsQuery = () => ( {
-	queryKey: [ 'domains' ],
-	queryFn: fetchDomains,
-} );
+export const domainsQuery = () =>
+	queryOptions( {
+		queryKey: [ 'domains' ],
+		queryFn: fetchDomains,
+	} );
 
 export const domainSuggestionsQuery = (
 	search: string,
 	domainSuggestionQuery?: Partial< DomainSuggestionQuery >
-) => ( {
-	queryKey: [ 'domain-suggestions', search, domainSuggestionQuery ],
-	queryFn: () => fetchDomainSuggestions( search, domainSuggestionQuery ),
-} );
+) =>
+	queryOptions( {
+		queryKey: [ 'domain-suggestions', search, domainSuggestionQuery ],
+		queryFn: () => fetchDomainSuggestions( search, domainSuggestionQuery ),
+	} );

--- a/client/dashboard/app/queries/emails.ts
+++ b/client/dashboard/app/queries/emails.ts
@@ -1,6 +1,8 @@
+import { queryOptions } from '@tanstack/react-query';
 import { fetchEmails } from '../../data/emails';
 
-export const emailsQuery = () => ( {
-	queryKey: [ 'emails' ],
-	queryFn: fetchEmails,
-} );
+export const emailsQuery = () =>
+	queryOptions( {
+		queryKey: [ 'emails' ],
+		queryFn: fetchEmails,
+	} );

--- a/client/dashboard/app/queries/me-a8c.ts
+++ b/client/dashboard/app/queries/me-a8c.ts
@@ -1,8 +1,9 @@
-import { fetchReaderTeams, ReaderTeam } from '../../data/reader-teams';
+import { queryOptions } from '@tanstack/react-query';
+import { fetchReaderTeams } from '../../data/reader-teams';
 
-export const isAutomatticianQuery = () => ( {
-	queryKey: [ 'me', 'is-automattician' ],
-	queryFn: fetchReaderTeams,
-	select: ( data: { number: number; teams: ReaderTeam[] } ): boolean =>
-		data.teams.some( ( team: ReaderTeam ) => team.slug === 'a8c' ),
-} );
+export const isAutomatticianQuery = () =>
+	queryOptions( {
+		queryKey: [ 'me', 'is-automattician' ],
+		queryFn: fetchReaderTeams,
+		select: ( data ) => data.teams.some( ( team ) => team.slug === 'a8c' ),
+	} );

--- a/client/dashboard/app/queries/me-preferences.ts
+++ b/client/dashboard/app/queries/me-preferences.ts
@@ -1,3 +1,4 @@
+import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { fetchPreferences, updatePreferences } from '../../data/me-preferences';
 import { queryClient } from '../query-client';
 import type { UserPreferences } from '../../data/me-preferences';
@@ -8,36 +9,36 @@ const defaultValues: Required< UserPreferences > = {
 };
 
 // Returns all user preferences, without applying any defaults.
-export const rawUserPreferencesQuery = () => ( {
-	queryKey: [ 'me', 'preferences' ],
-	queryFn: fetchPreferences,
-} );
+export const rawUserPreferencesQuery = () =>
+	queryOptions( {
+		queryKey: [ 'me', 'preferences' ],
+		queryFn: fetchPreferences,
+	} );
 
-export const userPreferenceQuery = < P extends keyof UserPreferences >( preferenceName: P ) => ( {
-	queryKey: rawUserPreferencesQuery().queryKey,
-	queryFn: fetchPreferences,
-	select: ( data: UserPreferences ): Required< UserPreferences >[ P ] => {
-		const fetchedValue = data[ preferenceName ];
-		return fetchedValue === undefined
-			? defaultValues[ preferenceName ]
-			: // `fetchedValue` is a `NonNullable< UserPreferences[ P ] >`, which we know is the same
-			  // as `Required< UserPreferences >[ P ]`, but the later gives better type hints when
-			  // the query is used in the component.
-			  ( fetchedValue as Required< UserPreferences >[ P ] );
-	},
-} );
+export const userPreferenceQuery = < P extends keyof UserPreferences >( preferenceName: P ) =>
+	queryOptions( {
+		queryKey: rawUserPreferencesQuery().queryKey,
+		queryFn: fetchPreferences,
+		select: ( data ): Required< UserPreferences >[ P ] => {
+			const fetchedValue = data[ preferenceName ];
+			return fetchedValue === undefined
+				? defaultValues[ preferenceName ]
+				: // `fetchedValue` is a `NonNullable< UserPreferences[ P ] >`, which we know is the same
+				  // as `Required< UserPreferences >[ P ]`, but the later gives better type hints when
+				  // the query is used in the component.
+				  ( fetchedValue as Required< UserPreferences >[ P ] );
+		},
+	} );
 
-export const userPreferenceMutation = < P extends keyof UserPreferences >(
-	preferenceName: P
-) => ( {
-	mutationFn: ( data: Required< UserPreferences >[ P ] ) =>
-		updatePreferences( {
-			[ preferenceName ]: data,
-		} ),
-	onSuccess: ( newData: UserPreferences ) => {
-		queryClient.setQueryData(
-			rawUserPreferencesQuery().queryKey,
-			( oldData: UserPreferences | undefined ) => ( oldData ? { ...oldData, ...newData } : newData )
-		);
-	},
-} );
+export const userPreferenceMutation = < P extends keyof UserPreferences >( preferenceName: P ) =>
+	mutationOptions( {
+		mutationFn: ( data: Required< UserPreferences >[ P ] ) =>
+			updatePreferences( {
+				[ preferenceName ]: data,
+			} ),
+		onSuccess: ( newData ) => {
+			queryClient.setQueryData( rawUserPreferencesQuery().queryKey, ( oldData ) =>
+				oldData ? { ...oldData, ...newData } : newData
+			);
+		},
+	} );

--- a/client/dashboard/app/queries/me-profile.ts
+++ b/client/dashboard/app/queries/me-profile.ts
@@ -1,17 +1,20 @@
+import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { fetchProfile, updateProfile } from '../../data/me-profile';
 import { queryClient } from '../query-client';
-import type { UserProfile } from '../../data/me-profile';
 
-export const profileQuery = () => ( {
-	queryKey: [ 'me', 'profile' ],
-	queryFn: fetchProfile,
-} );
+export const profileQuery = () =>
+	queryOptions( {
+		queryKey: [ 'me', 'profile' ],
+		queryFn: fetchProfile,
+	} );
 
-export const profileMutation = () => ( {
-	mutationFn: updateProfile,
-	onSuccess: ( newData: Partial< UserProfile > ) => {
-		queryClient.setQueryData( profileQuery().queryKey, ( oldData: UserProfile | undefined ) =>
-			oldData ? { ...oldData, ...newData } : newData
-		);
-	},
-} );
+export const profileMutation = () =>
+	mutationOptions( {
+		mutationFn: updateProfile,
+		onSuccess: ( newData ) => {
+			queryClient.setQueryData(
+				profileQuery().queryKey,
+				( oldData ) => oldData && { ...oldData, ...newData }
+			);
+		},
+	} );

--- a/client/dashboard/app/queries/p2.ts
+++ b/client/dashboard/app/queries/p2.ts
@@ -1,6 +1,8 @@
+import { queryOptions } from '@tanstack/react-query';
 import { fetchP2HubP2s } from '../../data/p2';
 
-export const p2HubP2sQuery = ( siteId: number, options: { limit?: number } = {} ) => ( {
-	queryKey: [ 'p2-hub', siteId, 'p2s', options ],
-	queryFn: () => fetchP2HubP2s( siteId, options ),
-} );
+export const p2HubP2sQuery = ( siteId: number, options: { limit?: number } = {} ) =>
+	queryOptions( {
+		queryKey: [ 'p2-hub', siteId, 'p2s', options ],
+		queryFn: () => fetchP2HubP2s( siteId, options ),
+	} );

--- a/client/dashboard/app/queries/performance.ts
+++ b/client/dashboard/app/queries/performance.ts
@@ -1,21 +1,20 @@
+import { queryOptions } from '@tanstack/react-query';
 import { fetchBasicMetrics, fetchPerformanceInsights } from '../../data/site-profiler';
-import type { UrlPerformanceInsights } from '../../data/site-profiler';
-import type { Query } from '@tanstack/react-query';
 
-export const basicMetricsQuery = ( url: string ) => ( {
-	queryKey: [ 'performance', url, 'basic-metrics' ],
-	queryFn: () => fetchBasicMetrics( url ),
-} );
+export const basicMetricsQuery = ( url: string ) =>
+	queryOptions( {
+		queryKey: [ 'performance', url, 'basic-metrics' ],
+		queryFn: () => fetchBasicMetrics( url ),
+	} );
 
-export const performanceInsightsQuery = ( url: string, token: string ) => ( {
-	queryKey: [ 'performance', url, token ],
-	queryFn: () => {
-		return fetchPerformanceInsights( url, token );
-	},
-	refetchInterval: ( query: Query< UrlPerformanceInsights > ) => {
-		if ( query.state.data?.pagespeed?.status === 'completed' ) {
-			return false;
-		}
-		return 5000;
-	},
-} );
+export const performanceInsightsQuery = ( url: string, token: string ) =>
+	queryOptions( {
+		queryKey: [ 'performance', url, token ],
+		queryFn: () => fetchPerformanceInsights( url, token ),
+		refetchInterval: ( query ) => {
+			if ( query.state.data?.pagespeed?.status === 'completed' ) {
+				return false;
+			}
+			return 5000;
+		},
+	} );

--- a/client/dashboard/app/queries/site-activity-log.ts
+++ b/client/dashboard/app/queries/site-activity-log.ts
@@ -1,8 +1,9 @@
+import { queryOptions } from '@tanstack/react-query';
 import { fetchSiteActivityLog } from '../../data/site-activity-log';
-import type { ActivityLog } from '../../data/site-activity-log';
 
-export const siteLastFiveActivityLogEntriesQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'activity-log', 'last-five' ],
-	queryFn: () => fetchSiteActivityLog( siteId, { number: 5 } ),
-	select: ( data: ActivityLog ) => data.current?.orderedItems?.slice( 0, 5 ) ?? [],
-} );
+export const siteLastFiveActivityLogEntriesQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'activity-log', 'last-five' ],
+		queryFn: () => fetchSiteActivityLog( siteId, { number: 5 } ),
+		select: ( data ) => data.current?.orderedItems?.slice( 0, 5 ) ?? [],
+	} );

--- a/client/dashboard/app/queries/site-agency.ts
+++ b/client/dashboard/app/queries/site-agency.ts
@@ -1,16 +1,17 @@
+import { queryOptions } from '@tanstack/react-query';
 import { fetchAgencyBlog } from '../../data/agency';
+import { isWpError } from '../../data/error';
 
-export const siteAgencyBlogQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'agency-blog' ],
-	queryFn: () => {
-		return fetchAgencyBlog( siteId );
-	},
-	retry: ( failureCount: number, error: { code?: string } ) => {
-		// Stop retrying if we already know the blog is not an agency blog.
-		if ( error.hasOwnProperty( 'code' ) && error.code === 'partner_for_blog_not_found' ) {
-			return false;
-		}
+export const siteAgencyBlogQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'agency-blog' ],
+		queryFn: () => fetchAgencyBlog( siteId ),
+		retry: ( failureCount, error ) => {
+			// Stop retrying if we already know the blog is not an agency blog.
+			if ( isWpError( error ) && error.code === 'partner_for_blog_not_found' ) {
+				return false;
+			}
 
-		return failureCount < 3;
-	},
-} );
+			return failureCount < 3;
+		},
+	} );

--- a/client/dashboard/app/queries/site-atomic-transfers.ts
+++ b/client/dashboard/app/queries/site-atomic-transfers.ts
@@ -1,6 +1,8 @@
+import { queryOptions } from '@tanstack/react-query';
 import { fetchLatestAtomicTransfer } from '../../data/site-atomic-transfers';
 
-export const siteLatestAtomicTransferQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'atomic', 'transfers', 'latest' ],
-	queryFn: () => fetchLatestAtomicTransfer( siteId ),
-} );
+export const siteLatestAtomicTransferQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'atomic', 'transfers', 'latest' ],
+		queryFn: () => fetchLatestAtomicTransfer( siteId ),
+	} );

--- a/client/dashboard/app/queries/site-backups.ts
+++ b/client/dashboard/app/queries/site-backups.ts
@@ -1,8 +1,9 @@
+import { queryOptions } from '@tanstack/react-query';
 import { fetchSiteRewindableActivityLog } from '../../data/site-activity-log';
-import type { ActivityLog } from '../../data/site-activity-log';
 
-export const siteLastBackupQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'backups', 'last' ],
-	queryFn: () => fetchSiteRewindableActivityLog( siteId, { number: 1 } ),
-	select: ( data: ActivityLog ) => data.current?.orderedItems[ 0 ] ?? null,
-} );
+export const siteLastBackupQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'backups', 'last' ],
+		queryFn: () => fetchSiteRewindableActivityLog( siteId, { number: 1 } ),
+		select: ( data ) => data.current?.orderedItems[ 0 ] ?? null,
+	} );

--- a/client/dashboard/app/queries/site-cache.ts
+++ b/client/dashboard/app/queries/site-cache.ts
@@ -1,3 +1,4 @@
+import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import { clearObjectCache } from '../../data/site-hosting';
 import {
 	clearEdgeCache,
@@ -6,46 +7,52 @@ import {
 } from '../../data/site-hosting-edge-cache';
 import { queryClient } from '../query-client';
 
-export const siteObjectCacheLastClearedTimestampQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'object-cache', 'last-cleared-timestamp' ],
-	queryFn: () => Promise.resolve( 0 ),
-	staleTime: Infinity,
-} );
+export const siteObjectCacheLastClearedTimestampQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'object-cache', 'last-cleared-timestamp' ],
+		queryFn: () => Promise.resolve( 0 ),
+		staleTime: Infinity,
+	} );
 
-export const siteObjectCacheClearMutation = ( siteId: number ) => ( {
-	mutationFn: ( reason: string ) => clearObjectCache( siteId, reason ),
-	onSuccess: () => {
-		queryClient.setQueryData(
-			siteObjectCacheLastClearedTimestampQuery( siteId ).queryKey,
-			new Date().valueOf()
-		);
-	},
-} );
+export const siteObjectCacheClearMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( reason: string ) => clearObjectCache( siteId, reason ),
+		onSuccess: () => {
+			queryClient.setQueryData(
+				siteObjectCacheLastClearedTimestampQuery( siteId ).queryKey,
+				new Date().valueOf()
+			);
+		},
+	} );
 
-export const siteEdgeCacheLastClearedTimestampQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'edge-cache', 'last-cleared-timestamp' ],
-	queryFn: () => Promise.resolve( 0 ),
-	staleTime: Infinity,
-} );
+export const siteEdgeCacheLastClearedTimestampQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'edge-cache', 'last-cleared-timestamp' ],
+		queryFn: () => Promise.resolve( 0 ),
+		staleTime: Infinity,
+	} );
 
-export const siteEdgeCacheClearMutation = ( siteId: number ) => ( {
-	mutationFn: () => clearEdgeCache( siteId ),
-	onSuccess: () => {
-		queryClient.setQueryData(
-			siteEdgeCacheLastClearedTimestampQuery( siteId ).queryKey,
-			new Date().valueOf()
-		);
-	},
-} );
+export const siteEdgeCacheClearMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: () => clearEdgeCache( siteId ),
+		onSuccess: () => {
+			queryClient.setQueryData(
+				siteEdgeCacheLastClearedTimestampQuery( siteId ).queryKey,
+				new Date().valueOf()
+			);
+		},
+	} );
 
-export const siteEdgeCacheStatusQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'edge-cache' ],
-	queryFn: () => fetchEdgeCacheStatus( siteId ),
-} );
+export const siteEdgeCacheStatusQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'edge-cache' ],
+		queryFn: () => fetchEdgeCacheStatus( siteId ),
+	} );
 
-export const siteEdgeCacheStatusMutation = ( siteId: number ) => ( {
-	mutationFn: ( active: boolean ) => updateEdgeCacheStatus( siteId, active ),
-	onSuccess: ( active: boolean ) => {
-		queryClient.setQueryData( siteEdgeCacheStatusQuery( siteId ).queryKey, active );
-	},
-} );
+export const siteEdgeCacheStatusMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( active: boolean ) => updateEdgeCacheStatus( siteId, active ),
+		onSuccess: ( active ) => {
+			queryClient.setQueryData( siteEdgeCacheStatusQuery( siteId ).queryKey, active );
+		},
+	} );

--- a/client/dashboard/app/queries/site-defensive-mode.ts
+++ b/client/dashboard/app/queries/site-defensive-mode.ts
@@ -1,22 +1,22 @@
+import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import {
 	fetchEdgeCacheDefensiveModeSettings,
 	updateEdgeCacheDefensiveModeSettings,
 } from '../../data/site-hosting-edge-cache';
 import { queryClient } from '../query-client';
-import type {
-	DefensiveModeSettings,
-	DefensiveModeSettingsUpdate,
-} from '../../data/site-hosting-edge-cache';
+import type { DefensiveModeSettingsUpdate } from '../../data/site-hosting-edge-cache';
 
-export const siteDefensiveModeSettingsQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'defensive-mode' ],
-	queryFn: () => fetchEdgeCacheDefensiveModeSettings( siteId ),
-} );
+export const siteDefensiveModeSettingsQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'defensive-mode' ],
+		queryFn: () => fetchEdgeCacheDefensiveModeSettings( siteId ),
+	} );
 
-export const siteDefensiveModeSettingsMutation = ( siteId: number ) => ( {
-	mutationFn: ( data: DefensiveModeSettingsUpdate ) =>
-		updateEdgeCacheDefensiveModeSettings( siteId, data ),
-	onSuccess: ( data: DefensiveModeSettings ) => {
-		queryClient.setQueryData( siteDefensiveModeSettingsQuery( siteId ).queryKey, data );
-	},
-} );
+export const siteDefensiveModeSettingsMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( data: DefensiveModeSettingsUpdate ) =>
+			updateEdgeCacheDefensiveModeSettings( siteId, data ),
+		onSuccess: ( data ) => {
+			queryClient.setQueryData( siteDefensiveModeSettingsQuery( siteId ).queryKey, data );
+		},
+	} );

--- a/client/dashboard/app/queries/site-domains.ts
+++ b/client/dashboard/app/queries/site-domains.ts
@@ -1,6 +1,8 @@
+import { queryOptions } from '@tanstack/react-query';
 import { fetchSiteDomains } from '../../data/site-domains';
 
-export const siteDomainsQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'domains' ],
-	queryFn: () => fetchSiteDomains( siteId ),
-} );
+export const siteDomainsQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'domains' ],
+		queryFn: () => fetchSiteDomains( siteId ),
+	} );

--- a/client/dashboard/app/queries/site-launchpad.ts
+++ b/client/dashboard/app/queries/site-launchpad.ts
@@ -1,6 +1,8 @@
+import { queryOptions } from '@tanstack/react-query';
 import { fetchSiteLaunchpad } from '../../data/site-launchpad';
 
-export const siteLaunchpadQuery = ( siteId: number, checklistSlug: string ) => ( {
-	queryKey: [ 'site', siteId, 'launchpad', checklistSlug ],
-	queryFn: () => fetchSiteLaunchpad( siteId, checklistSlug ),
-} );
+export const siteLaunchpadQuery = ( siteId: number, checklistSlug: string ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'launchpad', checklistSlug ],
+		queryFn: () => fetchSiteLaunchpad( siteId, checklistSlug ),
+	} );

--- a/client/dashboard/app/queries/site-media-storage.ts
+++ b/client/dashboard/app/queries/site-media-storage.ts
@@ -1,6 +1,8 @@
+import { queryOptions } from '@tanstack/react-query';
 import { fetchSiteMediaStorage } from '../../data/site-media-storage';
 
-export const siteMediaStorageQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'media-storage' ],
-	queryFn: () => fetchSiteMediaStorage( siteId ),
-} );
+export const siteMediaStorageQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'media-storage' ],
+		queryFn: () => fetchSiteMediaStorage( siteId ),
+	} );

--- a/client/dashboard/app/queries/site-owner-transfer.ts
+++ b/client/dashboard/app/queries/site-owner-transfer.ts
@@ -1,3 +1,4 @@
+import { mutationOptions } from '@tanstack/react-query';
 import {
 	startSiteOwnerTransfer,
 	checkSiteOwnerTransferEligibility,
@@ -5,27 +6,27 @@ import {
 } from '../../data/site-owner-transfer';
 import { queryClient } from '../query-client';
 import { siteQueryFilter } from './site';
-import type {
-	SiteOwnerTransferConfirmation,
-	SiteOwnerTransferContext,
-} from '../../data/site-owner-transfer';
+import type { SiteOwnerTransferContext } from '../../data/site-owner-transfer';
 
-export const siteOwnerTransferMutation = ( siteId: number ) => ( {
-	mutationFn: ( data: { new_site_owner: string; context?: SiteOwnerTransferContext } ) =>
-		startSiteOwnerTransfer( siteId, data ),
-} );
+export const siteOwnerTransferMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( data: { new_site_owner: string; context?: SiteOwnerTransferContext } ) =>
+			startSiteOwnerTransfer( siteId, data ),
+	} );
 
-export const siteOwnerTransferEligibilityCheckMutation = ( siteId: number ) => ( {
-	mutationFn: ( data: { new_site_owner: string } ) =>
-		checkSiteOwnerTransferEligibility( siteId, data ),
-} );
+export const siteOwnerTransferEligibilityCheckMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( data: { new_site_owner: string } ) =>
+			checkSiteOwnerTransferEligibility( siteId, data ),
+	} );
 
-export const siteOwnerTransferConfirmMutation = ( siteId: number ) => ( {
-	mutationFn: ( data: { hash: string } ) => confirmSiteOwnerTransfer( siteId, data ),
-	onSuccess: ( { transfer }: SiteOwnerTransferConfirmation ) => {
-		if ( transfer ) {
-			// Invalidate queries as the site has been transferred to new owner.
-			queryClient.invalidateQueries( siteQueryFilter( siteId ) );
-		}
-	},
-} );
+export const siteOwnerTransferConfirmMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( data: { hash: string } ) => confirmSiteOwnerTransfer( siteId, data ),
+		onSuccess: ( { transfer } ) => {
+			if ( transfer ) {
+				// Invalidate queries as the site has been transferred to new owner.
+				queryClient.invalidateQueries( siteQueryFilter( siteId ) );
+			}
+		},
+	} );

--- a/client/dashboard/app/queries/site-php-version.ts
+++ b/client/dashboard/app/queries/site-php-version.ts
@@ -1,14 +1,17 @@
+import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import { fetchPHPVersion, updatePHPVersion } from '../../data/site-hosting';
 import { queryClient } from '../query-client';
 
-export const sitePHPVersionQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'php-version' ],
-	queryFn: () => fetchPHPVersion( siteId ),
-} );
+export const sitePHPVersionQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'php-version' ],
+		queryFn: () => fetchPHPVersion( siteId ),
+	} );
 
-export const sitePHPVersionMutation = ( siteId: number ) => ( {
-	mutationFn: ( version: string ) => updatePHPVersion( siteId, version ),
-	onSuccess: () => {
-		queryClient.invalidateQueries( sitePHPVersionQuery( siteId ) );
-	},
-} );
+export const sitePHPVersionMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( version: string ) => updatePHPVersion( siteId, version ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( sitePHPVersionQuery( siteId ) );
+		},
+	} );

--- a/client/dashboard/app/queries/site-plans.ts
+++ b/client/dashboard/app/queries/site-plans.ts
@@ -1,11 +1,14 @@
+import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import { restoreSitePlanSoftware } from '../../data/site-hosting';
 import { fetchCurrentSitePlan } from '../../data/site-plans';
 
-export const siteCurrentPlanQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'plans', 'current' ],
-	queryFn: () => fetchCurrentSitePlan( siteId ),
-} );
+export const siteCurrentPlanQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'plans', 'current' ],
+		queryFn: () => fetchCurrentSitePlan( siteId ),
+	} );
 
-export const sitePlanSoftwareRestoreMutation = ( siteId: number ) => ( {
-	mutationFn: () => restoreSitePlanSoftware( siteId ),
-} );
+export const sitePlanSoftwareRestoreMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: () => restoreSitePlanSoftware( siteId ),
+	} );

--- a/client/dashboard/app/queries/site-preview-links.ts
+++ b/client/dashboard/app/queries/site-preview-links.ts
@@ -1,28 +1,29 @@
+import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import {
 	fetchSitePreviewLinks,
 	createSitePreviewLink,
 	deleteSitePreviewLink,
 } from '../../data/site-preview-links';
 import { queryClient } from '../query-client';
-import type { SitePreviewLink } from '../../data/site-preview-links';
 
-export const sitePreviewLinksQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'preview-links' ],
-	queryFn: () => {
-		return fetchSitePreviewLinks( siteId );
-	},
-} );
+export const sitePreviewLinksQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'preview-links' ],
+		queryFn: () => fetchSitePreviewLinks( siteId ),
+	} );
 
-export const sitePreviewLinkCreateMutation = ( siteId: number ) => ( {
-	mutationFn: () => createSitePreviewLink( siteId ),
-	onSuccess: ( data: SitePreviewLink ) => {
-		queryClient.setQueryData( sitePreviewLinksQuery( siteId ).queryKey, [ data ] );
-	},
-} );
+export const sitePreviewLinkCreateMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: () => createSitePreviewLink( siteId ),
+		onSuccess: ( data ) => {
+			queryClient.setQueryData( sitePreviewLinksQuery( siteId ).queryKey, [ data ] );
+		},
+	} );
 
-export const sitePreviewLinkDeleteMutation = ( siteId: number ) => ( {
-	mutationFn: ( code: string ) => deleteSitePreviewLink( siteId, code ),
-	onSuccess: () => {
-		queryClient.removeQueries( sitePreviewLinksQuery( siteId ) );
-	},
-} );
+export const sitePreviewLinkDeleteMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( code: string ) => deleteSitePreviewLink( siteId, code ),
+		onSuccess: () => {
+			queryClient.removeQueries( sitePreviewLinksQuery( siteId ) );
+		},
+	} );

--- a/client/dashboard/app/queries/site-primary-data-center.ts
+++ b/client/dashboard/app/queries/site-primary-data-center.ts
@@ -1,6 +1,8 @@
+import { queryOptions } from '@tanstack/react-query';
 import { fetchPrimaryDataCenter } from '../../data/site-hosting';
 
-export const sitePrimaryDataCenterQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'primary-data-center' ],
-	queryFn: () => fetchPrimaryDataCenter( siteId ),
-} );
+export const sitePrimaryDataCenterQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'primary-data-center' ],
+		queryFn: () => fetchPrimaryDataCenter( siteId ),
+	} );

--- a/client/dashboard/app/queries/site-purchases.ts
+++ b/client/dashboard/app/queries/site-purchases.ts
@@ -1,25 +1,25 @@
 import { queryOptions } from '@tanstack/react-query';
 import { fetchSitePurchases } from '../../data/site-purchases';
-import type { Purchase } from '../../data/site-purchases';
 
-export const siteHasCancelablePurchasesQuery = ( siteId: number, userId: number ) => ( {
-	queryKey: [ 'site', siteId, 'purchases', 'has-cancelable' ],
-	queryFn: () => fetchSitePurchases( siteId ),
-	select: ( purchases: Purchase[] ) => {
-		const cancelables = purchases
-			.filter( ( purchase ) => {
-				// Exclude inactive purchases and legacy premium theme purchases.
-				if ( ! purchase.active || purchase.product_slug === 'premium_theme' ) {
-					return false;
-				}
+export const siteHasCancelablePurchasesQuery = ( siteId: number, userId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'purchases', 'has-cancelable' ],
+		queryFn: () => fetchSitePurchases( siteId ),
+		select: ( purchases ) => {
+			const cancelables = purchases
+				.filter( ( purchase ) => {
+					// Exclude inactive purchases and legacy premium theme purchases.
+					if ( ! purchase.active || purchase.product_slug === 'premium_theme' ) {
+						return false;
+					}
 
-				return purchase.is_cancelable;
-			} )
-			.filter( ( purchase ) => Number( purchase.user_id ) === userId );
+					return purchase.is_cancelable;
+				} )
+				.filter( ( purchase ) => Number( purchase.user_id ) === userId );
 
-		return cancelables.length > 0;
-	},
-} );
+			return cancelables.length > 0;
+		},
+	} );
 
 export const sitePurchaseQuery = ( siteId: number, purchaseId: string ) =>
 	queryOptions( {

--- a/client/dashboard/app/queries/site-reset.ts
+++ b/client/dashboard/app/queries/site-reset.ts
@@ -1,19 +1,23 @@
+import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import {
 	fetchSiteResetContentSummary,
 	resetSite,
 	fetchSiteResetStatus,
 } from '../../data/site-reset';
 
-export const siteResetContentSummaryQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'reset', 'content-summary' ],
-	queryFn: () => fetchSiteResetContentSummary( siteId ),
-} );
+export const siteResetContentSummaryQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'reset', 'content-summary' ],
+		queryFn: () => fetchSiteResetContentSummary( siteId ),
+	} );
 
-export const siteResetMutation = ( siteId: number ) => ( {
-	mutationFn: () => resetSite( siteId ),
-} );
+export const siteResetMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: () => resetSite( siteId ),
+	} );
 
-export const siteResetStatusQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'reset', 'status' ],
-	queryFn: () => fetchSiteResetStatus( siteId ),
-} );
+export const siteResetStatusQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'reset', 'status' ],
+		queryFn: () => fetchSiteResetStatus( siteId ),
+	} );

--- a/client/dashboard/app/queries/site-scan.ts
+++ b/client/dashboard/app/queries/site-scan.ts
@@ -1,6 +1,8 @@
+import { queryOptions } from '@tanstack/react-query';
 import { fetchSiteScan } from '../../data/site-scan';
 
-export const siteScanQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'scan' ],
-	queryFn: () => fetchSiteScan( siteId ),
-} );
+export const siteScanQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'scan' ],
+		queryFn: () => fetchSiteScan( siteId ),
+	} );

--- a/client/dashboard/app/queries/site-settings.ts
+++ b/client/dashboard/app/queries/site-settings.ts
@@ -1,20 +1,27 @@
+import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { fetchSiteSettings, updateSiteSettings } from '../../data/site-settings';
 import { queryClient } from '../query-client';
 import { siteQueryFilter } from './site';
 import type { SiteSettings } from '../../data/site-settings';
 
-export const siteSettingsQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'settings' ],
-	queryFn: () => fetchSiteSettings( siteId ),
-} );
+export const siteSettingsQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'settings' ],
+		queryFn: () => fetchSiteSettings( siteId ),
+	} );
 
-export const siteSettingsMutation = ( siteId: number ) => ( {
-	mutationFn: ( data: Partial< SiteSettings > ) => updateSiteSettings( siteId, data ),
-	onSuccess: ( newData: Partial< SiteSettings > ) => {
-		queryClient.setQueryData( siteSettingsQuery( siteId ).queryKey, ( oldData: SiteSettings ) => ( {
-			...oldData,
-			...newData,
-		} ) );
-		queryClient.invalidateQueries( siteQueryFilter( siteId ) );
-	},
-} );
+export const siteSettingsMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( data: Partial< SiteSettings > ) => updateSiteSettings( siteId, data ),
+		onSuccess: ( newData ) => {
+			queryClient.setQueryData(
+				siteSettingsQuery( siteId ).queryKey,
+				( oldData ) =>
+					oldData && {
+						...oldData,
+						...newData,
+					}
+			);
+			queryClient.invalidateQueries( siteQueryFilter( siteId ) );
+		},
+	} );

--- a/client/dashboard/app/queries/site-ssh.ts
+++ b/client/dashboard/app/queries/site-ssh.ts
@@ -1,3 +1,4 @@
+import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import {
 	fetchSshAccessStatus,
 	enableSshAccess,
@@ -7,53 +8,49 @@ import {
 	detachSiteSshKey,
 } from '../../data/site-hosting-ssh';
 import { queryClient } from '../query-client';
-import type { SshAccessStatus, SiteSshKey } from '../../data/site-hosting-ssh';
+import type { SiteSshKey } from '../../data/site-hosting-ssh';
 
-export const siteSshAccessStatusQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'ssh-access' ],
-	queryFn: () => {
-		return fetchSshAccessStatus( siteId );
-	},
-} );
+export const siteSshAccessStatusQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'ssh-access' ],
+		queryFn: () => fetchSshAccessStatus( siteId ),
+	} );
 
-export const siteSshAccessEnableMutation = ( siteId: number ) => ( {
-	mutationFn: () => enableSshAccess( siteId ),
-	onSuccess: ( data: SshAccessStatus ) => {
-		queryClient.setQueryData( siteSshAccessStatusQuery( siteId ).queryKey, data );
-	},
-} );
-
-export const siteSshAccessDisableMutation = ( siteId: number ) => ( {
-	mutationFn: () => disableSshAccess( siteId ),
-	onSuccess: ( data: SshAccessStatus ) => {
-		queryClient.setQueryData( siteSshAccessStatusQuery( siteId ).queryKey, data );
-	},
-} );
-
-export function siteSshKeysQuery( siteId: number ) {
-	return {
-		queryKey: [ 'site', siteId, 'ssh-keys' ],
-		queryFn: () => {
-			return fetchSiteSshKeys( siteId );
+export const siteSshAccessEnableMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: () => enableSshAccess( siteId ),
+		onSuccess: ( data ) => {
+			queryClient.setQueryData( siteSshAccessStatusQuery( siteId ).queryKey, data );
 		},
-	};
-}
+	} );
 
-export function siteSshKeysAttachMutation( siteId: number ) {
-	return {
+export const siteSshAccessDisableMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: () => disableSshAccess( siteId ),
+		onSuccess: ( data ) => {
+			queryClient.setQueryData( siteSshAccessStatusQuery( siteId ).queryKey, data );
+		},
+	} );
+
+export const siteSshKeysQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'ssh-keys' ],
+		queryFn: () => fetchSiteSshKeys( siteId ),
+	} );
+
+export const siteSshKeysAttachMutation = ( siteId: number ) =>
+	mutationOptions( {
 		mutationFn: ( name: string ) => attachSiteSshKey( siteId, name ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteSshKeysQuery( siteId ) );
 		},
-	};
-}
+	} );
 
-export function siteSshKeysDetachMutation( siteId: number ) {
-	return {
+export const siteSshKeysDetachMutation = ( siteId: number ) =>
+	mutationOptions( {
 		mutationFn: ( siteSshKey: SiteSshKey ) =>
 			detachSiteSshKey( siteId, siteSshKey.user_login, siteSshKey.name ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteSshKeysQuery( siteId ) );
 		},
-	};
-}
+	} );

--- a/client/dashboard/app/queries/site-staging-sites.ts
+++ b/client/dashboard/app/queries/site-staging-sites.ts
@@ -1,30 +1,34 @@
+import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import {
 	createStagingSite,
 	deleteStagingSite,
 	fetchStagingSiteOf,
-	StagingSite,
 } from '../../data/site-staging-site';
 import { queryClient } from '../query-client';
 
-export const hasStagingSiteQuery = ( productionSiteId: number ) => ( {
-	queryKey: [ 'site', productionSiteId, 'has-staging-site' ],
-	queryFn: () => fetchStagingSiteOf( productionSiteId ),
-	select: ( data: Array< StagingSite > ) => data.length > 0,
-} );
+export const hasStagingSiteQuery = ( productionSiteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', productionSiteId, 'has-staging-site' ],
+		queryFn: () => fetchStagingSiteOf( productionSiteId ),
+		select: ( data ) => data.length > 0,
+	} );
 
-export const stagingSiteCreateMutation = ( siteId: number ) => ( {
-	mutationFn: () => createStagingSite( siteId ),
-} );
+export const stagingSiteCreateMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: () => createStagingSite( siteId ),
+	} );
 
-export const isDeletingStagingSiteQuery = ( stagingSiteId: number ) => ( {
-	queryKey: [ 'staging-site', stagingSiteId, 'is-deleting' ],
-	queryFn: () => Promise.resolve( false ),
-	staleTime: Infinity,
-} );
+export const isDeletingStagingSiteQuery = ( stagingSiteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'staging-site', stagingSiteId, 'is-deleting' ],
+		queryFn: () => Promise.resolve( false ),
+		staleTime: Infinity,
+	} );
 
-export const stagingSiteDeleteMutation = ( stagingSiteId: number, productionSiteId: number ) => ( {
-	mutationFn: () => deleteStagingSite( stagingSiteId, productionSiteId ),
-	onSuccess: () => {
-		queryClient.setQueryData( isDeletingStagingSiteQuery( stagingSiteId ).queryKey, true );
-	},
-} );
+export const stagingSiteDeleteMutation = ( stagingSiteId: number, productionSiteId: number ) =>
+	mutationOptions( {
+		mutationFn: () => deleteStagingSite( stagingSiteId, productionSiteId ),
+		onSuccess: () => {
+			queryClient.setQueryData( isDeletingStagingSiteQuery( stagingSiteId ).queryKey, true );
+		},
+	} );

--- a/client/dashboard/app/queries/site-static-file-404.ts
+++ b/client/dashboard/app/queries/site-static-file-404.ts
@@ -1,14 +1,17 @@
+import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import { fetchStaticFile404Setting, updateStaticFile404Setting } from '../../data/site-hosting';
 import { queryClient } from '../query-client';
 
-export const siteStaticFile404SettingQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'static-file-404' ],
-	queryFn: () => fetchStaticFile404Setting( siteId ),
-} );
+export const siteStaticFile404SettingQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'static-file-404' ],
+		queryFn: () => fetchStaticFile404Setting( siteId ),
+	} );
 
-export const siteStaticFile404SettingMutation = ( siteId: number ) => ( {
-	mutationFn: ( setting: string ) => updateStaticFile404Setting( siteId, setting ),
-	onSuccess: () => {
-		queryClient.invalidateQueries( siteStaticFile404SettingQuery( siteId ) );
-	},
-} );
+export const siteStaticFile404SettingMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( setting: string ) => updateStaticFile404Setting( siteId, setting ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( siteStaticFile404SettingQuery( siteId ) );
+		},
+	} );

--- a/client/dashboard/app/queries/site-stats.ts
+++ b/client/dashboard/app/queries/site-stats.ts
@@ -1,30 +1,44 @@
-import { EngagementStatsDataPoint, fetchSiteEngagementStats } from '../../data/site-stats';
+import { queryOptions } from '@tanstack/react-query';
+import { fetchSiteEngagementStats } from '../../data/site-stats';
 
-export const siteEngagementStatsQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'engagement-stats' ],
-	queryFn: () => fetchSiteEngagementStats( siteId ),
-	select: ( { data: stats }: { data: Array< [ string, number, number, number, number ] > } ) => {
-		// We need to normalize the returned data. We ask for 14 days of data (quantity:14)
-		// and we get a response with an array of data like: `[ '2025-04-13', 1, 3, 0, 0 ]`.
-		// Each number in the response is referring to the order of the field provided in `stat_fields`.
-		// The returned array is sorted with ascending date order, so we need to use the last 7 entries
-		// for our current data and the first 7 entries for the previous data.
-		// Noting that we can't use `unit:'week'` because the API has a specific behavior for start/end of weeks.
-		const calculateStats = ( data: Array< [ string, number, number, number, number ] > ) =>
-			data.reduce(
-				( accumulator: EngagementStatsDataPoint, [ , visitors, views, likes, comments ] ) => {
-					accumulator.visitors += Number( visitors );
-					accumulator.views += Number( views );
-					accumulator.likes += Number( likes );
-					accumulator.comments += Number( comments );
-					return accumulator;
-				},
-				{ visitors: 0, views: 0, likes: 0, comments: 0 }
-			);
+export interface EngagementStatsDataPoint {
+	visitors: number;
+	views: number;
+	likes: number;
+	comments: number;
+}
 
-		const dataLength = stats.length;
-		const currentData = calculateStats( stats.slice( Math.max( 0, dataLength - 7 ) ) );
-		const previousData = calculateStats( stats.slice( 0, Math.max( 0, dataLength - 7 ) ) );
-		return { previousData, currentData };
-	},
-} );
+export interface EngagementStats {
+	currentData: EngagementStatsDataPoint;
+	previousData: EngagementStatsDataPoint;
+}
+
+export const siteEngagementStatsQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'engagement-stats' ],
+		queryFn: () => fetchSiteEngagementStats( siteId ),
+		select: ( { data: stats } ) => {
+			// We need to normalize the returned data. We ask for 14 days of data (quantity:14)
+			// and we get a response with an array of data like: `[ '2025-04-13', 1, 3, 0, 0 ]`.
+			// Each number in the response is referring to the order of the field provided in `stat_fields`.
+			// The returned array is sorted with ascending date order, so we need to use the last 7 entries
+			// for our current data and the first 7 entries for the previous data.
+			// Noting that we can't use `unit:'week'` because the API has a specific behavior for start/end of weeks.
+			const calculateStats = ( data: typeof stats ) =>
+				data.reduce(
+					( accumulator, [ , visitors, views, likes, comments ] ) => {
+						accumulator.visitors += Number( visitors );
+						accumulator.views += Number( views );
+						accumulator.likes += Number( likes );
+						accumulator.comments += Number( comments );
+						return accumulator;
+					},
+					{ visitors: 0, views: 0, likes: 0, comments: 0 } as EngagementStatsDataPoint
+				);
+
+			const dataLength = stats.length;
+			const currentData = calculateStats( stats.slice( Math.max( 0, dataLength - 7 ) ) );
+			const previousData = calculateStats( stats.slice( 0, Math.max( 0, dataLength - 7 ) ) );
+			return { previousData, currentData };
+		},
+	} );

--- a/client/dashboard/app/queries/site-themes.ts
+++ b/client/dashboard/app/queries/site-themes.ts
@@ -1,14 +1,16 @@
+import { queryOptions } from '@tanstack/react-query';
 import { fetchSiteActiveThemes } from '../../data/site-themes';
-import type { Theme } from '../../data/site-themes';
 
-export const siteActiveThemesQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'themes', 'active' ],
-	queryFn: () => fetchSiteActiveThemes( siteId ),
-} );
+export const siteActiveThemesQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'themes', 'active' ],
+		queryFn: () => fetchSiteActiveThemes( siteId ),
+	} );
 
-export const isSiteUsingBlockThemeQuery = ( siteId: number ) => ( {
-	...siteActiveThemesQuery( siteId ),
-	select: ( themes: Theme[] ) => {
-		return themes[ 0 ]?.is_block_theme ?? false;
-	},
-} );
+export const isSiteUsingBlockThemeQuery = ( siteId: number ) =>
+	queryOptions( {
+		...siteActiveThemesQuery( siteId ),
+		select: ( themes ) => {
+			return themes[ 0 ]?.is_block_theme ?? false;
+		},
+	} );

--- a/client/dashboard/app/queries/site-uptime.ts
+++ b/client/dashboard/app/queries/site-uptime.ts
@@ -1,27 +1,29 @@
-import { fetchSiteUptime, type SiteUptime } from '../../data/site-jetpack-monitor-uptime';
+import { queryOptions } from '@tanstack/react-query';
+import { fetchSiteUptime } from '../../data/site-jetpack-monitor-uptime';
 
-export const siteUptimeQuery = ( siteId: number, period?: string ) => ( {
-	queryKey: [ 'site', siteId, 'uptime', period ],
-	queryFn: () => fetchSiteUptime( siteId, period ),
-	select: ( uptime: Record< string, SiteUptime > ) => {
-		// Post-process the data to calculate total number for up and down days during the time period.
-		const { upDays, downDays } = Object.values( uptime ).reduce(
-			( accumulator, { status } ) => {
-				if ( status === 'monitor_inactive' ) {
+export const siteUptimeQuery = ( siteId: number, period?: string ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'uptime', period ],
+		queryFn: () => fetchSiteUptime( siteId, period ),
+		select: ( uptime ) => {
+			// Post-process the data to calculate total number for up and down days during the time period.
+			const { upDays, downDays } = Object.values( uptime ).reduce(
+				( accumulator, { status } ) => {
+					if ( status === 'monitor_inactive' ) {
+						return accumulator;
+					}
+
+					accumulator[ status === 'up' ? 'upDays' : 'downDays' ] += 1;
 					return accumulator;
-				}
+				},
+				{ upDays: 0, downDays: 0 }
+			);
 
-				accumulator[ status === 'up' ? 'upDays' : 'downDays' ] += 1;
-				return accumulator;
-			},
-			{ upDays: 0, downDays: 0 }
-		);
+			if ( ! upDays && ! downDays ) {
+				return undefined;
+			}
 
-		if ( ! upDays && ! downDays ) {
-			return undefined;
-		}
-
-		// Calculate the uptime percentage.
-		return Math.round( ( upDays / ( upDays + downDays ) ) * 1000 ) / 10;
-	},
-} );
+			// Calculate the uptime percentage.
+			return Math.round( ( upDays / ( upDays + downDays ) ) * 1000 ) / 10;
+		},
+	} );

--- a/client/dashboard/app/queries/site-users.ts
+++ b/client/dashboard/app/queries/site-users.ts
@@ -1,19 +1,20 @@
+import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { fetchCurrentSiteUser, deleteSiteUser } from '../../data/site-users';
 import { queryClient } from '../query-client';
 import { siteQueryFilter } from './site';
 
-export const siteCurrentUserQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'users', 'current' ],
-	queryFn: () => fetchCurrentSiteUser( siteId ),
-} );
+export const siteCurrentUserQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'users', 'current' ],
+		queryFn: () => fetchCurrentSiteUser( siteId ),
+	} );
 
-export function siteUserDeleteMutation( siteId: number ) {
-	return {
+export const siteUserDeleteMutation = ( siteId: number ) =>
+	mutationOptions( {
 		mutationFn: ( userId: number ) => deleteSiteUser( siteId, userId ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteQueryFilter( siteId ) );
 			queryClient.invalidateQueries( { queryKey: [ 'site', siteId ] } );
 			queryClient.invalidateQueries( { queryKey: [ 'sites' ] } );
 		},
-	};
-}
+	} );

--- a/client/dashboard/app/queries/site-wordpress-version.ts
+++ b/client/dashboard/app/queries/site-wordpress-version.ts
@@ -1,14 +1,17 @@
+import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { fetchWordPressVersion, updateWordPressVersion } from '../../data/site-hosting';
 import { queryClient } from '../query-client';
 
-export const siteWordPressVersionQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site', siteId, 'wp-version' ],
-	queryFn: () => fetchWordPressVersion( siteId ),
-} );
+export const siteWordPressVersionQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'wp-version' ],
+		queryFn: () => fetchWordPressVersion( siteId ),
+	} );
 
-export const siteWordPressVersionMutation = ( siteId: number ) => ( {
-	mutationFn: ( version: string ) => updateWordPressVersion( siteId, version ),
-	onSuccess: () => {
-		queryClient.invalidateQueries( siteWordPressVersionQuery( siteId ) );
-	},
-} );
+export const siteWordPressVersionMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( version: string ) => updateWordPressVersion( siteId, version ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( siteWordPressVersionQuery( siteId ) );
+		},
+	} );

--- a/client/dashboard/app/queries/site.ts
+++ b/client/dashboard/app/queries/site.ts
@@ -1,4 +1,6 @@
+import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import { notFound } from '@tanstack/react-router';
+import { isWpError } from '../../data/error';
 import {
 	fetchSite,
 	deleteSite,
@@ -11,33 +13,35 @@ import { queryClient } from '../query-client';
 import type { Site } from '../../data/site';
 import type { Query } from '@tanstack/react-query';
 
-export const siteBySlugQuery = ( siteSlug: string ) => ( {
-	queryKey: [ 'site-by-slug', siteSlug, SITE_FIELDS, SITE_OPTIONS ],
-	queryFn: async () => {
-		try {
-			return await fetchSite( siteSlug );
-		} catch ( e: any ) /* eslint-disable-line @typescript-eslint/no-explicit-any */ {
-			if ( e.error === 'unknown_blog' ) {
-				throw notFound();
+export const siteBySlugQuery = ( siteSlug: string ) =>
+	queryOptions( {
+		queryKey: [ 'site-by-slug', siteSlug, SITE_FIELDS, SITE_OPTIONS ],
+		queryFn: async () => {
+			try {
+				return await fetchSite( siteSlug );
+			} catch ( e ) {
+				if ( isWpError( e ) && e.error === 'unknown_blog' ) {
+					throw notFound();
+				}
+				throw e;
 			}
-			throw e;
-		}
-	},
-} );
+		},
+	} );
 
-export const siteByIdQuery = ( siteId: number ) => ( {
-	queryKey: [ 'site-by-id', siteId, SITE_FIELDS, SITE_OPTIONS ],
-	queryFn: async () => {
-		try {
-			return await fetchSite( siteId );
-		} catch ( e: any ) /* eslint-disable-line @typescript-eslint/no-explicit-any */ {
-			if ( e.error === 'unknown_blog' ) {
-				throw notFound();
+export const siteByIdQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site-by-id', siteId, SITE_FIELDS, SITE_OPTIONS ],
+		queryFn: async () => {
+			try {
+				return await fetchSite( siteId );
+			} catch ( e ) {
+				if ( isWpError( e ) && e.error === 'unknown_blog' ) {
+					throw notFound();
+				}
+				throw e;
 			}
-			throw e;
-		}
-	},
-} );
+		},
+	} );
 
 export const siteQueryFilter = ( siteId: number ) => ( {
 	predicate: ( { queryKey, state }: Query ) => {
@@ -48,30 +52,33 @@ export const siteQueryFilter = ( siteId: number ) => ( {
 	},
 } );
 
-export const siteDeleteMutation = ( siteId: number ) => ( {
-	mutationFn: () => deleteSite( siteId ),
-	onSuccess: () => {
-		// Delay the invalidation for the redirection to complete first
-		window.setTimeout( () => {
+export const siteDeleteMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: () => deleteSite( siteId ),
+		onSuccess: () => {
+			// Delay the invalidation for the redirection to complete first
+			window.setTimeout( () => {
+				queryClient.invalidateQueries( siteQueryFilter( siteId ) );
+				queryClient.invalidateQueries( { queryKey: [ 'site', siteId ] } );
+				queryClient.invalidateQueries( { queryKey: [ 'sites' ] } );
+			}, 1000 );
+		},
+	} );
+
+export const siteLaunchMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: () => launchSite( siteId ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( siteQueryFilter( siteId ) );
+		},
+	} );
+
+export const siteRestoreMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: () => restoreSite( siteId ),
+		onSuccess: () => {
 			queryClient.invalidateQueries( siteQueryFilter( siteId ) );
 			queryClient.invalidateQueries( { queryKey: [ 'site', siteId ] } );
 			queryClient.invalidateQueries( { queryKey: [ 'sites' ] } );
-		}, 1000 );
-	},
-} );
-
-export const siteLaunchMutation = ( siteId: number ) => ( {
-	mutationFn: () => launchSite( siteId ),
-	onSuccess: () => {
-		queryClient.invalidateQueries( siteQueryFilter( siteId ) );
-	},
-} );
-
-export const siteRestoreMutation = ( siteId: number ) => ( {
-	mutationFn: () => restoreSite( siteId ),
-	onSuccess: () => {
-		queryClient.invalidateQueries( siteQueryFilter( siteId ) );
-		queryClient.invalidateQueries( { queryKey: [ 'site', siteId ] } );
-		queryClient.invalidateQueries( { queryKey: [ 'sites' ] } );
-	},
-} );
+		},
+	} );

--- a/client/dashboard/app/queries/sites.ts
+++ b/client/dashboard/app/queries/sites.ts
@@ -1,10 +1,12 @@
+import { queryOptions } from '@tanstack/react-query';
 import { fetchSites } from '../../data/me-sites';
 import { SITE_FIELDS, SITE_OPTIONS } from '../../data/site';
 import type { FetchSitesOptions } from '../../data/me-sites';
 
 export const sitesQuery = (
 	fetchSitesOptions: FetchSitesOptions = { site_visibility: 'visible', include_a8c_owned: false }
-) => ( {
-	queryKey: [ 'sites', SITE_FIELDS, SITE_OPTIONS, fetchSitesOptions ],
-	queryFn: () => fetchSites( fetchSitesOptions ),
-} );
+) =>
+	queryOptions( {
+		queryKey: [ 'sites', SITE_FIELDS, SITE_OPTIONS, fetchSitesOptions ],
+		queryFn: () => fetchSites( fetchSitesOptions ),
+	} );

--- a/client/dashboard/app/queries/ssh.ts
+++ b/client/dashboard/app/queries/ssh.ts
@@ -1,10 +1,12 @@
+import { queryOptions } from '@tanstack/react-query';
 import { fetchSshKeys } from '../../data/me-ssh';
 
-export const sshKeysQuery = () => ( {
-	queryKey: [ 'ssh-keys' ],
-	queryFn: fetchSshKeys,
-	retry: false, // Don't retry on 401 errors
-	meta: {
-		persist: false,
-	},
-} );
+export const sshKeysQuery = () =>
+	queryOptions( {
+		queryKey: [ 'ssh-keys' ],
+		queryFn: fetchSshKeys,
+		retry: false, // Don't retry on 401 errors
+		meta: {
+			persist: false,
+		},
+	} );

--- a/client/dashboard/data/me-profile.ts
+++ b/client/dashboard/data/me-profile.ts
@@ -14,7 +14,9 @@ export async function fetchProfile(): Promise< UserProfile > {
 	return await wpcom.req.get( '/me/settings' );
 }
 
-export async function updateProfile( data: Partial< UserProfile > ) {
+export async function updateProfile(
+	data: Partial< UserProfile >
+): Promise< Partial< UserProfile > > {
 	const saveableKeys = [ 'display_name', 'description', 'is_dev_account', 'user_URL' ];
 	for ( const key in data ) {
 		if ( ! saveableKeys.includes( key ) ) {

--- a/client/dashboard/data/site-hosting-ssh.ts
+++ b/client/dashboard/data/site-hosting-ssh.ts
@@ -18,7 +18,7 @@ export async function fetchSshAccessStatus( siteId: number ): Promise< SshAccess
 	} );
 }
 
-export async function enableSshAccess( siteId: number ) {
+export async function enableSshAccess( siteId: number ): Promise< SshAccessStatus > {
 	return wpcom.req.post(
 		{
 			path: `/sites/${ siteId }/hosting/ssh-access`,
@@ -28,7 +28,7 @@ export async function enableSshAccess( siteId: number ) {
 	);
 }
 
-export async function disableSshAccess( siteId: number ) {
+export async function disableSshAccess( siteId: number ): Promise< SshAccessStatus > {
 	return wpcom.req.post(
 		{
 			path: `/sites/${ siteId }/hosting/ssh-access`,

--- a/client/dashboard/data/site-settings.ts
+++ b/client/dashboard/data/site-settings.ts
@@ -24,7 +24,10 @@ export async function fetchSiteSettings( siteId: number ): Promise< SiteSettings
 	return settings;
 }
 
-export async function updateSiteSettings( siteId: number, data: Partial< SiteSettings > ) {
+export async function updateSiteSettings(
+	siteId: number,
+	data: Partial< SiteSettings >
+): Promise< Partial< SiteSettings > > {
 	const { updated } = await wpcom.req.post(
 		{
 			path: `/sites/${ siteId }/settings`,

--- a/client/dashboard/data/site-stats.ts
+++ b/client/dashboard/data/site-stats.ts
@@ -1,17 +1,16 @@
 import wpcom from 'calypso/lib/wp';
 
-export interface EngagementStatsDataPoint {
-	visitors: number;
-	views: number;
-	likes: number;
-	comments: number;
-}
-export interface EngagementStats {
-	currentData: EngagementStatsDataPoint;
-	previousData: EngagementStatsDataPoint;
+export interface SiteEngagementStatsResponse {
+	/**
+	 * Array of tuples in the format: [date, visitors, views, likes, comments],
+	 * e.g. `[ '2025-04-13', 1, 3, 0, 0 ]`.
+	 */
+	data: Array< [ string, number, number, number, number ] >;
 }
 
-export async function fetchSiteEngagementStats( siteId: number ) {
+export async function fetchSiteEngagementStats(
+	siteId: number
+): Promise< SiteEngagementStatsResponse > {
 	return wpcom.req.get( `/sites/${ siteId }/stats/visits`, {
 		unit: 'day',
 		quantity: 14,

--- a/client/dashboard/data/site-themes.ts
+++ b/client/dashboard/data/site-themes.ts
@@ -4,7 +4,7 @@ export interface Theme {
 	is_block_theme: boolean;
 }
 
-export async function fetchSiteActiveThemes( siteId: number ) {
+export async function fetchSiteActiveThemes( siteId: number ): Promise< Theme[] > {
 	return wpcom.req.get( {
 		path: `/sites/${ siteId }/themes?status=active`,
 		apiNamespace: 'wp/v2',

--- a/client/dashboard/data/site.ts
+++ b/client/dashboard/data/site.ts
@@ -90,7 +90,7 @@ export interface Site {
 	};
 	plan?: SitePlan;
 	capabilities: SiteCapabilities;
-	subscribers_count: number;
+	subscribers_count?: number; // Can be undefined if query cache is prefilled from old Calypso Redux store.
 	options?: SiteOptions; // Can be undefined for deleted sites.
 	is_a4a_dev_site: boolean;
 	is_a8c: boolean;

--- a/client/dashboard/docs/data-library.md
+++ b/client/dashboard/docs/data-library.md
@@ -37,7 +37,7 @@ export async function fetchSiteResetStatus( siteId: number ): Promise< SiteReset
 }
 ```
 
-We usually return the raw response from the API. If you need to process the response (e.g. filter), you can do so in the data fetching layer via TanStack's [select](https://tanstack.com/query/latest/docs/framework/react/guides/render-optimizations#select) option.
+We usually return the raw response from the API. If you need to process the response (e.g. filter), you can do so in the query layer via TanStack's [select](https://tanstack.com/query/latest/docs/framework/react/guides/render-optimizations#select) option.
 
 ### Data types
 
@@ -51,11 +51,31 @@ export type SiteResetStatus = {
 };
 ```
 
-An "index" `client/dashboard/data/types.ts` is provided, which re-exports all data types from all endpoints. This allows for easy import of all data types from the dashboard components.
+An "index" (or "barrel") `client/dashboard/data/types.ts` is provided, which re-exports all data types from all endpoints. This allows for easy import of all data types from the dashboard components. Import types using `import type ...` syntax to avoid the disadvantages of barrel files.
 
 ## Data queries (fetching and mutation): `client/dashboard/app/queries/`
 
 The dashboard uses a combination of route loaders and component-level queries to fetch data, all using TanStack Query. This allows for both prefetching data for routes and fetching data on-demand within components.
+
+### Queries object centralization
+
+Queries are reused between loaders and components. To encourage cache reusability between different parts of the app, we centralize the queries definitions in the `client/dashboard/app/queries/` directory.
+
+The query layer does not export hooks; it only exports the option objects which are passed to hooks (e.g. `useQuery()`). This makes the queries more reusable. You won't always want to use `useQuery()`, sometimes depending on the situation you may need `useSuspenseQuery()` or `queryClient.getQueryData()`. These all accept the same query options object. It also makes queries more easily composable. When your component has some unique requirement other queries don't, you do not need to parameterize the query options—you can compose your own query options:
+
+```typescript
+useQuery( {
+	...siteResetStatusQuery( site.ID ),
+	select: ( data ) => data.status,
+	enabled: transferStatus.status !== 'completed',
+} );
+```
+
+### `queryOptions` and `mutationOptions`
+
+React Query's tyes are very fancy. The downside is they can be hard to get write when written by hand. That is why React Query provides the `queryOptions` and `mutationOptions` utility functions.
+
+At runtime these functions are a no-op. But by you using them your editor will give you code completion and TypeScript will be able to confirm they are well formed. Callback functions like `onSuccess` and `select` in particular are tricky when you have to provide your own parameter types. These utility functions define the types for you.
 
 ### Route loaders
 
@@ -84,27 +104,23 @@ TanStack's `queryClient.ensureQueryData` checks if data is already cached before
 
 ### Component-level queries
 
-At the component level, we use the `useQuery` hook to fetch data. This includes the data that we preloaded in the route loader:
+At the component level, we use the `useQuery` and `useSuspenseQuery` hooks to fetch data. This includes the data that we preloaded in the route loader:
 
 
 ```typescript
-const { data: currentVersion } = useQuery( {
+const { data: currentVersion } = useSuspenseQuery( {
 	...sitePHPVersionQuery( site.ID ),
 	enabled: hasHostingFeature( site, HostingFeatures.PHP ),
 } );
 ```
 
-as well as data that are specific to a component or that need more dynamic control:
+as well as data that are specific to a component that you want to load dynamically:
 
 ```typescript
-const { data: siteContentSummary } = useQuery(
+const { data: siteContentSummary, isLoading } = useQuery(
 	siteResetContentSummaryQuery( site.ID )
 );
 ```
-
-### Queries centralization
-
-Queries are reused between loaders and components. To encourage cache reusability between different parts of the app, we centralize the queries definitions in the `client/dashboard/app/queries/` directory.
 
 ## Adding new data sources
 
@@ -137,7 +153,7 @@ export async function fetchNewEntity( id: string ): Promise< NewEntity > {
 `client/dashboard/app/queries/entity.ts`:
 ```typescript
 // Define the query
-export const newEntityQuery = ( id: string ) => ( {
+export const newEntityQuery = ( id: string ) => queryOptions( {
 	queryKey: [ 'newEntity', id ],
 	queryFn: () => fetchNewEntity( id ),
 	staleTime: 5 * 60 * 1000, // 5 minutes

--- a/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
@@ -31,6 +31,7 @@ import { sshKeysQuery } from '../../app/queries/ssh';
 import ClipboardInputControl from '../../components/clipboard-input-control';
 import InlineSupportLink from '../../components/inline-support-link';
 import { SectionHeader } from '../../components/section-header';
+import { isWpError } from '../../data/error';
 import type { SftpUser, SiteSshKey, UserSshKey } from '../../data/types';
 import type { DataFormControlProps, Field } from '@wordpress/dataviews';
 
@@ -94,12 +95,10 @@ export default function SshCard( {
 } ) {
 	const { user } = useAuth();
 	const { data: siteSshKeys } = useQuery( siteSshKeysQuery( siteId ) );
-	const { data: userSshKeys, error: userSshKeysError } = useQuery< UserSshKey[], { code: string } >(
-		{
-			...sshKeysQuery(),
-			enabled: sshEnabled,
-		}
-	);
+	const { data: userSshKeys, error: userSshKeysError } = useQuery( {
+		...sshKeysQuery(),
+		enabled: sshEnabled,
+	} );
 	const toggleSshAccessMutation = useMutation(
 		! sshEnabled ? siteSshAccessEnableMutation( siteId ) : siteSshAccessDisableMutation( siteId )
 	);
@@ -280,7 +279,7 @@ export default function SshCard( {
 		fields: [ 'connection_command', 'ssh_key' ],
 	};
 
-	if ( userSshKeysError?.code === 'reauthorization_required' ) {
+	if ( isWpError( userSshKeysError ) && userSshKeysError.code === 'reauthorization_required' ) {
 		const currentPath = window.location.pathname;
 		const loginUrl = `/me/reauth-required?redirect_to=${ encodeURIComponent( currentPath ) }`;
 		window.location.href = loginUrl;

--- a/client/dashboard/sites/site-reset-modal/index.tsx
+++ b/client/dashboard/sites/site-reset-modal/index.tsx
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, Query } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import {
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
@@ -153,14 +153,12 @@ export default function SiteResetModal( { site, onClose }: { site: Site; onClose
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const [ error, setError ] = useState< string | null >( null );
 
-	const { data: siteContentSummary } = useQuery< SiteResetContentSummary >(
-		siteResetContentSummaryQuery( site.ID )
-	);
+	const { data: siteContentSummary } = useQuery( siteResetContentSummaryQuery( site.ID ) );
 
 	const statusQuery = {
 		...siteResetStatusQuery( site.ID ),
 		...( site.is_wpcom_atomic && {
-			refetchInterval: ( query: Query< SiteResetStatus > ) => {
+			refetchInterval: ( query: { state: { data?: SiteResetStatus } } ) => {
 				const { data } = query.state;
 
 				if ( data?.status === 'ready' || data?.status === 'completed' ) {
@@ -175,8 +173,7 @@ export default function SiteResetModal( { site, onClose }: { site: Site; onClose
 		} ),
 	};
 
-	const { data: resetStatus, refetch: refetchResetStatus } =
-		useQuery< SiteResetStatus >( statusQuery );
+	const { data: resetStatus, refetch: refetchResetStatus } = useQuery( statusQuery );
 	const { mutate, isPending: isMutationPending } = useMutation( siteResetMutation( site.ID ) );
 
 	const showSuccessNotice = useCallback( () => {

--- a/client/sites/v2/site-settings/index.tsx
+++ b/client/sites/v2/site-settings/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { createRoot } from 'react-dom/client';
 import { AUTH_QUERY_KEY } from 'calypso/dashboard/app/auth';
+import { siteBySlugQuery } from 'calypso/dashboard/app/queries/site';
 import { siteSettingsQuery } from 'calypso/dashboard/app/queries/site-settings';
 import { queryClient, persistPromise } from 'calypso/dashboard/app/query-client';
 import { useSelector } from 'calypso/state';
@@ -74,8 +75,9 @@ export default function DashboardBackportSiteSettingsRenderer( {
 		}
 
 		if ( site ) {
-			// TODO: Figure out how to popular jetpack_modules and subscribers_count too
-			// queryClient.setQueryData( siteBySlugQuery( site.slug ).queryKey, site );
+			// The site type used by the hosting dashboard is slightly different, but _mostly_ compatible,
+			// so this is safe to copy in to the cache.
+			queryClient.setQueryData( siteBySlugQuery( site.slug ).queryKey, site as any ); // eslint-disable-line @typescript-eslint/no-explicit-any
 		}
 
 		if ( site && siteSettings ) {

--- a/client/sites/v2/site-settings/index.tsx
+++ b/client/sites/v2/site-settings/index.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { createRoot } from 'react-dom/client';
 import { AUTH_QUERY_KEY } from 'calypso/dashboard/app/auth';
-import { siteBySlugQuery } from 'calypso/dashboard/app/queries/site';
 import { siteSettingsQuery } from 'calypso/dashboard/app/queries/site-settings';
 import { queryClient, persistPromise } from 'calypso/dashboard/app/query-client';
 import { useSelector } from 'calypso/state';
@@ -75,7 +74,8 @@ export default function DashboardBackportSiteSettingsRenderer( {
 		}
 
 		if ( site ) {
-			queryClient.setQueryData( siteBySlugQuery( site.slug ).queryKey, site );
+			// TODO: Figure out how to popular jetpack_modules and subscribers_count too
+			// queryClient.setQueryData( siteBySlugQuery( site.slug ).queryKey, site );
 		}
 
 		if ( site && siteSettings ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Depends on https://github.com/Automattic/wp-calypso/pull/104955

## Proposed Changes
- Wraps all query objects in queryOptions or mutationOptions
- Update the MD docs
- Ensure types are flowing through nicely from data layer, to query layer, to component
  - The fixes mostly involve moving the data types from the query layer to the data layer where necessary
- Removing the types from onSuccess and select callback parameters. It is more likely that queryOptions gets these types correct than that we will type them correctly 😄
- Fixed some runtime bugs this change discovered 😲 Yay TypeScript!

## Why are these changes being made?

More contributors are coming onboarding to the hosting dashboard. We all have different levels of experience with React Query.
To ensure we all use a consist strategy in the query layer, and to ensure we don't tie ourselves in knots fighting TS like we have elsewhere in Calypso, lets the helpers React Query provides. It'll help us stick to this "extracted query object" pattern.

## Testing Instructions
You'll want to "ignore whitespace" to review this code 😄
Smoke test hosting dashboard

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
