### PR TITLE
Staging sites: don't show domain-related actions

### DIFF
--- a/client/dashboard/sites/overview-domains-card/index.tsx
+++ b/client/dashboard/sites/overview-domains-card/index.tsx
@@ -122,6 +122,10 @@ export default function DomainsCard( {
 	const { data: sitePlan } = useQuery( siteCurrentPlanQuery( site.ID ) );
 	const { data: siteDomains } = useQuery( siteDomainsQuery( site.ID ) );
 
+	if ( site.is_wpcom_staging_site ) {
+		return null;
+	}
+
 	if ( ! sitePlan || ! siteDomains ) {
 		return <CalloutSkeleton />;
 	}

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -192,42 +192,60 @@ export function PrivacyForm( {
 								form={ visibilityForm }
 								onChange={ handleChange }
 							/>
-							{ formData.visibility === 'public' && isPrimaryDomainStaging && (
-								<Notice
-									variant="warning"
-									density="medium"
-									actions={
-										hasNonWpcomDomain ? (
-											<Button variant="secondary" href={ `/domains/manage/${ site.slug }` }>
-												{ __( 'Manage domains' ) }
-											</Button>
-										) : (
-											<Button
-												variant="secondary"
-												href={ addQueryArgs( `/domains/add/${ site.slug }`, {
-													redirect_to: window.location.pathname,
-												} ) }
-											>
-												{ __( 'Add new domain' ) }
-											</Button>
-										)
-									}
-								>
-									{ createInterpolateElement(
-										__(
-											/* translators: <domain /> is a placeholder for the site's domain name. */
-											'Your site’s current primary domain is <domain />. This domain is intended for temporary use and will not be indexed by search engines. To ensure your site can be indexed, please register or connect a custom primary domain.'
-										),
-										{
-											domain: (
-												<strong style={ { overflowWrap: 'anywhere' } }>
-													{ primaryDomain?.domain }
-												</strong>
+							{ formData.visibility === 'public' &&
+								isPrimaryDomainStaging &&
+								( site.is_wpcom_staging_site ? (
+									<Notice variant="warning" density="medium">
+										{ createInterpolateElement(
+											__(
+												/* translators: <domain /> is a placeholder for the site's domain name. */
+												'Your site’s current primary domain is <domain />. This domain is intended for temporary use and will not be indexed by search engines.'
 											),
+											{
+												domain: (
+													<strong style={ { overflowWrap: 'anywhere' } }>
+														{ primaryDomain?.domain }
+													</strong>
+												),
+											}
+										) }
+									</Notice>
+								) : (
+									<Notice
+										variant="warning"
+										density="medium"
+										actions={
+											hasNonWpcomDomain ? (
+												<Button variant="secondary" href={ `/domains/manage/${ site.slug }` }>
+													{ __( 'Manage domains' ) }
+												</Button>
+											) : (
+												<Button
+													variant="secondary"
+													href={ addQueryArgs( `/domains/add/${ site.slug }`, {
+														redirect_to: window.location.pathname,
+													} ) }
+												>
+													{ __( 'Add new domain' ) }
+												</Button>
+											)
 										}
-									) }
-								</Notice>
-							) }
+									>
+										{ createInterpolateElement(
+											__(
+												/* translators: <domain /> is a placeholder for the site's domain name. */
+												'Your site’s current primary domain is <domain />. This domain is intended for temporary use and will not be indexed by search engines. To ensure your site can be indexed, please register or connect a custom primary domain.'
+											),
+											{
+												domain: (
+													<strong style={ { overflowWrap: 'anywhere' } }>
+														{ primaryDomain?.domain }
+													</strong>
+												),
+											}
+										) }
+									</Notice>
+								) ) }
 							<DataForm< PrivacyFormData & { isPrimaryDomainStaging: boolean } >
 								data={ { ...formData, isPrimaryDomainStaging } }
 								fields={ robotFields }

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -196,18 +196,8 @@ export function PrivacyForm( {
 								isPrimaryDomainStaging &&
 								( site.is_wpcom_staging_site ? (
 									<Notice variant="warning" density="medium">
-										{ createInterpolateElement(
-											__(
-												/* translators: <domain /> is a placeholder for the site's domain name. */
-												'Your site’s current primary domain is <domain />. This domain is intended for temporary use and will not be indexed by search engines.'
-											),
-											{
-												domain: (
-													<strong style={ { overflowWrap: 'anywhere' } }>
-														{ primaryDomain?.domain }
-													</strong>
-												),
-											}
+										{ __(
+											'Staging sites are intended for testing purposes and will not be indexed by search engines.'
 										) }
 									</Notice>
 								) : (

--- a/client/dashboard/sites/settings-site-visibility/test/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/test/index.tsx
@@ -466,7 +466,7 @@ describe( '<SiteVisibilitySettings>', () => {
 			await waitFor( () => {
 				expect( screen.getByRole( 'radio', { name: 'Public' } ) ).toBeChecked();
 				expect(
-					screen.getByText( /This domain is intended for temporary use/ )
+					screen.getByText( /Staging sites are intended for testing purposes/ )
 				).toBeInTheDocument();
 			} );
 

--- a/client/dashboard/sites/settings-site-visibility/test/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/test/index.tsx
@@ -24,6 +24,7 @@ interface TestSiteOptions {
 	blog_public: 0 | 1 | -1;
 	wpcom_public_coming_soon: 0 | 1;
 	wpcom_data_sharing_opt_out: boolean;
+	is_wpcom_staging_site?: boolean;
 	domains?: string[];
 	primary_domain?: string;
 }
@@ -38,6 +39,7 @@ function mockTestSite( options: TestSiteOptions ) {
 		blog_public,
 		wpcom_public_coming_soon,
 		wpcom_data_sharing_opt_out,
+		is_wpcom_staging_site,
 		domains = [ siteSlug ],
 		primary_domain = options.domains?.[ 0 ] || siteSlug,
 	} = options;
@@ -56,6 +58,7 @@ function mockTestSite( options: TestSiteOptions ) {
 		ID: siteId,
 		slug: primary_domain,
 		launch_status: 'launched',
+		is_wpcom_staging_site,
 	};
 
 	const settings = {
@@ -446,6 +449,32 @@ describe( '<SiteVisibilitySettings>', () => {
 				'href',
 				expect.stringMatching( /^\/domains\/manage\/[^/]+.wpcomstaging.com/ )
 			);
+		} );
+
+		test( 'staging site warning shows no domain management buttons', async () => {
+			mockTestSite( {
+				blog_public: 1,
+				wpcom_public_coming_soon: 0,
+				wpcom_data_sharing_opt_out: false,
+				is_wpcom_staging_site: true,
+				domains: [ 'staging-site.wpcomstaging.com' ],
+				primary_domain: 'staging-site.wpcomstaging.com',
+			} );
+
+			render( <SiteVisibilitySettings siteSlug="staging-site.wpcomstaging.com" /> );
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'radio', { name: 'Public' } ) ).toBeChecked();
+				expect(
+					screen.getByText( /This domain is intended for temporary use/ )
+				).toBeInTheDocument();
+			} );
+
+			const domainButton = screen.queryByRole( 'link', {
+				name: /domain/,
+			} );
+
+			expect( domainButton ).not.toBeInTheDocument();
 		} );
 
 		test( 'checkboxes disabled for wpcomstaging sites', async () => {


### PR DESCRIPTION
## Proposed Changes

This PR prevents domain-related actions from showing in a staging site's overview and visibility settings:

#### Site Overview

Before

<img width="1374" height="303" alt="image" src="https://github.com/user-attachments/assets/f371b684-e3b6-43d4-8578-dada81865c52" />

After

<img width="1367" height="291" alt="image" src="https://github.com/user-attachments/assets/f0b4e878-b566-43de-b380-3fff20f11cb1" />

#### Site Visibility Settings

|Before|After|
|-|-|
|<img width="674" height="609" alt="image" src="https://github.com/user-attachments/assets/7a62f483-03c0-4b66-b7ae-4635a3da85d0" />|<img width="692" height="623" alt="image" src="https://github.com/user-attachments/assets/1c37e052-a117-4a5e-8070-8d4f6a430e7a" />|


## Why are these changes being made?

Domain-related routes are blocked for staging sites. See the redirections: https://github.com/search?q=repo%3AAutomattic%2Fwp-calypso%20stagingSiteNotSupportedRedirect&type=code

## Testing Instructions

Test the scenarios above with a staging site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
