### PR TITLE
Use Summer Special styling for the Install plugins feature

### DIFF
--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -74,6 +74,7 @@ export const FEATURE_WORDADS_INSTANT = 'wordads-instant';
 export const FEATURE_NO_BRANDING = 'no-wp-branding';
 export const FEATURE_ADVANCED_SEO = 'advanced-seo';
 export const FEATURE_UPLOAD_PLUGINS = 'upload-plugins';
+export const FEATURE_UPLOAD_PLUGINS_SUMMER_SPECIAL = 'upload-plugins-summer-special';
 export const FEATURE_INSTALL_PLUGINS = 'install-plugins';
 export const FEATURE_INSTALL_THEMES = 'install-themes';
 export const FEATURE_UPLOAD_THEMES = 'upload-themes';

--- a/packages/calypso-products/src/feature-group-plan-map.ts
+++ b/packages/calypso-products/src/feature-group-plan-map.ts
@@ -147,6 +147,7 @@ import {
 	FEATURE_SUPPORT_FROM_EXPERTS,
 	FEATURE_AI_ASSISTANT,
 	FEATURE_ADVANCED_FORM_FEATURES_JP,
+	FEATURE_UPLOAD_PLUGINS_SUMMER_SPECIAL,
 } from './constants';
 import { FeatureGroupMap } from './types';
 
