### PR TITLE
Add all site domain-management routes and a placeholder

### DIFF
--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -478,6 +478,138 @@ const siteSettingsWebApplicationFirewallRoute = createRoute( {
 	)
 );
 
+const siteDomainManagementRoute = createRoute( {
+	getParentRoute: () => siteRoute,
+	path: 'domains/$domainName',
+} ).lazy( () =>
+	import( '../sites/domain-management/placeholder' ).then( ( d ) =>
+		createLazyRoute( 'site-domain-management' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const siteDomainDnsRoute = createRoute( {
+	getParentRoute: () => siteDomainManagementRoute,
+	path: 'dns',
+} ).lazy( () =>
+	import( '../sites/domain-management/placeholder' ).then( ( d ) =>
+		createLazyRoute( 'site-domain-dns' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const siteDomainDnsAddRoute = createRoute( {
+	getParentRoute: () => siteDomainManagementRoute,
+	path: 'dns/add',
+} ).lazy( () =>
+	import( '../sites/domain-management/placeholder' ).then( ( d ) =>
+		createLazyRoute( 'site-domain-dns-add' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const siteDomainDnsEditRoute = createRoute( {
+	getParentRoute: () => siteDomainManagementRoute,
+	path: 'dns/edit',
+} ).lazy( () =>
+	import( '../sites/domain-management/placeholder' ).then( ( d ) =>
+		createLazyRoute( 'site-domain-dns-edit' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const siteDomainForwardingRoute = createRoute( {
+	getParentRoute: () => siteDomainManagementRoute,
+	path: 'forwarding',
+} ).lazy( () =>
+	import( '../sites/domain-management/placeholder' ).then( ( d ) =>
+		createLazyRoute( 'site-domain-forwarding' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const siteDomainForwardingAddRoute = createRoute( {
+	getParentRoute: () => siteDomainManagementRoute,
+	path: 'forwarding/add',
+} ).lazy( () =>
+	import( '../sites/domain-management/placeholder' ).then( ( d ) =>
+		createLazyRoute( 'site-domain-forwarding-add' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const siteDomainForwardingEditRoute = createRoute( {
+	getParentRoute: () => siteDomainManagementRoute,
+	path: 'forwarding/edit',
+} ).lazy( () =>
+	import( '../sites/domain-management/placeholder' ).then( ( d ) =>
+		createLazyRoute( 'site-domain-forwarding-edit' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const siteDomainContactInfoRoute = createRoute( {
+	getParentRoute: () => siteDomainManagementRoute,
+	path: 'contact_info',
+} ).lazy( () =>
+	import( '../sites/domain-management/placeholder' ).then( ( d ) =>
+		createLazyRoute( 'site-domain-contact-info' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const siteDomainNameServersRoute = createRoute( {
+	getParentRoute: () => siteDomainManagementRoute,
+	path: 'name_servers',
+} ).lazy( () =>
+	import( '../sites/domain-management/placeholder' ).then( ( d ) =>
+		createLazyRoute( 'site-domain-name-servers' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const siteDomainGlueRecordsRoute = createRoute( {
+	getParentRoute: () => siteDomainManagementRoute,
+	path: 'glue_records',
+} ).lazy( () =>
+	import( '../sites/domain-management/placeholder' ).then( ( d ) =>
+		createLazyRoute( 'site-domain-glue-records' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const siteDomainDnssecRoute = createRoute( {
+	getParentRoute: () => siteDomainManagementRoute,
+	path: 'dnssec',
+} ).lazy( () =>
+	import( '../sites/domain-management/placeholder' ).then( ( d ) =>
+		createLazyRoute( 'site-domain-dnssec' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const siteDomainTransferRoute = createRoute( {
+	getParentRoute: () => siteDomainManagementRoute,
+	path: 'transfer',
+} ).lazy( () =>
+	import( '../sites/domain-management/placeholder' ).then( ( d ) =>
+		createLazyRoute( 'site-domain-transfer' )( {
+			component: d.default,
+		} )
+	)
+);
+
 const domainsRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'domains',
@@ -651,6 +783,19 @@ const createRouteTree = ( config: AppConfig ) => {
 			siteSettingsTransferSiteRoute,
 			siteSettingsSftpSshRoute,
 			siteSettingsWebApplicationFirewallRoute,
+			siteDomainManagementRoute.addChildren( [
+				siteDomainDnsRoute,
+				siteDomainDnsAddRoute,
+				siteDomainDnsEditRoute,
+				siteDomainForwardingRoute,
+				siteDomainForwardingAddRoute,
+				siteDomainForwardingEditRoute,
+				siteDomainContactInfoRoute,
+				siteDomainNameServersRoute,
+				siteDomainGlueRecordsRoute,
+				siteDomainDnssecRoute,
+				siteDomainTransferRoute,
+			] ),
 		];
 
 		if ( config.supports.sites.deployments ) {
@@ -757,6 +902,18 @@ export {
 	siteSettingsTransferSiteRoute,
 	siteSettingsSftpSshRoute,
 	siteSettingsWebApplicationFirewallRoute,
+	siteDomainManagementRoute,
+	siteDomainDnsRoute,
+	siteDomainDnsAddRoute,
+	siteDomainDnsEditRoute,
+	siteDomainForwardingRoute,
+	siteDomainForwardingAddRoute,
+	siteDomainForwardingEditRoute,
+	siteDomainContactInfoRoute,
+	siteDomainNameServersRoute,
+	siteDomainGlueRecordsRoute,
+	siteDomainDnssecRoute,
+	siteDomainTransferRoute,
 	domainsRoute,
 	emailsRoute,
 	meRoute,

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -40,8 +40,9 @@ import { sitesQuery } from './queries/sites';
 import { queryClient } from './query-client';
 import Root from './root';
 import {
-	domainsRoute,
 	setSiteRoute,
+	setRootRoute,
+	domainsRoute,
 	siteDomainsRoute,
 	siteDomainRoute,
 	siteDomainChildRoutes,
@@ -56,7 +57,6 @@ import {
 	siteDomainGlueRecordsRoute,
 	siteDomainDnssecRoute,
 	siteDomainTransferRoute,
-	setRootRoute,
 } from './routes/domain-routes';
 import type { AppConfig } from './context';
 import type { AnyRoute } from '@tanstack/react-router';
@@ -622,6 +622,7 @@ const notificationsRoute = createRoute( {
 const createRouteTree = ( config: AppConfig ) => {
 	const children = [];
 
+	// Set up the rootRoute reference for domain routes
 	setRootRoute( rootRoute );
 
 	// Set up the siteRoute reference for domain routes
@@ -741,6 +742,19 @@ export {
 	siteMonitoringRoute,
 	siteLogsRoute,
 	siteBackupsRoute,
+	siteDomainsRoute,
+	siteDomainRoute,
+	siteDomainDnsRoute,
+	siteDomainDnsAddRoute,
+	siteDomainDnsEditRoute,
+	siteDomainForwardingRoute,
+	siteDomainForwardingAddRoute,
+	siteDomainForwardingEditRoute,
+	siteDomainContactInfoRoute,
+	siteDomainNameServersRoute,
+	siteDomainGlueRecordsRoute,
+	siteDomainDnssecRoute,
+	siteDomainTransferRoute,
 	siteEmailsRoute,
 	siteSettingsRoute,
 	siteSettingsSiteVisibilityRoute,
@@ -757,19 +771,7 @@ export {
 	siteSettingsTransferSiteRoute,
 	siteSettingsSftpSshRoute,
 	siteSettingsWebApplicationFirewallRoute,
-	siteDomainsRoute,
-	siteDomainRoute,
-	siteDomainDnsRoute,
-	siteDomainDnsAddRoute,
-	siteDomainDnsEditRoute,
-	siteDomainForwardingRoute,
-	siteDomainForwardingAddRoute,
-	siteDomainForwardingEditRoute,
-	siteDomainContactInfoRoute,
-	siteDomainNameServersRoute,
-	siteDomainGlueRecordsRoute,
-	siteDomainDnssecRoute,
-	siteDomainTransferRoute,
+	domainsRoute,
 	emailsRoute,
 	meRoute,
 	profileRoute,

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -12,7 +12,6 @@ import { canViewHundredYearPlanSettings, canViewWordPressSettings } from '../sit
 import { hasHostingFeature } from '../utils/site-features';
 import NotFound from './404';
 import UnknownError from './500';
-import { domainsQuery } from './queries/domains';
 import { emailsQuery } from './queries/emails';
 import { isAutomatticianQuery } from './queries/me-a8c';
 import { rawUserPreferencesQuery } from './queries/me-preferences';
@@ -40,6 +39,25 @@ import { siteWordPressVersionQuery } from './queries/site-wordpress-version';
 import { sitesQuery } from './queries/sites';
 import { queryClient } from './query-client';
 import Root from './root';
+import {
+	domainsRoute,
+	setSiteRoute,
+	siteDomainsRoute,
+	siteDomainRoute,
+	siteDomainChildRoutes,
+	siteDomainDnsRoute,
+	siteDomainDnsAddRoute,
+	siteDomainDnsEditRoute,
+	siteDomainForwardingRoute,
+	siteDomainForwardingAddRoute,
+	siteDomainForwardingEditRoute,
+	siteDomainContactInfoRoute,
+	siteDomainNameServersRoute,
+	siteDomainGlueRecordsRoute,
+	siteDomainDnssecRoute,
+	siteDomainTransferRoute,
+	setRootRoute,
+} from './routes/domain-routes';
 import type { AppConfig } from './context';
 import type { AnyRoute } from '@tanstack/react-router';
 
@@ -192,17 +210,6 @@ const siteBackupsRoute = createRoute( {
 } ).lazy( () =>
 	import( '../sites/backups' ).then( ( d ) =>
 		createLazyRoute( 'site-backups' )( {
-			component: d.default,
-		} )
-	)
-);
-
-const siteDomainsRoute = createRoute( {
-	getParentRoute: () => siteRoute,
-	path: 'domains',
-} ).lazy( () =>
-	import( '../sites/domains' ).then( ( d ) =>
-		createLazyRoute( 'site-domains' )( {
 			component: d.default,
 		} )
 	)
@@ -478,150 +485,6 @@ const siteSettingsWebApplicationFirewallRoute = createRoute( {
 	)
 );
 
-const siteDomainManagementRoute = createRoute( {
-	getParentRoute: () => siteRoute,
-	path: 'domains/$domainName',
-} ).lazy( () =>
-	import( '../sites/domain-management/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'site-domain-management' )( {
-			component: d.default,
-		} )
-	)
-);
-
-const siteDomainDnsRoute = createRoute( {
-	getParentRoute: () => siteDomainManagementRoute,
-	path: 'dns',
-} ).lazy( () =>
-	import( '../sites/domain-management/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'site-domain-dns' )( {
-			component: d.default,
-		} )
-	)
-);
-
-const siteDomainDnsAddRoute = createRoute( {
-	getParentRoute: () => siteDomainManagementRoute,
-	path: 'dns/add',
-} ).lazy( () =>
-	import( '../sites/domain-management/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'site-domain-dns-add' )( {
-			component: d.default,
-		} )
-	)
-);
-
-const siteDomainDnsEditRoute = createRoute( {
-	getParentRoute: () => siteDomainManagementRoute,
-	path: 'dns/edit',
-} ).lazy( () =>
-	import( '../sites/domain-management/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'site-domain-dns-edit' )( {
-			component: d.default,
-		} )
-	)
-);
-
-const siteDomainForwardingRoute = createRoute( {
-	getParentRoute: () => siteDomainManagementRoute,
-	path: 'forwarding',
-} ).lazy( () =>
-	import( '../sites/domain-management/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'site-domain-forwarding' )( {
-			component: d.default,
-		} )
-	)
-);
-
-const siteDomainForwardingAddRoute = createRoute( {
-	getParentRoute: () => siteDomainManagementRoute,
-	path: 'forwarding/add',
-} ).lazy( () =>
-	import( '../sites/domain-management/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'site-domain-forwarding-add' )( {
-			component: d.default,
-		} )
-	)
-);
-
-const siteDomainForwardingEditRoute = createRoute( {
-	getParentRoute: () => siteDomainManagementRoute,
-	path: 'forwarding/edit',
-} ).lazy( () =>
-	import( '../sites/domain-management/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'site-domain-forwarding-edit' )( {
-			component: d.default,
-		} )
-	)
-);
-
-const siteDomainContactInfoRoute = createRoute( {
-	getParentRoute: () => siteDomainManagementRoute,
-	path: 'contact_info',
-} ).lazy( () =>
-	import( '../sites/domain-management/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'site-domain-contact-info' )( {
-			component: d.default,
-		} )
-	)
-);
-
-const siteDomainNameServersRoute = createRoute( {
-	getParentRoute: () => siteDomainManagementRoute,
-	path: 'name_servers',
-} ).lazy( () =>
-	import( '../sites/domain-management/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'site-domain-name-servers' )( {
-			component: d.default,
-		} )
-	)
-);
-
-const siteDomainGlueRecordsRoute = createRoute( {
-	getParentRoute: () => siteDomainManagementRoute,
-	path: 'glue_records',
-} ).lazy( () =>
-	import( '../sites/domain-management/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'site-domain-glue-records' )( {
-			component: d.default,
-		} )
-	)
-);
-
-const siteDomainDnssecRoute = createRoute( {
-	getParentRoute: () => siteDomainManagementRoute,
-	path: 'dnssec',
-} ).lazy( () =>
-	import( '../sites/domain-management/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'site-domain-dnssec' )( {
-			component: d.default,
-		} )
-	)
-);
-
-const siteDomainTransferRoute = createRoute( {
-	getParentRoute: () => siteDomainManagementRoute,
-	path: 'transfer',
-} ).lazy( () =>
-	import( '../sites/domain-management/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'site-domain-transfer' )( {
-			component: d.default,
-		} )
-	)
-);
-
-const domainsRoute = createRoute( {
-	getParentRoute: () => rootRoute,
-	path: 'domains',
-	loader: () => queryClient.ensureQueryData( domainsQuery() ),
-} ).lazy( () =>
-	import( '../domains' ).then( ( d ) =>
-		createLazyRoute( 'domains' )( {
-			component: d.default,
-		} )
-	)
-);
-
 const emailsRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'emails',
@@ -759,6 +622,11 @@ const notificationsRoute = createRoute( {
 const createRouteTree = ( config: AppConfig ) => {
 	const children = [];
 
+	setRootRoute( rootRoute );
+
+	// Set up the siteRoute reference for domain routes
+	setSiteRoute( siteRoute );
+
 	children.push( indexRoute );
 
 	if ( config.supports.overview ) {
@@ -783,19 +651,6 @@ const createRouteTree = ( config: AppConfig ) => {
 			siteSettingsTransferSiteRoute,
 			siteSettingsSftpSshRoute,
 			siteSettingsWebApplicationFirewallRoute,
-			siteDomainManagementRoute.addChildren( [
-				siteDomainDnsRoute,
-				siteDomainDnsAddRoute,
-				siteDomainDnsEditRoute,
-				siteDomainForwardingRoute,
-				siteDomainForwardingAddRoute,
-				siteDomainForwardingEditRoute,
-				siteDomainContactInfoRoute,
-				siteDomainNameServersRoute,
-				siteDomainGlueRecordsRoute,
-				siteDomainDnssecRoute,
-				siteDomainTransferRoute,
-			] ),
 		];
 
 		if ( config.supports.sites.deployments ) {
@@ -820,6 +675,7 @@ const createRouteTree = ( config: AppConfig ) => {
 
 		if ( config.supports.sites.domains ) {
 			siteChildren.push( siteDomainsRoute );
+			siteChildren.push( siteDomainRoute.addChildren( siteDomainChildRoutes ) );
 		}
 
 		if ( config.supports.sites.emails ) {
@@ -885,7 +741,6 @@ export {
 	siteMonitoringRoute,
 	siteLogsRoute,
 	siteBackupsRoute,
-	siteDomainsRoute,
 	siteEmailsRoute,
 	siteSettingsRoute,
 	siteSettingsSiteVisibilityRoute,
@@ -902,7 +757,8 @@ export {
 	siteSettingsTransferSiteRoute,
 	siteSettingsSftpSshRoute,
 	siteSettingsWebApplicationFirewallRoute,
-	siteDomainManagementRoute,
+	siteDomainsRoute,
+	siteDomainRoute,
 	siteDomainDnsRoute,
 	siteDomainDnsAddRoute,
 	siteDomainDnsEditRoute,
@@ -914,7 +770,6 @@ export {
 	siteDomainGlueRecordsRoute,
 	siteDomainDnssecRoute,
 	siteDomainTransferRoute,
-	domainsRoute,
 	emailsRoute,
 	meRoute,
 	profileRoute,

--- a/client/dashboard/app/routes/domain-routes.ts
+++ b/client/dashboard/app/routes/domain-routes.ts
@@ -1,0 +1,192 @@
+import { createRoute, createLazyRoute } from '@tanstack/react-router';
+import { domainsQuery } from '../queries/domains';
+import { queryClient } from '../query-client';
+import type { AnyRoute } from '@tanstack/react-router';
+
+// This will be passed in from the main router to avoid circular imports
+let siteRoute: AnyRoute;
+let rootRoute: AnyRoute;
+
+export const setRootRoute = ( route: AnyRoute ) => {
+	rootRoute = route;
+};
+
+export const setSiteRoute = ( route: AnyRoute ) => {
+	siteRoute = route;
+};
+
+// Standalone domains route - requires rootRoute
+export const domainsRoute = createRoute( {
+	getParentRoute: () => rootRoute,
+	path: 'domains',
+	loader: () => queryClient.ensureQueryData( domainsQuery() ),
+} ).lazy( () =>
+	import( '../../domains' ).then( ( d ) =>
+		createLazyRoute( 'domains' )( {
+			component: d.default,
+		} )
+	)
+);
+
+// Site domains route
+export const siteDomainsRoute = createRoute( {
+	getParentRoute: () => siteRoute,
+	path: 'domains',
+} ).lazy( () =>
+	import( '../../sites/domains' ).then( ( d ) =>
+		createLazyRoute( 'site-domains' )( {
+			component: d.default,
+		} )
+	)
+);
+
+// Site domain management route
+export const siteDomainRoute = createRoute( {
+	getParentRoute: () => siteRoute,
+	path: 'domains/$domainName',
+} ).lazy( () =>
+	import( '../../sites/domain-management/placeholder' ).then( ( d ) =>
+		createLazyRoute( 'site-domain-management' )( {
+			component: d.default,
+		} )
+	)
+);
+
+// Site domain DNS routes
+export const siteDomainDnsRoute = createRoute( {
+	getParentRoute: () => siteDomainRoute,
+	path: 'dns',
+} ).lazy( () =>
+	import( '../../sites/domain-management/placeholder' ).then( ( d ) =>
+		createLazyRoute( 'site-domain-dns' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const siteDomainDnsAddRoute = createRoute( {
+	getParentRoute: () => siteDomainRoute,
+	path: 'dns/add',
+} ).lazy( () =>
+	import( '../../sites/domain-management/placeholder' ).then( ( d ) =>
+		createLazyRoute( 'site-domain-dns-add' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const siteDomainDnsEditRoute = createRoute( {
+	getParentRoute: () => siteDomainRoute,
+	path: 'dns/edit',
+} ).lazy( () =>
+	import( '../../sites/domain-management/placeholder' ).then( ( d ) =>
+		createLazyRoute( 'site-domain-dns-edit' )( {
+			component: d.default,
+		} )
+	)
+);
+
+// Site domain forwarding routes
+export const siteDomainForwardingRoute = createRoute( {
+	getParentRoute: () => siteDomainRoute,
+	path: 'forwarding',
+} ).lazy( () =>
+	import( '../../sites/domain-management/placeholder' ).then( ( d ) =>
+		createLazyRoute( 'site-domain-forwarding' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const siteDomainForwardingAddRoute = createRoute( {
+	getParentRoute: () => siteDomainRoute,
+	path: 'forwarding/add',
+} ).lazy( () =>
+	import( '../../sites/domain-management/placeholder' ).then( ( d ) =>
+		createLazyRoute( 'site-domain-forwarding-add' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const siteDomainForwardingEditRoute = createRoute( {
+	getParentRoute: () => siteDomainRoute,
+	path: 'forwarding/edit',
+} ).lazy( () =>
+	import( '../../sites/domain-management/placeholder' ).then( ( d ) =>
+		createLazyRoute( 'site-domain-forwarding-edit' )( {
+			component: d.default,
+		} )
+	)
+);
+
+// Site domain management routes
+export const siteDomainContactInfoRoute = createRoute( {
+	getParentRoute: () => siteDomainRoute,
+	path: 'contact_info',
+} ).lazy( () =>
+	import( '../../sites/domain-management/placeholder' ).then( ( d ) =>
+		createLazyRoute( 'site-domain-contact-info' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const siteDomainNameServersRoute = createRoute( {
+	getParentRoute: () => siteDomainRoute,
+	path: 'name_servers',
+} ).lazy( () =>
+	import( '../../sites/domain-management/placeholder' ).then( ( d ) =>
+		createLazyRoute( 'site-domain-name-servers' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const siteDomainGlueRecordsRoute = createRoute( {
+	getParentRoute: () => siteDomainRoute,
+	path: 'glue_records',
+} ).lazy( () =>
+	import( '../../sites/domain-management/placeholder' ).then( ( d ) =>
+		createLazyRoute( 'site-domain-glue-records' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const siteDomainDnssecRoute = createRoute( {
+	getParentRoute: () => siteDomainRoute,
+	path: 'dnssec',
+} ).lazy( () =>
+	import( '../../sites/domain-management/placeholder' ).then( ( d ) =>
+		createLazyRoute( 'site-domain-dnssec' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const siteDomainTransferRoute = createRoute( {
+	getParentRoute: () => siteDomainRoute,
+	path: 'transfer',
+} ).lazy( () =>
+	import( '../../sites/domain-management/placeholder' ).then( ( d ) =>
+		createLazyRoute( 'site-domain-transfer' )( {
+			component: d.default,
+		} )
+	)
+);
+
+// Export all site domain child routes for easy inclusion
+export const siteDomainChildRoutes: AnyRoute[] = [
+	siteDomainDnsRoute,
+	siteDomainDnsAddRoute,
+	siteDomainDnsEditRoute,
+	siteDomainForwardingRoute,
+	siteDomainForwardingAddRoute,
+	siteDomainForwardingEditRoute,
+	siteDomainContactInfoRoute,
+	siteDomainNameServersRoute,
+	siteDomainGlueRecordsRoute,
+	siteDomainDnssecRoute,
+	siteDomainTransferRoute,
+];

--- a/client/dashboard/app/routes/domain-routes.ts
+++ b/client/dashboard/app/routes/domain-routes.ts
@@ -47,8 +47,8 @@ export const siteDomainRoute = createRoute( {
 	getParentRoute: () => siteRoute,
 	path: 'domains/$domainName',
 } ).lazy( () =>
-	import( '../../sites/domain-management/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'site-domain-management' )( {
+	import( '../../sites/domains/placeholder' ).then( ( d ) =>
+		createLazyRoute( 'site-domains' )( {
 			component: d.default,
 		} )
 	)
@@ -59,7 +59,7 @@ export const siteDomainDnsRoute = createRoute( {
 	getParentRoute: () => siteDomainRoute,
 	path: 'dns',
 } ).lazy( () =>
-	import( '../../sites/domain-management/placeholder' ).then( ( d ) =>
+	import( '../../sites/domains/placeholder' ).then( ( d ) =>
 		createLazyRoute( 'site-domain-dns' )( {
 			component: d.default,
 		} )
@@ -70,7 +70,7 @@ export const siteDomainDnsAddRoute = createRoute( {
 	getParentRoute: () => siteDomainRoute,
 	path: 'dns/add',
 } ).lazy( () =>
-	import( '../../sites/domain-management/placeholder' ).then( ( d ) =>
+	import( '../../sites/domains/placeholder' ).then( ( d ) =>
 		createLazyRoute( 'site-domain-dns-add' )( {
 			component: d.default,
 		} )
@@ -81,7 +81,7 @@ export const siteDomainDnsEditRoute = createRoute( {
 	getParentRoute: () => siteDomainRoute,
 	path: 'dns/edit',
 } ).lazy( () =>
-	import( '../../sites/domain-management/placeholder' ).then( ( d ) =>
+	import( '../../sites/domains/placeholder' ).then( ( d ) =>
 		createLazyRoute( 'site-domain-dns-edit' )( {
 			component: d.default,
 		} )
@@ -93,7 +93,7 @@ export const siteDomainForwardingRoute = createRoute( {
 	getParentRoute: () => siteDomainRoute,
 	path: 'forwarding',
 } ).lazy( () =>
-	import( '../../sites/domain-management/placeholder' ).then( ( d ) =>
+	import( '../../sites/domains/placeholder' ).then( ( d ) =>
 		createLazyRoute( 'site-domain-forwarding' )( {
 			component: d.default,
 		} )
@@ -104,7 +104,7 @@ export const siteDomainForwardingAddRoute = createRoute( {
 	getParentRoute: () => siteDomainRoute,
 	path: 'forwarding/add',
 } ).lazy( () =>
-	import( '../../sites/domain-management/placeholder' ).then( ( d ) =>
+	import( '../../sites/domains/placeholder' ).then( ( d ) =>
 		createLazyRoute( 'site-domain-forwarding-add' )( {
 			component: d.default,
 		} )
@@ -115,19 +115,18 @@ export const siteDomainForwardingEditRoute = createRoute( {
 	getParentRoute: () => siteDomainRoute,
 	path: 'forwarding/edit',
 } ).lazy( () =>
-	import( '../../sites/domain-management/placeholder' ).then( ( d ) =>
+	import( '../../sites/domains/placeholder' ).then( ( d ) =>
 		createLazyRoute( 'site-domain-forwarding-edit' )( {
 			component: d.default,
 		} )
 	)
 );
 
-// Site domain management routes
 export const siteDomainContactInfoRoute = createRoute( {
 	getParentRoute: () => siteDomainRoute,
 	path: 'contact_info',
 } ).lazy( () =>
-	import( '../../sites/domain-management/placeholder' ).then( ( d ) =>
+	import( '../../sites/domains/placeholder' ).then( ( d ) =>
 		createLazyRoute( 'site-domain-contact-info' )( {
 			component: d.default,
 		} )
@@ -138,7 +137,7 @@ export const siteDomainNameServersRoute = createRoute( {
 	getParentRoute: () => siteDomainRoute,
 	path: 'name_servers',
 } ).lazy( () =>
-	import( '../../sites/domain-management/placeholder' ).then( ( d ) =>
+	import( '../../sites/domains/placeholder' ).then( ( d ) =>
 		createLazyRoute( 'site-domain-name-servers' )( {
 			component: d.default,
 		} )
@@ -149,7 +148,7 @@ export const siteDomainGlueRecordsRoute = createRoute( {
 	getParentRoute: () => siteDomainRoute,
 	path: 'glue_records',
 } ).lazy( () =>
-	import( '../../sites/domain-management/placeholder' ).then( ( d ) =>
+	import( '../../sites/domains/placeholder' ).then( ( d ) =>
 		createLazyRoute( 'site-domain-glue-records' )( {
 			component: d.default,
 		} )
@@ -160,7 +159,7 @@ export const siteDomainDnssecRoute = createRoute( {
 	getParentRoute: () => siteDomainRoute,
 	path: 'dnssec',
 } ).lazy( () =>
-	import( '../../sites/domain-management/placeholder' ).then( ( d ) =>
+	import( '../../sites/domains/placeholder' ).then( ( d ) =>
 		createLazyRoute( 'site-domain-dnssec' )( {
 			component: d.default,
 		} )
@@ -171,7 +170,7 @@ export const siteDomainTransferRoute = createRoute( {
 	getParentRoute: () => siteDomainRoute,
 	path: 'transfer',
 } ).lazy( () =>
-	import( '../../sites/domain-management/placeholder' ).then( ( d ) =>
+	import( '../../sites/domains/placeholder' ).then( ( d ) =>
 		createLazyRoute( 'site-domain-transfer' )( {
 			component: d.default,
 		} )

--- a/client/dashboard/app/routes/domain-routes.ts
+++ b/client/dashboard/app/routes/domain-routes.ts
@@ -28,6 +28,8 @@ export const domainsRoute = createRoute( {
 	)
 );
 
+// TODO: Add all domains domain management routes here or figure out how to do that with the definitions below
+
 // Site domains route
 export const siteDomainsRoute = createRoute( {
 	getParentRoute: () => siteRoute,

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -9,6 +9,7 @@ import { dateI18n } from '@wordpress/date';
 import { sprintf, __ } from '@wordpress/i18n';
 import { caution, reusableBlock } from '@wordpress/icons';
 import { useMemo } from 'react';
+import { siteDomainRoute } from '../../app/router';
 import { DomainTypes } from '../../data/domains';
 import type { Domain, Site } from '../../data/types';
 import type { Field } from '@wordpress/dataviews';
@@ -34,11 +35,16 @@ const DomainName = ( {
 } ) => {
 	const siteSlug = site?.slug ?? domain.site_slug;
 	const domainManagementUrl = site
-		? `/v2/sites/${ siteSlug }/domains/${ domain.domain }`
+		? siteDomainRoute.fullPath
 		: `${ window.location.origin }/domains/manage/all/overview/${ domain.domain }/${ siteSlug }`;
+	const domainManagementParams = { siteSlug, domainName: domain.domain };
 
 	return (
-		<Link to={ domainManagementUrl } disabled={ domain.type === DomainTypes.WPCOM }>
+		<Link
+			to={ domainManagementUrl }
+			params={ domainManagementParams }
+			disabled={ domain.type === DomainTypes.WPCOM }
+		>
 			<HStack spacing={ 1 }>
 				<span style={ textOverflowStyles }>{ value }</span>
 				{ showPrimaryDomainBadge && domain.primary_domain && (

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -34,7 +34,7 @@ const DomainName = ( {
 } ) => {
 	const siteSlug = site?.slug ?? domain.site_slug;
 	const domainManagementUrl = site
-		? `${ window.location.origin }/overview/site-domain/domain/${ domain.domain }/${ siteSlug }`
+		? `/v2/sites/${ siteSlug }/domains/${ domain.domain }`
 		: `${ window.location.origin }/domains/manage/all/overview/${ domain.domain }/${ siteSlug }`;
 
 	return (

--- a/client/dashboard/sites/domain-management/placeholder.tsx
+++ b/client/dashboard/sites/domain-management/placeholder.tsx
@@ -1,0 +1,9 @@
+import { useParams } from '@tanstack/react-router';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+
+export default function DomainManagementPlaceholder() {
+	const { domainName } = useParams( { from: '/sites/$siteSlug/domains/$domainName' } );
+
+	return <PageLayout size="small" header={ <PageHeader title={ domainName } /> }></PageLayout>;
+}

--- a/client/dashboard/sites/domain-management/placeholder.tsx
+++ b/client/dashboard/sites/domain-management/placeholder.tsx
@@ -1,9 +1,9 @@
-import { useParams } from '@tanstack/react-router';
+import { siteDomainRoute } from '../../app/router';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 
 export default function DomainManagementPlaceholder() {
-	const { domainName } = useParams( { from: '/sites/$siteSlug/domains/$domainName' } );
+	const { domainName } = siteDomainRoute.useParams();
 
 	return <PageLayout size="small" header={ <PageHeader title={ domainName } /> }></PageLayout>;
 }

--- a/client/dashboard/sites/domains/placeholder.tsx
+++ b/client/dashboard/sites/domains/placeholder.tsx
@@ -2,7 +2,7 @@ import { siteDomainRoute } from '../../app/router';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 
-export default function DomainManagementPlaceholder() {
+export default function DomainPlaceholder() {
 	const { domainName } = siteDomainRoute.useParams();
 
 	return <PageLayout size="small" header={ <PageHeader title={ domainName } /> }></PageLayout>;


### PR DESCRIPTION
Define most of the routes needed to implement the domain management inside the hosting dashboard.

Things to discuss:
1. Do we want to keep this URL pattern?
2. What are the other URL pattern options?

Part of [DOTDASH-187: Create all the routes with TBD components](https://linear.app/a8c/issue/DOTDASH-187/create-all-the-routes-with-tbd-components)

## Proposed Changes

* Add the routes and show a domain management placeholder component

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We're starting to implement the Domian management inside the hosting dashboard

## Testing Instructions

* Run this branch and go to `/v2/sites/{site_slug}/domains/{any_domain_name}` and make sure that you see a header with the `any_domain_name` rendered

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
