### PR TITLE
Connect Refresh: Migrate VIP create-account to unified Signup

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -40,6 +40,7 @@ import {
 	isA4AOAuth2Client,
 	isCrowdsignalOAuth2Client,
 	isGravatarOAuth2Client,
+	isVIPOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login, lostPassword } from 'calypso/lib/paths';
 import { isExistingAccountError } from 'calypso/lib/signup/is-existing-account-error';
@@ -1041,7 +1042,8 @@ class SignupForm extends Component {
 			this.props.isA4A ||
 			this.props.isCrowdsignal ||
 			this.props.isBlazePro ||
-			this.props.isAkismet;
+			this.props.isAkismet ||
+			this.props.isVIPClient;
 		const isGravatar = this.props.isGravatar;
 		const emailErrorMessage = this.getErrorMessagesWithLogin( 'email' );
 		const showSeparator =
@@ -1199,6 +1201,7 @@ export default connect(
 			isA4A: isA4AOAuth2Client( oauth2Client ),
 			isCrowdsignal: isCrowdsignalOAuth2Client( oauth2Client ),
 			isAkismet: getIsAkismet( state ),
+			isVIPClient: isVIPOAuth2Client( oauth2Client ),
 		};
 	},
 	{

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -17,6 +17,7 @@ import {
 	isA4AOAuth2Client,
 	isBlazeProOAuth2Client,
 	isCrowdsignalOAuth2Client,
+	isVIPOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { isWpccFlow } from 'calypso/signup/is-flow';
 import { errorNotice } from 'calypso/state/notices/actions';
@@ -104,10 +105,12 @@ class SocialSignupForm extends Component {
 			isBlazePro,
 			isAkismet,
 			isCrowdsignal,
+			isVIPClient,
 			setCurrentStep,
 		} = this.props;
 
-		const isUnifiedCreateAccount = isWoo || isA4A || isCrowdsignal || isBlazePro || isAkismet;
+		const isUnifiedCreateAccount =
+			isWoo || isA4A || isCrowdsignal || isBlazePro || isAkismet || isVIPClient;
 
 		return (
 			<Card
@@ -165,6 +168,7 @@ export default connect(
 			isBlazePro: isBlazeProOAuth2Client( oauth2Client ),
 			isCrowdsignal: isCrowdsignalOAuth2Client( oauth2Client ),
 			isAkismet: getIsAkismet( state ),
+			isVIPClient: isVIPOAuth2Client( oauth2Client ),
 		};
 	},
 	{ showErrorNotice: errorNotice }

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -28,6 +28,7 @@ import {
 	isIosOAuth2Client,
 	isA4AOAuth2Client,
 	isCrowdsignalOAuth2Client,
+	isVIPOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { createAccountUrl } from 'calypso/lib/paths';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
@@ -84,6 +85,7 @@ const LayoutLoggedOut = ( {
 	colorScheme,
 	isA4A,
 	isCrowdsignal,
+	isVIPClient,
 } ) => {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const currentRoute = useSelector( getCurrentRoute );
@@ -124,7 +126,8 @@ const LayoutLoggedOut = ( {
 		userAllowedToHelpCenter;
 
 	const isUnifiedCreateAccount =
-		sectionName === 'signup' && ( isWoo || isA4A || isCrowdsignal || isBlazePro || isAkismet );
+		sectionName === 'signup' &&
+		( isWoo || isA4A || isCrowdsignal || isBlazePro || isAkismet || isVIPClient );
 
 	const classes = {
 		[ 'is-group-' + sectionGroup ]: sectionGroup,
@@ -392,6 +395,7 @@ export default withCurrentRoute(
 				colorScheme,
 				isA4A: isA4AOAuth2Client( oauth2Client ),
 				isCrowdsignal: isCrowdsignalOAuth2Client( oauth2Client ),
+				isVIPClient: isVIPOAuth2Client( oauth2Client ),
 			};
 		},
 		{ clearLastActionRequiresLogin }

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -49,6 +49,7 @@ import {
 	isA4AOAuth2Client,
 	isBlazeProOAuth2Client,
 	isCrowdsignalOAuth2Client,
+	isVIPOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import SignupFlowController from 'calypso/lib/signup/flow-controller';
 import FlowProgressIndicator from 'calypso/signup/flow-progress-indicator';
@@ -881,7 +882,8 @@ class Signup extends Component {
 				this.props.isA4A ||
 				this.props.isCrowdsignal ||
 				this.props.isBlazePro ||
-				this.props.isAkismet );
+				this.props.isAkismet ||
+				this.props.isVIPClient );
 
 		const showPageHeader = ! this.props.isGravatar && ! isUnifiedCreateAccount;
 		const isGravatarDomain = isDomainForGravatarFlow( this.props.flowName );
@@ -962,6 +964,7 @@ export default connect(
 			isBlazePro: isBlazeProOAuth2Client( oauth2Client ),
 			isCrowdsignal: isCrowdsignalOAuth2Client( oauth2Client ),
 			isAkismet: getIsAkismet( state ),
+			isVIPClient: isVIPOAuth2Client( oauth2Client ),
 		};
 	},
 	{

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -25,6 +25,7 @@ import {
 	isGravatarOAuth2Client,
 	isJetpackCloudOAuth2Client,
 	isPartnerPortalOAuth2Client,
+	isVIPOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
 import LoginContextProvider, { useLoginContext } from 'calypso/login/login-context';
@@ -486,6 +487,8 @@ export class UserStep extends Component {
 			isWCCOM,
 			isCrowdsignal,
 			isAkismet,
+			isVIPClient,
+			isA4A,
 		} = this.props;
 
 		if ( userLoggedIn ) {
@@ -501,7 +504,10 @@ export class UserStep extends Component {
 
 		// TODO clk This will encompass all unified OAuth2 clients,
 		// similar to get-header-text in wp-login (potentially the two being merged too)
-		if ( ( oauth2Client && isCrowdsignal ) || isAkismet ) {
+		if (
+			( oauth2Client && ( isCrowdsignal || isVIPClient || isA4A || isBlazePro ) ) ||
+			isAkismet
+		) {
 			const clientName = isAkismet ? 'Akismet' : oauth2Client.name;
 
 			return fixMe( {
@@ -512,14 +518,6 @@ export class UserStep extends Component {
 				} ),
 				oldCopy: translate( 'Create your account' ),
 			} );
-		}
-
-		if ( isA4AOAuth2Client( oauth2Client ) ) {
-			return translate( 'Sign up to Automattic for Agencies with WordPress.com' );
-		}
-
-		if ( isBlazeProOAuth2Client( oauth2Client ) ) {
-			return translate( 'Sign up to Blaze Pro with WordPress.com' );
 		}
 
 		if ( isWCCOM ) {
@@ -533,6 +531,9 @@ export class UserStep extends Component {
 				</span>
 			);
 		}
+		/**
+		 * END: Unified create account
+		 */
 
 		/**
 		 * END: Unified create account
@@ -602,6 +603,7 @@ export class UserStep extends Component {
 			isBlazePro,
 			isCrowdsignal,
 			isAkismet,
+			isVIPClient,
 		} = this.props;
 		const isPasswordless =
 			isMobile() ||
@@ -611,7 +613,8 @@ export class UserStep extends Component {
 			isA4A ||
 			isCrowdsignal ||
 			isBlazePro ||
-			isAkismet;
+			isAkismet ||
+			isVIPClient;
 		let socialService;
 		let socialServiceResponse;
 		let isSocialSignupEnabled = this.props.isSocialSignupEnabled;
@@ -765,7 +768,9 @@ const ConnectedUser = connect(
 		const isBlazePro = getIsBlazePro( state );
 		const isCrowdsignal = isCrowdsignalOAuth2Client( oauth2Client );
 		const isAkismet = getIsAkismet( state );
-		const isUnifiedCreateAccount = isWoo || isA4A || isCrowdsignal || isBlazePro || isAkismet;
+		const isVIPClient = isVIPOAuth2Client( oauth2Client );
+		const isUnifiedCreateAccount =
+			isWoo || isA4A || isCrowdsignal || isBlazePro || isAkismet || isVIPClient;
 
 		return {
 			oauth2Client: oauth2Client,
@@ -782,6 +787,7 @@ const ConnectedUser = connect(
 			isA4A,
 			isCrowdsignal,
 			isAkismet,
+			isVIPClient,
 		};
 	},
 	{

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -508,7 +508,17 @@ export class UserStep extends Component {
 			( oauth2Client && ( isCrowdsignal || isVIPClient || isA4A || isBlazePro ) ) ||
 			isAkismet
 		) {
-			const clientName = isAkismet ? 'Akismet' : oauth2Client.name;
+			let clientName = oauth2Client?.name;
+
+			if ( isAkismet ) {
+				clientName = 'Akismet';
+			} else if ( isA4A ) {
+				clientName = 'Automattic for Agencies';
+			} else if ( isBlazePro ) {
+				clientName = 'Blaze Pro';
+			} else if ( isVIPClient ) {
+				clientName = 'VIP';
+			}
 
 			return fixMe( {
 				text: 'Sign up for {{span}}%(client)s{{/span}} with WordPress.com',
@@ -531,10 +541,6 @@ export class UserStep extends Component {
 				</span>
 			);
 		}
-		/**
-		 * END: Unified create account
-		 */
-
 		/**
 		 * END: Unified create account
 		 */


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13218/signup-update-and-unify-the-account-creation-screens
Builds off the core foundation from Woo Signup unification: https://github.com/Automattic/wp-calypso/pull/104948

## Proposed Changes

- We migrate the VIP Signup (create account) screen to the unified design. This will align it closely to the Login view, so it's all one seamless flow.
- As with others, we bring the **passwordless** form and **social-signup** options.

### Before

| Before | After |
|--------|--------|
| <img width="992" height="779" alt="Screenshot 2025-08-10 at 6 15 38 PM" src="https://github.com/user-attachments/assets/4a67b858-580b-4b08-bdf3-072f2783620c" /> | <img width="986" height="751" alt="Screenshot 2025-08-10 at 6 15 22 PM" src="https://github.com/user-attachments/assets/739a73a8-48be-4602-a78b-c62b20207118" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13218/signup-update-and-unify-the-account-creation-screens


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [VIP signup](https://linear.app/a8c/issue/DOTCOM-13218/signup-update-and-unify-the-account-creation-screens) and confirm changes (this is a list of Login URLs, find the one for VIP and click on "create an account" from top-right once there)
* Confirm other signup (create account) screens aren't affected by the changes e.g. confirm Woo.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
