### PR TITLE
Move help-center managing code into the dashboard

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -44,6 +44,7 @@ module.exports = {
 							'!@automattic/calypso-analytics',
 							'!@automattic/domains-table',
 							'!@automattic/domains-table/src/utils/*',
+							'!@automattic/help-center',
 							'!@automattic/number-formatters',
 							'!@automattic/ui',
 							'!@automattic/viewport',

--- a/client/dashboard/app/help-center/help-center-app.scss
+++ b/client/dashboard/app/help-center/help-center-app.scss
@@ -1,0 +1,1 @@
+@import '@automattic/calypso-color-schemes/root-only';

--- a/client/dashboard/app/help-center/help-center-app.tsx
+++ b/client/dashboard/app/help-center/help-center-app.tsx
@@ -1,0 +1,10 @@
+import HelpCenter from '@automattic/help-center'; // eslint-disable-line no-restricted-imports
+import './help-center-app.scss';
+
+/**
+ * This additional wrapper around the HelpCenter component gives us a place to
+ * async load the stylesheet.
+ */
+export default function HelpCenterApp( props: React.ComponentProps< typeof HelpCenter > ) {
+	return <HelpCenter { ...props } />;
+}

--- a/client/dashboard/app/help-center/help-center-app.tsx
+++ b/client/dashboard/app/help-center/help-center-app.tsx
@@ -1,4 +1,4 @@
-import HelpCenter from '@automattic/help-center'; // eslint-disable-line no-restricted-imports
+import HelpCenter from '@automattic/help-center';
 import './help-center-app.scss';
 
 /**

--- a/client/dashboard/app/help-center/index.ts
+++ b/client/dashboard/app/help-center/index.ts
@@ -25,26 +25,34 @@ export function useHelpCenter() {
 		}
 
 		setIsLoading( true );
-		loadingPromiseRef.current = import(
-			/* webpackChunkName: "async-load-automattic-data-stores" */ '@automattic/data-stores'
-		).then( ( { HelpCenter: HelpCenterStore } ) => {
-			HelpCenterStore.register();
-			setIsLoading( false );
-			loadingPromiseRef.current = undefined;
-		} );
+		loadingPromiseRef.current = import( '@automattic/data-stores' ).then(
+			( { HelpCenter: HelpCenterStore } ) => {
+				HelpCenterStore.register();
+				setIsLoading( false );
+				loadingPromiseRef.current = undefined;
+			}
+		);
 
 		return loadingPromiseRef.current;
 	}
 
