### PR TITLE
Continue as User: fix spacing issue on Blaze

### DIFF
--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -938,7 +938,7 @@ $breakpoint-mobile: 660px;
 
 		.signup-form,
 		.login__body--continue-as-user {
-			width: 100%;
+			width: 540px;
 			margin: 0 auto;
 			padding: 0;
 			display: flex;

--- a/client/login/wp-login/components/one-login-layout.scss
+++ b/client/login/wp-login/components/one-login-layout.scss
@@ -54,7 +54,3 @@
 		}
 	}
 }
-
-.wp-login__one-login-layout-content-wrapper .login__body--continue-as-user {
-	max-width: 540px;
-}


### PR DESCRIPTION
GitHub: https://github.com/Automattic/wp-calypso/pull/104948#issuecomment-3160314633

## Proposed Changes

* Limit Woo continue as user to 540px width. This is until we unify them all.

## Testing Instructions

* Make sure you are logged in.
* Visit all [OAuth links](https://linear.app/a8c/issue/DOTCOM-13220/login-make-the-two-columnwhite-layout-the-default-across-all-contexts). Confirm they all look good.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
