### PR TITLE
Site Overview: Update retrofitted layout breakpoints

### DIFF
--- a/client/sites/v2/site-overview/router.tsx
+++ b/client/sites/v2/site-overview/router.tsx
@@ -16,8 +16,8 @@ const siteOverviewRoute = createRoute( {
 			component: function SiteOverview() {
 				const isWide = useBreakpoint( WIDE_BREAKPOINT );
 				const breakpoints = isWide
-					? { large: 'huge' as WPBreakpoint, small: 'huge' as WPBreakpoint }
-					: { large: 'large' as WPBreakpoint, small: 'large' as WPBreakpoint };
+					? { large: 'wide' as WPBreakpoint, small: 'wide' as WPBreakpoint }
+					: { large: 'medium' as WPBreakpoint, small: 'medium' as WPBreakpoint };
 				return (
 					<d.default
 						siteSlug={ siteRoute.useParams().siteSlug }


### PR DESCRIPTION
Ref DOTDASH-243

## Proposed Changes

This PR updates the retrofitted layout breakpoints so that the mobile layout is displayed on a lower viewport width than before.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Enhancement.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /sites?flags=dashboard/v2/backport/site-overview
* Ensure that the mobile view is only displayed < 782px

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
