### PR TITLE
Domain Search Retrofit: Design update exhibit B

### DIFF
--- a/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
+++ b/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
@@ -320,7 +320,7 @@ class DomainRegistrationSuggestion extends Component {
 		if ( isFeatured && this.isExactMatch() ) {
 			badges.push(
 				<DomainSuggestionBadge variation="success">
-					{ translate( 'It’s available!' ) }
+					{ translate( "It's available!" ) }
 				</DomainSuggestionBadge>
 			);
 		} else if ( isRecommended && isFeatured ) {

--- a/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
+++ b/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
@@ -359,6 +359,10 @@ class DomainRegistrationSuggestion extends Component {
 			);
 		}
 
+		if ( badges.length === 0 ) {
+			return null;
+		}
+
 		return badges;
 	}
 

--- a/client/components/domain-search-v2/domain-skip-suggestion/index.tsx
+++ b/client/components/domain-search-v2/domain-skip-suggestion/index.tsx
@@ -37,7 +37,7 @@ const DomainSkipSuggestion = ( { domain, onSkip }: Props ) => {
 								domainName: tlds.join( '.' ),
 							},
 							components: {
-								domain: <span style={ { wordBreak: 'break-all' } } />,
+								domain: <span style={ { wordBreak: 'break-word', hyphens: 'none' } } />,
 								strong: <strong style={ { whiteSpace: 'nowrap' } } />,
 							},
 						}
