### PR TITLE
Update the hosting dashboard domain routes to be under `domains`

### DIFF
--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -45,19 +45,20 @@ import {
 	setRootRoute,
 	domainsRoute,
 	siteDomainsRoute,
-	siteDomainRoute,
-	siteDomainChildRoutes,
-	siteDomainDnsRoute,
-	siteDomainDnsAddRoute,
-	siteDomainDnsEditRoute,
-	siteDomainForwardingRoute,
-	siteDomainForwardingAddRoute,
-	siteDomainForwardingEditRoute,
-	siteDomainContactInfoRoute,
-	siteDomainNameServersRoute,
-	siteDomainGlueRecordsRoute,
-	siteDomainDnssecRoute,
-	siteDomainTransferRoute,
+	domainRoute,
+	domainChildRoutes,
+	domainOverviewRoute,
+	domainDnsRoute,
+	domainDnsAddRoute,
+	domainDnsEditRoute,
+	domainForwardingRoute,
+	domainForwardingAddRoute,
+	domainForwardingEditRoute,
+	domainContactInfoRoute,
+	domainNameServersRoute,
+	domainGlueRecordsRoute,
+	domainDnssecRoute,
+	domainTransferRoute,
 } from './routes/domain-routes';
 import type { AppConfig } from './context';
 import type { AnyRoute } from '@tanstack/react-router';
