### PR TITLE
Reader: Show the related sites list when no user info is available

### DIFF
--- a/client/blocks/reader-suggested-follows/dialog.jsx
+++ b/client/blocks/reader-suggested-follows/dialog.jsx
@@ -55,7 +55,8 @@ const ReaderSuggestedFollowsDialog = ( {
 		enabled: prefetch || isVisible,
 	} );
 
-	const shouldCloseModal = isFetched && isVisible && data?.length === 0;
+	const hasData = Array.isArray( data ) && data.length > 0;
+	const shouldCloseModal = isFetched && isVisible && ! hasData;
 
 	useEffect( () => {
 		if ( isVisible && resourceType ) {

--- a/client/blocks/reader-suggested-follows/hooks/use-recommend-or-related-sites-query/index.ts
+++ b/client/blocks/reader-suggested-follows/hooks/use-recommend-or-related-sites-query/index.ts
@@ -39,6 +39,7 @@ export const useRecommendOrRelatedSitesQuery = ( query: QueryParams, options?: Q
 	const { author, siteId, postId } = query;
 	const userLogin = author?.wpcom_login || author?.ID;
 	const enabled = options?.enabled ?? true;
+	const hasUserLogin = Boolean( userLogin );
 
 	const {
 		data: recommendedFeeds,
@@ -49,14 +50,15 @@ export const useRecommendOrRelatedSitesQuery = ( query: QueryParams, options?: Q
 	} );
 
 	const hasRecommendedFeeds = recommendedFeeds && recommendedFeeds.length > 0;
-	const shouldLoadRelatedSites = enabled && isFetchedRecommendedFeeds && ! hasRecommendedFeeds;
+	const shouldLoadRelatedSites =
+		! hasUserLogin || ( isFetchedRecommendedFeeds && ! hasRecommendedFeeds );
 
 	const {
 		data: relatedSites,
 		isLoading: isLoadingRelatedSites,
 		isFetched: isFetchedRelatedSites,
 	} = useRelatedSites( siteId, postId, {
-		enabled: shouldLoadRelatedSites,
+		enabled: shouldLoadRelatedSites && enabled,
 	} );
 
 	const data = recommendedFeeds?.length > 0 ? recommendedFeeds : relatedSites;

--- a/client/blocks/reader-suggested-follows/test/dialog.test.tsx
+++ b/client/blocks/reader-suggested-follows/test/dialog.test.tsx
@@ -65,6 +65,21 @@ describe( 'ReaderSuggestedFollowsDialog', () => {
 		expect( onClose ).toHaveBeenCalled();
 	} );
 
+	it( 'closes the modal automatically when all data returned is undefined', () => {
+		jest.mocked( useRecommendOrRelatedSitesQuery ).mockReturnValue( {
+			data: undefined,
+			isLoading: false,
+			resourceType: null,
+			isFetched: true,
+		} );
+
+		const onClose = jest.fn();
+		render(
+			<ReaderSuggestedFollowsDialog onClose={ onClose } siteId={ 1 } postId={ 2 } isVisible />
+		);
+		expect( onClose ).toHaveBeenCalled();
+	} );
+
 	it( 'renders the loading state', () => {
 		jest.mocked( useRecommendOrRelatedSitesQuery ).mockReturnValue( {
 			data: [],
@@ -98,6 +113,7 @@ describe( 'ReaderSuggestedFollowsDialog', () => {
 				isVisible
 			/>
 		);
+
 		expect( screen.getByText( 'Recommended blogs' ) ).toBeVisible();
 		expect( screen.getByText( /Test Author/ ) ).toBeVisible();
 		expect( screen.getByText( 'Nice Recommended Blog' ) ).toBeVisible();


### PR DESCRIPTION

Closes CML-736

## Proposed Changes
* Loads the related sites directly when the feed doesn't have a WP.com user associated


## Testing Instructions
* Go to /reader/feeds/171890607/posts/5755956998
* Click on the " Subscribe" button and check that we show the list of suggested sites instead of a modal with an empty body


### Technical Details
Previously, the logic tried to load the related site list only if the user didn't have items on their recommended list. 
However,  when we don't have a user available, the attempt to load the recommend list was disabled, but the related list loading was not triggered. This PR fixes it, triggering the related list loading if no user info is available. 




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
