### PR TITLE
Onboarding: Clear signupSiteId when entering the flow

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -17,6 +17,7 @@ import {
 	clearSignupCompleteSlug,
 	clearSignupCompleteFlowName,
 	clearSignupDestinationCookie,
+	clearSignupCompleteSiteID,
 } from 'calypso/signup/storageUtils';
 import { useDispatch as useReduxDispatch } from 'calypso/state';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
@@ -320,6 +321,7 @@ const onboarding: FlowV2< typeof initialize > = {
 				clearSignupDestinationCookie();
 				clearSignupCompleteFlowName();
 				clearSignupCompleteSlug();
+				clearSignupCompleteSiteID();
 			}
 		}, [ currentStepSlug, reduxDispatch, resetOnboardStore ] );
 

--- a/client/signup/storageUtils.js
+++ b/client/signup/storageUtils.js
@@ -41,6 +41,8 @@ export const setSignupCompleteSlug = ( value ) =>
 	);
 export const clearSignupCompleteSlug = () =>
 	ignoreFatalsForStorage( () => sessionStorage?.removeItem( 'wpcom_signup_complete_site_slug' ) );
+export const clearSignupCompleteSiteID = () =>
+	ignoreFatalsForStorage( () => sessionStorage?.removeItem( 'wpcom_signup_complete_site_id' ) );
 export const getSignupCompleteSiteID = () =>
 	ignoreFatalsForStorage( () => sessionStorage?.getItem( 'wpcom_signup_complete_site_id' ) );
 export const setSignupCompleteSiteID = ( value ) =>


### PR DESCRIPTION
Fixes p1754522632912299/1754488703.128539-slack-C04H4NY6STW.

## Proposed Changes

Removes leftover persisted data from other flows when entering the flow without a specific step.

## Why are these changes being made?

There's a bug that renders a falsy site, preventing the user to skip the domains step.

## Testing Instructions

Try the steps from p1754594147498319/1754488703.128539-slack-C04H4NY6STW in production, and verify you don't see the same behavior locally.