### PR TITLE
Site overview v2: make Latest Activity card readonly

### DIFF
--- a/client/dashboard/sites/overview-latest-activity-card/index.tsx
+++ b/client/dashboard/sites/overview-latest-activity-card/index.tsx
@@ -73,7 +73,7 @@ export default function LatestActivityCard( {
 	};
 
 	return (
-		<Card>
+		<Card className="dashboard-overview-latest-activity-card">
 			<CardHeader>
 				<SectionHeader title={ __( 'Latest activity' ) } level={ 3 } />
 			</CardHeader>

--- a/client/dashboard/sites/overview-latest-activity-card/style.scss
+++ b/client/dashboard/sites/overview-latest-activity-card/style.scss
@@ -1,5 +1,20 @@
 @import "@wordpress/base-styles/colors";
 
+.dashboard-overview-latest-activity-card {
+    // Hacks to make DataViews look non-interactive
+    .dataviews-view-list {
+        button.dataviews-view-list__item {
+            display: none;
+        }
+
+        div[role="row"]:hover {
+            .dataviews-view-list__fields {
+                color: $gray-700;
+            }
+        }
+    }
+}
+
 .dashboard-overview-latest-activity-card__icon {
     display: block;
     position: relative;


### PR DESCRIPTION
See: DOTDASH-105

## Proposed Changes

This PR attempts to disable interactions in the Latest Activity card in Site Overview v2:

|Before|After|
|-|-|
|<img width="504" height="249" alt="image" src="https://github.com/user-attachments/assets/df1de399-58aa-453b-87d1-1e565cbb26c6" />|<img width="501" height="254" alt="image" src="https://github.com/user-attachments/assets/9670b489-d6b9-4a38-89a7-6dbae626afea" />

Note that the rows will still be highlighted when hovered, even though the data is static. I think this is pretty common UX in other libraries.

### Implementation

Sadly there's no programmatic way to do this, so I had to resort to CSS hacks 😬 I filed this issue upstream as well:

- https://github.com/WordPress/gutenberg/issues/71127


## Why are these changes being made?

The Latest Activity card does not have any actions; it's meant to show static data.

## Testing Instructions

1. Go to /v2/sites
2. Click any site
3. Verify you can't do anything to the Latest Activity card rows.
4. Verify that the mouse cursor doesn't hint that any row is clickable/selectable.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
