### PR TITLE
A4A: Add Premier Partner badges for download

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/download-badges/download-link.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/download-badges/download-link.tsx
@@ -34,6 +34,11 @@ function DownloadLink( {
 				href: 'https://automattic.com/wp-content/uploads/2024/10/agency_tier_wordpress_pro_partner.zip',
 				icon: <img src={ WordPressogo } alt="WordPress.com" />,
 			},
+			'premier-partner': {
+				name: translate( 'WordPress.com Premier Agency Partner' ),
+				href: 'https://automattic.com/wp-content/uploads/2025/08/agency_tier_wordpresscom_premier_partner.zip',
+				icon: <img src={ WordPressogo } alt="WordPress.com" />,
+			},
 		},
 		woocommerce: {
 			'agency-partner': {
@@ -44,6 +49,11 @@ function DownloadLink( {
 			'pro-agency-partner': {
 				name: translate( 'Woo Pro Agency Partner' ),
 				href: 'https://automattic.com/wp-content/uploads/2025/02/agency_tier_woo_pro_partner.zip',
+				icon: <img src={ WooLogo } alt="WooCommerce" />,
+			},
+			'premier-partner': {
+				name: translate( 'Woo Premier Agency Partner' ),
+				href: 'https://automattic.com/wp-content/uploads/2025/08/agency_tier_woo_premier_partner.zip',
 				icon: <img src={ WooLogo } alt="WooCommerce" />,
 			},
 		},
@@ -58,6 +68,11 @@ function DownloadLink( {
 				href: 'https://automattic.com/wp-content/uploads/2024/10/agency_tier_jetpack_pro_partner.zip',
 				icon: <JetpackLogo size={ 32 } />,
 			},
+			'premier-partner': {
+				name: translate( 'Jetpack Premier Agency Partner' ),
+				href: 'https://automattic.com/wp-content/uploads/2025/08/agency_tier_jetpack_premier_partner.zip',
+				icon: <JetpackLogo size={ 32 } />,
+			},
 		},
 		pressable: {
 			'agency-partner': {
@@ -68,6 +83,11 @@ function DownloadLink( {
 			'pro-agency-partner': {
 				name: translate( 'Pressable Pro Agency Partner' ),
 				href: 'https://automattic.com/wp-content/uploads/2024/10/agency_tier_pressable_pro_partner.zip',
+				icon: <img src={ PressableLogo } alt="Pressable" />,
+			},
+			'premier-partner': {
+				name: translate( 'Pressable Premier Agency Partner' ),
+				href: 'https://automattic.com/wp-content/uploads/2025/08/agency_tier_pressable_premier_partner.zip',
 				icon: <img src={ PressableLogo } alt="Pressable" />,
 			},
 		},
@@ -86,6 +106,7 @@ function DownloadLink( {
 	return (
 		<Button
 			href={ data.href }
+			target="_blank"
 			onClick={ () => {
 				dispatch(
 					recordTracksEvent( 'calypso_a8c_agency_tier_badges_download_modal_download_click', {

--- a/client/a8c-for-agencies/sections/agency-tier/download-badges/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/download-badges/index.tsx
@@ -18,7 +18,7 @@ export default function DownloadBadges() {
 
 	const agency = useSelector( getActiveAgency );
 
-	const partnerDirectorties = agency?.partner_directory?.directories ?? [];
+	const partnerDirectories = agency?.partner_directory?.directories ?? [];
 
 	const currentAgencyTier = agency?.tier?.id;
 
@@ -34,7 +34,7 @@ export default function DownloadBadges() {
 		dispatch( recordTracksEvent( 'calypso_a8c_agency_tier_badges_download_modal_open' ) );
 	};
 
-	if ( ! partnerDirectorties.length || ! currentAgencyTier ) {
+	if ( ! partnerDirectories.length || ! currentAgencyTier ) {
 		return null;
 	}
 
@@ -71,7 +71,7 @@ export default function DownloadBadges() {
 						</div>
 
 						<div className="agency-tier-download-badges-modal__list">
-							{ partnerDirectorties.map( ( directory ) => (
+							{ partnerDirectories.map( ( directory ) => (
 								<DownloadLink
 									key={ directory }
 									product={ directory }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

This PR makes Premier Partner badges available in the assets download section.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

**Prerequisites**: To see the badges, you must be approved for a directory. You can quickly simulate this behavior by applying this patch to your sandbox: 38a7e-pb/raw/


- Use the Agency MC tool and set the agency tier to Premier Partner
- Open the A4A live link > Go to Agency Tier > Verify that the download button is displayed as shown below

<img width="778" height="546" alt="image" src="https://github.com/user-attachments/assets/ee0ba77e-3107-4c1e-8a90-b71d1c2ccd14" />

- Click the Download your badges button > Verify that the modal is displayed as shown below > Download all the badges for the partner directories and verify its working and pointing to the right place

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?