### PR TITLE
Big Sky: Tracks event for offending break point

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
+++ b/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
@@ -2,6 +2,7 @@ import { Onboard } from '@automattic/data-stores';
 import { getAssemblerDesign } from '@automattic/design-picker';
 import { addPlanToCart, addProductsToCart, AI_SITE_BUILDER_FLOW } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+import { isWithinBreakpoint, getWindowInnerWidth } from '@automattic/viewport';
 import { resolveSelect, useDispatch as useWpDataDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useEffect } from 'react';
@@ -10,6 +11,7 @@ import { useAddBlogStickerMutation } from 'calypso/blocks/blog-stickers/use-add-
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
 import { SITE_STORE } from 'calypso/landing/stepper/stores';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useDispatch } from 'calypso/state';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
@@ -68,6 +70,15 @@ const aiSiteBuilder: FlowV2< typeof initialize > = {
 				window.sessionStorage.setItem( 'stored_ai_prompt', prompt );
 			}
 		}, [ prompt ] );
+
+		useEffect( () => {
+			if ( ! isWithinBreakpoint( '<782px' ) ) {
+				recordTracksEvent( 'calypso_big_sky_incompatible_screen', {
+					flow: AI_SITE_BUILDER_FLOW,
+					size: getWindowInnerWidth(),
+				} );
+			}
+		}, [] );
 	},
 	initialize,
 	useStepNavigation( _, navigate ) {

--- a/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
+++ b/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
@@ -72,7 +72,7 @@ const aiSiteBuilder: FlowV2< typeof initialize > = {
 		}, [ prompt ] );
 
 		useEffect( () => {
-			if ( ! isWithinBreakpoint( '<782px' ) ) {
+			if ( isWithinBreakpoint( '<782px' ) ) {
 				recordTracksEvent( 'calypso_big_sky_incompatible_screen', {
 					flow: AI_SITE_BUILDER_FLOW,
 					size: getWindowInnerWidth(),


### PR DESCRIPTION
This fixes BSKY-976

This throws an event when the braek point is what we know will fail in big sky so we can easily distinguish this in data

### Testing instructions

1. Open browser window with a very narrow size
2. Open console to observe events
3. Go to http://calypso.localhost:3000/setup/ai-site-builder/
4. Observe `t.gif` with the event

<img width="1025" height="648" alt="Zrzut ekranu 2025-08-8 o 10 45 07" src="https://github.com/user-attachments/assets/64cdb4d6-0e3b-47d7-b8e1-9aac2774765d" />

Then go to mc:

tracks/live/?eventname=calypso_big_sky_incompatible_screen&user=&useragent=


<img width="1332" height="705" alt="Zrzut ekranu 2025-08-8 o 10 55 14" src="https://github.com/user-attachments/assets/84f3c7de-f326-4483-b1d5-f3569c49984e" />
