### PR TITLE
A4A: [BD] Add the Automattic logo to the Checkout page header

### DIFF
--- a/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
@@ -5,6 +5,7 @@ import { createRequestCartProduct, useShoppingCart } from '@automattic/shopping-
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
+import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
 import useProductsById from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-products-by-id';
 import { getClientReferralQueryArgs } from 'calypso/a8c-for-agencies/sections/marketplace/lib/get-client-referral-query-args';
 import { getStripeConfiguration, getRazorpayConfiguration } from 'calypso/lib/store-transactions';
@@ -141,6 +142,11 @@ function ClientCheckoutContent() {
 
 	return (
 		<div className="client-checkout-v2">
+			<div className="client-checkout-v2__top-bar">
+				<div className="client-checkout-v2__top-bar-logo">
+					<A4ALogo full size={ 14 } />
+				</div>
+			</div>
 			<CheckoutMain
 				sitelessCheckoutType="a4a"
 				redirectTo={ window.location.origin + '/client/subscriptions' }

--- a/client/a8c-for-agencies/sections/client/primary/checkout-v2/style.scss
+++ b/client/a8c-for-agencies/sections/client/primary/checkout-v2/style.scss
@@ -7,6 +7,10 @@
 
 .client-checkout-v2 {
 	min-height: 100vh;
+
+	.checkout-sidebar-content {
+		margin-top: 0;
+	}
 }
 .client-checkout-v2__top-bar {
 	position: absolute;
@@ -18,6 +22,7 @@
 	z-index: 1000;
 
 	@media (max-width: $break-large) {
+		position: relative;
 		justify-content: center;
 	}
 }

--- a/client/a8c-for-agencies/sections/client/primary/checkout-v2/style.scss
+++ b/client/a8c-for-agencies/sections/client/primary/checkout-v2/style.scss
@@ -11,10 +11,10 @@
 .client-checkout-v2__top-bar {
 	position: absolute;
 	width: 100%;
-    box-sizing: border-box;
-    display: flex;
-    align-items: center;
-    padding: 24px 16px 16px;
+	box-sizing: border-box;
+	display: flex;
+	align-items: center;
+	padding: 24px 16px 16px;
 	z-index: 1000;
 
 	@media (max-width: $break-large) {

--- a/client/a8c-for-agencies/sections/client/primary/checkout-v2/style.scss
+++ b/client/a8c-for-agencies/sections/client/primary/checkout-v2/style.scss
@@ -8,3 +8,16 @@
 .client-checkout-v2 {
 	min-height: 100vh;
 }
+.client-checkout-v2__top-bar {
+	position: absolute;
+	width: 100%;
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    padding: 24px 16px 16px;
+	z-index: 1000;
+
+	@media (max-width: $break-large) {
+		justify-content: center;
+	}
+}


### PR DESCRIPTION
Part of Linear Issue: A4A-1355/add-a8c-logo-to-checkout-page

## Proposed Changes

This PR adds the Automattic logo to the BD Checkout page.

Desktop:

<img width="992" height="407" alt="image" src="https://github.com/user-attachments/assets/c38628c4-2a01-4ea1-adcb-59c6b4a6679e" />

Mobile:

<img width="669" height="389" alt="image" src="https://github.com/user-attachments/assets/3f03f9e7-c3f4-4f18-b80f-e3f5b02071e7" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Check the code
- Test it using the live link
- As an agency, send a referral to a client
- As a client, click on the link and change the route to `client/checkout/v2?` preserving the query parameters.
- Ensure you see the Automattic logo

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
