### PR TITLE
POC - Add Hosting Dashboard Domain contact info

### DIFF
--- a/client/dashboard/app/routes/domain-routes.ts
+++ b/client/dashboard/app/routes/domain-routes.ts
@@ -130,7 +130,7 @@ export const domainContactInfoRoute = createRoute( {
 	getParentRoute: () => domainRoute,
 	path: 'contact-info',
 } ).lazy( () =>
-	import( '../../sites/domains/placeholder' ).then( ( d ) =>
+	import( '../../domains/contact-details' ).then( ( d ) =>
 		createLazyRoute( 'domain-contact-info' )( {
 			component: d.default,
 		} )

--- a/client/dashboard/domains/contact-details/contact-form.scss
+++ b/client/dashboard/domains/contact-details/contact-form.scss
@@ -1,0 +1,110 @@
+.contact-form {
+	// Basic form spacing
+	.components-text-control,
+	.components-select-control,
+	.components-checkbox-control {
+		margin-block-end: 24px;
+	}
+
+	// Uppercase labels
+	.components-text-control__label,
+	.components-select-control__label {
+		text-transform: uppercase;
+		font-weight: 600;
+		font-size: 12px;
+		color: var(--studio-gray-80);
+		margin-block-end: 8px;
+	}
+
+	// Simple input styling
+	.components-text-control__input,
+	.components-select-control__input {
+		border: 1px solid var(--studio-gray-20);
+		border-radius: 4px;
+		padding: 12px;
+		font-size: 14px;
+		width: 100%;
+		background: var(--studio-white);
+
+		&:focus {
+			border-color: var(--studio-blue-50);
+			box-shadow: 0 0 0 1px var(--studio-blue-50);
+			outline: none;
+		}
+	}
+
+	// Checkbox styling
+	.components-checkbox-control {
+		margin-block-start: 32px;
+		margin-block-end: 32px;
+
+		.components-checkbox-control__label {
+			text-transform: none;
+			font-weight: 400;
+			font-size: 14px;
+			color: var(--studio-gray-70);
+		}
+	}
+
+	// Legal notice
+	&__legal-notice {
+		margin-block-end: 32px;
+
+		.components-notice__content {
+			padding: 0;
+		}
+
+		p {
+			margin: 0;
+			font-size: 14px;
+			line-height: 1.5;
+			color: var(--studio-gray-60);
+		}
+
+		.components-external-link {
+			color: var(--studio-blue-50);
+			text-decoration: underline;
+		}
+	}
+
+	// Action buttons
+	&__actions {
+		margin-block-start: 32px;
+		padding-block-start: 24px;
+		border-block-start: 1px solid var(--studio-gray-10);
+	}
+
+	&__submit-button,
+	&__cancel-button {
+		padding: 12px 24px;
+		border: 1px solid var(--studio-gray-20);
+		border-radius: 4px;
+		font-size: 14px;
+		font-weight: 500;
+		cursor: pointer;
+		transition: all 0.15s ease-in-out;
+
+		&:disabled {
+			opacity: 0.5;
+			cursor: not-allowed;
+		}
+	}
+
+	&__submit-button {
+		background: var(--studio-gray-5);
+		color: var(--studio-gray-80);
+
+		&:hover:not(:disabled) {
+			background: var(--studio-gray-10);
+		}
+	}
+
+	&__cancel-button {
+		background: var(--studio-white);
+		color: var(--studio-gray-80);
+
+		&:hover:not(:disabled) {
+			background: var(--studio-gray-5);
+		}
+	}
+} 

--- a/client/dashboard/domains/contact-details/contact-form.tsx
+++ b/client/dashboard/domains/contact-details/contact-form.tsx
@@ -1,0 +1,223 @@
+import {
+	CheckboxControl,
+	ExternalLink,
+	Flex,
+	FlexBlock,
+	Notice,
+	SelectControl,
+	TextControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+
+import './contact-form.scss';
+
+interface ContactFormData {
+	firstName: string;
+	lastName: string;
+	organization: string;
+	email: string;
+	phone: string;
+	country: string;
+	addressLine1: string;
+	addressLine2: string;
+	city: string;
+	postCode: string;
+	optOutTransferLock: boolean;
+}
+
+interface ContactFormProps {
+	initialData?: Partial< ContactFormData >;
+	onSubmit?: ( data: ContactFormData ) => void;
+	onCancel?: () => void;
+	errors?: Partial< Record< keyof ContactFormData, string > >;
+	isSubmitting?: boolean;
+}
+
+// Mock data - in a real implementation, this would come from an API
+const COUNTRIES = [
+	{ label: 'United Kingdom', value: 'GB' },
+	{ label: 'United States', value: 'US' },
+	{ label: 'Canada', value: 'CA' },
+	{ label: 'Brazil', value: 'BR' },
+	{ label: 'Germany', value: 'DE' },
+	{ label: 'France', value: 'FR' },
+	{ label: 'Spain', value: 'ES' },
+	{ label: 'Italy', value: 'IT' },
+	{ label: 'Netherlands', value: 'NL' },
+	{ label: 'Australia', value: 'AU' },
+];
+
+export default function ContactForm( {
+	initialData = {},
+	onSubmit,
+	onCancel,
+	errors = {},
+	isSubmitting = false,
+}: ContactFormProps ) {
+	const [ formData, setFormData ] = useState< ContactFormData >( {
+		firstName: 'Value',
+		lastName: 'Value',
+		organization: '',
+		email: 'email@email.com',
+		phone: '+44 1234 567890',
+		country: 'GB',
+		addressLine1: '',
+		addressLine2: '',
+		city: 'London',
+		postCode: 'NW1 1ED',
+		optOutTransferLock: false,
+		...initialData,
+	} );
+
+	const handleFieldChange = ( field: keyof ContactFormData, value: string | boolean ) => {
+		setFormData( ( prev ) => ( {
+			...prev,
+			[ field ]: value,
+		} ) );
+	};
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		onSubmit?.( formData );
+	};
+
+	return (
+		<form onSubmit={ handleSubmit } className="contact-form">
+			{ /* First Name & Last Name */ }
+			<Flex gap={ 4 }>
+				<FlexBlock>
+					<TextControl
+						label={ __( 'FIRST NAME' ) }
+						value={ formData.firstName }
+						onChange={ ( value ) => handleFieldChange( 'firstName', value ) }
+						error={ errors.firstName }
+					/>
+				</FlexBlock>
+				<FlexBlock>
+					<TextControl
+						label={ __( 'LAST NAME' ) }
+						value={ formData.lastName }
+						onChange={ ( value ) => handleFieldChange( 'lastName', value ) }
+						error={ errors.lastName }
+					/>
+				</FlexBlock>
+			</Flex>
+
+			{ /* Organisation */ }
+			<TextControl
+				label={ __( 'ORGANISATION' ) }
+				value={ formData.organization }
+				onChange={ ( value ) => handleFieldChange( 'organization', value ) }
+				placeholder={ __( 'Your organization' ) }
+				error={ errors.organization }
+			/>
+
+			{ /* Email & Phone */ }
+			<Flex gap={ 4 }>
+				<FlexBlock>
+					<TextControl
+						type="email"
+						label={ __( 'EMAIL' ) }
+						value={ formData.email }
+						onChange={ ( value ) => handleFieldChange( 'email', value ) }
+						error={ errors.email }
+					/>
+				</FlexBlock>
+				<FlexBlock>
+					<TextControl
+						label={ __( 'PHONE' ) }
+						value={ formData.phone }
+						onChange={ ( value ) => handleFieldChange( 'phone', value ) }
+						error={ errors.phone }
+					/>
+				</FlexBlock>
+			</Flex>
+
+			{ /* Country */ }
+			<SelectControl
+				label={ __( 'COUNTRY' ) }
+				value={ formData.country }
+				onChange={ ( value ) => handleFieldChange( 'country', value ) }
+				options={ COUNTRIES }
+				error={ errors.country }
+			/>
+
+			{ /* Address Line 1 */ }
+			<TextControl
+				label={ __( 'ADDRESS LINE 1' ) }
+				value={ formData.addressLine1 }
+				onChange={ ( value ) => handleFieldChange( 'addressLine1', value ) }
+				placeholder={ __( 'Address line 1' ) }
+				error={ errors.addressLine1 }
+			/>
+
+			{ /* Address Line 2 */ }
+			<TextControl
+				label={ __( 'ADDRESS LINE 2' ) }
+				value={ formData.addressLine2 }
+				onChange={ ( value ) => handleFieldChange( 'addressLine2', value ) }
+				placeholder={ __( 'Address line 2' ) }
+				error={ errors.addressLine2 }
+			/>
+
+			{ /* City & Post Code */ }
+			<Flex gap={ 4 }>
+				<FlexBlock>
+					<TextControl
+						label={ __( 'CITY' ) }
+						value={ formData.city }
+						onChange={ ( value ) => handleFieldChange( 'city', value ) }
+						error={ errors.city }
+					/>
+				</FlexBlock>
+				<FlexBlock>
+					<TextControl
+						label={ __( 'POST CODE' ) }
+						value={ formData.postCode }
+						onChange={ ( value ) => handleFieldChange( 'postCode', value ) }
+						error={ errors.postCode }
+					/>
+				</FlexBlock>
+			</Flex>
+
+			{ /* Transfer Lock Checkbox */ }
+			<CheckboxControl
+				label={ __( 'Opt-out of the 60-day transfer lock' ) }
+				checked={ formData.optOutTransferLock }
+				onChange={ ( value ) => handleFieldChange( 'optOutTransferLock', value ) }
+			/>
+
+			{ /* Legal Disclaimer */ }
+			<Notice status="info" isDismissible={ false } className="contact-form__legal-notice">
+				<p>
+					{ __( 'By clicking **Save contact info**, you agree to the applicable' ) }{ ' ' }
+					<ExternalLink href="#">{ __( 'Domain Registration Agreement' ) }</ExternalLink>{ ' ' }
+					{ __(
+						'and confirm that the Transferee has agreed in writing to be bound by the same agreement. You authorize the respective registrar to act as your'
+					) }{ ' ' }
+					<ExternalLink href="#">{ __( 'Designated Agent' ) }</ExternalLink>.
+				</p>
+			</Notice>
+
+			{ /* Action Buttons */ }
+			<div className="contact-form__actions">
+				<Flex gap={ 3 } justify="start">
+					<button type="submit" className="contact-form__submit-button" disabled={ isSubmitting }>
+						{ __( 'Save contact info' ) }
+					</button>
+					{ onCancel && (
+						<button
+							type="button"
+							className="contact-form__cancel-button"
+							onClick={ onCancel }
+							disabled={ isSubmitting }
+						>
+							{ __( 'Cancel' ) }
+						</button>
+					) }
+				</Flex>
+			</div>
+		</form>
+	);
+}

--- a/client/dashboard/domains/contact-details/index.tsx
+++ b/client/dashboard/domains/contact-details/index.tsx
@@ -1,11 +1,9 @@
 import { useNavigate } from '@tanstack/react-router';
-import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import Breadcrumb, { Item as BreadcrumbItem } from 'calypso/components/breadcrumb';
-import EditContactInfoPageContent from 'calypso/my-sites/domains/domain-management/edit-contact-info-page/edit-contact-info-page-content';
 import { domainRoute } from '../../app/routes/domain-routes';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import ContactForm from './contact-form';
 
 import './style.scss';
 
@@ -13,37 +11,35 @@ export default function DomainContactInfo() {
 	const { domainName } = domainRoute.useParams();
 	const navigate = useNavigate();
 
-	const breadcrumbItems: BreadcrumbItem[] = [
-		{
-			label: __( 'Overview' ),
-			href: `/v2/domains/${ domainName }`,
-			onClick: () => {
-				navigate( { to: '/domains/$domainName', params: { domainName } } );
-			},
-		},
-	];
+	const handleSubmit = ( formData: any ) => {
+		// TODO: Implement form submission
+		// Form data will be processed here
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		void formData;
+	};
 
-	const handleCloseInfo = () => {
-		// TODO: Implement close functionality for the info box
+	const handleCancel = () => {
+		navigate( { to: '/domains/$domainName', params: { domainName } } );
 	};
 
 	return (
-		<PageLayout
-			size="small"
-			header={
-				<PageHeader
-					title={ __( 'Contact details' ) }
-					prefix={ <Breadcrumb items={ breadcrumbItems } /> }
-				/>
-			}
-		>
+		<PageLayout size="small" header={ <PageHeader title={ __( 'Contact details' ) } /> }>
 			<div className="domain-contact-info">
-				<div className="domain-contact-info__content">Here's the info box</div>
-
-				<EditContactInfoPageContent
-					domains={ [] }
-					selectedDomainName={ domainName }
-					selectedSite={ null }
+				<ContactForm
+					initialData={ {
+						firstName: 'Value',
+						lastName: 'Value',
+						organization: '',
+						email: 'email@email.com',
+						phone: '+44 1234 567890',
+						country: 'GB',
+						addressLine1: '',
+						addressLine2: '',
+						city: 'London',
+						postCode: 'NW1 1ED',
+					} }
+					onSubmit={ handleSubmit }
+					onCancel={ handleCancel }
 				/>
 			</div>
 		</PageLayout>

--- a/client/dashboard/domains/contact-details/index.tsx
+++ b/client/dashboard/domains/contact-details/index.tsx
@@ -1,0 +1,51 @@
+import { useNavigate } from '@tanstack/react-router';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import Breadcrumb, { Item as BreadcrumbItem } from 'calypso/components/breadcrumb';
+import EditContactInfoPageContent from 'calypso/my-sites/domains/domain-management/edit-contact-info-page/edit-contact-info-page-content';
+import { domainRoute } from '../../app/routes/domain-routes';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+
+import './style.scss';
+
+export default function DomainContactInfo() {
+	const { domainName } = domainRoute.useParams();
+	const navigate = useNavigate();
+
+	const breadcrumbItems: BreadcrumbItem[] = [
+		{
+			label: __( 'Overview' ),
+			href: `/v2/domains/${ domainName }`,
+			onClick: () => {
+				navigate( { to: '/domains/$domainName', params: { domainName } } );
+			},
+		},
+	];
+
+	const handleCloseInfo = () => {
+		// TODO: Implement close functionality for the info box
+	};
+
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					title={ __( 'Contact details' ) }
+					prefix={ <Breadcrumb items={ breadcrumbItems } /> }
+				/>
+			}
+		>
+			<div className="domain-contact-info">
+				<div className="domain-contact-info__content">Here's the info box</div>
+
+				<EditContactInfoPageContent
+					domains={ [] }
+					selectedDomainName={ domainName }
+					selectedSite={ null }
+				/>
+			</div>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/domains/contact-details/style.scss
+++ b/client/dashboard/domains/contact-details/style.scss
@@ -1,5 +1,4 @@
 .domain-contact-info {
-	
-
-	
+	// Styles for the main container
+	// Additional styles can be added here as needed
 } 

--- a/client/dashboard/domains/contact-details/style.scss
+++ b/client/dashboard/domains/contact-details/style.scss
@@ -1,0 +1,5 @@
+.domain-contact-info {
+	
+
+	
+} 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTDASH-200/add-contact-details-editing-screen

## Proposed Changes

* This is a POC for experimenting with the new Hosting Dashboard

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
