### PR TITLE
One Tap Auth: Improve loading overlay between screens

### DIFF
--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -6,6 +6,7 @@ import { Step } from '@automattic/onboarding';
 import clsx from 'clsx';
 import { Component } from 'react';
 import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
+import OneTapAuthLoaderOverlay from 'calypso/blocks/login/one-tap-auth-loader-overlay';
 import EnvironmentBadge, {
 	Branch,
 	AccountSettingsHelper,
@@ -183,6 +184,7 @@ class Document extends Component {
 										app={ app }
 										sectionName={ sectionName }
 										isWCCOM={ isWCCOM }
+										isOneTapAuth={ !! query?.oneTapAuth }
 										showStepContainerV2Loader={ showStepContainerV2Loader }
 									/>
 								</div>
@@ -289,7 +291,17 @@ class Document extends Component {
 		);
 	}
 }
-function LoadingPlaceholder( { app, sectionName, isWCCOM, showStepContainerV2Loader } ) {
+function LoadingPlaceholder( {
+	app,
+	sectionName,
+	isWCCOM,
+	isOneTapAuth,
+	showStepContainerV2Loader,
+} ) {
+	if ( isOneTapAuth ) {
+		return <OneTapAuthLoaderOverlay />;
+	}
+
 	const shouldNotShowLoadingLogo =
 		sectionName === 'checkout' || sectionName === 'stepper' || sectionName === 'signup';
 

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -6,7 +6,6 @@ import { Step } from '@automattic/onboarding';
 import clsx from 'clsx';
 import { Component } from 'react';
 import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
-import OneTapAuthLoaderOverlay from 'calypso/blocks/login/one-tap-auth-loader-overlay';
 import EnvironmentBadge, {
 	Branch,
 	AccountSettingsHelper,
@@ -298,15 +297,14 @@ function LoadingPlaceholder( {
 	isOneTapAuth,
 	showStepContainerV2Loader,
 } ) {
-	if ( isOneTapAuth ) {
-		return <OneTapAuthLoaderOverlay />;
-	}
-
 	const shouldNotShowLoadingLogo =
-		sectionName === 'checkout' || sectionName === 'stepper' || sectionName === 'signup';
+		sectionName === 'checkout' ||
+		sectionName === 'stepper' ||
+		sectionName === 'signup' ||
+		isOneTapAuth;
 
 	if ( shouldNotShowLoadingLogo ) {
-		return showStepContainerV2Loader ? (
+		return showStepContainerV2Loader || isOneTapAuth ? (
 			<Step.Loading />
 		) : (
 			<Loading className="wpcom-loading__boot" />


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves https://linear.app/a8c/issue/DOTOBRD-264/improve-one-tap-login-flow-transition-between-screens

## Proposed Changes

This PR makes the loading screen transition consistent. Before this change, the W logo was shown as a first transition, then the progress bar animation, and the W logo again.


https://github.com/user-attachments/assets/3a37b272-73cc-4ffa-bd90-24dd9a43a889



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* More context can be found here: pdtkmj-3O7-p2#comment-7271

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Testing the loader only:

* Make sure you are logged out
* Go to `/log-in?oneTapAuth=true`
* Make sure the W logo is not displayed initially, and you see only the progress bar loader.

Testing the flow:

* Map `wordpress.com`, `public-api.wordpress.com`, and `s1.wp.com` to your sandbox.
* Map `wpcalypso.wordpress.com` to `127.0.0.1`.
* In your sandbox, open `wp-content/plugins/landpack/src/blocks/custom-html/html/google-one-tap-auth.php` and search and replace `window.location.href = '/...` with `window.location.href = 'https://wpcalypso.wordpress.com/...`.
* In the sandbox CLI, go to the `public_html` folder and run `wp landing-pages render-hp 2024-jul`.
* Start Calypso using the following command: `yarn build && HOST=wpcalypso.wordpress.com PORT=443 PROTOCOL=https yarn start`
* Authenticate to your Google account.
* Go to the LOHP and use the Google One Tap Auth.
* Make sure the W logo is not displayed initially, and you see only the progress bar loader.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?