### PR TITLE
Purchases: Convert cancel-purchase to TypeScript

### DIFF
--- a/client/me/purchases/cancel-purchase/button.tsx
+++ b/client/me/purchases/cancel-purchase/button.tsx
@@ -7,7 +7,7 @@ import {
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import PropTypes from 'prop-types';
+import moment from 'moment';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import CancelJetpackForm from 'calypso/components/marketing-survey/cancel-jetpack-form';
@@ -26,32 +26,55 @@ import { clearPurchases } from 'calypso/state/purchases/actions';
 import { refreshSitePlans } from 'calypso/state/sites/plans/actions';
 import { MarketPlaceSubscriptionsDialog } from '../marketplace-subscriptions-dialog';
 import { willShowDomainOptionsRadioButtons } from './domain-options';
+import type { Purchases } from '@automattic/data-stores';
+import type { LocalizeProps } from 'i18n-calypso';
 
-class CancelPurchaseButton extends Component {
-	static propTypes = {
-		purchase: PropTypes.object.isRequired,
-		purchaseListUrl: PropTypes.string,
-		siteSlug: PropTypes.string.isRequired,
-		cancelBundledDomain: PropTypes.bool.isRequired,
-		includedDomainPurchase: PropTypes.object,
-		disabled: PropTypes.bool,
-		activeSubscriptions: PropTypes.array,
-		onCancellationStart: PropTypes.func,
-		onCancellationComplete: PropTypes.func,
-		onSurveyComplete: PropTypes.func,
-		moment: PropTypes.func,
-		// Props from parent component
-		showDialog: PropTypes.bool,
-		isLoading: PropTypes.bool,
-		onDialogClose: PropTypes.func,
-		onSetLoading: PropTypes.func,
-		// Methods from parent component
-		downgradeClick: PropTypes.func,
-		freeMonthOfferClick: PropTypes.func,
-		// Control marketplace dialog visibility
-		showMarketplaceDialog: PropTypes.bool,
-	};
+interface MomentProps {
+	moment: typeof moment;
+}
 
+export interface CancelPurchaseButtonConnectedProps {
+	isJetpack: boolean;
+	isAkismet: boolean;
+}
+
+export interface CancelPurchaseButtonProps {
+	purchase: Purchases.Purchase;
+	purchaseListUrl: string;
+	siteSlug: string;
+	cancelBundledDomain: boolean;
+	includedDomainPurchase: Purchases.Purchase;
+	disabled?: boolean;
+	activeSubscriptions: Array< { id: number; productName: string } >;
+	onCancellationStart: null | ( () => void );
+	onCancellationComplete: () => void;
+	onSurveyComplete: () => void;
+	// Props from parent component
+	showDialog: boolean;
+	isLoading: boolean;
+	onDialogClose: () => void;
+	onSetLoading: ( isLoading: boolean ) => void;
+	// Methods from parent component
+	downgradeClick: ( upsell: string ) => void;
+	freeMonthOfferClick: () => void;
+	// Control marketplace dialog visibility
+	showMarketplaceDialog?: boolean;
+}
+
+export type CancelPurchaseButtonAllProps = CancelPurchaseButtonProps &
+	CancelPurchaseButtonConnectedProps &
+	LocalizeProps &
+	MomentProps;
+
+export interface CancelPurchaseButtonState {
+	disabled: boolean;
+	isShowingMarketplaceSubscriptionsDialog: boolean;
+}
+
+class CancelPurchaseButton extends Component<
+	CancelPurchaseButtonAllProps,
+	CancelPurchaseButtonState
+> {
 	static defaultProps = {
 		purchaseListUrl: purchasesRoot,
 		showMarketplaceDialog: true,
@@ -62,7 +85,7 @@ class CancelPurchaseButton extends Component {
 		isShowingMarketplaceSubscriptionsDialog: false,
 	};
 
-	setDisabled = ( disabled ) => {
+	setDisabled = ( disabled: boolean ) => {
 		this.setState( { disabled } );
 	};
 
@@ -252,7 +275,7 @@ class CancelPurchaseButton extends Component {
 }
 
 export default connect(
-	( state, { purchase } ) => ( {
+	( state, { purchase }: CancelPurchaseButtonProps ) => ( {
 		isJetpack: purchase && ( isJetpackPlan( purchase ) || isJetpackProduct( purchase ) ),
 		isAkismet: purchase && isAkismetProduct( purchase ),
 	} ),

--- a/client/me/purchases/cancel-purchase/button.tsx
+++ b/client/me/purchases/cancel-purchase/button.tsx
@@ -40,7 +40,7 @@ export interface CancelPurchaseButtonConnectedProps {
 
 export interface CancelPurchaseButtonProps {
 	purchase: Purchases.Purchase;
-	purchaseListUrl: string;
+	purchaseListUrl?: string;
 	siteSlug: string;
 	cancelBundledDomain: boolean;
 	includedDomainPurchase: Purchases.Purchase;
@@ -75,11 +75,6 @@ class CancelPurchaseButton extends Component<
 	CancelPurchaseButtonAllProps,
 	CancelPurchaseButtonState
 > {
-	static defaultProps = {
-		purchaseListUrl: purchasesRoot,
-		showMarketplaceDialog: true,
-	};
-
 	state = {
 		disabled: false,
 		isShowingMarketplaceSubscriptionsDialog: false,
@@ -124,13 +119,13 @@ class CancelPurchaseButton extends Component<
 		}
 
 		// Always redirect to purchases page when dialog is closed
-		page.redirect( this.props.purchaseListUrl );
+		page.redirect( this.props.purchaseListUrl ?? purchasesRoot );
 	};
 
 	shouldHandleMarketplaceSubscriptions() {
 		const { activeSubscriptions, showMarketplaceDialog } = this.props;
 
-		return activeSubscriptions?.length > 0 && showMarketplaceDialog;
+		return activeSubscriptions?.length > 0 && ( showMarketplaceDialog ?? true );
 	}
 
 	showMarketplaceDialog = () => {
@@ -226,7 +221,7 @@ class CancelPurchaseButton extends Component<
 					<CancelJetpackForm
 						disableButtons={ disableButtons }
 						purchase={ purchase }
-						purchaseListUrl={ purchaseListUrl }
+						purchaseListUrl={ purchaseListUrl ?? purchasesRoot }
 						isVisible={ showDialog }
 						onClose={ this.closeDialog }
 						onSurveyComplete={ this.props.onSurveyComplete }
@@ -240,7 +235,7 @@ class CancelPurchaseButton extends Component<
 					<DomainCancellationSurvey
 						disableButtons={ disableButtons }
 						purchase={ purchase }
-						purchaseListUrl={ purchaseListUrl }
+						purchaseListUrl={ purchaseListUrl ?? purchasesRoot }
 						isVisible={ showDialog }
 						onClose={ this.closeDialog }
 						onSurveyComplete={ this.props.onSurveyComplete }

--- a/client/me/purchases/cancel-purchase/cancellation-effect.tsx
+++ b/client/me/purchases/cancel-purchase/cancellation-effect.tsx
@@ -9,8 +9,13 @@ import {
 import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import { getName, getSubscriptionEndDate, isRefundable } from 'calypso/lib/purchases';
 import { isTemporarySitePurchase } from '../utils';
+import type { Purchases } from '@automattic/data-stores';
+import type { LocalizeProps } from 'i18n-calypso';
 
-export function cancellationEffectHeadline( purchase, translate ) {
+export function cancellationEffectHeadline(
+	purchase: Purchases.Purchase,
+	translate: LocalizeProps[ 'translate' ]
+) {
 	const { domain } = purchase;
 	const purchaseName = getName( purchase );
 
@@ -51,7 +56,13 @@ export function cancellationEffectHeadline( purchase, translate ) {
 	);
 }
 
-function refundableCancellationEffectDetail( purchase, translate, overrides ) {
+function refundableCancellationEffectDetail(
+	purchase: Purchases.Purchase,
+	translate: LocalizeProps[ 'translate' ],
+	overrides: {
+		refundText?: string;
+	}
+) {
 	const refundText = overrides.refundText || purchase.refundText;
 
 	if ( isThemePurchase( purchase ) ) {
@@ -109,7 +120,10 @@ function refundableCancellationEffectDetail( purchase, translate, overrides ) {
 	} );
 }
 
-function nonrefundableCancellationEffectDetail( purchase, translate ) {
+function nonrefundableCancellationEffectDetail(
+	purchase: Purchases.Purchase,
+	translate: LocalizeProps[ 'translate' ]
+) {
 	const subscriptionEndDate = getSubscriptionEndDate( purchase );
 
 	if ( isGSuiteOrGoogleWorkspace( purchase ) ) {
@@ -150,7 +164,13 @@ function nonrefundableCancellationEffectDetail( purchase, translate ) {
 	return '';
 }
 
-export function cancellationEffectDetail( purchase, translate, overrides = {} ) {
+export function cancellationEffectDetail(
+	purchase: Purchases.Purchase,
+	translate: LocalizeProps[ 'translate' ],
+	overrides: {
+		refundText?: string;
+	} = {}
+) {
 	if ( isRefundable( purchase ) ) {
 		return refundableCancellationEffectDetail( purchase, translate, overrides );
 	}

--- a/client/me/purchases/cancel-purchase/domain-options.tsx
+++ b/client/me/purchases/cancel-purchase/domain-options.tsx
@@ -13,9 +13,14 @@ import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormRadio from 'calypso/components/forms/form-radio';
 import { getName, isRefundable, isSubscription } from 'calypso/lib/purchases';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import type { CancelPurchaseState } from './index';
+import type { Purchases } from '@automattic/data-stores';
 
 // Helper function to determine if radio buttons will be shown
-export const willShowDomainOptionsRadioButtons = ( includedDomainPurchase, purchase ) => {
+export const willShowDomainOptionsRadioButtons = (
+	includedDomainPurchase: Purchases.Purchase,
+	purchase: Purchases.Purchase
+) => {
 	return (
 		isDomainRegistration( includedDomainPurchase ) &&
 		isRefundable( purchase ) &&
@@ -23,8 +28,15 @@ export const willShowDomainOptionsRadioButtons = ( includedDomainPurchase, purch
 	);
 };
 
-const NonRefundableDomainMappingMessage = ( { includedDomainPurchase } ) => {
+const NonRefundableDomainMappingMessage = ( {
+	includedDomainPurchase,
+}: {
+	includedDomainPurchase: Purchases.Purchase;
+} ) => {
 	const translate = useTranslate();
+	if ( ! includedDomainPurchase.meta ) {
+		return null;
+	}
 	return (
 		<div>
 			<p>
@@ -42,8 +54,17 @@ const NonRefundableDomainMappingMessage = ( { includedDomainPurchase } ) => {
 	);
 };
 
-const CancelableDomainMappingMessage = ( { includedDomainPurchase, purchase } ) => {
+const CancelableDomainMappingMessage = ( {
+	includedDomainPurchase,
+	purchase,
+}: {
+	includedDomainPurchase: Purchases.Purchase;
+	purchase: Purchases.Purchase;
+} ) => {
 	const translate = useTranslate();
+	if ( ! includedDomainPurchase.meta ) {
+		return null;
+	}
 	return (
 		<div>
 			<p>
@@ -83,8 +104,17 @@ const CancelableDomainMappingMessage = ( { includedDomainPurchase, purchase } ) 
 	);
 };
 
-const CancelPlanWithoutCancellingDomainMessage = ( { planPurchase, includedDomainPurchase } ) => {
+const CancelPlanWithoutCancellingDomainMessage = ( {
+	planPurchase,
+	includedDomainPurchase,
+}: {
+	planPurchase: Purchases.Purchase;
+	includedDomainPurchase: Purchases.Purchase;
+} ) => {
 	const translate = useTranslate();
+	if ( ! includedDomainPurchase.meta ) {
+		return null;
+	}
 	return (
 		<div>
 			<p>
@@ -131,13 +161,19 @@ const CancelPurchaseDomainOptions = ( {
 	purchase,
 	onCancelConfirmationStateChange,
 	isLoading = false,
+}: {
+	includedDomainPurchase: Purchases.Purchase;
+	cancelBundledDomain: boolean;
+	purchase: Purchases.Purchase;
+	onCancelConfirmationStateChange: ( newState: Partial< CancelPurchaseState > ) => void;
+	isLoading: boolean;
 } ) => {
 	const translate = useTranslate();
 	const [ confirmCancel, setConfirmCancel ] = useState( false );
 	const dispatch = useDispatch();
 
 	const onCancelBundledDomainChange = useCallback(
-		( event ) => {
+		( event: { currentTarget: { value: string } } ) => {
 			const newCancelBundledDomainValue = event.currentTarget.value === 'cancel';
 			onCancelConfirmationStateChange( {
 				cancelBundledDomain: newCancelBundledDomainValue,
@@ -148,7 +184,7 @@ const CancelPurchaseDomainOptions = ( {
 	);
 
 	const onConfirmCancelBundledDomainChange = useCallback(
-		( event ) => {
+		( event: { target: { checked: boolean } } ) => {
 			const checked = event.target.checked;
 			setConfirmCancel( checked );
 			onCancelConfirmationStateChange( {
@@ -224,6 +260,10 @@ const CancelPurchaseDomainOptions = ( {
 				planPurchase={ purchase }
 			/>
 		);
+	}
+
+	if ( ! includedDomainPurchase.meta ) {
+		return null;
 	}
 
 	return (

--- a/client/me/purchases/cancel-purchase/feature-list.tsx
+++ b/client/me/purchases/cancel-purchase/feature-list.tsx
@@ -2,8 +2,15 @@ import { getFeatureByKey } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { getName, isRefundable } from 'calypso/lib/purchases';
+import type { Purchases } from '@automattic/data-stores';
 
-const CancelPurchaseFeatureList = ( { purchase, cancellationFeatures } ) => {
+const CancelPurchaseFeatureList = ( {
+	purchase,
+	cancellationFeatures,
+}: {
+	purchase: Purchases.Purchase;
+	cancellationFeatures: string[];
+} ) => {
 	const translate = useTranslate();
 
 	if ( ! cancellationFeatures.length ) {

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -12,8 +12,8 @@ import {
 import page from '@automattic/calypso-router';
 import { Card, CompactCard } from '@automattic/components';
 import { formatCurrency } from '@automattic/number-formatters';
-import { localize } from 'i18n-calypso';
-import PropTypes from 'prop-types';
+import { localize, LocalizeProps } from 'i18n-calypso';
+import moment from 'moment';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import BackupRetentionOptionOnCancelPurchase from 'calypso/components/backup-retention-management/retention-option-on-cancel-purchase';
@@ -69,25 +69,75 @@ import CancelPurchaseButton from './button';
 import CancelPurchaseDomainOptions, { willShowDomainOptionsRadioButtons } from './domain-options';
 import CancelPurchaseFeatureList from './feature-list';
 import CancelPurchaseRefundInformation from './refund-information';
+import type { Purchases, SiteDetails } from '@automattic/data-stores';
+import type { GetManagePurchaseUrlFor } from 'calypso/lib/purchases/types';
+import type { ReactNode } from 'react';
 
 import './style.scss';
 
-class CancelPurchase extends Component {
-	static propTypes = {
-		purchaseListUrl: PropTypes.string,
-		getManagePurchaseUrlFor: PropTypes.func,
-		getConfirmCancelDomainUrlFor: PropTypes.func,
-		hasLoadedSites: PropTypes.bool.isRequired,
-		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
-		includedDomainPurchase: PropTypes.object,
-		isJetpackPurchase: PropTypes.bool,
-		purchase: PropTypes.object,
-		purchaseId: PropTypes.number.isRequired,
-		site: PropTypes.object,
-		siteSlug: PropTypes.string.isRequired,
-		atomicTransfer: PropTypes.object,
-	};
+interface MomentProps {
+	moment: typeof moment;
+}
 
+export interface CancelPurchaseState {
+	cancelBundledDomain: boolean;
+	confirmCancelBundledDomain: boolean;
+	surveyShown: boolean;
+	atomicRevertConfirmed: boolean;
+	isLoading: boolean;
+	domainConfirmationConfirmed: boolean;
+	showDomainOptionsStep: boolean;
+	showDialog: boolean;
+}
+
+export interface CancelPurchaseActions {
+	recordTracksEvent: (
+		name: string,
+		properties: { [ key: string ]: string | boolean | number }
+	) => void;
+	clearPurchases: () => void;
+	refreshSitePlans: ( siteId: string | number ) => void;
+	successNotice: (
+		message: string | ReactNode,
+		properties: { displayOnNextPage?: boolean; duration?: number }
+	) => void;
+	errorNotice: ( message: string | ReactNode ) => void;
+}
+
+export interface CancelPurchaseConnectedProps {
+	atomicTransfer: { created_at: string };
+	hasLoadedSites: boolean;
+	hasLoadedUserPurchasesFromServer: boolean;
+	includedDomainPurchase: Purchases.Purchase;
+	isAkismet: boolean;
+	isDomainRegistrationPurchase: boolean;
+	isHundredYearDomain: boolean | undefined;
+	isJetpack: boolean;
+	isJetpackPurchase: boolean;
+	productsList: Record< string, { product_type: string; billing_product_slug: string } >;
+	purchase: Purchases.Purchase;
+	purchases: Purchases.Purchase[];
+	site: SiteDetails;
+}
+
+export interface CancelPurchaseProps {
+	getConfirmCancelDomainUrlFor: (
+		targetSiteSlug: string,
+		targetPurchaseId: string | number
+	) => string;
+	getManagePurchaseUrlFor: GetManagePurchaseUrlFor;
+	purchaseId: number;
+	purchaseListUrl: string;
+	siteSlug: string;
+}
+
+export type CancelPurchaseAllProps = CancelPurchaseProps &
+	CancelPurchaseConnectedProps &
+	LocalizeProps &
+	MomentProps &
+	CancelPurchaseActions;
+
+class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseState > {
 	state = {
 		cancelBundledDomain: false,
 		confirmCancelBundledDomain: false,
@@ -112,7 +162,7 @@ class CancelPurchase extends Component {
 		}
 	}
 
-	componentDidUpdate( prevProps ) {
+	componentDidUpdate( prevProps: CancelPurchaseAllProps ) {
 		if ( this.state.surveyShown ) {
 			return;
 		}
@@ -160,7 +210,7 @@ class CancelPurchase extends Component {
 		page.redirect( redirectPath );
 	};
 
-	onCancelConfirmationStateChange = ( newState ) => {
+	onCancelConfirmationStateChange = ( newState: CancelPurchaseState ) => {
 		this.setState( newState );
 	};
 
@@ -186,7 +236,10 @@ class CancelPurchase extends Component {
 		}
 	};
 
-	onDomainOptionsComplete = ( domainOptions ) => {
+	onDomainOptionsComplete = ( domainOptions: {
+		cancelBundledDomain: boolean;
+		confirmCancelBundledDomain: boolean;
+	} ) => {
 		this.setState( {
 			showDomainOptionsStep: false,
 			surveyShown: true,
@@ -195,7 +248,7 @@ class CancelPurchase extends Component {
 		} );
 	};
 
-	cancelPurchase = async ( purchase ) => {
+	cancelPurchase = async ( purchase: Purchases.Purchase ) => {
 		const { translate, moment } = this.props;
 		try {
 			const success = await cancelPurchaseAsync( purchase.id );
@@ -230,7 +283,7 @@ class CancelPurchase extends Component {
 		}
 	};
 
-	cancelAndRefund = async ( purchase ) => {
+	cancelAndRefund = async ( purchase: Purchases.Purchase ) => {
 		const { cancelBundledDomain } = this.state;
 		try {
 			await cancelAndRefundPurchaseAsync( purchase.id, {
@@ -244,11 +297,11 @@ class CancelPurchase extends Component {
 				),
 			};
 		} catch ( error ) {
-			return { success: false, error: error.message };
+			return { success: false, error: ( error as Error ).message };
 		}
 	};
 
-	submitCancelAndRefundPurchase = async ( purchase ) => {
+	submitCancelAndRefundPurchase = async ( purchase: Purchases.Purchase ) => {
 		const refundable = hasAmountAvailableToRefund( purchase );
 		if ( refundable ) {
 			return await this.cancelAndRefund( purchase );
@@ -256,7 +309,7 @@ class CancelPurchase extends Component {
 		return await this.cancelPurchase( purchase );
 	};
 
-	handleMarketplaceSubscriptions = async ( isPlanRefundable ) => {
+	handleMarketplaceSubscriptions = async ( isPlanRefundable: boolean ) => {
 		const activeSubscriptions = this.getActiveMarketplaceSubscriptions();
 		if ( activeSubscriptions?.length > 0 ) {
 			return Promise.all(
@@ -288,7 +341,7 @@ class CancelPurchase extends Component {
 				this.props.errorNotice( result.error );
 			}
 		} catch ( error ) {
-			this.props.errorNotice( error.message );
+			this.props.errorNotice( ( error as Error ).message );
 		} finally {
 			// Reset loading state
 			this.setState( { surveyShown: false, isLoading: false } );
@@ -302,7 +355,7 @@ class CancelPurchase extends Component {
 		} );
 	};
 
-	onSetLoading = ( isLoading ) => {
+	onSetLoading = ( isLoading: boolean ) => {
 		this.setState( { isLoading } );
 	};
 
@@ -324,7 +377,7 @@ class CancelPurchase extends Component {
 		}
 	};
 
-	downgradeClick = ( upsell ) => {
+	downgradeClick = ( upsell: string ) => {
 		const { purchase } = this.props;
 		let downgradePlan = getDowngradePlanFromPurchase( purchase );
 		if ( 'downgrade-monthly' === upsell ) {
@@ -333,6 +386,9 @@ class CancelPurchase extends Component {
 		}
 
 		this.setState( { isLoading: true } );
+		if ( ! downgradePlan ) {
+			throw new Error( 'Cannot find a plan to downgrade to' );
+		}
 
 		cancelAndRefundPurchase(
 			purchase.id,
@@ -341,7 +397,7 @@ class CancelPurchase extends Component {
 				type: 'downgrade',
 				to_product_id: downgradePlan.getProductId(),
 			},
-			( error, response ) => {
+			( error: Error, response: { message: string } ) => {
 				this.setState( { isLoading: false } );
 
 				if ( error ) {
@@ -371,13 +427,13 @@ class CancelPurchase extends Component {
 				page.redirect( this.props.purchaseListUrl );
 			}
 		} catch ( err ) {
-			this.props.errorNotice( err.message );
+			this.props.errorNotice( ( err as Error ).message );
 		} finally {
 			this.setState( { isLoading: false } );
 		}
 	};
 
-	onAtomicRevertConfirmationChange = ( isConfirmed ) => {
+	onAtomicRevertConfirmationChange = ( isConfirmed: boolean ) => {
 		this.setState( { atomicRevertConfirmed: isConfirmed } );
 	};
 
@@ -502,7 +558,11 @@ class CancelPurchase extends Component {
 		}
 	};
 
-	renderRefundAmountString = ( purchase, cancelBundledDomain, includedDomainPurchase ) => {
+	renderRefundAmountString = (
+		purchase: Purchases.Purchase,
+		cancelBundledDomain: boolean,
+		includedDomainPurchase: Purchases.Purchase
+	) => {
 		const { refundInteger, totalRefundInteger, totalRefundCurrency } = purchase;
 
 		if ( hasAmountAvailableToRefund( purchase ) ) {
@@ -688,7 +748,9 @@ class CancelPurchase extends Component {
 					atomicTransfer={ atomicTransfer }
 					purchase={ purchase }
 					onConfirmationChange={ this.onAtomicRevertConfirmationChange }
-					needsAtomicRevertConfirmation={ atomicTransfer?.created_at && ! isRefundable( purchase ) }
+					needsAtomicRevertConfirmation={ Boolean(
+						atomicTransfer?.created_at && ! isRefundable( purchase )
+					) }
 					isLoading={ this.state.isLoading }
 				/>
 
@@ -710,7 +772,7 @@ class CancelPurchase extends Component {
 			return null;
 		}
 
-		const onCancelConfirmationStateChange = ( newState ) => {
+		const onCancelConfirmationStateChange = ( newState: CancelPurchaseState ) => {
 			this.setState( newState );
 		};
 
@@ -858,7 +920,7 @@ class CancelPurchase extends Component {
 }
 
 export default connect(
-	( state, props ) => {
+	( state, props: CancelPurchaseProps ) => {
 		const purchase = getByPurchaseId( state, props.purchaseId );
 		const isJetpackPurchase =
 			purchase && ( isJetpackPlan( purchase ) || isJetpackProduct( purchase ) );

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -121,9 +121,9 @@ export interface CancelPurchaseConnectedProps {
 }
 
 export interface CancelPurchaseProps {
-	getManagePurchaseUrlFor: GetManagePurchaseUrlFor;
+	getManagePurchaseUrlFor?: GetManagePurchaseUrlFor;
 	purchaseId: number;
-	purchaseListUrl: string;
+	purchaseListUrl?: string;
 	siteSlug: string;
 }
 
@@ -144,11 +144,6 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		showDomainOptionsStep: false,
 		// Cancellation state moved from button component
 		showDialog: false,
-	};
-
-	static defaultProps = {
-		getManagePurchaseUrlFor: managePurchase,
-		purchaseListUrl: purchasesRoot,
 	};
 
 	componentDidMount() {
@@ -193,14 +188,17 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 
 	redirect = () => {
 		const { purchase, siteSlug } = this.props;
-		let redirectPath = this.props.purchaseListUrl;
+		let redirectPath = this.props.purchaseListUrl ?? purchasesRoot;
 
 		if (
 			siteSlug &&
 			purchase &&
 			( ! canAutoRenewBeTurnedOff( purchase ) || isDomainTransfer( purchase ) )
 		) {
-			redirectPath = this.props.getManagePurchaseUrlFor( siteSlug, purchase.id );
+			redirectPath = ( this.props.getManagePurchaseUrlFor ?? managePurchase )(
+				siteSlug,
+				purchase.id
+			);
 		}
 
 		page.redirect( redirectPath );
@@ -335,7 +333,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 				this.props.refreshSitePlans( this.props.purchase.siteId );
 				this.props.clearPurchases();
 				this.props.successNotice( result.message, { displayOnNextPage: true, duration: 10000 } );
-				page.redirect( this.props.purchaseListUrl );
+				page.redirect( this.props.purchaseListUrl ?? purchasesRoot );
 			} else {
 				this.props.errorNotice( result.error );
 			}
@@ -407,7 +405,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 				this.props.refreshSitePlans( purchase.siteId );
 				this.props.clearPurchases();
 				this.props.successNotice( response.message, { displayOnNextPage: true } );
-				page.redirect( this.props.purchaseListUrl );
+				page.redirect( this.props.purchaseListUrl ?? purchasesRoot );
 			}
 		);
 	};
@@ -423,7 +421,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 				this.props.refreshSitePlans( purchase.siteId );
 				this.props.clearPurchases();
 				this.props.successNotice( res.message, { displayOnNextPage: true } );
-				page.redirect( this.props.purchaseListUrl );
+				page.redirect( this.props.purchaseListUrl ?? purchasesRoot );
 			}
 		} catch ( err ) {
 			this.props.errorNotice( ( err as Error ).message );
@@ -605,7 +603,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 				disabled={ isDisabled }
 				siteSlug={ siteSlug }
 				cancelBundledDomain={ this.state.cancelBundledDomain }
-				purchaseListUrl={ purchaseListUrl }
+				purchaseListUrl={ purchaseListUrl ?? purchasesRoot }
 				activeSubscriptions={ this.getActiveMarketplaceSubscriptions() }
 				onCancellationStart={ this.onCancellationStart }
 				onCancellationComplete={ this.onCancellationComplete }
@@ -628,7 +626,10 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		return (
 			<FormButton
 				isPrimary={ false }
-				href={ this.props.getManagePurchaseUrlFor( siteSlug, this.props.purchaseId ) }
+				href={ ( this.props.getManagePurchaseUrlFor ?? managePurchase )(
+					siteSlug,
+					this.props.purchaseId
+				) }
 				onClick={ this.onKeepSubscriptionClick }
 			>
 				{ translate( 'Keep subscription' ) }
@@ -799,7 +800,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 						disabled={ ! canContinue() }
 						siteSlug={ this.props.siteSlug }
 						cancelBundledDomain={ cancelBundledDomain }
-						purchaseListUrl={ this.props.purchaseListUrl }
+						purchaseListUrl={ this.props.purchaseListUrl ?? purchasesRoot }
 						activeSubscriptions={ this.getActiveMarketplaceSubscriptions() }
 						onCancellationComplete={ this.onCancellationComplete }
 						onSurveyComplete={ this.onSurveyComplete }
@@ -885,7 +886,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 					<div className="cancel-purchase__back">
 						<HeaderCakeBack
 							icon="chevron-left"
-							href={ this.props.getManagePurchaseUrlFor(
+							href={ ( this.props.getManagePurchaseUrlFor ?? managePurchase )(
 								this.props.siteSlug,
 								this.props.purchaseId
 							) }

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -121,10 +121,6 @@ export interface CancelPurchaseConnectedProps {
 }
 
 export interface CancelPurchaseProps {
-	getConfirmCancelDomainUrlFor: (
-		targetSiteSlug: string,
-		targetPurchaseId: string | number
-	) => string;
 	getManagePurchaseUrlFor: GetManagePurchaseUrlFor;
 	purchaseId: number;
 	purchaseListUrl: string;
@@ -588,7 +584,6 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			includedDomainPurchase,
 			siteSlug,
 			purchaseListUrl,
-			getConfirmCancelDomainUrlFor,
 			isDomainRegistrationPurchase,
 		} = this.props;
 
@@ -611,7 +606,6 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 				siteSlug={ siteSlug }
 				cancelBundledDomain={ this.state.cancelBundledDomain }
 				purchaseListUrl={ purchaseListUrl }
-				getConfirmCancelDomainUrlFor={ getConfirmCancelDomainUrlFor }
 				activeSubscriptions={ this.getActiveMarketplaceSubscriptions() }
 				onCancellationStart={ this.onCancellationStart }
 				onCancellationComplete={ this.onCancellationComplete }

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -210,7 +210,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		page.redirect( redirectPath );
 	};
 
-	onCancelConfirmationStateChange = ( newState: CancelPurchaseState ) => {
+	onCancelConfirmationStateChange = ( newState: Partial< CancelPurchaseState > ) => {
 		this.setState( newState );
 	};
 

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -211,7 +211,10 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 	};
 
 	onCancelConfirmationStateChange = ( newState: Partial< CancelPurchaseState > ) => {
-		this.setState( newState );
+		this.setState( ( state ) => ( {
+			...state,
+			newState,
+		} ) );
 	};
 
 	onCancellationStart = () => {
@@ -772,8 +775,11 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			return null;
 		}
 
-		const onCancelConfirmationStateChange = ( newState: CancelPurchaseState ) => {
-			this.setState( newState );
+		const onCancelConfirmationStateChange = ( newState: Partial< CancelPurchaseState > ) => {
+			this.setState( ( state ) => ( {
+				...state,
+				newState,
+			} ) );
 		};
 
 		const canContinue = () => {

--- a/client/me/purchases/cancel-purchase/refund-information.tsx
+++ b/client/me/purchases/cancel-purchase/refund-information.tsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { isDomainRegistration } from '@automattic/calypso-products';
+import { Purchases } from '@automattic/data-stores';
 import i18n from 'i18n-calypso';
-import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import {
@@ -13,11 +13,20 @@ import {
 } from 'calypso/lib/purchases';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 
+export interface CancelPurchaseRefundInformationConnectedProps {
+	isGravatarRestrictedDomain: boolean;
+}
+
+export interface CancelPurchaseRefundInformationProps {
+	purchase: Purchases.Purchase;
+	isJetpackPurchase: boolean;
+}
+
 const CancelPurchaseRefundInformation = ( {
 	purchase,
 	isGravatarRestrictedDomain,
 	isJetpackPurchase,
-} ) => {
+}: CancelPurchaseRefundInformationProps & CancelPurchaseRefundInformationConnectedProps ) => {
 	const { refundPeriodInDays } = purchase;
 	let text;
 
@@ -135,15 +144,7 @@ const CancelPurchaseRefundInformation = ( {
 	);
 };
 
-CancelPurchaseRefundInformation.propTypes = {
-	purchase: PropTypes.object.isRequired,
-	isJetpackPurchase: PropTypes.bool.isRequired,
-	cancelBundledDomain: PropTypes.bool,
-	confirmCancelBundledDomain: PropTypes.bool,
-	onCancelConfirmationStateChange: PropTypes.func,
-};
-
-export default connect( ( state, props ) => {
+export default connect( ( state, props: CancelPurchaseRefundInformationProps ) => {
 	const domains = getDomainsBySiteId( state, props.purchase.siteId );
 	const selectedDomainName = getName( props.purchase );
 	const selectedDomain = getSelectedDomain( { domains, selectedDomainName } );

--- a/client/me/purchases/marketplace-subscriptions-dialog/index.tsx
+++ b/client/me/purchases/marketplace-subscriptions-dialog/index.tsx
@@ -8,7 +8,7 @@ interface MarketPlaceSubscriptionsDialogProps {
 	closeDialog: () => void;
 	removePlan: () => void;
 	isDialogVisible: boolean;
-	isRemoving: boolean;
+	isRemoving?: boolean;
 	activeSubscriptions: Array< { id: number; productName: string } >;
 	sectionHeadingText?: TranslateResult;
 	primaryButtonText?: TranslateResult;

--- a/client/state/purchases/selectors/get-by-purchase-id.js
+++ b/client/state/purchases/selectors/get-by-purchase-id.js
@@ -4,7 +4,7 @@ import 'calypso/state/purchases/init';
 
 /**
  * Returns a Purchase object from the state using its id
- * @param   {Object} state       global state
+ * @param   {import('calypso/types').AppState} state       global state
  * @param   {number} purchaseId  the purchase id
  * @returns {import('calypso/lib/purchases/types').Purchase|undefined} the matching purchase if there is one
  */

--- a/client/state/sites/domains/selectors.js
+++ b/client/state/sites/domains/selectors.js
@@ -4,7 +4,7 @@ const EMPTY_SITE_DOMAINS = Object.freeze( [] );
 
 /**
  * Returns the list of site domains for the specified site identifier.
- * @param {Object} state - global state tree
+ * @param {import('calypso/types').AppState} state - global state tree
  * @param {number|undefined} siteId - identifier of the site
  * @returns {import('./types').ResponseDomain[]} the list of domains
  */

--- a/client/state/sites/selectors/is-requesting-sites.js
+++ b/client/state/sites/selectors/is-requesting-sites.js
@@ -1,6 +1,6 @@
 /**
  * Returns true if we are requesting all sites.
- * @param {Object}    state  Global state tree
+ * @param {import("calypso/types").AppState}    state  Global state tree
  * @returns {boolean}        Request State
  */
 export default function isRequestingSites( state ) {


### PR DESCRIPTION
Fixes SHILL-993

## Proposed Changes

This PR converts the `CancelPurchase` component and its children to TypeScript.

## Why are these changes being made?

TS helps to identify bugs and prevent regressions. As we investigate cancellation bugs like https://linear.app/a8c/issue/SHILL-941/cancelling-a-plan-and-domain-together-is-no-longer-possible it will be easier with TypeScript guards to prevent regressions.

## Testing Instructions

Visit `/me/purchases` and click through to the cancel flow for some purchases to be sure they work as expected.
