### PR TITLE
Enable Survicate survey service

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -7,6 +7,7 @@ import { addQueryArgs, getQueryArg, getQueryArgs, removeQueryArgs } from '@wordp
 import { useState, useEffect } from 'react';
 import { isSimplifiedOnboarding } from 'calypso/landing/stepper/hooks/use-simplified-onboarding';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
+import { addSurvicate } from 'calypso/lib/analytics/survicate';
 import { pathToUrl } from 'calypso/lib/url';
 import {
 	persistSignupDestination,
@@ -308,6 +309,11 @@ const onboarding: FlowV2< typeof initialize > = {
 				clearSignupCompleteSlug();
 			}
 		}, [ currentStepSlug, reduxDispatch, resetOnboardStore ] );
+
+		// Load Survicate
+		useEffect( () => {
+			addSurvicate();
+		}, [] );
 	},
 };
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -34,6 +34,7 @@ import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import { getMessagePathForJITM } from 'calypso/lib/route';
 import UserVerificationChecker from 'calypso/lib/user/verification-checker';
 import { isFetchingAdminColor } from 'calypso/state/admin-color/selectors';
+import { loadTrackingTool } from 'calypso/state/analytics/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getSidebarType, SidebarType } from 'calypso/state/global-sidebar/selectors';
 import { isUserNewerThan, WEEK_IN_MILLISECONDS } from 'calypso/state/guided-tours/contexts';
@@ -152,6 +153,9 @@ class Layout extends Component {
 		} );
 
 		refreshColorScheme( undefined, this.props.colorScheme );
+
+		// Load Survicate survey on all pages
+		this.props.dispatch( loadTrackingTool( 'Survicate' ) );
 	}
 
 	componentDidUpdate( prevProps ) {

--- a/client/lib/analytics/survicate.js
+++ b/client/lib/analytics/survicate.js
@@ -1,0 +1,38 @@
+import config from '@automattic/calypso-config';
+import debug from 'debug';
+import { getLocaleSlug } from 'calypso/lib/i18n-utils';
+
+const survicateDebug = debug( 'calypso:analytics:survicate' );
+
+let survicateScriptLoaded = false;
+
+export function mayWeLoadSurvicateScript() {
+	return config( 'survicate_enabled' );
+}
+
+export function addSurvicate() {
+	const workspaceId = 'e4794374cce15378101b63de24117572';
+
+	// Only add survicate for en languages
+	if ( ! getLocaleSlug().startsWith( 'en' ) ) {
+		survicateDebug( 'Not loading Survicate script for non-en language' );
+		return;
+	}
+
+	if ( survicateScriptLoaded || ! mayWeLoadSurvicateScript() ) {
+		survicateDebug( 'Not loading Survicate script' );
+		return;
+	}
+
+	( function () {
+		const s = document.createElement( 'script' );
+		s.src = `https://survey.survicate.com/workspaces/${ workspaceId }/web_surveys.js`;
+		s.async = true;
+		const e = document.getElementsByTagName( 'script' )[ 0 ];
+		e.parentNode.insertBefore( s, e );
+
+		survicateDebug( 'Survicate script loaded' );
+	} )();
+
+	survicateScriptLoaded = true;
+}

--- a/client/state/analytics/middleware.js
+++ b/client/state/analytics/middleware.js
@@ -7,6 +7,7 @@ import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
 import { maybeAddLogRocketScript } from 'calypso/lib/analytics/logrocket';
 import { bumpStat } from 'calypso/lib/analytics/mc';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
+import { addSurvicate } from 'calypso/lib/analytics/survicate';
 import { recordTracksEvent, setTracksOptOut } from 'calypso/lib/analytics/tracks';
 import {
 	ANALYTICS_EVENT_RECORD,
@@ -35,6 +36,10 @@ const loadTrackingTool = ( trackingTool ) => {
 
 	if ( trackingTool === 'LogRocket' ) {
 		maybeAddLogRocketScript();
+	}
+
+	if ( trackingTool === 'Survicate' ) {
+		addSurvicate();
 	}
 };
 

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -10,6 +10,7 @@
 	"features": {},
 	"google_recaptcha_site_key": false,
 	"hotjar_enabled": false,
+	"survicate_enabled": false,
 	"hostname": false,
 	"i18n_default_locale_slug": "en",
 	"lasagna_url": "wss://rt-api.wordpress.com/socket",

--- a/config/development.json
+++ b/config/development.json
@@ -17,6 +17,7 @@
 	"boom_analytics_key": "development",
 	"theme_color": "#1D2327",
 	"hotjar_enabled": true,
+	"survicate_enabled": true,
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -140,5 +140,6 @@
 	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "horizon",
 	"theme_color": "#1D2327",
-	"hotjar_enabled": true
+	"hotjar_enabled": true,
+	"survicate_enabled": true
 }

--- a/config/production.json
+++ b/config/production.json
@@ -173,5 +173,6 @@
 	"server_side_boom_analytics_enabled": true,
 	"boom_analytics_key": "production",
 	"theme_color": "#1D2327",
-	"hotjar_enabled": true
+	"hotjar_enabled": true,
+	"survicate_enabled": false
 }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -175,5 +175,6 @@
 	"server_side_boom_analytics_enabled": true,
 	"boom_analytics_key": "wpcalypso",
 	"theme_color": "#1D2327",
-	"hotjar_enabled": true
+	"hotjar_enabled": true,
+	"survicate_enabled": true
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTEMAL-46/add-survicate-survey-to-calypso

## Proposed Changes

* We're adding Survicate to Calypso so we can do specific surveys there.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open your Calypso home, Calypso main onboarding or any Calypso page and you should see the survey:
		<img width="1210" height="737" alt="image" src="https://github.com/user-attachments/assets/d0c30e01-0021-4cc9-b984-68f129aade24" />


* Make sure we'll only show the survey on Staging for now as we [force disabled it on production](https://github.com/Automattic/wp-calypso/pull/104992/files#diff-07e0c2ac42cdc22639d12b2282f02825cda2dcf94c741cad1f57706e93b62d2fR177) in this first iteration.

* If you enable survicate debug with: `localStorage.setItem('debug', 'calypso:analytics:survicate')`, you can see the logs (useful for prod):
		<img width="470" height="93" alt="image" src="https://github.com/user-attachments/assets/7a234304-1d71-4088-90d4-a16c3a05ef41" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
