### PR TITLE
Staging Sites Redesign: Fix warning related to usage of Icon component wrapped inside Tooltip

### DIFF
--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -479,7 +479,12 @@ export default function SyncModal( {
 								'Selecting this option will overwrite the site database, including any posts, pages, products, or orders.'
 							) }
 						>
-							<Icon icon={ error } style={ { fill: 'var(--studio-orange-50)' } } />
+							<span>
+								<Icon
+									icon={ error }
+									style={ { fill: 'var(--studio-orange-50)', display: 'flex' } }
+								/>
+							</span>
 						</Tooltip>
 					</HStack>
 					<VStack spacing={ 7 }>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DOTCOM-14025

## Proposed Changes

Looks like the Icon component doesn't work well when wrapped in the Tooltip component:

<img width="3612" height="1200" alt="Markup on 2025-07-30 at 11:46:33" src="https://github.com/user-attachments/assets/673de4b4-2676-4709-968d-9d1339482a21" />

This PR proposes to wrap the Icon component inside `span` to prevent the above warning.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To prevent the issue outlined above.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start` (or use Calypso Live link).
2. Head over to a staging site, (with browser console open) click the Sync dropdown button and pick any of the two options.
3. Once the Sync modal opens, hover over the ⚠️ icon by the Database tables checkbox and observe the tooltip.
4. There should be no `Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React. forwardRef()?` warning in the console.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
