### PR TITLE
Allow editing of VAT details

### DIFF
--- a/client/me/purchases/vat-info/types.ts
+++ b/client/me/purchases/vat-info/types.ts
@@ -10,12 +10,14 @@ export interface VatFormData {
 export type VatField = Field< VatFormData > & {
 	isDisabled?: boolean;
 	isVatAlreadySet?: boolean;
+	canUserEdit?: boolean;
 	taxName?: string;
 };
 
 export type VatNormalizedField = NormalizedField< VatFormData > & {
 	isDisabled?: boolean;
 	isVatAlreadySet?: boolean;
+	canUserEdit?: boolean;
 	taxName?: string;
 };
 

--- a/client/me/purchases/vat-info/vat-form.tsx
+++ b/client/me/purchases/vat-info/vat-form.tsx
@@ -51,25 +51,27 @@ function VatIdControl( { data, field, onChange }: VatFormControlProps ) {
 	const { getValue, id, isDisabled, isVatAlreadySet, canUserEdit, label, taxName } = field;
 	const { country } = data;
 
-	const vatIdHelp = translate(
-		/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
-		'To change your %(taxName)s ID, {{contactSupportLink}}please contact support{{/contactSupportLink}}.',
-		{
-			args: { taxName: taxName ?? translate( 'VAT', { textOnly: true } ) },
-			components: {
-				contactSupportLink: (
-					<a
-						target="_blank"
-						href={ CALYPSO_CONTACT }
-						rel="noreferrer"
-						onClick={ () => {
-							dispatch( recordTracksEvent( 'calypso_vat_details_support_click' ) );
-						} }
-					/>
-				),
-			},
-		}
-	);
+	const vatIdHelp =
+		! canUserEdit &&
+		translate(
+			/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
+			'To change your %(taxName)s ID, {{contactSupportLink}}please contact support{{/contactSupportLink}}.',
+			{
+				args: { taxName: taxName ?? translate( 'VAT', { textOnly: true } ) },
+				components: {
+					contactSupportLink: (
+						<a
+							target="_blank"
+							href={ CALYPSO_CONTACT }
+							rel="noreferrer"
+							onClick={ () => {
+								dispatch( recordTracksEvent( 'calypso_vat_details_support_click' ) );
+							} }
+						/>
+					),
+				},
+			}
+		);
 
 	return (
 		<InputControl

--- a/client/me/purchases/vat-info/vat-form.tsx
+++ b/client/me/purchases/vat-info/vat-form.tsx
@@ -106,7 +106,6 @@ export default function VatForm() {
 
 	const { isLoading, isUpdateSuccessful, isUpdating, setVatDetails, vatDetails, updateError } =
 		useVatDetails();
-
 	const countryCodes = useDataFormCountryCodes();
 
 	const formData = useMemo( () => {

--- a/client/me/purchases/vat-info/vat-form.tsx
+++ b/client/me/purchases/vat-info/vat-form.tsx
@@ -25,7 +25,7 @@ import type { VatField, VatFormControlProps, VatFormData } from './types';
 function VatSelectControl( { data, field, onChange }: VatFormControlProps ) {
 	const translate = useTranslate();
 
-	const { elements, getValue, id, label, isDisabled, isVatAlreadySet } = field;
+	const { elements, getValue, id, label, isDisabled, isVatAlreadySet, canUserEdit } = field;
 
 	const options =
 		elements?.length === 0
@@ -35,7 +35,7 @@ function VatSelectControl( { data, field, onChange }: VatFormControlProps ) {
 		<SelectControl
 			__next40pxDefaultSize
 			__nextHasNoMarginBottom
-			disabled={ isDisabled || isVatAlreadySet || elements?.length === 0 }
+			disabled={ isDisabled || ( isVatAlreadySet && ! canUserEdit ) || elements?.length === 0 }
 			label={ label }
 			value={ getValue( { item: data } ) }
 			onChange={ ( value ) => onChange( { [ id ]: value } ) }
@@ -48,7 +48,7 @@ function VatIdControl( { data, field, onChange }: VatFormControlProps ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const { getValue, id, isDisabled, isVatAlreadySet, label, taxName } = field;
+	const { getValue, id, isDisabled, isVatAlreadySet, canUserEdit, label, taxName } = field;
 	const { country } = data;
 
 	const vatIdHelp = translate(
@@ -74,7 +74,7 @@ function VatIdControl( { data, field, onChange }: VatFormControlProps ) {
 	return (
 		<InputControl
 			__next40pxDefaultSize
-			disabled={ isDisabled || isVatAlreadySet }
+			disabled={ isDisabled || ( isVatAlreadySet && ! canUserEdit ) }
 			help={ isVatAlreadySet && vatIdHelp }
 			label={ label }
 			onChange={ ( value ) => onChange( { [ id ]: value } ) }
@@ -106,6 +106,7 @@ export default function VatForm() {
 
 	const { isLoading, isUpdateSuccessful, isUpdating, setVatDetails, vatDetails, updateError } =
 		useVatDetails();
+
 	const countryCodes = useDataFormCountryCodes();
 
 	const formData = useMemo( () => {
@@ -129,6 +130,7 @@ export default function VatForm() {
 
 	const isVatAlreadySet = !! vatDetails.id;
 	const isDisabled = isLoading || isUpdating;
+	const canUserEdit = vatDetails.can_user_edit ?? false;
 
 	const fields: VatField[] = [
 		{
@@ -137,6 +139,7 @@ export default function VatForm() {
 			id: 'country',
 			isDisabled,
 			isVatAlreadySet,
+			canUserEdit,
 			label: translate( 'Country' ),
 		},
 		{
@@ -144,6 +147,7 @@ export default function VatForm() {
 			id: 'id',
 			isDisabled,
 			isVatAlreadySet,
+			canUserEdit,
 			label: translate( 'VAT ID' ),
 			taxName,
 		},

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -458,6 +458,7 @@ export interface VatDetails {
 	name?: string | null;
 	address?: string | null;
 	isForBusiness?: boolean | null;
+	can_user_edit?: boolean | false;
 }
 
 /*


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of SHILL-943

## Proposed Changes

* Allow editing of VAT details

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To utilize support for modification of VAT details by the user via the public API.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this patch. A12s can point the public API to their sandbox to enable store sandbox mode (be sure to also enable writes).
* Visit the [VAT Details](http://calypso.localhost:3000/me/purchases/vat-details) page.
* Add VAT Details if you don't have any already set. For fake VAT numbers to use while testing, see [the VIES API docs](https://viesapi.eu/test-vies-api/). Click "Validate and save" and confirm the values are saved.
* If this is your first time with VAT details in the system, you should be able to modify them once. Modify the VAT number (and possibly country), click "Validate and save" and confirm the values are saved.
* There are a maximum of 2 changes, and so at this point, you should not be able to modify the VAT details.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
