### PR TITLE
Staging sites redesign: Focus add staging site button

### DIFF
--- a/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
@@ -118,6 +118,11 @@ export default function HeaderStagingSiteButton( {
 		isAtomic && ! isStagingSite && ( stagingSites.length === 0 || isCreatingStagingSite );
 
 	const onAddClick = useCallback( () => {
+		// Reset highlight when user clicks the button
+		const button = document.querySelector( '.hosting-dashboard-item-view__header-add-staging' );
+		if ( button ) {
+			button.classList.remove( 'staging-button-highlighted' );
+		}
 		dispatch( setStagingSiteStatus( siteId, StagingSiteStatus.INITIATE_TRANSFERRING ) );
 		dispatch( recordTracksEvent( 'calypso_hosting_configuration_staging_site_add_click' ) );
 		addStagingSite( { name: '' } );

--- a/client/layout/hosting-dashboard/item-view/item-view-header/style.scss
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/style.scss
@@ -50,6 +50,23 @@ $blueberry-color: #3858e9;
 				&.components-button.has-icon {
 					padding: 0 0 0 2px;
 				}
+
+				&.staging-button-highlighted {
+					outline: 2px solid #3858e9;
+					outline-offset: 0;
+					border-radius: 2px;
+					animation: highlightPulse 0.5s ease-in-out;
+
+					&:hover {
+						outline-color: #2c4ccc;
+						background-color: rgba(56, 88, 233, 0.05);
+					}
+
+					&:focus {
+						outline-color: #2c4ccc;
+						outline-offset: 2px;
+					}
+				}
 			}
 		}
 
@@ -161,5 +178,20 @@ $blueberry-color: #3858e9;
 				}
 			}
 		}
+	}
+}
+
+@keyframes highlightPulse {
+	0% {
+		outline-width: 2px;
+		outline-color: rgba(56, 88, 233, 0.8);
+	}
+	50% {
+		outline-width: 3px;
+		outline-color: rgba(56, 88, 233, 1);
+	}
+	100% {
+		outline-width: 2px;
+		outline-color: rgba(56, 88, 233, 0.8);
 	}
 }

--- a/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
+++ b/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
@@ -134,7 +134,7 @@ const InfoCard: FunctionComponent< InfoCardProps > = ( { item, onLocationClick }
 											padding: 0,
 											textDecoration: 'none',
 											cursor: 'pointer',
-											color: 'var(--wp-admin-theme-color, #0073aa)',
+											color: '#3858e9',
 											font: 'inherit',
 										} }
 									>

--- a/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
+++ b/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
@@ -171,7 +171,6 @@ const StagingSiteManagementMoveInfo: FunctionComponent = () => {
 
 	const infoCardItems = getInfoCardItems( settingsLink );
 
-	// Check if we should enable highlighting - only on production sites without staging sites
 	const canHighlightStagingButton = ! isCurrentSiteStaging && ! stagingSiteId;
 
 	const handleCreateStagingSiteLocationClick = () => {
@@ -180,7 +179,6 @@ const StagingSiteManagementMoveInfo: FunctionComponent = () => {
 			if ( button ) {
 				button.classList.add( 'staging-button-highlighted' );
 
-				// Reset the highlight after 3 seconds
 				setTimeout( () => {
 					button.classList.remove( 'staging-button-highlighted' );
 				}, 3000 );

--- a/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
+++ b/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
@@ -89,9 +89,10 @@ const getInfoCardItems = ( settingsLink?: string ): InfoCardItem[] => [
 
 interface InfoCardProps {
 	item: InfoCardItem;
+	onLocationClick?: () => void;
 }
 
-const InfoCard: FunctionComponent< InfoCardProps > = ( { item } ) => {
+const InfoCard: FunctionComponent< InfoCardProps > = ( { item, onLocationClick } ) => {
 	return (
 		<Card>
 			<CardBody style={ { padding: '16px' } }>
@@ -118,15 +119,30 @@ const InfoCard: FunctionComponent< InfoCardProps > = ( { item } ) => {
 						<Text>{ item.description }</Text>
 						<HStack alignment="left" spacing={ 1 }>
 							<Icon icon={ item.locationIcon } size={ 16 } style={ { fill: '#757575' } } />
-							{ item.link ? (
-								<Text variant="muted">
+							<Text variant="muted">
+								{ item.link && (
 									<a href={ item.link } style={ { textDecoration: 'none' } }>
 										{ item.location }
 									</a>
-								</Text>
-							) : (
-								<Text variant="muted">{ item.location }</Text>
-							) }
+								) }
+								{ onLocationClick && ! item.link && (
+									<button
+										onClick={ onLocationClick }
+										style={ {
+											background: 'none',
+											border: 'none',
+											padding: 0,
+											textDecoration: 'none',
+											cursor: 'pointer',
+											color: 'var(--wp-admin-theme-color, #0073aa)',
+											font: 'inherit',
+										} }
+									>
+										{ item.location }
+									</button>
+								) }
+								{ ! item.link && ! onLocationClick && item.location }
+							</Text>
 						</HStack>
 					</VStack>
 				</HStack>
@@ -155,6 +171,23 @@ const StagingSiteManagementMoveInfo: FunctionComponent = () => {
 
 	const infoCardItems = getInfoCardItems( settingsLink );
 
+	// Check if we should enable highlighting - only on production sites without staging sites
+	const canHighlightStagingButton = ! isCurrentSiteStaging && ! stagingSiteId;
+
+	const handleCreateStagingSiteLocationClick = () => {
+		if ( canHighlightStagingButton ) {
+			const button = document.querySelector( '.hosting-dashboard-item-view__header-add-staging' );
+			if ( button ) {
+				button.classList.add( 'staging-button-highlighted' );
+
+				// Reset the highlight after 3 seconds
+				setTimeout( () => {
+					button.classList.remove( 'staging-button-highlighted' );
+				}, 3000 );
+			}
+		}
+	};
+
 	return (
 		<VStack spacing={ 10 }>
 			<VStack spacing={ 2 }>
@@ -177,7 +210,14 @@ const StagingSiteManagementMoveInfo: FunctionComponent = () => {
 			>
 				{ infoCardItems.map( ( item, index ) => (
 					<Item key={ index } style={ { padding: '0' } }>
-						<InfoCard item={ item } />
+						<InfoCard
+							item={ item }
+							onLocationClick={
+								index === 0 && canHighlightStagingButton
+									? handleCreateStagingSiteLocationClick
+									: undefined
+							}
+						/>
 					</Item>
 				) ) }
 			</Grid>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DOTCOM-14115

## Proposed Changes

This PR adds a highlight around the `Add staging site` button when you click on `Located in top navigation` button in the `Create new staging site` card. It should be available only on production and not on staging sites:

<img width="998" height="478" alt="Screenshot 2025-08-08 at 2 17 52 PM" src="https://github.com/user-attachments/assets/57fa3fbf-6159-44ab-b8ca-bc03e38fce09" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch or use the Calypso Live Link below
* Ensure that you have at least one Atomic site 
* Ensure that Atomic site does not have a staging site
* Navigate to `/staging-site/{yourAtomicSite}`
* Click on `Staging site` tab
* Observe that there is a link under `Create staging site card` 
* Click on `Located in the top navigation`
* Observe that the `Add staging site` gets highlighted
* Observe that the highlight goes away after 3 seconds

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
