### PR TITLE
Fix misleading copy on cancel flow

### DIFF
--- a/client/me/purchases/cancel-purchase/button.tsx
+++ b/client/me/purchases/cancel-purchase/button.tsx
@@ -158,7 +158,14 @@ class CancelPurchaseButton extends Component<
 			return this.handleCancelPurchaseClick;
 		} )();
 
+		const needsDomainOptionsStep =
+			this.props.includedDomainPurchase &&
+			! willShowDomainOptionsRadioButtons( this.props.includedDomainPurchase, this.props.purchase );
 		const text = ( () => {
+			if ( includedDomainPurchase && needsDomainOptionsStep ) {
+				return translate( 'Continue with cancellation' );
+			}
+
 			if ( hasAmountAvailableToRefund( purchase ) ) {
 				if ( isDomainRegistration( purchase ) ) {
 					return translate( 'Cancel domain and refund' );

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -738,7 +738,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 	};
 
 	renderPlanRevertContent = () => {
-		const { purchase, atomicTransfer } = this.props;
+		const { purchase, atomicTransfer, includedDomainPurchase } = this.props;
 
 		return (
 			<>
@@ -752,7 +752,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 					isLoading={ this.state.isLoading }
 				/>
 
-				<p>{ this.renderFullText() }</p>
+				{ ! includedDomainPurchase && <p>{ this.renderFullText() }</p> }
 
 				<div className="cancel-purchase__confirm-buttons">
 					{ this.renderCancelButton() }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/CHE-226/cancelling-a-plan-with-an-included-domain-makes-it-sound-like-you-wont

## Proposed Changes

* Remove the "If you confirm this cancellation…" sentence entirely.  The only new information that sentence adds to the page is the refund amount, but since we won't know the actual refund amount until the user makes a choice on the next screen anyway, it seems good to just remove the whole thing.

* Retitle the button to "Continue with cancellation"

_Note: I could not reproduce the second screen mentioned in the issue._

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Buy a plan with a domain
* Open `/me/purchases` on calypso live and start cancelling the receipt
* When cancelling, you should notice
  * The "If you confirm this cancellation…" sentence waa removed entirely.
  * Button should say "Continue with cancellation"
<img width="800" height="804" alt="Screenshot 2025-08-08 at 19 07 53" src="https://github.com/user-attachments/assets/c200a7a6-b8ee-472e-8f30-0c64413daa1f" /> 


