### PR TITLE
Hosting Config: Redirect to site settings or hosting features depends on the site type

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
@@ -65,7 +65,7 @@ export default function useLicenseActions(
 			},
 			{
 				name: translate( 'Hosting configuration' ),
-				href: `https://wordpress.com/hosting-config/${ siteSlug }`,
+				href: `https://wordpress.com/sites/${ siteSlug }/settings`,
 				onClick: () => handleClickMenuItem( 'calypso_a4a_licenses_hosting_configuration_click' ),
 				isExternalLink: true,
 				isEnabled: true,

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
@@ -106,7 +106,7 @@ export default function useSiteActions( {
 			},
 			{
 				name: translate( 'Hosting configuration' ),
-				href: `https://wordpress.com/hosting-config/${ blog_id }`,
+				href: `https://wordpress.com/sites/${ blog_id }/settings`,
 				onClick: () => handleClickMenuItem( 'hosting_configuration' ),
 				isExternalLink: true,
 				isEnabled: isWPCOMSite && ! isUrlOnly,
@@ -315,7 +315,7 @@ export function useSiteActionsDataViews( {
 					return canHaveActions( item ) && isAtomicSite( item ) && ! isUrlOnly( item );
 				},
 				callback( items: SiteData[] ) {
-					window.open( `https://wordpress.com/hosting-config/${ getBlogId( items[ 0 ] ) }` );
+					window.open( `https://wordpress.com/sites/${ getBlogId( items[ 0 ] ) }/settings` );
 					dispatch(
 						recordTracksEvent( getActionEventName( 'hosting_configuration', isLargeScreen ) )
 					);

--- a/client/hosting/overview/controller.tsx
+++ b/client/hosting/overview/controller.tsx
@@ -35,6 +35,6 @@ export async function hostingConfiguration( context: PageJSContext, next: () => 
 	next();
 }
 
-export async function redirectToServerSettingsIfDuplicatedView( context: PageJSContext ) {
-	return page.redirect( `/sites/settings/server/${ context.params.site_id }` );
+export async function redirectToSettingsIfDuplicatedView( context: PageJSContext ) {
+	return page.redirect( `/sites/${ context.params.site_id }/settings` );
 }

--- a/client/hosting/server-settings/components/hosting-upsell-nudge/index.tsx
+++ b/client/hosting/server-settings/components/hosting-upsell-nudge/index.tsx
@@ -50,7 +50,7 @@ export function HostingUpsellNudge( { siteId, targetPlan }: HostingUpsellNudgePr
 	const href = targetPlan
 		? targetPlan.href
 		: addQueryArgs( `/checkout/${ siteId }/business`, {
-				redirect_to: `/hosting-config/${ siteId }`,
+				redirect_to: `/hosting-features/${ siteId }`,
 		  } );
 	const plan = targetPlan ? targetPlan.plan : PLAN_BUSINESS;
 	const title = targetPlan ? targetPlan.title : titleText;

--- a/client/hosting/server-settings/main.tsx
+++ b/client/hosting/server-settings/main.tsx
@@ -302,7 +302,7 @@ const ServerSettings = ( { fetchUpdatedData }: ServerSettingsProps ) => {
 					icon="globe"
 				>
 					<TrackComponentView eventName="calypso_hosting_configuration_activate_impression" />
-					<NoticeAction onClick={ clickActivate } href={ `/hosting-config/activate/${ siteSlug }` }>
+					<NoticeAction onClick={ clickActivate } href={ `/hosting-features/${ siteSlug }` }>
 						{ translate( 'Activate' ) }
 					</NoticeAction>
 				</Notice>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/use-site-actions.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/use-site-actions.ts
@@ -64,7 +64,7 @@ export default function useSiteActions( { site, isLargeScreen, siteError }: Prop
 			},
 			{
 				name: translate( 'Hosting configuration' ),
-				href: `https://wordpress.com/hosting-config/${ siteSlug }`,
+				href: `https://wordpress.com/sites/${ siteSlug }/settings`,
 				onClick: () => handleClickMenuItem( 'hosting_configuration' ),
 				isExternalLink: true,
 				isEnabled: isWPCOMAtomicSiteCreationEnabled && ! isUrlOnly,

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/use-license-actions.ts
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/use-license-actions.ts
@@ -49,7 +49,7 @@ export default function useLicenseActions(
 			},
 			{
 				name: translate( 'Hosting configuration' ),
-				href: `https://wordpress.com/hosting-config/${ siteSlug }`,
+				href: `https://wordpress.com/sites/${ siteSlug }/settings`,
 				onClick: () =>
 					handleClickMenuItem( 'calypso_jetpack_licenses_hosting_configuration_click' ),
 				isExternalLink: true,

--- a/client/layout/hosting-dashboard/item-view/item-view-header/index.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useMediaQuery } from '@wordpress/compose';
@@ -140,11 +139,7 @@ export default function ItemViewHeader( {
 													WordPress{ ' ' }
 													<a
 														className="hosting-dashboard-item-view__header-env-data-item-link"
-														href={
-															isEnabled( 'dashboard/v2/backport/site-settings' )
-																? `/sites/${ selectedSite?.domain }/settings/wordpress`
-																: `/hosting-config/${ selectedSite?.domain }#wp`
-														}
+														href={ `/sites/${ selectedSite?.domain }/settings/wordpress` }
 														onClick={ handleWpVersionClick }
 													>
 														{ wpVersion }
@@ -159,11 +154,7 @@ export default function ItemViewHeader( {
 													<a
 														className="hosting-dashboard-item-view__header-env-data-item-link"
 														onClick={ handlePhpVersionClick }
-														href={
-															isEnabled( 'dashboard/v2/backport/site-settings' )
-																? `/sites/${ selectedSite?.domain }/settings/php`
-																: `/hosting-config/${ selectedSite?.domain }#php`
-														}
+														href={ `/sites/${ selectedSite?.domain }/settings/php` }
 													>
 														{ phpVersion }
 													</a>

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -60,7 +60,7 @@ class CheckoutThankYouHeader extends PureComponent {
 
 		this.props.recordTracksEvent( 'calypso_thank_you_back_to_hosting' );
 
-		window.location.href = `/hosting-config/${ selectedSite.slug }`;
+		window.location.href = `/sites/${ selectedSite.slug }/settings`;
 	};
 
 	visitScheduler = ( event ) => {

--- a/client/my-sites/customer-home/cards/actions/quick-links-for-hosted-sites/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links-for-hosted-sites/index.jsx
@@ -47,13 +47,13 @@ const QuickLinksForHostedSites = ( props ) => {
 	const quickLinks = (
 		<div className="quick-links-for-hosted-sites__boxes quick-links__boxes">
 			<ActionBox
-				href={ `/hosting-config/${ siteSlug }#sftp-credentials` }
+				href={ `/sites/${ siteSlug }/settings/sftp-ssh` }
 				hideLinkIndicator
 				label={ translate( 'Set up SSH' ) }
 				materialIcon="key"
 			/>
 			<ActionBox
-				href={ `/hosting-config/${ siteSlug }#staging-site` }
+				href={ `/staging-site/${ siteSlug }` }
 				hideLinkIndicator
 				label={ translate( 'Create staging site' ) }
 				gridicon="science"

--- a/client/my-sites/customer-home/cards/tasks/revive-auto-reverted-atomic/index.tsx
+++ b/client/my-sites/customer-home/cards/tasks/revive-auto-reverted-atomic/index.tsx
@@ -62,7 +62,7 @@ export const ReviveAutoRevertedAtomic = ( { card }: { card: string } ) => {
 					),
 					timing: 2,
 					actionText: translate( 'Activate Hosting Features' ),
-					actionUrl: `/hosting-config/${ siteSlug }`,
+					actionUrl: `/hosting-features/${ siteSlug }`,
 					enableSkipOptions: false,
 					skipText: translate( 'I do not need hosting features' ),
 				};

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -361,7 +361,7 @@ export const getTask = (
 					'Connect to your site via SSH to run commands and manage files on your server.'
 				),
 				actionText: translate( 'Setup' ),
-				actionUrl: `/hosting-config/${ siteSlug }#sftp-credentials`,
+				actionUrl: `/sites/${ siteSlug }/settings/sftp-ssh`,
 				isSkippable: false,
 			};
 			break;

--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -75,7 +75,7 @@ export const useCommandsCalypso = (): Command[] => {
 				null,
 				{
 					button: translate( 'Manage Hosting Configuration' ),
-					onClick: () => navigate( `/hosting-config/${ siteSlug }#sftp-credentials` ),
+					onClick: () => navigate( `/sites/${ siteSlug }/settings/sftp-ssh` ),
 				}
 			);
 			return;
@@ -107,7 +107,7 @@ export const useCommandsCalypso = (): Command[] => {
 				null,
 				{
 					button: translate( 'Manage Hosting Configuration' ),
-					onClick: () => navigate( `/hosting-config/${ siteSlug }#sftp-credentials` ),
+					onClick: () => navigate( `/sites/${ siteSlug }/settings/sftp-ssh` ),
 				}
 			);
 			return;

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -23,10 +23,6 @@ export const getManagePluginsUrl = ( slug: string ) => {
 	return `/plugins/manage/${ slug }`;
 };
 
-export const getHostingConfigUrl = ( slug: string ) => {
-	return `/hosting-config/${ slug }`;
-};
-
 export const displaySiteUrl = ( siteUrl: string ) => {
 	return siteUrl.replace( 'https://', '' ).replace( 'http://', '' );
 };

--- a/client/sites/components/site-preview-pane/constants.ts
+++ b/client/sites/components/site-preview-pane/constants.ts
@@ -31,9 +31,7 @@ export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
 	[ HOSTING_FEATURES ]: 'hosting-features/:site',
 	[ STAGING_SITE ]: 'staging-site/:site',
 	[ PERFORMANCE ]: 'sites/performance/:site',
-	[ SETTINGS_SITE ]: isEnabled( 'dashboard/v2/backport/site-settings' )
-		? 'sites/:site/settings'
-		: 'sites/settings/site/:site',
+	[ SETTINGS_SITE ]: 'sites/:site/settings',
 	[ SETTINGS_ADMINISTRATION_RESET_SITE ]: 'sites/settings/site/:site/reset-site',
 	[ SETTINGS_ADMINISTRATION_TRANSFER_SITE ]: 'sites/settings/site/:site/transfer-site',
 	[ SETTINGS_ADMINISTRATION_DELETE_SITE ]: 'sites/settings/site/:site/delete-site',

--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { getPlanPath, WPCOM_FEATURES_COPY_SITE } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { useLocalizeUrl } from '@automattic/i18n-utils';
@@ -386,9 +385,7 @@ export function useActions( {
 				id: 'prepare-for-launch',
 				label: __( 'Prepare for launch' ),
 				callback: ( sites ) => {
-					const url = isEnabled( 'dashboard/v2/backport/site-settings' )
-						? `/sites/${ sites[ 0 ].slug }/settings/site-visibility`
-						: `/sites/settings/site/${ sites[ 0 ].ID }`;
+					const url = `/sites/${ sites[ 0 ].slug }/settings/site-visibility`;
 
 					page( url );
 					dispatch(

--- a/client/sites/controller.tsx
+++ b/client/sites/controller.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { siteLaunchStatusGroupValues } from '@automattic/sites';
 import { Global, css } from '@emotion/react';
@@ -152,10 +151,7 @@ export function redirectToHostingFeaturesIfNotAtomic( context: PageJSContext, ne
 	const state = context.store.getState();
 	const site = getSelectedSite( state );
 
-	if (
-		! areHostingFeaturesSupported( site ) &&
-		! isEnabled( 'hosting/hosting-features-callout' )
-	) {
+	if ( ! areHostingFeaturesSupported( site ) ) {
 		return page.redirect( `/hosting-features/${ site?.slug }` );
 	}
 

--- a/client/sites/hosting/components/hosting-features.tsx
+++ b/client/sites/hosting/components/hosting-features.tsx
@@ -54,7 +54,7 @@ const HostingFeatures = ( { showAsTools }: HostingFeaturesProps ) => {
 
 	let redirectUrl = redirectToRef.current as string;
 	if ( ! redirectUrl ) {
-		redirectUrl = hasSftpFeature ? `/hosting-config/${ siteSlug }` : `/overview/${ siteId }`;
+		redirectUrl = hasSftpFeature ? `/sites/${ siteSlug }/settings` : `/overview/${ siteId }`;
 	}
 
 	const hasEnTranslation = useHasEnTranslation();

--- a/client/sites/hosting/controller.tsx
+++ b/client/sites/hosting/controller.tsx
@@ -23,7 +23,7 @@ export function hostingFeatures( context: PageJSContext, next: () => void ) {
 
 		let redirectUrl = context.query.redirect_to;
 		if ( redirectUrl ) {
-			redirectUrl = hasSftpFeature ? `/hosting-config/${ site.slug }` : `/overview/${ site.slug }`;
+			redirectUrl = hasSftpFeature ? `/sites/${ site.slug }/settings` : `/overview/${ site.slug }`;
 		}
 
 		content = (

--- a/client/sites/hosting/index.tsx
+++ b/client/sites/hosting/index.tsx
@@ -8,7 +8,7 @@ import {
 } from 'calypso/controller';
 import {
 	hostingConfiguration,
-	redirectToServerSettingsIfDuplicatedView,
+	redirectToSettingsIfDuplicatedView,
 } from 'calypso/hosting/overview/controller';
 import { handleHostingPanelRedirect } from 'calypso/hosting/server-settings/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
@@ -39,7 +39,7 @@ export default function () {
 		// @ts-ignore
 		redirectIfCurrentUserCannot( 'manage_options' ),
 		redirectToHostingFeaturesIfNotAtomic,
-		redirectToServerSettingsIfDuplicatedView,
+		redirectToSettingsIfDuplicatedView,
 		handleHostingPanelRedirect,
 		hostingConfiguration,
 		siteDashboard( HOSTING_CONFIG ),

--- a/client/sites/hosting/index.tsx
+++ b/client/sites/hosting/index.tsx
@@ -24,7 +24,9 @@ const redirectForNonSimpleSite = ( context: PageJSContext, next: () => void ) =>
 	const state = context.store.getState();
 	const site = getSelectedSite( state );
 	if ( site && site.jetpack && ! site.plan?.expired ) {
-		return page.redirect( addQueryArgs( `/overview/${ context.params.site }`, context.query ) );
+		return page.redirect(
+			addQueryArgs( `/sites/${ context.params.site }/settings`, context.query )
+		);
 	}
 	return next();
 };

--- a/client/sites/settings/controller.tsx
+++ b/client/sites/settings/controller.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { __ } from '@wordpress/i18n';
 import { useSelector } from 'react-redux';
@@ -212,10 +211,6 @@ export function performanceSettings( context: PageJSContext, next: () => void ) 
  */
 export async function dashboardBackportSiteSettings( context: PageJSContext, next: () => void ) {
 	const { site: siteSlug, feature } = context.params;
-
-	if ( ! isEnabled( 'dashboard/v2/backport/site-settings' ) ) {
-		return page.redirect( `/sites/settings/site/${ siteSlug }` );
-	}
 
 	// Route doesn't require a <PageViewTracker /> because the dashboard
 	// fires its own page view events.

--- a/client/sites/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
+++ b/client/sites/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
@@ -147,7 +147,7 @@ export const ManageStagingSiteCardContent = ( {
 						<SiteInfo>
 							<SiteNameContainer>
 								<SiteName
-									href={ `/hosting-config/${ urlToSlug( stagingSite.url ) }` }
+									href={ `/sites/${ urlToSlug( stagingSite.url ) }` }
 									title={ translate( 'Visit Dashboard' ) }
 								>
 									{ stagingSite.name }

--- a/client/sites/v2/site-settings/controller.tsx
+++ b/client/sites/v2/site-settings/controller.tsx
@@ -1,14 +1,6 @@
-import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import type { Context as PageJSContext } from '@automattic/calypso-router';
 
-export function redirectToHostingDashboardBackportIfEnabled(
-	context: PageJSContext,
-	next: () => void
-) {
-	if ( isEnabled( 'dashboard/v2/backport/site-settings' ) ) {
-		return page.redirect( `/sites/${ context.params.site }/settings` );
-	}
-
-	next();
+export function redirectToHostingDashboardBackportIfEnabled( context: PageJSContext ) {
+	return page.redirect( `/sites/${ context.params.site }/settings` );
 }

--- a/config/development.json
+++ b/config/development.json
@@ -52,7 +52,6 @@
 		"current-site/notice": true,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": false,
-		"dashboard/v2/backport/site-settings": true,
 		"dashboard/v2/backport/sites-list": true,
 		"dashboard/v2/security-settings": true,
 		"design-picker/use-assembler-styles": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -27,7 +27,6 @@
 		"current-site/notice": true,
 		"dashboard/v2": false,
 		"dashboard/v2/backport/site-overview": false,
-		"dashboard/v2/backport/site-settings": true,
 		"dashboard/v2/backport/sites-list": true,
 		"dashboard/v2/security-settings": false,
 		"design-picker/use-assembler-styles": true,

--- a/config/production.json
+++ b/config/production.json
@@ -39,7 +39,6 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dashboard/v2/backport/site-overview": false,
-		"dashboard/v2/backport/site-settings": true,
 		"dashboard/v2/backport/sites-list": true,
 		"dashboard/v2/security-settings": false,
 		"domains/ui-redesign": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -37,7 +37,6 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dashboard/v2/backport/site-overview": false,
-		"dashboard/v2/backport/site-settings": true,
 		"dashboard/v2/backport/sites-list": true,
 		"dashboard/v2/security-settings": false,
 		"dev/preferences-helper": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -36,7 +36,6 @@
 		"current-site/notice": true,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": false,
-		"dashboard/v2/backport/site-settings": true,
 		"dashboard/v2/backport/sites-list": true,
 		"dashboard/v2/security-settings": true,
 		"design-picker/use-assembler-styles": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of p1754442462188699-slack-CRWCHQGUB

## Proposed Changes

* Get rid of the `hosting-config` path. Instead, it should
  * Redirect to hosting features screen if the site doesn't have the ability to the hosting features
  * Redirect to site settings screen as now we don't have a server settings page
* Clean up the `dashboard/v2/backport/site-settings` flag

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/hosting-config/:site`
* It will redirect to the site settings page if your site is the atomic site
* It will redirect to the hosting features page if your site is not an atomic site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?