### PR TITLE
Hosting Dashboard: HD styles require the use of logical properties in CSS/SCSS

### DIFF
--- a/client/dashboard/.stylelintrc
+++ b/client/dashboard/.stylelintrc
@@ -1,0 +1,38 @@
+{
+	"extends": ["../../.stylelintrc"],
+	"rules": {
+		"property-disallowed-list": [
+			[
+				"margin-left",
+				"margin-right",
+				"padding-left",
+				"padding-right",
+				"border-left",
+				"border-right",
+				"border-left-width",
+				"border-right-width",
+				"border-left-style",
+				"border-right-style",
+				"border-left-color",
+				"border-right-color",
+				"left",
+				"right"
+			],
+			{
+				"message": "Use logical CSS properties for better RTL support e.g. `margin-inline-start/end` instead of `margin-left/right`.",
+				"severity": "warning"
+			}
+		],
+		"declaration-property-value-disallowed-list": [
+			{
+				"text-align": ["left", "right"],
+				"float": ["left", "right"],
+				"clear": ["left", "right"]
+			},
+			{
+				"message": "Use logical values for better RTL support e.g. `text-align: start/end` and `float: inline-start/inline-end`.",
+				"severity": "warning"
+			}
+		]
+	}
+}

--- a/client/dashboard/app/loading-screen.scss
+++ b/client/dashboard/app/loading-screen.scss
@@ -16,7 +16,7 @@
 .wpcom-site__logo {
 	position: absolute;
 	top: 50%;
-	left: 50%;
+	inset-inline-start: 50%;
 	transform: translate(-50%, -50%);
 	margin: 0;
 	fill: $gray-900;

--- a/client/dashboard/app/snackbars/style.scss
+++ b/client/dashboard/app/snackbars/style.scss
@@ -2,7 +2,7 @@
 
 .dashboard-snackbars {
 	position: fixed;
-	left: 0;
+	inset-inline-start: 0;
 	bottom: 0;
 	display: flex;
 	flex-direction: column;

--- a/client/dashboard/components/callout-overlay/style.scss
+++ b/client/dashboard/components/callout-overlay/style.scss
@@ -5,7 +5,7 @@
 	min-height: calc( 100% - 2 * 161px ) !important; // Overriding VStack style
 	width: calc( 100% - 2 * $grid-unit-20 );
 	top: 0;
-	left: 0;
+	inset-inline-start: 0;
 	padding: 161px $grid-unit-20;
 	background: linear-gradient(180deg, rgba(252, 252, 252, 0.65) 0%, #FCFCFC 100%);
 	backdrop-filter: blur(3px);

--- a/client/dashboard/components/loading-line/style.scss
+++ b/client/dashboard/components/loading-line/style.scss
@@ -10,7 +10,7 @@
 .loading-line-wrapper {
 	position: fixed;
 	top: 0;
-	left: 0;
+	inset-inline-start: 0;
 	width: 100%;
 	height: 2px;
 	background-color: transparent;

--- a/client/dashboard/components/menu-divider/style.scss
+++ b/client/dashboard/components/menu-divider/style.scss
@@ -2,6 +2,6 @@
 
 .dashboard-menu-divider {
 	height: $grid-unit-20;
-	border-left: $border-width solid var( --dashboard-header__divider-color );
+	border-inline-start: $border-width solid var( --dashboard-header__divider-color );
 	transform: skew( -10deg );
 }

--- a/client/dashboard/components/section-header/style.scss
+++ b/client/dashboard/components/section-header/style.scss
@@ -6,12 +6,10 @@
 	z-index: 1;
 
 	.components-button.dashboard-page-header__back-button {
-		padding-left: 0;
-		padding-right: 0;
+		padding-inline: 0;
 
 		svg {
-			margin-left: -4px;
-			margin-right: -4px;
+			margin-inline: -4px;
 		}
 	}
 

--- a/client/dashboard/sites/add-new-site/style.scss
+++ b/client/dashboard/sites/add-new-site/style.scss
@@ -5,7 +5,7 @@
 
 .dashboard-add-new-site__menu-item {
 	height: auto;
-	text-align: left;;
+	text-align: start;
 	padding: 8px;
 	color: inherit !important; // avoid changing the color on hover
 

--- a/client/dashboard/sites/overview-latest-activity-card/style.scss
+++ b/client/dashboard/sites/overview-latest-activity-card/style.scss
@@ -4,7 +4,7 @@
     display: block;
     position: relative;
     top: 50%;
-    left: 50%;
+    inset-inline-start: 50%;
     transform: translate(-50%, -50%);
     fill: $gray-700;
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Adds rules to prevent usage of non-logical properties like `padding-left`
* Fixes all existing properties with logical properties like `padding-inline-start`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

See p1754518249307699-slack-C0982082MSR

Currently the hosting dashboard is depending on Calypso's autortl tooling. But maybe in the future we port the HD to vite? Autortl also doesn't work for css-in-js.

CSS has a built-in tool to make RTL easy now, seems a shame not to use it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `./node_modules/.bin/stylelint client/dashboard/**/*.{css,scss}`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?