@@ -710,7 +711,6 @@ const createRouteTree = ( config: AppConfig ) => {
 
 		if ( config.supports.sites.domains ) {
 			siteChildren.push( siteDomainsRoute );
-			siteChildren.push( siteDomainRoute.addChildren( siteDomainChildRoutes ) );
 		}
 
 		if ( config.supports.sites.emails ) {
@@ -722,6 +722,7 @@ const createRouteTree = ( config: AppConfig ) => {
 
 	if ( config.supports.domains ) {
 		children.push( domainsRoute );
+		children.push( domainRoute.addChildren( domainChildRoutes ) );
 	}
 
 	if ( config.supports.emails ) {
@@ -777,18 +778,6 @@ export {
 	siteLogsRoute,
 	siteBackupsRoute,
 	siteDomainsRoute,
-	siteDomainRoute,
-	siteDomainDnsRoute,
-	siteDomainDnsAddRoute,
-	siteDomainDnsEditRoute,
-	siteDomainForwardingRoute,
-	siteDomainForwardingAddRoute,
-	siteDomainForwardingEditRoute,
-	siteDomainContactInfoRoute,
-	siteDomainNameServersRoute,
-	siteDomainGlueRecordsRoute,
-	siteDomainDnssecRoute,
-	siteDomainTransferRoute,
 	siteEmailsRoute,
 	siteSettingsRoute,
 	siteSettingsSiteVisibilityRoute,
@@ -806,6 +795,19 @@ export {
 	siteSettingsSftpSshRoute,
 	siteSettingsWebApplicationFirewallRoute,
 	domainsRoute,
+	domainRoute,
+	domainOverviewRoute,
+	domainDnsRoute,
+	domainDnsAddRoute,
+	domainDnsEditRoute,
+	domainForwardingRoute,
+	domainForwardingAddRoute,
+	domainForwardingEditRoute,
+	domainContactInfoRoute,
+	domainNameServersRoute,
+	domainGlueRecordsRoute,
+	domainDnssecRoute,
+	domainTransferRoute,
 	emailsRoute,
 	meRoute,
 	profileRoute,

--- a/client/dashboard/app/routes/domain-routes.ts
+++ b/client/dashboard/app/routes/domain-routes.ts
@@ -128,7 +128,7 @@ export const domainForwardingEditRoute = createRoute( {
 
 export const domainContactInfoRoute = createRoute( {
 	getParentRoute: () => domainRoute,
-	path: 'contact_info',
+	path: 'contact-info',
 } ).lazy( () =>
 	import( '../../sites/domains/placeholder' ).then( ( d ) =>
 		createLazyRoute( 'domain-contact-info' )( {
@@ -139,7 +139,7 @@ export const domainContactInfoRoute = createRoute( {
 
 export const domainNameServersRoute = createRoute( {
 	getParentRoute: () => domainRoute,
-	path: 'name_servers',
+	path: 'name-servers',
 } ).lazy( () =>
 	import( '../../sites/domains/placeholder' ).then( ( d ) =>
 		createLazyRoute( 'domain-name-servers' )( {
@@ -150,7 +150,7 @@ export const domainNameServersRoute = createRoute( {
 
 export const domainGlueRecordsRoute = createRoute( {
 	getParentRoute: () => domainRoute,
-	path: 'glue_records',
+	path: 'glue-records',
 } ).lazy( () =>
 	import( '../../sites/domains/placeholder' ).then( ( d ) =>
 		createLazyRoute( 'domain-glue-records' )( {

--- a/client/dashboard/app/routes/domain-routes.ts
+++ b/client/dashboard/app/routes/domain-routes.ts
@@ -28,8 +28,6 @@ export const domainsRoute = createRoute( {
 	)
 );
 
-// TODO: Add all domains domain management routes here or figure out how to do that with the definitions below
-
 // Site domains route
 export const siteDomainsRoute = createRoute( {
 	getParentRoute: () => siteRoute,
@@ -42,152 +40,159 @@ export const siteDomainsRoute = createRoute( {
 	)
 );
 
-// Site domain management route
-export const siteDomainRoute = createRoute( {
-	getParentRoute: () => siteRoute,
+// Domain management root route
+export const domainRoute = createRoute( {
+	getParentRoute: () => rootRoute,
 	path: 'domains/$domainName',
+	// TODO: add the submenu nav components here
+} );
+
+export const domainOverviewRoute = createRoute( {
+	getParentRoute: () => domainRoute,
+	path: '/',
 } ).lazy( () =>
 	import( '../../sites/domains/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'site-domains' )( {
+		createLazyRoute( 'domain' )( {
 			component: d.default,
 		} )
 	)
 );
 
-// Site domain DNS routes
-export const siteDomainDnsRoute = createRoute( {
-	getParentRoute: () => siteDomainRoute,
+// Domain DNS routes
+export const domainDnsRoute = createRoute( {
+	getParentRoute: () => domainRoute,
 	path: 'dns',
 } ).lazy( () =>
 	import( '../../sites/domains/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'site-domain-dns' )( {
+		createLazyRoute( 'domain-dns' )( {
 			component: d.default,
 		} )
 	)
 );
 
-export const siteDomainDnsAddRoute = createRoute( {
-	getParentRoute: () => siteDomainRoute,
+export const domainDnsAddRoute = createRoute( {
+	getParentRoute: () => domainRoute,
 	path: 'dns/add',
 } ).lazy( () =>
 	import( '../../sites/domains/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'site-domain-dns-add' )( {
+		createLazyRoute( 'domain-dns-add' )( {
 			component: d.default,
 		} )
 	)
 );
 
-export const siteDomainDnsEditRoute = createRoute( {
-	getParentRoute: () => siteDomainRoute,
+export const domainDnsEditRoute = createRoute( {
+	getParentRoute: () => domainRoute,
 	path: 'dns/edit',
 } ).lazy( () =>
 	import( '../../sites/domains/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'site-domain-dns-edit' )( {
+		createLazyRoute( 'domain-dns-edit' )( {
 			component: d.default,
 		} )
 	)
 );
 
-// Site domain forwarding routes
-export const siteDomainForwardingRoute = createRoute( {
-	getParentRoute: () => siteDomainRoute,
+// Domain forwarding routes
+export const domainForwardingRoute = createRoute( {
+	getParentRoute: () => domainRoute,
 	path: 'forwarding',
 } ).lazy( () =>
 	import( '../../sites/domains/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'site-domain-forwarding' )( {
+		createLazyRoute( 'domain-forwarding' )( {
 			component: d.default,
 		} )
 	)
 );
 
-export const siteDomainForwardingAddRoute = createRoute( {
-	getParentRoute: () => siteDomainRoute,
+export const domainForwardingAddRoute = createRoute( {
+	getParentRoute: () => domainRoute,
 	path: 'forwarding/add',
 } ).lazy( () =>
 	import( '../../sites/domains/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'site-domain-forwarding-add' )( {
+		createLazyRoute( 'domain-forwarding-add' )( {
 			component: d.default,
 		} )
 	)
 );
 
-export const siteDomainForwardingEditRoute = createRoute( {
-	getParentRoute: () => siteDomainRoute,
+export const domainForwardingEditRoute = createRoute( {
+	getParentRoute: () => domainRoute,
 	path: 'forwarding/edit',
 } ).lazy( () =>
 	import( '../../sites/domains/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'site-domain-forwarding-edit' )( {
+		createLazyRoute( 'domain-forwarding-edit' )( {
 			component: d.default,
 		} )
 	)
 );
 
-export const siteDomainContactInfoRoute = createRoute( {
-	getParentRoute: () => siteDomainRoute,
+export const domainContactInfoRoute = createRoute( {
+	getParentRoute: () => domainRoute,
 	path: 'contact_info',
 } ).lazy( () =>
 	import( '../../sites/domains/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'site-domain-contact-info' )( {
+		createLazyRoute( 'domain-contact-info' )( {
 			component: d.default,
 		} )
 	)
 );
 
-export const siteDomainNameServersRoute = createRoute( {
-	getParentRoute: () => siteDomainRoute,
+export const domainNameServersRoute = createRoute( {
+	getParentRoute: () => domainRoute,
 	path: 'name_servers',
 } ).lazy( () =>
 	import( '../../sites/domains/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'site-domain-name-servers' )( {
+		createLazyRoute( 'domain-name-servers' )( {
 			component: d.default,
 		} )
 	)
 );
 
-export const siteDomainGlueRecordsRoute = createRoute( {
-	getParentRoute: () => siteDomainRoute,
+export const domainGlueRecordsRoute = createRoute( {
+	getParentRoute: () => domainRoute,
 	path: 'glue_records',
 } ).lazy( () =>
 	import( '../../sites/domains/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'site-domain-glue-records' )( {
+		createLazyRoute( 'domain-glue-records' )( {
 			component: d.default,
 		} )
 	)
 );
 
-export const siteDomainDnssecRoute = createRoute( {
-	getParentRoute: () => siteDomainRoute,
+export const domainDnssecRoute = createRoute( {
+	getParentRoute: () => domainRoute,
 	path: 'dnssec',
 } ).lazy( () =>
 	import( '../../sites/domains/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'site-domain-dnssec' )( {
+		createLazyRoute( 'domain-dnssec' )( {
 			component: d.default,
 		} )
 	)
 );
 
-export const siteDomainTransferRoute = createRoute( {
-	getParentRoute: () => siteDomainRoute,
+export const domainTransferRoute = createRoute( {
+	getParentRoute: () => domainRoute,
 	path: 'transfer',
 } ).lazy( () =>
 	import( '../../sites/domains/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'site-domain-transfer' )( {
+		createLazyRoute( 'domain-transfer' )( {
 			component: d.default,
 		} )
 	)
 );
 
-// Export all site domain child routes for easy inclusion
-export const siteDomainChildRoutes: AnyRoute[] = [
-	siteDomainDnsRoute,
-	siteDomainDnsAddRoute,
-	siteDomainDnsEditRoute,
-	siteDomainForwardingRoute,
-	siteDomainForwardingAddRoute,
-	siteDomainForwardingEditRoute,
-	siteDomainContactInfoRoute,
-	siteDomainNameServersRoute,
-	siteDomainGlueRecordsRoute,
-	siteDomainDnssecRoute,
-	siteDomainTransferRoute,
+// Export all domain child routes for easy inclusion
+export const domainChildRoutes: AnyRoute[] = [
+	domainOverviewRoute,
+	domainDnsRoute,
+	domainDnsAddRoute,
+	domainDnsEditRoute,
+	domainForwardingRoute,
+	domainForwardingAddRoute,
+	domainForwardingEditRoute,
+	domainContactInfoRoute,
+	domainNameServersRoute,
+	domainGlueRecordsRoute,
+	domainDnssecRoute,
+	domainTransferRoute,
 ];

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -34,15 +34,11 @@ const DomainName = ( {
 	showPrimaryDomainBadge?: boolean;
 } ) => {
 	const siteSlug = site?.slug ?? domain.site_slug;
-	const domainManagementUrl = site
-		? domainOverviewRoute.fullPath
-		: `${ window.location.origin }/domains/manage/all/overview/${ domain.domain }/${ siteSlug }`;
-	const domainManagementParams = { siteSlug, domainName: domain.domain };
 
 	return (
 		<Link
-			to={ domainManagementUrl }
-			params={ domainManagementParams }
+			to={ domainOverviewRoute.fullPath }
+			params={ { siteSlug, domainName: domain.domain } }
 			disabled={ domain.type === DomainTypes.WPCOM }
 		>
 			<HStack spacing={ 1 }>

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -9,7 +9,7 @@ import { dateI18n } from '@wordpress/date';
 import { sprintf, __ } from '@wordpress/i18n';
 import { caution, reusableBlock } from '@wordpress/icons';
 import { useMemo } from 'react';
-import { siteDomainRoute } from '../../app/router';
+import { domainOverviewRoute } from '../../app/router';
 import { DomainTypes } from '../../data/domains';
 import type { Domain, Site } from '../../data/types';
 import type { Field } from '@wordpress/dataviews';
@@ -35,7 +35,7 @@ const DomainName = ( {
 } ) => {
 	const siteSlug = site?.slug ?? domain.site_slug;
 	const domainManagementUrl = site
-		? siteDomainRoute.fullPath
+		? domainOverviewRoute.fullPath
 		: `${ window.location.origin }/domains/manage/all/overview/${ domain.domain }/${ siteSlug }`;
 	const domainManagementParams = { siteSlug, domainName: domain.domain };
 

--- a/client/dashboard/sites/domains/placeholder.tsx
+++ b/client/dashboard/sites/domains/placeholder.tsx
@@ -1,9 +1,9 @@
-import { siteDomainRoute } from '../../app/router';
+import { domainRoute } from '../../app/router';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 
 export default function DomainPlaceholder() {
-	const { domainName } = siteDomainRoute.useParams();
+	const { domainName } = domainRoute.useParams();
 
 	return <PageLayout size="small" header={ <PageHeader title={ domainName } /> }></PageLayout>;
 }


### PR DESCRIPTION
We consulted with @matt-west about this - all domain screens should be under the `/domains` route (except for the list of site domains) which means that there is no need to duplicate the routes for any of the domain management pages.

So basically - we'll have the following routes for domains:
```
/domains - all domains list
/sites/$siteSlug/domains - site domains list
/domains/$domainName/ - the domain overview page
/domains/$domainName/dns - DNS records list
/domains/$domainName/dnssec - DNSSEC section
and etc...
...
```

see: p1754385212876679/1754322688.212309-slack-C04H4NY6STW

Part of https://linear.app/a8c/issue/DOTDASH-187/create-all-the-routes-with-tbd-components

## Proposed Changes

* Update the hosting dashboard domain routes according to the latest directions
* Fix the overview route to work properly
* Change some of the paths to use dash instead of underscore

## Why are these changes being made?

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2/domains and click on a domain - you should see the TBD screen
* Go to /v2/sites/some_site.com/domains - you should see the list of the site domains
* Click on a domain from that list - you should see the placeholder component
* Go to /v2/domains/someDomain/randomstring - you should see 404

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?