### PR TITLE
Purchases: Convert more pieces of purchase settings to TypeScript

### DIFF
--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-payment-method-dialog/index.tsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-payment-method-dialog/index.tsx
@@ -1,19 +1,20 @@
 import { Dialog } from '@automattic/components';
-import { localize } from 'i18n-calypso';
-import PropTypes from 'prop-types';
+import { localize, type LocalizeProps } from 'i18n-calypso';
 import { Component } from 'react';
+import type { Purchases } from '@automattic/data-stores';
 
 import './style.scss';
 
-class AutoRenewPaymentMethodDialog extends Component {
-	static propTypes = {
-		isVisible: PropTypes.bool,
-		translate: PropTypes.func.isRequired,
-		purchase: PropTypes.object.isRequired,
-		onClose: PropTypes.func.isRequired,
-		onAddClick: PropTypes.func.isRequired,
-	};
+interface AutoRenewPaymentMethodDialogProps {
+	isVisible: boolean;
+	purchase: Purchases.Purchase;
+	onClose: () => void;
+	onAddClick: () => void;
+}
 
+class AutoRenewPaymentMethodDialog extends Component<
+	AutoRenewPaymentMethodDialogProps & LocalizeProps
+> {
 	render() {
 		const { isVisible, translate } = this.props;
 		const buttons = [

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.tsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.tsx
@@ -234,6 +234,10 @@ class AutoRenewToggle extends Component<
 			return null;
 		}
 
+		if ( ! planName ) {
+			return null;
+		}
+
 		let toggle;
 		if ( showLink ) {
 			toggle = this.isUpdatingAutoRenew() ? (

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1262,7 +1262,7 @@ class ManagePurchase extends Component<
 						}
 					/>
 				</Card>
-				<PurchasePlanDetails isPlaceholder />
+				<PurchasePlanDetails isPlaceholder purchaseId={ 0 } />
 				<VerticalNavItem isPlaceholder />
 				<VerticalNavItem isPlaceholder />
 			</Fragment>
@@ -1405,7 +1405,7 @@ class ManagePurchase extends Component<
 				{ ! isPartnerPurchase( purchase ) && (
 					<PurchasePlanDetails
 						purchaseId={ this.props.purchaseId }
-						isProductOwner={ isProductOwner }
+						isProductOwner={ isProductOwner ?? undefined }
 					/>
 				) }
 				{ isProductOwner && ! purchase.isLocked && (

--- a/client/me/purchases/manage-purchase/plan-details/billing-period.tsx
+++ b/client/me/purchases/manage-purchase/plan-details/billing-period.tsx
@@ -3,8 +3,8 @@ import page from '@automattic/calypso-router';
 import { Button, FormLabel } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { JETPACK_SUPPORT } from '@automattic/urls';
-import { localize } from 'i18n-calypso';
-import PropTypes from 'prop-types';
+import { localize, type LocalizeProps } from 'i18n-calypso';
+import moment from 'moment';
 import { Fragment, Component } from 'react';
 import { connect } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -19,14 +19,28 @@ import {
 } from 'calypso/lib/purchases';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isTemporarySitePurchase } from '../../utils';
+import type { Purchases, SiteDetails } from '@automattic/data-stores';
 
-export class PlanBillingPeriod extends Component {
-	static propTypes = {
-		purchase: PropTypes.object,
-		site: PropTypes.object,
-		isProductOwner: PropTypes.bool,
-	};
+interface MomentProps {
+	moment: typeof moment;
+}
 
+export interface PlanBillingPeriodProps {
+	purchase: Purchases.Purchase;
+	site: SiteDetails | null | undefined;
+	isProductOwner: boolean;
+}
+
+export class PlanBillingPeriod extends Component<
+	PlanBillingPeriodProps &
+		LocalizeProps &
+		MomentProps & {
+			recordTracksEvent: (
+				event: string,
+				options: { current_plan: string; upgrading_to: string }
+			) => void;
+		}
+> {
 	handleMonthlyToYearlyButtonClick = () => {
 		const { purchase } = this.props;
 		const yearlyPlanSlug = getYearlyPlanByMonthly( purchase.productSlug );

--- a/client/me/purchases/manage-purchase/plan-details/index.tsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.tsx
@@ -34,8 +34,8 @@ export interface PurchasePlanDetailsConnectedProps {
 
 export interface PurchasePlanDetailsProps {
 	purchaseId: number;
-	isPlaceholder: boolean;
-	isProductOwner: boolean;
+	isPlaceholder?: boolean;
+	isProductOwner?: boolean;
 }
 
 export class PurchasePlanDetails extends Component<

--- a/client/me/purchases/manage-purchase/plan-details/index.tsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.tsx
@@ -1,7 +1,6 @@
 import { isJetpackPlan, isFreeJetpackPlan } from '@automattic/calypso-products';
 import { Card, FormLabel } from '@automattic/components';
-import { localize } from 'i18n-calypso';
-import PropTypes from 'prop-types';
+import { localize, LocalizeProps } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
@@ -17,29 +16,31 @@ import {
 } from 'calypso/state/purchases/selectors';
 import { isRequestingSites, getSite } from 'calypso/state/sites/selectors';
 import PlanBillingPeriod from './billing-period';
+import type { Purchases, SiteDetails } from '@automattic/data-stores';
 
 import './style.scss';
 
-export class PurchasePlanDetails extends Component {
-	static propTypes = {
-		purchaseId: PropTypes.number,
-		isPlaceholder: PropTypes.bool,
-		isProductOwner: PropTypes.bool,
+export interface PurchasePlanDetailsConnectedProps {
+	purchase: Purchases.Purchase | undefined;
+	hasLoadedSites: boolean;
+	hasLoadedPurchasesFromServer: boolean;
+	pluginList: Array< {
+		slug: string;
+		key: string;
+	} >;
+	site: SiteDetails | null | undefined;
+	siteId: number | null | undefined;
+}
 
-		// Connected props
-		purchase: PropTypes.object,
-		hasLoadedSites: PropTypes.bool,
-		hasLoadedPurchasesFromServer: PropTypes.bool,
-		pluginList: PropTypes.arrayOf(
-			PropTypes.shape( {
-				slug: PropTypes.string.isRequired,
-				key: PropTypes.string,
-			} ).isRequired
-		).isRequired,
-		site: PropTypes.object,
-		siteId: PropTypes.number,
-	};
+export interface PurchasePlanDetailsProps {
+	purchaseId: number;
+	isPlaceholder: boolean;
+	isProductOwner: boolean;
+}
 
+export class PurchasePlanDetails extends Component<
+	PurchasePlanDetailsProps & PurchasePlanDetailsConnectedProps & LocalizeProps
+> {
 	renderPlaceholder() {
 		return (
 			<div className="plan-details__wrapper is-placeholder">
@@ -52,7 +53,7 @@ export class PurchasePlanDetails extends Component {
 		);
 	}
 
-	renderPluginLabel( slug ) {
+	renderPluginLabel( slug: string ) {
 		switch ( slug ) {
 			case 'vaultpress':
 				return this.props.translate( 'Backups and security scanning API key' );
@@ -61,7 +62,7 @@ export class PurchasePlanDetails extends Component {
 		}
 	}
 
-	isDataLoading( props ) {
+	isDataLoading( props: PurchasePlanDetailsProps & PurchasePlanDetailsConnectedProps ) {
 		return ! props.hasLoadedSites || ! props.hasLoadedPurchasesFromServer;
 	}
 
@@ -77,7 +78,7 @@ export class PurchasePlanDetails extends Component {
 			return this.renderPlaceholder();
 		}
 
-		if ( isExpired( purchase ) ) {
+		if ( ! purchase || isExpired( purchase ) ) {
 			return null;
 		}
 
@@ -116,7 +117,7 @@ export class PurchasePlanDetails extends Component {
 	}
 }
 
-export default connect( ( state, props ) => {
+export default connect( ( state, props: PurchasePlanDetailsProps ) => {
 	const purchase = getByPurchaseId( state, props.purchaseId );
 	const siteId = purchase ? purchase.siteId : null;
 	return {
@@ -126,7 +127,7 @@ export default connect( ( state, props ) => {
 			? hasLoadedSitePurchasesFromServer( state )
 			: hasLoadedUserPurchasesFromServer( state ),
 		purchase,
-		pluginList: getPluginsForSite( state, siteId ),
+		pluginList: getPluginsForSite( state, siteId ?? 0 ),
 		siteId,
 	};
 } )( localize( PurchasePlanDetails ) );

--- a/client/state/plugins/premium/selectors.js
+++ b/client/state/plugins/premium/selectors.js
@@ -21,10 +21,10 @@ export const hasRequested = function ( state, siteId ) {
 /**
  * Gets the list of plugins for a site and optionally filters to a single specific
  * plugin.
- * @param {Object} state The current state.
+ * @param {import('calypso/types').AppState} state The current state.
  * @param {number} siteId The site ID.
  * @param {string?} forPlugin Name of a specific plugin to filter for, `false` otherwise to return the full list.
- * @returns {Array<Object>} The list of plugins.
+ * @returns {Array<{ slug: string; key: string; }>} The list of plugins.
  */
 export const getPluginsForSite = function ( state, siteId, forPlugin = false ) {
 	const pluginList = state.plugins.premium.plugins[ siteId ];


### PR DESCRIPTION
Fixes SHILL-1006

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

This PR converts some remaining components of the "Purchase Settings" (single purchase view) to TypeScript.

- **Convert AutoRenewDisablingDialog to TS**
- **Convert PlanBillingPeriod and PurchasePlanDetails to TS**

## Why are these changes being made?

TS helps to identify bugs and prevent regressions. As we investigate cancellation bugs like https://linear.app/a8c/issue/SHILL-941/cancelling-a-plan-and-domain-together-is-no-longer-possible it will be easier with TypeScript guards to prevent regressions.

## Testing Instructions

TypeScript should be enough
