### PR TITLE
Domain Search Retrofit: Handle lone featured suggestions

### DIFF
--- a/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
+++ b/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
@@ -449,6 +449,7 @@ class DomainRegistrationSuggestion extends Component {
 
 		return (
 			<SuggestionComponent
+				isSingleFeaturedSuggestion={ this.props.isSingleFeaturedSuggestion }
 				badges={ badges }
 				uuid={ fullDomain }
 				domain={ domainName }

--- a/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
+++ b/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
@@ -410,57 +410,55 @@ class DomainRegistrationSuggestion extends Component {
 
 		const matchReasons = this.renderMatchReasons();
 
+		const priceRule = this.getPriceRule();
+
+		let cta = null;
+		let price = null;
+		let onClick = null;
+
 		if ( premiumDomain?.is_price_limit_exceeded ) {
-			return (
-				<SuggestionComponent
-					badges={ badges }
-					matchReasons={ matchReasons }
-					notice={ notice }
-					domain={ domainName }
-					tld={ tld.join( '.' ) }
-					cta={
-						<DomainSuggestionCTA.Primary
-							href="https://wordpress.com/help/contact"
-							label={ translate( 'Interested in this domain? Contact support' ) }
-							icon={ envelope }
-						>
-							{ translate( 'Contact support' ) }
-						</DomainSuggestionCTA.Primary>
-					}
-					price={
-						<DomainSuggestionPrice
-							salePrice={ productSaleCost }
-							price={ productCost }
-							renewPrice={ renewCost }
-						/>
-					}
+			cta = (
+				<DomainSuggestionCTA.Primary
+					href="https://wordpress.com/help/contact"
+					label={ translate( 'Interested in this domain? Contact support' ) }
+					icon={ envelope }
+				>
+					{ translate( 'Contact support' ) }
+				</DomainSuggestionCTA.Primary>
+			);
+
+			price = (
+				<DomainSuggestionPrice
+					salePrice={ productSaleCost }
+					price={ productCost }
+					renewPrice={ renewCost }
+				/>
+			);
+		} else {
+			onClick = this.onButtonClick;
+			price = ! isHundredYearPlanFlow( flowName ) && (
+				<DomainProductPrice
+					zeroCost={ zeroCost }
+					rule={ priceRule }
+					salePrice={ productSaleCost }
+					price={ productCost }
+					renewPrice={ renewCost }
 				/>
 			);
 		}
-
-		const priceRule = this.getPriceRule();
 
 		return (
 			<SuggestionComponent
 				badges={ badges }
 				uuid={ fullDomain }
 				domain={ domainName }
-				onClick={ this.onButtonClick }
 				isHighlighted={ isFeatured && this.isExactMatch() }
 				matchReasons={ matchReasons }
 				notice={ notice }
 				tld={ tld.join( '.' ) }
-				price={
-					! isHundredYearPlanFlow( flowName ) && (
-						<DomainProductPrice
-							zeroCost={ zeroCost }
-							rule={ priceRule }
-							salePrice={ productSaleCost }
-							price={ productCost }
-							renewPrice={ renewCost }
-						/>
-					)
-				}
+				onClick={ onClick }
+				price={ price }
+				cta={ cta }
 			/>
 		);
 	}

--- a/client/components/domain-search-v2/domain-search-results/index.jsx
+++ b/client/components/domain-search-v2/domain-search-results/index.jsx
@@ -1,19 +1,10 @@
-import {
-	DomainSuggestionsList,
-	DomainSuggestion,
-	DomainSuggestionBadge,
-	DomainSuggestionCTA,
-	DomainSuggestionPrice,
-} from '@automattic/domain-search';
-import { formatCurrency } from '@automattic/number-formatters';
+import { DomainSuggestionsList, DomainSuggestion } from '@automattic/domain-search';
 import { __experimentalVStack as VStack } from '@wordpress/components';
-import { envelope } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import { get, times } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import { parseMatchReasons } from 'calypso/components/domain-search-v2/domain-registration-suggestion/utility';
 import { isDomainMappingFree, isNextDomainFree } from 'calypso/lib/cart-values/cart-items';
 import { isSubdomain } from 'calypso/lib/domains';
 import { domainAvailability } from 'calypso/lib/domains/constants';
@@ -22,7 +13,6 @@ import { DESIGN_TYPE_STORE } from 'calypso/signup/constants';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getDesignType } from 'calypso/state/signup/steps/design-type/selectors';
 import DomainRegistrationSuggestion from '../domain-registration-suggestion';
-import PremiumBadge from '../domain-registration-suggestion/premium-badge';
 import DomainSkipSuggestion from '../domain-skip-suggestion';
 import FeaturedDomainSuggestions from '../featured-domain-suggestions';
 
@@ -73,7 +63,6 @@ class DomainSearchResults extends Component {
 			lastDomainSearched,
 			lastDomainTld,
 			selectedSite,
-			translate,
 			isDomainOnly,
 		} = this.props;
 		const suggestions = this.props.suggestions || [];
@@ -89,69 +78,6 @@ class DomainSearchResults extends Component {
 			TRANSFERRABLE_PREMIUM,
 			UNKNOWN,
 		} = domainAvailability;
-
-		const premiumDomain = this.props.premiumDomains[ lastDomainSearched ];
-
-		if ( premiumDomain?.is_price_limit_exceeded ) {
-			const [ domainName, ...tld ] = lastDomainSearched.split( '.' );
-
-			const currentUserCurrencyCode =
-				premiumDomain.currency_code || this.props.currentUserCurrencyCode;
-
-			let productSaleCost;
-
-			const badges = [];
-
-			if ( premiumDomain.sale_cost ) {
-				productSaleCost = formatCurrency( premiumDomain.sale_cost, currentUserCurrencyCode, {
-					stripZeros: true,
-				} );
-
-				const saleBadgeText = translate( 'Sale', {
-					comment: 'Shown next to a domain that has a special discounted sale price',
-				} );
-				badges.push(
-					<DomainSuggestionBadge key="sale" variation="warning">
-						{ saleBadgeText }
-					</DomainSuggestionBadge>
-				);
-			}
-
-			badges.push( <PremiumBadge key="premium" restrictedPremium /> );
-
-			const suggestion = this.props.suggestions.find(
-				( s ) => s.domain_name === lastDomainSearched
-			);
-
-			return (
-				<DomainSuggestion.Featured
-					badges={ badges }
-					domain={ domainName }
-					tld={ tld.join( '.' ) }
-					matchReasons={
-						this.props.hideMatchReasons
-							? undefined
-							: parseMatchReasons( lastDomainSearched, suggestion.match_reasons )
-					}
-					cta={
-						<DomainSuggestionCTA.Primary
-							href="https://wordpress.com/help/contact"
-							label={ translate( 'Interested in this domain? Contact support' ) }
-							icon={ envelope }
-						>
-							{ translate( 'Contact support' ) }
-						</DomainSuggestionCTA.Primary>
-					}
-					price={
-						<DomainSuggestionPrice
-							salePrice={ productSaleCost }
-							price={ premiumDomain.cost }
-							renewPrice={ premiumDomain.renew_cost }
-						/>
-					}
-				/>
-			);
-		}
 
 		const domain = get( availableDomain, 'domain_name', lastDomainSearched );
 
@@ -290,9 +216,7 @@ class DomainSearchResults extends Component {
 					! suggestion.isSubDomainSuggestion
 			);
 			const featuredSuggestions = suggestions.filter(
-				( suggestion ) =>
-					( suggestion.isRecommended || suggestion.isBestAlternative ) &&
-					! this.props.premiumDomains[ suggestion.domain_name ]?.is_price_limit_exceeded
+				( suggestion ) => suggestion.isRecommended || suggestion.isBestAlternative
 			);
 
 			featuredSuggestionElement = featuredSuggestions.length > 0 && (

--- a/client/components/domain-search-v2/featured-domain-suggestions/index.jsx
+++ b/client/components/domain-search-v2/featured-domain-suggestions/index.jsx
@@ -61,6 +61,10 @@ export class FeaturedDomainSuggestions extends Component {
 			return this.renderPlaceholders();
 		}
 
+		const featuredSuggestionsWithoutExactMatch = featuredSuggestions.filter(
+			( suggestion ) => suggestion.domain_name !== this.props.query
+		);
+
 		return (
 			<div className="featured-domain-suggestions-v2">
 				<div className="featured-domain-suggestions-v2__content">
@@ -69,6 +73,7 @@ export class FeaturedDomainSuggestions extends Component {
 							<DomainRegistrationSuggestion
 								suggestion={ suggestion }
 								isFeatured
+								isSingleFeaturedSuggestion={ featuredSuggestionsWithoutExactMatch.length === 1 }
 								railcarId={ this.props.railcarId + '-' + index }
 								isSignupStep={ this.props.isSignupStep }
 								uiPosition={ index }

--- a/packages/domain-search/src/components/domain-suggestion-price/index.tsx
+++ b/packages/domain-search/src/components/domain-suggestion-price/index.tsx
@@ -29,7 +29,8 @@ export const DomainSuggestionPrice = ( {
 	}
 
 	const alignment =
-		containerContext.alignment ?? ( containerContext.activeQuery === 'large' ? 'right' : 'left' );
+		containerContext.priceAlignment ??
+		( containerContext.activeQuery === 'large' ? 'right' : 'left' );
 
 	const getPriceSize = () => {
 		if ( containerContext.priceSize ) {

--- a/packages/domain-search/src/components/domain-suggestion/featured.skeleton.tsx
+++ b/packages/domain-search/src/components/domain-suggestion/featured.skeleton.tsx
@@ -17,10 +17,20 @@ interface SkeletonProps {
 	matchReasonsList?: React.ReactNode;
 	price: React.ReactNode;
 	cta: React.ReactNode;
+	isSingleFeaturedSuggestion?: boolean;
 }
 
 export const FeaturedSkeleton = forwardRef< HTMLDivElement, SkeletonProps >( ( props, ref ) => {
-	const { activeQuery, className, badges, title, matchReasonsList, price, cta } = props;
+	const {
+		activeQuery,
+		className,
+		badges,
+		title,
+		matchReasonsList,
+		price,
+		cta,
+		isSingleFeaturedSuggestion,
+	} = props;
 
 	const getContent = () => {
 		if ( activeQuery === 'large' ) {
@@ -37,6 +47,25 @@ export const FeaturedSkeleton = forwardRef< HTMLDivElement, SkeletonProps >( ( p
 								{ title }
 								{ matchReasonsList }
 							</VStack>
+						</VStack>
+						<VStack
+							spacing={ 6 }
+							alignment="right"
+							className="domain-suggestion-featured__price-info"
+						>
+							{ price }
+							{ cta }
+						</VStack>
+					</HStack>
+				);
+			}
+
+			if ( isSingleFeaturedSuggestion ) {
+				return (
+					<HStack spacing={ 6 } className="domain-suggestion-featured__content">
+						<VStack spacing={ 3 } style={ { justifyContent: 'center', height: '100%' } }>
+							{ badges }
+							{ title }
 						</VStack>
 						<VStack
 							spacing={ 6 }

--- a/packages/domain-search/src/components/domain-suggestion/featured.skeleton.tsx
+++ b/packages/domain-search/src/components/domain-suggestion/featured.skeleton.tsx
@@ -68,7 +68,7 @@ export const FeaturedSkeleton = forwardRef< HTMLDivElement, SkeletonProps >( ( p
 							{ title }
 						</VStack>
 						<VStack
-							spacing={ 6 }
+							spacing={ 5 }
 							alignment="right"
 							className="domain-suggestion-featured__price-info"
 						>

--- a/packages/domain-search/src/components/domain-suggestion/featured.tsx
+++ b/packages/domain-search/src/components/domain-suggestion/featured.tsx
@@ -21,6 +21,7 @@ type DomainSuggestionFeaturedProps = {
 	price: React.ReactNode;
 	isHighlighted?: boolean;
 	cta?: React.ReactNode;
+	isSingleFeaturedSuggestion?: boolean;
 } & Pick< ComponentProps< typeof DomainSuggestionCTA >, 'onClick' | 'disabled' >;
 
 const Featured = ( {
@@ -34,6 +35,7 @@ const Featured = ( {
 	onClick,
 	disabled,
 	cta,
+	isSingleFeaturedSuggestion,
 }: DomainSuggestionFeaturedProps ) => {
 	const { containerRef, activeQuery } = useDomainSuggestionContainer();
 
@@ -41,11 +43,17 @@ const Featured = ( {
 		() =>
 			( {
 				activeQuery,
-				alignment: ! matchReasons ? 'left' : undefined,
+				priceAlignment:
+					// eslint-disable-next-line no-nested-ternary
+					activeQuery === 'large' && isSingleFeaturedSuggestion
+						? 'right'
+						: ! matchReasons
+						? 'left'
+						: undefined,
 				priceSize: activeQuery === 'large' ? 20 : 18,
 				isFeatured: true,
 			} ) as const,
-		[ activeQuery, matchReasons ]
+		[ activeQuery, matchReasons, isSingleFeaturedSuggestion ]
 	);
 
 	const title = (
@@ -78,6 +86,7 @@ const Featured = ( {
 				cta={
 					cta ?? <DomainSuggestionCTA onClick={ onClick } disabled={ disabled } uuid={ uuid } />
 				}
+				isSingleFeaturedSuggestion={ isSingleFeaturedSuggestion }
 			/>
 		</DomainSuggestionContainerContext.Provider>
 	);

--- a/packages/domain-search/src/hooks/use-domain-suggestion-container.ts
+++ b/packages/domain-search/src/hooks/use-domain-suggestion-container.ts
@@ -12,7 +12,7 @@ export const useDomainSuggestionContainer = () => {
 
 interface DomainSuggestionContainerContextValue {
 	activeQuery: 'small' | 'large';
-	alignment?: 'left' | 'right';
+	priceAlignment?: 'left' | 'right';
 	priceSize?: number;
 	isFeatured?: boolean;
 }


### PR DESCRIPTION
Related to p1754062199047349/1753896225.846579-slack-C04H4NY6STW.

## Proposed Changes

As the title says, there are some queries that return a lone featured suggestion. There are some reasons why this might happen (check Slack thread).

In this case, we were rendering it like that:

<img width="1110" height="436" alt="image" src="https://github.com/user-attachments/assets/54c7c7bb-9823-454f-9feb-845af6addaa2" />

But that's bad because the price is disconnected from the CTA, and all other prices on the page are close to the CTA on the right. This PR changes it so it looks like this:

<img width="1087" height="381" alt="image" src="https://github.com/user-attachments/assets/4fbc2f78-f017-47ab-b530-2a19a614da94" />

Which matches the designs (check aiyAvhP2AQTQllMWHw99OI-fi-4858_19717).

## Testing Instructions

Search for `books` and verify you see the price to the right, next to the CTA (screenshot above.) Make sure the component is still responsive.

Search for `works.space` and verify you can transfer it as well as see a lone featured suggestion for `works.blog`:

<img width="1112" height="445" alt="image" src="https://github.com/user-attachments/assets/9946f3a4-e8f3-4b27-b663-c9f94063b143" />

Search for `work.online` and verify that the restricted premium is rendered outline (not related, but fixes this problem as well.)

<img width="1104" height="415" alt="image" src="https://github.com/user-attachments/assets/dd06291e-73d4-42f2-b3c1-e60f92478aad" />
