### PR TITLE
Hosting Dashboard Purchases: wait for sites to load before render

### DIFF
--- a/client/dashboard/me/billing-purchases/index.tsx
+++ b/client/dashboard/me/billing-purchases/index.tsx
@@ -23,7 +23,7 @@ export default function PurchasesList() {
 	const { data: transferredPurchases, isLoading: isLoadingTransferredPurchases } = useQuery(
 		userTransferredPurchasesQuery()
 	);
-	const { data: sites } = useQuery( sitesQuery() );
+	const { data: sites, isLoading: isLoadingSites } = useQuery( sitesQuery() );
 	const [ currentView, setView ] = useState( purchasesDataView );
 	const ref = useResizeObserver( ( entries ) => {
 		const firstEntry = entries[ 0 ];
@@ -70,7 +70,7 @@ export default function PurchasesList() {
 		<PageLayout size="large" header={ <PageHeader title={ __( 'Active Upgrades' ) } /> }>
 			<div ref={ ref }>
 				<DataViews
-					isLoading={ isLoadingPurchases || isLoadingTransferredPurchases }
+					isLoading={ isLoadingPurchases || isLoadingTransferredPurchases || isLoadingSites }
 					data={ filteredSubscriptions ?? [] }
 					fields={ purchasesDataFields }
 					view={ currentView }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/CHE-229/hosting-dashboard-migrate-existing-purchases-list-to-dashboard

## Proposed Changes

A follow-up to https://github.com/Automattic/wp-calypso/pull/104914 to fix a small bug in the new purchases list on the hosting dashboard (this feature is not yet live).

We were not waiting for the user's sites to load, which would cause every purchase to display a notice that they did not own it. In this PR we modify the purchases list to wait for the sites to load.
 
Before             |  After
:-------------------------:|:-------------------------:
<img width="1263" height="115" alt="Screenshot 2025-08-08 at 10 21 13 AM" src="https://github.com/user-attachments/assets/1df25b45-70eb-4302-83c3-f14152140a8d" /> | <img width="1271" height="127" alt="Screenshot 2025-08-08 at 10 21 59 AM" src="https://github.com/user-attachments/assets/99d82394-1009-44ae-8b3a-4d9461db167d" />


## Testing Instructions

Visit http://calypso.localhost:3000/v2/me/billing/purchases with a cold cache and on an account with lots of purchases across many sites. Verify that your purchases display correctly and do not render "You no longer have access to this site and its purchases".
