### PR TITLE
Site overview v2: implement Migrate Site card

### DIFF
--- a/client/dashboard/sites/overview-migrate-site-card/index.tsx
+++ b/client/dashboard/sites/overview-migrate-site-card/index.tsx
@@ -1,0 +1,19 @@
+import { __ } from '@wordpress/i18n';
+import { shuffle } from '@wordpress/icons';
+import { addQueryArgs } from '@wordpress/url';
+import OverviewCard from '../overview-card';
+import type { Site } from '../../data/types';
+
+export default function MigrateSiteCard( { site }: { site: Site } ) {
+	return (
+		<OverviewCard
+			icon={ shuffle }
+			title={ __( 'Migrate' ) }
+			heading={ __( 'Migrate site' ) }
+			description={ __( 'Bring your site to WordPress.com.' ) }
+			externalLink={ addQueryArgs( '/setup/site-migration', { siteSlug: site.slug } ) }
+			intent="upsell"
+			tracksId="migrate-site"
+		/>
+	);
+}

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -20,6 +20,7 @@ import OverviewCard from '../overview-card';
 import DIFMUpsellCard from '../overview-difm-upsell-card';
 import DomainsCard from '../overview-domains-card';
 import LatestActivityCard from '../overview-latest-activity-card';
+import MigrateSiteCard from '../overview-migrate-site-card';
 import PlanCard from '../overview-plan-card';
 import ScanCard from '../overview-scan-card';
 import SiteActionMenu from '../overview-site-action-menu';
@@ -117,17 +118,23 @@ function SiteOverview( {
 						<BackupCard site={ site } />
 					</Grid>
 					<Grid columns={ 1 } rows={ 2 } gap={ spacing }>
-						{ site.is_a4a_dev_site ? (
-							<AgencySiteShareCard site={ site } />
-						) : (
-							<OverviewCard
-								title={ __( 'Performance' ) }
-								icon={ chartBar }
-								heading="TBA"
-								description="TBA"
-								disabled
-							/>
-						) }
+						{ ( () => {
+							if ( site.is_a4a_dev_site ) {
+								return <AgencySiteShareCard site={ site } />;
+							}
+							if ( site.is_wpcom_atomic ) {
+								return (
+									<OverviewCard
+										title={ __( 'Performance' ) }
+										icon={ chartBar }
+										heading="TBA"
+										description="TBA"
+										disabled
+									/>
+								);
+							}
+							return <MigrateSiteCard site={ site } />;
+						} )() }
 						<ScanCard site={ site } />
 					</Grid>
 					<PlanCard site={ site } />


### PR DESCRIPTION
Fixes DOTDASH-117

## Proposed Changes

This PR implements the Migrate Site card as follows:

<img width="335" height="159" alt="image" src="https://github.com/user-attachments/assets/2269f318-546e-493a-83f5-7e920454c4b6" />


## Testing Instructions

1. Go to `/v2/sites/:slug` of a Simple site.
2. Verify you see the card.
3. Click the card.
4. Verify you land in the Site Migration flow, and the Tracks event is fired.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
