### PR TITLE
Hosting Overview: Add plan description and link for a4a sites

### DIFF
--- a/client/dashboard/sites/overview-plan-card/site-bandwidth-stat.tsx
+++ b/client/dashboard/sites/overview-plan-card/site-bandwidth-stat.tsx
@@ -1,0 +1,63 @@
+import { useQuery } from '@tanstack/react-query';
+import { __ } from '@wordpress/i18n';
+import filesize from 'filesize';
+import { siteMetricsQuery } from '../../app/queries/site-metrics';
+import { Stat } from '../../components/stat';
+import { getSiteDisplayUrl } from '../../utils/site-url';
+import type { Site } from '../../data/types';
+
+function getCurrentMonthRangeTimestamps() {
+	const now = new Date();
+	const firstDayOfMonth = new Date( now.getFullYear(), now.getMonth(), 1 );
+	const startInSeconds = Math.floor( firstDayOfMonth.getTime() / 1000 );
+
+	const today = new Date();
+	today.setMinutes( 59 );
+	today.setSeconds( 59 );
+	const endInSeconds = Math.floor( today.getTime() / 1000 );
+
+	return {
+		startInSeconds,
+		endInSeconds,
+	};
+}
+
+export default function SiteBandwidthStat( { site }: { site: Site } ) {
+	const { startInSeconds, endInSeconds } = getCurrentMonthRangeTimestamps();
+	const { data: bandwidth, isLoading: isLoadingBandwidth } = useQuery( {
+		...siteMetricsQuery( site.ID, {
+			start: startInSeconds,
+			end: endInSeconds,
+			metric: 'response_bytes_persec',
+		} ),
+		enabled: !! site.is_wpcom_atomic,
+		select: ( data ) => {
+			if ( ! data ) {
+				return data;
+			}
+			const domain = getSiteDisplayUrl( site );
+			return data.data.periods.reduce(
+				( acc, curr ) => acc + ( curr.dimension[ domain ] || 0 ),
+				0
+			);
+		},
+
+		// Don't update until page is refreshed
+		meta: { persist: false },
+		staleTime: Infinity,
+	} );
+
+	return (
+		<Stat
+			density="high"
+			strapline={ __( 'Bandwidth' ) }
+			metric={
+				bandwidth && site.is_wpcom_atomic ? filesize( bandwidth, { round: 1 } ) : __( 'Unlimited' )
+			}
+			description={ site.is_wpcom_atomic ? __( 'Unlimited' ) : undefined }
+			progressValue={ 100 }
+			progressColor="alert-green"
+			isLoading={ isLoadingBandwidth }
+		/>
+	);
+}

--- a/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
+++ b/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
@@ -1,0 +1,48 @@
+import { useQuery } from '@tanstack/react-query';
+import { __ } from '@wordpress/i18n';
+import filesize from 'filesize';
+import { siteMediaStorageQuery } from '../../app/queries/site-media-storage';
+import { Stat } from '../../components/stat';
+import type { Site } from '../../data/types';
+
+const MINIMUM_DISPLAYED_USAGE = 2.5;
+
+const ALERT_PERCENT = 80;
+
+export default function SiteStorageStat( { site }: { site: Site } ) {
+	const { data: mediaStorage, isLoading: isLoadingMediaStorage } = useQuery(
+		siteMediaStorageQuery( site.ID )
+	);
+
+	const storageUsagePercent = ! mediaStorage
+		? 0
+		: Math.round(
+				( ( mediaStorage.storage_used_bytes / mediaStorage.max_storage_bytes ) * 1000 ) / 10
+		  );
+
+	// Ensure that the displayed usage is never fully empty to avoid a confusing UI.
+	const progressBarValue = Math.max(
+		MINIMUM_DISPLAYED_USAGE,
+		Math.min( storageUsagePercent, 100 )
+	);
+
+	let storageWarningColor = undefined;
+	if ( storageUsagePercent > 100 ) {
+		storageWarningColor = 'alert-red' as const;
+	} else if ( storageUsagePercent > ALERT_PERCENT ) {
+		storageWarningColor = 'alert-yellow' as const;
+	}
+
+	return (
+		<Stat
+			density="high"
+			strapline={ __( 'Storage' ) }
+			metric={ mediaStorage && filesize( mediaStorage.storage_used_bytes, { round: 0 } ) }
+			description={ mediaStorage && filesize( mediaStorage.max_storage_bytes, { round: 0 } ) }
+			progressValue={ progressBarValue }
+			progressColor={ storageWarningColor }
+			progressLabel={ `${ storageUsagePercent }%` }
+			isLoading={ isLoadingMediaStorage }
+		/>
+	);
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-114

## Proposed Changes

Updates the copy and link of the a4a plan card.

<img width="762" height="822" alt="CleanShot 2025-07-31 at 14 38 02@2x" src="https://github.com/user-attachments/assets/3f6ff0ac-e81f-4ab3-b194-7c50b06b2ec2" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

a4a plans are managed separately, so link to the correct place

See figma QOBjujZah0UlGDDdLKZhzi-fi-7256_103322

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add an a4a site if you don't have one: https://agencies.automattic.com/marketplace/hosting/wpcom
* Check the plan card on the overview page
* Test free/business/commerce plan'd sites to confirm they haven't been changed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?