### PR TITLE
TanStack Query: fix dehydration options after v5 upgrade

### DIFF
--- a/client/dashboard/app/query-client.ts
+++ b/client/dashboard/app/query-client.ts
@@ -1,5 +1,5 @@
 import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister';
-import { QueryClient } from '@tanstack/react-query';
+import { QueryClient, defaultShouldDehydrateQuery } from '@tanstack/react-query';
 import { persistQueryClient } from '@tanstack/react-query-persist-client';
 
 export const queryClient = new QueryClient( {
@@ -32,11 +32,12 @@ const [ , persistPromise ] = persistQueryClient( {
 	buster: '3', // Bump when query data shape changes.
 	maxAge,
 	dehydrateOptions: {
-		shouldDehydrateQuery: ( { meta } ) => {
-			if ( meta?.persist === false ) {
+		shouldRedactErrors: () => false,
+		shouldDehydrateQuery: ( query ) => {
+			if ( query.meta?.persist === false ) {
 				return false;
 			}
-			return true;
+			return defaultShouldDehydrateQuery( query );
 		},
 	},
 } );


### PR DESCRIPTION
Fixes p1753934956448929-slack-CRWCHQGUB


## Proposed Changes

After:

- https://github.com/Automattic/wp-calypso/pull/104955
 
, we are seeing warnings and/or errors related to dehydrations in the console. This PR fixes that by following the best practices in https://tanstack.com/query/v5/docs/framework/react/guides/advanced-ssr#streaming-with-server-components.

## Testing Instructions

1. Go to /v2.
2. Click an Atomic site.
3. Click around while opening your console; verify no errors related to react-query.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?