### PR TITLE
Support Search: Handle the new navigation header

### DIFF
--- a/apps/happy-blocks/block-library/search-card/index.php
+++ b/apps/happy-blocks/block-library/search-card/index.php
@@ -11,6 +11,8 @@ if ( ! isset( $args ) ) {
 	$args = array();
 }
 
+$show_search = isset( $args['show-search'] ) && $args['show-search'] === true;
+
 if ( ! function_exists( 'get_support_search_link_for_query' ) ) {
 	function get_support_search_link_for_query( $query ) {
 		$blog_id = get_current_blog_id();
@@ -25,17 +27,18 @@ if ( ! function_exists( 'get_support_search_link_for_query' ) ) {
 }
 
 ?>
-<div class="happy-blocks-search-card">
-<!-- TODO: to be added later across the sites
-	<ul class="navigation">
-		<li class="active"><?php echo esc_html( __( 'Support Center', 'happy-blocks' ) ); ?></li>
-		<li class="separator"></li>
-		<li><?php echo esc_html( __( 'Guides', 'happy-blocks' ) ); ?></li>
-		<li><?php echo esc_html( __( 'Courses', 'happy-blocks' ) ); ?></li>
-		<li><?php echo esc_html( __( 'Forums', 'happy-blocks' ) ); ?></li>
-		<li><?php echo esc_html( __( 'Contact', 'happy-blocks' ) ); ?></li>
-	</ul>
--->
+<div class="happy-blocks-search-card<?php echo $show_search ? '' : ' navigation-only'; ?>">
+	<nav class="navigation-header">
+		<ul class="navigation">
+			<li class="active"><?php echo esc_html( __( 'Support Center', 'happy-blocks' ) ); ?></li>
+			<li class="separator"></li>
+			<li><a href="https://wordpress.com/support/guides"><?php echo esc_html( __( 'Guides', 'happy-blocks' ) ); ?></a></li>
+			<li><?php echo esc_html( __( 'Courses', 'happy-blocks' ) ); ?></li>
+			<li><?php echo esc_html( __( 'Forums', 'happy-blocks' ) ); ?></li>
+			<li><?php echo esc_html( __( 'Contact', 'happy-blocks' ) ); ?></li>
+		</ul>
+	</nav>
+	<?php if ( $show_search ): ?>
 	<div class="content">
 			<h2><?php echo esc_html( __( 'How can we help you?', 'happy-blocks' ) ); ?></h2>
 			<form id="support-search-form" class="" role="search" method="get" action="">
@@ -57,4 +60,5 @@ if ( ! function_exists( 'get_support_search_link_for_query' ) ) {
 				<li><a data-search-query="<?php echo esc_attr( __( 'Reset my password', 'happy-blocks' ) ); ?>" href="<?php echo esc_url( get_support_search_link_for_query( 'reset my password' ) ); ?>"><?php echo esc_html( __( 'Reset my password', 'happy-blocks' ) ); ?></a></li>
 			</ul>
 	</div>
+	<?php endif; ?>
 </div>

--- a/apps/happy-blocks/block-library/search-card/index.php
+++ b/apps/happy-blocks/block-library/search-card/index.php
@@ -7,11 +7,6 @@
  * @package happy-blocks
  */
 
-/**
- * Load functions from the h4 theme, we're using localized_wpcom_url here.
- */
-require_once WP_CONTENT_DIR . '/themes/h4/landing/marketing/pages/_common/lib/functions.php';
-
 if ( ! isset( $args ) ) {
 	$args = array();
 }

--- a/apps/happy-blocks/block-library/search-card/index.php
+++ b/apps/happy-blocks/block-library/search-card/index.php
@@ -11,7 +11,7 @@ if ( ! isset( $args ) ) {
 	$args = array();
 }
 
-$show_search = isset( $args['show-search'] ) && $args['show-search'] === true;
+$show_search = isset( $args['show-search'] ) && ( true === $args['show-search'] );
 $active_page = isset( $args['active_page'] ) ? $args['active_page'] : '';
 
 
@@ -35,13 +35,13 @@ if ( ! function_exists( 'get_support_search_link_for_query' ) ) {
 		<ul class="navigation">
 			<li class="active"><a href="<?php echo esc_url( localized_wpcom_url( 'https://wordpress.com/support' ) ); ?>"><?php echo esc_html( __( 'Support Center', 'happy-blocks' ) ); ?></a></li>
 			<li class="separator"></li>
-			<li class="<?php echo ( $active_page === 'guides' ) ? 'active' : ''; ?>"><a href="<?php echo esc_url( localized_wpcom_url( 'https://wordpress.com/support/guides' ) ); ?>"><?php echo esc_html( __( 'Guides', 'happy-blocks' ) ); ?></a></li>
-			<li class="<?php echo ( $active_page === 'courses' ) ? 'active' : ''; ?>"><a href="<?php echo esc_url( localized_wpcom_url( 'https://wordpress.com/support/courses' ) ); ?>"><?php echo esc_html( __( 'Courses', 'happy-blocks' ) ); ?></a></li>
-			<li class="<?php echo ( $active_page === 'forums' ) ? 'active' : ''; ?>"><a href="<?php echo esc_url( localized_wpcom_url( 'https://wordpress.com/forums' ) ); ?>"><?php echo esc_html( __( 'Forums', 'happy-blocks' ) ); ?></a></li>
-			<li class="<?php echo ( $active_page === 'contact' ) ? 'active' : ''; ?>"><a href="<?php echo esc_url( localized_wpcom_url( 'https://wordpress.com/support/contact' ) ); ?>"><?php echo esc_html( __( 'Contact', 'happy-blocks' ) ); ?></a></li>
+			<li class="<?php echo ( 'guides' === $active_page ) ? 'active' : ''; ?>"><a href="<?php echo esc_url( localized_wpcom_url( 'https://wordpress.com/support/guides' ) ); ?>"><?php echo esc_html( __( 'Guides', 'happy-blocks' ) ); ?></a></li>
+			<li class="<?php echo ( 'courses' === $active_page ) ? 'active' : ''; ?>"><a href="<?php echo esc_url( localized_wpcom_url( 'https://wordpress.com/support/courses' ) ); ?>"><?php echo esc_html( __( 'Courses', 'happy-blocks' ) ); ?></a></li>
+			<li class="<?php echo ( 'forums' === $active_page ) ? 'active' : ''; ?>"><a href="<?php echo esc_url( localized_wpcom_url( 'https://wordpress.com/forums' ) ); ?>"><?php echo esc_html( __( 'Forums', 'happy-blocks' ) ); ?></a></li>
+			<li class="<?php echo ( 'contact' === $active_page ) ? 'active' : ''; ?>"><a href="<?php echo esc_url( localized_wpcom_url( 'https://wordpress.com/support/contact' ) ); ?>"><?php echo esc_html( __( 'Contact', 'happy-blocks' ) ); ?></a></li>
 		</ul>
 	</nav>
-	<?php if ( $show_search ): ?>
+	<?php if ( $show_search ) : ?>
 	<div class="content">
 			<h2><?php echo esc_html( __( 'How can we help you?', 'happy-blocks' ) ); ?></h2>
 			<form id="support-search-form" class="" role="search" method="get" action="">

--- a/apps/happy-blocks/block-library/search-card/index.php
+++ b/apps/happy-blocks/block-library/search-card/index.php
@@ -7,11 +7,19 @@
  * @package happy-blocks
  */
 
+/**
+ * Load functions from the h4 theme, we're using localized_wpcom_url here.
+ */
+require_once WP_CONTENT_DIR . '/themes/h4/landing/marketing/pages/_common/lib/functions.php';
+
 if ( ! isset( $args ) ) {
 	$args = array();
 }
 
 $show_search = isset( $args['show-search'] ) && $args['show-search'] === true;
+$active_page = isset( $args['active_page'] ) ? $args['active_page'] : '';
+
+
 
 if ( ! function_exists( 'get_support_search_link_for_query' ) ) {
 	function get_support_search_link_for_query( $query ) {
@@ -30,12 +38,12 @@ if ( ! function_exists( 'get_support_search_link_for_query' ) ) {
 <div class="happy-blocks-search-card<?php echo $show_search ? '' : ' navigation-only'; ?>">
 	<nav class="navigation-header">
 		<ul class="navigation">
-			<li class="active"><?php echo esc_html( __( 'Support Center', 'happy-blocks' ) ); ?></li>
+			<li class="active"><a href="<?php echo esc_url( localized_wpcom_url( 'https://wordpress.com/support' ) ); ?>"><?php echo esc_html( __( 'Support Center', 'happy-blocks' ) ); ?></a></li>
 			<li class="separator"></li>
-			<li><a href="https://wordpress.com/support/guides"><?php echo esc_html( __( 'Guides', 'happy-blocks' ) ); ?></a></li>
-			<li><?php echo esc_html( __( 'Courses', 'happy-blocks' ) ); ?></li>
-			<li><?php echo esc_html( __( 'Forums', 'happy-blocks' ) ); ?></li>
-			<li><?php echo esc_html( __( 'Contact', 'happy-blocks' ) ); ?></li>
+			<li class="<?php echo ( $active_page === 'guides' ) ? 'active' : ''; ?>"><a href="<?php echo esc_url( localized_wpcom_url( 'https://wordpress.com/support/guides' ) ); ?>"><?php echo esc_html( __( 'Guides', 'happy-blocks' ) ); ?></a></li>
+			<li class="<?php echo ( $active_page === 'courses' ) ? 'active' : ''; ?>"><a href="<?php echo esc_url( localized_wpcom_url( 'https://wordpress.com/support/courses' ) ); ?>"><?php echo esc_html( __( 'Courses', 'happy-blocks' ) ); ?></a></li>
+			<li class="<?php echo ( $active_page === 'forums' ) ? 'active' : ''; ?>"><a href="<?php echo esc_url( localized_wpcom_url( 'https://wordpress.com/forums' ) ); ?>"><?php echo esc_html( __( 'Forums', 'happy-blocks' ) ); ?></a></li>
+			<li class="<?php echo ( $active_page === 'contact' ) ? 'active' : ''; ?>"><a href="<?php echo esc_url( localized_wpcom_url( 'https://wordpress.com/support/contact' ) ); ?>"><?php echo esc_html( __( 'Contact', 'happy-blocks' ) ); ?></a></li>
 		</ul>
 	</nav>
 	<?php if ( $show_search ): ?>

--- a/apps/happy-blocks/block-library/search-card/style.scss
+++ b/apps/happy-blocks/block-library/search-card/style.scss
@@ -8,47 +8,88 @@ $breakpoint-desktop: 1440px; //Desktop size.
 	background-size: contain;
 
 	flex-shrink: 0;
-	padding: 72px 24px;
+	padding: 0;
 
-	@media ( max-width: $breakpoint-mobile ) {
-		padding: 36px 16px;
+	&.navigation-only {
+		background: none;
+	}
+
+	.navigation-header {
+		padding: 0 24px;
+
+		@media ( max-width: $breakpoint-mobile ) {
+			padding: 0 16px;
+		}
 	}
 
 	.navigation {
 		display: flex;
 		align-items: center;
-		gap: 16px;
+		gap: 32px;
 		list-style: none;
 		margin: 0;
-		padding: 0;
-
-		li {
-			&.active {
-				color: #000;
-				font-weight: 600;
-			}
-			overflow: hidden;
-			color: #50575E;
-			text-align: justify;
-			text-overflow: ellipsis;
-			font-size: 13px;
-			font-style: normal;
-			font-weight: 400;
-			line-height: 20px;
-
-			&.separator::before {
-				content: "|";
-				stroke: #ccc;
-			}
-		}
-	}
-
-	div.content {
+		padding: 16px 0;
 		max-width: 1260px;
 		margin-left: auto;
 		margin-right: auto;
 
 		@media ( max-width: $breakpoint-mobile ) {
+			gap: 16px;
+			padding: 12px 0;
+			overflow-x: auto;
+			white-space: nowrap;
+			scrollbar-width: none;
+			&::-webkit-scrollbar {
+				display: none;
+			}
+		}
+
+		li {
+			&.active {
+				color: #000;
+				font-weight: 500;
+				position: relative;
+			}
+			overflow: hidden;
+			color: #646970;
+			text-align: justify;
+			text-overflow: ellipsis;
+			font-size: 14px;
+			font-style: normal;
+			font-weight: 400;
+			line-height: 20px;
+			cursor: pointer;
+			transition: color 0.2s ease;
+
+			&:hover:not(.separator) {
+				color: #000;
+			}
+
+			&.separator::before {
+				content: "|";
+				color: #ddd;
+				font-weight: 300;
+			}
+
+			a {
+				color: inherit;
+				text-decoration: none;
+				
+				&:hover {
+					color: #000;
+				}
+			}
+		}
+	}
+
+	.content {
+		padding: 72px 24px;
+		max-width: 1260px;
+		margin-left: auto;
+		margin-right: auto;
+
+		@media ( max-width: $breakpoint-mobile ) {
+			padding: 36px 16px;
 			margin-left: 0;
 		}
 

--- a/apps/happy-blocks/block-library/search-card/style.scss
+++ b/apps/happy-blocks/block-library/search-card/style.scss
@@ -10,6 +10,10 @@ $breakpoint-desktop: 1440px; //Desktop size.
 	flex-shrink: 0;
 	padding: 0;
 
+	@media ( max-width: $breakpoint-mobile ) {
+		display: none;
+	}
+
 	&.navigation-only {
 		background: none;
 	}
@@ -67,7 +71,7 @@ $breakpoint-desktop: 1440px; //Desktop size.
 			&.separator::before {
 				content: "|";
 				color: #ddd;
-				font-weight: 300;
+				font-weight: 400;
 			}
 
 			a {

--- a/apps/happy-blocks/block-library/search-card/style.scss
+++ b/apps/happy-blocks/block-library/search-card/style.scss
@@ -30,7 +30,6 @@ $breakpoint-desktop: 1440px; //Desktop size.
 		margin: 0;
 		padding: 16px 0;
 		max-width: 1260px;
-		margin-left: auto;
 		margin-right: auto;
 
 		@media ( max-width: $breakpoint-mobile ) {

--- a/apps/happy-blocks/block-library/search-card/style.scss
+++ b/apps/happy-blocks/block-library/search-card/style.scss
@@ -86,7 +86,7 @@ $breakpoint-desktop: 1440px; //Desktop size.
 	}
 
 	.content {
-		padding: 72px 24px;
+		padding: 33px 24px 72px 24px;
 		max-width: 1260px;
 		margin-left: auto;
 		margin-right: auto;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/HAPD-863/implement-new-support-navigation

## Proposed Changes

Create the new navigation ( Support Center | Guides ... )
 
<img width="728" height="351" alt="image" src="https://github.com/user-attachments/assets/f8583bd2-5a30-43e8-8cbf-5a7e79e9186c" />



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Follow 156669-ghe-Automattic/wpcom-a8c-themes