### PR TITLE
Connect Refresh: Migrate Studio create-account to unified Signup

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -41,11 +41,8 @@ import {
 	isCrowdsignalOAuth2Client,
 	isGravatarOAuth2Client,
 	isVIPOAuth2Client,
-<<<<<<< HEAD
 	isJetpackCloudOAuth2Client,
-=======
 	isStudioAppOAuth2Client,
->>>>>>> 715cf36e3b3 (Connect Refresh: Migrate Studio create-account to unified Signup)
 } from 'calypso/lib/oauth2-clients';
 import { login, lostPassword } from 'calypso/lib/paths';
 import { isExistingAccountError } from 'calypso/lib/signup/is-existing-account-error';

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -41,7 +41,11 @@ import {
 	isCrowdsignalOAuth2Client,
 	isGravatarOAuth2Client,
 	isVIPOAuth2Client,
+<<<<<<< HEAD
 	isJetpackCloudOAuth2Client,
+=======
+	isStudioAppOAuth2Client,
+>>>>>>> 715cf36e3b3 (Connect Refresh: Migrate Studio create-account to unified Signup)
 } from 'calypso/lib/oauth2-clients';
 import { login, lostPassword } from 'calypso/lib/paths';
 import { isExistingAccountError } from 'calypso/lib/signup/is-existing-account-error';
