### PR TITLE
Add storage warning banner to the top of overview page

### DIFF
--- a/client/dashboard/app/queries/me-preferences.ts
+++ b/client/dashboard/app/queries/me-preferences.ts
@@ -5,7 +5,7 @@ import type { UserPreferences } from '../../data/me-preferences';
 
 const defaultValues: Required< UserPreferences > = {
 	'sites-view': {},
-	'some-string': '',
+	'hosting-dashboard-overview-storage-notice-dismissed': null,
 };
 
 // Returns all user preferences, without applying any defaults.
@@ -35,7 +35,7 @@ export const userPreferenceMutation = < P extends keyof UserPreferences >( prefe
 		mutationFn: ( data: Required< UserPreferences >[ P ] ) =>
 			updatePreferences( {
 				[ preferenceName ]: data,
-			} ),
+			} as Partial< UserPreferences > ),
 		onSuccess: ( newData ) => {
 			queryClient.setQueryData( rawUserPreferencesQuery().queryKey, ( oldData ) =>
 				oldData ? { ...oldData, ...newData } : newData

--- a/client/dashboard/app/queries/me-preferences.ts
+++ b/client/dashboard/app/queries/me-preferences.ts
@@ -5,7 +5,6 @@ import type { UserPreferences } from '../../data/me-preferences';
 
 const defaultValues: Required< UserPreferences > = {
 	'sites-view': {},
-	'hosting-dashboard-overview-storage-notice-dismissed': null,
 };
 
 // Returns all user preferences, without applying any defaults.

--- a/client/dashboard/app/queries/site-media-storage.ts
+++ b/client/dashboard/app/queries/site-media-storage.ts
@@ -1,35 +1,8 @@
 import { queryOptions } from '@tanstack/react-query';
-import filesize from 'filesize';
 import { fetchSiteMediaStorage } from '../../data/site-media-storage';
-
-const ALERT_PERCENT = 80;
 
 export const siteMediaStorageQuery = ( siteId: number ) =>
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'media-storage' ],
 		queryFn: () => fetchSiteMediaStorage( siteId ),
-		select: ( data ) => {
-			return {
-				...data,
-				extra: {
-					alertLevel: getAlertLevel( data.storage_used_bytes, data.max_storage_bytes ),
-					storageUsedDisplay: filesize( data.storage_used_bytes, { round: 0 } ),
-					maxStorageDisplay: filesize( data.max_storage_bytes, { round: 0 } ),
-				},
-			};
-		},
 	} );
-
-function getAlertLevel(
-	storageUsedBytes: number,
-	maxStorageBytes: number
-): 'none' | 'low' | 'exceeded' {
-	const storageUsagePercent = Math.round( ( ( storageUsedBytes / maxStorageBytes ) * 1000 ) / 10 );
-
-	if ( storageUsagePercent > 100 ) {
-		return 'exceeded';
-	} else if ( storageUsagePercent > ALERT_PERCENT ) {
-		return 'low';
-	}
-	return 'none';
-}

--- a/client/dashboard/app/queries/site-media-storage.ts
+++ b/client/dashboard/app/queries/site-media-storage.ts
@@ -1,8 +1,35 @@
 import { queryOptions } from '@tanstack/react-query';
+import filesize from 'filesize';
 import { fetchSiteMediaStorage } from '../../data/site-media-storage';
+
+const ALERT_PERCENT = 80;
 
 export const siteMediaStorageQuery = ( siteId: number ) =>
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'media-storage' ],
 		queryFn: () => fetchSiteMediaStorage( siteId ),
+		select: ( data ) => {
+			return {
+				...data,
+				extra: {
+					alertLevel: getAlertLevel( data.storage_used_bytes, data.max_storage_bytes ),
+					storageUsedDisplay: filesize( data.storage_used_bytes, { round: 0 } ),
+					maxStorageDisplay: filesize( data.max_storage_bytes, { round: 0 } ),
+				},
+			};
+		},
 	} );
+
+function getAlertLevel(
+	storageUsedBytes: number,
+	maxStorageBytes: number
+): 'none' | 'low' | 'exceeded' {
+	const storageUsagePercent = Math.round( ( ( storageUsedBytes / maxStorageBytes ) * 1000 ) / 10 );
+
+	if ( storageUsagePercent > 100 ) {
+		return 'exceeded';
+	} else if ( storageUsagePercent > ALERT_PERCENT ) {
+		return 'low';
+	}
+	return 'none';
+}

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -177,7 +177,10 @@ const siteOverviewRoute = createRoute( {
 			} );
 		}
 		// Ensure storage specifically is loaded because the warning notice can cause a layout shift
