### PR TITLE
A8C Components: Export validated controls

### DIFF
--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -69,3 +69,6 @@ export { WooLogo } from './logos/woo-logo';
 export { WordPressLogo } from './logos/wordpress-logo';
 export { WooCommerceWooLogo } from './logos/woocommerce-woo-logo';
 export { GravatarTextLogo } from './logos/gravatar-text-logo';
+
+// Validated form controls
+export * from './validated-form-controls';

--- a/packages/components/src/validated-form-controls/index.ts
+++ b/packages/components/src/validated-form-controls/index.ts
@@ -1,0 +1,33 @@
+// Core components
+export { ControlWithError } from './control-with-error';
+
+// Validated form controls
+export { ValidatedCheckboxControl } from './components/checkbox-control';
+export { ValidatedComboboxControl } from './components/combobox-control';
+export { ValidatedCustomSelectControl } from './components/custom-select-control';
+export { ValidatedInputControl } from './components/input-control';
+export { ValidatedNumberControl } from './components/number-control';
+export { ValidatedRadioControl } from './components/radio-control';
+export { ValidatedRangeControl } from './components/range-control';
+export { ValidatedSelectControl } from './components/select-control';
+export { ValidatedTextControl } from './components/text-control';
+export { ValidatedTextareaControl } from './components/textarea-control';
+export { ValidatedToggleControl } from './components/toggle-control';
+export { ValidatedToggleGroupControl } from './components/toggle-group-control';
+
+// Types
+export type {
+	ValidatedControlProps,
+	CheckboxControlProps,
+	ComboboxControlProps,
+	CustomSelectControlProps,
+	InputControlProps,
+	NumberControlProps,
+	RadioControlProps,
+	RangeControlProps,
+	SelectControlProps,
+	TextControlProps,
+	TextareaControlProps,
+	ToggleControlProps,
+	ToggleGroupControlProps,
+} from './components/types';


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
