### PR TITLE
New hosted site e2e: Remove Site Settings test admin menu

### DIFF
--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
@@ -16,7 +16,6 @@ import {
 	MeSidebarComponent,
 	cancelSubscriptionFlow,
 	cancelAtomicPurchaseFlow,
-	WPAdminSidebarComponent,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { apiCloseAccount } from '../shared';
@@ -91,18 +90,13 @@ describe(
 			} );
 		} );
 
-		describe( 'View server settings', function () {
-			it( 'See WP Admin', async function () {
+		describe( 'View WP Admin', function () {
+			it( 'WP Admin', async function () {
 				await page.waitForURL( /wp-admin/, {
 					timeout: 180 * 1000,
 				} );
 
 				siteSlug = new URL( page.url() ).hostname;
-			} );
-
-			it( 'Navigate to Hosting > Site Settings', async function () {
-				const wpAdminSidebarComponent = new WPAdminSidebarComponent( page );
-				await wpAdminSidebarComponent.navigate( 'Hosting', 'Site Settings' );
 			} );
 		} );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->
Since Hosting > Site Settings admin menu has been removed as part of the untangling work, this e2e test has to be also updated.

Part of DOTCOM-14148

## Proposed Changes

* Remove the step that checks for the Hosting > Site Settings

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The pre-release tests were failing
* see p1754059444320799-slack-C02DQP0FP

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TC

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?