### PR TITLE
Hide deployments behind a feature

### DIFF
--- a/client/sites/deployments/components/deployments-upsell-nudge/index.tsx
+++ b/client/sites/deployments/components/deployments-upsell-nudge/index.tsx
@@ -1,0 +1,35 @@
+import { PLAN_BUSINESS, FEATURE_SSH, getPlanBusinessTitle } from '@automattic/calypso-products';
+import { addQueryArgs } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+const DeploymentsUpsellNudge = () => {
+	const translate = useTranslate();
+
+	const siteId = useSelector( getSelectedSiteId );
+
+	const href = addQueryArgs( `/checkout/${ siteId }/business`, {
+		redirect_to: `/github-deployments/${ siteId }`,
+	} );
+
+	return (
+		<UpsellNudge
+			className="deployments-upsell-nudge"
+			title={ translate( 'Upgrade to the %(businessPlanName)s plan to use GitHub Deployments.', {
+				args: { businessPlanName: getPlanBusinessTitle() },
+			} ) }
+			tracksImpressionName="calypso_deployments_upgrade_impression"
+			event="calypso_deployments_upgrade_upsell"
+			tracksClickName="calypso_deployments_upgrade_click"
+			href={ href }
+			callToAction={ translate( 'Upgrade' ) }
+			plan={ PLAN_BUSINESS }
+			showIcon
+			feature={ FEATURE_SSH }
+		/>
+	);
+};
+
+export default DeploymentsUpsellNudge;

--- a/client/sites/deployments/deployments/index.tsx
+++ b/client/sites/deployments/deployments/index.tsx
@@ -1,9 +1,13 @@
+import { FEATURE_SSH } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { useI18n } from '@wordpress/react-i18n';
 import { HostingCard } from 'calypso/components/hosting-card';
 import { useSelector } from 'calypso/state';
+import isRequestingSiteFeatures from 'calypso/state/selectors/is-requesting-site-features';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { GitHubDeploymentSurvey } from '../components/deployments-survey';
+import DeploymentsUpsellNudge from '../components/deployments-upsell-nudge';
 import { GitHubLoadingPlaceholder } from '../components/loading-placeholder';
 import { PageShell } from '../components/page-shell';
 import { GitHubDeploymentCreationForm } from '../deployment-creation/deployment-creation-form';
@@ -19,7 +23,20 @@ export function GitHubDeployments() {
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const { __ } = useI18n();
 
+	const requestingSiteFeatures = useSelector( ( state ) =>
+		isRequestingSiteFeatures( state, siteId )
+	);
+	const hasSshFeature = useSelector( ( state ) => siteHasFeature( state, siteId, FEATURE_SSH ) );
+
 	const { data: deployments, isLoading, refetch } = useCodeDeploymentsQuery( siteId );
+
+	if ( requestingSiteFeatures ) {
+		return null;
+	}
+
+	if ( ! hasSshFeature ) {
+		return <DeploymentsUpsellNudge />;
+	}
 
 	const renderContent = () => {
 		if ( deployments?.length ) {

--- a/client/sites/deployments/deployments/index.tsx
+++ b/client/sites/deployments/deployments/index.tsx
@@ -35,7 +35,11 @@ export function GitHubDeployments() {
 	}
 
 	if ( ! hasSshFeature ) {
-		return <DeploymentsUpsellNudge />;
+		return (
+			<PageShell pageTitle={ __( 'Deployments' ) }>
+				<DeploymentsUpsellNudge />
+			</PageShell>
+		);
 	}
 
 	const renderContent = () => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Hide Deployments behind the SSH feature

## Why are these changes being made?

* Make this screen available to plans that support it

## Testing Instructions

* With wpsh, add yourself a sticker
```
add_blog_sticker( 'summer-special-2025', null, null, 246962256 )
```
* Get a _production_ Personal plan with Credits
* Install a free plugin such as the facebook pixel
* Go to the hosting dashboard > Deployments. You should see an upsell

http://calypso.localhost:3000/github-deployments/dzver13h.wpcomstaging.com

<img width="942" height="402" alt="Screenshot 2025-07-30 at 17 02 20" src="https://github.com/user-attachments/assets/88917e3a-29cc-43ac-bf5a-4474a127a0f8" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
