### PR TITLE
Domain Search Retrofit: Fix input box shadow rendering on Firefox

### DIFF
--- a/packages/domain-search/src/components/domain-search-controls/input.scss
+++ b/packages/domain-search/src/components/domain-search-controls/input.scss
@@ -3,6 +3,12 @@
 .domain-search-controls__input {
 	width: 100%;
 
+	@supports ( -moz-appearance: none ) {
+		// Force hardware acceleration and sub-pixel alignment on Firefox.
+		transform: translateZ( 0 );
+		will-change: transform;
+	}
+
 	.components-input-base {
 		border-radius: var( --domain-search-input-border-radius );
 	}


### PR DESCRIPTION
Closes DOMAINS-1567.

## Proposed Changes

Fixes the box shadow rendering on Firefox. Here's how it looks now:

<img width="978" height="362" alt="image" src="https://github.com/user-attachments/assets/53567d8b-1255-4f23-8db7-fc5a31901215" />

It's not perfect (i.e., not as thick) but at least now it follows the other input border renderings for other inputs in WPDS, without the strange thick border at the top:

<img width="912" height="137" alt="image" src="https://github.com/user-attachments/assets/02798a48-b607-49cd-a2c9-11ac145e4bee" />

## Testing Instructions

Enter any flow with the domain search input. Verify that the change only affects Firefox.

