### PR TITLE
Staging Sites Redesign: Fix redirect to production site Overview tab after staging site deletion

### DIFF
--- a/client/dashboard/sites/staging-site-delete-banner/index.tsx
+++ b/client/dashboard/sites/staging-site-delete-banner/index.tsx
@@ -51,7 +51,7 @@ export default function StagingSiteDeleteBanner( { site }: { site: Site } ) {
 
 			// Staging site has been deleted, redirect to production site
 			router.navigate( {
-				to: '/$siteSlug',
+				to: '/overview/$siteSlug',
 				params: { siteSlug: productionSite.slug },
 			} );
 			createSuccessNotice( __( 'Staging site deleted.' ), { type: 'snackbar' } );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-14063

## Proposed Changes

* ensure the user is redirected to the Overview tab of the production site after staging site is deleted

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Currently, the user is redirected to non-existing page:

<img width="6468" height="1488" alt="Markup on 2025-07-31 at 12:28:01" src="https://github.com/user-attachments/assets/3fe97ef3-571d-49e1-a36d-47ab4698fe92" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start` (or use the Calypso Live link in the comment below).
2. Ensure the `hosting/staging-sites-redesign` feature flag is enabled.
3. Create a staging site and then try to delete it from the Settings tab of the staging site.
4. After the staging site is successfully deleted, the redirection should get you to the Overview tab of the related production site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
