### PR TITLE
Connect Refresh: Migrate Blaze Pro create-account to unified Signup

### DIFF
--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -149,6 +149,8 @@
 		--wp-components-color-accent-inverted: var(--studio-black);
 		--wp-components-color-accent-darker-10: var(--color-blaze-pro-darker);
 		--wp-components-color-accent-darker-20: var(--color-blaze-pro-darker);
+
+		font-weight: 600;
 	}
 
 	.components-button.is-tertiary {

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -955,20 +955,10 @@ class SignupForm extends Component {
 	}
 
 	footerLink() {
-		const { isWoo, isBlazePro } = this.props;
+		const { isWoo } = this.props;
 
 		if ( isWoo ) {
 			return null;
-		}
-
-		if ( isBlazePro ) {
-			return (
-				<p className="signup-form__login-link">
-					{ this.props.translate( 'Already have an account? {{link}}Log in here{{/link}}.', {
-						components: { link: <a href={ this.getLoginLink() } /> },
-					} ) }
-				</p>
-			);
 		}
 
 		return null;
@@ -1067,7 +1057,7 @@ class SignupForm extends Component {
 			);
 		}
 
-		const isUnifiedCreateAccount = this.props.isWoo || this.props.isA4A;
+		const isUnifiedCreateAccount = this.props.isWoo || this.props.isA4A || this.props.isBlazePro;
 		const isGravatar = this.props.isGravatar;
 		const emailErrorMessage = this.getErrorMessagesWithLogin( 'email' );
 		const showSeparator =

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -12,7 +12,7 @@ import {
 	GithubSocialButton,
 	UsernameOrEmailButton,
 } from 'calypso/components/social-buttons';
-import { isA4AOAuth2Client } from 'calypso/lib/oauth2-clients';
+import { isA4AOAuth2Client, isBlazeProOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { isWpccFlow } from 'calypso/signup/is-flow';
 import { recordTracksEvent as recordTracks } from 'calypso/state/analytics/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
@@ -97,10 +97,11 @@ class SocialSignupForm extends Component {
 			flowName,
 			isWoo,
 			isA4A,
+			isBlazePro,
 			setCurrentStep,
 		} = this.props;
 
-		const isUnifiedCreateAccount = isWoo || isA4A;
+		const isUnifiedCreateAccount = isWoo || isA4A || isBlazePro;
 
 		return (
 			<Card
@@ -155,6 +156,7 @@ export default connect(
 			isDevAccount: isDevAccount,
 			isWoo: getIsWoo( state ),
 			isA4A: isA4AOAuth2Client( getCurrentOAuth2Client( state ) ),
+			isBlazePro: isBlazeProOAuth2Client( getCurrentOAuth2Client( state ) ),
 		};
 	},
 	{ showErrorNotice: errorNotice }

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -121,7 +121,7 @@ const LayoutLoggedOut = ( {
 			currentRoute?.startsWith( '/start/do-it-for-me/' ) ) &&
 		userAllowedToHelpCenter;
 
-	const isUnifiedCreateAccount = sectionName === 'signup' && ( isWoo || isA4A );
+	const isUnifiedCreateAccount = sectionName === 'signup' && ( isWoo || isA4A || isBlazePro );
 
 	const classes = {
 		[ 'is-group-' + sectionGroup ]: sectionGroup,

--- a/client/layout/masterbar/blaze-pro.scss
+++ b/client/layout/masterbar/blaze-pro.scss
@@ -71,10 +71,6 @@ body.is-section-login {
 
 	$login-form-max-width: 327px;
 
-	.components-button {
-		font-weight: 600;
-	}
-
 	.masterbar__blaze-pro-nav {
 		display: flex;
 		flex-direction: row;

--- a/client/layout/masterbar/blaze-pro.scss
+++ b/client/layout/masterbar/blaze-pro.scss
@@ -16,7 +16,8 @@ $inter: Inter, $sans; // for general
 $sfProText: "SF Pro Text", $sans; // for sub title
 $colorBlack: #1f1f1f;
 
-body.is-section-signup {
+body.is-section-signup,
+body.is-section-login {
 	--font-inter:
 		"Inter",
 		-apple-system,
@@ -31,7 +32,6 @@ body.is-section-signup {
 		sans-serif;
 
 	&:has(.is-blaze-pro) {
-		background: #fff;
 
 		.layout:not(.dops):not(.is-wccom-oauth-flow) .formatted-header .formatted-header__title {
 			color: $colorBlack;
@@ -39,6 +39,20 @@ body.is-section-signup {
 			font-size: 2rem;
 			font-weight: 700;
 			line-height: 40px;
+		}
+
+		.wp-login__one-login-layout-heading-text {
+			font-family: Inter, -apple-system, system-ui, blinkmacsystemfont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+			font-size: 2rem;
+			font-weight: 700;
+			line-height: 40px;
+		}
+
+		.wp-login__one-login-layout-heading-subtext {
+			font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+			font-size: rem(18px);
+			font-weight: 500;
+			line-height: 25px;
 		}
 	}
 }
@@ -321,46 +335,6 @@ body.is-section-signup {
 		}
 	}
 
-	.auth-form__separator + .card {
-		clip-path: none;
-		border: none;
-	}
-
-	.signup__step {
-		.step-wrapper__header {
-			display: flex;
-			flex-direction: column;
-			align-items: center;
-		}
-
-		.formatted-header {
-			margin-bottom: 20px;
-
-			& > div {
-				width: 360px;
-
-				.formatted-header__title {
-					font-family: $inter;
-					font-size: 2rem;
-					font-weight: 700;
-					line-height: 40px;
-
-					@media (min-width: 661px) {
-						margin-bottom: 24px;
-					}
-				}
-
-				.formatted-header__subtitle {
-					font-family: $sfProText;
-					font-size: rem(18px);
-					font-weight: 500;
-					line-height: 25px;
-					margin-bottom: 0;
-				}
-			}
-		}
-	}
-
 	.logged-out-form__link-item.logged-out-form__back-link {
 		display: none;
 	}
@@ -401,14 +375,6 @@ body.is-section-signup {
 			font-weight: 500;
 			line-height: 25px;
 		}
-	}
-
-	.signup-form__login-link {
-		color: var(--studio-gray-60);
-		font-size: rem(18px);
-		font-weight: 500;
-		line-height: 25px;
-		text-align: center;
 	}
 
 	// Log in Styles
@@ -463,45 +429,6 @@ body.is-section-signup {
 
 	.login__lostpassword-subtitle {
 		width: 360px;
-	}
-
-	.login form.is-blaze-pro {
-		display: flex;
-		flex-direction: row;
-		margin-top: 48px;
-		padding: 0;
-		justify-content: center;
-		max-width: 758px;
-
-		@media (max-width: $break-medium) {
-			flex-direction: column;
-		}
-
-		.card.login__form {
-			padding: 0;
-			display: flex;
-			flex-direction: column;
-			justify-content: center;
-			width: 100%;
-			max-width: $login-form-max-width;
-			margin: 0;
-
-			~ .auth-form__social.card {
-				width: 100%;
-				max-width: $login-form-max-width;
-				margin: 0;
-			}
-		}
-
-		.auth-form__separator {
-			@media screen and (min-width: $break-medium) {
-				margin-block: 0;
-			}
-		}
-	}
-
-	.wp-login__main.main:has(.login form.is-blaze-pro) {
-		max-width: unset;
 	}
 }
 

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -30,28 +30,6 @@ $image-height: 47px;
 		}
 	}
 
-	// /* Start: Blaze Pro OAuth client font styles for login page */
-	// &.is-blaze-pro {
-	// 	* {
-	// 		font-family: Inter, -apple-system, system-ui, blinkmacsystemfont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	// 	}
-
-	// 	.wp-login__one-login-layout-heading-text {
-	// 		font-family: Inter, -apple-system, system-ui, blinkmacsystemfont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	// 		font-size: 2rem;
-	// 		font-weight: 700;
-	// 		line-height: 40px;
-	// 	}
-
-	// 	.wp-login__one-login-layout-heading-subtext {
-	// 		font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	// 		font-size: rem(18px);
-	// 		font-weight: 500;
-	// 		line-height: 25px;
-	// 	}
-	// }
-	/* End: Blaze Pro OAuth client font styles for login page */
-
 	/*
 	* Start: Jetpack font styles for login page
 	*

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -30,26 +30,26 @@ $image-height: 47px;
 		}
 	}
 
-	/* Start: Blaze Pro OAuth client font styles for login page */
-	&.is-blaze-pro {
-		* {
-			font-family: Inter, -apple-system, system-ui, blinkmacsystemfont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-		}
+	// /* Start: Blaze Pro OAuth client font styles for login page */
+	// &.is-blaze-pro {
+	// 	* {
+	// 		font-family: Inter, -apple-system, system-ui, blinkmacsystemfont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	// 	}
 
-		.wp-login__one-login-layout-heading-text {
-			font-family: Inter, -apple-system, system-ui, blinkmacsystemfont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-			font-size: 2rem;
-			font-weight: 700;
-			line-height: 40px;
-		}
+	// 	.wp-login__one-login-layout-heading-text {
+	// 		font-family: Inter, -apple-system, system-ui, blinkmacsystemfont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	// 		font-size: 2rem;
+	// 		font-weight: 700;
+	// 		line-height: 40px;
+	// 	}
 
-		.wp-login__one-login-layout-heading-subtext {
-			font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-			font-size: rem(18px);
-			font-weight: 500;
-			line-height: 25px;
-		}
-	}
+	// 	.wp-login__one-login-layout-heading-subtext {
+	// 		font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	// 		font-size: rem(18px);
+	// 		font-weight: 500;
+	// 		line-height: 25px;
+	// 	}
+	// }
 	/* End: Blaze Pro OAuth client font styles for login page */
 
 	/*

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -47,6 +47,7 @@ import {
 	isGravatarOAuth2Client,
 	isPartnerPortalOAuth2Client,
 	isA4AOAuth2Client,
+	isBlazeProOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import SignupFlowController from 'calypso/lib/signup/flow-controller';
 import FlowProgressIndicator from 'calypso/signup/flow-progress-indicator';
@@ -874,7 +875,7 @@ class Signup extends Component {
 		const isUnifiedCreateAccount =
 			0 === this.getPositionInFlow() &&
 			! this.props.isLoggedIn &&
-			( this.props.isWoo || this.props.isA4A );
+			( this.props.isWoo || this.props.isA4A || this.props.isBlazePro );
 
 		const showPageHeader = ! this.props.isGravatar && ! isUnifiedCreateAccount;
 		const isGravatarDomain = isDomainForGravatarFlow( this.props.flowName );
@@ -952,6 +953,7 @@ export default connect(
 			hostingFlow,
 			isWoo: getIsWoo( state ),
 			isA4A: isA4AOAuth2Client( oauth2Client ),
+			isBlazePro: isBlazeProOAuth2Client( oauth2Client ),
 		};
 	},
 	{

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -538,11 +538,7 @@ export class UserStep extends Component {
 		}
 
 		if ( isBlazeProOAuth2Client( oauth2Client ) ) {
-			return translate( 'Welcome to %(clientTitle)s', {
-				args: { clientTitle: oauth2Client.title },
-				comment:
-					"'clientTitle' is the name of the app that uses WordPress.com Connect (e.g. 'Akismet' or 'VaultPress')",
-			} );
+			return translate( 'Sign up to Blaze Pro with WordPress.com' );
 		}
 
 		if ( isPartnerPortalOAuth2Client( oauth2Client ) ) {
@@ -591,23 +587,20 @@ export class UserStep extends Component {
 	}
 
 	renderSignupForm() {
-		const { oauth2Client, isWCCOM, isWoo, isUnifiedCreateAccount, isA4A } = this.props;
+		const { oauth2Client, isWCCOM, isWoo, isUnifiedCreateAccount, isA4A, isBlazePro } = this.props;
 		const isPasswordless =
 			isMobile() ||
 			this.props.isPasswordless ||
 			isNewsletterFlow( this.props?.queryObject?.variationName ) ||
 			isWoo ||
-			isA4A;
+			isA4A ||
+			isBlazePro;
 		let socialService;
 		let socialServiceResponse;
 		let isSocialSignupEnabled = this.props.isSocialSignupEnabled;
 
 		if ( isWCCOM || isUnifiedCreateAccount ) {
 			isSocialSignupEnabled = true;
-		}
-
-		if ( isBlazeProOAuth2Client( oauth2Client ) ) {
-			isSocialSignupEnabled = false;
 		}
 
 		const hashObject = this.props.initialContext && this.props.initialContext.hash;
@@ -757,7 +750,8 @@ const ConnectedUser = connect(
 		const oauth2Client = getCurrentOAuth2Client( state );
 		const isWoo = getIsWoo( state );
 		const isA4A = isA4AOAuth2Client( oauth2Client );
-		const isUnifiedCreateAccount = isWoo || isA4A;
+		const isBlazePro = getIsBlazePro( state );
+		const isUnifiedCreateAccount = isWoo || isA4A || isBlazePro;
 
 		return {
 			oauth2Client: oauth2Client,
@@ -766,7 +760,7 @@ const ConnectedUser = connect(
 			isWCCOM: getIsWCCOM( state ),
 			isWoo,
 			isWooJPC: isWooJPCFlow( state ),
-			isBlazePro: getIsBlazePro( state ),
+			isBlazePro,
 			from: get( getCurrentQueryArguments( state ), 'from' ),
 			userLoggedIn: isUserLoggedIn( state ),
 			isOnboardingAffiliateFlow: getIsOnboardingAffiliateFlow( state ),


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13218/signup-update-and-unify-the-account-creation-screens
Builds off the core foundation from Woo Signup unification: https://github.com/Automattic/wp-calypso/pull/104948

## Proposed Changes

- We migrate the Blaze Pro Signup (create account) screen to the unified design. This will align it closely to the Login view, so it's all one seamless flow.
- As with other OAuth2 clients, this isn't a simple redesign. We bring the **passwordless** form, social-signup options, and remove some of the previous branding/text.

| Before | After |
|--------|--------|
| <img width="979" height="860" alt="Screenshot 2025-08-06 at 5 56 56 PM" src="https://github.com/user-attachments/assets/6a795be3-85cd-4c4c-871d-cbd5d3f8ff34" /> | <img width="975" height="860" alt="Screenshot 2025-08-06 at 5 56 43 PM" src="https://github.com/user-attachments/assets/4621cfa4-1fcd-4dd3-8660-f8746d159526" /> |

## TODO/Confirm

- [ ] We have provision for introducing a secondary sub-header like done for WooJPC Login (see below). We can use this space for branding/intro notes.

<img width="500" alt="Screenshot 2025-08-06 at 2 24 36 PM" src="https://github.com/user-attachments/assets/5bfb6659-9baf-427a-ade9-562b2a8b6ce2" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13218/signup-update-and-unify-the-account-creation-screens

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to [Blaze Pro Signup](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D99370%26state%3D0f0d1f16975b65cf8e9e924461b7c892f78eabeeb190dc03654cef0465786da0%26redirect_uri%3Dhttps%253A%252F%252Fblazepro.tumblr.com%252Fauth%252Fconnected%26blog_id%3D0%26wpcom_connect%3D1%26calypso_env%3Dproduction%26scope%3Dglobal%26from-calypso%3D1&client_id=99370&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D99370%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%253Fresponse_type%253Dcode%2526client_id%253D99370%2526state%253D0f0d1f16975b65cf8e9e924461b7c892f78eabeeb190dc03654cef0465786da0%2526redirect_uri%253Dhttps%25253A%25252F%25252Fblazepro.tumblr.com%25252Fauth%25252Fconnected%2526blog_id%253D0%2526wpcom_connect%253D1%2526calypso_env%253Dproduction%2526scope%253Dglobal%2526from-calypso%253D1) and confirm changes (this is the Login URL - click on "Create an account" on the top-right to view Signup)
- Confirm other signup (create account) screens aren't affected by the changes e.g. confirm Woo.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
