### PR TITLE
Build Calypso Apps: parallelize using xargs instead of `yarn`

### DIFF
--- a/apps/help-center/help-center.scss
+++ b/apps/help-center/help-center.scss
@@ -1,5 +1,6 @@
 @import "calypso/assets/stylesheets/shared/mixins/breakpoints";
 @import "@automattic/calypso-color-schemes";
+@import "@automattic/some-bad-import";
 
 .help-center.entry-point-button {
 	&.is-active {

--- a/apps/help-center/help-center.scss
+++ b/apps/help-center/help-center.scss
@@ -1,6 +1,5 @@
 @import "calypso/assets/stylesheets/shared/mixins/breakpoints";
 @import "@automattic/calypso-color-schemes";
-@import "@automattic/some-bad-import";
 
 .help-center.entry-point-button {
 	&.is-active {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-14055/fix-the-build-calypso-apps-job

## Proposed Changes

This parallelizes the Calypso build apps job using xargs instead of `yarn workspace` own parallelization. `yarn workspace` has a [bug](https://github.com/yarnpkg/berry/issues/2486) where it always exits with code zero even if one build process failed. 

## Why are these changes being made?
To make sure the failed builds are caught early.

## Testing Instructions

I already tested.

1. I sent the first commit with the change.
2. I [broke](https://github.com/Automattic/wp-calypso/pull/105014/commits/34de5bdd671db4c3b1aa94be9bc83bc8769ed3c0) the Help Center. And the build failed. 
3. I [fixed the app](https://github.com/Automattic/wp-calypso/pull/105014/commits/6c690d45960e588719034d2d3a49e77516687000), and the build passed.