### PR TITLE
Site overview v2: implement performance card

### DIFF
--- a/client/dashboard/app/hooks/site-performance.ts
+++ b/client/dashboard/app/hooks/site-performance.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
-import { basicMetricsQuery, performanceInsightsQuery } from '../../app/queries/performance';
-import { siteSettingsQuery } from '../../app/queries/site-settings';
-import { UrlPerformanceInsights } from '../../data/types';
+import { basicMetricsQuery, performanceInsightsQuery } from '../queries/performance';
+import { siteSettingsQuery } from '../queries/site-settings';
+import type { UrlPerformanceInsights } from '../../data/types';
 
 interface PerformanceData {
 	performanceData: UrlPerformanceInsights | undefined;

--- a/client/dashboard/data/site-profiler.ts
+++ b/client/dashboard/data/site-profiler.ts
@@ -5,7 +5,9 @@ export interface BasicMetricsData {
 }
 
 export interface PerformanceReport {
+	audits: Record< string, unknown >;
 	overall_score: number;
+	timestamp: string;
 }
 
 export interface UrlPerformanceInsights {

--- a/client/dashboard/sites/overview-card/index.tsx
+++ b/client/dashboard/sites/overview-card/index.tsx
@@ -31,7 +31,7 @@ export interface OverviewCardProps {
 		label: string;
 		variant?: ComponentProps< typeof CircularProgressBar >[ 'variant' ];
 	};
-	intent?: 'upsell' | 'success' | 'error';
+	intent?: 'upsell' | 'success' | 'warning' | 'error';
 	disabled?: boolean;
 	isLoading?: boolean;
 	link?: string;

--- a/client/dashboard/sites/overview-card/style.scss
+++ b/client/dashboard/sites/overview-card/style.scss
@@ -57,6 +57,12 @@
 		fill: $alert-red;
 	}
 
+	.dashboard-overview-card--warning & {
+		background-color: color-mix(in srgb, #b36100 8%, transparent);
+		color: #b36100;
+		fill: #b36100;
+	}
+
 	.dashboard-overview-card--disabled & {
 		color: $gray-600;
 		fill: $gray-600;
@@ -116,6 +122,9 @@
 .dashboard-overview-card__description {
 	.dashboard-overview-card--error & {
 		color: $alert-red;
+	}
+	.dashboard-overview-card--warning & {
+		color: #b36100;
 	}
 }
 

--- a/client/dashboard/sites/overview-performance-card/index.tsx
+++ b/client/dashboard/sites/overview-performance-card/index.tsx
@@ -52,10 +52,8 @@ function PerformanceCardContentWithFinishedTests( {
 	const status = getPerformanceStatus( worseScore );
 	const statusText = getPerformanceStatusText( status );
 
-	const report =
-		desktopScore < mobileScore
-			? ( performanceData.pagespeed.desktop as PerformanceReport )
-			: ( performanceData.pagespeed.mobile as PerformanceReport );
+	const device = desktopScore < mobileScore ? 'desktop' : 'mobile';
+	const report = performanceData.pagespeed[ device ] as PerformanceReport;
 
 	const timeSinceLastTest = useTimeSince( report.timestamp );
 
@@ -83,8 +81,6 @@ function PerformanceCardContentWithFinishedTests( {
 			recommendationCount
 		);
 	}
-
-	const device = desktopScore < mobileScore ? 'desktop' : 'mobile';
 
 	return (
 		<OverviewCard

--- a/client/dashboard/sites/overview-performance-card/index.tsx
+++ b/client/dashboard/sites/overview-performance-card/index.tsx
@@ -122,6 +122,28 @@ function PerformanceCardContent( { site }: { site: Site } ) {
 		return <OverviewCard { ...CARD_PROPS } isLoading />;
 	}
 
+	if ( site.launch_status === 'unlaunched' ) {
+		return (
+			<OverviewCard
+				{ ...CARD_PROPS }
+				heading={ __( 'No results' ) }
+				description={ __( 'Launch your site to test performance.' ) }
+				disabled
+			/>
+		);
+	}
+
+	if ( site.is_coming_soon || site.is_private ) {
+		return (
+			<OverviewCard
+				{ ...CARD_PROPS }
+				heading={ __( 'No results' ) }
+				description={ __( 'Make your site public to test performance.' ) }
+				disabled
+			/>
+		);
+	}
+
 	if ( ! settings.wpcom_performance_report_url ) {
 		return <PerformanceCardContentWithoutTests site={ site } />;
 	}

--- a/client/dashboard/sites/overview-performance-card/index.tsx
+++ b/client/dashboard/sites/overview-performance-card/index.tsx
@@ -1,0 +1,148 @@
+import { useQuery } from '@tanstack/react-query';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
+import { addQueryArgs } from '@wordpress/url';
+import { usePerformanceData } from '../../app/hooks/site-performance';
+import { siteSettingsQuery } from '../../app/queries/site-settings';
+import { useTimeSince } from '../../components/time-since';
+import { HostingFeatures } from '../../data/constants';
+import { getStatus, getStatusText } from '../../utils/site-performance';
+import HostingFeatureGatedWithOverviewCard from '../hosting-feature-gated-with-overview-card';
+import OverviewCard from '../overview-card';
+import type { PerformanceReport, Site, UrlPerformanceInsights } from '../../data/types';
+
+const CARD_PROPS = {
+	icon: chartBar,
+	title: __( 'Performance' ),
+	tracksId: 'performance',
+};
+
+function getPerformanceUrl( site: Site, device?: string ) {
+	return addQueryArgs(
+		`/sites/performance/${ site.slug }`,
+		device !== 'mobile' ? { initialTab: device } : {}
+	);
+}
+
+function PerformanceCardContentWithoutTests( { site }: { site: Site } ) {
+	return (
+		<OverviewCard
+			{ ...CARD_PROPS }
+			heading={ __( 'Run a test' ) }
+			description={ __( 'Your site hasn’t been tested yet' ) }
+			link={ getPerformanceUrl( site ) }
+		/>
+	);
+}
+
+function PerformanceCardContentWithFinishedTests( {
+	site,
+	performanceData,
+	desktopScore,
+	mobileScore,
+}: {
+	site: Site;
+	performanceData: UrlPerformanceInsights;
+	desktopScore: number;
+	mobileScore: number;
+} ) {
+	const worseScore = Math.min( desktopScore, mobileScore );
+
+	const status = getStatus( worseScore );
+	const statusText = getStatusText( status );
+
+	const report =
+		desktopScore < mobileScore
+			? ( performanceData.pagespeed.desktop as PerformanceReport )
+			: ( performanceData.pagespeed.mobile as PerformanceReport );
+
+	const timeSinceLastTest = useTimeSince( report.timestamp );
+
+	let intent;
+	if ( status === 'poor' ) {
+		intent = 'error' as const;
+	} else if ( status === 'neutral' ) {
+		intent = 'warning' as const;
+	} else {
+		intent = 'success' as const;
+	}
+
+	let description;
+	if ( status === 'good' ) {
+		description = sprintf(
+			/* translators: %s: time since last test run */
+			__( 'Tested %s' ),
+			timeSinceLastTest
+		);
+	} else {
+		const recommendationCount = Object.keys( report.audits ).length;
+		description = sprintf(
+			// translators: %(days) is the number of days until the link expires.
+			_n( '%d recommendation available', '%d recommendations available', recommendationCount ),
+			recommendationCount
+		);
+	}
+
+	const device = desktopScore < mobileScore ? 'desktop' : 'mobile';
+
+	return (
+		<OverviewCard
+			{ ...CARD_PROPS }
+			heading={ statusText }
+			description={ description }
+			intent={ intent }
+			link={ getPerformanceUrl( site, device ) }
+		/>
+	);
+}
+
+function PerformanceCardContentWithTests( { site }: { site: Site } ) {
+	const { performanceData, desktopScore, mobileScore } = usePerformanceData( site.ID, site.URL );
+
+	if ( performanceData === undefined ) {
+		return <OverviewCard { ...CARD_PROPS } isLoading />;
+	}
+
+	if ( desktopScore === undefined || mobileScore === undefined ) {
+		return <PerformanceCardContentWithoutTests site={ site } />;
+	}
+
+	return (
+		<PerformanceCardContentWithFinishedTests
+			site={ site }
+			performanceData={ performanceData }
+			desktopScore={ desktopScore }
+			mobileScore={ mobileScore }
+		/>
+	);
+}
+
+function PerformanceCardContent( { site }: { site: Site } ) {
+	const { data: settings } = useQuery( siteSettingsQuery( site.ID ) );
+
+	if ( settings === undefined ) {
+		return <OverviewCard { ...CARD_PROPS } isLoading />;
+	}
+
+	if ( ! settings.wpcom_performance_report_url ) {
+		return <PerformanceCardContentWithoutTests site={ site } />;
+	}
+
+	return <PerformanceCardContentWithTests site={ site } />;
+}
+
+export default function PerformanceCard( { site }: { site: Site } ) {
+	return (
+		<HostingFeatureGatedWithOverviewCard
+			site={ site }
+			feature={ HostingFeatures.PERFORMANCE }
+			featureIcon={ CARD_PROPS.icon }
+			tracksFeatureId={ CARD_PROPS.tracksId }
+			upsellHeading={ __( 'Run a test' ) }
+			upsellDescription={ __( 'Your site hasn’t been tested yet' ) }
+			upsellExternalLink={ getPerformanceUrl( site ) }
+		>
+			<PerformanceCardContent site={ site } />
+		</HostingFeatureGatedWithOverviewCard>
+	);
+}

--- a/client/dashboard/sites/overview-performance-card/index.tsx
+++ b/client/dashboard/sites/overview-performance-card/index.tsx
@@ -18,7 +18,10 @@ const CARD_PROPS = {
 };
 
 function getPerformanceUrl( site: Site, device?: string ) {
-	const url = `/sites/performance/${ site.slug }`;
+	const url = window?.location?.pathname?.startsWith( '/v2' )
+		? `https://wordpress.com/sites/performance/${ site.slug }`
+		: `/sites/performance/${ site.slug }`;
+
 	return device && device !== 'mobile' ? addQueryArgs( url, { initialTab: device } ) : url;
 }
 

--- a/client/dashboard/sites/overview-performance-card/index.tsx
+++ b/client/dashboard/sites/overview-performance-card/index.tsx
@@ -27,7 +27,7 @@ function PerformanceCardContentWithoutTests( { site }: { site: Site } ) {
 		<OverviewCard
 			{ ...CARD_PROPS }
 			heading={ __( 'Run a test' ) }
-			description={ __( 'Your site hasn’t been tested yet' ) }
+			description={ __( 'Your site hasn’t been tested yet.' ) }
 			link={ getPerformanceUrl( site ) }
 		/>
 	);
@@ -69,14 +69,14 @@ function PerformanceCardContentWithFinishedTests( {
 	if ( status === 'good' ) {
 		description = sprintf(
 			/* translators: %s: time since last test run */
-			__( 'Tested %s' ),
+			__( 'Tested %s.' ),
 			timeSinceLastTest
 		);
 	} else {
 		const recommendationCount = Object.keys( report.audits ).length;
 		description = sprintf(
 			// translators: %(days) is the number of days until the link expires.
-			_n( '%d recommendation available', '%d recommendations available', recommendationCount ),
+			_n( '%d recommendation available.', '%d recommendations available.', recommendationCount ),
 			recommendationCount
 		);
 	}
@@ -137,7 +137,7 @@ export default function PerformanceCard( { site }: { site: Site } ) {
 			featureIcon={ CARD_PROPS.icon }
 			tracksFeatureId={ CARD_PROPS.tracksId }
 			upsellHeading={ __( 'Run a test' ) }
-			upsellDescription={ __( 'Your site hasn’t been tested yet' ) }
+			upsellDescription={ __( 'Your site hasn’t been tested yet.' ) }
 			upsellExternalLink={ getPerformanceUrl( site ) }
 		>
 			<PerformanceCardContent site={ site } />

--- a/client/dashboard/sites/overview-performance-card/index.tsx
+++ b/client/dashboard/sites/overview-performance-card/index.tsx
@@ -18,10 +18,8 @@ const CARD_PROPS = {
 };
 
 function getPerformanceUrl( site: Site, device?: string ) {
-	return addQueryArgs(
-		`/sites/performance/${ site.slug }`,
-		device !== 'mobile' ? { initialTab: device } : {}
-	);
+	const url = `/sites/performance/${ site.slug }`;
+	return device && device !== 'mobile' ? addQueryArgs( url, { initialTab: device } ) : url;
 }
 
 function PerformanceCardContentWithoutTests( { site }: { site: Site } ) {

--- a/client/dashboard/sites/overview-performance-card/index.tsx
+++ b/client/dashboard/sites/overview-performance-card/index.tsx
@@ -157,8 +157,8 @@ export default function PerformanceCard( { site }: { site: Site } ) {
 			feature={ HostingFeatures.PERFORMANCE }
 			featureIcon={ CARD_PROPS.icon }
 			tracksFeatureId={ CARD_PROPS.tracksId }
-			upsellHeading={ __( 'Run a test' ) }
-			upsellDescription={ __( 'Your site hasn’t been tested yet.' ) }
+			upsellHeading={ __( 'Test site performance' ) }
+			upsellDescription={ __( 'Get detailed metrics and recommendations.' ) }
 			upsellExternalLink={ getPerformanceUrl( site ) }
 		>
 			<PerformanceCardContent site={ site } />

--- a/client/dashboard/sites/overview-performance-card/index.tsx
+++ b/client/dashboard/sites/overview-performance-card/index.tsx
@@ -6,7 +6,7 @@ import { usePerformanceData } from '../../app/hooks/site-performance';
 import { siteSettingsQuery } from '../../app/queries/site-settings';
 import { useTimeSince } from '../../components/time-since';
 import { HostingFeatures } from '../../data/constants';
-import { getStatus, getStatusText } from '../../utils/site-performance';
+import { getPerformanceStatus, getPerformanceStatusText } from '../../utils/site-performance';
 import HostingFeatureGatedWithOverviewCard from '../hosting-feature-gated-with-overview-card';
 import OverviewCard from '../overview-card';
 import type { PerformanceReport, Site, UrlPerformanceInsights } from '../../data/types';
@@ -48,8 +48,8 @@ function PerformanceCardContentWithFinishedTests( {
 } ) {
 	const worseScore = Math.min( desktopScore, mobileScore );
 
-	const status = getStatus( worseScore );
-	const statusText = getStatusText( status );
+	const status = getPerformanceStatus( worseScore );
+	const statusText = getPerformanceStatusText( status );
 
 	const report =
 		desktopScore < mobileScore

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -13,7 +13,10 @@ import clsx from 'clsx';
 import { siteBySlugQuery } from '../../app/queries/site';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import { HostingFeatures } from '../../data/constants';
+import { hasPlanFeature } from '../../utils/site-features';
 import { getSiteDisplayName } from '../../utils/site-name';
+import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import AgencySiteShareCard from '../overview-agency-site-share-card';
 import BackupCard from '../overview-backup-card';
 import OverviewCard from '../overview-card';
@@ -21,6 +24,7 @@ import DIFMUpsellCard from '../overview-difm-upsell-card';
 import DomainsCard from '../overview-domains-card';
 import LatestActivityCard from '../overview-latest-activity-card';
 import MigrateSiteCard from '../overview-migrate-site-card';
+import PerformanceCard from '../overview-performance-card';
 import PlanCard from '../overview-plan-card';
 import ScanCard from '../overview-scan-card';
 import SiteActionMenu from '../overview-site-action-menu';
@@ -122,16 +126,19 @@ function SiteOverview( {
 							if ( site.is_a4a_dev_site ) {
 								return <AgencySiteShareCard site={ site } />;
 							}
-							if ( site.is_wpcom_atomic ) {
+							if ( isSelfHostedJetpackConnected( site ) ) {
 								return (
 									<OverviewCard
-										title={ __( 'Performance' ) }
+										title="TBA"
 										icon={ chartBar }
 										heading="TBA"
 										description="TBA"
 										disabled
 									/>
 								);
+							}
+							if ( hasPlanFeature( site, HostingFeatures.PERFORMANCE ) ) {
+								return <PerformanceCard site={ site } />;
 							}
 							return <MigrateSiteCard site={ site } />;
 						} )() }

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -13,8 +13,6 @@ import clsx from 'clsx';
 import { siteBySlugQuery } from '../../app/queries/site';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { HostingFeatures } from '../../data/constants';
-import { hasPlanFeature } from '../../utils/site-features';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import AgencySiteShareCard from '../overview-agency-site-share-card';
@@ -137,10 +135,10 @@ function SiteOverview( {
 									/>
 								);
 							}
-							if ( hasPlanFeature( site, HostingFeatures.PERFORMANCE ) ) {
-								return <PerformanceCard site={ site } />;
+							if ( site.plan?.is_free && ! site.is_wpcom_staging_site ) {
+								return <MigrateSiteCard site={ site } />;
 							}
-							return <MigrateSiteCard site={ site } />;
+							return <PerformanceCard site={ site } />;
 						} )() }
 						<ScanCard site={ site } />
 					</Grid>

--- a/client/dashboard/utils/site-performance.ts
+++ b/client/dashboard/utils/site-performance.ts
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 
-export function getStatus( score: number ): 'poor' | 'neutral' | 'good' {
+export function getPerformanceStatus( score: number ): 'poor' | 'neutral' | 'good' {
 	if ( score <= 49 ) {
 		return 'poor';
 	} else if ( score < 90 ) {
@@ -9,7 +9,7 @@ export function getStatus( score: number ): 'poor' | 'neutral' | 'good' {
 	return 'good';
 }
 
-export function getStatusText( status: 'poor' | 'neutral' | 'good' ) {
+export function getPerformanceStatusText( status: 'poor' | 'neutral' | 'good' ) {
 	return {
 		poor: __( 'Poor' ),
 		neutral: __( 'Needs improvement' ),

--- a/client/dashboard/utils/site-performance.ts
+++ b/client/dashboard/utils/site-performance.ts
@@ -1,0 +1,18 @@
+import { __ } from '@wordpress/i18n';
+
+export function getStatus( score: number ): 'poor' | 'neutral' | 'good' {
+	if ( score <= 49 ) {
+		return 'poor';
+	} else if ( score < 90 ) {
+		return 'neutral';
+	}
+	return 'good';
+}
+
+export function getStatusText( status: 'poor' | 'neutral' | 'good' ) {
+	return {
+		poor: __( 'Poor' ),
+		neutral: __( 'Needs improvement' ),
+		good: __( 'Excellent' ),
+	}[ status ];
+}

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -348,8 +348,9 @@ const SitePerformanceContent = () => {
 };
 
 export const SitePerformance = () => {
+	const queryParams = useSelector( getCurrentQueryArguments );
 	return (
-		<DeviceTabProvider>
+		<DeviceTabProvider initialTab={ queryParams?.initialTab as TabType }>
 			<SitePerformanceContent />
 		</DeviceTabProvider>
 	);

--- a/client/performance-profiler/components/performance-score/index.tsx
+++ b/client/performance-profiler/components/performance-score/index.tsx
@@ -3,6 +3,7 @@ import { useResizeObserver } from '@wordpress/compose';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
+import { getStatus, getStatusText } from 'calypso/dashboard/utils/site-performance';
 import './style.scss';
 
 type PerformanceScoreProps = {
@@ -20,20 +21,8 @@ export const PerformanceScore = ( props: PerformanceScoreProps ) => {
 	const isMobile = useMobileBreakpoint();
 
 	const { value, recommendationsQuantity, recommendationsRef } = props;
-	const getStatus = ( value: number ) => {
-		if ( value <= 49 ) {
-			return 'poor';
-		} else if ( value > 49 && value < 90 ) {
-			return 'neutral';
-		}
-		return 'good';
-	};
 	const status = getStatus( value );
-	const statusText = {
-		poor: translate( 'Poor' ),
-		neutral: translate( 'Needs improvement' ),
-		good: translate( 'Excellent' ),
-	}[ status ];
+	const statusText = getStatusText( status );
 
 	useEffect( () => {
 		if ( ! entry ) {

--- a/client/performance-profiler/components/performance-score/index.tsx
+++ b/client/performance-profiler/components/performance-score/index.tsx
@@ -3,7 +3,10 @@ import { useResizeObserver } from '@wordpress/compose';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
-import { getStatus, getStatusText } from 'calypso/dashboard/utils/site-performance';
+import {
+	getPerformanceStatus,
+	getPerformanceStatusText,
+} from 'calypso/dashboard/utils/site-performance';
 import './style.scss';
 
 type PerformanceScoreProps = {
@@ -21,8 +24,8 @@ export const PerformanceScore = ( props: PerformanceScoreProps ) => {
 	const isMobile = useMobileBreakpoint();
 
 	const { value, recommendationsQuantity, recommendationsRef } = props;
-	const status = getStatus( value );
-	const statusText = getStatusText( status );
+	const status = getPerformanceStatus( value );
+	const statusText = getPerformanceStatusText( status );
 
 	useEffect( () => {
 		if ( ! entry ) {


### PR DESCRIPTION
Fixes DOTDASH-112

## Proposed Changes

This PR implements the Performance Card in Site Overview v2:

|Status||
|-|-|
|Self-hosted|Placeholder for now<br><br><img width="334" height="157" alt="image" src="https://github.com/user-attachments/assets/6f510569-4987-4bae-8953-bceb353f3f02" />|
|Free plan|None; the Migrate site card will be shown instead|
|Premium/Personal plans|<img width="328" height="148" alt="image" src="https://github.com/user-attachments/assets/8cf7a3c2-33c4-4ca8-8dec-82546da3f31d" />|
|Needs hosting activation|<img width="326" height="149" alt="image" src="https://github.com/user-attachments/assets/5da3beba-f58a-4d9a-b943-769e81473dde" />|
|Unlaunched site|<img width="327" height="151" alt="image" src="https://github.com/user-attachments/assets/5f593d2e-2631-4268-ac46-c3cb7d4883a6" />|
|Non-public site|<img width="330" height="155" alt="image" src="https://github.com/user-attachments/assets/f58ca532-bfa8-488a-b7c8-8d8d2df64090" />|
|No test yet / A test is still running|<img width="389" height="152" alt="image" src="https://github.com/user-attachments/assets/3964c16d-5eb9-459e-9665-c7aa159fd32f" />|
|Excellent|<img width="388" height="154" alt="image" src="https://github.com/user-attachments/assets/859b1161-6848-4dd8-9a46-387c23af97bc" />|
|Needs improvements|<img width="386" height="151" alt="image" src="https://github.com/user-attachments/assets/06612a79-f884-4019-8f66-c0145a8d14d2" />|
|Poor|<img width="388" height="155" alt="image" src="https://github.com/user-attachments/assets/624ccfe1-e3a0-4581-941f-009f7dbbb217" />|

The result will show the worse score between Desktop and Mobile tests. The card will link to the Site Perfomance tab, with the worse device test shown by default, by implementing addition `?initialTab=xxx` query param logic.

## Testing Instructions

It's better to check this PR locally so that we can manually tweak the performance score for testing 🙈 

1. Check out this branch locally
2. Update `dashboard/v2/backport/site-overview` to `true` in `development.json` (you might need to rerun yarn start)
    - This is so that the Site Performance internal link in the card points to the correct URL.
3. Open /sites (NOT /v2/sites!)
    - This is so that the Site Performance internal link in the card points to the correct URL.
5. Test various cases as shown above.
     - You can manually update your score here: https://github.com/Automattic/wp-calypso/pull/105011/files#diff-a841e16499f987b74b4622427951b946d1de1a0fa3ee8314cabad8f9a5199398R49
6. Test opening the site performance tab with additional `?initialTab=desktop` and verify it opens the Desktop tab by default.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
