### PR TITLE
Adds strikethrough to refunded payments

### DIFF
--- a/client/my-sites/promote-post-i2/components/payment-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/payment-item/index.tsx
@@ -99,7 +99,14 @@ export default function PaymentItem( props: Props ) {
 				payment.credits_used || 0,
 				2
 			) }` }</td>
-			<td className="payment-item__total">{ `$${ formatCents( payment.total_paid || 0, 2 ) }` }</td>
+			<td
+				className="payment-item__total"
+				style={
+					payment.status === paymentStatus.REFUNDED ? { textDecoration: 'line-through' } : undefined
+				}
+			>
+				{ `$${ formatCents( payment.total_paid || 0, 2 ) }` }
+			</td>
 			<td className="payment-item__actions">{ getActionButton( payment.status ) }</td>
 		</tr>
 	);

--- a/client/my-sites/promote-post-i2/components/payments-receipt/Receipt.tsx
+++ b/client/my-sites/promote-post-i2/components/payments-receipt/Receipt.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { DetailedPayment } from 'calypso/data/promote-post/use-promote-post-payment-details-query';
 import { Payment } from 'calypso/data/promote-post/use-promote-post-payments-query';
 import { WPCOMPrintLogo } from 'calypso/my-sites/promote-post-i2/components/payments-receipt/WPComPrintLogo';
+import { paymentStatus } from 'calypso/my-sites/promote-post-i2/utils';
 
 interface ReceiptTemplateProps {
 	payment: Payment | DetailedPayment;
@@ -220,7 +221,16 @@ export const Receipt = ( {
 						<div className="payment-receipt__row">
 							<div className="payment-receipt__label">{ __( 'Total:' ) }</div>
 							<div className="payment-receipt__value payment-receipt__value-bold">
-								${ payment.total_paid.toFixed( 2 ) }
+								{ payment.status === paymentStatus.REFUNDED ? (
+									<>
+										<span style={ { textDecoration: 'line-through' } }>
+											${ payment.total_paid.toFixed( 2 ) }
+										</span>{ ' ' }
+										<span>$0.00</span>
+									</>
+								) : (
+									`$${ payment.total_paid.toFixed( 2 ) }`
+								) }
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
Part of ADS-364

## Proposed Changes

* Adds a strike through to refunded payments in the payments list.
* Adds a strike through and reduces the total to zero on refunded receipts.

## Why are these changes being made?

The refunded receipts were showing the full total, which is a bit misleading because the user hasn't actually paid this amount.

## Testing Instructions

Visit `http://calypso.localhost:3000/advertising/payments/site.com`

- Check a refund receipt in the list.
- Open the refunded receipt

<img width="1281" height="382" alt="image" src="https://github.com/user-attachments/assets/330b4a74-c8b2-419e-a062-cd27dc1d91b5" />


<img width="1048" height="275" alt="image" src="https://github.com/user-attachments/assets/bf7e1784-69bd-47cb-9748-2d3ed4eee590" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- x ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
