### PR TITLE
A4A: Remove migration incentive banners

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hero-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hero-section/index.tsx
@@ -1,8 +1,7 @@
 import { useBreakpoint } from '@automattic/viewport-react';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { forwardRef, useCallback, useEffect, useMemo, useState } from 'react';
-import MigrationOfferV3 from 'calypso/a8c-for-agencies/components/a4a-migration-offer-v3';
+import { forwardRef, useMemo } from 'react';
 import NavItem from 'calypso/components/section-nav/item';
 import { preventWidows } from 'calypso/lib/formatting';
 import { SectionProps } from '..';
@@ -21,12 +20,6 @@ export function HeroSection(
 	const translate = useTranslate();
 
 	const isLargeScreen = useBreakpoint( '>1280px' );
-
-	const [ isMigrationOfferExpanded, setIsMigrationOfferExpanded ] = useState( false );
-
-	const onToggleMigrationOfferView = useCallback( () => {
-		setIsMigrationOfferExpanded( ( isExpanded ) => ! isExpanded );
-	}, [] );
 
 	const featureTabs = useMemo(
 		() => [
@@ -77,12 +70,6 @@ export function HeroSection(
 		);
 	} );
 
-	useEffect( () => {
-		if ( isCompact ) {
-			setIsMigrationOfferExpanded( false );
-		}
-	}, [ isCompact ] );
-
 	return (
 		<div className={ clsx( 'hosting-hero-section', { 'is-compact': isCompact } ) } ref={ ref }>
 			<div className="hosting-hero-section__content">
@@ -98,11 +85,6 @@ export function HeroSection(
 						)
 					) }
 				</div>
-
-				<MigrationOfferV3
-					isExpanded={ isMigrationOfferExpanded }
-					onToggleView={ onToggleMigrationOfferView }
-				/>
 			</div>
 
 			<ul className="hosting-hero-section__tabs">{ navItems }</ul>

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-banner/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-banner/index.tsx
@@ -1,6 +1,4 @@
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
-import MigrationOfferV3 from 'calypso/a8c-for-agencies/components/a4a-migration-offer-v3';
 import PageSection from 'calypso/a8c-for-agencies/components/page-section';
 import { BackgroundType5 } from 'calypso/a8c-for-agencies/components/page-section/backgrounds';
 
@@ -8,7 +6,6 @@ import './style.scss';
 
 export default function MigrationsBanner() {
 	const translate = useTranslate();
-	const [ isMigrationOfferExpanded, setIsMigrationOfferExpanded ] = useState( true );
 
 	return (
 		<PageSection
@@ -22,10 +19,7 @@ export default function MigrationsBanner() {
 			) }
 			background={ BackgroundType5 }
 		>
-			<MigrationOfferV3
-				isExpanded={ isMigrationOfferExpanded }
-				onToggleView={ () => setIsMigrationOfferExpanded( ( prev ) => ! prev ) }
-			/>
+			<div />
 		</PageSection>
 	);
 }

--- a/client/a8c-for-agencies/sections/overview/body/hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/hosting/index.tsx
@@ -2,8 +2,7 @@ import page from '@automattic/calypso-router';
 import { WordPressLogo } from '@automattic/components';
 import { useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useState } from 'react';
-import MigrationOfferV3 from 'calypso/a8c-for-agencies/components/a4a-migration-offer-v3';
+import { useCallback } from 'react';
 import Offering from 'calypso/a8c-for-agencies/components/offering';
 import { OfferingItemProps } from 'calypso/a8c-for-agencies/components/offering/types';
 import { A4A_MARKETPLACE_HOSTING_WPCOM_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
@@ -14,8 +13,6 @@ import PressableOffering from './pressable-offering';
 const OverviewBodyHosting = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-
-	const [ isMigrationOfferExpanded, setIsMigrationOfferExpanded ] = useState( true );
 
 	const actionHandlerCallback = useCallback(
 		( section: string, product: string ) => {
@@ -66,10 +63,6 @@ const OverviewBodyHosting = () => {
 			) }
 			items={ [ wpcom ] }
 		>
-			<MigrationOfferV3
-				isExpanded={ isMigrationOfferExpanded }
-				onToggleView={ () => setIsMigrationOfferExpanded( ( prev ) => ! prev ) }
-			/>
 			<PressableOffering />
 		</Offering>
 	);


### PR DESCRIPTION


## Proposed Changes

* Hide A4A Migration incentive banners

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The incentives expire July 31 so the banners need to be removed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the live link
* Go to `/overview`, confirm you don't see this banner:

<img width="981" height="403" alt="Screenshot 2025-07-31 at 16 15 43" src="https://github.com/user-attachments/assets/f082df34-2ab5-4a53-80d1-9fbea25428ba" />

* Go to `/migrations/overview`, confirm you don't see this banner:

<img width="1480" height="461" alt="Screenshot 2025-07-31 at 16 16 27" src="https://github.com/user-attachments/assets/299e9880-20bd-49bb-a837-4f1553d1a9eb" />

* Go to `/marketplace/hosting/pressable`, confirm you don't see this banner:

<img width="1432" height="394" alt="Screenshot 2025-07-31 at 16 16 54" src="https://github.com/user-attachments/assets/8d3754af-e027-46b3-a79a-6a85d1f99938" />


## Pre-merge Checklist

<!--

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
