### PR TITLE
Hosting dashboard: Fetch domain details through its dedicated endpoint

### DIFF
--- a/client/dashboard/app/queries/domain.ts
+++ b/client/dashboard/app/queries/domain.ts
@@ -1,0 +1,8 @@
+import { queryOptions } from '@tanstack/react-query';
+import { fetchDomain } from '../../data/domain';
+
+export const domainQuery = ( domainName: string ) =>
+	queryOptions( {
+		queryKey: [ 'domains', domainName ],
+		queryFn: () => fetchDomain( domainName ),
+	} );

--- a/client/dashboard/app/routes/domain-routes.ts
+++ b/client/dashboard/app/routes/domain-routes.ts
@@ -106,8 +106,8 @@ export const domainDnsEditRoute = createRoute( {
 export const domainForwardingsRoute = createRoute( {
 	getParentRoute: () => domainRoute,
 	path: 'forwardings',
-	loader: ( { params } ) =>
-		queryClient.ensureQueryData( domainForwardingQuery( params.domainName ) ),
+	loader: ( { params: { domainName } } ) =>
+		queryClient.ensureQueryData( domainForwardingQuery( domainName ) ),
 } ).lazy( () =>
 	import( '../../domains/domain-forwardings' ).then( ( d ) =>
 		createLazyRoute( 'domain-forwardings' )( {
@@ -174,9 +174,6 @@ export const domainGlueRecordsRoute = createRoute( {
 export const domainDnssecRoute = createRoute( {
 	getParentRoute: () => domainRoute,
 	path: 'dnssec',
-	loader: ( { params: { domainName } } ) => {
-		return queryClient.ensureQueryData( domainQuery( domainName ) );
-	},
 } ).lazy( () =>
 	import( '../../domains/overview-dnssec' ).then( ( d ) =>
 		createLazyRoute( 'domain-dnssec' )( {

--- a/client/dashboard/app/routes/domain-routes.ts
+++ b/client/dashboard/app/routes/domain-routes.ts
@@ -1,4 +1,5 @@
-import { createRoute, createLazyRoute, notFound } from '@tanstack/react-router';
+import { createRoute, createLazyRoute } from '@tanstack/react-router';
+import { domainQuery } from '../queries/domain';
 import { domainForwardingQuery } from '../queries/domain-forwarding';
 import { domainsQuery } from '../queries/domains';
 import { siteDomainsQuery } from '../queries/site-domains';
@@ -46,12 +47,8 @@ export const siteDomainsRoute = createRoute( {
 export const domainRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'domains/$domainName',
-	loader: async ( { params: { domainName } } ) => {
-		const domains = await queryClient.ensureQueryData( domainsQuery() );
-		const domain = domains.find( ( domain ) => domain.domain === domainName );
-		if ( ! domain ) {
-			throw notFound();
-		}
+	loader: ( { params: { domainName } } ) => {
+		return queryClient.ensureQueryData( domainQuery( domainName ) );
 	},
 } ).lazy( () =>
 	import( '../../domains/domain' ).then( ( d ) =>

--- a/client/dashboard/app/routes/domain-routes.ts
+++ b/client/dashboard/app/routes/domain-routes.ts
@@ -2,7 +2,6 @@ import { createRoute, createLazyRoute } from '@tanstack/react-router';
 import { domainQuery } from '../queries/domain';
 import { domainForwardingQuery } from '../queries/domain-forwarding';
 import { domainsQuery } from '../queries/domains';
-import { siteDomainsQuery } from '../queries/site-domains';
 import { queryClient } from '../query-client';
 import type { AnyRoute } from '@tanstack/react-router';
 
@@ -175,17 +174,8 @@ export const domainGlueRecordsRoute = createRoute( {
 export const domainDnssecRoute = createRoute( {
 	getParentRoute: () => domainRoute,
 	path: 'dnssec',
-	loader: async ( { params: { domainName } } ) => {
-		// TODO: Replace with the new api that query for a specific domain
-
-		// Prefetch the domains data
-		const allDomains = await queryClient.ensureQueryData( domainsQuery() );
-		// Find the domain to get the blog_id
-		const domain = allDomains.find( ( domain ) => domain.domain === domainName );
-		if ( domain ) {
-			// Prefetch the site domains data
-			await queryClient.ensureQueryData( siteDomainsQuery( domain.blog_id ) );
-		}
+	loader: ( { params: { domainName } } ) => {
+		return queryClient.ensureQueryData( domainQuery( domainName ) );
 	},
 } ).lazy( () =>
 	import( '../../domains/overview-dnssec' ).then( ( d ) =>

--- a/client/dashboard/data/domain.ts
+++ b/client/dashboard/data/domain.ts
@@ -3,9 +3,9 @@ import type { DomainSummary } from './domains';
 
 export interface Domain extends DomainSummary {}
 
-export async function fetchDomain( domainName: string ): Promise< Domain > {
+export function fetchDomain( domainName: string ): Promise< Domain > {
 	return wpcom.req.get( {
 		path: `/domain-details/${ domainName }`,
-		apiNamespace: 'rest/v1.2',
+		apiVersion: '1.2',
 	} );
 }

--- a/client/dashboard/data/domain.ts
+++ b/client/dashboard/data/domain.ts
@@ -6,6 +6,6 @@ export interface Domain extends DomainSummary {}
 export async function fetchDomain( domainName: string ): Promise< Domain > {
 	return wpcom.req.get( {
 		path: `/domain-details/${ domainName }`,
-		version: '1.2',
+		apiNamespace: 'rest/v1.2',
 	} );
 }

--- a/client/dashboard/data/domain.ts
+++ b/client/dashboard/data/domain.ts
@@ -1,0 +1,11 @@
+import wpcom from 'calypso/lib/wp';
+import type { DomainSummary } from './domains';
+
+export interface Domain extends DomainSummary {}
+
+export async function fetchDomain( domainName: string ): Promise< Domain > {
+	return wpcom.req.get( {
+		path: `/domain-details/${ domainName }`,
+		version: '1.2',
+	} );
+}

--- a/client/dashboard/data/domains.ts
+++ b/client/dashboard/data/domains.ts
@@ -12,7 +12,7 @@ export enum DomainTypes {
 	TRANSFER = 'transfer',
 }
 
-export interface Domain {
+export interface DomainSummary {
 	aftermarket_auction: boolean;
 	auto_renewing: boolean;
 	blog_id: number;
@@ -43,7 +43,7 @@ export interface Domain {
 	wpcom_domain: boolean;
 }
 
-export async function fetchDomains(): Promise< Domain[] > {
+export async function fetchDomains(): Promise< DomainSummary[] > {
 	const { domains } = await wpcom.req.get( '/all-domains', {
 		no_wpcom: true,
 		resolve_status: true,

--- a/client/dashboard/data/site-domains.ts
+++ b/client/dashboard/data/site-domains.ts
@@ -1,7 +1,7 @@
 import wpcom from 'calypso/lib/wp';
-import type { Domain } from './domains';
+import type { DomainSummary } from './domains';
 
-export type SiteDomain = Omit< Domain, 'domain_status' >;
+export type SiteDomain = Omit< DomainSummary, 'domain_status' >;
 
 export async function fetchSiteDomains( siteId: number ): Promise< SiteDomain[] > {
 	const { domains } = await wpcom.req.get( {

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -1,4 +1,5 @@
 export type * from './agency';
+export type * from './domain';
 export type * from './domains';
 export type * from './emails';
 export type * from './me';

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -12,14 +12,14 @@ import { useMemo } from 'react';
 import { siteSetPrimaryDomainMutation } from '../../app/queries/site-domains';
 import { DomainTypes } from '../../data/domains';
 import { isRecentlyRegistered, isDomainRenewable, canSetAsPrimary } from '../../utils/domain';
-import type { Domain, Site, User } from '../../data/types';
+import type { DomainSummary, Site, User } from '../../data/types';
 import type { Action } from '@wordpress/dataviews';
 
 export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const setPrimaryDomainMutation = useMutation( siteSetPrimaryDomainMutation() );
 
-	const actions: Action< Domain >[] = useMemo(
+	const actions: Action< DomainSummary >[] = useMemo(
 		() => [
 			{
 				id: 'renew',
@@ -27,35 +27,35 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 				icon: <Icon icon={ payment } />,
 				label: __( 'Renew now' ),
 				callback: () => {},
-				isEligible: ( item: Domain ) => isDomainRenewable( item ),
+				isEligible: ( item: DomainSummary ) => isDomainRenewable( item ),
 			},
 			{
 				id: 'setup',
 				isPrimary: true,
 				icon: <Icon icon={ tool } />,
 				label: __( 'Setup' ),
-				callback: ( items: Domain[] ) => {
+				callback: ( items: DomainSummary[] ) => {
 					const domain = items[ 0 ];
 					const siteSlug = domain.primary_domain ? domain.domain : domain.site_slug;
 					window.location.pathname = domainMappingSetup( siteSlug, domain.domain );
 				},
-				isEligible: ( item: Domain ) => item.type === DomainTypes.MAPPED,
+				isEligible: ( item: DomainSummary ) => item.type === DomainTypes.MAPPED,
 			},
 			{
 				id: 'manage-domain',
-				label: ( items: Domain[] ) => {
+				label: ( items: DomainSummary[] ) => {
 					const domain = items[ 0 ];
 					return domain.type === DomainTypes.TRANSFER
 						? __( 'View transfer' )
 						: __( 'View settings' );
 				},
 				supportsBulk: false,
-				callback: ( items: Domain[] ) => {
+				callback: ( items: DomainSummary[] ) => {
 					const domain = items[ 0 ];
 					const siteSlug = domain.primary_domain ? domain.domain : domain.site_slug;
 					window.location.pathname = domainManagementLink( domain, siteSlug, false );
 				},
-				isEligible: ( item: Domain ) => {
+				isEligible: ( item: DomainSummary ) => {
 					return item.type !== DomainTypes.WPCOM;
 				},
 			},
@@ -77,7 +77,7 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 				id: 'set-primary-site-address',
 				label: __( 'Make primary site address' ),
 				supportsBulk: false,
-				callback: ( domains: Domain[] ) => {
+				callback: ( domains: DomainSummary[] ) => {
 					if ( ! site ) {
 						return;
 					}
@@ -109,7 +109,7 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 						}
 					);
 				},
-				isEligible: ( item: Domain ) => {
+				isEligible: ( item: DomainSummary ) => {
 					return (
 						!! site &&
 						canSetAsPrimary( { domain: item, site, user } ) &&

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -11,7 +11,7 @@ import { caution, reusableBlock } from '@wordpress/icons';
 import { useMemo } from 'react';
 import { domainOverviewRoute } from '../../app/router';
 import { DomainTypes } from '../../data/domains';
-import type { Domain, Site } from '../../data/types';
+import type { DomainSummary, Site } from '../../data/types';
 import type { Field } from '@wordpress/dataviews';
 
 const textOverflowStyles = {
@@ -28,7 +28,7 @@ const DomainName = ( {
 	value,
 	showPrimaryDomainBadge,
 }: {
-	domain: Domain;
+	domain: DomainSummary;
 	site?: Site;
 	value: string;
 	showPrimaryDomainBadge?: boolean;
@@ -58,7 +58,7 @@ const DomainExpiry = ( {
 	value,
 	isCompact = false,
 }: {
-	domain: Domain;
+	domain: DomainSummary;
 	value: string;
 	isCompact?: boolean;
 } ) => {
@@ -122,7 +122,7 @@ export const useFields = ( {
 	site?: Site;
 	showPrimaryDomainBadge?: boolean;
 } = {} ) => {
-	const fields: Field< Domain >[] = useMemo(
+	const fields: Field< DomainSummary >[] = useMemo(
 		() => [
 			{
 				id: 'domain',
@@ -130,7 +130,7 @@ export const useFields = ( {
 				enableHiding: false,
 				enableSorting: true,
 				enableGlobalSearch: true,
-				getValue: ( { item }: { item: Domain } ) => item.domain,
+				getValue: ( { item }: { item: DomainSummary } ) => item.domain,
 				render: ( { field, item } ) => (
 					<DomainName
 						domain={ item }
@@ -142,7 +142,7 @@ export const useFields = ( {
 			},
 			{
 				id: 'is_primary_domain',
-				getValue: ( { item }: { item: Domain } ) => item.primary_domain,
+				getValue: ( { item }: { item: DomainSummary } ) => item.primary_domain,
 				render: ( { field, item } ) =>
 					field.getValue( { item } ) ? <Text>{ __( 'Primary' ) }</Text> : null,
 			},
@@ -163,7 +163,7 @@ export const useFields = ( {
 				label: __( 'Site' ),
 				enableHiding: false,
 				enableSorting: true,
-				getValue: ( { item }: { item: Domain } ) => item.blog_name ?? '',
+				getValue: ( { item }: { item: DomainSummary } ) => item.blog_name ?? '',
 			},
 			// {
 			// 	id: 'ssl_status',
@@ -176,7 +176,7 @@ export const useFields = ( {
 				label: __( 'Expires/Renews on' ),
 				enableHiding: false,
 				enableSorting: true,
-				getValue: ( { item }: { item: Domain } ) =>
+				getValue: ( { item }: { item: DomainSummary } ) =>
 					item.expiry ? dateI18n( 'F j, Y', item.expiry ) : '',
 				render: ( { field, item } ) => (
 					<DomainExpiry
@@ -191,7 +191,7 @@ export const useFields = ( {
 				label: __( 'Status' ),
 				enableHiding: false,
 				enableSorting: true,
-				getValue: ( { item }: { item: Domain } ) => item.domain_status?.status ?? '',
+				getValue: ( { item }: { item: DomainSummary } ) => item.domain_status?.status ?? '',
 				render: ( { field, item } ) => {
 					const value = field.getValue( { item } );
 					return value || <IneligibleIndicator />;

--- a/client/dashboard/domains/domain/index.tsx
+++ b/client/dashboard/domains/domain/index.tsx
@@ -1,8 +1,9 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
-import { Outlet, notFound } from '@tanstack/react-router';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { Outlet } from '@tanstack/react-router';
 import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { globe } from '@wordpress/icons';
+import { domainQuery } from '../../app/queries/domain';
 import { domainsQuery } from '../../app/queries/domains';
 import { domainRoute } from '../../app/router';
 import HeaderBar from '../../components/header-bar';
@@ -15,12 +16,8 @@ import './style.scss';
 function Domain() {
 	const isDesktop = useViewportMatch( 'medium' );
 	const { domainName } = domainRoute.useParams();
-	const { data: domains } = useSuspenseQuery( domainsQuery() );
-	const domain = domains.find( ( domain ) => domain.domain === domainName );
-
-	if ( ! domain ) {
-		throw notFound();
-	}
+	const domains = useQuery( domainsQuery() ).data;
+	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 
 	return (
 		<>

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -10,9 +10,9 @@ import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
 import { useActions, useFields, DEFAULT_VIEW, DEFAULT_LAYOUTS } from './dataviews';
 import type { DomainsView } from './dataviews';
-import type { Domain } from '../data/types';
+import type { DomainSummary } from '../data/types';
 
-export function getDomainId( domain: Domain ): string {
+export function getDomainId( domain: DomainSummary ): string {
 	return `${ domain.domain }-${ domain.blog_id }`;
 }
 
@@ -46,7 +46,7 @@ function Domains() {
 			}
 		>
 			<DataViewsCard>
-				<DataViews< Domain >
+				<DataViews< DomainSummary >
 					data={ filteredData || [] }
 					fields={ fields }
 					onChangeView={ ( nextView ) => setView( () => nextView as DomainsView ) }

--- a/client/dashboard/utils/domain.ts
+++ b/client/dashboard/utils/domain.ts
@@ -3,7 +3,7 @@ import { DotcomFeatures } from '../data/constants';
 import { DomainTypes } from '../data/domains';
 import { hasPlanFeature } from './site-features';
 import { userHasFlag } from './user';
-import type { Domain, Site, User } from '../data/types';
+import type { DomainSummary, Site, User } from '../data/types';
 
 export function isRecentlyRegistered( registrationDate: string, numberOfMinutes = 30 ) {
 	return (
@@ -12,7 +12,7 @@ export function isRecentlyRegistered( registrationDate: string, numberOfMinutes 
 	);
 }
 
-export function isDomainRenewable( domain: Domain ) {
+export function isDomainRenewable( domain: DomainSummary ) {
 	// Only registered domains can be manually renewed
 	if ( domain.type !== DomainTypes.REGISTERED ) {
 		return false;
@@ -34,7 +34,7 @@ const shouldUpgradeToMakeDomainPrimary = ( {
 	site,
 	user,
 }: {
-	domain: Domain;
+	domain: DomainSummary;
 	site: Site;
 	user: User;
 } ) => {
@@ -55,7 +55,7 @@ export function canSetAsPrimary( {
 	site,
 	user,
 }: {
-	domain: Domain;
+	domain: DomainSummary;
 	site: Site;
 	user: User;
 } ): boolean {


### PR DESCRIPTION
Related to DOTDASH-253 and DOTDASH-231.

## Proposed Changes

Fetches the domain information through the newly-introduced endpoint instead of the `/all-domains` array.

## Why are these changes being made?

Independence from the general list endpoint for item browsing.

## Testing Instructions

Enter `/domains`, choose any domain and verify you can enter `/domains/%s` directly (type it in the address bar, don't click it.)

Enter `/domains/%s/dnssec` with the same methodology and verify you can still enter the page, despite having no domains endpoint caching.