-	const setShowHelpCenter = useCallback( async ( show: boolean ) => {
-		await ensureHelpCenterLoaded();
+	const setShowHelpCenter = useCallback(
+		async (
+			show: boolean,
+			allowPremiumSupport?: boolean,
+			options?: import('@automattic/data-stores/src/help-center/types').HelpCenterShowOptions,
+			forceClose?: boolean
+		) => {
+			await ensureHelpCenterLoaded();
 
-		return (
-			dispatch(
-				HELP_CENTER_STORE
-			) as import('@automattic/data-stores').HelpCenterDispatch[ 'dispatch' ]
-		 ).setShowHelpCenter( show );
-	}, [] );
+			return (
+				dispatch(
+					HELP_CENTER_STORE
+				) as import('@automattic/data-stores').HelpCenterDispatch[ 'dispatch' ]
+			 ).setShowHelpCenter( show, allowPremiumSupport, options, forceClose );
+		},
+		[]
+	);
 
 	const setNavigateToRoute = useCallback( async ( route?: string ) => {
 		await ensureHelpCenterLoaded();

--- a/client/dashboard/app/help-center/index.ts
+++ b/client/dashboard/app/help-center/index.ts
@@ -1,0 +1,76 @@
+import { dispatch, useSelect } from '@wordpress/data';
+import { useCallback, useState, useRef } from 'react';
+
+const HELP_CENTER_STORE = 'automattic/help-center';
+
+export function useHelpCenter() {
+	const loadingPromiseRef = useRef< Promise< unknown > >();
+	const [ isLoading, setIsLoading ] = useState( false );
+	const isShown = useSelect(
+		( select ) =>
+			!! (
+				select( HELP_CENTER_STORE ) as import('@automattic/data-stores').HelpCenterSelect
+			 )?.isHelpCenterShown?.(),
+		[ isLoading ] // We need to re-evaluate this incase a component used the hook before the store was loaded.
+	);
+
+	// Load `@automattic/data-stores` asynchronously to avoid including it in the main bundle and reduce initial load size.
+	async function ensureHelpCenterLoaded() {
+		if ( dispatch( HELP_CENTER_STORE ) ) {
+			return Promise.resolve();
+		}
+
+		if ( loadingPromiseRef.current ) {
+			return loadingPromiseRef.current;
+		}
+
+		setIsLoading( true );
+		loadingPromiseRef.current = import(
+			/* webpackChunkName: "async-load-automattic-data-stores" */ '@automattic/data-stores'
+		).then( ( { HelpCenter: HelpCenterStore } ) => {
+			HelpCenterStore.register();
+			setIsLoading( false );
+			loadingPromiseRef.current = undefined;
+		} );
+
+		return loadingPromiseRef.current;
+	}
+
+	const setShowHelpCenter = useCallback( async ( show: boolean ) => {
+		await ensureHelpCenterLoaded();
+
+		return (
+			dispatch(
+				HELP_CENTER_STORE
+			) as import('@automattic/data-stores').HelpCenterDispatch[ 'dispatch' ]
+		 ).setShowHelpCenter( show );
+	}, [] );
+
+	const setNavigateToRoute = useCallback( async ( route?: string ) => {
+		await ensureHelpCenterLoaded();
+
+		return (
+			dispatch(
+				HELP_CENTER_STORE
+			) as import('@automattic/data-stores').HelpCenterDispatch[ 'dispatch' ]
+		 ).setNavigateToRoute( route );
+	}, [] );
+
+	const setSubject = useCallback( async ( subject: string ) => {
+		await ensureHelpCenterLoaded();
+
+		return (
+			dispatch(
+				HELP_CENTER_STORE
+			) as import('@automattic/data-stores').HelpCenterDispatch[ 'dispatch' ]
+		 ).setSubject( subject );
+	}, [] );
+
+	return {
+		isLoading,
+		isShown,
+		setShowHelpCenter,
+		setNavigateToRoute,
+		setSubject,
+	};
+}

--- a/client/dashboard/app/help-center/index.ts
+++ b/client/dashboard/app/help-center/index.ts
@@ -1,5 +1,13 @@
 import { dispatch, useSelect } from '@wordpress/data';
 import { useCallback, useState, useRef } from 'react';
+// eslint-disable-next-line no-restricted-imports
+import type {
+	HelpCenterSelect,
+	HelpCenterDispatch as HelpCenterDispatchObject,
+} from '@automattic/data-stores';
+import type { HelpCenterShowOptions } from '@automattic/data-stores/src/help-center/types'; // eslint-disable-line no-restricted-imports
+
+type HelpCenterDispatch = HelpCenterDispatchObject[ 'dispatch' ];
 
 const HELP_CENTER_STORE = 'automattic/help-center';
 
@@ -7,10 +15,7 @@ export function useHelpCenter() {
 	const loadingPromiseRef = useRef< Promise< unknown > >();
 	const [ isLoading, setIsLoading ] = useState( false );
 	const isShown = useSelect(
-		( select ) =>
-			!! (
-				select( HELP_CENTER_STORE ) as import('@automattic/data-stores').HelpCenterSelect
-			 )?.isHelpCenterShown?.(),
+		( select ) => !! ( select( HELP_CENTER_STORE ) as HelpCenterSelect )?.isHelpCenterShown?.(),
 		[ isLoading ] // We need to re-evaluate this incase a component used the hook before the store was loaded.
 	);
 
@@ -40,16 +45,17 @@ export function useHelpCenter() {
 		async (
 			show: boolean,
 			allowPremiumSupport?: boolean,
-			options?: import('@automattic/data-stores/src/help-center/types').HelpCenterShowOptions,
+			options?: HelpCenterShowOptions,
 			forceClose?: boolean
 		) => {
 			await ensureHelpCenterLoaded();
 
-			return (
-				dispatch(
-					HELP_CENTER_STORE
-				) as import('@automattic/data-stores').HelpCenterDispatch[ 'dispatch' ]
-			 ).setShowHelpCenter( show, allowPremiumSupport, options, forceClose );
+			return ( dispatch( HELP_CENTER_STORE ) as HelpCenterDispatch ).setShowHelpCenter(
+				show,
+				allowPremiumSupport,
+				options,
+				forceClose
+			);
 		},
 		[]
 	);
@@ -57,21 +63,13 @@ export function useHelpCenter() {
 	const setNavigateToRoute = useCallback( async ( route?: string ) => {
 		await ensureHelpCenterLoaded();
 
-		return (
-			dispatch(
-				HELP_CENTER_STORE
-			) as import('@automattic/data-stores').HelpCenterDispatch[ 'dispatch' ]
-		 ).setNavigateToRoute( route );
+		return ( dispatch( HELP_CENTER_STORE ) as HelpCenterDispatch ).setNavigateToRoute( route );
 	}, [] );
 
 	const setSubject = useCallback( async ( subject: string ) => {
 		await ensureHelpCenterLoaded();
 
-		return (
-			dispatch(
-				HELP_CENTER_STORE
-			) as import('@automattic/data-stores').HelpCenterDispatch[ 'dispatch' ]
-		 ).setSubject( subject );
+		return ( dispatch( HELP_CENTER_STORE ) as HelpCenterDispatch ).setSubject( subject );
 	}, [] );
 
 	return {

--- a/client/dashboard/app/secondary-menu/index.tsx
+++ b/client/dashboard/app/secondary-menu/index.tsx
@@ -10,18 +10,21 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { help, bellUnread, bell, commentAuthorAvatar } from '@wordpress/icons';
+import { Suspense, lazy } from 'react';
 import ReaderIcon from 'calypso/assets/icons/reader/reader-icon';
-import { AsyncHelpCenterApp, useShowHelpCenter } from 'calypso/components/help-center'; // eslint-disable-line no-restricted-imports
 import RouterLinkMenuItem from '../../components/router-link-menu-item';
 import { useAuth } from '../auth';
 import { useOpenCommandPalette } from '../command-palette/utils';
 import { useAppContext } from '../context';
+import { useHelpCenter } from '../help-center';
 
 import './style.scss';
 
+const AsyncHelpCenterApp = lazy( () => import( 'calypso/components/help-center/help-center-app' ) );
+
 function Help() {
 	const { user } = useAuth();
-	const { isLoading, isShown, setShowHelpCenter } = useShowHelpCenter();
+	const { isLoading, isShown, setShowHelpCenter } = useHelpCenter();
 
 	const handleToggleHelpCenter = () => {
 		setShowHelpCenter( ! isShown );
@@ -37,7 +40,15 @@ function Help() {
 				isBusy={ isLoading }
 				onClick={ handleToggleHelpCenter }
 			/>
-			{ isShown && <AsyncHelpCenterApp currentUser={ user } sectionName="dashboard" /> }
+			<Suspense fallback={ null }>
+				{ isShown && (
+					<AsyncHelpCenterApp
+						currentUser={ user }
+						locale={ user.language }
+						sectionName="dashboard"
+					/>
+				) }
+			</Suspense>
 		</>
 	);
 }

--- a/client/dashboard/app/secondary-menu/index.tsx
+++ b/client/dashboard/app/secondary-menu/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useNavigate } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
@@ -10,7 +11,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { help, bellUnread, bell, commentAuthorAvatar } from '@wordpress/icons';
-import { Suspense, lazy } from 'react';
+import { Suspense, lazy, useCallback } from 'react';
 import ReaderIcon from 'calypso/assets/icons/reader/reader-icon';
 import RouterLinkMenuItem from '../../components/router-link-menu-item';
 import { useAuth } from '../auth';
@@ -20,7 +21,7 @@ import { useHelpCenter } from '../help-center';
 
 import './style.scss';
 
-const AsyncHelpCenterApp = lazy( () => import( 'calypso/components/help-center/help-center-app' ) );
+const AsyncHelpCenterApp = lazy( () => import( '../help-center/help-center-app' ) );
 
 function Help() {
 	const { user } = useAuth();
@@ -29,6 +30,10 @@ function Help() {
 	const handleToggleHelpCenter = () => {
 		setShowHelpCenter( ! isShown );
 	};
+
+	const handleCloseHelpCenterApp = useCallback( () => {
+		setShowHelpCenter( false, undefined, undefined, true );
+	}, [ setShowHelpCenter ] );
 
 	return (
 		<>
@@ -44,7 +49,9 @@ function Help() {
 				{ isShown && (
 					<AsyncHelpCenterApp
 						currentUser={ user }
+						handleClose={ handleCloseHelpCenterApp }
 						locale={ user.language }
+						onboardingUrl={ config( 'wpcom_signup_url' ) }
 						sectionName="dashboard"
 					/>
 				) }

--- a/client/dashboard/sites/add-new-site/index.tsx
+++ b/client/dashboard/sites/add-new-site/index.tsx
@@ -13,7 +13,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
 import { download, reusableBlock, Icon } from '@wordpress/icons';
 import devSiteBanner from 'calypso/assets/images/a8c-for-agencies/dev-site-banner.svg';
-import { useShowHelpCenter } from 'calypso/components/help-center'; // eslint-disable-line no-restricted-imports
+import { useHelpCenter } from '../../app/help-center';
 import Column from './column';
 import MenuItem from './menu-item';
 import type { AddNewSiteProps } from './types';
@@ -59,7 +59,7 @@ function AddNewSite( { context }: AddNewSiteProps ) {
 		} )
 	);
 
-	const { setShowHelpCenter } = useShowHelpCenter();
+	const { setShowHelpCenter } = useHelpCenter();
 
 	return (
 		<Wrapper alignment="flex-start" style={ { padding: '16px' } } spacing={ 6 }>
@@ -79,7 +79,7 @@ function AddNewSite( { context }: AddNewSiteProps ) {
 						'Prompt, edit, and launch WordPress websites with Artificial Intelligence.'
 					) }
 					onClick={ () => {
-						setShowHelpCenter( false ); // Close the help center
+						setShowHelpCenter( false );
 						recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
 							action: 'big-sky',
 						} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-242

## Proposed Changes

* Makes the help center's `setSubject` and `setNavigateToRoute` methods available in the dashboard too
* Lazy loads the help center data store, regardless of what method is used first
* Async loads the help center UI using `React.lazy` rather than Calypso's `AsyncLoad`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The DOTDASH-241 task needs access to more help center methods than just show/hide. It also needs the ability to set the search terms within the help center. That was the impetus to rearranging the hook so that it would async load the data store, regardless of what method was used first.

It also removes some dependency on the calypso client code. The `client/component/help-center` code is a pretty thin wrapper around the `@automattic/` packages. So I figured it was better to just depend on the packages directly.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The two existing ways the help center is currently accessed in the HD should work just as they used to.

The help button in the top-right works just as it did before. Clicking the button toggles the help center.

https://github.com/user-attachments/assets/8471a808-1d6e-4912-aa84-c49a30760011

When the help center is currently open and you create a new site with AI, the help center is closed. I don't know why this is exactly, but I'm guessing it is to prevent the help center from being auto opened when you sand in the big sky environment.

https://github.com/user-attachments/assets/d29a30ea-9d77-46ec-b9c3-157fb77600fa




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
