### PR TITLE
Hosting overview: Add loading state to bandwidth and storage stats on overview

### DIFF
--- a/client/dashboard/components/stat/index.stories.tsx
+++ b/client/dashboard/components/stat/index.stories.tsx
@@ -28,3 +28,14 @@ export const NoProgress: Story = {
 		description: '33% left',
 	},
 };
+
+export const Loading: Story = {
+	args: {
+		isLoading: true,
+		density: 'low',
+		strapline: 'Storage',
+		metric: '1.3 GB',
+		description: '5 GB',
+		progressValue: 50,
+	},
+};

--- a/client/dashboard/components/stat/index.tsx
+++ b/client/dashboard/components/stat/index.tsx
@@ -1,4 +1,5 @@
 import { __experimentalHStack as HStack, ProgressBar } from '@wordpress/components';
+import clsx from 'clsx';
 import { TextSkeleton } from '../text-skeleton';
 import './style.scss';
 
@@ -58,7 +59,11 @@ export function Stat( {
 	strapline,
 }: StatProps ) {
 	return (
-		<div className={ `dashboard-stat--density-${ density }` }>
+		<div
+			className={ clsx( `dashboard-stat--density-${ density }`, {
+				'dashboard-stat--is-loading': isLoading,
+			} ) }
+		>
 			{ strapline && <div className="dashboard-stat__strapline">{ strapline }</div> }
 			<HStack
 				alignment="baseline"
@@ -77,7 +82,7 @@ export function Stat( {
 			{ progressValue !== undefined && (
 				<ProgressBar
 					className={ `dashboard-stat__progress-bar dashboard-stat__progress-bar--${ progressColor }` }
-					value={ isLoading ? 0 : progressValue }
+					value={ progressValue }
 					aria-label={ progressLabel }
 					aria-hidden={ isLoading }
 				/>

--- a/client/dashboard/components/stat/index.tsx
+++ b/client/dashboard/components/stat/index.tsx
@@ -1,5 +1,5 @@
 import { __experimentalHStack as HStack, ProgressBar } from '@wordpress/components';
-import { TextBlur } from '../text-blur';
+import { TextSkeleton } from '../text-skeleton';
 import './style.scss';
 
 interface StatProps {
@@ -22,7 +22,7 @@ interface StatProps {
 	/**
 	 * The main value to display. Remember to include units.
 	 */
-	metric: string;
+	metric?: string;
 
 	/**
 	 * The color of the progress bar. If none is provided the admin theme colour
@@ -57,9 +57,6 @@ export function Stat( {
 	progressLabel = `${ progressValue }%`,
 	strapline,
 }: StatProps ) {
-	const metricElement = isLoading ? <TextBlur>{ metric }</TextBlur> : metric;
-	const descriptionElement = isLoading ? <TextBlur>{ description }</TextBlur> : description;
-
 	return (
 		<div className={ `dashboard-stat--density-${ density }` }>
 			{ strapline && <div className="dashboard-stat__strapline">{ strapline }</div> }
@@ -68,8 +65,14 @@ export function Stat( {
 				spacing={ 2 }
 				justify={ progressValue === undefined ? 'start' : 'space-between' }
 			>
-				<div className="dashboard-stat__metric">{ metricElement }</div>
-				{ description && <div className="dashboard-stat__description">{ descriptionElement }</div> }
+				<div className="dashboard-stat__metric">
+					{ isLoading ? <TextSkeleton length={ 5 } /> : metric }
+				</div>
+				{ description && ! isLoading && (
+					<div className="dashboard-stat__description">
+						{ isLoading ? <TextSkeleton length={ 8 } /> : description }
+					</div>
+				) }
 			</HStack>
 			{ progressValue !== undefined && (
 				<ProgressBar

--- a/client/dashboard/components/stat/index.tsx
+++ b/client/dashboard/components/stat/index.tsx
@@ -1,4 +1,5 @@
 import { __experimentalHStack as HStack, ProgressBar } from '@wordpress/components';
+import { TextBlur } from '../text-blur';
 import './style.scss';
 
 interface StatProps {
@@ -12,6 +13,11 @@ interface StatProps {
 	 * beside the metric. Otherwise, it describes the maximum value of the metric.
 	 */
 	description?: string;
+
+	/**
+	 * Obscure text while loading.
+	 */
+	isLoading?: boolean;
 
 	/**
 	 * The main value to display. Remember to include units.
@@ -44,12 +50,16 @@ interface StatProps {
 export function Stat( {
 	density = 'low',
 	description,
+	isLoading = false,
 	metric,
 	progressColor,
 	progressValue,
 	progressLabel = `${ progressValue }%`,
 	strapline,
 }: StatProps ) {
+	const metricElement = isLoading ? <TextBlur>{ metric }</TextBlur> : metric;
+	const descriptionElement = isLoading ? <TextBlur>{ description }</TextBlur> : description;
+
 	return (
 		<div className={ `dashboard-stat--density-${ density }` }>
 			{ strapline && <div className="dashboard-stat__strapline">{ strapline }</div> }
@@ -58,14 +68,15 @@ export function Stat( {
 				spacing={ 2 }
 				justify={ progressValue === undefined ? 'start' : 'space-between' }
 			>
-				<div className="dashboard-stat__metric">{ metric }</div>
-				{ description && <div className="dashboard-stat__description">{ description }</div> }
+				<div className="dashboard-stat__metric">{ metricElement }</div>
+				{ description && <div className="dashboard-stat__description">{ descriptionElement }</div> }
 			</HStack>
 			{ progressValue !== undefined && (
 				<ProgressBar
 					className={ `dashboard-stat__progress-bar dashboard-stat__progress-bar--${ progressColor }` }
-					value={ progressValue }
+					value={ isLoading ? 0 : progressValue }
 					aria-label={ progressLabel }
+					aria-hidden={ isLoading }
 				/>
 			) }
 		</div>

--- a/client/dashboard/components/stat/style.scss
+++ b/client/dashboard/components/stat/style.scss
@@ -38,6 +38,10 @@
 	--wp-components-color-foreground: #{$alert-green};
 }
 
+.dashboard-stat--is-loading .dashboard-stat__progress-bar > * {
+	display: none;
+}
+
 .dashboard-stat--density-low {
 	.dashboard-stat__metric {
 		font-size: $font-size-2x-large;

--- a/client/dashboard/sites/overview-plan-card/index.tsx
+++ b/client/dashboard/sites/overview-plan-card/index.tsx
@@ -110,6 +110,7 @@ export default function PlanCard( { site }: { site: Site } ) {
 						progressValue={ progressBarValue }
 						progressColor={ storageWarningColor }
 						progressLabel={ `${ storageUsagePercent }%` }
+						isLoading={ isLoadingMediaStorage }
 					/>
 					<Stat
 						density="high"
@@ -122,6 +123,7 @@ export default function PlanCard( { site }: { site: Site } ) {
 						description={ site.is_wpcom_atomic ? __( 'Unlimited' ) : undefined }
 						progressValue={ 100 }
 						progressColor="alert-green"
+						isLoading={ isLoadingBandwidth }
 					/>
 				</VStack>
 			}

--- a/client/dashboard/sites/overview-plan-card/index.tsx
+++ b/client/dashboard/sites/overview-plan-card/index.tsx
@@ -105,8 +105,8 @@ export default function PlanCard( { site }: { site: Site } ) {
 					<Stat
 						density="high"
 						strapline={ __( 'Storage' ) }
-						metric={ filesize( mediaStorage?.storage_used_bytes ?? 0, { round: 0 } ) }
-						description={ filesize( mediaStorage?.max_storage_bytes ?? 0, { round: 0 } ) }
+						metric={ mediaStorage && filesize( mediaStorage.storage_used_bytes, { round: 0 } ) }
+						description={ mediaStorage && filesize( mediaStorage.max_storage_bytes, { round: 0 } ) }
 						progressValue={ progressBarValue }
 						progressColor={ storageWarningColor }
 						progressLabel={ `${ storageUsagePercent }%` }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-114

## Proposed Changes

Adds a loading state to `<Stat>`

While this isn't the loading state described in the figma, this appears to be the style used elsewhere in the overview?

<img width="928" height="1048" alt="CleanShot 2025-07-30 at 18 37 47@2x" src="https://github.com/user-attachments/assets/c7fc0f62-81cb-458f-a7f0-40e8b25e4ee8" />

<img width="798" height="726" alt="CleanShot 2025-07-30 at 18 39 21@2x" src="https://github.com/user-attachments/assets/1c39ab65-d17c-40ca-b218-21abe3d8f48d" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Delete `REACT_QUERY_OFFLINE_CACHE` from your local storage
* Refresh page and observe loading state
* Try a simple and atomic site, since there's bandwidth logic is different.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
