### PR TITLE
Site Overview: Fix the alignment of the overview card

### DIFF
--- a/client/dashboard/sites/overview-card/index.tsx
+++ b/client/dashboard/sites/overview-card/index.tsx
@@ -79,7 +79,11 @@ export default function OverviewCard( {
 	};
 
 	const topContent = (
-		<HStack justify="space-between" className="dashboard-overview-card__content">
+		<HStack
+			className="dashboard-overview-card__content"
+			justify="space-between"
+			alignment="flex-start"
+		>
 			<VStack spacing={ 4 } style={ { flexGrow: 1 } }>
 				<HStack justify="space-between">
 					<HStack spacing={ 2 } alignment="center" expanded={ false }>
@@ -229,7 +233,12 @@ export default function OverviewCard( {
 				{ bottom && (
 					<>
 						<Divider style={ { color: 'var(--dashboard-header__divider-color)' } } />
-						<VStack spacing={ 2 } className="dashboard-overview-card__content">
+						<VStack
+							className="dashboard-overview-card__content"
+							spacing={ 2 }
+							justify="flex-start"
+							style={ { flexGrow: 1 } }
+						>
 							{ bottom }
 						</VStack>
 					</>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Fix the alignment of the overview card if the screen width is not enough

<img width="852" height="422" alt="image" src="https://github.com/user-attachments/assets/24b63d88-2d84-4196-8d98-501a678a4c5d" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Select any site
* On the Overview screen, resize the window
* Ensure the content of the overview card aligns to the top
* Ensure the separator of the plan card aligns to the bottom of the first row, and the bottom of the plan card aligns to the top as well

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
