### PR TITLE
Site Overview: Introduce Sync button

### DIFF
--- a/client/dashboard/app/queries/site-staging-sites.ts
+++ b/client/dashboard/app/queries/site-staging-sites.ts
@@ -3,6 +3,7 @@ import {
 	createStagingSite,
 	deleteStagingSite,
 	fetchStagingSiteOf,
+	fetchStagingSiteSyncState,
 } from '../../data/site-staging-site';
 import { queryClient } from '../query-client';
 
@@ -31,4 +32,10 @@ export const stagingSiteDeleteMutation = ( stagingSiteId: number, productionSite
 		onSuccess: () => {
 			queryClient.setQueryData( isDeletingStagingSiteQuery( stagingSiteId ).queryKey, true );
 		},
+	} );
+
+export const stagingSiteSyncStateQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'staging-site-sync-state' ],
+		queryFn: () => fetchStagingSiteSyncState( siteId ),
 	} );

--- a/client/dashboard/data/site-staging-site.ts
+++ b/client/dashboard/data/site-staging-site.ts
@@ -7,6 +7,37 @@ export interface StagingSite {
 	user_has_permission: boolean;
 }
 
+export type StagingSiteSyncDirection = 'pull' | 'push';
+
+export type StagingSiteSyncStateOptions =
+	| 'sqls'
+	| 'themes'
+	| 'plugins'
+	| 'uploads'
+	| 'roots'
+	| 'contents';
+
+export type StagingSiteSyncStatus =
+	| 'pending'
+	| 'backing_up'
+	| 'restoring'
+	| 'completed'
+	| 'failed'
+	| 'allow_retry';
+
+export interface StagingSiteSyncState {
+	direction: StagingSiteSyncDirection;
+	options: StagingSiteSyncStateOptions[];
+	production_blog_id: number;
+	staging_blog_id: number;
+	status: StagingSiteSyncStatus;
+	started_at: number;
+	updated_at: number;
+	completed_at: number;
+	restore_id: number;
+	last_restore_id: number;
+}
+
 export async function createStagingSite( siteId: number ) {
 	return wpcom.req.post( {
 		path: `/sites/${ siteId }/staging-site`,
@@ -27,6 +58,13 @@ export async function fetchStagingSiteOf(
 ): Promise< Array< StagingSite > > {
 	return wpcom.req.get( {
 		path: `/sites/${ productionSiteId }/staging-site`,
+		apiNamespace: 'wpcom/v2',
+	} );
+}
+
+export async function fetchStagingSiteSyncState( siteId: number ) {
+	return wpcom.req.get( {
+		path: `/sites/${ siteId }/staging-site/sync-state`,
 		apiNamespace: 'wpcom/v2',
 	} );
 }

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -22,5 +22,6 @@ export type * from './site-profiler';
 export type * from './site-purchases';
 export type * from './site-reset';
 export type * from './site-settings';
+export type * from './site-staging-site';
 export type * from './site-stats';
 export type * from './site-users';

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import {
 	__experimentalDivider as Divider,
@@ -29,6 +30,7 @@ import SiteActionMenu from '../overview-site-action-menu';
 import SiteOverviewFields from '../overview-site-fields';
 import SitePreviewCard from '../overview-site-preview-card';
 import VisibilityCard from '../overview-visibility-card';
+import StagingSiteSyncDropdown from '../staging-site-sync-dropdown';
 import './style.scss';
 import type { WPBreakpoint } from '@wordpress/compose/build-types/hooks/use-viewport-match';
 
@@ -95,6 +97,9 @@ function SiteOverview( {
 						actions={
 							site.options?.admin_url && (
 								<>
+									{ isEnabled( 'hosting/staging-sites-redesign' ) && (
+										<StagingSiteSyncDropdown siteSlug={ siteSlug } />
+									) }
 									<Button
 										__next40pxDefaultSize
 										variant="primary"

--- a/client/dashboard/sites/site/environment-switcher.tsx
+++ b/client/dashboard/sites/site/environment-switcher.tsx
@@ -15,7 +15,7 @@ import { siteByIdQuery } from '../../app/queries/site';
 import { stagingSiteCreateMutation } from '../../app/queries/site-staging-sites';
 import { production, staging } from '../../components/icons';
 import RouterLinkMenuItem from '../../components/router-link-menu-item';
-import { getStagingSiteId } from '../../utils/site-staging-site';
+import { hasStagingSite } from '../../utils/site-staging-site';
 import { canManageSite, canCreateStagingSite } from '../features';
 import type { Site } from '../../data/types';
 
@@ -134,7 +134,7 @@ const EnvironmentSwitcher = ( { site }: { site: Site } ) => {
 			<Dropdown
 				renderToggle={ ( { onToggle } ) => {
 					const canToggle =
-						( otherEnvironment === 'staging' && !! getStagingSiteId( site ) ) ||
+						hasStagingSite( site ) ||
 						( otherEnvironmentSite && canManageSite( otherEnvironmentSite ) );
 
 					return (

--- a/client/dashboard/sites/site/environment-switcher.tsx
+++ b/client/dashboard/sites/site/environment-switcher.tsx
@@ -15,6 +15,7 @@ import { siteByIdQuery } from '../../app/queries/site';
 import { stagingSiteCreateMutation } from '../../app/queries/site-staging-sites';
 import { production, staging } from '../../components/icons';
 import RouterLinkMenuItem from '../../components/router-link-menu-item';
+import { getStagingSiteId } from '../../utils/site-staging-site';
 import { canManageSite, canCreateStagingSite } from '../features';
 import type { Site } from '../../data/types';
 
@@ -118,9 +119,6 @@ const EnvironmentSwitcherDropdown = ( {
 };
 
 const EnvironmentSwitcher = ( { site }: { site: Site } ) => {
-	const hasStagingSite =
-		! site.is_wpcom_staging_site && site?.options?.wpcom_staging_blog_ids?.length;
-
 	const otherEnvironment = site.is_wpcom_staging_site ? 'production' : 'staging';
 	const otherEnvironmentSiteId = site.is_wpcom_staging_site
 		? site.options?.wpcom_production_blog_id
@@ -136,7 +134,7 @@ const EnvironmentSwitcher = ( { site }: { site: Site } ) => {
 			<Dropdown
 				renderToggle={ ( { onToggle } ) => {
 					const canToggle =
-						( otherEnvironment === 'staging' && ! hasStagingSite ) ||
+						( otherEnvironment === 'staging' && !! getStagingSiteId( site ) ) ||
 						( otherEnvironmentSite && canManageSite( otherEnvironmentSite ) );
 
 					return (

--- a/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
@@ -13,6 +13,9 @@ import {
 } from '../../utils/site-staging-site';
 import type { StagingSiteSyncDirection } from '../../data/types';
 
+// TODO: We need to rewrite the modal, as it’s not compatible with v2.
+// Both the Modal and especially the FileBrowser rely heavily on Redux state
+// which makes integration problematic in the current setup.
 const StagingSiteSyncModal = lazy(
 	() =>
 		import(

--- a/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
@@ -69,6 +69,8 @@ export default function StagingSiteSyncDropdown( {
 		onSyncStart();
 	};
 
+	// The sync is not allowed if the staging site is in a transition or is deleting.
+	// We should consider this when we start to rewrite the StagingSiteSyncModal.
 	if ( ! productionSiteId || ! stagingSiteId ) {
 		return null;
 	}

--- a/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
@@ -1,46 +1,77 @@
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { chevronDown, cloudDownload, cloudUpload } from '@wordpress/icons';
 import { lazy, Suspense } from 'react';
+import { siteBySlugQuery } from '../../app/queries/site';
+import { stagingSiteSyncStateQuery } from '../../app/queries/site-staging-sites';
+import {
+	getProductionSiteId,
+	getStagingSiteId,
+	isStagingSiteSyncing,
+} from '../../utils/site-staging-site';
+import type { StagingSiteSyncDirection } from '../../data/types';
 
 const StagingSiteSyncModal = lazy(
-	() => import( 'calypso/sites/staging-site/components/staging-site-sync-modal' )
+	() =>
+		import(
+			/* webpackChunkName: "async-load-staging-site-sync-modal" */ 'calypso/sites/staging-site/components/staging-site-sync-modal'
+		)
 );
 
-interface SyncDropdownProps {
+interface StagingSiteSyncDropdownProps {
+	siteSlug: string;
 	className?: string;
-	environment: 'production' | 'staging';
-	productionSiteId: number;
-	stagingSiteId: number;
-	isSyncInProgress: boolean;
-	onSyncStart: () => void;
+	onSyncStart?: () => void;
 }
 
-export default function SyncDropdown( {
+export default function StagingSiteSyncDropdown( {
+	siteSlug,
 	className,
-	environment,
-	productionSiteId,
-	stagingSiteId,
-	isSyncInProgress,
-	onSyncStart,
-}: SyncDropdownProps ) {
+	onSyncStart = () => {},
+}: StagingSiteSyncDropdownProps ) {
 	const [ isModalOpen, setIsModalOpen ] = useState< boolean >( false );
-	const [ syncType, setSyncType ] = useState< 'pull' | 'push' >( 'pull' );
+	const [ syncDirection, setSyncDirection ] = useState< StagingSiteSyncDirection >( 'pull' );
+	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+	const environment = site.is_wpcom_staging_site ? 'staging' : 'production';
+
+	const productionSiteId = getProductionSiteId( site );
+
+	const stagingSiteId = getStagingSiteId( site );
+
+	const { data: stagingSiteSyncState, refetch: fetchStagingSiteSyncState } = useQuery( {
+		...stagingSiteSyncStateQuery( productionSiteId ?? 0 ),
+		refetchInterval: ( query ) => {
+			return isStagingSiteSyncing( query.state.data ) ? 5000 : false;
+		},
+		refetchIntervalInBackground: true,
+	} );
+
+	const isSyncing = isStagingSiteSyncing( stagingSiteSyncState );
 
 	const pullLabel =
 		environment === 'staging' ? __( 'Pull from Production' ) : __( 'Pull from Staging' );
 	const pushLabel =
 		environment === 'staging' ? __( 'Push to Production' ) : __( 'Push to Staging' );
 
-	const handleOpenModal = ( type: 'pull' | 'push' ): void => {
-		setSyncType( type );
+	const handleOpenModal = ( direction: StagingSiteSyncDirection ): void => {
+		setSyncDirection( direction );
 		setIsModalOpen( true );
 	};
 
 	const handleCloseModal = (): void => {
 		setIsModalOpen( false );
 	};
+
+	const handleSyncStart = () => {
+		fetchStagingSiteSyncState();
+		onSyncStart();
+	};
+
+	if ( ! productionSiteId || ! stagingSiteId ) {
+		return null;
+	}
 
 	return (
 		<>
@@ -54,9 +85,9 @@ export default function SyncDropdown( {
 						variant="secondary"
 						aria-expanded={ isOpen }
 						onClick={ () => onToggle() }
-						disabled={ isSyncInProgress }
+						disabled={ isSyncing }
 					>
-						{ isSyncInProgress ? __( 'Syncing…' ) : __( 'Sync' ) }
+						{ isSyncing ? __( 'Syncing…' ) : __( 'Sync' ) }
 					</Button>
 				) }
 				renderContent={ ( { onClose } ) => (
@@ -90,11 +121,11 @@ export default function SyncDropdown( {
 				<Suspense fallback={ null }>
 					<StagingSiteSyncModal
 						onClose={ handleCloseModal }
-						syncType={ syncType }
+						syncType={ syncDirection }
 						environment={ environment }
 						productionSiteId={ productionSiteId }
 						stagingSiteId={ stagingSiteId }
-						onSyncStart={ onSyncStart }
+						onSyncStart={ handleSyncStart }
 					/>
 				</Suspense>
 			) }

--- a/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
@@ -42,6 +42,7 @@ export default function StagingSiteSyncDropdown( {
 
 	const { data: stagingSiteSyncState, refetch: fetchStagingSiteSyncState } = useQuery( {
 		...stagingSiteSyncStateQuery( productionSiteId ?? 0 ),
+		enabled: !! productionSiteId,
 		refetchInterval: ( query ) => {
 			return isStagingSiteSyncing( query.state.data ) ? 5000 : false;
 		},

--- a/client/dashboard/utils/site-staging-site.ts
+++ b/client/dashboard/utils/site-staging-site.ts
@@ -1,0 +1,18 @@
+import type { Site, StagingSiteSyncState } from '../data/types';
+
+export const getProductionSiteId = ( site: Site ) =>
+	! site.is_wpcom_staging_site ? site.ID : site.options?.wpcom_production_blog_id;
+
+export const getStagingSiteId = ( site: Site ) =>
+	site.is_wpcom_staging_site ? site.ID : site.options?.wpcom_staging_blog_ids?.[ 0 ];
+
+export const hasProductionSite = ( site: Site ) => !! getProductionSiteId( site );
+
+export const hasStagingSite = ( site: Site ) => !! getStagingSiteId( site );
+
+export const isStagingSiteSyncing = ( stagingSiteSyncState?: StagingSiteSyncState ) => {
+	return (
+		stagingSiteSyncState &&
+		! [ 'completed', 'allow_retry', 'failed' ].includes( stagingSiteSyncState.status )
+	);
+};

--- a/client/sites/components/site-preview-pane/preview-pane-header-buttons.tsx
+++ b/client/sites/components/site-preview-pane/preview-pane-header-buttons.tsx
@@ -65,12 +65,6 @@ const PreviewPaneHeaderButtons = ( { focusRef, itemData }: Props ) => {
 		? site?.options?.wpcom_production_blog_id ?? 0
 		: itemData.blogId ?? 0;
 
-	const stagingSiteId = hasStagingSite
-		? site?.options?.wpcom_staging_blog_ids?.[ 0 ] ?? 0
-		: itemData.blogId ?? 0;
-
-	const environment = isStagingSite ? 'staging' : 'production';
-
 	const { resetSyncStatus, isSyncInProgress, status } = useCheckSyncStatus( productionSiteId );
 
 	useEffect( () => {
@@ -87,13 +81,10 @@ const PreviewPaneHeaderButtons = ( { focusRef, itemData }: Props ) => {
 
 	return (
 		<>
-			{ shouldShowSyncDropdown && (
+			{ site && shouldShowSyncDropdown && (
 				<SyncDropdown
 					className="item-preview__sync-dropdown"
-					environment={ environment }
-					productionSiteId={ productionSiteId }
-					stagingSiteId={ stagingSiteId }
-					isSyncInProgress={ isSyncInProgress }
+					siteSlug={ site.slug }
 					onSyncStart={ resetSyncStatus }
 				/>
 			) }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-109

## Proposed Changes

* Introduce Sync button to the Site Overview page on v2
* Note that the Sync modal doesn’t work on v2 as both the `Modal` and the `FileBrowser` rely heavily on the redux state (selector and dispatch), especially the `FileBrowser`… See [previous try](https://github.com/Automattic/wp-calypso/compare/DOTDASH-109/site-overview-sync-button?expand=1).

<img width="1139" height="469" alt="image" src="https://github.com/user-attachments/assets/041c1af5-0412-4a1e-b972-3cf41f7a2a13" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### V2

* Go to /v2
* Select any staging site
* Ensure you can see the Sync button

### V1

* Go to /sites?flags=dashboard/v2/backport/site-overview
* Select any staging site
* Click the Sync button
* Try "Pull from Production"
* Ensure the button becomes `Syncing...`
* Refresh the page, and the button should still be `Syncing...`
* Once the sync process is done, the button should be `Sync` again

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
