### PR TITLE
GitHub Deployments: Add confirmation dialog for manual production deployments

### DIFF
--- a/client/sites/deployments/deployments/styles.scss
+++ b/client/sites/deployments/deployments/styles.scss
@@ -189,7 +189,8 @@ $brand-text: "SF Pro Text", $sans;
 	}
 }
 
-.github-deployments-delete-deployment-dialog {
+.github-deployments-delete-deployment-dialog,
+.github-deployments-production-deployment-dialog {
 	max-width: 560px;
 
 	p,

--- a/client/sites/deployments/deployments/styles.scss
+++ b/client/sites/deployments/deployments/styles.scss
@@ -1,5 +1,5 @@
-@import "@automattic/typography/styles/variables";
-$brand-text: "SF Pro Text", $sans;
+@import '@automattic/typography/styles/variables';
+$brand-text: 'SF Pro Text', $sans;
 
 .github-deployments-list {
 	display: flex;
@@ -35,14 +35,14 @@ $brand-text: "SF Pro Text", $sans;
 	}
 
 	thead tr,
-	tbody tr:not(:last-of-type) {
-		border-bottom: 1px solid var(--color-border-subtle);
+	tbody tr:not( :last-of-type ) {
+		border-bottom: 1px solid var( --color-border-subtle );
 	}
 
 	tr th {
 		padding: 8px 0 16px 0;
 		font-weight: 500;
-		color: var(--studio-gray-60, #50575e);
+		color: var( --studio-gray-60, #50575e );
 	}
 
 	td {
@@ -93,16 +93,16 @@ $brand-text: "SF Pro Text", $sans;
 			text-align: left;
 			padding: 0;
 			border: none;
-			color: var(--studio-gray-100, #101517);
+			color: var( --studio-gray-100, #101517 );
 
 			&:hover {
 				text-decoration: underline;
-				color: var(--studio-gray-100, #101517);
+				color: var( --studio-gray-100, #101517 );
 			}
 		}
 
 		span {
-			color: var(--studio-gray-60);
+			color: var( --studio-gray-60 );
 			font-size: $font-body-extra-small;
 			font-weight: 400;
 		}
@@ -125,15 +125,14 @@ $brand-text: "SF Pro Text", $sans;
 
 		a {
 			text-decoration: underline;
-			color: var(--studio-gray-60);
+			color: var( --studio-gray-60 );
 		}
 	}
 
 	&__menu-item-danger {
-		color: var(--color-error);
+		color: var( --color-error );
 	}
 }
-
 
 .github-deployments-status {
 	display: inline-flex;
@@ -149,30 +148,30 @@ $brand-text: "SF Pro Text", $sans;
 
 	&__pending,
 	&__queued {
-		border: 1px solid var(--Gray-Gray-10, #c3c4c7);
-		color: var(--Gray-Gray-60, #50575e);
-		background-color: var(--studio-white);
+		border: 1px solid var( --Gray-Gray-10, #c3c4c7 );
+		color: var( --Gray-Gray-60, #50575e );
+		background-color: var( --studio-white );
 	}
 
 	&__success {
-		background-color: var(--Green-Green-5, #b8e6bf);
-		color: var(--Green-Green-80, #00450c);
+		background-color: var( --Green-Green-5, #b8e6bf );
+		color: var( --Green-Green-80, #00450c );
 	}
 
 	&__failed {
-		background-color: var(--Red-Red-5, #facfd2);
-		color: var(--Red-Red-80, #691c1c);
+		background-color: var( --Red-Red-5, #facfd2 );
+		color: var( --Red-Red-80, #691c1c );
 	}
 
 	&__running,
 	&__building {
-		background-color: var(--Blue-Blue-5, #bbe0fa);
-		color: var(--Blue-Blue-80, #02395c);
+		background-color: var( --Blue-Blue-5, #bbe0fa );
+		color: var( --Blue-Blue-80, #02395c );
 	}
 
 	&__warnings {
-		background-color: var(--Yellow-Yellow-5, #f5c4a1);
-		color: var(--Yellow-Yellow-80, #4f3500);
+		background-color: var( --Yellow-Yellow-5, #f5c4a1 );
+		color: var( --Yellow-Yellow-80, #4f3500 );
 	}
 
 	span {
@@ -189,7 +188,8 @@ $brand-text: "SF Pro Text", $sans;
 	}
 }
 
-.github-deployments-delete-deployment-dialog {
+.github-deployments-delete-deployment-dialog,
+.github-deployments-production-deployment-dialog {
 	max-width: 560px;
 
 	p,
@@ -215,13 +215,13 @@ $brand-text: "SF Pro Text", $sans;
 
 .github-deployments {
 	.header-cake__back {
-		color: var(--studio-gray-60);
+		color: var( --studio-gray-60 );
 		font-size: $font-body-small;
 		padding: 0;
 		margin-bottom: 16px;
 		svg {
 			margin-right: 2px;
-			fill: var(--studio-gray-60);
+			fill: var( --studio-gray-60 );
 		}
 	}
 }

--- a/client/sites/deployments/deployments/styles.scss
+++ b/client/sites/deployments/deployments/styles.scss
@@ -1,5 +1,5 @@
-@import '@automattic/typography/styles/variables';
-$brand-text: 'SF Pro Text', $sans;
+@import "@automattic/typography/styles/variables";
+$brand-text: "SF Pro Text", $sans;
 
 .github-deployments-list {
 	display: flex;
@@ -35,14 +35,14 @@ $brand-text: 'SF Pro Text', $sans;
 	}
 
 	thead tr,
-	tbody tr:not( :last-of-type ) {
-		border-bottom: 1px solid var( --color-border-subtle );
+	tbody tr:not(:last-of-type) {
+		border-bottom: 1px solid var(--color-border-subtle);
 	}
 
 	tr th {
 		padding: 8px 0 16px 0;
 		font-weight: 500;
-		color: var( --studio-gray-60, #50575e );
+		color: var(--studio-gray-60, #50575e);
 	}
 
 	td {
@@ -93,16 +93,16 @@ $brand-text: 'SF Pro Text', $sans;
 			text-align: left;
 			padding: 0;
 			border: none;
-			color: var( --studio-gray-100, #101517 );
+			color: var(--studio-gray-100, #101517);
 
 			&:hover {
 				text-decoration: underline;
-				color: var( --studio-gray-100, #101517 );
+				color: var(--studio-gray-100, #101517);
 			}
 		}
 
 		span {
-			color: var( --studio-gray-60 );
+			color: var(--studio-gray-60);
 			font-size: $font-body-extra-small;
 			font-weight: 400;
 		}
@@ -125,14 +125,15 @@ $brand-text: 'SF Pro Text', $sans;
 
 		a {
 			text-decoration: underline;
-			color: var( --studio-gray-60 );
+			color: var(--studio-gray-60);
 		}
 	}
 
 	&__menu-item-danger {
-		color: var( --color-error );
+		color: var(--color-error);
 	}
 }
+
 
 .github-deployments-status {
 	display: inline-flex;
@@ -148,30 +149,30 @@ $brand-text: 'SF Pro Text', $sans;
 
 	&__pending,
 	&__queued {
-		border: 1px solid var( --Gray-Gray-10, #c3c4c7 );
-		color: var( --Gray-Gray-60, #50575e );
-		background-color: var( --studio-white );
+		border: 1px solid var(--Gray-Gray-10, #c3c4c7);
+		color: var(--Gray-Gray-60, #50575e);
+		background-color: var(--studio-white);
 	}
 
 	&__success {
-		background-color: var( --Green-Green-5, #b8e6bf );
-		color: var( --Green-Green-80, #00450c );
+		background-color: var(--Green-Green-5, #b8e6bf);
+		color: var(--Green-Green-80, #00450c);
 	}
 
 	&__failed {
-		background-color: var( --Red-Red-5, #facfd2 );
-		color: var( --Red-Red-80, #691c1c );
+		background-color: var(--Red-Red-5, #facfd2);
+		color: var(--Red-Red-80, #691c1c);
 	}
 
 	&__running,
 	&__building {
-		background-color: var( --Blue-Blue-5, #bbe0fa );
-		color: var( --Blue-Blue-80, #02395c );
+		background-color: var(--Blue-Blue-5, #bbe0fa);
+		color: var(--Blue-Blue-80, #02395c);
 	}
 
 	&__warnings {
-		background-color: var( --Yellow-Yellow-5, #f5c4a1 );
-		color: var( --Yellow-Yellow-80, #4f3500 );
+		background-color: var(--Yellow-Yellow-5, #f5c4a1);
+		color: var(--Yellow-Yellow-80, #4f3500);
 	}
 
 	span {
@@ -188,8 +189,7 @@ $brand-text: 'SF Pro Text', $sans;
 	}
 }
 
-.github-deployments-delete-deployment-dialog,
-.github-deployments-production-deployment-dialog {
+.github-deployments-delete-deployment-dialog {
 	max-width: 560px;
 
 	p,
@@ -215,13 +215,13 @@ $brand-text: 'SF Pro Text', $sans;
 
 .github-deployments {
 	.header-cake__back {
-		color: var( --studio-gray-60 );
+		color: var(--studio-gray-60);
 		font-size: $font-body-small;
 		padding: 0;
 		margin-bottom: 16px;
 		svg {
 			margin-right: 2px;
-			fill: var( --studio-gray-60 );
+			fill: var(--studio-gray-60);
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves [DOTDEV-138 Enhancement: Confirmation dialog when deploying to production](https://linear.app/a8c/issue/DOTDEV-138/enhancement-confirmation-dialog-when-deploying-to-production)

## Proposed Changes

* Added a confirmation dialog that appears when deploying to production sites
* Added a selector to distinguish between staging and production sites
* Matched the styles of the delete dialog for consistency

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We would like to have a confirmation dialog when triggering manual deployments to a production site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to a production site's deployments page
* Click the "Deploy" button for any deployment
* Verify that a confirmation dialog appears with a warning message about replacing live site contents
* Test both "Cancel" (should close dialog without deploying) and "Deploy to production" (should proceed with deployment) buttons
* Repeat the test on a staging site to verify no confirmation dialog appears, and the deployment starts immediately

<img width="1599" height="1325" alt="image" src="https://github.com/user-attachments/assets/30b76b1b-f326-4e3c-b5ec-d318686b7b61" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
