### PR TITLE
Staging Sites Redesign: Fix design issues with dropdowns

### DIFF
--- a/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
@@ -61,7 +61,7 @@ export default function SyncDropdown( {
 				) }
 				renderContent={ ( { onClose } ) => (
 					<div>
-						<MenuGroup>
+						<MenuGroup className={ className }>
 							<MenuItem
 								onClick={ () => {
 									onClose();

--- a/client/sites/components/site-preview-pane/preview-pane-header-buttons.scss
+++ b/client/sites/components/site-preview-pane/preview-pane-header-buttons.scss
@@ -1,4 +1,6 @@
 .item-preview__sync-dropdown {
+	width: min-content;
+
 	.components-button {
 		height: 40px;
 		border-radius: 4px;

--- a/client/sites/components/site-preview-pane/site-environment-switcher.scss
+++ b/client/sites/components/site-preview-pane/site-environment-switcher.scss
@@ -4,7 +4,7 @@
 		padding: calc( 4px * 1 );
 	}
 
-	.components-dropdown-menu__menu-item {
+	.components-button.components-dropdown-menu__menu-item {
 		justify-content: flex-start;
 		padding-left: 10px
 	}

--- a/client/sites/components/site-preview-pane/site-environment-switcher.scss
+++ b/client/sites/components/site-preview-pane/site-environment-switcher.scss
@@ -6,9 +6,11 @@
 
 	.components-dropdown-menu__menu-item {
 		justify-content: flex-start;
+		padding-left: 10px
 	}
 
-	.components-dropdown-menu__menu-item.is-active {
+	.components-dropdown-menu__menu-item.is-active,
+	.components-dropdown-menu__menu-item.is-active:hover {
 		background-color: var( --color-primary );
 		color: var( --color-light-backdrop );
 	}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTCOM-14114

## Proposed Changes

* Update the CSS to reduce the width in the Sync dropdown
* Add some left padding to the environment switcher
* Remove the unwanted background when hovering over the environment switcher

||Before | After|
|-------|-------|------|
|Sync dropdown|<img width="1021" height="318" alt="image" src="https://github.com/user-attachments/assets/d77468ad-2ccc-4c73-bd07-fb2f98c4d23e" />|  <img width="1528" height="452" alt="CleanShot 2025-08-05 at 17 19 38@2x" src="https://github.com/user-attachments/assets/e00b34fb-7d8a-4597-9ee8-88043737986e" />|
| Environment switcher hover over menu items |<img width="620" height="360" alt="image" src="https://github.com/user-attachments/assets/0d3f9db3-226d-4e1f-9a06-4c031192bd33" /> |  <img width="1528" height="452" alt="CleanShot 2025-08-05 at 17 20 15@2x" src="https://github.com/user-attachments/assets/a7d1cf60-55c6-4c5d-b8f5-90d18157f3bf" /> |
| Environment switcher left padding | <img width="988" height="450" alt="image" src="https://github.com/user-attachments/assets/418d2e27-f97f-4022-898a-7022695f871a" />| <img width="1528" height="452" alt="CleanShot 2025-08-05 at 17 35 59@2x" src="https://github.com/user-attachments/assets/af67341a-ca5d-4a2c-874b-681ec3b82730" />|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To address some feedback received during CfT pdtkmj-3Qm-p2#comment-7375 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch and run Calypso locally or use Calypso Live link below
* Navigate to a site with a Staging site or add a staging site to an existing site
* Expand the Sync dropdown on the top right and check that the width of the dropdown looks like the design ASqz3fW9Go9m5bHL2XiuUR-fi-777_33943
* Expand the environment switcher and hover over the Production and Staging menu items
* Check they are not highlighted in the same color than the background
* Check that the menu items have some left padding

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?