### PR TITLE
Reader: Show recommended list on the feed view

### DIFF
--- a/client/blocks/reader-feed-header/follow.jsx
+++ b/client/blocks/reader-feed-header/follow.jsx
@@ -46,31 +46,38 @@ export default function ReaderFeedHeaderFollow( props ) {
 		}
 	}, [ dispatch, hasRequestedRecommendedBlogs, isRequestingRecommendedBlogs, owner ] );
 
-	const { following, hasOrganization, isEmailBlocked, isWPForTeamsItem, subscriptionId } =
-		useSelector( ( state ) => {
-			let _siteId = siteId;
-			let _feedId = feed?.feed_ID;
-			let _feed = _feedId ? getFeed( state, _feedId ) : undefined;
-			let _site = _siteId ? getSite( state, _siteId ) : undefined;
+	const {
+		following,
+		hasOrganization,
+		isEmailBlocked,
+		isWPForTeamsItem,
+		subscriptionId,
+		blogOwner,
+	} = useSelector( ( state ) => {
+		let _siteId = siteId;
+		let _feedId = feed?.feed_ID;
+		let _feed = _feedId ? getFeed( state, _feedId ) : undefined;
+		let _site = _siteId ? getSite( state, _siteId ) : undefined;
 
-			if ( _feed && ! _siteId ) {
-				_siteId = _feed.blog_ID || undefined;
-				_site = _siteId ? getSite( state, _feed.blog_ID ) : undefined;
-			}
+		if ( _feed && ! _siteId ) {
+			_siteId = _feed.blog_ID || undefined;
+			_site = _siteId ? getSite( state, _feed.blog_ID ) : undefined;
+		}
 
-			if ( _site && ! _feedId ) {
-				_feedId = _site.feed_ID;
-				_feed = _feedId ? getFeed( state, _site.feed_ID ) : undefined;
-			}
+		if ( _site && ! _feedId ) {
+			_feedId = _site.feed_ID;
+			_feed = _feedId ? getFeed( state, _site.feed_ID ) : undefined;
+		}
 
-			return {
-				following: _feed && isFollowing( state, { feedUrl: _feed.feed_URL } ),
-				hasOrganization: hasReaderFollowOrganization( state, _feedId, _siteId ),
-				isEmailBlocked: getUserSetting( state, 'subscription_delivery_email_blocked' ),
-				isWPForTeamsItem: isSiteWPForTeams( state, _siteId ) || isFeedWPForTeams( state, _feedId ),
-				subscriptionId: _feed?.subscription_id,
-			};
-		}, shallowEqual );
+		return {
+			following: _feed && isFollowing( state, { feedUrl: _feed.feed_URL } ),
+			hasOrganization: hasReaderFollowOrganization( state, _feedId, _siteId ),
+			isEmailBlocked: getUserSetting( state, 'subscription_delivery_email_blocked' ),
+			isWPForTeamsItem: isSiteWPForTeams( state, _siteId ) || isFeedWPForTeams( state, _feedId ),
+			subscriptionId: _feed?.subscription_id,
+			blogOwner: _feed?.blog_owner,
+		};
+	}, shallowEqual );
 
 	const openSuggestedFollowsModal = ( followClicked ) => {
 		setIsSuggestedFollowsModalOpen( followClicked );
@@ -147,6 +154,8 @@ export default function ReaderFeedHeaderFollow( props ) {
 					onClose={ onCloseSuggestedFollowModal }
 					siteId={ +siteId }
 					isVisible={ isSuggestedFollowsModalOpen }
+					author={ blogOwner }
+					prefetch
 				/>
 			) }
 		</div>

--- a/client/state/reader/feeds/reducer.js
+++ b/client/state/reader/feeds/reducer.js
@@ -30,6 +30,7 @@ function adaptFeed( feed ) {
 		name: feed.name && decodeEntities( feed.name ),
 		URL: safeLink( feed.URL ),
 		feed_URL: safeLink( feed.feed_URL ),
+		blog_owner: feed.blog_owner,
 		is_following: feed.is_following,
 		subscribers_count: feed.subscribers_count,
 		description: feed.description && decodeEntities( stripHTML( feed.description ) ),


### PR DESCRIPTION
Closes CML-720

## Proposed Changes

* Show the recommended list of sites from the blog_owner 

## Why are these changes being made?
Following up on https://github.com/Automattic/wp-calypso/pull/104927, we want to show the blog owner's recommended list when users subscribe to a feed on the feed view.

## Testing Instructions
* Go to `reader/feeds/166150816`
* Subscribe to the feed
* Check if you can see the list of recommended blogs from the blog author, instead of the related sites list


<img width="3374" height="2630" alt="CleanShot 2025-08-01 at 16 01 40@2x" src="https://github.com/user-attachments/assets/6bed92fe-f774-4714-bffe-e660474b5ac3" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
