### PR TITLE
Help Center: Adjust feedback buttons

### DIFF
--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -600,30 +600,8 @@ $feedback-button-size: 28px;
 		gap: 8px;
 
 		.odie-feedback-component-button {
-			font-family: $a8c-font-family-sans;
-			border-style: solid;
-			border-width: 1px;
-			cursor: pointer;
-			margin: 0;
-			outline: 0;
-			overflow: hidden;
-			text-align: center;
-			text-overflow: ellipsis;
-			text-decoration: none;
-			vertical-align: top;
-			box-sizing: border-box;
-			border-radius: 2px;
-			font-size: $font-body-extra-small;
-			line-height: 1;
-			appearance: none;
-			background-color: var( --color-surface );
-			color: var( --color-neutral-70 );
-			border-color: var( --color-neutral-10 );
-			display: flex;
-			height: $feedback-button-size;
-			width: $feedback-button-size;
-			justify-content: center;
-			align-items: center;
+			border: solid 0.5px var(--studio-gray-5);
+			padding: 6px;
 
 			&:focus {
 				outline: 0;

--- a/packages/odie-client/src/components/message/was-this-helpful-buttons.tsx
+++ b/packages/odie-client/src/components/message/was-this-helpful-buttons.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { ODIE_THUMBS_DOWN_RATING_VALUE, ODIE_THUMBS_UP_RATING_VALUE } from '../../constants';
@@ -91,7 +92,7 @@ const WasThisHelpfulButtons = ( {
 				) }
 			</div>
 			<div className="odie-feedback-component-button-container">
-				<button
+				<Button
 					className={ buttonLikedClasses }
 					onClick={ () => handleIsHelpful( true ) }
 					disabled={ notLiked }
@@ -99,8 +100,8 @@ const WasThisHelpfulButtons = ( {
 					aria-label={ __( 'Yes, this was helpful', __i18n_text_domain__ ) }
 				>
 					<ThumbsUpIcon className={ thumbsUpClasses } />
-				</button>
-				<button
+				</Button>
+				<Button
 					className={ buttonDislikedClasses }
 					onClick={ () => handleIsHelpful( false ) }
 					disabled={ liked }
@@ -108,7 +109,7 @@ const WasThisHelpfulButtons = ( {
 					aria-label={ __( 'No, this was not helpful', __i18n_text_domain__ ) }
 				>
 					<ThumbsDownIcon className={ thumbsDownClasses } />
-				</button>
+				</Button>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTSUP-266/was-this-helpful-is-too-large-and-thumbs-too-little

| Before | After |
|--------|--------|
| <img width="427" height="225" alt="image" src="https://github.com/user-attachments/assets/fe99ac04-d7a6-46af-9146-be8e34919bcb" /> | <img width="450" height="231" alt="image" src="https://github.com/user-attachments/assets/6513339e-cdc0-4a9c-b183-50b85294b1ed" /> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start a chat and ask a question to Odie