### PR TITLE
Domain Search: Display unavailable transferrable premium domains

### DIFF
--- a/client/components/domain-search-v2/domain-search-results/index.jsx
+++ b/client/components/domain-search-v2/domain-search-results/index.jsx
@@ -85,6 +85,7 @@ class DomainSearchResults extends Component {
 			TLD_NOT_SUPPORTED_AND_DOMAIN_NOT_AVAILABLE,
 			TLD_NOT_SUPPORTED_TEMPORARILY,
 			TRANSFERRABLE,
+			TRANSFERRABLE_PREMIUM,
 			UNKNOWN,
 		} = domainAvailability;
 
@@ -158,6 +159,7 @@ class DomainSearchResults extends Component {
 			suggestions.length !== 0 &&
 			[
 				TRANSFERRABLE,
+				TRANSFERRABLE_PREMIUM,
 				MAPPABLE,
 				MAPPED,
 				RECENT_REGISTRATION_LOCK_NOT_TRANSFERRABLE,

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -84,6 +84,7 @@ class DomainSearchResults extends Component {
 			TLD_NOT_SUPPORTED_AND_DOMAIN_NOT_AVAILABLE,
 			TLD_NOT_SUPPORTED_TEMPORARILY,
 			TRANSFERRABLE,
+			TRANSFERRABLE_PREMIUM,
 			UNKNOWN,
 		} = domainAvailability;
 
@@ -97,6 +98,7 @@ class DomainSearchResults extends Component {
 			suggestions.length !== 0 &&
 			[
 				TRANSFERRABLE,
+				TRANSFERRABLE_PREMIUM,
 				MAPPABLE,
 				MAPPED,
 				RECENT_REGISTRATION_LOCK_NOT_TRANSFERRABLE,


### PR DESCRIPTION
Closes DOMAINS-1576.

## Proposed Changes

Shows transferrable premium domains in the domain search.

## Why are these changes being made?

That particular case wasn't being handled by our code (both in production and the new version.)

## Testing Instructions

First, verify that you DON'T see the `lup.dev` domain show up at all in wordpress.com/setup.

Search (any flow, `/setup` works fine) for the transferrable premium domain, in this case `lup.dev`.

Verify you see the availability message with the `domains/ui-redesign` feature flag turned OFF (current production behavior).

Verify you see the availability message with the `domains/ui-redesign` feature flag turned ON (new design, which allows you to 'bring it over'.)

