### PR TITLE
Fix the Help Center build

### DIFF
--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -1,5 +1,6 @@
 @import '@automattic/typography/styles/variables';
 @import '@automattic/components/src/styles/typography';
+@import "@wordpress/base-styles/variables";
 @import "@wordpress/base-styles/mixins";
 
 $blueberry-color: #3858e9;


### PR DESCRIPTION
Fixes the Help Center app build.

### Testing instructions
The generated artifcats from the "Build Calypso Apps" job should be

```sh
build_meta.json                               help-center-gutenberg.js                      help-center-wp-admin.css
chunks-map.json                               help-center-gutenberg.min.js                  help-center-wp-admin.js
help-center-gutenberg-disconnected.asset.json help-center-gutenberg.rtl.css                 help-center-wp-admin.min.js
help-center-gutenberg-disconnected.css        help-center-wp-admin-disconnected.asset.json  help-center-wp-admin.rtl.css
help-center-gutenberg-disconnected.js         help-center-wp-admin-disconnected.css         help-icon.svg
help-center-gutenberg-disconnected.min.js     help-center-wp-admin-disconnected.js          images
help-center-gutenberg-disconnected.rtl.css    help-center-wp-admin-disconnected.min.js      languages
help-center-gutenberg.asset.json              help-center-wp-admin-disconnected.rtl.css     README.md
help-center-gutenberg.css                     help-center-wp-admin.asset.json
```