### PR TITLE
Update password reset page

### DIFF
--- a/client/blocks/login/lost-password-form.jsx
+++ b/client/blocks/login/lost-password-form.jsx
@@ -171,7 +171,7 @@ const LostPasswordForm = ( {
 			onSubmit={ onSubmit }
 		>
 			<div className="login__form-userdata">
-				<FormLabel htmlFor="userLogin">{ translate( 'Username or email address' ) }</FormLabel>
+				<FormLabel htmlFor="userLogin">{ translate( 'Email address or username' ) }</FormLabel>
 				<FormTextInput
 					autoCapitalize="off"
 					autoCorrect="off"

--- a/client/blocks/login/test/lost-password-form.jsx
+++ b/client/blocks/login/test/lost-password-form.jsx
@@ -27,7 +27,7 @@ describe( 'LostPasswordForm', () => {
 	test( 'displays a lost password form without errors', () => {
 		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );
 
-		const userLogin = screen.getByLabelText( /Username or email address/i );
+		const userLogin = screen.getByLabelText( /Email address or username/i );
 		expect( userLogin ).toBeInTheDocument();
 
 		const btn = screen.getByRole( 'button', { name: /Reset my password/i } );
@@ -41,7 +41,7 @@ describe( 'LostPasswordForm', () => {
 		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );
 
 		await userEvent.type(
-			screen.getByRole( 'textbox', { name: 'Username or email address' } ),
+			screen.getByRole( 'textbox', { name: 'Email address or username' } ),
 			'invalid@email'
 		);
 		// The error message is displayed after the user blurs the input.
@@ -59,7 +59,7 @@ describe( 'LostPasswordForm', () => {
 		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );
 
 		await userEvent.type(
-			screen.getByRole( 'textbox', { name: 'Username or email address' } ),
+			screen.getByRole( 'textbox', { name: 'Email address or username' } ),
 			'user@example.com'
 		);
 		// The error message is displayed after the user blurs the input.
@@ -73,15 +73,15 @@ describe( 'LostPasswordForm', () => {
 		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );
 
 		await userEvent.type(
-			screen.getByRole( 'textbox', { name: 'Username or email address' } ),
+			screen.getByRole( 'textbox', { name: 'Email address or username' } ),
 			'invalid@email'
 		);
 		// The error message is displayed after the user blurs the input.
 		userEvent.tab();
 
-		await userEvent.clear( screen.getByRole( 'textbox', { name: 'Username or email address' } ) );
+		await userEvent.clear( screen.getByRole( 'textbox', { name: 'Email address or username' } ) );
 		await userEvent.type(
-			screen.getByRole( 'textbox', { name: 'Username or email address' } ),
+			screen.getByRole( 'textbox', { name: 'Email address or username' } ),
 			'user@example.com'
 		);
 		// The error message is displayed after the user blurs the input.
@@ -96,13 +96,13 @@ describe( 'LostPasswordForm', () => {
 		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );
 
 		await userEvent.type(
-			screen.getByRole( 'textbox', { name: 'Username or email address' } ),
+			screen.getByRole( 'textbox', { name: 'Email address or username' } ),
 			'invalid@email'
 		);
 		// The error message is displayed after the user blurs the input.
 		userEvent.tab();
 
-		await userEvent.clear( screen.getByRole( 'textbox', { name: 'Username or email address' } ) );
+		await userEvent.clear( screen.getByRole( 'textbox', { name: 'Email address or username' } ) );
 		// The error message is displayed after the user blurs the input.
 		userEvent.tab();
 
@@ -115,7 +115,7 @@ describe( 'LostPasswordForm', () => {
 		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );
 
 		await userEvent.type(
-			screen.getByRole( 'textbox', { name: 'Username or email address' } ),
+			screen.getByRole( 'textbox', { name: 'Email address or username' } ),
 			'validusername'
 		);
 		// The validation happens after the user blurs the input.
@@ -129,7 +129,7 @@ describe( 'LostPasswordForm', () => {
 		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );
 
 		await userEvent.type(
-			screen.getByRole( 'textbox', { name: 'Username or email address' } ),
+			screen.getByRole( 'textbox', { name: 'Email address or username' } ),
 			'ab'
 		);
 		// The validation happens after the user blurs the input.
@@ -144,7 +144,7 @@ describe( 'LostPasswordForm', () => {
 		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );
 
 		await userEvent.type(
-			screen.getByRole( 'textbox', { name: 'Username or email address' } ),
+			screen.getByRole( 'textbox', { name: 'Email address or username' } ),
 			'user123'
 		);
 		// The validation happens after the user blurs the input.
@@ -172,7 +172,7 @@ describe( 'LostPasswordForm', () => {
 		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );
 
 		await userEvent.type(
-			screen.getByRole( 'textbox', { name: 'Username or email address' } ),
+			screen.getByRole( 'textbox', { name: 'Email address or username' } ),
 			'user@example.com'
 		);
 

--- a/client/login/wp-login/components/one-login-footer.scss
+++ b/client/login/wp-login/components/one-login-footer.scss
@@ -1,20 +1,15 @@
 .one-login__footer {
     display: flex;
-    flex-direction: column;
     align-self: center;
     gap: 1em;
 
     .one-login__footer-link {
+        color: var(--studio-gray-90, #1d2327);
+        font-weight: 500;
         font-size: $font-body-small;
         display: inline-flex;
         align-items: center;
         align-self: center;
         gap: 0.1em;
-    }
-
-    .one-login__footer-link a,
-    a.one-login__footer-link {
-        color: var(--studio-gray-90, #1d2327);
-        font-weight: 500;
     }
 }

--- a/client/login/wp-login/components/one-login-footer.tsx
+++ b/client/login/wp-login/components/one-login-footer.tsx
@@ -13,7 +13,11 @@ interface OneLoginFooterProps {
 	/**
 	 * when `isLoginView` is false, this is the "back to login" link
 	 */
-	loginLink?: string;
+	loginLink?: JSX.Element;
+	/**
+	 * when `isLoginView` is false, this is the "support" link
+	 */
+	supportLink?: JSX.Element;
 	/**
 	 * when true, this is the footer for the main login screen
 	 */
@@ -24,8 +28,16 @@ const recordBackToWpcomLinkClick = () => {
 	recordTracksEvent( 'calypso_login_back_to_wpcom_link_click' );
 };
 
-const OneLoginFooter = ( { lostPasswordLink, loginLink, isLoginView }: OneLoginFooterProps ) => {
-	const oauth2Client = useSelector( getCurrentOAuth2Client );
+const OneLoginFooter = ( {
+	lostPasswordLink,
+	loginLink,
+	isLoginView,
+	supportLink,
+}: OneLoginFooterProps ) => {
+	const oauth2Client = useSelector( getCurrentOAuth2Client ) as {
+		name: string;
+		image: string;
+	} | null;
 	const isVIPClient = isVIPOAuth2Client( oauth2Client );
 
 	if ( isLoginView ) {
@@ -47,7 +59,12 @@ const OneLoginFooter = ( { lostPasswordLink, loginLink, isLoginView }: OneLoginF
 		);
 	}
 
-	return <div className="one-login__footer">{ loginLink }</div>;
+	return (
+		<div className="one-login__footer">
+			{ loginLink }
+			{ supportLink }
+		</div>
+	);
 };
 
 export default OneLoginFooter;

--- a/client/login/wp-login/components/one-login-layout.tsx
+++ b/client/login/wp-login/components/one-login-layout.tsx
@@ -21,7 +21,7 @@ interface OneLoginLayoutProps {
 	signupUrl?: string;
 	isSectionSignup?: boolean;
 	loginUrl?: string;
-	shouldHideCreateAccountLink?: boolean;
+	isLostPasswordView?: boolean;
 }
 
 const OneLoginLayout = ( {
@@ -30,7 +30,7 @@ const OneLoginLayout = ( {
 	signupUrl: signupUrlProp,
 	isSectionSignup,
 	loginUrl,
-	shouldHideCreateAccountLink,
+	isLostPasswordView,
 }: OneLoginLayoutProps ) => {
 	const translate = useTranslate();
 	const locale = useSelector( getCurrentUserLocale );
@@ -55,7 +55,8 @@ const OneLoginLayout = ( {
 				dispatch( redirectToLogout( signupUrl ) );
 			}
 		};
-		if ( shouldHideCreateAccountLink ) {
+
+		if ( isLostPasswordView ) {
 			return null;
 		}
 

--- a/client/login/wp-login/components/one-login-layout.tsx
+++ b/client/login/wp-login/components/one-login-layout.tsx
@@ -21,6 +21,7 @@ interface OneLoginLayoutProps {
 	signupUrl?: string;
 	isSectionSignup?: boolean;
 	loginUrl?: string;
+	shouldHideCreateAccountLink?: boolean;
 }
 
 const OneLoginLayout = ( {
@@ -29,6 +30,7 @@ const OneLoginLayout = ( {
 	signupUrl: signupUrlProp,
 	isSectionSignup,
 	loginUrl,
+	shouldHideCreateAccountLink,
 }: OneLoginLayoutProps ) => {
 	const translate = useTranslate();
 	const locale = useSelector( getCurrentUserLocale );
@@ -53,6 +55,9 @@ const OneLoginLayout = ( {
 				dispatch( redirectToLogout( signupUrl ) );
 			}
 		};
+		if ( shouldHideCreateAccountLink ) {
+			return null;
+		}
 
 		return (
 			<Step.LinkButton href={ signupUrl } key="sign-up-link" onClick={ handleClick } rel="external">

--- a/client/login/wp-login/hooks/get-header-text.tsx
+++ b/client/login/wp-login/hooks/get-header-text.tsx
@@ -118,7 +118,7 @@ export function getHeaderText( {
 	}
 
 	if ( action === 'lostpassword' ) {
-		headerText = translate( 'Forgot your password?' );
+		headerText = translate( 'Lost your password?' );
 	} else if ( currentQuery?.lostpassword_flow === 'true' ) {
 		headerText = translate( "You've got mail" );
 	} else if ( oauth2Client ) {

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -380,8 +380,7 @@ export class Login extends Component {
 			</Main>
 		);
 
-		const shouldHideCreateAccountLink =
-			action === 'lostpassword' || action === 'jetpack/lostpassword';
+		const isLostPasswordView = action === 'lostpassword' || action === 'jetpack/lostpassword';
 
 		return (
 			<>
@@ -390,7 +389,7 @@ export class Login extends Component {
 						isJetpack={ isJetpack }
 						isFromAkismet={ isFromAkismet }
 						signupUrl={ this.props.signupUrl }
-						shouldHideCreateAccountLink={ shouldHideCreateAccountLink }
+						isLostPasswordView={ isLostPasswordView }
 					>
 						{ mainContent }
 					</OneLoginLayout>

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -208,6 +208,17 @@ export class Login extends Component {
 		);
 	}
 
+	getSupportLink() {
+		return (
+			<a
+				className="one-login__footer-link"
+				href="/support/category/manage-your-account/account-settings/"
+			>
+				{ this.props.translate( 'Support' ) }
+			</a>
+		);
+	}
+
 	renderContent( isSocialFirst ) {
 		const {
 			clientId,
@@ -258,6 +269,7 @@ export class Login extends Component {
 							isLoginView={ isLoginView }
 							lostPasswordLink={ this.getLostPasswordLink() }
 							loginLink={ this.getLoginLink() }
+							supportLink={ this.getSupportLink() }
 						/>
 					)
 				}

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -336,7 +336,15 @@ export class Login extends Component {
 	}
 
 	render() {
-		const { locale, translate, isGenericOauth, isGravPoweredClient, isJetpack } = this.props;
+		const {
+			locale,
+			translate,
+			isGenericOauth,
+			isGravPoweredClient,
+			isJetpack,
+			isFromAkismet,
+			action,
+		} = this.props;
 
 		const canonicalUrl = localizeUrl( 'https://wordpress.com/log-in', locale );
 
@@ -372,10 +380,18 @@ export class Login extends Component {
 			</Main>
 		);
 
+		const shouldHideCreateAccountLink =
+			action === 'lostpassword' || action === 'jetpack/lostpassword';
+
 		return (
 			<>
 				{ ! isGravPoweredClient && (
-					<OneLoginLayout isJetpack={ isJetpack } signupUrl={ this.props.signupUrl }>
+					<OneLoginLayout
+						isJetpack={ isJetpack }
+						isFromAkismet={ isFromAkismet }
+						signupUrl={ this.props.signupUrl }
+						shouldHideCreateAccountLink={ shouldHideCreateAccountLink }
+					>
 						{ mainContent }
 					</OneLoginLayout>
 				) }


### PR DESCRIPTION
## Proposed Changes

* Add **Support** link which goes to https://wordpress.com/support/category/manage-your-account/account-settings/. 
    * We can make this optional if needed. 
* Remove **Create an account** link from header when on the password reset page
* Update copy  

## Why are these changes being made?

* With the connect unification work, we have new designs to follow. 

## Testing Instructions

* Go to password reset page for:
    * [WordPress.com](http://calypso.localhost:3000/log-in/lostpassword) 
    * [Jetpack](http://calypso.localhost:3000/log-in/jetpack/lostpassword)
    * [Woo](http://calypso.localhost:3000/log-in/lostpassword?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Dbabd2834d29179c7104bba84668042e1f8a4c310f62299dd24992cf002dbda31%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%3Dnux%26calypso_env%3Dproduction%26from-calypso%3D1&client_id=50916)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
