### PR TITLE
Domain Search Retrofitting: Remove cart items check for the isInInitialState

### DIFF
--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -901,13 +901,7 @@ class RegisterDomainStep extends Component {
 	};
 
 	isInInitialState = () => {
-		const domainsInCart = this.getDomainsInCart();
-
-		return (
-			! Array.isArray( this.state.searchResults ) &&
-			! this.state.loadingResults &&
-			! domainsInCart.length
-		);
+		return ! Array.isArray( this.state.searchResults ) && ! this.state.loadingResults;
 	};
 
 	save = () => {


### PR DESCRIPTION
Part of DOMAINS-1571/domain-only-flow-doesnt-show-the-initial-empty-state-if-there-are

## Proposed Changes

* Update domain search **initial state** logic

## Why are these changes being made?

* DOMAINS-1571/domain-only-flow-doesnt-show-the-initial-empty-state-if-there-are

## Testing Instructions

* Make sure you have a feature flag `domains/ui-redesign`
* Go to `/setup/onboarding/domains`
* Add one or more domains to cart
* Open the browser dev tool and clear the local storage
* Refresh the browser and check that you ended up on the initial domain search screen

https://github.com/user-attachments/assets/3fa7bcd0-cc06-4210-9bca-e8aec0a3a5fb

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
