### PR TITLE
Sync modal: Keep confirmation input visible

### DIFF
--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -467,7 +467,7 @@ export default function SyncModal( {
 							borderBottom: '1px solid var(--wp-components-color-gray-300, #ddd)',
 							padding: '16px 0',
 							marginTop: '8px',
-							marginBottom: '20px',
+							marginBottom: '24px',
 						} }
 					>
 						<CheckboxControl
@@ -490,8 +490,8 @@ export default function SyncModal( {
 							</span>
 						</Tooltip>
 					</HStack>
-					<VStack style={ { paddingBottom: '48px' } }>
-						{ showWooCommerceWarning && (
+					{ showWooCommerceWarning && (
+						<VStack style={ { paddingBottom: '52px' } }>
 							<Notice status="warning" isDismissible={ false }>
 								<Text as="p" weight="bold" style={ { lineHeight: '24px' } }>
 									{ __( 'Warning! WooCommerce data will be overwritten.' ) }
@@ -510,8 +510,8 @@ export default function SyncModal( {
 									}
 								) }
 							</Notice>
-						) }
-					</VStack>
+						</VStack>
+					) }
 				</div>
 				<VStack className="staging-site-card__footer" spacing={ 6 }>
 					{ showDomainConfirmation && (

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -22,6 +22,7 @@ import {
 } from '@wordpress/element';
 import { __, isRTL } from '@wordpress/i18n';
 import { error, chevronRight, chevronLeft } from '@wordpress/icons';
+import clsx from 'clsx';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import InlineSupportLink from 'calypso/dashboard/components/inline-support-link';
 import { SectionHeader } from 'calypso/dashboard/components/section-header';
@@ -402,7 +403,11 @@ export default function SyncModal( {
 				</HStack>
 				<SectionHeader level={ 3 } title={ syncConfig.syncSelectionHeading } />
 
-				<div className="staging-site-card">
+				<div
+					className={ clsx( 'staging-site-card', {
+						'confirmation-input': showDomainConfirmation,
+					} ) }
+				>
 					<Tooltip
 						text={
 							shouldDisableGranularSync
@@ -485,7 +490,7 @@ export default function SyncModal( {
 							</span>
 						</Tooltip>
 					</HStack>
-					<VStack spacing={ 7 }>
+					<VStack style={ { paddingBottom: '48px' } }>
 						{ showWooCommerceWarning && (
 							<Notice status="warning" isDismissible={ false }>
 								<Text as="p" weight="bold" style={ { lineHeight: '24px' } }>
@@ -506,41 +511,45 @@ export default function SyncModal( {
 								) }
 							</Notice>
 						) }
-						{ showDomainConfirmation && (
-							<VStack>
-								<InputControl
-									__next40pxDefaultSize
-									label={
-										<HStack style={ { textTransform: 'none' } } alignment="left" spacing={ 1 }>
-											<Text>{ __( "Enter your site's name" ) }</Text>
-											<Text color="var(--studio-red-50)">{ productionSiteSlug }</Text>
-											<Text>{ __( 'to confirm.' ) }</Text>
-										</HStack>
-									}
-									onChange={ handleDomainConfirmation }
-								/>
-							</VStack>
-						) }
 					</VStack>
 				</div>
-				<HStack className="staging-site-card__footer">
+				<VStack className="staging-site-card__footer" spacing={ 6 }>
+					{ showDomainConfirmation && (
+						<InputControl
+							__next40pxDefaultSize
+							label={
+								<HStack style={ { textTransform: 'none' } } alignment="left" spacing={ 1 }>
+									<Text>
+										{ __( 'Enter your site‘s name' ) }{ ' ' }
+										<Text color="var(--studio-red-50)">{ productionSiteSlug }</Text>{ ' ' }
+										{ __( 'to confirm.' ) }
+									</Text>
+								</HStack>
+							}
+							onChange={ handleDomainConfirmation }
+						/>
+					) }
 					<HStack>
-						<Text className="staging-site-card__footer-text">
-							{ createInterpolateElement( syncConfig.learnMore, {
-								a: <InlineSupportLink onClick={ onClose } supportContext="hosting-staging-site" />,
-							} ) }
-						</Text>
-					</HStack>
+						<HStack>
+							<Text className="staging-site-card__footer-text">
+								{ createInterpolateElement( syncConfig.learnMore, {
+									a: (
+										<InlineSupportLink onClick={ onClose } supportContext="hosting-staging-site" />
+									),
+								} ) }
+							</Text>
+						</HStack>
 
-					<HStack justify="flex-end" spacing={ 4 }>
-						<Button variant="tertiary" onClick={ onClose }>
-							{ __( 'Cancel' ) }
-						</Button>
-						<Button variant="primary" onClick={ handleConfirm } disabled={ isButtonDisabled }>
-							{ syncConfig.submit }
-						</Button>
+						<HStack justify="flex-end" spacing={ 4 }>
+							<Button variant="tertiary" onClick={ onClose }>
+								{ __( 'Cancel' ) }
+							</Button>
+							<Button variant="primary" onClick={ handleConfirm } disabled={ isButtonDisabled }>
+								{ syncConfig.submit }
+							</Button>
+						</HStack>
 					</HStack>
-				</HStack>
+				</VStack>
 			</VStack>
 		</Modal>
 	);

--- a/client/sites/staging-site/components/staging-site-sync-modal/style.scss
+++ b/client/sites/staging-site/components/staging-site-sync-modal/style.scss
@@ -5,6 +5,9 @@
 
 .staging-site-card {
 	padding-bottom: 48px;
+	&.confirmation-input {
+		padding-bottom: 82px;
+	}
 	.card {
 		padding: 24px 22px;
 	}
@@ -291,7 +294,6 @@
 }
 
 .staging-site-card__footer {
-	border-top: 1px solid var(--studio-gray-5);
 	position: absolute;
 	bottom: 0;
 	width: 100%;

--- a/client/sites/staging-site/components/staging-site-sync-modal/style.scss
+++ b/client/sites/staging-site/components/staging-site-sync-modal/style.scss
@@ -6,7 +6,7 @@
 .staging-site-card {
 	padding-bottom: 48px;
 	&.confirmation-input {
-		padding-bottom: 82px;
+		padding-bottom: 100px;
 	}
 	.card {
 		padding: 24px 22px;
@@ -294,6 +294,7 @@
 }
 
 .staging-site-card__footer {
+	border-top: 1px solid var(--studio-gray-5);
 	position: absolute;
 	bottom: 0;
 	width: 100%;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTCOM-14061

## Proposed Changes

* Move the confirmation input to the footer
* Adapt the paddings to take into account the moved element

|Before | After|
|-------|------|
| <img width="1480" height="1804" alt="CleanShot 2025-07-31 at 13 13 57@2x" src="https://github.com/user-attachments/assets/b44e82eb-39fc-4b29-9c26-96f08288651f" />| <img width="1480" height="1804" alt="CleanShot 2025-07-31 at 13 13 31@2x" src="https://github.com/user-attachments/assets/5874f3c7-a5b7-4535-a15f-d6a9ec8fa18b" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To avoid hiding the confirmation input when there is scroll so the user is always aware of that confirmation requirement

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply these changes and run Calypso locally
* On a site with staging site click on the top right `Sync` dropdown and select Pull from Staging
* Select `Specific files and folders` and expand the file tree so the scroll bar is displayed, for example, expand the plugins node
* Check the confirmation input is displayed always and it looks fine
* On a production site with WooCommerce installed, check the `Database tables` node
* Confirm the Woo warning is displayed and it looks fine

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