@@ -50,6 +50,7 @@ const DomainSkipSuggestion = ( { domain, onSkip }: Props ) => {
 					variant="secondary"
 					onClick={ onSkip }
 					disabled={ cart.isBusy }
+					__next40pxDefaultSize
 				>
 					{ translate( 'Skip purchase' ) }
 				</Button>

--- a/client/components/domain-search-v2/domain-skip-suggestion/style.scss
+++ b/client/components/domain-search-v2/domain-skip-suggestion/style.scss
@@ -4,9 +4,9 @@
 	.components-card__body {
 		display: flex;
 		flex-direction: row;
-		justify-content: space-between;
 		align-items: center;
-		gap: 1rem;
+		justify-content: space-between;
+		gap: 1.5rem;
 	}
 
 	.subdomain-skip-suggestion__content {

--- a/client/components/domain-search-v2/register-domain-step/style.scss
+++ b/client/components/domain-search-v2/register-domain-step/style.scss
@@ -2,6 +2,8 @@
 @import '@wordpress/base-styles/mixins';
 
 .wpcom-domain-search-v2 {
+	--domain-search-v2-background-color: var( --color-main-background );
+
 	&.initial-state {
 		max-width: 800px;
 		margin-inline: auto;

--- a/packages/domain-search/src/components/domain-search-controls/filter-button.scss
+++ b/packages/domain-search/src/components/domain-search-controls/filter-button.scss
@@ -15,10 +15,12 @@
 		height: 1.5rem;
 		min-width: 1.5rem;
 		position: absolute;
-		top: -1rem;
-		right: -1rem;
+		pointer-events: none;
+		top: 0;
+		right: 0;
+		transform: translate( 50%, -50% );
 		background: var( --wp-admin-theme-color );
-		border: solid 2px #fff;
+		border: solid 2px var( --domain-search-v2-background-color );
 		border-radius: 50%;
 		color: #fff;
 		font-size: 0.75rem;

--- a/packages/domain-search/src/components/domain-search/style.scss
+++ b/packages/domain-search/src/components/domain-search/style.scss
@@ -1,6 +1,7 @@
 @import '@wordpress/base-styles/colors';
 
 .domain-search {
+	--domain-search-v2-background-color: #fcfcfc;
 	--domain-search-secondary-action-color: #{$gray-900};
 	--domain-search-secondary-action-box-shadow-color: #{$gray-400};
 	--domain-search-input-size: 56px;

--- a/packages/domain-search/src/components/domain-suggestion-badge/style.scss
+++ b/packages/domain-search/src/components/domain-suggestion-badge/style.scss
@@ -7,6 +7,7 @@
 	align-items: center;
 	border-radius: 2px;
 	box-shadow: 0 0 0 1px rgba( 0, 0, 0, 0.1 );
+	line-height: 1;
 }
 
 .domain-suggestion-badge--warning {

--- a/packages/domain-search/src/components/domain-suggestion-match-reasons/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-match-reasons/index.tsx
@@ -13,7 +13,7 @@ export const DomainSuggestionMatchReasons = ( { reasons }: DomainSuggestionMatch
 			{ reasons.map( ( reason ) => {
 				return (
 					<li key={ reason }>
-						<Text variant="muted" className="domain-suggestion-match-reason__text">
+						<Text className="domain-suggestion-match-reason__text">
 							<Icon icon={ check } className="domain-suggestion-match-reason__icon" />
 							{ reason }
 						</Text>

--- a/packages/domain-search/src/components/domain-suggestion-match-reasons/style.scss
+++ b/packages/domain-search/src/components/domain-suggestion-match-reasons/style.scss
@@ -9,8 +9,8 @@
 .domain-suggestion-match-reason__icon {
 	display: inline-block;
 	vertical-align: middle;
-	margin-right: 4px;
-	margin-top: -2px;
+	margin-right: 8px;
+	margin-top: -4px;
 	flex-shrink: 0;
 	fill: var( --color-accent, var( --wp-admin-theme-color, #3858e9 ) );
 }

--- a/packages/domain-search/src/components/domain-suggestion-match-reasons/style.scss
+++ b/packages/domain-search/src/components/domain-suggestion-match-reasons/style.scss
@@ -1,3 +1,5 @@
+@import '@wordpress/base-styles/colors';
+
 .domain-suggestion-match-reasons {
 	margin: 0;
 	padding: 0;
@@ -11,4 +13,8 @@
 	margin-top: -2px;
 	flex-shrink: 0;
 	fill: var( --color-accent, var( --wp-admin-theme-color, #3858e9 ) );
+}
+
+.domain-suggestion-match-reason__text {
+	color: #{$gray-800};
 }

--- a/packages/domain-search/src/components/domain-suggestion/featured.skeleton.tsx
+++ b/packages/domain-search/src/components/domain-suggestion/featured.skeleton.tsx
@@ -78,12 +78,13 @@ export const FeaturedSkeleton = forwardRef< HTMLDivElement, SkeletonProps >( ( p
 	};
 
 	return (
-		<Card
-			ref={ ref }
-			size={ activeQuery === 'large' ? 'medium' : 'small' }
-			className={ clsx( 'domain-suggestion-featured', className ) }
-		>
-			<CardBody className="domain-suggestion-featured__body">{ getContent() }</CardBody>
+		<Card ref={ ref } className={ clsx( 'domain-suggestion-featured', className ) }>
+			<CardBody
+				className="domain-suggestion-featured__body"
+				style={ { padding: activeQuery === 'large' ? '1.5rem' : '1rem' } }
+			>
+				{ getContent() }
+			</CardBody>
 		</Card>
 	);
 } );

--- a/packages/domain-search/src/components/domain-suggestion/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion/index.tsx
@@ -51,10 +51,6 @@ const DomainSuggestionComponent = ( {
 			<span
 				aria-label={ `${ domain }.${ tld }` }
 				className="domain-suggestions-list-item__domain-name"
-				style={ {
-					// eslint-disable-next-line no-nested-ternary
-					marginRight: notice ? ( activeQuery === 'large' ? '8px' : '4px' ) : undefined,
-				} }
 			>
 				{ domain }
 				<Text
@@ -65,12 +61,20 @@ const DomainSuggestionComponent = ( {
 				>
 					.{ tld }
 				</Text>
+				{ notice && (
+					<>
+						<span
+							aria-hidden="true"
+							style={ {
+								marginRight: activeQuery === 'large' ? '8px' : '4px',
+							} }
+						/>
+						<span className="domain-suggestions-list-item__notice">
+							<DomainSuggestionPopover>{ notice }</DomainSuggestionPopover>
+						</span>
+					</>
+				) }
 			</span>
-			{ notice && (
-				<span className="domain-suggestions-list-item__notice">
-					<DomainSuggestionPopover>{ notice }</DomainSuggestionPopover>
-				</span>
-			) }
 			{ badges && <span className="domain-suggestions-list-item__badges">{ badges }</span> }
 		</Text>
 	);

--- a/packages/domain-search/src/components/domain-suggestion/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion/index.tsx
@@ -22,6 +22,8 @@ type DomainSuggestionProps = {
 	cta?: React.ReactNode;
 } & Pick< ComponentProps< typeof DomainSuggestionCTA >, 'onClick' | 'disabled' >;
 
+const ICON_SIZE = 24;
+
 const DomainSuggestionComponent = ( {
 	uuid,
 	domain,
@@ -42,43 +44,42 @@ const DomainSuggestionComponent = ( {
 	const { activeQuery } = listContext;
 
 	const domainName = (
-		<span style={ { lineHeight: '24px' } }>
-			<Text
-				size={ activeQuery === 'large' ? 18 : 16 }
+		<Text
+			size={ activeQuery === 'large' ? 18 : 16 }
+			className="domain-suggestions-list-item__domain-name-container"
+		>
+			<span
+				aria-label={ `${ domain }.${ tld }` }
+				className="domain-suggestions-list-item__domain-name"
 				style={ {
-					verticalAlign: 'middle',
-					lineHeight: 'inherit',
-					marginRight: badges ? '12px' : undefined,
+					// eslint-disable-next-line no-nested-ternary
+					marginRight: notice ? ( activeQuery === 'large' ? '8px' : '4px' ) : undefined,
 				} }
 			>
-				<span
-					aria-label={ `${ domain }.${ tld }` }
-					style={ {
-						wordBreak: 'break-all',
-						// eslint-disable-next-line no-nested-ternary
-						marginRight: notice ? ( activeQuery === 'large' ? '8px' : '4px' ) : undefined,
-					} }
+				{ domain }
+				<Text
+					size="inherit"
+					lineHeight="inherit"
+					weight={ 500 }
+					className="domain-suggestions-list-item__domain-name-tld"
 				>
-					{ domain }
-					<Text size="inherit" weight={ 500 } style={ { whiteSpace: 'nowrap' } }>
-						.{ tld }
-					</Text>
+					.{ tld }
+				</Text>
+			</span>
+			{ notice && (
+				<span className="domain-suggestions-list-item__notice">
+					<DomainSuggestionPopover>{ notice }</DomainSuggestionPopover>
 				</span>
-				{ notice && (
-					<span className="domain-suggestions-list-item__notice">
-						<DomainSuggestionPopover>{ notice }</DomainSuggestionPopover>
-					</span>
-				) }
-			</Text>
+			) }
 			{ badges && <span className="domain-suggestions-list-item__badges">{ badges }</span> }
-		</span>
+		</Text>
 	);
 
 	const domainNameElement =
 		activeQuery === 'large' ? (
 			<HStack alignment="left" spacing={ 3 }>
-				<Icon icon={ globe } size={ 24 } className="domain-suggestions-list-item__icon" />
-				{ domainName }
+				<Icon icon={ globe } size={ ICON_SIZE } className="domain-suggestions-list-item__icon" />
+				<span style={ { lineHeight: `${ ICON_SIZE }px` } }>{ domainName }</span>
 			</HStack>
 		) : (
 			domainName

--- a/packages/domain-search/src/components/domain-suggestion/style.scss
+++ b/packages/domain-search/src/components/domain-suggestion/style.scss
@@ -11,8 +11,27 @@
 	flex-shrink: 0;
 }
 
+.domain-suggestions-list-item__domain-name-container {
+	display: flex;
+	align-items: center;
+	row-gap: 4px;
+	column-gap: 12px;
+	flex-wrap: wrap;
+	line-height: inherit;
+}
+
+.domain-suggestions-list-item__domain-name {
+	word-break: break-all;
+	line-height: inherit;
+}
+
+.domain-suggestions-list-item__domain-name-tld {
+	white-space: nowrap;
+}
+
 .domain-suggestions-list-item__badges {
 	display: inline-flex;
 	flex-wrap: wrap;
 	gap: 8px;
+	line-height: 1;
 }

--- a/packages/domain-search/src/components/domain-suggestion/unavailable.scss
+++ b/packages/domain-search/src/components/domain-suggestion/unavailable.scss
@@ -1,6 +1,6 @@
 .domain-suggestions-list-item-unavailable {
 	overflow: hidden;
-	--wp-components-color-gray-100: #fcfcfc;
+	--wp-components-color-gray-100: var( --domain-search-v2-background-color );
 }
 
 .domain-suggestions-list-item-unavailable__transfer-button {

--- a/packages/domain-search/src/components/domain-suggestion/unavailable.tsx
+++ b/packages/domain-search/src/components/domain-suggestion/unavailable.tsx
@@ -22,6 +22,8 @@ export interface UnavailableProps {
 	transferLink?: string;
 }
 
+const ICON_SIZE = 24;
+
 const UnavailableComponent = ( {
 	domain,
 	tld,
@@ -41,7 +43,7 @@ const UnavailableComponent = ( {
 
 	const reasonText = useMemo( () => {
 		const styledTld = (
-			<Text size="inherit" weight={ 500 } style={ { whiteSpace: 'nowrap' } }>
+			<Text size="inherit" weight={ 500 } lineHeight="inherit" style={ { whiteSpace: 'nowrap' } }>
 				.{ tld }
 			</Text>
 		);
@@ -49,6 +51,7 @@ const UnavailableComponent = ( {
 		const styledDomain = (
 			<Text
 				size="inherit"
+				lineHeight="inherit"
 				aria-label={ `${ domain }.${ tld }` }
 				style={ { wordBreak: 'break-all' } }
 			>
@@ -88,7 +91,11 @@ const UnavailableComponent = ( {
 		throw new Error( `Unknown reason: ${ reason }` );
 	}
 
-	const reasonElement = <Text size={ activeQuery === 'large' ? 18 : 16 }>{ reasonText }</Text>;
+	const reasonElement = (
+		<Text size={ activeQuery === 'large' ? 18 : 16 } lineHeight="inherit">
+			{ reasonText }
+		</Text>
+	);
 
 	const onTransfer = ( onTransferClick || transferLink ) && (
 		<div
@@ -117,8 +124,12 @@ const UnavailableComponent = ( {
 			return (
 				<HStack alignment="left" spacing={ 6 }>
 					<HStack alignment="left" spacing={ 3 } style={ { width: 'auto' } }>
-						<Icon icon={ notAllowed } size={ 24 } className="domain-suggestions-list-item__icon" />
-						{ reasonElement }
+						<Icon
+							icon={ notAllowed }
+							size={ ICON_SIZE }
+							className="domain-suggestions-list-item__icon"
+						/>
+						<span style={ { lineHeight: `${ ICON_SIZE }px` } }>{ reasonElement }</span>
 					</HStack>
 					{ onTransfer }
 				</HStack>

--- a/packages/domain-search/src/components/domain-suggestion/unavailable.tsx
+++ b/packages/domain-search/src/components/domain-suggestion/unavailable.tsx
@@ -115,9 +115,11 @@ const UnavailableComponent = ( {
 	const getContent = () => {
 		if ( activeQuery === 'large' ) {
 			return (
-				<HStack alignment="left" spacing={ 3 }>
-					<Icon icon={ notAllowed } size={ 24 } className="domain-suggestions-list-item__icon" />
-					{ reasonElement }
+				<HStack alignment="left" spacing={ 6 }>
+					<HStack alignment="left" spacing={ 3 } style={ { width: 'auto' } }>
+						<Icon icon={ notAllowed } size={ 24 } className="domain-suggestions-list-item__icon" />
+						{ reasonElement }
+					</HStack>
 					{ onTransfer }
 				</HStack>
 			);


### PR DESCRIPTION
Part of DOMAINS-1555.

## Proposed Changes

- Add more spacing between transfer CTA and text
- Center text with icon
- Adjust skip suggestion button size
- Adjust featured element padding
- Use regular apostrophe in the its available badge
- Use gray-800 in match reasons
- Adjust match reason icon margin
- Center filter count icon

## Why are these changes being made?

Second batch of changes from Ollie's design notes.