-		await queryClient.ensureQueryData( siteMediaStorageQuery( site.ID ) );
+		await Promise.all( [
+			queryClient.ensureQueryData( siteMediaStorageQuery( site.ID ) ),
+			queryClient.ensureQueryData( rawUserPreferencesQuery() ),
+		] );
 	},
 } ).lazy( () =>
 	import( '../sites/overview' ).then( ( d ) =>

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -161,8 +161,6 @@ const siteOverviewRoute = createRoute( {
 	path: '/',
 	loader: async ( { params: { siteSlug }, preload } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		// Ensure storage specifically is loaded because the warning notice can cause a layout shift
-		await queryClient.ensureQueryData( siteMediaStorageQuery( site.ID ) );
 		if ( preload ) {
 			Promise.all( [
 				queryClient.ensureQueryData( siteCurrentPlanQuery( site.ID ) ),
@@ -178,6 +176,8 @@ const siteOverviewRoute = createRoute( {
 				}
 			} );
 		}
+		// Ensure storage specifically is loaded because the warning notice can cause a layout shift
+		await queryClient.ensureQueryData( siteMediaStorageQuery( site.ID ) );
 	},
 } ).lazy( () =>
 	import( '../sites/overview' ).then( ( d ) =>

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -26,6 +26,7 @@ import { siteDefensiveModeSettingsQuery } from './queries/site-defensive-mode';
 import { siteDomainsQuery } from './queries/site-domains';
 import { siteJetpackModulesQuery } from './queries/site-jetpack-module';
 import { siteJetpackSettingsQuery } from './queries/site-jetpack-settings';
+import { siteMediaStorageQuery } from './queries/site-media-storage';
 import { sitePHPVersionQuery } from './queries/site-php-version';
 import { siteCurrentPlanQuery } from './queries/site-plans';
 import { sitePreviewLinksQuery } from './queries/site-preview-links';
@@ -160,6 +161,8 @@ const siteOverviewRoute = createRoute( {
 	path: '/',
 	loader: async ( { params: { siteSlug }, preload } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		// Ensure storage specifically is loaded because the warning notice can cause a layout shift
+		await queryClient.ensureQueryData( siteMediaStorageQuery( site.ID ) );
 		if ( preload ) {
 			Promise.all( [
 				queryClient.ensureQueryData( siteCurrentPlanQuery( site.ID ) ),

--- a/client/dashboard/components/notice/index.tsx
+++ b/client/dashboard/components/notice/index.tsx
@@ -6,6 +6,7 @@ import {
 	CardBody,
 	Icon,
 } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { info, published, error, closeSmall } from '@wordpress/icons';
 import clsx from 'clsx';
 import { forwardRef } from 'react';
@@ -70,6 +71,7 @@ function UnforwardedNotice(
 					</VStack>
 					{ !! onClose && (
 						<Button
+							aria-label={ __( 'Dismiss' ) }
 							className="dashboard-notice__close-button"
 							icon={ closeSmall }
 							onClick={ onClose }

--- a/client/dashboard/data/me-preferences.ts
+++ b/client/dashboard/data/me-preferences.ts
@@ -12,7 +12,7 @@ export type SitesViewPreferences = Partial< Omit< SitesView, 'type' | 'layout' >
 
 export interface UserPreferences {
 	'sites-view'?: SitesViewPreferences;
-	[ key: `hosting-dashboard-overview-storage-notice-dismissed-${ number }` ]: string | null; // Timestamp when the user dismissed the notice
+	[ key: `hosting-dashboard-overview-storage-notice-dismissed-${ number }` ]: string | undefined; // Timestamp when the user dismissed the notice
 }
 
 export async function fetchPreferences(): Promise< UserPreferences > {

--- a/client/dashboard/data/me-preferences.ts
+++ b/client/dashboard/data/me-preferences.ts
@@ -12,7 +12,7 @@ export type SitesViewPreferences = Partial< Omit< SitesView, 'type' | 'layout' >
 
 export interface UserPreferences {
 	'sites-view'?: SitesViewPreferences;
-	'some-string'?: string;
+	[ key: `hosting-dashboard-overview-storage-notice-dismissed-${ number }` ]: string | null; // Timestamp when the user dismissed the notice
 }
 
 export async function fetchPreferences(): Promise< UserPreferences > {

--- a/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
+++ b/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
@@ -1,4 +1,5 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { ExternalLink, __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import filesize from 'filesize';
 import { siteMediaStorageQuery } from '../../app/queries/site-media-storage';
@@ -31,14 +32,19 @@ export default function SiteStorageStat( { site }: { site: Site } ) {
 	}
 
 	return (
-		<Stat
-			density="high"
-			strapline={ __( 'Storage' ) }
-			metric={ filesize( mediaStorage.storage_used_bytes, { round: 0 } ) }
-			description={ filesize( mediaStorage.max_storage_bytes, { round: 0 } ) }
-			progressValue={ progressBarValue }
-			progressColor={ storageWarningColor }
-			progressLabel={ `${ storageUsagePercent }%` }
-		/>
+		<VStack spacing={ 2 }>
+			<Stat
+				density="high"
+				strapline={ __( 'Storage' ) }
+				metric={ filesize( mediaStorage.storage_used_bytes, { round: 0 } ) }
+				description={ filesize( mediaStorage.max_storage_bytes, { round: 0 } ) }
+				progressValue={ progressBarValue }
+				progressColor={ storageWarningColor }
+				progressLabel={ `${ storageUsagePercent }%` }
+			/>
+			{ alertLevel !== 'none' && (
+				<ExternalLink href={ `/add-ons/${ site.slug }` }>{ __( 'Add more storage' ) }</ExternalLink>
+			) }
+		</VStack>
 	);
 }

--- a/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
+++ b/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
@@ -1,24 +1,17 @@
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
-import filesize from 'filesize';
 import { siteMediaStorageQuery } from '../../app/queries/site-media-storage';
 import { Stat } from '../../components/stat';
 import type { Site } from '../../data/types';
 
 const MINIMUM_DISPLAYED_USAGE = 2.5;
 
-const ALERT_PERCENT = 80;
-
 export default function SiteStorageStat( { site }: { site: Site } ) {
-	const { data: mediaStorage, isLoading: isLoadingMediaStorage } = useQuery(
-		siteMediaStorageQuery( site.ID )
-	);
+	const { data: mediaStorage } = useSuspenseQuery( siteMediaStorageQuery( site.ID ) );
 
-	const storageUsagePercent = ! mediaStorage
-		? 0
-		: Math.round(
-				( ( mediaStorage.storage_used_bytes / mediaStorage.max_storage_bytes ) * 1000 ) / 10
-		  );
+	const storageUsagePercent = Math.round(
+		( ( mediaStorage.storage_used_bytes / mediaStorage.max_storage_bytes ) * 1000 ) / 10
+	);
 
 	// Ensure that the displayed usage is never fully empty to avoid a confusing UI.
 	const progressBarValue = Math.max(
@@ -27,9 +20,9 @@ export default function SiteStorageStat( { site }: { site: Site } ) {
 	);
 
 	let storageWarningColor = undefined;
-	if ( storageUsagePercent > 100 ) {
+	if ( mediaStorage.extra.alertLevel === 'exceeded' ) {
 		storageWarningColor = 'alert-red' as const;
-	} else if ( storageUsagePercent > ALERT_PERCENT ) {
+	} else if ( mediaStorage.extra.alertLevel === 'low' ) {
 		storageWarningColor = 'alert-yellow' as const;
 	}
 
@@ -37,12 +30,11 @@ export default function SiteStorageStat( { site }: { site: Site } ) {
 		<Stat
 			density="high"
 			strapline={ __( 'Storage' ) }
-			metric={ mediaStorage && filesize( mediaStorage.storage_used_bytes, { round: 0 } ) }
-			description={ mediaStorage && filesize( mediaStorage.max_storage_bytes, { round: 0 } ) }
+			metric={ mediaStorage.extra.storageUsedDisplay }
+			description={ mediaStorage.extra.maxStorageDisplay }
 			progressValue={ progressBarValue }
 			progressColor={ storageWarningColor }
 			progressLabel={ `${ storageUsagePercent }%` }
-			isLoading={ isLoadingMediaStorage }
 		/>
 	);
 }

--- a/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
+++ b/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
@@ -27,7 +27,7 @@ export default function SiteStorageStat( { site }: { site: Site } ) {
 	let storageWarningColor = undefined;
 	if ( alertLevel === 'exceeded' ) {
 		storageWarningColor = 'alert-red' as const;
-	} else if ( alertLevel === 'low' ) {
+	} else if ( alertLevel === 'warning' ) {
 		storageWarningColor = 'alert-yellow' as const;
 	}
 

--- a/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
+++ b/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
@@ -1,7 +1,9 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
+import filesize from 'filesize';
 import { siteMediaStorageQuery } from '../../app/queries/site-media-storage';
 import { Stat } from '../../components/stat';
+import { getStorageAlertLevel } from '../../utils/site-storage';
 import type { Site } from '../../data/types';
 
 const MINIMUM_DISPLAYED_USAGE = 2.5;
@@ -19,10 +21,12 @@ export default function SiteStorageStat( { site }: { site: Site } ) {
 		Math.min( storageUsagePercent, 100 )
 	);
 
+	const alertLevel = getStorageAlertLevel( mediaStorage );
+
 	let storageWarningColor = undefined;
-	if ( mediaStorage.extra.alertLevel === 'exceeded' ) {
+	if ( alertLevel === 'exceeded' ) {
 		storageWarningColor = 'alert-red' as const;
-	} else if ( mediaStorage.extra.alertLevel === 'low' ) {
+	} else if ( alertLevel === 'low' ) {
 		storageWarningColor = 'alert-yellow' as const;
 	}
 
@@ -30,8 +34,8 @@ export default function SiteStorageStat( { site }: { site: Site } ) {
 		<Stat
 			density="high"
 			strapline={ __( 'Storage' ) }
-			metric={ mediaStorage.extra.storageUsedDisplay }
-			description={ mediaStorage.extra.maxStorageDisplay }
+			metric={ filesize( mediaStorage.storage_used_bytes, { round: 0 } ) }
+			description={ filesize( mediaStorage.max_storage_bytes, { round: 0 } ) }
 			progressValue={ progressBarValue }
 			progressColor={ storageWarningColor }
 			progressLabel={ `${ storageUsagePercent }%` }

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -31,8 +31,9 @@ import SiteOverviewFields from '../overview-site-fields';
 import SitePreviewCard from '../overview-site-preview-card';
 import VisibilityCard from '../overview-visibility-card';
 import StagingSiteSyncDropdown from '../staging-site-sync-dropdown';
-import './style.scss';
+import { StorageWarningBanner } from './storage-warning-banner';
 import type { WPBreakpoint } from '@wordpress/compose/build-types/hooks/use-viewport-match';
+import './style.scss';
 
 const SPACING = {
 	DEFAULT: 6,
@@ -118,6 +119,7 @@ function SiteOverview( {
 			}
 		>
 			<VStack alignment="stretch" spacing={ isSmallViewport ? 5 : 10 }>
+				<StorageWarningBanner site={ site } />
 				<Grid { ...gridLayout } gap={ spacing }>
 					{ showSitePreview && <SitePreviewCard site={ site } /> }
 					<Grid columns={ 1 } rows={ 2 } gap={ spacing }>

--- a/client/dashboard/sites/overview/storage-warning-banner.tsx
+++ b/client/dashboard/sites/overview/storage-warning-banner.tsx
@@ -1,17 +1,15 @@
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { sprintf, __ } from '@wordpress/i18n';
+import filesize from 'filesize';
 import { userPreferenceQuery, userPreferenceMutation } from '../../app/queries/me-preferences';
 import { siteMediaStorageQuery } from '../../app/queries/site-media-storage';
 import Notice from '../../components/notice';
 import UpsellCTAButton from '../../components/upsell-cta-button';
+import { getStorageAlertLevel } from '../../utils/site-storage';
 import type { Site } from '../../data/types';
 
 export function StorageWarningBanner( { site }: { site: Site } ) {
-	const {
-		data: {
-			extra: { alertLevel, storageUsedDisplay, maxStorageDisplay },
-		},
-	} = useSuspenseQuery( siteMediaStorageQuery( site.ID ) );
+	const { data: mediaStorage } = useSuspenseQuery( siteMediaStorageQuery( site.ID ) );
 	const { data: isDismissedPersisted } = useSuspenseQuery(
 		userPreferenceQuery( `hosting-dashboard-overview-storage-notice-dismissed-${ site.ID }` )
 	);
@@ -21,6 +19,8 @@ export function StorageWarningBanner( { site }: { site: Site } ) {
 
 	// Optimistically hide the banner assuming the preference will get saved.
 	const isDismissed = isDismissedPersisted || isDismissing;
+
+	const alertLevel = getStorageAlertLevel( mediaStorage );
 
 	if ( alertLevel === 'none' || ( alertLevel === 'low' && isDismissed ) ) {
 		return null;
@@ -57,8 +57,8 @@ export function StorageWarningBanner( { site }: { site: Site } ) {
 					'%(used)s of your %(available)s storage limit has been used. Upgrade to continue storing media, plugins, themes, and backups.'
 				),
 				{
-					used: storageUsedDisplay,
-					available: maxStorageDisplay,
+					used: filesize( mediaStorage.storage_used_bytes, { round: 0 } ),
+					available: filesize( mediaStorage.max_storage_bytes, { round: 0 } ),
 				}
 			) }
 		</Notice>

--- a/client/dashboard/sites/overview/storage-warning-banner.tsx
+++ b/client/dashboard/sites/overview/storage-warning-banner.tsx
@@ -22,12 +22,12 @@ export function StorageWarningBanner( { site }: { site: Site } ) {
 
 	const alertLevel = getStorageAlertLevel( mediaStorage );
 
-	if ( alertLevel === 'none' || ( alertLevel === 'low' && isDismissed ) ) {
+	if ( alertLevel === 'none' || ( alertLevel === 'warning' && isDismissed ) ) {
 		return null;
 	}
 
 	const noticeProps =
-		alertLevel === 'low'
+		alertLevel === 'warning'
 			? {
 					variant: 'warning' as const,
 					isDismissible: true,
@@ -40,7 +40,7 @@ export function StorageWarningBanner( { site }: { site: Site } ) {
 					title: __( 'Your site is out of storage' ),
 			  };
 
-	const tracksId = alertLevel === 'low' ? 'storage-warning-low' : 'storage-warning-exceeded';
+	const tracksId = alertLevel === 'warning' ? 'storage-warning-low' : 'storage-warning-exceeded';
 
 	return (
 		<Notice

--- a/client/dashboard/sites/overview/storage-warning-banner.tsx
+++ b/client/dashboard/sites/overview/storage-warning-banner.tsx
@@ -1,0 +1,66 @@
+import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
+import { sprintf, __ } from '@wordpress/i18n';
+import { userPreferenceQuery, userPreferenceMutation } from '../../app/queries/me-preferences';
+import { siteMediaStorageQuery } from '../../app/queries/site-media-storage';
+import Notice from '../../components/notice';
+import UpsellCTAButton from '../../components/upsell-cta-button';
+import type { Site } from '../../data/types';
+
+export function StorageWarningBanner( { site }: { site: Site } ) {
+	const {
+		data: {
+			extra: { alertLevel, storageUsedDisplay, maxStorageDisplay },
+		},
+	} = useSuspenseQuery( siteMediaStorageQuery( site.ID ) );
+	const { data: isDismissedPersisted } = useSuspenseQuery(
+		userPreferenceQuery( `hosting-dashboard-overview-storage-notice-dismissed-${ site.ID }` )
+	);
+	const { mutate: updateDismissed, isPending: isDismissing } = useMutation(
+		userPreferenceMutation( `hosting-dashboard-overview-storage-notice-dismissed-${ site.ID }` )
+	);
+
+	// Optimistically hide the banner assuming the preference will get saved.
+	const isDismissed = isDismissedPersisted || isDismissing;
+
+	if ( alertLevel === 'none' || ( alertLevel === 'low' && isDismissed ) ) {
+		return null;
+	}
+
+	const noticeProps =
+		alertLevel === 'low'
+			? {
+					variant: 'warning' as const,
+					isDismissible: true,
+					title: __( 'Your site is low on storage' ),
+					onClose: () => updateDismissed( new Date().toISOString() ),
+			  }
+			: {
+					variant: 'error' as const,
+					isDismissible: false,
+					title: __( 'Your site is out of storage' ),
+			  };
+
+	const tracksId = alertLevel === 'low' ? 'storage-warning-low' : 'storage-warning-exceeded';
+
+	return (
+		<Notice
+			{ ...noticeProps }
+			actions={
+				<UpsellCTAButton variant="primary" tracksId={ tracksId } href={ `/add-ons/${ site.slug }` }>
+					{ __( 'Add more storage' ) }
+				</UpsellCTAButton>
+			}
+		>
+			{ sprintf(
+				// translators: "used" and "available" amounts data including a unit, e.g. "2.03 MB" or "1.5 GB".
+				__(
+					'%(used)s of your %(available)s storage limit has been used. Upgrade to continue storing media, plugins, themes, and backups.'
+				),
+				{
+					used: storageUsedDisplay,
+					available: maxStorageDisplay,
+				}
+			) }
+		</Notice>
+	);
+}

--- a/client/dashboard/sites/overview/test/storage-warning-banner.tsx
+++ b/client/dashboard/sites/overview/test/storage-warning-banner.tsx
@@ -1,0 +1,116 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import { StorageWarningBanner } from '../storage-warning-banner';
+
+interface TestOptions {
+	storage_used_bytes: number;
+	max_storage_bytes: number;
+	isDismissed?: boolean | string;
+}
+
+const siteId = 123;
+
+// Only mocks site and settings fields that are necessary for the tests.
+// Feel free to add more fields as they are needed.
+function mockTestEndpoints( options: TestOptions ) {
+	const { storage_used_bytes, max_storage_bytes, isDismissed = false } = options;
+
+	const mediaStorage = {
+		storage_used_bytes,
+		max_storage_bytes,
+		max_storage_bytes_from_addons: 0,
+	};
+
+	const preferences = {
+		[ `hosting-dashboard-overview-storage-notice-dismissed-${ siteId }` ]:
+			typeof isDismissed === 'string' ? isDismissed : isDismissed && 'today',
+	};
+
+	const scope = nock( 'https://public-api.wordpress.com' )
+		.get( `/rest/v1.1/sites/${ siteId }/media-storage` )
+		.query( true )
+		.reply( 200, mediaStorage )
+		.get( '/rest/v1.1/me/preferences' )
+		.query( true )
+		.reply( 200, { calypso_preferences: preferences } )
+		.post( '/rest/v1.1/me/preferences' )
+		.reply( 200, ( _uri, body ) => body );
+
+	return { mediaStorage, scope };
+}
+
+function renderTestBanner() {
+	// The only site field used by the banner is ID.
+	const testSite = { ID: siteId };
+	render( <StorageWarningBanner site={ testSite as any } /> ); // eslint-disable-line @typescript-eslint/no-explicit-any
+}
+
+afterEach( () => nock.cleanAll() );
+
+test( 'no banner when storage is not low', async () => {
+	mockTestEndpoints( {
+		storage_used_bytes: 100,
+		max_storage_bytes: 5000,
+	} );
+
+	renderTestBanner();
+
+	await waitFor( () => expect( screen.queryByText( 'Loading...' ) ).not.toBeInTheDocument() );
+	await waitFor( () => expect( screen.queryByText( /storage/i ) ).not.toBeInTheDocument() );
+} );
+
+test( 'no banner when storage is low and banner dismissed', async () => {
+	mockTestEndpoints( {
+		storage_used_bytes: 900,
+		max_storage_bytes: 1000,
+		isDismissed: true,
+	} );
+
+	renderTestBanner();
+
+	await waitFor( () => expect( screen.queryByText( 'Loading...' ) ).not.toBeInTheDocument() );
+	await waitFor( () => expect( screen.queryByText( /storage/i ) ).not.toBeInTheDocument() );
+} );
+
+test( 'banner can not be dismissed when storage is exceeded', async () => {
+	mockTestEndpoints( {
+		storage_used_bytes: 5001,
+		max_storage_bytes: 5000,
+	} );
+
+	renderTestBanner();
+
+	await waitFor( () => expect( screen.queryByText( 'Loading...' ) ).not.toBeInTheDocument() );
+	await waitFor( () =>
+		expect( screen.queryByText( 'Your site is out of storage' ) ).toBeInTheDocument()
+	);
+
+	expect( screen.queryByRole( 'button', { name: 'Dismiss' } ) ).not.toBeInTheDocument();
+} );
+
+test( 'banner can be dismissed when storage is over 80%', async () => {
+	const user = userEvent.setup();
+	mockTestEndpoints( {
+		storage_used_bytes: 850,
+		max_storage_bytes: 1000,
+		isDismissed: false,
+	} );
+
+	renderTestBanner();
+
+	await waitFor( () => expect( screen.queryByText( 'Loading...' ) ).not.toBeInTheDocument() );
+	await waitFor( () =>
+		expect( screen.queryByText( 'Your site is low on storage' ) ).toBeInTheDocument()
+	);
+
+	await user.click( screen.getByRole( 'button', { name: 'Dismiss' } ) );
+
+	await waitFor( () =>
+		expect( screen.queryByText( 'Your site is low on storage' ) ).not.toBeInTheDocument()
+	);
+} );

--- a/client/dashboard/sites/overview/test/storage-warning-banner.tsx
+++ b/client/dashboard/sites/overview/test/storage-warning-banner.tsx
@@ -44,37 +44,36 @@ function mockTestEndpoints( options: TestOptions ) {
 	return { mediaStorage, scope };
 }
 
-async function renderTestBanner() {
+function renderTestBanner() {
 	// The only site field used by the banner is ID.
 	const testSite = { ID: siteId };
-	render( <StorageWarningBanner site={ testSite as any } /> ); // eslint-disable-line @typescript-eslint/no-explicit-any
-
-	await waitFor( () => expect( screen.queryByTestId( 'loading' ) ).not.toBeInTheDocument() );
+	return render( <StorageWarningBanner site={ testSite as any } /> ); // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 afterEach( () => nock.cleanAll() );
 
-test( 'no banner when storage is not low', async () => {
-	mockTestEndpoints( {
-		storage_used_bytes: 100,
-		max_storage_bytes: 5000,
-	} );
-
-	await renderTestBanner();
-
-	await waitFor( () => expect( screen.queryByText( /storage/i ) ).not.toBeInTheDocument() );
-} );
-
-test( 'no banner when storage is low and banner dismissed', async () => {
+test( 'warning banner when storage is low, and no banner when storage is not low', async () => {
 	mockTestEndpoints( {
 		storage_used_bytes: 900,
 		max_storage_bytes: 1000,
-		isDismissed: true,
 	} );
 
-	await renderTestBanner();
+	const { queryClient } = renderTestBanner();
 
-	await waitFor( () => expect( screen.queryByText( /storage/i ) ).not.toBeInTheDocument() );
+	await waitFor( () =>
+		expect( screen.queryByText( 'Your site is low on storage' ) ).toBeInTheDocument()
+	);
+
+	mockTestEndpoints( {
+		storage_used_bytes: 100,
+		max_storage_bytes: 1000,
+	} );
+
+	queryClient.invalidateQueries();
+
+	await waitFor( () =>
+		expect( screen.queryByText( /Upgrade to continue storing media/ ) ).not.toBeInTheDocument()
+	);
 } );
 
 test( 'banner can not be dismissed when storage is exceeded', async () => {
@@ -83,7 +82,7 @@ test( 'banner can not be dismissed when storage is exceeded', async () => {
 		max_storage_bytes: 5000,
 	} );
 
-	await renderTestBanner();
+	renderTestBanner();
 
 	await waitFor( () =>
 		expect( screen.queryByText( 'Your site is out of storage' ) ).toBeInTheDocument()
@@ -100,7 +99,7 @@ test( 'banner can be dismissed when storage is over 80%', async () => {
 		isDismissed: false,
 	} );
 
-	await renderTestBanner();
+	renderTestBanner();
 
 	await waitFor( () =>
 		expect( screen.queryByText( 'Your site is low on storage' ) ).toBeInTheDocument()

--- a/client/dashboard/sites/overview/test/storage-warning-banner.tsx
+++ b/client/dashboard/sites/overview/test/storage-warning-banner.tsx
@@ -44,10 +44,12 @@ function mockTestEndpoints( options: TestOptions ) {
 	return { mediaStorage, scope };
 }
 
-function renderTestBanner() {
+async function renderTestBanner() {
 	// The only site field used by the banner is ID.
 	const testSite = { ID: siteId };
 	render( <StorageWarningBanner site={ testSite as any } /> ); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+	await waitFor( () => expect( screen.queryByTestId( 'loading' ) ).not.toBeInTheDocument() );
 }
 
 afterEach( () => nock.cleanAll() );
@@ -58,9 +60,8 @@ test( 'no banner when storage is not low', async () => {
 		max_storage_bytes: 5000,
 	} );
 
-	renderTestBanner();
+	await renderTestBanner();
 
-	await waitFor( () => expect( screen.queryByText( 'Loading...' ) ).not.toBeInTheDocument() );
 	await waitFor( () => expect( screen.queryByText( /storage/i ) ).not.toBeInTheDocument() );
 } );
 
@@ -71,9 +72,8 @@ test( 'no banner when storage is low and banner dismissed', async () => {
 		isDismissed: true,
 	} );
 
-	renderTestBanner();
+	await renderTestBanner();
 
-	await waitFor( () => expect( screen.queryByText( 'Loading...' ) ).not.toBeInTheDocument() );
 	await waitFor( () => expect( screen.queryByText( /storage/i ) ).not.toBeInTheDocument() );
 } );
 
@@ -83,9 +83,8 @@ test( 'banner can not be dismissed when storage is exceeded', async () => {
 		max_storage_bytes: 5000,
 	} );
 
-	renderTestBanner();
+	await renderTestBanner();
 
-	await waitFor( () => expect( screen.queryByText( 'Loading...' ) ).not.toBeInTheDocument() );
 	await waitFor( () =>
 		expect( screen.queryByText( 'Your site is out of storage' ) ).toBeInTheDocument()
 	);
@@ -101,9 +100,8 @@ test( 'banner can be dismissed when storage is over 80%', async () => {
 		isDismissed: false,
 	} );
 
-	renderTestBanner();
+	await renderTestBanner();
 
-	await waitFor( () => expect( screen.queryByText( 'Loading...' ) ).not.toBeInTheDocument() );
 	await waitFor( () =>
 		expect( screen.queryByText( 'Your site is low on storage' ) ).toBeInTheDocument()
 	);

--- a/client/dashboard/sites/settings-site-visibility/test/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/test/index.tsx
@@ -1,24 +1,11 @@
 /**
  * @jest-environment jsdom
  */
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { RouterProvider, createRouter, createRootRoute } from '@tanstack/react-router';
-import { render as testingLibraryRender, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
+import { render } from '../../../test-utils';
 import SiteVisibilitySettings from '../index';
-
-function render( ui: React.ReactElement ) {
-	const queryClient = new QueryClient();
-	const router = createRouter( {
-		routeTree: createRootRoute( { component: () => ui } ),
-	} );
-	return testingLibraryRender(
-		<QueryClientProvider client={ queryClient }>
-			<RouterProvider router={ router } context={ { config: { basePath: '/' } } } />
-		</QueryClientProvider>
-	);
-}
 
 interface TestSiteOptions {
 	blog_public: 0 | 1 | -1;

--- a/client/dashboard/test-utils.tsx
+++ b/client/dashboard/test-utils.tsx
@@ -1,0 +1,22 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { RouterProvider, createRouter, createRootRoute } from '@tanstack/react-router';
+import { render as testingLibraryRender } from '@testing-library/react';
+import { Suspense } from 'react';
+
+export function render( ui: React.ReactElement ) {
+	const queryClient = new QueryClient( {
+		defaultOptions: {
+			queries: { retry: false },
+		},
+	} );
+	const router = createRouter( {
+		routeTree: createRootRoute( { component: () => ui } ),
+	} );
+	return testingLibraryRender(
+		<QueryClientProvider client={ queryClient }>
+			<Suspense fallback={ <div>Loading...</div> }>
+				<RouterProvider router={ router } context={ { config: { basePath: '/' } } } />
+			</Suspense>
+		</QueryClientProvider>
+	);
+}

--- a/client/dashboard/test-utils.tsx
+++ b/client/dashboard/test-utils.tsx
@@ -9,14 +9,20 @@ export function render( ui: React.ReactElement ) {
 			queries: { retry: false },
 		},
 	} );
+	const Component = () => ui;
 	const router = createRouter( {
-		routeTree: createRootRoute( { component: () => ui } ),
+		routeTree: createRootRoute( {
+			pendingMs: 0,
+			component: () => (
+				<Suspense fallback={ <div data-testid="loading" /> }>
+					<Component />
+				</Suspense>
+			),
+		} ),
 	} );
 	return testingLibraryRender(
 		<QueryClientProvider client={ queryClient }>
-			<Suspense fallback={ <div>Loading...</div> }>
-				<RouterProvider router={ router } context={ { config: { basePath: '/' } } } />
-			</Suspense>
+			<RouterProvider router={ router } context={ { config: { basePath: '/' } } } />
 		</QueryClientProvider>
 	);
 }

--- a/client/dashboard/test-utils.tsx
+++ b/client/dashboard/test-utils.tsx
@@ -3,14 +3,10 @@ import { RouterProvider, createRouter, createRootRoute } from '@tanstack/react-r
 import { render as testingLibraryRender } from '@testing-library/react';
 import { Suspense } from 'react';
 
-export function render( ui: React.ReactElement ) {
-	const queryClient = new QueryClient( {
-		defaultOptions: {
-			queries: { retry: false },
-		},
-	} );
+function createTestRouter( ui: React.ReactElement ) {
 	const Component = () => ui;
-	const router = createRouter( {
+
+	return createRouter( {
 		routeTree: createRootRoute( {
 			pendingMs: 0,
 			component: () => (
@@ -20,9 +16,30 @@ export function render( ui: React.ReactElement ) {
 			),
 		} ),
 	} );
-	return testingLibraryRender(
+}
+
+type RenderResult = ReturnType< typeof testingLibraryRender > & {
+	router: ReturnType< typeof createTestRouter >;
+	queryClient: QueryClient;
+};
+
+export function render( ui: React.ReactElement ): RenderResult {
+	const queryClient = new QueryClient( {
+		defaultOptions: {
+			queries: { retry: false },
+		},
+	} );
+	const router = createTestRouter( ui );
+
+	const testingLibraryResult = testingLibraryRender(
 		<QueryClientProvider client={ queryClient }>
 			<RouterProvider router={ router } context={ { config: { basePath: '/' } } } />
 		</QueryClientProvider>
 	);
+
+	return {
+		...testingLibraryResult,
+		router,
+		queryClient,
+	};
 }

--- a/client/dashboard/utils/site-storage.ts
+++ b/client/dashboard/utils/site-storage.ts
@@ -1,0 +1,19 @@
+import type { SiteMediaStorage } from '../data/types';
+
+const ALERT_PERCENT = 80;
+
+export function getStorageAlertLevel( {
+	storage_used_bytes,
+	max_storage_bytes,
+}: SiteMediaStorage ): 'none' | 'low' | 'exceeded' {
+	const storageUsagePercent = Math.round(
+		( ( storage_used_bytes / max_storage_bytes ) * 1000 ) / 10
+	);
+
+	if ( storageUsagePercent > 100 ) {
+		return 'exceeded';
+	} else if ( storageUsagePercent > ALERT_PERCENT ) {
+		return 'low';
+	}
+	return 'none';
+}

--- a/client/dashboard/utils/site-storage.ts
+++ b/client/dashboard/utils/site-storage.ts
@@ -5,13 +5,13 @@ const ALERT_FRACTION = 0.8;
 export function getStorageAlertLevel( {
 	storage_used_bytes,
 	max_storage_bytes,
-}: SiteMediaStorage ): 'none' | 'low' | 'exceeded' {
+}: SiteMediaStorage ): 'none' | 'warning' | 'exceeded' {
 	const storageFraction = storage_used_bytes / max_storage_bytes;
 
 	if ( storageFraction > 1 ) {
 		return 'exceeded';
 	} else if ( storageFraction > ALERT_FRACTION ) {
-		return 'low';
+		return 'warning';
 	}
 	return 'none';
 }

--- a/client/dashboard/utils/site-storage.ts
+++ b/client/dashboard/utils/site-storage.ts
@@ -1,18 +1,16 @@
 import type { SiteMediaStorage } from '../data/types';
 
-const ALERT_PERCENT = 80;
+const ALERT_FRACTION = 0.8;
 
 export function getStorageAlertLevel( {
 	storage_used_bytes,
 	max_storage_bytes,
 }: SiteMediaStorage ): 'none' | 'low' | 'exceeded' {
-	const storageUsagePercent = Math.round(
-		( ( storage_used_bytes / max_storage_bytes ) * 1000 ) / 10
-	);
+	const storageFraction = storage_used_bytes / max_storage_bytes;
 
-	if ( storageUsagePercent > 100 ) {
+	if ( storageFraction > 1 ) {
 		return 'exceeded';
-	} else if ( storageUsagePercent > ALERT_PERCENT ) {
+	} else if ( storageFraction > ALERT_FRACTION ) {
 		return 'low';
 	}
 	return 'none';


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTDASH-138

## Proposed Changes

* Render `<StorageWarningBanner>` at top of overview page
* Ensure all necessary data is loaded before rendering the overview
  * Prevents layout shift
* "Low storage" warnings can be dismissed
* Move logic that decides what counts as "low" storage into a shared function
* Tidy up: remove the `'some-string'` placeholder from the `UserPreferences` type. It was only there to check the types were working nicely.
* Accessible label for `<Notice>` components dismiss button
* Unit tests

**Site has used over 80%**

<img width="2830" height="1240" alt="CleanShot 2025-08-04 at 16 31 22@2x" src="https://github.com/user-attachments/assets/dad7b173-0161-46ec-b799-1c4673e279ea" />

**Site has used over 100%**

<img width="2786" height="1196" alt="CleanShot 2025-08-04 at 16 32 20@2x" src="https://github.com/user-attachments/assets/6a6e04ac-e499-4778-a37d-dea15d4054c9" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Pretty sure this design supersedes this figma QOBjujZah0UlGDDdLKZhzi-fi-7256_103340 which shows the link in the plan card. I can't find the P2 now, but we discussed the warning for low-storage needing to be more prominent because when it gets too low backups can start failing. CC @matt-west 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I found the easiest way to test this was simply to hardcode the new `getStorageAlertLevel()` function to return the value I wanted.

The easiest way to clear any old preferences is to use the dev menu in v1

<img width="2382" height="395" alt="CleanShot 2025-08-04 at 16 30 06@2x" src="https://github.com/user-attachments/assets/0cbc00a9-415f-4f80-bc14-aa30e11aa583" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?