### PR TITLE
Purchases: Fix missing props for PurchaseItemStatus

### DIFF
--- a/client/me/purchases/purchase-item/index.tsx
+++ b/client/me/purchases/purchase-item/index.tsx
@@ -310,13 +310,11 @@ export function PurchaseItemStatus( {
 	purchase,
 	translate,
 	moment,
-	isJetpack,
 	isDisconnectedSite,
 }: {
 	purchase: Purchases.Purchase;
 	translate: LocalizeProps[ 'translate' ];
 	moment: ReturnType< typeof useLocalizedMoment >;
-	isJetpack?: boolean;
 	isDisconnectedSite?: boolean;
 } ) {
 	const expiry = moment( purchase.expiryDate );
@@ -380,7 +378,7 @@ export function PurchaseItemStatus( {
 			);
 		}
 
-		if ( isJetpack ) {
+		if ( purchase.isJetpackPlanOrProduct ) {
 			return (
 				<span className="purchase-item__is-error">
 					{ translate( 'Disconnected from WordPress.com' ) }
@@ -756,7 +754,6 @@ class PurchaseItem extends Component<
 			iconUrl,
 			isBackupMethodAvailable,
 			moment,
-			isJetpack,
 			isDisconnectedSite,
 			transferredOwnershipPurchases = [],
 		} = this.props;
@@ -802,7 +799,6 @@ class PurchaseItem extends Component<
 						purchase={ purchase }
 						translate={ translate }
 						moment={ moment }
-						isJetpack={ isJetpack }
 						isDisconnectedSite={ isDisconnectedSite }
 					/>
 				</div>
@@ -836,7 +832,6 @@ class PurchaseItem extends Component<
 			getManagePurchaseUrlFor,
 			purchase,
 			slug,
-			isJetpack,
 			transferredOwnershipPurchases = [],
 		} = this.props;
 
@@ -856,7 +851,11 @@ class PurchaseItem extends Component<
 			// A "disconnected" Jetpack site's purchases may be managed.
 			// A "disconnected" WordPress.com site may *NOT* be managed (the user has been removed), unless it is a
 			// WPCOM generated temporary site, which is created during the siteless checkout flow. (currently Jetpack & Akismet can have siteless purchases).
-			if ( ! isDisconnectedSite || isJetpack || isTemporarySitePurchase( purchase ) ) {
+			if (
+				! isDisconnectedSite ||
+				purchase.isJetpackPlanOrProduct ||
+				isTemporarySitePurchase( purchase )
+			) {
 				onClick = () => {
 					window.scrollTo( 0, 0 );
 				};

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -300,6 +300,7 @@ export function getPurchasesFieldDefinitions( {
 				return item.expiryDate + ' ' + item.expiryStatus;
 			},
 			render: ( { item }: { item: Purchases.Purchase } ) => {
+				const site = sites.find( ( site ) => site.ID === item.siteId );
 				return (
 					<PurchaseItemRowStatus
 						purchase={ item }

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -42,10 +42,9 @@ function PurchaseItemRowStatus( props: {
 	purchase: Purchases.Purchase;
 	translate: LocalizeProps[ 'translate' ];
 	moment: ReturnType< typeof useLocalizedMoment >;
-	isJetpack?: boolean;
 	isDisconnectedSite?: boolean;
 } ) {
-	const { purchase, translate, moment, isJetpack, isDisconnectedSite } = props;
+	const { purchase, translate, moment, isDisconnectedSite } = props;
 
 	return (
 		<div className="purchase-item__status purchases-layout__status">
@@ -53,7 +52,6 @@ function PurchaseItemRowStatus( props: {
 				purchase={ purchase }
 				translate={ translate }
 				moment={ moment }
-				isJetpack={ isJetpack }
 				isDisconnectedSite={ isDisconnectedSite }
 			/>
 		</div>
@@ -303,7 +301,12 @@ export function getPurchasesFieldDefinitions( {
 			},
 			render: ( { item }: { item: Purchases.Purchase } ) => {
 				return (
-					<PurchaseItemRowStatus purchase={ item } translate={ translate } moment={ moment } />
+					<PurchaseItemRowStatus
+						purchase={ item }
+						translate={ translate }
+						moment={ moment }
+						isDisconnectedSite={ ! site }
+					/>
 				);
 			},
 		},

--- a/packages/data-stores/src/purchases/lib/assembler.ts
+++ b/packages/data-stores/src/purchases/lib/assembler.ts
@@ -123,6 +123,7 @@ export function createPurchaseObject( purchase: RawPurchase | RawPurchaseCreditC
 		purchaseRenewalQuantity: purchase.renewal_price_tier_usage_quantity || null,
 		userId: Number( purchase.user_id ),
 		isAutoRenewEnabled: parseInt( purchase.auto_renew ?? '' ) === 1,
+		isJetpackPlanOrProduct: purchase.is_jetpack_plan_or_product,
 	};
 
 	if ( purchase.purchaser_id ) {

--- a/packages/data-stores/src/purchases/types.ts
+++ b/packages/data-stores/src/purchases/types.ts
@@ -175,6 +175,8 @@ export interface Purchase {
 	 * Example: If the discount is 10%, this will have the value `10`.
 	 */
 	autoRenewCouponDiscountPercentage: number | null;
+
+	isJetpackPlanOrProduct: boolean;
 }
 
 export interface PurchasePriceTier {
@@ -232,6 +234,7 @@ export interface RawPurchase {
 	is_renewable: boolean;
 	is_renewal: boolean;
 	is_woo_express_trial: boolean;
+	is_jetpack_plan_or_product: boolean;
 	meta: string | undefined;
 	ownership_id: number | undefined;
 	partner_name: string | undefined;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CHE-242/dataviews-purchases-list-is-missing-properties-for-purchaseitemstatus

## Proposed Changes

This PR makes sure to handle the cases of a Jetpack site or a siteless purchase when rendering `PurchaseItemStatus`.

## Why are these changes being made?

There was a small regression added when we switched to the DataViews version of the purchases list. The PurchaseItemStatus component has an optional isJetpack and isDisconnectedSite prop but those were not included in the DataViews version. There were no errors because they are optional, but we need to pass them along.

Here's where they're needed:

https://github.com/Automattic/wp-calypso/blob/23607149289a189dff90a75f54d522d106d2d012/client/me/purchases/purchase-item/index.tsx#L354-L388

## Testing Instructions

I'm not actually sure how to trigger this but according to the logic, you'll need to have a Jetpack siteless temporary purchase and a Jetpack siteless non-temporary purchase. Verify that the temporary purchase shows `Activate your product license key` and that the non-temporary purchase renders `Disconnected from WordPress.com`. I found it easiest to hack the logic to make such purchases appear.