### PR TITLE
Dashboard v2: fix success and warning intent colors on texts, icons, backgrounds, progress bars

### DIFF
--- a/client/dashboard/app-a4a/style.scss
+++ b/client/dashboard/app-a4a/style.scss
@@ -16,11 +16,13 @@
 
 	// Layout
 	--dashboard__background-color: #fcfcfc;
-	--dashboard__icon-color-warning: #d47608;
-	--dashboard__icon-color-error: #{$alert-red};
+	--dashboard__background-color-success: #3ca758;
+	--dashboard__background-color-warning: #d47608;
+	--dashboard__background-color-error: #{$alert-red};
+	--dashboard__foreground-color-success: #21873b;
+	--dashboard__foreground-color-warning: #b36100;
+	--dashboard__foreground-color-error: #{$alert-red};
 	--dashboard__text-color: #{$gray-900};
-	--dashboard__text-color-warning: #b36100;
-	--dashboard__text-color-error: #{$alert-red};
 	--dashboard__text-max-width: 660px;
 
 	// Header bar

--- a/client/dashboard/app-a4a/style.scss
+++ b/client/dashboard/app-a4a/style.scss
@@ -16,7 +16,11 @@
 
 	// Layout
 	--dashboard__background-color: #fcfcfc;
+	--dashboard__icon-color-warning: #d47608;
+	--dashboard__icon-color-error: #{$alert-red};
 	--dashboard__text-color: #{$gray-900};
+	--dashboard__text-color-warning: #b36100;
+	--dashboard__text-color-error: #{$alert-red};
 	--dashboard__text-max-width: 660px;
 
 	// Header bar

--- a/client/dashboard/app-dotcom/style.scss
+++ b/client/dashboard/app-dotcom/style.scss
@@ -16,11 +16,13 @@
 
 	// Layout
 	--dashboard__background-color: #fcfcfc;
-	--dashboard__icon-color-warning: #d47608;
-	--dashboard__icon-color-error: #{$alert-red};
+	--dashboard__background-color-success: #3ca758;
+	--dashboard__background-color-warning: #d47608;
+	--dashboard__background-color-error: #{$alert-red};
+	--dashboard__foreground-color-success: #21873b;
+	--dashboard__foreground-color-warning: #b36100;
+	--dashboard__foreground-color-error: #{$alert-red};
 	--dashboard__text-color: #{$gray-900};
-	--dashboard__text-color-warning: #b36100;
-	--dashboard__text-color-error: #{$alert-red};
 	--dashboard__text-max-width: 660px;
 
 	// Header bar

--- a/client/dashboard/app-dotcom/style.scss
+++ b/client/dashboard/app-dotcom/style.scss
@@ -16,7 +16,11 @@
 
 	// Layout
 	--dashboard__background-color: #fcfcfc;
+	--dashboard__icon-color-warning: #d47608;
+	--dashboard__icon-color-error: #{$alert-red};
 	--dashboard__text-color: #{$gray-900};
+	--dashboard__text-color-warning: #b36100;
+	--dashboard__text-color-error: #{$alert-red};
 	--dashboard__text-max-width: 660px;
 
 	// Header bar

