### PR TITLE
Site overview v2: add loading state to Domains Card

### DIFF
--- a/client/dashboard/components/callout-skeleton/index.tsx
+++ b/client/dashboard/components/callout-skeleton/index.tsx
@@ -4,7 +4,7 @@ import { TextSkeleton } from '../text-skeleton';
 export function CalloutSkeleton() {
 	return (
 		<Card>
-			<CardBody>
+			<CardBody style={ { padding: '24px' } }>
 				<VStack spacing="4">
 					<TextSkeleton length={ 15 } />
 					<TextSkeleton length={ 30 } />

--- a/client/dashboard/components/callout-skeleton/index.tsx
+++ b/client/dashboard/components/callout-skeleton/index.tsx
@@ -1,0 +1,15 @@
+import { Card, CardBody, __experimentalVStack as VStack } from '@wordpress/components';
+import { TextSkeleton } from '../text-skeleton';
+
+export function CalloutSkeleton() {
+	return (
+		<Card>
+			<CardBody>
+				<VStack spacing="4">
+					<TextSkeleton length={ 15 } />
+					<TextSkeleton length={ 30 } />
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/sites/overview-domains-card/index.tsx
+++ b/client/dashboard/sites/overview-domains-card/index.tsx
@@ -6,6 +6,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { useState, useMemo } from 'react';
 import { siteDomainsQuery } from '../../app/queries/site-domains';
 import { siteCurrentPlanQuery } from '../../app/queries/site-plans';
+import { CalloutSkeleton } from '../../components/callout-skeleton';
 import { SectionHeader } from '../../components/section-header';
 import { useFields, actions, DEFAULT_VIEW, DEFAULT_LAYOUTS } from '../../domains/dataviews';
 import { isTransferrableToWpcom } from '../../utils/domain-types';
@@ -122,7 +123,7 @@ export default function DomainsCard( {
 	const { data: siteDomains } = useQuery( siteDomainsQuery( site.ID ) );
 
 	if ( ! sitePlan || ! siteDomains ) {
-		return null;
+		return <CalloutSkeleton />;
 	}
 
 	if (


### PR DESCRIPTION
## Proposed Changes

This PR adds a loading state to Domains Card in Site Overview v2, to avoid layout shift:

<img width="1429" height="399" alt="image" src="https://github.com/user-attachments/assets/ec6c59e9-7ce1-4ccc-96f1-8a899f93fbb6" />


## Why are these changes being made?

Polish.

## Testing Instructions

1. Clear TanStack Query cache
1. Go to /v2/sites/:slug of an Atomic site
2. Verify you see the above loading state

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
