### PR TITLE
Domain Search Retrofitting: Add 'Choose a domain later' button within the full cart

### DIFF
--- a/client/components/domain-search-v2/domain-cart/choose-domain-later.tsx
+++ b/client/components/domain-search-v2/domain-cart/choose-domain-later.tsx
@@ -1,0 +1,16 @@
+import { Button } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
+
+interface Props {
+	onSkip: () => void;
+}
+
+export const ChooseDomainLater = ( { onSkip }: Props ) => {
+	const { __ } = useI18n();
+
+	return (
+		<Button className="choose-domain-later__btn" variant="link" onClick={ onSkip }>
+			{ __( 'Choose a domain later' ) }
+		</Button>
+	);
+};

--- a/client/components/domain-search-v2/domain-cart/index.tsx
+++ b/client/components/domain-search-v2/domain-cart/index.tsx
@@ -6,11 +6,17 @@ import {
 	__experimentalSpacer as Spacer,
 } from '@wordpress/components';
 import { FreeDomainForAYearPromo } from '../free-domain-for-a-year-promo';
+import { ChooseDomainLater } from './choose-domain-later';
 import { HundredYearPromo } from './hundred-year-promo';
 
 import './style.scss';
 
-export const DomainCartV2 = ( { showFreeDomainPromo = false } ) => {
+interface Props {
+	showFreeDomainPromo?: boolean;
+	onSkip?: () => void;
+}
+
+export const DomainCartV2 = ( { showFreeDomainPromo = false, onSkip }: Props ) => {
 	const hasDomainInCartEligibleFor100YearDomainUpgrade = false;
 
 	return (
@@ -20,6 +26,11 @@ export const DomainCartV2 = ( { showFreeDomainPromo = false } ) => {
 				<VStack spacing={ 6 }>
 					{ showFreeDomainPromo && <FreeDomainForAYearPromo textOnly /> }
 					<DomainsFullCart.Items />
+					{ onSkip && (
+						<div>
+							<ChooseDomainLater onSkip={ onSkip } />
+						</div>
+					) }
 					{ hasDomainInCartEligibleFor100YearDomainUpgrade && (
 						<View>
 							<Spacer marginTop={ 4 }>

--- a/client/components/domain-search-v2/domain-cart/style.scss
+++ b/client/components/domain-search-v2/domain-cart/style.scss
@@ -1,4 +1,9 @@
 .domains-search-v2__mini-cart,
 .domains-search-v2__full-cart {
 	z-index: z-index( 'root', '.drawer' );
+
+	.choose-domain-later__btn,
+	.choose-domain-later__btn:hover {
+		color: var( --studio-gray-900 );
+	}
 }

--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -685,7 +685,7 @@ class RegisterDomainStep extends Component {
 					{ showFreeDomainPromo && <FreeDomainForAYearPromo /> }
 					{ this.renderContent() }
 				</VStack>
-				<DomainCartV2 showFreeDomainPromo={ showFreeDomainPromo } />
+				<DomainCartV2 showFreeDomainPromo={ showFreeDomainPromo } onSkip={ this.props.onSkip } />
 			</DomainSearch>
 		);
 	}


### PR DESCRIPTION
Part of DOMAINS-1577/update-cart-to-support-choose-a-domain-later-action

## Proposed Changes

* Add 'Choose a domain later' button within the full cart

## Why are these changes being made?

* Discussion: p1753876510297429-slack-C04H4NY6STW

## Testing Instructions

* Make sure you have a feature flag `domains/ui-redesign`
* Go to `/setup/onboarding/domains`
* Add a suggestion domain to a cart
* Open full cart
* Check if there is a "Choose a domain later" button
* Click and check if it redirects to the next step

<img width="1728" height="803" alt="Screenshot 2025-07-31 at 17 13 01" src="https://github.com/user-attachments/assets/71787248-1328-4c12-9abc-82a997ecd3e8" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?