### PR TITLE
Connect Refresh: Migrate Woo JPC/DNA create-account to unified Signup

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -414,9 +414,13 @@ export function signupForm( context, next ) {
 		} );
 
 		const authorizeUrlWithApproval = addQueryArgs( { auth_approved: true }, context.path );
+		const { woodna_service_name, woodna_help_url, plugin_name } = context.query || {};
 		const urlQueryArgs = {
 			redirect_to: authorizeUrlWithApproval,
 			from,
+			...( woodna_service_name ? { woodna_service_name } : {} ),
+			...( woodna_help_url ? { woodna_help_url } : {} ),
+			...( plugin_name ? { plugin_name } : {} ),
 		};
 
 		return page( addQueryArgs( urlQueryArgs, '/start/account' ) );

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import {
 	PLAN_JETPACK_BUSINESS,
@@ -33,6 +34,7 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { startAuthorizeStep } from 'calypso/state/jetpack-connect/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import isWooJPCFlow from 'calypso/state/selectors/is-woo-jpc-flow';
 import { isCurrentPlanPaid, isJetpackSite } from 'calypso/state/sites/selectors';
 import { hideMasterbar, showMasterbar } from 'calypso/state/ui/actions';
 import { getSelectedSite, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -399,6 +401,25 @@ export function signupForm( context, next ) {
 	if ( retrieveMobileRedirect() && ! isLoggedIn ) {
 		// Force login for mobile app flow. App will intercept this request and prompt native login.
 		return window.location.replace( login( { redirectTo: context.path } ) );
+	}
+
+	// For WooJPC and WooDNA flows, redirect signup to Start/account and return here afterwards.
+	const isWooFlow = isWooJPCFlow( context.store.getState() );
+
+	if ( isWooFlow ) {
+		// Track the redirect to Start/account instead of rendering the inline signup form.
+		recordTracksEvent( 'calypso_jpc_signup_redirect_to_start', {
+			from,
+			site: Number( context.query?.client_id ),
+		} );
+
+		const authorizeUrlWithApproval = addQueryArgs( { auth_approved: true }, context.path );
+		const urlQueryArgs = {
+			redirect_to: authorizeUrlWithApproval,
+			from,
+		};
+
+		return page( addQueryArgs( urlQueryArgs, '/start/account' ) );
 	}
 
 	const transformedQuery = parseAuthorizationQuery( query );

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -633,7 +633,7 @@ export class UserStep extends Component {
 					recaptchaClientId={ this.state.recaptchaClientId }
 					horizontal
 					shouldDisplayUserExistsError={ ! isWCCOM && ! isBlazeProOAuth2Client( oauth2Client ) }
-					isSocialFirst={ this.props.isSocialFirst }
+					isSocialFirst={ this.props.isSocialFirst && ! isUnifiedCreateAccount }
 					labelText={ isUnifiedCreateAccount ? this.props.translate( 'Your email' ) : null }
 					disableTosText={ isUnifiedCreateAccount }
 				/>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13218/signup-update-and-unify-the-account-creation-screens
Part of https://linear.app/a8c/issue/DOTCOM-14131/signup-woojpc-and-woodna-update-create-an-account-screen

## Proposed Changes

The WooJPC and WooDNA signup (create-account) forms are currently rendered directly from the JP connect components. This makes it difficult/tricky to unify with the rest, also potentially raising concerns with bypassing the Signup frameworks (Stepper or Start) completely when signing up new users.

This PR implements a redirection to `/start/account` and back, which should allow the forms to pick up the unified styles defined for Woo OAuth2 clients. 

| Before | After |
|--------|--------|
| <img width="743" height="820" alt="Screenshot 2025-08-11 at 2 12 37 PM" src="https://github.com/user-attachments/assets/79b306f9-cf77-46ec-98ae-2d95a33e1049" /> | <img width="896" height="859" alt="Screenshot 2025-08-11 at 2 01 30 PM" src="https://github.com/user-attachments/assets/4a847db9-8093-4a8a-99a5-819b0e001961" /> |


## TODO

- We will fine-tune the marked parts in the image in a follow-up.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13218/signup-update-and-unify-the-account-creation-screens
Part of https://linear.app/a8c/issue/DOTCOM-14131/signup-woojpc-and-woodna-update-create-an-account-screen

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [WooJPC and WooDNA create-account](https://linear.app/a8c/issue/DOTCOM-13218/signup-update-and-unify-the-account-creation-screens) screens and verify these render exactly as Woo. There are various links provided to reach these screens.
* Confirm Woo create-account isn't affected by the changes.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
