### PR TITLE
Domain search: Fix track event record when subdomains are still loading

### DIFF
--- a/client/components/domain-search-v2/domain-search-results/index.jsx
+++ b/client/components/domain-search-v2/domain-search-results/index.jsx
@@ -32,6 +32,7 @@ class DomainSearchResults extends Component {
 		availableDomain: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 		suggestions: PropTypes.array,
 		isLoadingSuggestions: PropTypes.bool.isRequired,
+		isLoadingSubdomainSuggestions: PropTypes.bool,
 		placeholderQuantity: PropTypes.number.isRequired,
 		buttonLabel: PropTypes.string,
 		mappingSuggestionLabel: PropTypes.string,
@@ -284,6 +285,7 @@ class DomainSearchResults extends Component {
 			domainSkipSuggestion = showSkipButton && (
 				<DomainSkipSuggestion
 					selectedSite={ selectedSite }
+					isLoadingSubdomainSuggestions={ this.props.isLoadingSubdomainSuggestions }
 					subdomainSuggestion={ subdomainSuggestion }
 					flowName={ this.props.flowName }
 					query={ this.props.lastDomainSearched }

--- a/client/components/domain-search-v2/domain-skip-suggestion/index.tsx
+++ b/client/components/domain-search-v2/domain-skip-suggestion/index.tsx
@@ -20,6 +20,7 @@ type BaseProps = {
 	flowName?: string;
 	query?: string;
 	onSkip: () => void;
+	isLoadingSubdomainSuggestions?: boolean;
 };
 
 type WithSelectedSite = BaseProps & {
@@ -37,6 +38,7 @@ type Props = WithSelectedSite | WithSubdomainSuggestion;
 const DomainSkipSuggestion = ( {
 	selectedSite,
 	subdomainSuggestion,
+	isLoadingSubdomainSuggestions,
 	flowName,
 	query,
 	onSkip,
@@ -46,11 +48,15 @@ const DomainSkipSuggestion = ( {
 	const { cart } = useDomainSearch();
 
 	const hasExistingSite = !! selectedSite;
-	const hasSubdomainSuggestion = !! subdomainSuggestion;
+	const hasSubdomainSuggestion = subdomainSuggestion !== undefined;
 	const domain = hasExistingSite ? selectedSite?.slug : subdomainSuggestion?.domain_name;
 	const [ subdomain, ...tlds ] = domain?.split( '.' ) ?? [];
 
 	useEffect( () => {
+		if ( isLoadingSubdomainSuggestions ) {
+			return;
+		}
+
 		if ( ! hasExistingSite && ! hasSubdomainSuggestion ) {
 			recordTracksEvent( 'calypso_domain_search_skip_no_site_and_suggestion', {
 				query,
@@ -58,7 +64,14 @@ const DomainSkipSuggestion = ( {
 				flow_name: flowName,
 			} );
 		}
-	}, [ hasExistingSite, hasSubdomainSuggestion, query, currentUser?.ID, flowName ] );
+	}, [
+		hasExistingSite,
+		hasSubdomainSuggestion,
+		query,
+		currentUser?.ID,
+		flowName,
+		isLoadingSubdomainSuggestions,
+	] );
 
 	const onSkipClick = useCallback( () => {
 		if ( selectedSite ) {

--- a/client/components/domain-search-v2/domain-skip-suggestion/index.tsx
+++ b/client/components/domain-search-v2/domain-skip-suggestion/index.tsx
@@ -48,7 +48,7 @@ const DomainSkipSuggestion = ( {
 	const { cart } = useDomainSearch();
 
 	const hasExistingSite = !! selectedSite;
-	const hasSubdomainSuggestion = subdomainSuggestion !== undefined;
+	const hasSubdomainSuggestion = !! subdomainSuggestion;
 	const domain = hasExistingSite ? selectedSite?.slug : subdomainSuggestion?.domain_name;
 	const [ subdomain, ...tlds ] = domain?.split( '.' ) ?? [];
 

--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -1644,6 +1644,7 @@ class RegisterDomainStep extends Component {
 				lastDomainSearched: domain,
 				railcarId: this.getNewRailcarId(),
 				loadingResults: true,
+				loadingSubdomainResults: this.isSubdomainResultsVisible(),
 			},
 			() => {
 				const timestamp = Date.now();
@@ -1815,6 +1816,7 @@ class RegisterDomainStep extends Component {
 				suggestions={ suggestions }
 				premiumDomains={ premiumDomains }
 				isLoadingSuggestions={ this.state.loadingResults || this.props.hasPendingRequests }
+				isLoadingSubdomainSuggestions={ this.state.loadingSubdomainResults }
 				products={ this.props.products }
 				selectedSite={ this.props.selectedSite }
 				offerUnavailableOption={ this.props.offerUnavailableOption }


### PR DESCRIPTION
Part of p1754652706592689-slack-C04H4NY6STW

## Proposed Changes

* Added proper loading state tracking for subdomain suggestions and updated the DomainSkipSuggestion component to wait for suggestions to finish loading before firing analytics events.

## Why are these changes being made?

* Previously, the domain search component wasn't properly tracking when subdomain suggestions were still loading, causing analytics events to fire too early.

## Testing Instructions

* Go to `/setup/onboarding/`
* Open Dev tool and run `localStorage.setItem('debug', 'calypso:*');`
* Search any domain
* Make sure that the `calypso_domain_search_skip_no_site_and_suggestion` is not triggered

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?