@@ -1045,7 +1049,8 @@ class SignupForm extends Component {
 			this.props.isBlazePro ||
 			this.props.isAkismet ||
 			this.props.isVIPClient ||
-			this.props.isJetpackCloud;
+			this.props.isJetpackCloud ||
+			isStudioAppOAuth2Client( this.props.oauth2Client );
 		const isGravatar = this.props.isGravatar;
 		const emailErrorMessage = this.getErrorMessagesWithLogin( 'email' );
 		const showSeparator =

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -18,6 +18,7 @@ import {
 	isBlazeProOAuth2Client,
 	isCrowdsignalOAuth2Client,
 	isJetpackCloudOAuth2Client,
+	isStudioAppOAuth2Client,
 	isVIPOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { isWpccFlow } from 'calypso/signup/is-flow';
@@ -108,11 +109,19 @@ class SocialSignupForm extends Component {
 			isCrowdsignal,
 			isVIPClient,
 			isJetpackCloud,
+			isStudioApp,
 			setCurrentStep,
 		} = this.props;
 
 		const isUnifiedCreateAccount =
-			isWoo || isA4A || isCrowdsignal || isBlazePro || isAkismet || isVIPClient || isJetpackCloud;
+			isWoo ||
+			isA4A ||
+			isCrowdsignal ||
+			isBlazePro ||
+			isAkismet ||
+			isVIPClient ||
+			isJetpackCloud ||
+			isStudioApp;
 
 		return (
 			<Card
@@ -172,6 +181,7 @@ export default connect(
 			isAkismet: getIsAkismet( state ),
 			isVIPClient: isVIPOAuth2Client( oauth2Client ),
 			isJetpackCloud: isJetpackCloudOAuth2Client( oauth2Client ),
+			isStudioApp: isStudioAppOAuth2Client( oauth2Client ),
 		};
 	},
 	{ showErrorNotice: errorNotice }

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -29,6 +29,7 @@ import {
 	isA4AOAuth2Client,
 	isCrowdsignalOAuth2Client,
 	isVIPOAuth2Client,
+	isStudioAppOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { createAccountUrl } from 'calypso/lib/paths';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
@@ -128,7 +129,14 @@ const LayoutLoggedOut = ( {
 
 	const isUnifiedCreateAccount =
 		sectionName === 'signup' &&
-		( isWoo || isA4A || isCrowdsignal || isBlazePro || isAkismet || isVIPClient || isJetpackCloud );
+		( isWoo ||
+			isA4A ||
+			isCrowdsignal ||
+			isBlazePro ||
+			isAkismet ||
+			isVIPClient ||
+			isJetpackCloud ||
+			isStudioAppOAuth2Client( oauth2Client ) );
 
 	const classes = {
 		[ 'is-group-' + sectionGroup ]: sectionGroup,

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -11,7 +11,6 @@ import {
 	isJetpackCloudOAuth2Client,
 	isWooOAuth2Client,
 	isIntenseDebateOAuth2Client,
-	isStudioAppOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
 
@@ -108,16 +107,6 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 			redirectTo: redirectTo,
 			gravatarFrom: isGravatarOAuth2Client( oauth2Client ) && gravatarFrom,
 			gravatarFlow: isGravatarFlowOAuth2Client( oauth2Client ),
-		} );
-	}
-
-	if ( isStudioAppOAuth2Client( oauth2Client ) ) {
-		// Studio app signup via the magic login page
-		return login( {
-			locale,
-			twoFactorAuthType: 'link',
-			oauth2ClientId: oauth2Client.id,
-			redirectTo: redirectTo,
 		} );
 	}
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -51,6 +51,7 @@ import {
 	isCrowdsignalOAuth2Client,
 	isVIPOAuth2Client,
 	isJetpackCloudOAuth2Client,
+	isStudioAppOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import SignupFlowController from 'calypso/lib/signup/flow-controller';
 import FlowProgressIndicator from 'calypso/signup/flow-progress-indicator';
@@ -885,7 +886,8 @@ class Signup extends Component {
 				this.props.isBlazePro ||
 				this.props.isAkismet ||
 				this.props.isVIPClient ||
-				this.props.isJetpackCloud );
+				this.props.isJetpackCloud ||
+				isStudioAppOAuth2Client( this.props.oauth2Client ) );
 
 		const showPageHeader = ! this.props.isGravatar && ! isUnifiedCreateAccount;
 		const isGravatarDomain = isDomainForGravatarFlow( this.props.flowName );

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -490,6 +490,7 @@ export class UserStep extends Component {
 			isVIPClient,
 			isA4A,
 			isJetpackCloud,
+			isStudioApp,
 		} = this.props;
 
 		if ( userLoggedIn ) {
@@ -507,7 +508,12 @@ export class UserStep extends Component {
 		// similar to get-header-text in wp-login (potentially the two being merged too)
 		if (
 			( oauth2Client &&
-				( isCrowdsignal || isVIPClient || isA4A || isBlazePro || isJetpackCloud ) ) ||
+				( isCrowdsignal ||
+					isVIPClient ||
+					isA4A ||
+					isBlazePro ||
+					isJetpackCloud ||
+					isStudioApp ) ) ||
 			isAkismet
 		) {
 			let clientName = oauth2Client?.name;
@@ -531,6 +537,14 @@ export class UserStep extends Component {
 					components: { span: <span className="wp-login__one-login-header-client-name" /> },
 				} ),
 				oldCopy: translate( 'Create your account' ),
+			} );
+		}
+
+		if ( isStudioApp ) {
+			const clientName = 'Studio';
+			return translate( 'Sign up for {{span}}%(client)s{{/span}} with WordPress.com', {
+				args: { client: clientName },
+				components: { span: <span className="wp-login__one-login-header-client-name" /> },
 			} );
 		}
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -25,6 +25,7 @@ import {
 	isJetpackCloudOAuth2Client,
 	isPartnerPortalOAuth2Client,
 	isVIPOAuth2Client,
+	isStudioAppOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
 import LoginContextProvider, { useLoginContext } from 'calypso/login/login-context';
@@ -605,6 +606,7 @@ export class UserStep extends Component {
 			isAkismet,
 			isVIPClient,
 			isJetpackCloud,
+			isStudioApp,
 		} = this.props;
 		const isPasswordless =
 			isMobile() ||
@@ -616,7 +618,8 @@ export class UserStep extends Component {
 			isBlazePro ||
 			isAkismet ||
 			isVIPClient ||
-			isJetpackCloud;
+			isJetpackCloud ||
+			isStudioApp;
 		let socialService;
 		let socialServiceResponse;
 		let isSocialSignupEnabled = this.props.isSocialSignupEnabled;
@@ -772,8 +775,16 @@ const ConnectedUser = connect(
 		const isAkismet = getIsAkismet( state );
 		const isVIPClient = isVIPOAuth2Client( oauth2Client );
 		const isJetpackCloud = isJetpackCloudOAuth2Client( oauth2Client );
+		const isStudioApp = isStudioAppOAuth2Client( oauth2Client );
 		const isUnifiedCreateAccount =
-			isWoo || isA4A || isCrowdsignal || isBlazePro || isAkismet || isVIPClient || isJetpackCloud;
+			isWoo ||
+			isA4A ||
+			isCrowdsignal ||
+			isBlazePro ||
+			isAkismet ||
+			isVIPClient ||
+			isJetpackCloud ||
+			isStudioApp;
 
 		return {
 			oauth2Client: oauth2Client,
@@ -792,6 +803,7 @@ const ConnectedUser = connect(
 			isAkismet,
 			isVIPClient,
 			isJetpackCloud,
+			isStudioApp,
 		};
 	},
 	{


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13218/signup-update-and-unify-the-account-creation-screens
Builds off the core foundation from Woo Signup unification: https://github.com/Automattic/wp-calypso/pull/104948

## Proposed Changes

- We migrate the Studio Signup (create account) screen to the unified design. This will align it closely to the Login view, so it's all one seamless flow.
- As with others, this isn't a simple redesign. We bring the **passwordless** form and **social-signup** options.

### Caveats

Studio currently renders the Magic Login form when clicking on "create an account" (or anywhere else the `getSignupUrl` is utilised). Switching to passwordless & social options may have an effect on tracking/stats, as ultimately this may result in less access to the Magic Login form.

### Media

| Before | After |
|--------|--------|
| <img width="677" height="676" alt="Screenshot 2025-08-12 at 2 39 25 PM" src="https://github.com/user-attachments/assets/45ffa639-f1d5-41dc-80cd-2964d4b06ee5" /> | <img width="947" height="864" alt="Screenshot 2025-08-10 at 6 28 55 PM" src="https://github.com/user-attachments/assets/b67a7596-4047-4179-83dd-782f8f789ade" /> |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13218/signup-update-and-unify-the-account-creation-screens


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [Studio signup](https://linear.app/a8c/issue/DOTCOM-13218/signup-update-and-unify-the-account-creation-screens) and confirm changes (this is a list of Login URLs, find the one for Studio and click on "create an account" from top-right once there)
* Confirm other signup (create account) screens aren't affected by the changes e.g. confirm Woo.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
