### PR TITLE
Connect: clicking "create an account" logs you out first

### DIFF
--- a/client/login/wp-login/components/one-login-layout.tsx
+++ b/client/login/wp-login/components/one-login-layout.tsx
@@ -15,6 +15,9 @@ interface OneLoginLayoutProps {
 	isJetpack: boolean;
 	isFromAkismet: boolean;
 	children: React.ReactNode;
+	/**
+	 * `signupUrl` prop should merge with `getSignupLinkComponent` logic in `/client/block/login/index.js`, so we have a single source for this logic.
+	 */
 	signupUrl?: string;
 }
 

--- a/client/login/wp-login/components/one-login-layout.tsx
+++ b/client/login/wp-login/components/one-login-layout.tsx
@@ -1,10 +1,11 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Step } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
 import { getSignupUrl, pathWithLeadingSlash } from 'calypso/lib/login';
 import { useLoginContext } from 'calypso/login/login-context';
-import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import { useDispatch, useSelector } from 'calypso/state';
+import { redirectToLogout } from 'calypso/state/current-user/actions';
+import { isUserLoggedIn, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import { getCurrentQueryArguments } from 'calypso/state/selectors/get-current-query-arguments';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
@@ -28,23 +29,27 @@ const OneLoginLayout = ( {
 	const currentRoute = useSelector( getCurrentRoute );
 	const currentQuery = useSelector( getCurrentQueryArguments );
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
+	const isLoggedIn = useSelector( isUserLoggedIn );
+	const dispatch = useDispatch();
 	const { headingText, subHeadingText, subHeadingTextSecondary } = useLoginContext();
 
 	const SignUpLink = () => {
 		// use '?signup_url' if explicitly passed as URL query param
-		const signupUrl = signupUrlProp
+		const signupUrl: string = signupUrlProp
 			? window.location.origin + pathWithLeadingSlash( signupUrlProp )
 			: getSignupUrl( currentQuery, currentRoute, oauth2Client, locale );
 
+		const handleClick = ( event: React.MouseEvent< HTMLElement > ) => {
+			recordTracksEvent( 'calypso_login_sign_up_link_click', { origin: 'login-layout' } );
+
+			if ( isLoggedIn ) {
+				event.preventDefault();
+				dispatch( redirectToLogout( signupUrl ) );
+			}
+		};
+
 		return (
-			<Step.LinkButton
-				href={ signupUrl }
-				key="sign-up-link"
-				onClick={ () => {
-					recordTracksEvent( 'calypso_login_sign_up_link_click', { origin: 'login-layout' } );
-				} }
-				rel="external"
-			>
+			<Step.LinkButton href={ signupUrl } key="sign-up-link" onClick={ handleClick } rel="external">
 				{ translate( 'Create an account' ) }
 			</Step.LinkButton>
 		);


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-13983/woo-login-logged-in-wpcom-user-cant-switch-to-create-an-account-flow

Clicking "create an account" when on the continue as user page, doesn't actually log you out, and upon clicking, we arrive at the same page. 

<img width="915" height="658" alt="image" src="https://github.com/user-attachments/assets/d86062c5-2d56-43c6-9364-fdf4842f354d" />

## Proposed Changes

* Actually, log users first before redirecting to the sign up page.

## Testing Instructions


* Make sure you are logged in to WordPress.com
* Visit http://calypso.localhost:3000/log-in
* Click on **Create an account** from the header
* Confirm you are now on the create an account page
* Visit http://calypso.localhost:3000/log-in and see that you are logged out

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