@@ -457,7 +458,7 @@ export const featureGroups: Partial< FeatureGroupMap > = {
 	[ FEATURE_GROUP_CUSTOM_PLUGINS ]: {
 		slug: FEATURE_GROUP_CUSTOM_PLUGINS,
 		getTitle: () => null,
-		getFeatures: () => [ FEATURE_UPLOAD_PLUGINS ],
+		getFeatures: () => [ FEATURE_UPLOAD_PLUGINS, FEATURE_UPLOAD_PLUGINS_SUMMER_SPECIAL ],
 	},
 	[ FEATURE_GROUP_DEV_TOOLS ]: {
 		slug: FEATURE_GROUP_DEV_TOOLS,

--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -3,7 +3,6 @@ import { MaterialIcon, ExternalLink, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { DOMAIN_PRICING_AND_AVAILABLE_TLDS } from '@automattic/urls';
 import i18n from 'i18n-calypso';
-import moment from 'moment';
 import { MemoExoticComponent } from 'react';
 import Theme2Image from './assets/images/theme-2.jpg';
 import {
@@ -818,7 +817,13 @@ const FEATURES_LIST: FeatureList = {
 				// translators: %(date)s is a date string in the format of "August 25, 2025"
 				'One-time offer: Install plugins available in all paid plans. Valid until %(date)s!',
 				{
-					args: { date: moment( '2025-08-25' ).format( 'MMMM, Do' ) },
+					args: {
+						date: new Intl.DateTimeFormat( i18n.getLocaleSlug() || 'en-US', {
+							month: 'long',
+							day: 'numeric',
+							year: 'numeric',
+						} ).format( new Date( '2025-08-25' ) ),
+					},
 				}
 			),
 	},

--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -805,8 +805,9 @@ const FEATURES_LIST: FeatureList = {
 						size={ 16 }
 						style={ {
 							fill: 'var(--studio-blue-50)',
-							verticalAlign: 'bottom',
+							verticalAlign: 'middle',
 							marginLeft: '2px',
+							marginTop: '-2px',
 						} }
 					/>
 				</span>

--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -1,8 +1,9 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { MaterialIcon, ExternalLink } from '@automattic/components';
+import { MaterialIcon, ExternalLink, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { DOMAIN_PRICING_AND_AVAILABLE_TLDS } from '@automattic/urls';
 import i18n from 'i18n-calypso';
+import moment from 'moment';
 import { MemoExoticComponent } from 'react';
 import Theme2Image from './assets/images/theme-2.jpg';
 import {
@@ -123,6 +124,7 @@ import {
 	FEATURE_UNLIMITED_PRODUCTS_SERVICES,
 	FEATURE_UNLIMITED_STORAGE,
 	FEATURE_UPLOAD_PLUGINS,
+	FEATURE_UPLOAD_PLUGINS_SUMMER_SPECIAL,
 	FEATURE_UPLOAD_THEMES,
 	FEATURE_UPLOAD_THEMES_PLUGINS,
 	FEATURE_VIDEO_HOSTING_V2,
@@ -791,6 +793,33 @@ const FEATURES_LIST: FeatureList = {
 			i18n.translate(
 				'Plugins extend the functionality of your site and ' +
 					'open up endless possibilities for presenting your content and interacting with visitors.'
+			),
+	},
+	[ FEATURE_UPLOAD_PLUGINS_SUMMER_SPECIAL ]: {
+		getSlug: () => FEATURE_UPLOAD_PLUGINS_SUMMER_SPECIAL,
+		getTitle: () => {
+			return (
+				<>
+					{ i18n.translate( 'Install plugins' ) }
+					<Gridicon
+						icon="info-outline"
+						size={ 16 }
+						style={ {
+							fill: 'var(--studio-blue-50)',
+							verticalAlign: 'bottom',
+							marginLeft: '2px',
+						} }
+					/>
+				</>
+			);
+		},
+		getDescription: () =>
+			i18n.translate(
+				// translate: %(date)s is a date string in the format of "August 25, 2025"
+				'One-time offer: Install plugins available in all paid plans. Valid until %(date)s!',
+				{
+					args: { date: moment( '2025-08-25' ).format( 'LL' ) },
+				}
 			),
 	},
 

--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -815,10 +815,10 @@ const FEATURES_LIST: FeatureList = {
 		},
 		getDescription: () =>
 			i18n.translate(
-				// translate: %(date)s is a date string in the format of "August 25, 2025"
+				// translators: %(date)s is a date string in the format of "August 25, 2025"
 				'One-time offer: Install plugins available in all paid plans. Valid until %(date)s!',
 				{
-					args: { date: moment( '2025-08-25' ).format( 'LL' ) },
+					args: { date: moment( '2025-08-25' ).format( 'MMMM, Do' ) },
 				}
 			),
 	},

--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -799,7 +799,7 @@ const FEATURES_LIST: FeatureList = {
 		getSlug: () => FEATURE_UPLOAD_PLUGINS_SUMMER_SPECIAL,
 		getTitle: () => {
 			return (
-				<>
+				<span style={ { fontWeight: 500 } }>
 					{ i18n.translate( 'Install plugins' ) }
 					<Gridicon
 						icon="info-outline"
@@ -810,7 +810,7 @@ const FEATURES_LIST: FeatureList = {
 							marginLeft: '2px',
 						} }
 					/>
-				</>
+				</span>
 			);
 		},
 		getDescription: () =>

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1028,7 +1028,7 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 			FEATURE_SHIPPING_CARRIERS,
 			PREMIUM_DESIGN_FOR_STORES,
 		].filter( isValueTruthy ),
-	get2023PricingGridSignupWpcomFeatures: () => {
+	get2023PricingGridSignupWpcomFeatures: ( props?: { isSummerSpecial?: boolean } ) => {
 		return [
 			FEATURE_UNLIMITED_ENTITIES,
 			FEATURE_CUSTOM_DOMAIN,
@@ -1039,7 +1039,7 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 			FEATURE_CONNECT_ANALYTICS,
 			FEATURE_UPLOAD_VIDEO,
 			FEATURE_STATS_ADVANCED_20250206,
-			FEATURE_UPLOAD_PLUGINS,
+			props?.isSummerSpecial ? FEATURE_UPLOAD_PLUGINS_SUMMER_SPECIAL : FEATURE_UPLOAD_PLUGINS,
 			FEATURE_DEV_TOOLS,
 			FEATURE_WOOCOMMERCE_HOSTING,
 		];
@@ -1619,7 +1619,7 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 			FEATURE_SITE_BACKUPS_AND_RESTORE,
 			FEATURE_SFTP_DATABASE,
 		].filter( isValueTruthy ),
-	get2023PricingGridSignupWpcomFeatures: () => {
+	get2023PricingGridSignupWpcomFeatures: ( props?: { isSummerSpecial?: boolean } ) => {
 		return [
 			...( isBigSkyOnboarding() ? [ FEATURE_BIG_SKY_WEBSITE_BUILDER ] : [] ),
 			FEATURE_UNLIMITED_ENTITIES,
@@ -1631,7 +1631,7 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 			FEATURE_CONNECT_ANALYTICS,
 			FEATURE_UPLOAD_VIDEO,
 			FEATURE_STATS_ADVANCED_20250206,
-			FEATURE_UPLOAD_PLUGINS,
+			props?.isSummerSpecial ? FEATURE_UPLOAD_PLUGINS_SUMMER_SPECIAL : FEATURE_UPLOAD_PLUGINS,
 			FEATURE_DEV_TOOLS,
 		];
 	},

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -449,6 +449,7 @@ import {
 	FEATURE_SUPPORT_FROM_EXPERTS,
 	FEATURE_AI_ASSISTANT,
 	FEATURE_ADVANCED_FORM_FEATURES_JP,
+	FEATURE_UPLOAD_PLUGINS_SUMMER_SPECIAL,
 } from './constants';
 import { isBigSkyOnboarding } from './is-big-sky-onboarding';
 import { isGlobalStylesOnPersonalEnabled } from './is-global-styles-on-personal-enabled';
@@ -822,7 +823,7 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		let features = baseFeatures;
 
 		if ( props?.isSummerSpecial ) {
-			features = [ FEATURE_UPLOAD_PLUGINS, ...features ];
+			features = [ FEATURE_UPLOAD_PLUGINS_SUMMER_SPECIAL, ...features ];
 		}
 
 		if ( isGlobalStylesOnPersonalEnabled() ) {
@@ -1431,7 +1432,7 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 		let features = baseFeatures;
 
 		if ( props?.isSummerSpecial ) {
-			features = [ FEATURE_UPLOAD_PLUGINS, ...features ];
+			features = [ FEATURE_UPLOAD_PLUGINS_SUMMER_SPECIAL, ...features ];
 		}
 
 		return features;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTOBRD-275](https://linear.app/a8c/issue/DOTOBRD-275)

## Proposed Changes

* adds a Summer Special styling and tooltip to the Install plugins feature

<img width="667" height="182" alt="Screenshot 2025-07-30 at 15 15 43" src="https://github.com/user-attachments/assets/771207ab-7c95-4e97-aa5a-81cc176d35c4" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup/onboarding/plans
* You should not see the updated styling for the  install plugins feature

<img width="1660" height="1234" alt="Screenshot 2025-08-01 at 11 50 47" src="https://github.com/user-attachments/assets/b9c165dd-8664-411a-894a-142a49572997" />


* Go to /setup/onboarding/plans?flags=summer-special-2025
* You should see the updated styling for the  install plugins feature

<img width="1571" height="1120" alt="Screenshot 2025-08-01 at 12 28 19" src="https://github.com/user-attachments/assets/62976ab0-c4a0-4186-bfde-7d81956d145e" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
