### PR TITLE
Domains: Make sure we're giving the free domain credit to the most expensive domain

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -217,7 +217,7 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 		}
 
 		if ( domainCartItems?.length && site?.siteSlug ) {
-			await addProductsToCart( site.siteSlug, flow, productCartItems );
+			await addProductsToCart( site.siteSlug, flow, domainCartItems );
 		}
 
 		return {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -960,7 +960,7 @@ class RenderDomainsStepComponent extends Component {
 		const { step, cart, multiDomainDefaultPlan, shoppingCartManager, goToNextStep } = this.props;
 		const { lastDomainSearched } = step.domainForm ?? {};
 
-		const domainCart = getDomainsInCart( this.props.cart );
+		const domainCart = sortProductsByPriceDescending( getDomainsInCart( this.props.cart ) );
 		const { suggestion } = step;
 		const isPurchasingItem =
 			( suggestion && Boolean( suggestion.product_slug ) ) || domainCart?.length > 0;


### PR DESCRIPTION
Closes DOMAINS-1580.

## Proposed Changes

- Make sure we're setting the more expensive domain in the cart as the `domainItem` so it gets the discount
- Adds the `domainCartItems` to the created site cart

## Why are these changes being made?

When the user picks two domains in the domain search step, with one of them being more expensive, we should apply the discount to that more expensive domain, regardless of the order it was picked.

## Testing Instructions

In production, go to `/setup/onboarding` and pick one domain, then a second one, making sure that the second one is more expensive. Verify that the more expensive one gets the discount applied in the mini cart.

Move forward and pick a plan. At checkout, you should see that the first one (the cheaper domain) got the discount, not the more expensive one.

Perform the same actions in this branch, but this time verify that the most expensive domain gets the discount, not the first domain (cheaper.)