### PR TITLE
Connect Refresh: Migrate Akismet create-account to unified Signup

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -52,6 +52,7 @@ import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { createSocialUserFailed } from 'calypso/state/login/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import getIsAkismet from 'calypso/state/selectors/get-is-akismet';
 import getIsBlazePro from 'calypso/state/selectors/get-is-blaze-pro';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
 import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
@@ -1036,7 +1037,11 @@ class SignupForm extends Component {
 		}
 
 		const isUnifiedCreateAccount =
-			this.props.isWoo || this.props.isA4A || this.props.isBlazePro || this.props.isCrowdsignal;
+			this.props.isWoo ||
+			this.props.isA4A ||
+			this.props.isCrowdsignal ||
+			this.props.isBlazePro ||
+			this.props.isAkismet;
 		const isGravatar = this.props.isGravatar;
 		const emailErrorMessage = this.getErrorMessagesWithLogin( 'email' );
 		const showSeparator =
@@ -1193,6 +1198,7 @@ export default connect(
 			isBlazePro: getIsBlazePro( state ),
 			isA4A: isA4AOAuth2Client( oauth2Client ),
 			isCrowdsignal: isCrowdsignalOAuth2Client( oauth2Client ),
+			isAkismet: getIsAkismet( state ),
 		};
 	},
 	{

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -23,6 +23,7 @@ import { errorNotice } from 'calypso/state/notices/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import getIsAkismet from 'calypso/state/selectors/get-is-akismet';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
 
 class SocialSignupForm extends Component {
@@ -101,11 +102,12 @@ class SocialSignupForm extends Component {
 			isWoo,
 			isA4A,
 			isBlazePro,
+			isAkismet,
 			isCrowdsignal,
 			setCurrentStep,
 		} = this.props;
 
-		const isUnifiedCreateAccount = isWoo || isA4A || isBlazePro || isCrowdsignal;
+		const isUnifiedCreateAccount = isWoo || isA4A || isCrowdsignal || isBlazePro || isAkismet;
 
 		return (
 			<Card
@@ -162,6 +164,7 @@ export default connect(
 			isA4A: isA4AOAuth2Client( oauth2Client ),
 			isBlazePro: isBlazeProOAuth2Client( oauth2Client ),
 			isCrowdsignal: isCrowdsignalOAuth2Client( oauth2Client ),
+			isAkismet: getIsAkismet( state ),
 		};
 	},
 	{ showErrorNotice: errorNotice }

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -15,7 +15,6 @@ import MasterbarLoggedOut from 'calypso/layout/masterbar/logged-out';
 import OauthClientMasterbar from 'calypso/layout/masterbar/oauth-client';
 import { isInStepContainerV2FlowContext } from 'calypso/layout/utils';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
-import isAkismetRedirect from 'calypso/lib/akismet/is-akismet-redirect';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import {
@@ -34,7 +33,7 @@ import { createAccountUrl } from 'calypso/lib/paths';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import { getOnboardingUrl as getPatternLibraryOnboardingUrl } from 'calypso/my-sites/patterns/paths';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { getRedirectToOriginal, isTwoFactorEnabled } from 'calypso/state/login/selectors';
+import { isTwoFactorEnabled } from 'calypso/state/login/selectors';
 import {
 	getCurrentOAuth2Client,
 	showOAuth2Layout,
@@ -42,6 +41,7 @@ import {
 import { clearLastActionRequiresLogin } from 'calypso/state/reader-ui/actions';
 import { getLastActionRequiresLogin } from 'calypso/state/reader-ui/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import getIsAkismet from 'calypso/state/selectors/get-is-akismet';
 import getIsBlazePro from 'calypso/state/selectors/get-is-blaze-pro';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
 import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
@@ -124,7 +124,7 @@ const LayoutLoggedOut = ( {
 		userAllowedToHelpCenter;
 
 	const isUnifiedCreateAccount =
-		sectionName === 'signup' && ( isWoo || isA4A || isBlazePro || isCrowdsignal );
+		sectionName === 'signup' && ( isWoo || isA4A || isCrowdsignal || isBlazePro || isAkismet );
 
 	const classes = {
 		[ 'is-group-' + sectionGroup ]: sectionGroup,
@@ -336,9 +336,7 @@ export default withCurrentRoute(
 			const sectionGroup = currentSection?.group ?? null;
 			const sectionName = currentSection?.name ?? null;
 			const sectionTitle = currentSection?.title ?? '';
-			const isAkismet = isAkismetRedirect(
-				new URLSearchParams( getRedirectToOriginal( state )?.split( '?' )[ 1 ] ).get( 'back' )
-			);
+			const isAkismet = getIsAkismet( state );
 			const isInvitationURL = currentRoute.startsWith( '/accept-invite' );
 			const oauth2Client = getCurrentOAuth2Client( state );
 			const isGravatar = isGravatarOAuth2Client( oauth2Client );

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -9,7 +9,6 @@ import { shouldUseMagicCode } from 'calypso/blocks/login/utils/should-use-magic-
 import GlobalNotices from 'calypso/components/global-notices';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import Main from 'calypso/components/main';
-import isAkismetRedirect from 'calypso/lib/akismet/is-akismet-redirect';
 import { isGravPoweredOAuth2Client, isStudioAppOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
 import OneLoginFooter from 'calypso/login/wp-login/components/one-login-footer';
@@ -293,11 +292,7 @@ class MagicLogin extends Component {
 			</Main>
 		);
 
-		return (
-			<OneLoginLayout isJetpack={ isJetpackLogin } isFromAkismet={ this.props.isFromAkismet }>
-				{ mainContent }
-			</OneLoginLayout>
-		);
+		return <OneLoginLayout isJetpack={ isJetpackLogin }>{ mainContent }</OneLoginLayout>;
 	}
 }
 
@@ -321,9 +316,6 @@ const mapState = ( state ) => ( {
 		'jetpack-onboarding',
 	isWooJPC: isWooJPCFlow( state ),
 	publicToken: getMagicLoginPublicToken( state ),
-	isFromAkismet: isAkismetRedirect(
-		new URLSearchParams( getRedirectToOriginal( state )?.split( '?' )[ 1 ] ).get( 'back' )
-	),
 } );
 
 const mapDispatch = {

--- a/client/login/wp-login/components/heading-logo.tsx
+++ b/client/login/wp-login/components/heading-logo.tsx
@@ -22,23 +22,24 @@ import {
 } from 'calypso/lib/oauth2-clients';
 import { useSelector } from 'calypso/state';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import getIsAkismet from 'calypso/state/selectors/get-is-akismet';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
 
 interface Props {
-	isFromAkismet?: boolean;
 	isJetpack?: boolean;
 }
 
-const HeadingLogo = ( { isFromAkismet, isJetpack }: Props ) => {
+const HeadingLogo = ( { isJetpack }: Props ) => {
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
 	const isWoo = useSelector( getIsWoo );
+	const isAkismet = useSelector( getIsAkismet );
 
 	let logo = null;
 	if ( isStudioAppOAuth2Client( oauth2Client ) ) {
 		logo = <img src={ studioAppLogo } alt="Studio App Logo" />;
 	} else if ( isCrowdsignalOAuth2Client( oauth2Client ) ) {
 		logo = <img src={ crowdsignalLogo } alt="Crowdsignal Logo" />;
-	} else if ( isFromAkismet ) {
+	} else if ( isAkismet ) {
 		logo = <img src={ akismetLogo } alt="Akismet Logo" />;
 	} else if ( isWPJobManagerOAuth2Client( oauth2Client ) ) {
 		logo = <img src={ wpJobManagerLogo } alt="WP Job Manager Logo" />;

--- a/client/login/wp-login/components/one-login-layout.tsx
+++ b/client/login/wp-login/components/one-login-layout.tsx
@@ -9,12 +9,12 @@ import { isUserLoggedIn, getCurrentUserLocale } from 'calypso/state/current-user
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import { getCurrentQueryArguments } from 'calypso/state/selectors/get-current-query-arguments';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
+import getIsAkismet from 'calypso/state/selectors/get-is-akismet';
 import HeadingLogo from './heading-logo';
 import './one-login-layout.scss';
 
 interface OneLoginLayoutProps {
 	isJetpack: boolean;
-	isFromAkismet: boolean;
 	children: React.ReactNode;
 	/**
 	 * `signupUrl` prop should merge with `getSignupLinkComponent` logic in `/client/block/login/index.js`, so we have a single source for this logic.
@@ -26,7 +26,6 @@ interface OneLoginLayoutProps {
 
 const OneLoginLayout = ( {
 	isJetpack,
-	isFromAkismet,
 	children,
 	signupUrl: signupUrlProp,
 	isSectionSignup,
@@ -38,6 +37,7 @@ const OneLoginLayout = ( {
 	const currentQuery = useSelector( getCurrentQueryArguments );
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
 	const isLoggedIn = useSelector( isUserLoggedIn );
+	const isAkismet = useSelector( getIsAkismet );
 	const dispatch = useDispatch();
 	const { headingText, subHeadingText, subHeadingTextSecondary } = useLoginContext();
 
@@ -88,7 +88,7 @@ const OneLoginLayout = ( {
 		>
 			<div className="wp-login__one-login-layout-content-wrapper">
 				<div className="wp-login__one-login-layout-heading">
-					<HeadingLogo isFromAkismet={ isFromAkismet } isJetpack={ isJetpack } />
+					<HeadingLogo isAkismet={ isAkismet } isJetpack={ isJetpack } />
 					<Step.Heading
 						text={ <div className="wp-login__one-login-layout-heading-text">{ headingText }</div> }
 					/>

--- a/client/login/wp-login/components/one-login-layout.tsx
+++ b/client/login/wp-login/components/one-login-layout.tsx
@@ -9,7 +9,6 @@ import { isUserLoggedIn, getCurrentUserLocale } from 'calypso/state/current-user
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import { getCurrentQueryArguments } from 'calypso/state/selectors/get-current-query-arguments';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
-import getIsAkismet from 'calypso/state/selectors/get-is-akismet';
 import HeadingLogo from './heading-logo';
 import './one-login-layout.scss';
 
@@ -37,7 +36,6 @@ const OneLoginLayout = ( {
 	const currentQuery = useSelector( getCurrentQueryArguments );
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
 	const isLoggedIn = useSelector( isUserLoggedIn );
-	const isAkismet = useSelector( getIsAkismet );
 	const dispatch = useDispatch();
 	const { headingText, subHeadingText, subHeadingTextSecondary } = useLoginContext();
 
@@ -88,7 +86,7 @@ const OneLoginLayout = ( {
 		>
 			<div className="wp-login__one-login-layout-content-wrapper">
 				<div className="wp-login__one-login-layout-heading">
-					<HeadingLogo isAkismet={ isAkismet } isJetpack={ isJetpack } />
+					<HeadingLogo isJetpack={ isJetpack } />
 					<Step.Heading
 						text={ <div className="wp-login__one-login-layout-heading-text">{ headingText }</div> }
 					/>

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -324,8 +324,7 @@ export class Login extends Component {
 	}
 
 	render() {
-		const { locale, translate, isGenericOauth, isGravPoweredClient, isJetpack, isFromAkismet } =
-			this.props;
+		const { locale, translate, isGenericOauth, isGravPoweredClient, isJetpack } = this.props;
 
 		const canonicalUrl = localizeUrl( 'https://wordpress.com/log-in', locale );
 
@@ -364,11 +363,7 @@ export class Login extends Component {
 		return (
 			<>
 				{ ! isGravPoweredClient && (
-					<OneLoginLayout
-						isJetpack={ isJetpack }
-						isFromAkismet={ isFromAkismet }
-						signupUrl={ this.props.signupUrl }
-					>
+					<OneLoginLayout isJetpack={ isJetpack } signupUrl={ this.props.signupUrl }>
 						{ mainContent }
 					</OneLoginLayout>
 				) }

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -63,6 +63,7 @@ import {
 } from 'calypso/state/current-user/selectors';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
+import getIsAkismet from 'calypso/state/selectors/get-is-akismet';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
 import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
@@ -876,7 +877,11 @@ class Signup extends Component {
 		const isUnifiedCreateAccount =
 			0 === this.getPositionInFlow() &&
 			! this.props.isLoggedIn &&
-			( this.props.isWoo || this.props.isA4A || this.props.isBlazePro || this.props.isCrowdsignal );
+			( this.props.isWoo ||
+				this.props.isA4A ||
+				this.props.isCrowdsignal ||
+				this.props.isBlazePro ||
+				this.props.isAkismet );
 
 		const showPageHeader = ! this.props.isGravatar && ! isUnifiedCreateAccount;
 		const isGravatarDomain = isDomainForGravatarFlow( this.props.flowName );
@@ -956,6 +961,7 @@ export default connect(
 			isA4A: isA4AOAuth2Client( oauth2Client ),
 			isBlazePro: isBlazeProOAuth2Client( oauth2Client ),
 			isCrowdsignal: isCrowdsignalOAuth2Client( oauth2Client ),
+			isAkismet: getIsAkismet( state ),
 		};
 	},
 	{

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -47,6 +47,7 @@ import { errorNotice } from 'calypso/state/notices/actions';
 import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import getIsAkismet from 'calypso/state/selectors/get-is-akismet';
 import getIsBlazePro from 'calypso/state/selectors/get-is-blaze-pro';
 import getIsWCCOM from 'calypso/state/selectors/get-is-wccom';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
@@ -484,6 +485,7 @@ export class UserStep extends Component {
 			isBlazePro,
 			isWCCOM,
 			isCrowdsignal,
+			isAkismet,
 		} = this.props;
 
 		if ( userLoggedIn ) {
@@ -499,8 +501,8 @@ export class UserStep extends Component {
 
 		// TODO clk This will encompass all unified OAuth2 clients,
 		// similar to get-header-text in wp-login (potentially the two being merged too)
-		if ( oauth2Client && isCrowdsignal ) {
-			const clientName = oauth2Client.name;
+		if ( ( oauth2Client && isCrowdsignal ) || isAkismet ) {
+			const clientName = isAkismet ? 'Akismet' : oauth2Client.name;
 
 			return fixMe( {
 				text: 'Sign up for {{span}}%(client)s{{/span}} with WordPress.com',
@@ -599,6 +601,7 @@ export class UserStep extends Component {
 			isA4A,
 			isBlazePro,
 			isCrowdsignal,
+			isAkismet,
 		} = this.props;
 		const isPasswordless =
 			isMobile() ||
@@ -606,8 +609,9 @@ export class UserStep extends Component {
 			isNewsletterFlow( this.props?.queryObject?.variationName ) ||
 			isWoo ||
 			isA4A ||
+			isCrowdsignal ||
 			isBlazePro ||
-			isCrowdsignal;
+			isAkismet;
 		let socialService;
 		let socialServiceResponse;
 		let isSocialSignupEnabled = this.props.isSocialSignupEnabled;
@@ -728,12 +732,7 @@ export class UserStep extends Component {
 							isWooJPC: this.props.isWooJPC,
 						} ) }
 					>
-						<OneLoginLayout
-							isJetpack={ false }
-							isFromAkismet={ false }
-							isSectionSignup
-							loginUrl={ this.getLoginUrl() }
-						>
+						<OneLoginLayout isJetpack={ false } isSectionSignup loginUrl={ this.getLoginUrl() }>
 							{ this.renderSignupForm() }
 						</OneLoginLayout>
 					</LoginContextWrapper>
@@ -765,7 +764,8 @@ const ConnectedUser = connect(
 		const isA4A = isA4AOAuth2Client( oauth2Client );
 		const isBlazePro = getIsBlazePro( state );
 		const isCrowdsignal = isCrowdsignalOAuth2Client( oauth2Client );
-		const isUnifiedCreateAccount = isWoo || isA4A || isBlazePro || isCrowdsignal;
+		const isAkismet = getIsAkismet( state );
+		const isUnifiedCreateAccount = isWoo || isA4A || isCrowdsignal || isBlazePro || isAkismet;
 
 		return {
 			oauth2Client: oauth2Client,
@@ -781,6 +781,7 @@ const ConnectedUser = connect(
 			isUnifiedCreateAccount,
 			isA4A,
 			isCrowdsignal,
+			isAkismet,
 		};
 	},
 	{

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -261,7 +261,7 @@ body.is-section-signup .layout:not(.dops) {
 }
 
 body.is-section-stepper,
-body.is-section-signup .layout:not(.dops):not(.is-wccom-oauth-flow) {
+body.is-section-signup .layout:not(.dops):not(.is-wccom-oauth-flow):not(.is-unified-create-account) {
 	$gray-100: #101517;
 	$gray-60: #50575e;
 	$gray-50: #646970;

--- a/client/state/selectors/get-is-akismet.ts
+++ b/client/state/selectors/get-is-akismet.ts
@@ -1,0 +1,17 @@
+import isAkismetRedirect from 'calypso/lib/akismet/is-akismet-redirect';
+import { isAkismetOAuth2Client } from 'calypso/lib/oauth2-clients';
+import { getRedirectToOriginal } from 'calypso/state/login/selectors';
+import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Return if it's Akismet (either via Akismet OAuth client or Akismet redirect)
+ */
+export default function getIsAkismet( state: AppState ): boolean {
+	return (
+		isAkismetOAuth2Client( getCurrentOAuth2Client( state ) ) ||
+		isAkismetRedirect(
+			new URLSearchParams( getRedirectToOriginal( state )?.split( '?' )[ 1 ] ).get( 'back' )
+		)
+	);
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13218/signup-update-and-unify-the-account-creation-screens
Builds off the core foundation from Woo Signup unification: https://github.com/Automattic/wp-calypso/pull/104948

## Proposed Changes

- We migrate the Akismet Signup (create account) screen to the unified design. This will align it closely to the Login view, so it's all one seamless flow.
- As with other OAuth2 clients, this isn't a simple redesign. We bring the passwordless form, social-signup options, and remove some of the previous branding/text. Akismet was missing any branding in this instance.
- There are (apparently) two forms of Akismet checks in the code (one that is solely based on the redirect param in the URL and another that checks for the Akismet OAuth2 client). We bring both of these together into a single state selector.
  - This may have ramifications to Login, not just Signup

| Before | After |
|--------|--------|
| <img width="1055" height="748" alt="Screenshot 2025-08-07 at 7 15 06 PM" src="https://github.com/user-attachments/assets/f24fe280-5b80-42ed-94b7-1dde149daaf2" /> | <img width="1064" height="863" alt="Screenshot 2025-08-07 at 7 14 49 PM" src="https://github.com/user-attachments/assets/6a4f71ae-e5d4-49c5-aed9-45bbb61b2e13" /> |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13218/signup-update-and-unify-the-account-creation-screens

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to [Akismet Signup](https://linear.app/a8c/issue/DOTCOM-13218/signup-update-and-unify-the-account-creation-screens) and confirm changes (this is the Login URL - click on "Create an account" on the top-right to view Signup)
  - Double confirm Akismet Login screens as they may be affected, like lost-password, magic-login.
- Confirm other signup (create account) screens aren't affected by the changes e.g. confirm Woo.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
