### PR TITLE
Sync Modal: Update wording for backup information message

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
@@ -81,13 +81,13 @@ const FileBrowser: FunctionComponent< FileBrowserProps > = ( {
 						style={ { marginInlineStart: '14px', marginTop: '10px' } }
 					>
 						{ displayBackupDate
-							? createInterpolateElement( __( 'Listing files from the latest backup: <date />.' ), {
+							? createInterpolateElement( __( 'Content from the latest backup: <date />.' ), {
 									date: <span>{ displayBackupDate }</span>,
 							  } )
 							: __( 'There are no backups.' ) }{ ' ' }
 						<ExternalLink
 							href={ `/backup/${ effectiveSiteSlug }` }
-							children={ __( 'Create fresh backup now' ) }
+							children={ __( 'Create new backup' ) }
 						/>
 					</Text>
 				</HStack>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTCOM-14137

## Proposed Changes

* Update the wording for the Backup information message under `Files and folders`

|Before | After|
|-------|------|
| <img width="1364" height="1346" alt="CleanShot 2025-08-06 at 18 48 01@2x" src="https://github.com/user-attachments/assets/c75a6672-807a-430a-b6a4-82a991f19a6b" />| <img width="1364" height="1346" alt="CleanShot 2025-08-06 at 18 47 31@2x" src="https://github.com/user-attachments/assets/7d9cda11-1cd2-4717-934c-9ebf83914fa2" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To address feedback from the CfT

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply these changes or open the Calypso Live link below
* Navigate to a site with staging sites and select the Sync dropdown
* Select either Push or Pull
* Expand the `All files and folders` dropdown and select `Specific files and folders`
* Check the text below the `Files and folders`
* Check the message is clear and correspond to the linked task 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
