### PR TITLE
Dashboard v1: Fix the incorrect redirection when accessing feature tabs on simple sites

### DIFF
--- a/client/hosting/performance/index.tsx
+++ b/client/hosting/performance/index.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
 import { PERFORMANCE } from 'calypso/sites/components/site-preview-pane/constants';
-import { redirectToHostingFeaturesIfNotAtomic, siteDashboard } from 'calypso/sites/controller';
+import { siteDashboard } from 'calypso/sites/controller';
 import { sitePerformance, sitePerformanceCallout } from './controller';
 
 export default function () {
@@ -11,7 +11,6 @@ export default function () {
 	page(
 		'/sites/performance/:site',
 		siteSelection,
-		redirectToHostingFeaturesIfNotAtomic,
 		navigation,
 		sitePerformance,
 		sitePerformanceCallout,

--- a/client/sites/deployments/index.tsx
+++ b/client/sites/deployments/index.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import { DEPLOYMENTS } from 'calypso/sites/components/site-preview-pane/constants';
-import { redirectToHostingFeaturesIfNotAtomic, siteDashboard } from 'calypso/sites/controller';
+import { siteDashboard } from 'calypso/sites/controller';
 import {
 	deploymentCallout,
 	deploymentCreation,
@@ -17,7 +17,6 @@ export default function () {
 	page(
 		'/github-deployments/:site',
 		siteSelection,
-		redirectToHostingFeaturesIfNotAtomic,
 		navigation,
 		deploymentsList,
 		deploymentCallout,
@@ -29,7 +28,6 @@ export default function () {
 	page(
 		'/github-deployments/:site/create',
 		siteSelection,
-		redirectToHostingFeaturesIfNotAtomic,
 		navigation,
 		deploymentCreation,
 		deploymentCallout,
@@ -41,7 +39,6 @@ export default function () {
 	page(
 		'/github-deployments/:site/manage/:deploymentId',
 		siteSelection,
-		redirectToHostingFeaturesIfNotAtomic,
 		navigation,
 		deploymentManagement,
 		deploymentCallout,
@@ -53,7 +50,6 @@ export default function () {
 	page(
 		'/github-deployments/:site/logs/:deploymentId',
 		siteSelection,
-		redirectToHostingFeaturesIfNotAtomic,
 		navigation,
 		deploymentRunLogs,
 		deploymentCallout,

--- a/client/sites/logs/index.tsx
+++ b/client/sites/logs/index.tsx
@@ -2,7 +2,7 @@ import page, { type Callback, type Context } from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
 import { LOGS_PHP, LOGS_WEB } from 'calypso/sites/components/site-preview-pane/constants';
-import { siteDashboard, redirectToHostingFeaturesIfNotAtomic } from 'calypso/sites/controller';
+import { siteDashboard } from 'calypso/sites/controller';
 import { phpErrorLogs, webServerLogs, siteLogsCallout } from './controller';
 
 export default function () {
@@ -16,7 +16,6 @@ export default function () {
 	page(
 		'/site-logs/:site/php',
 		siteSelection,
-		redirectToHostingFeaturesIfNotAtomic,
 		navigation,
 		phpErrorLogs,
 		siteLogsCallout,
@@ -27,7 +26,6 @@ export default function () {
 	page(
 		'/site-logs/:site/web',
 		siteSelection,
-		redirectToHostingFeaturesIfNotAtomic,
 		navigation,
 		webServerLogs,
 		siteLogsCallout,

--- a/client/sites/monitoring/index.tsx
+++ b/client/sites/monitoring/index.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
 import { MONITORING } from 'calypso/sites/components/site-preview-pane/constants';
-import { redirectToHostingFeaturesIfNotAtomic, siteDashboard } from 'calypso/sites/controller';
+import { siteDashboard } from 'calypso/sites/controller';
 import { siteMonitoring, siteMonitoringCallout } from './controller';
 
 export default function () {
@@ -11,7 +11,6 @@ export default function () {
 	page(
 		'/site-monitoring/:site',
 		siteSelection,
-		redirectToHostingFeaturesIfNotAtomic,
 		navigation,
 		siteMonitoring,
 		siteMonitoringCallout,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of p1754548579008859-slack-CRWCHQGUB

## Proposed Changes

* Fix the incorrect redirection when accessing feature tabs on simple sites

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Select any simple site
* Navigate between feature tabs
* Ensure you can see the upsell callout

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?