### PR TITLE
Added TrainTracks to Help Center Search

### DIFF
--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -268,7 +268,7 @@ function HelpSearchResults( {
 		}
 	}, [ isSearching, hasAPIResults, searchQuery ] );
 
-	const onLinkClickHandler = async (
+	const onLinkClickHandler = (
 		event: React.MouseEvent< HTMLAnchorElement, MouseEvent >,
 		result: SearchResult,
 		type: string

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -274,6 +274,16 @@ function HelpSearchResults( {
 		type: string
 	) => {
 		const { link, post_id, blog_id, source } = result;
+
+		recordTracksEvent( 'calypso_help_center_search_traintracks_interact', {
+			action: 'click',
+			railcar: result.railcar.railcar,
+			href: result.link,
+			search_type: ! contextSearch && ! searchQuery ? 'tailored' : 'search',
+			location,
+			section: sectionName,
+		} );
+
 		// check and catch admin section links.
 		if ( type === SUPPORT_TYPE_ADMIN_SECTION && link ) {
 			// record track-event.

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -276,7 +276,7 @@ function HelpSearchResults( {
 		const { link, post_id, blog_id, source } = result;
 
 		// Make the first recordTracksEvent call asynchronous
-		Promise.resolve().then( () => {
+		queueMicrotask( () => {
 			recordTracksEvent( 'calypso_help_center_search_traintracks_interact', {
 				action: 'click',
 				railcar: result.railcar.railcar,

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -268,30 +268,35 @@ function HelpSearchResults( {
 		}
 	}, [ isSearching, hasAPIResults, searchQuery ] );
 
-	const onLinkClickHandler = (
+	const onLinkClickHandler = async (
 		event: React.MouseEvent< HTMLAnchorElement, MouseEvent >,
 		result: SearchResult,
 		type: string
 	) => {
 		const { link, post_id, blog_id, source } = result;
 
-		recordTracksEvent( 'calypso_help_center_search_traintracks_interact', {
-			action: 'click',
-			railcar: result.railcar.railcar,
-			href: result.link,
-			search_type: ! contextSearch && ! searchQuery ? 'tailored' : 'search',
-			location,
-			section: sectionName,
+		// Make the first recordTracksEvent call asynchronous
+		Promise.resolve().then( () => {
+			recordTracksEvent( 'calypso_help_center_search_traintracks_interact', {
+				action: 'click',
+				railcar: result.railcar.railcar,
+				href: result.link,
+				search_type: ! contextSearch && ! searchQuery ? 'tailored' : 'search',
+				location,
+				section: sectionName,
+			} );
 		} );
 
 		// check and catch admin section links.
 		if ( type === SUPPORT_TYPE_ADMIN_SECTION && link ) {
-			// record track-event.
-			recordTracksEvent( 'calypso_inlinehelp_admin_section_visit', {
-				link: link,
-				search_term: searchQuery,
-				location,
-				section: sectionName,
+			// Make the admin section recordTracksEvent call asynchronous
+			Promise.resolve().then( () => {
+				recordTracksEvent( 'calypso_inlinehelp_admin_section_visit', {
+					link: link,
+					search_term: searchQuery,
+					location,
+					section: sectionName,
+				} );
 			} );
 
 			event.preventDefault();
@@ -322,7 +327,10 @@ function HelpSearchResults( {
 				? 'calypso_inlinehelp_tailored_article_select'
 				: 'calypso_inlinehelp_article_select';
 
-		recordTracksEvent( eventName, eventData );
+		// Make the final recordTracksEvent call asynchronous
+		Promise.resolve().then( () => {
+			recordTracksEvent( eventName, eventData );
+		} );
 		onSelect( event, result );
 	};
 

--- a/packages/help-center/src/hooks/use-help-search-query.ts
+++ b/packages/help-center/src/hooks/use-help-search-query.ts
@@ -3,27 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import { buildQueryString } from '@wordpress/url';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
-import type { ReactNode } from 'react';
-
-export interface SearchResult {
-	railcar: {
-		railcar?: string;
-		fetch_algo?: string;
-		fetch_lang?: string;
-		fetch_position?: string;
-		fetch_query?: string;
-		rec_post_id?: number;
-		rec_blog_id?: number;
-		session_id?: string;
-	};
-	link: string;
-	title: ReactNode;
-	content?: string;
-	icon?: string;
-	post_id?: number;
-	blog_id?: number;
-	source?: string;
-}
+import { SearchResult } from '../types';
 
 interface APIFetchOptions {
 	global: boolean;
@@ -53,18 +33,11 @@ const fetchArticlesAPI = async (
 	// Record TrainTracks render events
 	searchResultResponse?.forEach( ( source: SearchResult, index: number ) => {
 		if ( source.railcar ) {
-			Promise.resolve().then( () => {
+			queueMicrotask( () => {
 				recordTracksEvent( 'calypso_help_center_search_traintracks_render', {
-					fetch_algo: source?.railcar?.fetch_algo,
+					...source.railcar,
 					ui_algo: 'default',
-					railcar: source?.railcar?.railcar,
-					fetch_position: source?.railcar?.fetch_position,
-					fetch_query: source?.railcar?.fetch_query,
-					fetch_lang: source?.railcar?.fetch_lang,
 					ui_position: index,
-					rec_blog_id: source?.railcar?.rec_blog_id,
-					rec_post_id: source?.railcar?.rec_post_id,
-					session_id: source?.railcar?.session_id,
 				} );
 			} );
 		}

--- a/packages/help-center/src/hooks/use-help-search-query.ts
+++ b/packages/help-center/src/hooks/use-help-search-query.ts
@@ -43,17 +43,19 @@ const fetchArticlesAPI = async (
 	// Record TrainTracks render events
 	searchResultResponse?.forEach( ( source: Source, index: number ) => {
 		if ( source.railcar ) {
-			recordTracksEvent( 'calypso_help_center_search_traintracks_render', {
-				fetch_algo: source?.railcar?.fetch_algo,
-				ui_algo: 'default',
-				railcar: source?.railcar?.railcar,
-				fetch_position: source?.railcar?.fetch_position,
-				fetch_query: source?.railcar?.fetch_query,
-				fetch_lang: source?.railcar?.fetch_lang,
-				ui_position: index,
-				rec_blog_id: source?.railcar?.rec_blog_id,
-				rec_post_id: source?.railcar?.rec_post_id,
-				session_id: source?.railcar?.session_id,
+			Promise.resolve().then( () => {
+				recordTracksEvent( 'calypso_help_center_search_traintracks_render', {
+					fetch_algo: source?.railcar?.fetch_algo,
+					ui_algo: 'default',
+					railcar: source?.railcar?.railcar,
+					fetch_position: source?.railcar?.fetch_position,
+					fetch_query: source?.railcar?.fetch_query,
+					fetch_lang: source?.railcar?.fetch_lang,
+					ui_position: index,
+					rec_blog_id: source?.railcar?.rec_blog_id,
+					rec_post_id: source?.railcar?.rec_post_id,
+					session_id: source?.railcar?.session_id,
+				} );
 			} );
 		}
 	} );

--- a/packages/help-center/src/hooks/use-help-search-query.ts
+++ b/packages/help-center/src/hooks/use-help-search-query.ts
@@ -6,6 +6,7 @@ import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import type { ReactNode } from 'react';
 
 export interface SearchResult {
+	railcar: any;
 	link: string;
 	title: ReactNode;
 	content?: string;
@@ -41,7 +42,7 @@ const fetchArticlesAPI = async (
 	}
 
 	// Record TrainTracks render events
-	searchResultResponse?.forEach( ( source: Source, index: number ) => {
+	searchResultResponse?.forEach( ( source: SearchResult, index: number ) => {
 		if ( source.railcar ) {
 			Promise.resolve().then( () => {
 				recordTracksEvent( 'calypso_help_center_search_traintracks_render', {

--- a/packages/help-center/src/hooks/use-help-search-query.ts
+++ b/packages/help-center/src/hooks/use-help-search-query.ts
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useQuery } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import { buildQueryString } from '@wordpress/url';
@@ -39,6 +40,23 @@ const fetchArticlesAPI = async (
 		} as APIFetchOptions ) ) as SearchResult[];
 	}
 
+	// Record TrainTracks render events
+	searchResultResponse?.forEach( ( source: Source, index: number ) => {
+		if ( source.railcar ) {
+			recordTracksEvent( 'calypso_help_center_search_traintracks_render', {
+				fetch_algo: source?.railcar?.fetch_algo,
+				ui_algo: 'default',
+				railcar: source?.railcar?.railcar,
+				fetch_position: source?.railcar?.fetch_position,
+				fetch_query: source?.railcar?.fetch_query,
+				fetch_lang: source?.railcar?.fetch_lang,
+				ui_position: index,
+				rec_blog_id: source?.railcar?.rec_blog_id,
+				rec_post_id: source?.railcar?.rec_post_id,
+				session_id: source?.railcar?.session_id,
+			} );
+		}
+	} );
 	return searchResultResponse;
 };
 

--- a/packages/help-center/src/hooks/use-help-search-query.ts
+++ b/packages/help-center/src/hooks/use-help-search-query.ts
@@ -6,7 +6,16 @@ import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import type { ReactNode } from 'react';
 
 export interface SearchResult {
-	railcar: any;
+	railcar: {
+		railcar?: string;
+		fetch_algo?: string;
+		fetch_lang?: string;
+		fetch_position?: string;
+		fetch_query?: string;
+		rec_post_id?: number;
+		rec_blog_id?: number;
+		session_id?: string;
+	};
 	link: string;
 	title: ReactNode;
 	content?: string;

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -54,6 +54,7 @@ export interface FeatureFlags {
 }
 
 export interface SearchResult {
+	railcar: any;
 	link: string;
 	title: string;
 	content?: string;

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -54,7 +54,16 @@ export interface FeatureFlags {
 }
 
 export interface SearchResult {
-	railcar: any;
+	railcar: {
+		railcar?: string;
+		fetch_algo?: string;
+		fetch_lang?: string;
+		fetch_position?: string;
+		fetch_query?: string;
+		rec_post_id?: number;
+		rec_blog_id?: number;
+		session_id?: string;
+	};
 	link: string;
 	title: string;
 	content?: string;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->
This change is part of the experiment to use elasticsearch instead of Qdrant for searching support sites. See P2 post for more info: pflv1o-XW-p2 

We have already tested using Elasticsearch with Odie and with the main support site search. Now we also want to test inside the help center. Ideally, we would be able to use the same algorithms for each, to get consistent results for all use cases. 


## Proposed Changes

In order to evaluate how well the search is working, we want to calculate click-through rate. To do so, we need proper tracking in place. We will use TrainTracks for this, which allows us to connect two events together - a render event, which is triggered when search results are returned, and an interact event, which is triggered when a user clicks on a result. 


## Testing Instructions

* Sandbox the Public API
* Apply this 189752-ghe-Automattic/wpcom on your sandbox
* Either open calypso locally or try out the live link below. 
* Open the dev tools in your browser (make sure that you are not blocking tracking pixels). On the Network tab, filter for t.gif
* Open the help center. You should initially see several recommended resources
* Looking at the network tab, you should see several t.gif requests with `_en=calypso_help_center_search_traintracks_render`. Note the railcar property
* Now click on one of the results. Now you should see another `t.gif` request with `_en=calypso_help_center_search_traintracks_interact`. Look at the railcar property and make sure it matches the one from the render event

### Testing the A/B test
* Next, go to the experiment page: 22308-explat-experiment and assign yourself to one of the experimental variants
* Update the Explat cache on your sandbox using
```
php bin/cron/refresh-explat-cache.php
```

* Try another search query. 
* Now in the `t.gif` requests you should see that the fetch_algo is different, e.g. `jetpack:search/17-hybrid-score_default`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?