### PR TITLE
Fix the LOHP e2e test

### DIFF
--- a/test/e2e/specs/onboarding/signup__with-theme-LOHP.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-LOHP.ts
@@ -15,13 +15,13 @@ import {
 	NewUserResponse,
 	MyProfilePage,
 	MeSidebarComponent,
-	cancelPurchaseFlow,
 	NoticeComponent,
 	PurchasesPage,
 	envVariables,
 	LoggedOutHomePage,
 	LoggedOutThemesPage,
 	ThemesDetailPage,
+	cancelAtomicPurchaseFlow,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { apiCloseAccount } from '../shared';
@@ -144,7 +144,7 @@ describe( 'Lifecyle: Logged Out Home Page, signup, onboard, launch and cancel su
 			await meSidebarComponent.navigate( 'Purchases' );
 		} );
 
-		it( 'View details of purchased plan', async function () {
+		it( 'View details of purchased plan and cancel plan renewal', async function () {
 			purchasesPage = new PurchasesPage( page );
 
 			await purchasesPage.clickOnPurchase(
@@ -155,7 +155,7 @@ describe( 'Lifecyle: Logged Out Home Page, signup, onboard, launch and cancel su
 		} );
 
 		it( 'Cancel plan renewal', async function () {
-			await cancelPurchaseFlow( page, {
+			await cancelAtomicPurchaseFlow( page, {
 				reason: 'Another reason…',
 				customReasonText: 'E2E TEST CANCELLATION',
 			} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->


## Proposed Changes

* We're fixing the e2e LOHP test

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want a test suite that doesn't generate false positives.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Prepare your environment to run tests on wpcalypso with `export CALYPSO_BASE_URL=http://wpcalypso.wordpress.com`
* Run the test `yarn workspace wp-e2e-tests test specs/onboarding/signup__with-theme-LOHP.ts` and make sure it passes:

<img width="910" height="530" alt="image" src="https://github.com/user-attachments/assets/b112bdb5-b238-4b6c-86ff-8516c9cfe8f0" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
