### PR TITLE
Hide 'Add staging site' button while loading staging sites

### DIFF
--- a/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
@@ -58,7 +58,7 @@ export default function HeaderStagingSiteButton( {
 	// Notice IDs for staging site operations
 	const stagingSiteAddFailureNoticeId = 'staging-site-add-failure';
 
-	const { data: stagingSites = [] } = useStagingSite( siteId, {
+	const { data: stagingSites = [], isLoading: isLoadingStagingSites } = useStagingSite( siteId, {
 		enabled: ! hideEnvDataInHeader && isAtomic,
 	} );
 
@@ -115,7 +115,10 @@ export default function HeaderStagingSiteButton( {
 	);
 
 	const showAddStagingButton =
-		isAtomic && ! isStagingSite && ( stagingSites.length === 0 || isCreatingStagingSite );
+		isAtomic &&
+		! isStagingSite &&
+		! isLoadingStagingSites &&
+		( stagingSites.length === 0 || isCreatingStagingSite );
 
 	const onAddClick = useCallback( () => {
 		dispatch( setStagingSiteStatus( siteId, StagingSiteStatus.INITIATE_TRANSFERRING ) );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves [DOTCOM-14138 Staging Sites Redesign: Add staging site button appears briefly when reloading](https://linear.app/a8c/issue/DOTCOM-14138/staging-sites-redesign-add-staging-site-button-appears-briefly-when)

## Proposed Changes

- Added a loading condition to showAddStagingButton
- Now the button only shows when not loading AND there are no staging sites

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When reloading a page that has a staging site, the `Add staging site +` button has been appearing briefly. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply these changes or open the Calypso Live link below
* Navigate to a site with a staging site and refresh the page
* Check in the header that the `Add staging site +` button is not rendered at all
* Navigate to a site that doesn't have a staging site and refresh the page
* Check in the header that the `Add staging site +` button is rendered after the page is initially loaded

https://github.com/user-attachments/assets/aa0830bf-176d-4195-ac26-4911ea74afc1

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
