### PR TITLE
Site overview v2: ensure card descriptions end with period

### DIFF
--- a/client/dashboard/sites/overview-agency-site-share-card/index.tsx
+++ b/client/dashboard/sites/overview-agency-site-share-card/index.tsx
@@ -13,7 +13,7 @@ export default function AgencySiteShareCard( { site }: { site: Site } ) {
 		<OverviewCard
 			icon={ link }
 			heading={ heading }
-			description={ __( 'Collaborators with the link can view your site' ) }
+			description={ __( 'Collaborators with the link can view your site.' ) }
 			link={ `/sites/${ site.slug }/settings/site-visibility` }
 			title={ __( 'Share' ) }
 			tracksId="agency-site-share"

--- a/client/dashboard/sites/overview-backup-card/index.tsx
+++ b/client/dashboard/sites/overview-backup-card/index.tsx
@@ -38,7 +38,7 @@ function BackupCardContent( { site }: { site: Site } ) {
 			<OverviewCard
 				{ ...CARD_PROPS }
 				heading={ __( 'No backups yet' ) }
-				description={ __( 'Your first backup will be ready soon' ) }
+				description={ __( 'Your first backup will be ready soon.' ) }
 				externalLink={ getBackupUrl( site ) }
 			/>
 		);
@@ -63,7 +63,7 @@ export default function BackupCard( { site }: { site: Site } ) {
 			featureIcon={ CARD_PROPS.icon }
 			tracksFeatureId={ CARD_PROPS.tracksId }
 			upsellHeading={ __( 'Back up your site' ) }
-			upsellDescription={ __( 'Get back online quickly with one-click restores' ) }
+			upsellDescription={ __( 'Get back online quickly with one-click restores.' ) }
 			upsellExternalLink={ getBackupUrl( site ) }
 		>
 			<BackupCardContent site={ site } />

--- a/client/dashboard/sites/overview-plan-card/index.tsx
+++ b/client/dashboard/sites/overview-plan-card/index.tsx
@@ -153,7 +153,7 @@ function AgencyPlanCard( { site, isLoading }: { site: Site; isLoading: boolean }
 			title={ __( 'Development license' ) }
 			icon={ wordpress }
 			heading={ getSitePlanDisplayName( site ) }
-			description={ __( 'Managed by Automattic for Agencies' ) }
+			description={ __( 'Managed by Automattic for Agencies.' ) }
 			externalLink={ `https://agencies.automattic.com/sites/overview/${ site.slug }` }
 			tracksId="plan"
 			isLoading={ isLoading }

--- a/client/dashboard/sites/overview-scan-card/index.tsx
+++ b/client/dashboard/sites/overview-scan-card/index.tsx
@@ -34,7 +34,7 @@ function ScanCardWithThreats( { site, scan }: { site: Site; scan: SiteScan } ) {
 		<OverviewCard
 			{ ...CARD_PROPS }
 			heading={ description }
-			description={ __( 'Auto fixes are available' ) }
+			description={ __( 'Auto fixes are available.' ) }
 			externalLink={ getScanURL( site ) }
 			intent="error"
 		/>
@@ -48,7 +48,7 @@ function ScanCardNoThreats( { site, scan }: { site: Site; scan: SiteScan } ) {
 	if ( lastScanDate ) {
 		description = sprintf(
 			/* translators: %s: time since last scan */
-			__( 'Scanned %s' ),
+			__( 'Scanned %s.' ),
 			lastScanDate
 		);
 	}

--- a/client/dashboard/sites/overview-visibility-card/index.tsx
+++ b/client/dashboard/sites/overview-visibility-card/index.tsx
@@ -58,7 +58,7 @@ function VisibilityCardUnlaunched( { site }: { site: Site } ) {
 				  }
 				: {
 						heading: __( 'Coming soon' ),
-						description: __( 'Finish setting up your site' ),
+						description: __( 'Finish setting up your site.' ),
 						externalLink: `/home/${ site.slug }`,
 				  } ) }
 			progress={ {
@@ -79,7 +79,7 @@ function VisibilityCardComingSoon( { site }: { site: Site } ) {
 			heading={ __( 'Coming soon' ) }
 			description={
 				site.is_wpcom_staging_site
-					? __( 'Visitors will see a coming soon page' )
+					? __( 'Visitors will see a coming soon page.' )
 					: __( 'Ready to go public?' )
 			}
 			link={ getVisibilityURL( site ) }
@@ -93,7 +93,7 @@ function VisibilityCardPrivate( { site }: { site: Site } ) {
 			{ ...CARD_PROPS }
 			icon={ lockOutline }
 			heading={ __( 'Private' ) }
-			description={ __( 'Only invited users can view your site' ) }
+			description={ __( 'Only invited users can view your site.' ) }
 			link={ getVisibilityURL( site ) }
 		/>
 	);
@@ -101,8 +101,8 @@ function VisibilityCardPrivate( { site }: { site: Site } ) {
 
 function VisibilityCardPublic( { site }: { site: Site } ) {
 	const description = site.is_wpcom_staging_site
-		? __( 'Anyone can view your staging site' )
-		: __( 'Anyone can view your site' );
+		? __( 'Anyone can view your staging site.' )
+		: __( 'Anyone can view your site.' );
 
 	return (
 		<OverviewCard


### PR DESCRIPTION
Resolves p1753935125453589-slack-C08JZTRS6NA

## Proposed Changes

This PR appends full stops to description in Overview Card for consistency, as discussed in the Slack convo above.

### Visibility card

|<img width="329" height="151" alt="image" src="https://github.com/user-attachments/assets/ea0f6644-043d-4970-9323-de500808ed45" />|<img width="327" height="150" alt="image" src="https://github.com/user-attachments/assets/f10277e3-e809-422f-9482-2543cb6d12e1" />|
|-|-|
|<img width="326" height="148" alt="image" src="https://github.com/user-attachments/assets/d184ac6a-5dee-4022-8236-0975c0e3c28b" />|<img width="327" height="152" alt="image" src="https://github.com/user-attachments/assets/11ce6bff-254a-41e1-bca6-fb449d35ec70" />|
|<img width="325" height="148" alt="image" src="https://github.com/user-attachments/assets/dd8a34e4-d4a1-4552-9ed1-b61aee74f87e" />||

### Agency site card

|<img width="327" height="152" alt="image" src="https://github.com/user-attachments/assets/93bf7d93-176e-4523-8487-46ec5c86d6cf" />|
|-|

### Backup card

|<img width="327" height="151" alt="image" src="https://github.com/user-attachments/assets/c62c2176-1b7d-4e94-9d20-d5355d8dcb2b" />|<img width="325" height="150" alt="image" src="https://github.com/user-attachments/assets/ce4acf3e-2c7c-433e-9bac-74277d5b3349" />|
|-|-|

### Scan card

|<img width="326" height="148" alt="image" src="https://github.com/user-attachments/assets/24925724-dbd4-441c-8e15-6e5b4b9c17d3" />|<img width="326" height="152" alt="image" src="https://github.com/user-attachments/assets/eb040fc9-0434-480c-b422-7c956ffe442c" />|
|-|-|

### Plan card

|<img width="328" height="148" alt="image" src="https://github.com/user-attachments/assets/c0e464e5-3815-4ac5-8caf-a00c4a30e5e4" />|
|-|

## Why are these changes being made?

Consistency.

## Testing instructions

You can just check the code changes; the images are for translators 😄 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?