--- a/client/dashboard/components/notice/style.scss
+++ b/client/dashboard/components/notice/style.scss
@@ -41,7 +41,7 @@
 	}
 
 	&.is-warning {
-		background-color: color-mix(in srgb, $alert-yellow 4%, transparent);
+		background-color: color-mix(in srgb, var(--dashboard__background-color-warning) 4%, transparent);
 
 		.dashboard-notice__icon {
 			fill: #a77f30;
@@ -49,7 +49,7 @@
 	}
 
 	&.is-success {
-		background-color: color-mix(in srgb, $alert-green 4%, transparent);
+		background-color: color-mix(in srgb, var(--dashboard__background-color-success) 4%, transparent);
 
 		.dashboard-notice__icon {
 			fill: #2c723e;
@@ -57,7 +57,7 @@
 	}
 
 	&.is-error {
-		background-color: color-mix(in srgb, $alert-red 4%, transparent);
+		background-color: color-mix(in srgb, var(--dashboard__background-color-error) 4%, transparent);
 
 		.dashboard-notice__icon {
 			fill: #8c0b0b;

--- a/client/dashboard/components/stat/style.scss
+++ b/client/dashboard/components/stat/style.scss
@@ -27,15 +27,15 @@
 }
 
 .dashboard-stat__progress-bar--alert-yellow {
-	--wp-components-color-foreground: #{$alert-yellow};
+	--wp-components-color-foreground: var(--dashboard__background-color-warning);
 }
 
 .dashboard-stat__progress-bar--alert-red {
-	--wp-components-color-foreground: #{$alert-red};
+	--wp-components-color-foreground: var(--dashboard__background-color-error);
 }
 
 .dashboard-stat__progress-bar--alert-green {
-	--wp-components-color-foreground: #{$alert-green};
+	--wp-components-color-foreground: var(--dashboard__background-color-success);
 }
 
 .dashboard-stat--is-loading .dashboard-stat__progress-bar > * {
@@ -59,4 +59,3 @@
 		line-height: $font-line-height-small;
 	}
 }
-

--- a/client/dashboard/components/text/index.tsx
+++ b/client/dashboard/components/text/index.tsx
@@ -15,15 +15,7 @@ function UnforwardedText(
 		<WPText
 			ref={ ref }
 			{ ...props }
-			className={ clsx(
-				{
-					'dashboard-text--success': intent === 'success',
-					'dashboard-text--warning': intent === 'warning',
-					'dashboard-text--error': intent === 'error',
-				},
-				props.className
-			) }
-			variant={ intent ? undefined : ( 'muted' as const ) }
+			className={ clsx( intent && `dashboard-text--${ intent }`, props.className ) }
 		/>
 	);
 }

--- a/client/dashboard/components/text/index.tsx
+++ b/client/dashboard/components/text/index.tsx
@@ -4,7 +4,7 @@ import { forwardRef } from 'react';
 import './style.scss';
 
 export interface TextProps extends React.ComponentProps< typeof WPText > {
-	intent?: 'warning' | 'error';
+	intent?: 'success' | 'warning' | 'error';
 }
 
 function UnforwardedText(
@@ -17,6 +17,7 @@ function UnforwardedText(
 			{ ...props }
 			className={ clsx(
 				{
+					'dashboard-text--success': intent === 'success',
 					'dashboard-text--warning': intent === 'warning',
 					'dashboard-text--error': intent === 'error',
 				},

--- a/client/dashboard/components/text/index.tsx
+++ b/client/dashboard/components/text/index.tsx
@@ -1,0 +1,30 @@
+import { __experimentalText as WPText } from '@wordpress/components';
+import clsx from 'clsx';
+import { forwardRef } from 'react';
+import './style.scss';
+
+export interface TextProps extends React.ComponentProps< typeof WPText > {
+	intent?: 'warning' | 'error';
+}
+
+function UnforwardedText(
+	{ intent, ...props }: TextProps,
+	ref: React.ForwardedRef< HTMLElement >
+) {
+	return (
+		<WPText
+			ref={ ref }
+			{ ...props }
+			className={ clsx(
+				{
+					'dashboard-text--warning': intent === 'warning',
+					'dashboard-text--error': intent === 'error',
+				},
+				props.className
+			) }
+			variant={ intent ? undefined : ( 'muted' as const ) }
+		/>
+	);
+}
+
+export const Text = forwardRef( UnforwardedText );

--- a/client/dashboard/components/text/style.scss
+++ b/client/dashboard/components/text/style.scss
@@ -1,0 +1,7 @@
+.dashboard-text--warning {
+	--wp-components-color-foreground: var(--dashboard__text-color-warning);
+}
+
+.dashboard-text--error {
+	--wp-components-color-foreground: var(--dashboard__text-color-error);
+}

--- a/client/dashboard/components/text/style.scss
+++ b/client/dashboard/components/text/style.scss
@@ -1,7 +1,7 @@
 .dashboard-text--warning {
-	--wp-components-color-foreground: var(--dashboard__text-color-warning);
+	--wp-components-color-foreground: var(--dashboard__foreground-color-warning);
 }
 
 .dashboard-text--error {
-	--wp-components-color-foreground: var(--dashboard__text-color-error);
+	--wp-components-color-foreground: var(--dashboard__foreground-color-error);
 }

--- a/client/dashboard/components/text/style.scss
+++ b/client/dashboard/components/text/style.scss
@@ -1,3 +1,7 @@
+.dashboard-text--success {
+	--wp-components-color-foreground: var(--dashboard__foreground-color-success);
+}
+
 .dashboard-text--warning {
 	--wp-components-color-foreground: var(--dashboard__foreground-color-warning);
 }

--- a/client/dashboard/sites/overview-card/index.tsx
+++ b/client/dashboard/sites/overview-card/index.tsx
@@ -126,6 +126,7 @@ export default function OverviewCard( {
 						</Heading>
 						<Text
 							intent={ intent === 'warning' || intent === 'error' ? intent : undefined }
+							variant={ intent === 'warning' || intent === 'error' ? undefined : 'muted' }
 							lineHeight="16px"
 							size={ 12 }
 						>

--- a/client/dashboard/sites/overview-card/index.tsx
+++ b/client/dashboard/sites/overview-card/index.tsx
@@ -7,7 +7,6 @@ import {
 	__experimentalDivider as Divider,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
-	__experimentalText as Text,
 	__experimentalHeading as Heading,
 	Icon,
 } from '@wordpress/components';
@@ -16,6 +15,7 @@ import { chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useAnalytics } from '../../app/analytics';
 import ComponentViewTracker from '../../components/component-view-tracker';
+import { Text } from '../../components/text';
 import { TextSkeleton } from '../../components/text-skeleton';
 import type { ComponentProps, ReactElement, ReactNode } from 'react';
 import './style.scss';
@@ -125,8 +125,7 @@ export default function OverviewCard( {
 							{ renderHeading() }
 						</Heading>
 						<Text
-							className="dashboard-overview-card__description"
-							variant="muted"
+							intent={ intent === 'warning' || intent === 'error' ? intent : undefined }
 							lineHeight="16px"
 							size={ 12 }
 						>

--- a/client/dashboard/sites/overview-card/style.scss
+++ b/client/dashboard/sites/overview-card/style.scss
@@ -52,15 +52,15 @@
 	}
 
 	.dashboard-overview-card--error & {
-		background-color: color-mix(in srgb, $alert-red 8%, transparent);
-		color: $alert-red;
-		fill: $alert-red;
+		background-color: color-mix(in srgb, var( --dashboard__icon-color-error ) 8%, transparent);
+		color: var( --dashboard__icon-color-error );
+		fill: var( --dashboard__icon-color-error );
 	}
 
 	.dashboard-overview-card--warning & {
-		background-color: color-mix(in srgb, #b36100 8%, transparent);
-		color: #b36100;
-		fill: #b36100;
+		background-color: color-mix(in srgb, var( --dashboard__icon-color-warning ) 8%, transparent);
+		color: var( --dashboard__icon-color-warning );
+		fill: var( --dashboard__icon-color-warning );
 	}
 
 	.dashboard-overview-card--disabled & {
@@ -117,15 +117,6 @@
 	width: 100%;
 	padding: 0;
 	text-align: start;
-}
-
-.dashboard-overview-card__description {
-	.dashboard-overview-card--error & {
-		color: $alert-red;
-	}
-	.dashboard-overview-card--warning & {
-		color: #b36100;
-	}
 }
 
 .dashboard-overview-card__progress-bar {

--- a/client/dashboard/sites/overview-card/style.scss
+++ b/client/dashboard/sites/overview-card/style.scss
@@ -47,20 +47,20 @@
 	fill: var(--wp-admin-theme-color);
 
 	.dashboard-overview-card--success & {
-		color: $alert-green;
-		fill: $alert-green;
+		color: var(--dashboard__background-color-success);
+		fill: var(--dashboard__background-color-success);
 	}
 
 	.dashboard-overview-card--error & {
-		background-color: color-mix(in srgb, var( --dashboard__icon-color-error ) 8%, transparent);
-		color: var( --dashboard__icon-color-error );
-		fill: var( --dashboard__icon-color-error );
+		background-color: color-mix(in srgb, var(--dashboard__background-color-error) 8%, transparent);
+		color: var(--dashboard__background-color-error );
+		fill: var(--dashboard__background-color-error );
 	}
 
 	.dashboard-overview-card--warning & {
-		background-color: color-mix(in srgb, var( --dashboard__icon-color-warning ) 8%, transparent);
-		color: var( --dashboard__icon-color-warning );
-		fill: var( --dashboard__icon-color-warning );
+		background-color: color-mix(in srgb, var(--dashboard__background-color-warning) 8%, transparent);
+		color: var(--dashboard__background-color-warning);
+		fill: var(--dashboard__background-color-warning);
 	}
 
 	.dashboard-overview-card--disabled & {

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -2,7 +2,6 @@ import { Badge } from '@automattic/ui';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import {
-	__experimentalText as Text,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	ExternalLink,
@@ -19,6 +18,7 @@ import { sitePHPVersionQuery } from '../../app/queries/site-php-version';
 import { siteEngagementStatsQuery } from '../../app/queries/site-stats';
 import { siteUptimeQuery } from '../../app/queries/site-uptime';
 import ComponentViewTracker from '../../components/component-view-tracker';
+import { Text } from '../../components/text';
 import { TextBlur } from '../../components/text-blur';
 import TimeSince from '../../components/time-since';
 import { DotcomFeatures, HostingFeatures, JetpackModules } from '../../data/constants';
@@ -355,7 +355,7 @@ export function Status( { site }: { site: Site } ) {
 	const label = getSiteStatusLabel( site );
 
 	if ( status === 'deleted' ) {
-		return <Text isDestructive>{ label }</Text>;
+		return <Text intent="error">{ label }</Text>;
 	}
 
 	if ( status === 'difm_lite_in_progress' ) {
@@ -373,7 +373,7 @@ export function Status( { site }: { site: Site } ) {
 	if ( site.plan?.expired ) {
 		return (
 			<VStack spacing={ 1 }>
-				<Text isDestructive>{ __( 'Plan expired' ) }</Text>
+				<Text intent="error">{ __( 'Plan expired' ) }</Text>
 				<PlanRenewNag site={ site } source="status" />
 			</VStack>
 		);
@@ -425,7 +425,7 @@ export function Plan( { site }: { site: Site } ) {
 	if ( site.plan?.expired ) {
 		return (
 			<VStack spacing={ 1 }>
-				<Text isDestructive>
+				<Text intent="error">
 					{ sprintf(
 						/* translators: %s: plan name */
 						__( '%s-expired' ),


### PR DESCRIPTION
(The PR description has been modified after @matt-west [comment](https://github.com/Automattic/wp-calypso/pull/105057#issuecomment-3154716003))

---

## Proposed Changes

This PR fixes colors for "success" and "warning" states as per Figma QOBjujZah0UlGDDdLKZhzi-fi-6676_101633.

For text color, there are 2 challenges:

-  For error state, we are currently using Core's `<Text isDestructive>`, but the color does not match Figma. 🫠 
    - It's weird that it just does not use `$alert-red`. `<Button isDestructive>` already uses `$alert-red` but `<Text> does not. 🫠 
- There is no `isWarning` or equivalent prop there. Currently we add ad-hoc CSS to components that need it (such as `<OverviewCard>`).

So, here I'm proposing to build a `<Text>` component in our dashboard, which adds a new `intent` prop on top of Core's `<Text>`.

## Why are these changes being made?

Fit & finish.

## Testing Instructions

Check the following colors. Verify they are good. Note that some might be hard to spot the difference.

1. Text (error state)

|Before|After|
|-|-|
|<img width="144" height="88" alt="image" src="https://github.com/user-attachments/assets/3a13a395-1beb-4ef0-9f30-91dddba6b58c" />|<img width="144" height="88" alt="image" src="https://github.com/user-attachments/assets/ae75a648-e577-4743-8806-74ec5f761939" />|

2. Overview cards (warning & error states) (no changes)

To test, might need to hardcode the score locally in Performance card 🙈

|No change; already correct|No change; already correct|
|-|-|
|<img width="331" height="155" alt="image" src="https://github.com/user-attachments/assets/ceb332eb-6d21-45cd-9b29-9b9140bb4d1f" />|<img width="329" height="151" alt="image" src="https://github.com/user-attachments/assets/427536dc-b06b-4463-b8cb-537bbce812bb" />|

3. Overview card icon (success state)

|Before|After|
|-|-|
|<img width="199" height="77" alt="image" src="https://github.com/user-attachments/assets/e5f14067-ce2e-44bf-8172-312c2bcc91ab" />|<img width="199" height="77" alt="image" src="https://github.com/user-attachments/assets/7b32d52b-031f-428a-8f86-97b15ff581c3" />|

4. Notice background (success state)

|Before|After|
|-|-|
|<img width="944" height="252" alt="wpcalypso wordpress com_v2_sites_testfusharbusiness6 wpcomstaging com_settings_defensive-mode" src="https://github.com/user-attachments/assets/0d82ff33-9e2e-4878-a465-6f04d36904f0" />|<img width="944" height="252" alt="calypso localhost_3000_v2_sites_testfusharbusiness6 wpcomstaging com_settings_defensive-mode" src="https://github.com/user-attachments/assets/3ef83c3e-1786-42e1-bce0-e4504639ead9" />|

5. Notice background (warning state)

|Before|After|
|-|-|
|<img width="896" height="136" alt="wpcalypso wordpress com_v2_sites_testfusharcreator16 wordpress com_settings" src="https://github.com/user-attachments/assets/3c34348b-c25f-43a5-9a68-1e6c2b4867a5" />|<img width="896" height="136" alt="calypso localhost_3000_v2_sites_testfusharbusiness6 wpcomstaging com_settings_defensive-mode (1)" src="https://github.com/user-attachments/assets/1a583601-1c17-4471-9f22-f2003630453f" />

6. Progress bars (warning and success states)

|Before|After|
|-|-|
|<img width="636" height="330" alt="calypso localhost_3000_v2_sites_testfusharwoa8 wpcomstaging com_ (1)" src="https://github.com/user-attachments/assets/bc384dbb-8a6b-42ce-89e3-d57552b56e91" />|<img width="636" height="330" alt="calypso localhost_3000_v2_sites_testfusharwoa8 wpcomstaging com_" src="https://github.com/user-attachments/assets/56cc7685-025e-4a00-9c73-6c1f34096a8d" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?