### PR TITLE
Update site plan display name logic

### DIFF
--- a/client/dashboard/data/site.ts
+++ b/client/dashboard/data/site.ts
@@ -55,6 +55,7 @@ export interface SitePlan {
 	product_name_short: string;
 	expired: boolean;
 	is_free: boolean;
+	license_key: string;
 	billing_period: 'Yearly' | 'Monthly';
 	features: {
 		active: string[];

--- a/client/dashboard/utils/site-plan.ts
+++ b/client/dashboard/utils/site-plan.ts
@@ -79,7 +79,12 @@ export function getSitePlanDisplayName( site: Site ) {
 		return __( 'Staging site' );
 	}
 
-	if ( site.plan?.product_slug === DotcomPlans.JETPACK_FREE ) {
+	const plan = site.plan;
+	if ( ! plan ) {
+		return '';
+	}
+
+	if ( plan.product_slug === DotcomPlans.JETPACK_FREE ) {
 		const products = getJetpackProductsForSite( site );
 		if ( products.length === 1 ) {
 			return products[ 0 ].label;
@@ -89,5 +94,11 @@ export function getSitePlanDisplayName( site: Site ) {
 		}
 	}
 
-	return site.plan?.product_name || site.plan?.product_name_short || '';
+	// Display the short name for WP.com plans.
+	// Determine if the plan is a WP.com plan by checking if the license key is empty.
+	if ( ! plan.license_key ) {
+		return plan.product_name_short;
+	}
+
+	return plan.product_name || plan.product_name_short;
 }


### PR DESCRIPTION
Ref p1754037620026149-slack-CRWCHQGUB

## Proposed Changes

This PR updates the plan display name so that WP.com plans are displayed with their short names.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Polish.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Ensure that WP.com plans are displayed with their short names
* Ensure that non-WP.com plans are displayed with their full names

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?