### PR TITLE
Site Overview: Don't show *.wordpress.com domain on domains card for the atomic site

### DIFF
--- a/client/dashboard/sites/overview-domains-card/index.tsx
+++ b/client/dashboard/sites/overview-domains-card/index.tsx
@@ -122,17 +122,14 @@ export default function DomainsCard( {
 	const { data: sitePlan } = useQuery( siteCurrentPlanQuery( site.ID ) );
 	const { data: siteDomains } = useQuery( siteDomainsQuery( site.ID ) );
 	const filteredSiteDomains = useMemo( () => {
-		if ( ! siteDomains || ! siteDomains.find( ( domain ) => domain.is_wpcom_staging_domain ) ) {
-			return siteDomains;
+		// If the site has *.wpcomstaging.com domain, exclude *.wordpress.com
+		if ( siteDomains && siteDomains.find( ( domain ) => domain.is_wpcom_staging_domain ) ) {
+			return siteDomains.filter(
+				( domain ) => ! domain.wpcom_domain || domain.is_wpcom_staging_domain
+			);
 		}
 
-		return siteDomains.filter( ( domain ) => {
-			if ( domain.wpcom_domain ) {
-				return domain.is_wpcom_staging_domain;
-			}
-
-			return true;
-		} );
+		return siteDomains;
 	}, [ siteDomains ] );
 
 	if ( site.is_wpcom_staging_site ) {

--- a/client/dashboard/sites/overview-domains-card/index.tsx
+++ b/client/dashboard/sites/overview-domains-card/index.tsx
@@ -121,23 +121,36 @@ export default function DomainsCard( {
 } ) {
 	const { data: sitePlan } = useQuery( siteCurrentPlanQuery( site.ID ) );
 	const { data: siteDomains } = useQuery( siteDomainsQuery( site.ID ) );
+	const filteredSiteDomains = useMemo( () => {
+		if ( ! siteDomains || ! siteDomains.find( ( domain ) => domain.is_wpcom_staging_domain ) ) {
+			return siteDomains;
+		}
+
+		return siteDomains.filter( ( domain ) => {
+			if ( domain.wpcom_domain ) {
+				return domain.is_wpcom_staging_domain;
+			}
+
+			return true;
+		} );
+	}, [ siteDomains ] );
 
 	if ( site.is_wpcom_staging_site ) {
 		return null;
 	}
 
-	if ( ! sitePlan || ! siteDomains ) {
+	if ( ! sitePlan || ! filteredSiteDomains ) {
 		return <CalloutSkeleton />;
 	}
 
 	if (
 		isSelfHostedJetpackConnected( site ) &&
-		siteDomains.find( ( domain ) => isTransferrableToWpcom( domain ) )
+		filteredSiteDomains.find( ( domain ) => isTransferrableToWpcom( domain ) )
 	) {
 		return <DomainTransferUpsellCard />;
 	}
 
-	if ( ! siteDomains.find( ( domain ) => ! domain.wpcom_domain ) ) {
+	if ( ! filteredSiteDomains.find( ( domain ) => ! domain.wpcom_domain ) ) {
 		return <DomainUpsellCard site={ site } />;
 	}
 
@@ -145,7 +158,7 @@ export default function DomainsCard( {
 		<SiteDomainDataViews
 			type={ isCompact ? 'list' : 'table' }
 			site={ site }
-			domains={ siteDomains }
+			domains={ filteredSiteDomains }
 		/>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* We should not show both `*.wpcomstaging.com`  and `*.wordpress.com` domains for the site. Instead, if a site has `*.wpcomstaging.com`, we should not show the `*.wordpress.com` domain

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Select any atomic site
* On the Domains card, you should not see the `*.wordpress.com` domain

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
