### PR TITLE
Site overview v2: implement Plan card remaining cases

### DIFF
--- a/client/dashboard/sites/overview-plan-card/index.tsx
+++ b/client/dashboard/sites/overview-plan-card/index.tsx
@@ -111,7 +111,11 @@ function WpcomPlanCard( {
 			icon={ wordpress }
 			heading={ getSitePlanDisplayName( site ) }
 			description={ getCardDescription( site, purchase ) }
-			externalLink={ `/plans/${ site.slug }` }
+			externalLink={
+				site.plan?.is_free
+					? `/plans/${ site.slug }`
+					: `/purchases/subscriptions/${ site.slug }/${ purchase?.ID }`
+			}
 			tracksId="plan"
 			isLoading={ isLoading }
 			bottom={ <SitePlanStats site={ site } /> }

--- a/client/dashboard/sites/overview-plan-card/index.tsx
+++ b/client/dashboard/sites/overview-plan-card/index.tsx
@@ -9,6 +9,7 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
+import { siteByIdQuery } from '../../app/queries/site';
 import { siteCurrentPlanQuery } from '../../app/queries/site-plans';
 import { sitePurchaseQuery } from '../../app/queries/site-purchases';
 import { DotcomPlans } from '../../data/constants';
@@ -38,6 +39,15 @@ function getJetpackProductsDescription( products: typeof JETPACK_PRODUCTS ) {
 	}
 
 	return `${ products.map( ( product ) => product.label ).join( ', ' ) }.`;
+}
+
+function SitePlanStats( { site }: { site: Site } ) {
+	return (
+		<VStack spacing={ 4 }>
+			<SiteStorageStat site={ site } />
+			<SiteBandwidthStat site={ site } />
+		</VStack>
+	);
 }
 
 function JetpackPlanCard( {
@@ -101,15 +111,34 @@ function WpcomPlanCard( {
 			icon={ wordpress }
 			heading={ getSitePlanDisplayName( site ) }
 			description={ getCardDescription( site, purchase ) }
-			link={ site.plan?.is_free ? undefined : '/v2/me/billing/active-subscriptions' }
+			externalLink={ `/plans/${ site.slug }` }
 			tracksId="plan"
 			isLoading={ isLoading }
-			bottom={
-				<VStack spacing={ 4 }>
-					<SiteStorageStat site={ site } />
-					<SiteBandwidthStat site={ site } />
-				</VStack>
-			}
+			bottom={ <SitePlanStats site={ site } /> }
+		/>
+	);
+}
+
+function WpcomStagingSitePlanCard( { site }: { site: Site } ) {
+	const { data: productionSite, isLoading: isLoadingProductionSite } = useQuery(
+		siteByIdQuery( site.options?.wpcom_production_blog_id ?? 0 )
+	);
+
+	const description = sprintf(
+		/* translators: %s: the site plan name */
+		__( 'Included with your %s plan.' ),
+		productionSite?.plan?.product_name_short
+	);
+
+	return (
+		<OverviewCard
+			title={ __( 'Plan' ) }
+			icon={ wordpress }
+			heading={ getSitePlanDisplayName( site ) }
+			description={ description }
+			tracksId="plan"
+			isLoading={ isLoadingProductionSite }
+			bottom={ <SitePlanStats site={ site } /> }
 		/>
 	);
 }
@@ -124,12 +153,7 @@ function AgencyPlanCard( { site, isLoading }: { site: Site; isLoading: boolean }
 			externalLink={ `https://agencies.automattic.com/sites/overview/${ site.slug }` }
 			tracksId="plan"
 			isLoading={ isLoading }
-			bottom={
-				<VStack spacing={ 4 }>
-					<SiteStorageStat site={ site } />
-					<SiteBandwidthStat site={ site } />
-				</VStack>
-			}
+			bottom={ <SitePlanStats site={ site } /> }
 		/>
 	);
 }
@@ -153,6 +177,10 @@ export default function PlanCard( { site }: { site: Site } ) {
 				isLoading={ isLoadingPlan || isLoadingPurchase }
 			/>
 		);
+	}
+
+	if ( site.is_wpcom_staging_site ) {
+		return <WpcomStagingSitePlanCard site={ site } />;
 	}
 
 	return (

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -409,10 +409,6 @@ export function Status( { site }: { site: Site } ) {
 
 export function Plan( { site }: { site: Site } ) {
 	const planName = getSitePlanDisplayName( site );
-	if ( site.is_wpcom_staging_site ) {
-		// translator: this is the label of a staging site.
-		return __( 'Staging' );
-	}
 
 	if ( isSelfHostedJetpackConnected( site ) ) {
 		if ( ! site.jetpack ) {

--- a/client/dashboard/sites/site-fields/test/plan.tsx
+++ b/client/dashboard/sites/site-fields/test/plan.tsx
@@ -15,12 +15,12 @@ function render( ui: React.ReactElement ) {
 }
 
 describe( '<Plan>', () => {
-	test( 'for staging sites, it renders "Staging"', () => {
+	test( 'for staging sites, it renders "Staging site"', () => {
 		const site = {
 			is_wpcom_staging_site: true,
 		} as Site;
 		const { container } = render( <Plan site={ site } /> );
-		expect( container.textContent ).toBe( 'Staging' );
+		expect( container.textContent ).toBe( 'Staging site' );
 	} );
 
 	test( 'for self-hosted, Jetpack-connected sites, active Jetpack plugin, it renders the Jetpack logo and plan name', () => {

--- a/client/dashboard/utils/site-plan.ts
+++ b/client/dashboard/utils/site-plan.ts
@@ -75,6 +75,10 @@ export function getJetpackProductsForSite( site: Site ) {
 }
 
 export function getSitePlanDisplayName( site: Site ) {
+	if ( site.is_wpcom_staging_site ) {
+		return __( 'Staging site' );
+	}
+
 	if ( site.plan?.product_slug === DotcomPlans.JETPACK_FREE ) {
 		const products = getJetpackProductsForSite( site );
 		if ( products.length === 1 ) {


### PR DESCRIPTION
Fixes DOTDASH-114

## Proposed Changes

This PR implements the remaining of the Site Overview v2's Plan Card 

1. Add a link to `/plans/:slug`, even for Free sites:

<img width="307" height="143" alt="image" src="https://github.com/user-attachments/assets/588a9553-807c-45fc-8db8-1568fa681b6e" />

2. Implement the card for Staging sites. I don't think the card should link anywhere:

<img width="330" height="156" alt="image" src="https://github.com/user-attachments/assets/31ff2ee8-a4fa-447a-bd5d-219a780d60de" />

I am also proposing that we use the same label `Staging site` in the Status column in Site List for consistency, so that we can use the same function. I hope this makes more sense cc: @matt-west (currently it is just `Staging`):

Before

<img width="663" height="119" alt="image" src="https://github.com/user-attachments/assets/9dd6564f-47d9-44ac-a448-2d3d981f4310" />


After

<img width="623" height="139" alt="image" src="https://github.com/user-attachments/assets/e1976662-6db4-4531-9435-cadbd4a1ea48" />


## Testing Instructions

Test the cases above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
