### PR TITLE
Purchases: Remove content wrapper for NoSitesMessage

### DIFF
--- a/client/me/purchases/purchases-list-in-dataviews/index.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/index.tsx
@@ -214,14 +214,7 @@ function PurchasesContent( {
 	// If the user has no regular subscriptions, no memberships subscriptions,
 	// and no sites, render the "no sites" page.
 	if ( ! sites.length ) {
-		return (
-			<Main wideLayout className="purchases-list">
-				<PageViewTracker path="/me/purchases" title="Purchases > No Sites" />
-				<NavigationHeader navigationItems={ [] } title={ titles.sectionTitle } />
-				<PurchasesNavigation section="activeUpgrades" />
-				<NoSitesMessage />
-			</Main>
-		);
+		return <NoSitesMessage />;
 	}
 
 	// If the user has no regular subscriptions, no memberships subscriptions,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CHE-241/purchases-page-looks-broken-for-users-with-no-sites

## Proposed Changes

This PR removes the content wrapper that surrounded the `NoSitesMessage` component on the `/me/purchases` page which is shown when you have no subscriptions and no sites.

Before             |  After
:-------------------------:|:-------------------------:
<img width="959" height="645" alt="Screenshot 2025-08-05 at 1 30 38 PM" src="https://github.com/user-attachments/assets/08f3f704-8458-46f0-a8bb-bd0c7bd6e69b" /> | <img width="945" height="431" alt="Screenshot 2025-08-05 at 1 30 49 PM" src="https://github.com/user-attachments/assets/4e57da4d-d426-470f-b2a8-29caadb4cf52" />


## Testing Instructions

First you'll need an account with no subscritions and no sites. You can also simulate this by hacking the code as follows.

```diff
diff --git a/client/me/purchases/purchases-list-in-dataviews/index.tsx b/client/me/purchases/purchases-list-in-dataviews/index.tsx
index 64405d2e5a7..5d5d5744733 100644
--- a/client/me/purchases/purchases-list-in-dataviews/index.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/index.tsx
@@ -156,7 +156,6 @@ const PurchasesListDataView: React.FC<
 				isUserBlocked={ isUserBlocked }
 				availableSessions={ availableSessions }
 			/>
-			<MembershipSubscriptions memberships={ subscriptions } />
 			<QueryConciergeInitial />
 		</Main>
 	);
@@ -190,6 +189,10 @@ function PurchasesContent( {
 		return <PurchasesSite isPlaceholder />;
 	}
 
+	allPurchases = [];
+	subscriptions = [];
+	sites = [];
+
 	// If the user has regular subscriptions, render them. Note that
 	// memberships subscriptions are rendered separately in the parent
 	// component.
```

Then visit `/me/purchases` and verify that the "You don't have any sites yet" message does not contain its own duplicate header and navigation bar.
