### PR TITLE
Staging Sites Redesign: Add options to push and pull analytics events

### DIFF
--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -258,7 +258,6 @@ export default function SyncModal( {
 			dispatch(
 				recordTracksEvent( 'calypso_hosting_configuration_staging_site_pull_success', options )
 			);
-			// setSyncError( null );
 		},
 		onError: ( error, options ) => {
 			dispatch(
@@ -276,7 +275,6 @@ export default function SyncModal( {
 			dispatch(
 				recordTracksEvent( 'calypso_hosting_configuration_staging_site_push_success', options )
 			);
-			// setSyncError( null );
 		},
 		onError: ( error, options ) => {
 			dispatch(

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -254,14 +254,17 @@ export default function SyncModal( {
 	}, [ wpContentNode, wpConfigNode ] );
 
 	const { pullFromStaging } = usePullFromStagingMutation( productionSiteId, stagingSiteId, {
-		onSuccess: () => {
-			dispatch( recordTracksEvent( 'calypso_hosting_configuration_staging_site_pull_success' ) );
+		onSuccess: ( _, options ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_hosting_configuration_staging_site_pull_success', options )
+			);
 			// setSyncError( null );
 		},
-		onError: ( error ) => {
+		onError: ( error, options ) => {
 			dispatch(
 				recordTracksEvent( 'calypso_hosting_configuration_staging_site_pull_failure', {
 					code: error.code,
+					...options,
 				} )
 			);
 			// setSyncError( error.code );
@@ -269,14 +272,17 @@ export default function SyncModal( {
 	} );
 
 	const { pushToStaging } = usePushToStagingMutation( productionSiteId, stagingSiteId, {
-		onSuccess: () => {
-			dispatch( recordTracksEvent( 'calypso_hosting_configuration_staging_site_push_success' ) );
+		onSuccess: ( _, options ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_hosting_configuration_staging_site_push_success', options )
+			);
 			// setSyncError( null );
 		},
-		onError: ( error ) => {
+		onError: ( error, options ) => {
 			dispatch(
 				recordTracksEvent( 'calypso_hosting_configuration_staging_site_push_failure', {
 					code: error.code,
+					...options,
 				} )
 			);
 			// setSyncError( error.code );


### PR DESCRIPTION

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DOTCOM-14021

## Proposed Changes

* Add pull and push options passed to backend to be saved in the track events

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We can check those values to differentiate between full and selective sync

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start` (or use the Calypso Live link in the comment below).
2. Open Calypso and then run `localStorage.setItem( 'debug', 'calypso:analytics*' );` in the browser console. It might be necessary to reload the page for it to pick up the new localStorage item.
3. Open a site that has staging sites or create one
4. On the top right, select `Sync` and do either a Push or a Pull 
5. When the synchronization starts successfully, you should see in the console the track events with the following properties:
  - include_paths
  - exclude_paths
 
<img width="2012" height="440" alt="CleanShot 2025-07-30 at 14 11 20@2x" src="https://github.com/user-attachments/assets/bf002a99-b255-4048-afeb-ed7f7b5ce553" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
