### PR TITLE
Hosting Dashboard: Add purchase settings page

### DIFF
--- a/client/dashboard/app/queries/me-purchases.ts
+++ b/client/dashboard/app/queries/me-purchases.ts
@@ -1,9 +1,6 @@
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
-import {
-	fetchUserPurchases,
-	fetchUserTransferredPurchases,
-	setPurchaseAutoRenew,
-} from '../../data/me-purchases';
+import { fetchUserPurchases, fetchUserTransferredPurchases } from '../../data/me-purchases';
+import { setPurchaseAutoRenew } from '../../data/upgrades';
 import { queryClient } from '../query-client';
 
 export const userPurchasesQuery = () =>

--- a/client/dashboard/app/queries/me-purchases.ts
+++ b/client/dashboard/app/queries/me-purchases.ts
@@ -1,5 +1,10 @@
-import { queryOptions } from '@tanstack/react-query';
-import { fetchUserPurchases, fetchUserTransferredPurchases } from '../../data/me-purchases';
+import { queryOptions, mutationOptions } from '@tanstack/react-query';
+import {
+	fetchUserPurchases,
+	fetchUserTransferredPurchases,
+	setPurchaseAutoRenew,
+} from '../../data/me-purchases';
+import { queryClient } from '../query-client';
 
 export const userPurchasesQuery = () =>
 	queryOptions( {
@@ -13,3 +18,18 @@ export function userTransferredPurchasesQuery() {
 		queryFn: () => fetchUserTransferredPurchases(),
 	} );
 }
+
+export const purchaseQuery = ( purchaseId: number ) =>
+	queryOptions( {
+		queryKey: [ 'me', 'purchases', purchaseId ],
+		queryFn: () => fetchUserPurchases(),
+		select: ( purchases ) => purchases.find( ( p ) => parseInt( p.ID ) === purchaseId ),
+	} );
+
+export const userPurchaseSetAutoRenewQuery = ( purchaseId: number ) =>
+	mutationOptions( {
+		mutationFn: ( autoRenew: boolean ) => setPurchaseAutoRenew( purchaseId, autoRenew ),
+		onSuccess: ( data ) => {
+			queryClient.setQueryData( purchaseQuery( purchaseId ).queryKey, [ data.upgrade ] );
+		},
+	} );

--- a/client/dashboard/app/queries/site-jetpack-keys.ts
+++ b/client/dashboard/app/queries/site-jetpack-keys.ts
@@ -1,0 +1,15 @@
+import { queryOptions } from '@tanstack/react-query';
+import { fetchJetpackKeys } from '../../data/site-jetpack-keys';
+
+export const siteJetpackKeysQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'jetpack_keys' ],
+		queryFn: () => fetchJetpackKeys( siteId ),
+		select: ( data ): { slug: string; key: string }[] => {
+			const plugins: { slug: string; key: string }[] = [];
+			Object.entries( data.keys ).forEach( ( [ slug, key ] ) => {
+				plugins.push( { slug, key } );
+			} );
+			return plugins;
+		},
+	} );

--- a/client/dashboard/app/queries/site-jetpack-keys.ts
+++ b/client/dashboard/app/queries/site-jetpack-keys.ts
@@ -5,11 +5,4 @@ export const siteJetpackKeysQuery = ( siteId: number ) =>
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'jetpack_keys' ],
 		queryFn: () => fetchJetpackKeys( siteId ),
-		select: ( data ): { slug: string; key: string }[] => {
-			const plugins: { slug: string; key: string }[] = [];
-			Object.entries( data.keys ).forEach( ( [ slug, key ] ) => {
-				plugins.push( { slug, key } );
-			} );
-			return plugins;
-		},
 	} );

--- a/client/dashboard/app/queries/site-marketplace.ts
+++ b/client/dashboard/app/queries/site-marketplace.ts
@@ -1,0 +1,7 @@
+import { mutationOptions } from '@tanstack/react-query';
+import { reinstallMarketplacePlugins } from '../../data/site-marketplace';
+
+export const reinstallMarketplacePluginsQuery = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: () => reinstallMarketplacePlugins( siteId ),
+	} );

--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -1,7 +1,7 @@
 import { createRoute, createLazyRoute } from '@tanstack/react-router';
 import { fetchTwoStep } from '../../data/me';
 import { profileQuery } from '../queries/me-profile';
-import { userPurchasesQuery } from '../queries/me-purchases';
+import { userPurchasesQuery, purchaseQuery } from '../queries/me-purchases';
 import { sitesQuery } from '../queries/sites';
 import { queryClient } from '../query-client';
 import { rootRoute } from './root';
@@ -59,6 +59,20 @@ export const billingHistoryRoute = createRoute( {
 } ).lazy( () =>
 	import( '../../me/billing-history' ).then( ( d ) =>
 		createLazyRoute( 'billing-history' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const purchaseSettingsRoute = createRoute( {
+	getParentRoute: () => meRoute,
+	loader: async ( { params: { purchaseId } } ) => {
+		queryClient.ensureQueryData( purchaseQuery( parseInt( purchaseId ) ) );
+	},
+	path: 'billing/purchases/purchase/$purchaseId',
+} ).lazy( () =>
+	import( '../../me/billing-purchases/purchase-settings' ).then( ( d ) =>
+		createLazyRoute( 'purchases-purchase-settings' )( {
 			component: d.default,
 		} )
 	)
@@ -149,6 +163,7 @@ export const createMeRoutes = ( config: AppConfig ) => {
 		billingRoute,
 		billingHistoryRoute,
 		purchasesRoute,
+		purchaseSettingsRoute,
 		paymentMethodsRoute,
 		taxDetailsRoute,
 		securityRoute,

--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -81,8 +81,10 @@ export const purchaseSettingsRoute = createRoute( {
 export const purchasesRoute = createRoute( {
 	getParentRoute: () => meRoute,
 	loader: async () => {
-		await queryClient.ensureQueryData( userPurchasesQuery() );
-		await queryClient.ensureQueryData( sitesQuery() );
+		await Promise.all( [
+			queryClient.ensureQueryData( userPurchasesQuery() ),
+			queryClient.ensureQueryData( sitesQuery() ),
+		] );
 	},
 	validateSearch: ( search ): { site: string | undefined } => {
 		return {

--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -67,7 +67,7 @@ export const billingHistoryRoute = createRoute( {
 export const purchaseSettingsRoute = createRoute( {
 	getParentRoute: () => meRoute,
 	loader: async ( { params: { purchaseId } } ) => {
-		queryClient.ensureQueryData( purchaseQuery( parseInt( purchaseId ) ) );
+		await queryClient.ensureQueryData( purchaseQuery( parseInt( purchaseId ) ) );
 	},
 	path: 'billing/purchases/purchase/$purchaseId',
 } ).lazy( () =>
@@ -81,8 +81,8 @@ export const purchaseSettingsRoute = createRoute( {
 export const purchasesRoute = createRoute( {
 	getParentRoute: () => meRoute,
 	loader: async () => {
-		queryClient.ensureQueryData( userPurchasesQuery() );
-		queryClient.ensureQueryData( sitesQuery() );
+		await queryClient.ensureQueryData( userPurchasesQuery() );
+		await queryClient.ensureQueryData( sitesQuery() );
 	},
 	validateSearch: ( search ): { site: string | undefined } => {
 		return {

--- a/client/dashboard/data/constants.ts
+++ b/client/dashboard/data/constants.ts
@@ -186,3 +186,16 @@ export const DomainProductSlugs = {
 	DOTCOM_DOMAIN_REGISTRATION: 'domain_reg',
 	DOMAIN_MOVE_INTERNAL: 'domain_move_internal',
 } as const;
+
+export const TitanMailSlugs = {
+	TITAN_MAIL_MONTHLY_SLUG: 'wp_titan_mail_monthly',
+	TITAN_MAIL_YEARLY_SLUG: 'wp_titan_mail_yearly',
+} as const;
+
+export const GoogleWorkspaceSlugs = {
+	GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY: 'wp_google_workspace_business_starter_monthly',
+	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY: 'wp_google_workspace_business_starter_yearly',
+	GSUITE_BASIC_SLUG: 'gapps',
+	GSUITE_BUSINESS_SLUG: 'gapps_unlimited',
+	GSUITE_EXTRA_LICENSE_SLUG: 'gapps_extra_license',
+} as const;

--- a/client/dashboard/data/constants.ts
+++ b/client/dashboard/data/constants.ts
@@ -154,6 +154,8 @@ export const JetpackPlans = {
 
 export const WPCOM_DIFM_LITE = 'wp_difm_lite';
 
+export const OFFSITE_REDIRECT = 'offsite_redirect';
+
 export const AkismetUpgradesProductMap: Record< string, string > = {
 	[ AkismetPlans.PRODUCT_AKISMET_FREE ]: `/checkout/akismet/${ AkismetPlans.PRODUCT_AKISMET_PERSONAL_YEARLY }:-q-36`,
 	// This upgrade path should never be used in it's current form, PRODUCT_AKISMET_PERSONAL_MONTHLY is not a sellable product

--- a/client/dashboard/data/constants.ts
+++ b/client/dashboard/data/constants.ts
@@ -128,4 +128,55 @@ export const AkismetPlans = {
 	PRODUCT_AKISMET_ENTERPRISE_25K_BI_YEARLY: 'ak_ep25k_bi_yearly',
 } as const;
 
+export const JetpackPlans = {
+	PLAN_JETPACK_FREE: 'jetpack_free',
+	PLAN_JETPACK_PERSONAL: 'jetpack_personal',
+	PLAN_JETPACK_PERSONAL_MONTHLY: 'jetpack_personal_monthly',
+	PLAN_JETPACK_PREMIUM: 'jetpack_premium',
+	PLAN_JETPACK_PREMIUM_MONTHLY: 'jetpack_premium_monthly',
+	PLAN_JETPACK_BUSINESS: 'jetpack_business',
+	PLAN_JETPACK_BUSINESS_MONTHLY: 'jetpack_business_monthly',
+	PLAN_JETPACK_SECURITY_T1_YEARLY: 'jetpack_security_t1_yearly',
+	PLAN_JETPACK_SECURITY_T1_MONTHLY: 'jetpack_security_t1_monthly',
+	PLAN_JETPACK_SECURITY_T1_BI_YEARLY: 'jetpack_security_t1_bi_yearly',
+	PLAN_JETPACK_SECURITY_T2_YEARLY: 'jetpack_security_t2_yearly',
+	PLAN_JETPACK_SECURITY_T2_MONTHLY: 'jetpack_security_t2_monthly',
+	PLAN_JETPACK_COMPLETE_BI_YEARLY: 'jetpack_complete_bi_yearly',
+	PLAN_JETPACK_COMPLETE: 'jetpack_complete',
+	PLAN_JETPACK_COMPLETE_MONTHLY: 'jetpack_complete_monthly',
+	PLAN_JETPACK_STARTER_YEARLY: 'jetpack_starter_yearly',
+	PLAN_JETPACK_STARTER_MONTHLY: 'jetpack_starter_monthly',
+	PLAN_JETPACK_GOLDEN_TOKEN: 'jetpack_golden_token_lifetime',
+	PLAN_JETPACK_GROWTH_MONTHLY: 'jetpack_growth_monthly',
+	PLAN_JETPACK_GROWTH_YEARLY: 'jetpack_growth_yearly',
+	PLAN_JETPACK_GROWTH_BI_YEARLY: 'jetpack_growth_bi_yearly',
+} as const;
+
 export const WPCOM_DIFM_LITE = 'wp_difm_lite';
+
+export const AkismetUpgradesProductMap: Record< string, string > = {
+	[ AkismetPlans.PRODUCT_AKISMET_FREE ]: `/checkout/akismet/${ AkismetPlans.PRODUCT_AKISMET_PERSONAL_YEARLY }:-q-36`,
+	// This upgrade path should never be used in it's current form, PRODUCT_AKISMET_PERSONAL_MONTHLY is not a sellable product
+	[ AkismetPlans.PRODUCT_AKISMET_PERSONAL_MONTHLY ]: `/checkout/akismet/${ AkismetPlans.PRODUCT_AKISMET_PRO_500_MONTHLY }`,
+	[ AkismetPlans.PRODUCT_AKISMET_PERSONAL_YEARLY ]: `/checkout/akismet/${ AkismetPlans.PRODUCT_AKISMET_PRO_500_YEARLY }`,
+	[ AkismetPlans.PRODUCT_AKISMET_PRO_500_MONTHLY ]: `/checkout/akismet/${ AkismetPlans.PRODUCT_AKISMET_BUSINESS_5K_MONTHLY }`,
+	[ AkismetPlans.PRODUCT_AKISMET_PRO_500_YEARLY ]: `/checkout/akismet/${ AkismetPlans.PRODUCT_AKISMET_BUSINESS_5K_YEARLY }`,
+	[ AkismetPlans.PRODUCT_AKISMET_PRO_500_BI_YEARLY ]: `/checkout/akismet/${ AkismetPlans.PRODUCT_AKISMET_BUSINESS_5K_BI_YEARLY }`,
+	[ AkismetPlans.PRODUCT_AKISMET_BUSINESS_5K_MONTHLY ]: `/checkout/akismet/${ AkismetPlans.PRODUCT_AKISMET_ENTERPRISE_15K_MONTHLY }`,
+	[ AkismetPlans.PRODUCT_AKISMET_BUSINESS_5K_YEARLY ]: `/checkout/akismet/${ AkismetPlans.PRODUCT_AKISMET_ENTERPRISE_15K_YEARLY }`,
+	[ AkismetPlans.PRODUCT_AKISMET_BUSINESS_5K_BI_YEARLY ]: `/checkout/akismet/${ AkismetPlans.PRODUCT_AKISMET_ENTERPRISE_15K_BI_YEARLY }`,
+	[ AkismetPlans.PRODUCT_AKISMET_ENTERPRISE_15K_MONTHLY ]: `/checkout/akismet/${ AkismetPlans.PRODUCT_AKISMET_ENTERPRISE_25K_MONTHLY }`,
+	[ AkismetPlans.PRODUCT_AKISMET_ENTERPRISE_15K_YEARLY ]: `/checkout/akismet/${ AkismetPlans.PRODUCT_AKISMET_ENTERPRISE_25K_YEARLY }`,
+	[ AkismetPlans.PRODUCT_AKISMET_ENTERPRISE_15K_BI_YEARLY ]: `/checkout/akismet/${ AkismetPlans.PRODUCT_AKISMET_ENTERPRISE_25K_BI_YEARLY }`,
+	[ AkismetPlans.PRODUCT_AKISMET_ENTERPRISE_25K_MONTHLY ]: 'https://akismet.com/enterprise',
+	[ AkismetPlans.PRODUCT_AKISMET_ENTERPRISE_25K_YEARLY ]: 'https://akismet.com/enterprise',
+	[ AkismetPlans.PRODUCT_AKISMET_ENTERPRISE_25K_BI_YEARLY ]: 'https://akismet.com/enterprise',
+};
+
+export const ProductUpgradeMap: Record< string, string > = {
+	[ JetpackPlans.PLAN_JETPACK_STARTER_YEARLY ]: JetpackPlans.PLAN_JETPACK_SECURITY_T1_YEARLY,
+	[ JetpackPlans.PLAN_JETPACK_STARTER_MONTHLY ]: JetpackPlans.PLAN_JETPACK_SECURITY_T1_MONTHLY,
+	[ JetpackPlans.PLAN_JETPACK_GROWTH_BI_YEARLY ]: JetpackPlans.PLAN_JETPACK_COMPLETE_BI_YEARLY,
+	[ JetpackPlans.PLAN_JETPACK_GROWTH_YEARLY ]: JetpackPlans.PLAN_JETPACK_COMPLETE,
+	[ JetpackPlans.PLAN_JETPACK_GROWTH_MONTHLY ]: JetpackPlans.PLAN_JETPACK_COMPLETE_MONTHLY,
+};

--- a/client/dashboard/data/constants.ts
+++ b/client/dashboard/data/constants.ts
@@ -180,3 +180,9 @@ export const ProductUpgradeMap: Record< string, string > = {
 	[ JetpackPlans.PLAN_JETPACK_GROWTH_YEARLY ]: JetpackPlans.PLAN_JETPACK_COMPLETE,
 	[ JetpackPlans.PLAN_JETPACK_GROWTH_MONTHLY ]: JetpackPlans.PLAN_JETPACK_COMPLETE_MONTHLY,
 };
+
+export const DomainProductSlugs = {
+	TRANSFER_IN: 'domain_transfer',
+	DOTCOM_DOMAIN_REGISTRATION: 'domain_reg',
+	DOMAIN_MOVE_INTERNAL: 'domain_move_internal',
+} as const;

--- a/client/dashboard/data/constants.ts
+++ b/client/dashboard/data/constants.ts
@@ -201,3 +201,11 @@ export const GoogleWorkspaceSlugs = {
 	GSUITE_BUSINESS_SLUG: 'gapps_unlimited',
 	GSUITE_EXTRA_LICENSE_SLUG: 'gapps_extra_license',
 } as const;
+
+export const useMyDomainInputMode = {
+	domainInput: 'domain-input' as const,
+	transferOrConnect: 'transfer-or-connect' as const,
+	ownershipVerification: 'ownership-verification' as const,
+	transferDomain: 'transfer-domain' as const,
+	startPendingTransfer: 'start-pending-transfer' as const,
+} as const;

--- a/client/dashboard/data/constants.ts
+++ b/client/dashboard/data/constants.ts
@@ -74,6 +74,7 @@ export enum HostingFeatures {
 }
 
 export const SubscriptionBillPeriod = {
+	PLAN_ONE_TIME_PERIOD: -1,
 	PLAN_MONTHLY_PERIOD: 31,
 	PLAN_ANNUAL_PERIOD: 365,
 	PLAN_BIENNIAL_PERIOD: 730,

--- a/client/dashboard/data/domains.ts
+++ b/client/dashboard/data/domains.ts
@@ -57,6 +57,8 @@ export interface DomainSummary {
 	transfer_status: ( typeof DomainTransferStatus )[ keyof typeof DomainTransferStatus ] | null;
 	type: ( typeof DomainTypes )[ keyof typeof DomainTypes ];
 	wpcom_domain: boolean;
+	last_transfer_error?: string;
+	transfer_start_date?: string;
 }
 
 export async function fetchDomains(): Promise< DomainSummary[] > {

--- a/client/dashboard/data/me-purchases.ts
+++ b/client/dashboard/data/me-purchases.ts
@@ -14,14 +14,3 @@ export async function fetchUserTransferredPurchases(): Promise< Purchase[] > {
 		apiVersion: '1.1',
 	} );
 }
-
-export async function setPurchaseAutoRenew(
-	purchaseId: number,
-	autoRenew: boolean
-): Promise< { success: boolean; upgrade: Purchase } > {
-	const action = autoRenew ? 'enable-auto-renew' : 'disable-auto-renew';
-	return wpcom.req.post( {
-		path: `/upgrades/${ purchaseId }/${ action }`,
-		apiVersion: '1.1',
-	} );
-}

--- a/client/dashboard/data/me-purchases.ts
+++ b/client/dashboard/data/me-purchases.ts
@@ -14,3 +14,14 @@ export async function fetchUserTransferredPurchases(): Promise< Purchase[] > {
 		apiVersion: '1.1',
 	} );
 }
+
+export async function setPurchaseAutoRenew(
+	purchaseId: number,
+	autoRenew: boolean
+): Promise< { success: boolean; upgrade: Purchase } > {
+	const action = autoRenew ? 'enable-auto-renew' : 'disable-auto-renew';
+	return wpcom.req.post( {
+		path: `/upgrades/${ purchaseId }/${ action }`,
+		apiVersion: '1.1',
+	} );
+}

--- a/client/dashboard/data/purchase.ts
+++ b/client/dashboard/data/purchase.ts
@@ -165,7 +165,9 @@ export interface Purchase {
 	is_domain?: 'true';
 
 	is_domain_registration: boolean;
+	is_pending_registration: boolean;
 	is_free_jetpack_stats_product: boolean;
+	is_jetpack_backup_t1: boolean;
 	is_google_workspace_product: boolean;
 	is_hundred_year_domain: boolean;
 	is_iap_purchase: boolean;
@@ -272,4 +274,14 @@ export interface Purchase {
 	payment_card_processor: string | undefined;
 	payment_details: string | undefined;
 	payment_expiry: string | undefined;
+
+	/**
+	 * True if this subscription can be upgraded to a different one.
+	 *
+	 * If this is set, we will display an "Upgrade" link in some places. That
+	 * link will typically go to the plans page for the site or some other
+	 * location depending on the product. To cause these buttons to instead add
+	 * a product directly to the cart, also set `upgrade_product_slug`.
+	 */
+	is_upgradable: boolean;
 }

--- a/client/dashboard/data/purchase.ts
+++ b/client/dashboard/data/purchase.ts
@@ -193,6 +193,7 @@ export interface Purchase {
 	is_pending_registration: boolean;
 	is_free_jetpack_stats_product: boolean;
 	is_jetpack_backup_t1: boolean;
+	is_jetpack_legacy_plan: boolean;
 	is_google_workspace_product: boolean;
 	is_hundred_year_domain: boolean;
 	is_iap_purchase: boolean;

--- a/client/dashboard/data/purchase.ts
+++ b/client/dashboard/data/purchase.ts
@@ -1,3 +1,5 @@
+import { SubscriptionBillPeriod } from '../data/constants';
+
 export interface RefundOptions {
 	to_product_id: number;
 	refund_amount: number;
@@ -90,7 +92,14 @@ export interface Purchase {
 	ID: string;
 
 	amount: number;
+
+	/**
+	 * The ID number of a WordPress.com purchase whose renewal will renew this
+	 * purchase (eg: the plan or domain registration for a domain connection)
+	 * as a string.
+	 */
 	attached_to_purchase_id: string | null;
+
 	auto_renew_coupon_code: string | null;
 	auto_renew_coupon_discount_percentage: number | null;
 
@@ -99,9 +108,22 @@ export interface Purchase {
 	 * number of days in every billing period! It's just a numeric key that is
 	 * close to the average billing period for this billing plan. For example,
 	 * `31` means "monthly" although the expiry date may be fewer than 31 days
-	 * from the last renewal.
+	 * from the last renewal. `-1` means that it does not expire.
 	 */
-	bill_period_days: number;
+	bill_period_days:
+		| typeof SubscriptionBillPeriod.PLAN_ONE_TIME_PERIOD
+		| typeof SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD
+		| typeof SubscriptionBillPeriod.PLAN_ANNUAL_PERIOD
+		| typeof SubscriptionBillPeriod.PLAN_BIENNIAL_PERIOD
+		| typeof SubscriptionBillPeriod.PLAN_TRIENNIAL_PERIOD
+		| typeof SubscriptionBillPeriod.PLAN_QUADRENNIAL_PERIOD
+		| typeof SubscriptionBillPeriod.PLAN_QUINQUENNIAL_PERIOD
+		| typeof SubscriptionBillPeriod.PLAN_SEXENNIAL_PERIOD
+		| typeof SubscriptionBillPeriod.PLAN_SEPTENNIAL_PERIOD
+		| typeof SubscriptionBillPeriod.PLAN_OCTENNIAL_PERIOD
+		| typeof SubscriptionBillPeriod.PLAN_NOVENNIAL_PERIOD
+		| typeof SubscriptionBillPeriod.PLAN_DECENNIAL_PERIOD
+		| typeof SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD;
 
 	bill_period_label: string;
 	most_recent_renew_date: string;
@@ -236,7 +258,15 @@ export interface Purchase {
 	 */
 	user_id: string;
 
-	auto_renew: '1' | '0' | null;
+	/**
+	 * True if auto-renew is enabled.
+	 *
+	 * IMPORTANT: Just because auto-renew is enabled does not mean that the
+	 * purchase will attempt to auto-renew. If a purchase does not have a
+	 * payment method attached, no auto-renew will be attempted.
+	 */
+	is_auto_renew_enabled: boolean;
+
 	payment_card_id: number | string | undefined;
 	payment_card_type: string | undefined;
 	payment_card_processor: string | undefined;

--- a/client/dashboard/data/purchase.ts
+++ b/client/dashboard/data/purchase.ts
@@ -156,7 +156,32 @@ export interface Purchase {
 	included_domain: string;
 	included_domain_purchase_amount: number;
 	introductory_offer: RawPurchaseIntroductoryOffer | null;
+
+	/**
+	 * True if the subscription can be cancelled by the user (removed and
+	 * possibly refunded). A subscription can be removable (see `is_removable`)
+	 * even if it cannot be cancelled.
+	 */
 	is_cancelable: boolean;
+
+	/**
+	 * True if the subscription can be removed by the user (directly removed,
+	 * without a refund). A subscription can still be cancelled (see
+	 * `is_cancelable`) or refunded (see `is_refundable`) even if it is not
+	 * removable.
+	 */
+	is_removable: boolean;
+
+	/**
+	 * True if this subscription has refundable receipts.
+	 *
+	 * If this is true, it means that it's possible the subscription could
+	 * be refunded. It does not mean there is money that would be refunded! For
+	 * that, check `total_refund_amount` instead. As an example, if a
+	 * subscription has already been refunded, `is_refundable` may be true,
+	 * but `total_refund_amount` will return a Store_Price of 0.
+	 */
+	is_refundable: boolean;
 
 	/**
 	 * If this is a domain product (eg: registration, mapping, or transfer), it
@@ -177,7 +202,6 @@ export interface Purchase {
 	is_locked: boolean;
 	is_plan: boolean;
 	is_rechargable: boolean;
-	is_refundable: boolean;
 	is_renewable: boolean;
 	is_renewal: boolean;
 	is_titan_mail_product: boolean;

--- a/client/dashboard/data/site-jetpack-keys.ts
+++ b/client/dashboard/data/site-jetpack-keys.ts
@@ -1,6 +1,6 @@
 import wpcom from 'calypso/lib/wp';
 
-export interface JetpackPluginKeys {
+interface RawJetpackPluginKeys {
 	success: true;
 	keys: {
 		vaultpress?: string;
@@ -8,6 +8,16 @@ export interface JetpackPluginKeys {
 	};
 }
 
-export async function fetchJetpackKeys( siteId: number ): Promise< JetpackPluginKeys > {
-	return wpcom.req.get( `/jetpack-blogs/${ siteId }/keys/` );
+export interface JetpackPluginKey {
+	slug: string;
+	key: string;
+}
+
+export async function fetchJetpackKeys( siteId: number ): Promise< JetpackPluginKey[] > {
+	const raw: RawJetpackPluginKeys = await wpcom.req.get( `/jetpack-blogs/${ siteId }/keys/` );
+	const plugins: JetpackPluginKey[] = [];
+	Object.entries( raw.keys ).forEach( ( [ slug, key ] ) => {
+		plugins.push( { slug, key } );
+	} );
+	return plugins;
 }

--- a/client/dashboard/data/site-jetpack-keys.ts
+++ b/client/dashboard/data/site-jetpack-keys.ts
@@ -1,0 +1,13 @@
+import wpcom from 'calypso/lib/wp';
+
+export interface JetpackPluginKeys {
+	success: true;
+	keys: {
+		vaultpress?: string;
+		akismet?: string;
+	};
+}
+
+export async function fetchJetpackKeys( siteId: number ): Promise< JetpackPluginKeys > {
+	return wpcom.req.get( `/jetpack-blogs/${ siteId }/keys/` );
+}

--- a/client/dashboard/data/site-marketplace.ts
+++ b/client/dashboard/data/site-marketplace.ts
@@ -1,0 +1,14 @@
+import wpcom from 'calypso/lib/wp';
+
+export interface ReinstallPluginsResponse {
+	message: string;
+}
+
+export async function reinstallMarketplacePlugins(
+	siteId: number
+): Promise< ReinstallPluginsResponse > {
+	return wpcom.req.get( {
+		path: `/sites/${ siteId }/marketplace/products/reinstall`,
+		apiNamespace: 'wpcom/v2',
+	} );
+}

--- a/client/dashboard/data/upgrades.ts
+++ b/client/dashboard/data/upgrades.ts
@@ -1,0 +1,13 @@
+import wpcom from 'calypso/lib/wp';
+import type { Purchase } from './purchase';
+
+export async function setPurchaseAutoRenew(
+	purchaseId: number,
+	autoRenew: boolean
+): Promise< { success: boolean; upgrade: Purchase } > {
+	const action = autoRenew ? 'enable-auto-renew' : 'disable-auto-renew';
+	return wpcom.req.post( {
+		path: `/upgrades/${ purchaseId }/${ action }`,
+		apiVersion: '1.1',
+	} );
+}

--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -1,5 +1,5 @@
-import { formatNumber } from '@automattic/number-formatters';
 import { JETPACK_CONTACT_SUPPORT } from '@automattic/urls';
+import { Link, useNavigate } from '@tanstack/react-router';
 import { Popover, Icon } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
@@ -16,6 +16,7 @@ import {
 	isTransferredOwnership,
 	isAkismetTemporarySitePurchase,
 	isMarketplaceTemporarySitePurchase,
+	getTitleForDisplay,
 } from '../../utils/purchase';
 import { PurchasePaymentMethod } from './purchase-payment-method';
 import { PurchaseProduct } from './purchase-product';
@@ -48,49 +49,6 @@ export const purchasesDataView: View = {
 	sort: defaultSort,
 	layout: {},
 };
-
-function getDisplayName( purchase: Purchase ): string {
-	if (
-		purchase.is_jetpack_ai_product &&
-		purchase.renewal_price_tier_usage_quantity &&
-		purchase.price_tier_list?.length
-	) {
-		// translators: productName is the name of the product and quantity is a number
-		return sprintf( __( '%(productName)s (%(quantity)s requests per month)' ), {
-			productName: purchase.product_name,
-			quantity: formatNumber( purchase.renewal_price_tier_usage_quantity ),
-		} );
-	}
-
-	if (
-		purchase.is_jetpack_stats_product &&
-		! purchase.is_free_jetpack_stats_product &&
-		purchase.renewal_price_tier_usage_quantity &&
-		purchase.price_tier_list?.length
-	) {
-		// translators: productName is the name of the product and quantity is a number
-		return sprintf( __( '%(productName)s (%(quantity)s views per month)' ), {
-			productName: purchase.product_name,
-			quantity: formatNumber( purchase.renewal_price_tier_usage_quantity ),
-		} );
-	}
-
-	if (
-		'wordpress_com_1gb_space_addon_yearly' === purchase.product_slug &&
-		purchase.renewal_price_tier_usage_quantity
-	) {
-		// translators: productName is the name of the product and quantity is a number (GB stands for GigaBytes)
-		return sprintf( __( '%(productName)s %(quantity)s GB' ), {
-			productName: purchase.product_name,
-			quantity: purchase.renewal_price_tier_usage_quantity,
-		} );
-	}
-
-	if ( purchase.meta && ( purchase.is_domain_registration || purchase.is_domain ) ) {
-		return purchase.meta;
-	}
-	return purchase.product_name;
-}
 
 function getPurchaseUrl( purchase: Purchase ) {
 	const siteUrl = purchase.site_slug || purchase.domain;
@@ -275,9 +233,9 @@ export function getFields( {
 			render: ( { item }: { item: Purchase } ) => {
 				const site = sites.find( ( site ) => String( site.ID ) === item.blog_id );
 				return (
-					<a href={ getPurchaseUrl( item ) } title={ __( 'Manage purchase' ) }>
+					<Link to={ getPurchaseUrl( item ) } title={ __( 'Manage purchase' ) }>
 						<PurchaseItemSiteIcon purchase={ item } site={ site } />
-					</a>
+					</Link>
 				);
 			},
 		},
@@ -293,7 +251,7 @@ export function getFields( {
 				const site = sites.find( ( site ) => String( site.ID ) === item.blog_id );
 				// Render a bunch of things to make this easily searchable.
 				return (
-					getDisplayName( item ) +
+					getTitleForDisplay( item ) +
 					' ' +
 					item.blogname +
 					' ' +
@@ -307,11 +265,11 @@ export function getFields( {
 				return (
 					<div>
 						{ isTransferred ? (
-							getDisplayName( item ) + '&nbsp;'
+							getTitleForDisplay( item ) + '&nbsp;'
 						) : (
-							<a href={ getPurchaseUrl( item ) } title={ __( 'Manage purchase' ) }>
-								{ getDisplayName( item ) }
-							</a>
+							<Link to={ getPurchaseUrl( item ) } title={ __( 'Manage purchase' ) }>
+								{ getTitleForDisplay( item ) }
+							</Link>
 						) }
 						<OwnerInfo purchase={ item } isTransferredOwnership={ isTransferred } />
 					</div>
@@ -538,6 +496,7 @@ export function usePurchasesListActions( {
 }: {
 	transferredPurchases: Purchase[];
 } ) {
+	const navigate = useNavigate();
 	return useMemo(
 		() => [
 			{
@@ -553,10 +512,12 @@ export function usePurchasesListActions( {
 				},
 				callback: ( items: Purchase[] ) => {
 					const item = items[ 0 ];
-					window.location.href = getPurchaseUrl( item );
+					navigate( {
+						to: getPurchaseUrl( item ),
+					} );
 				},
 			},
 		],
-		[ transferredPurchases ]
+		[ transferredPurchases, navigate ]
 	);
 }

--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../utils/purchase';
 import { PurchasePaymentMethod } from './purchase-payment-method';
 import { PurchaseProduct } from './purchase-product';
+import { getPurchaseUrl, getAddPaymentMethodUrlFor } from './urls';
 import type { StoredPaymentMethod } from '../../data/me-payment-methods';
 import type { Purchase } from '../../data/purchase';
 import type { Site } from '../../data/site';
@@ -49,20 +50,6 @@ export const purchasesDataView: View = {
 	sort: defaultSort,
 	layout: {},
 };
-
-function getPurchaseUrl( purchase: Purchase ) {
-	const subscriptionId = purchase.ID;
-	if ( ! subscriptionId ) {
-		// eslint-disable-next-line no-console
-		console.error( 'Cannot display manage purchase page for subscription without ID' );
-		throw new Error( 'Cannot display manage purchase page for subscription without ID' );
-	}
-	return `/v2/me/billing/purchases/purchase/${ subscriptionId }`;
-}
-
-function getAddPaymentMethodUrlFor( purchase: Purchase ): string {
-	return `/me/purchases/${ purchase.site_slug ?? 'unknown' }/${ purchase.ID }/payment-method/add`;
-}
 
 function InfoPopover( { children }: { children: ReactNode } ) {
 	const [ isTooltipVisible, setIsTooltipVisible ] = useState( false );

--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -51,19 +51,13 @@ export const purchasesDataView: View = {
 };
 
 function getPurchaseUrl( purchase: Purchase ) {
-	const siteUrl = purchase.site_slug || purchase.domain;
 	const subscriptionId = purchase.ID;
-	if ( ! siteUrl ) {
-		// eslint-disable-next-line no-console
-		console.error( 'Cannot display manage purchase page for subscription without site' );
-		throw new Error( 'Cannot display manage purchase page for subscription without site' );
-	}
 	if ( ! subscriptionId ) {
 		// eslint-disable-next-line no-console
 		console.error( 'Cannot display manage purchase page for subscription without ID' );
 		throw new Error( 'Cannot display manage purchase page for subscription without ID' );
 	}
-	return `/me/purchases/${ siteUrl }/${ subscriptionId }`;
+	return `/v2/me/billing/purchases/purchase/${ subscriptionId }`;
 }
 
 function getAddPaymentMethodUrlFor( purchase: Purchase ): string {

--- a/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
@@ -25,11 +25,11 @@ export function PurchasePaymentMethod( {
 	}
 
 	if (
-		( purchase.is_auto_renew_enabled,
+		purchase.is_auto_renew_enabled &&
 		! isExpired( purchase ) &&
-			( ! purchase.payment_type || purchase.payment_type === 'credits' ) &&
-			! purchase.partner_name &&
-			! isAkismetFreeProduct( purchase ) ) &&
+		( ! purchase.payment_type || purchase.payment_type === 'credits' ) &&
+		! purchase.partner_name &&
+		! isAkismetFreeProduct( purchase ) &&
 		! isDisconnectedSite
 	) {
 		return (

--- a/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
@@ -1,10 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import {
-	isAutoRenewEnabled,
-	isExpired,
-	isRenewing,
-	isAkismetFreeProduct,
-} from '../../utils/purchase';
+import { isExpired, isRenewing, isAkismetFreeProduct } from '../../utils/purchase';
 import { PaymentMethodImage } from './payment-method-image';
 import type { Purchase } from '../../data/purchase';
 
@@ -30,7 +25,7 @@ export function PurchasePaymentMethod( {
 	}
 
 	if (
-		( isAutoRenewEnabled( purchase ),
+		( purchase.is_auto_renew_enabled,
 		! isExpired( purchase ) &&
 			( ! purchase.payment_type || purchase.payment_type === 'credits' ) &&
 			! purchase.partner_name &&
@@ -47,7 +42,7 @@ export function PurchasePaymentMethod( {
 	if (
 		! isAkismetFreeProduct( purchase ) &&
 		! purchase.is_rechargable &&
-		isAutoRenewEnabled( purchase )
+		purchase.is_auto_renew_enabled
 	) {
 		return (
 			<div>

--- a/client/dashboard/me/billing-purchases/purchase-product.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-product.tsx
@@ -1,81 +1,9 @@
 import { ExternalLink, Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { isTemporarySitePurchase, isA4ATemporarySitePurchase } from '../../utils/purchase';
+import { isTemporarySitePurchase, getSubtitleForDisplay } from '../../utils/purchase';
 import type { Purchase } from '../../data/purchase';
 import type { Site } from '../../data/site';
-
-function purchaseType( purchase: Purchase ): string | null {
-	if ( 'theme' === purchase.product_type ) {
-		return __( 'Premium Theme' );
-	}
-
-	if ( 'concierge-session' === purchase.product_slug ) {
-		return __( 'One-on-one Support' );
-	}
-
-	if ( purchase.partner_name ) {
-		if ( purchase.partner_type && [ 'agency', 'a4a_agency' ].includes( purchase.partner_type ) ) {
-			return __( 'Agency Managed Plan' );
-		}
-
-		return __( 'Host Managed Plan' );
-	}
-
-	if ( purchase.is_plan ) {
-		return __( 'Site Plan' );
-	}
-
-	if ( purchase.is_domain_registration ) {
-		return purchase.product_name;
-	}
-
-	if ( purchase.product_slug === 'domain_map' ) {
-		return purchase.product_name;
-	}
-
-	if ( isTemporarySitePurchase( purchase ) && purchase.product_type === 'akismet' ) {
-		return null;
-	}
-
-	if ( isTemporarySitePurchase( purchase ) && purchase.product_type === 'saas_plugin' ) {
-		return null;
-	}
-
-	if ( isTemporarySitePurchase( purchase ) && isA4ATemporarySitePurchase( purchase ) ) {
-		return null;
-	}
-
-	if ( purchase.is_google_workspace_product && purchase.meta ) {
-		return sprintf(
-			// translators: The domain is the domain name of the site
-			__( 'Mailboxes and Productivity Tools at %(domain)s' ),
-			{
-				domain: purchase.meta,
-			}
-		);
-	}
-
-	if ( purchase.is_titan_mail_product && purchase.meta ) {
-		return sprintf(
-			// translators: The domain is the domain name of the site
-			__( 'Mailboxes at %(domain)s' ),
-			{
-				domain: purchase.meta,
-			}
-		);
-	}
-
-	if ( purchase.product_type === 'marketplace_plugin' || purchase.product_type === 'saas_plugin' ) {
-		return __( 'Plugin' );
-	}
-
-	if ( purchase.meta ) {
-		return purchase.meta;
-	}
-
-	return null;
-}
 
 export function PurchaseProduct( {
 	purchase,
@@ -90,7 +18,7 @@ export function PurchaseProduct( {
 		return null;
 	}
 
-	const productType = purchaseType( purchase );
+	const productType = getSubtitleForDisplay( purchase );
 
 	if ( site ) {
 		if ( productType && site.name && site.slug ) {

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -40,7 +40,6 @@ import PageLayout from '../../../components/page-layout';
 import {
 	ProductUpgradeMap,
 	AkismetUpgradesProductMap,
-	DomainProductSlugs,
 	SubscriptionBillPeriod,
 } from '../../../data/constants';
 import { formatDate } from '../../../utils/datetime';
@@ -56,7 +55,6 @@ import {
 	isMarketplaceTemporarySitePurchase,
 	isJetpackTemporarySitePurchase,
 	isAkismetProduct,
-	isAkismetFreeProduct,
 } from '../../../utils/purchase';
 import { encodeProductForUrl } from '../../../utils/wpcom-checkout';
 import { getPurchaseUrlForId } from '../urls';
@@ -130,25 +128,17 @@ function canPurchaseBeUpgraded( purchase: Purchase ): boolean {
 }
 
 function isAutoRenewToggleDisabled( purchase: Purchase, user: User ): boolean {
-	if ( purchase.is_iap_purchase ) {
-		return true;
-	}
-	if ( purchase.product_slug === DomainProductSlugs.TRANSFER_IN ) {
-		return true;
-	}
 	if ( String( user.ID ) !== String( purchase.user_id ) ) {
 		return true;
 	}
-	if ( isAkismetFreeProduct( purchase ) ) {
+	if ( isExpired( purchase ) && shouldAllowExpiredAutoRenewToggle( purchase ) ) {
+		// Special case!
+		return false;
+	}
+	if ( purchase.is_auto_renew_enabled && ! purchase.can_disable_auto_renew ) {
 		return true;
 	}
-	if ( isOneTimePurchase( purchase ) ) {
-		return true;
-	}
-	if ( isExpired( purchase ) && ! shouldAllowExpiredAutoRenewToggle( purchase ) ) {
-		return true;
-	}
-	if ( isIncludedWithPlan( purchase ) ) {
+	if ( ! purchase.is_auto_renew_enabled && ! purchase.can_reenable_auto_renewal ) {
 		return true;
 	}
 	return false;
@@ -159,12 +149,19 @@ function isAutoRenewToggleDisabled( purchase: Purchase, user: User ): boolean {
  * which case we should allow toggling it even if the subscription has expired.
  */
 function shouldAllowExpiredAutoRenewToggle( purchase: Purchase ): boolean {
-	return (
-		! purchase.is_auto_renew_enabled &&
-		( ! purchase.is_jetpack_legacy_plan || purchase.is_renewable ) &&
-		purchase.bill_period_days !== SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD &&
-		purchase.is_jetpack_plan_or_product
-	);
+	if ( ! purchase.is_auto_renew_enabled ) {
+		return false;
+	}
+	if ( ! purchase.is_jetpack_plan_or_product ) {
+		return false;
+	}
+	if ( purchase.is_renewable ) {
+		return true;
+	}
+	if ( ! purchase.is_jetpack_plan_or_product ) {
+		return true;
+	}
+	return false;
 }
 
 function upgradePurchase( upgradeUrl: string ): void {

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -129,6 +129,44 @@ function canPurchaseBeUpgraded( purchase: Purchase ): boolean {
 	);
 }
 
+function isAutoRenewToggleDisabled( purchase: Purchase, user: User ): boolean {
+	if ( purchase.is_iap_purchase ) {
+		return true;
+	}
+	if ( purchase.product_slug === DomainProductSlugs.TRANSFER_IN ) {
+		return true;
+	}
+	if ( String( user.ID ) !== String( purchase.user_id ) ) {
+		return true;
+	}
+	if ( isAkismetFreeProduct( purchase ) ) {
+		return true;
+	}
+	if ( isOneTimePurchase( purchase ) ) {
+		return true;
+	}
+	if ( isExpired( purchase ) && ! shouldAllowExpiredAutoRenewToggle( purchase ) ) {
+		return true;
+	}
+	if ( isIncludedWithPlan( purchase ) ) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Sometimes the auto-renew toggle will read "Re-activate subscription" in
+ * which case we should allow toggling it even if the subscription has expired.
+ */
+function shouldAllowExpiredAutoRenewToggle( purchase: Purchase ): boolean {
+	return (
+		! purchase.is_auto_renew_enabled &&
+		( ! purchase.is_jetpack_legacy_plan || purchase.is_renewable ) &&
+		purchase.bill_period_days !== SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD &&
+		purchase.is_jetpack_plan_or_product
+	);
+}
+
 function upgradePurchase( upgradeUrl: string ): void {
 	window.location.href = upgradeUrl;
 }
@@ -343,7 +381,6 @@ function RenewActionButton( { purchase }: { purchase: Purchase } ) {
 }
 
 function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
-	// FIXME: show re-enable button (see subsReEnableText)
 	return (
 		<VStack spacing={ 4 }>
 			<ActionList>
@@ -454,18 +491,13 @@ function getFields( {
 				return (
 					<ToggleControl
 						__nextHasNoMarginBottom
-						label={ field.label }
-						checked={ getValue( { item: purchase } ) }
-						disabled={
-							isMutationPending ||
-							purchase.is_iap_purchase ||
-							purchase.product_slug === DomainProductSlugs.TRANSFER_IN ||
-							String( user.ID ) !== String( purchase.user_id ) ||
-							isAkismetFreeProduct( purchase ) ||
-							isOneTimePurchase( purchase ) ||
-							isExpired( purchase ) ||
-							isIncludedWithPlan( purchase )
+						label={
+							shouldAllowExpiredAutoRenewToggle( purchase )
+								? __( 'Re-activate subscription' )
+								: field.label
 						}
+						checked={ getValue( { item: purchase } ) }
+						disabled={ isMutationPending || isAutoRenewToggleDisabled( purchase, user ) }
 						onChange={ ( value: boolean ) => onChange( { is_auto_renew_enabled: value } ) }
 						help={ helpText }
 					/>

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -200,6 +200,7 @@ function PurchaseSettingsActions( {
 } ) {
 	const canBeRemoved = ! isExpired( purchase ) && ! isIncludedWithPlan( purchase );
 	const canBeRenewed = purchase.can_explicit_renew;
+	// FIXME: handle all conditions in renderCancelPurchaseNavItem like canAutoRenewBeTurnedOff and hasAmountAvailableToRefund and isDomainTransfer and isHundredYearDomain
 	const canCancel = purchase.is_cancelable;
 	const { recordTracksEvent } = useAnalytics();
 	// FIXME: prevent renew if purchase.isLocked

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -1006,7 +1006,6 @@ function PurchaseSecondSubtitle( { purchase }: { purchase: Purchase } ) {
 		if ( purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD ) {
 			return (
 				<Text variant="muted">
-					{ ' ' }
 					{ __(
 						'Your stories, achievements, and memories preserved for generations to come. One payment. One hundred years of legacy.'
 					) }

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -209,6 +209,48 @@ function PurchaseSettingsCardLinkWrapper( {
 	return children;
 }
 
+function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
+	if ( purchase.is_cancelable ) {
+		return (
+			<ActionList.ActionItem
+				title={ __( 'Downgrade or cancel your subscription' ) }
+				description={ __( "We'll be sorry to see you go!" ) }
+				actions={
+					<Button
+						variant="secondary"
+						size="compact"
+						onClick={ () => ( {
+							// FIXME: add cancel and downgrade action
+						} ) }
+					>
+						{ __( 'Downgrade or cancel' ) }
+					</Button>
+				}
+			/>
+		);
+	}
+	if ( purchase.is_removable ) {
+		return (
+			<ActionList.ActionItem
+				title={ __( 'Remove subscription' ) }
+				description={ __( "We'll be sorry to see you go!" ) }
+				actions={
+					<Button
+						variant="secondary"
+						size="compact"
+						onClick={ () => ( {
+							// FIXME: add remove action
+						} ) }
+					>
+						{ __( 'Remove subscription' ) }
+					</Button>
+				}
+			/>
+		);
+	}
+	return null;
+}
+
 function PurchaseSettingsActions( {
 	purchase,
 	upgradeUrl,
@@ -217,10 +259,8 @@ function PurchaseSettingsActions( {
 	upgradeUrl: string | undefined;
 } ) {
 	const { user } = useAuth();
-	const canBeRemoved = ! isExpired( purchase ) && ! isIncludedWithPlan( purchase );
 	const canBeRenewed =
 		purchase.can_explicit_renew && String( user.ID ) === String( purchase.user_id );
-	const canCancel = purchase.is_cancelable;
 	const { recordTracksEvent } = useAnalytics();
 	// FIXME: show re-enable button (see subsReEnableText)
 	return (
@@ -288,40 +328,7 @@ function PurchaseSettingsActions( {
 						}
 					/>
 				) }
-				{ canCancel && (
-					<ActionList.ActionItem
-						title={ __( 'Downgrade or cancel your subscription' ) }
-						description={ __( "We'll be sorry to see you go!" ) }
-						actions={
-							<Button
-								variant="secondary"
-								size="compact"
-								onClick={ () => ( {
-									// FIXME: add cancel and downgrade action
-								} ) }
-							>
-								{ __( 'Downgrade or cancel' ) }
-							</Button>
-						}
-					/>
-				) }
-				{ ! canCancel && canBeRemoved && (
-					<ActionList.ActionItem
-						title={ __( 'Remove subscription' ) }
-						description={ __( 'Remove this product.' ) }
-						actions={
-							<Button
-								variant="secondary"
-								size="compact"
-								onClick={ () => ( {
-									// FIXME: add remove action
-								} ) }
-							>
-								{ __( 'Remove subscription' ) }
-							</Button>
-						}
-					/>
-				) }
+				<CancelOrRemoveActionButton purchase={ purchase } />
 			</ActionList>
 		</VStack>
 	);

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -1,0 +1,466 @@
+import { formatCurrency } from '@automattic/number-formatters';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { useRouter, Link } from '@tanstack/react-router';
+import {
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	__experimentalHeading as Heading,
+	DropdownMenu,
+	MenuGroup,
+	MenuItem,
+	Card,
+	CardBody,
+	Button,
+	Icon,
+	ToggleControl,
+	Notice,
+} from '@wordpress/components';
+import { DataForm } from '@wordpress/dataviews';
+import { __, isRTL, sprintf } from '@wordpress/i18n';
+import {
+	moreVertical,
+	chevronLeft,
+	chevronRight,
+	calendar,
+	currencyDollar,
+	siteLogo,
+	commentAuthorAvatar,
+} from '@wordpress/icons';
+import { useAuth } from '../../../app/auth';
+import { useLocale } from '../../../app/locale';
+import { purchaseQuery, userPurchaseSetAutoRenewQuery } from '../../../app/queries/me-purchases';
+import { siteBySlugQuery } from '../../../app/queries/site';
+import { purchaseSettingsRoute } from '../../../app/router/me';
+import { ActionList } from '../../../components/action-list';
+import { useFormattedTime } from '../../../components/formatted-time';
+import { PageHeader } from '../../../components/page-header';
+import PageLayout from '../../../components/page-layout';
+import { formatDate } from '../../../utils/datetime';
+import {
+	getBillPeriodLabel,
+	getTitleForDisplay,
+	getSubtitleForDisplay,
+	isExpiring,
+	isExpired,
+	isRenewing,
+	isIncludedWithPlan,
+	isOneTimePurchase,
+} from '../../../utils/purchase';
+import { getPurchaseUrlForId } from '../urls';
+import type { Purchase } from '../../../data/purchase';
+import type { Field } from '@wordpress/dataviews';
+import type { ReactNode, ReactElement } from 'react';
+
+import './style.scss';
+
+const BackButton = () => {
+	const router = useRouter();
+
+	return (
+		<Button
+			className="dashboard-page-header__back-button"
+			icon={ isRTL() ? chevronRight : chevronLeft }
+			onClick={ () => {
+				router.navigate( {
+					to: '/me/billing/purchases',
+				} );
+			} }
+		>
+			{ __( 'Purchases' ) }
+		</Button>
+	);
+};
+
+const PurchaseActionMenu = () => {
+	// FIXME: figure out what these actions should be
+	return (
+		<DropdownMenu icon={ moreVertical } label={ __( 'Quick actions' ) }>
+			{ () => (
+				<MenuGroup>
+					<MenuItem onClick={ () => ( {} ) }>Do something</MenuItem>
+				</MenuGroup>
+			) }
+		</DropdownMenu>
+	);
+};
+
+function PurchaseSettingsCardLinkWrapper( {
+	link,
+	children,
+}: {
+	link?: string;
+	children: ReactNode;
+} ) {
+	if ( link ) {
+		return (
+			<Link to={ link } className="purchase-settings-card__link">
+				{ children }
+			</Link>
+		);
+	}
+	return children;
+}
+
+function PurchaseSettingsActions( {
+	purchase,
+	isEligibleForUpgrade,
+}: {
+	purchase: Purchase;
+	isEligibleForUpgrade: boolean;
+} ) {
+	// FIXME: determine what actions to include
+	const canBeRemoved = ! isExpired( purchase ) && ! isIncludedWithPlan( purchase );
+	const canBeRenewed = purchase.can_explicit_renew;
+	const canCancel = purchase.is_cancelable;
+	return (
+		<VStack spacing={ 4 }>
+			<ActionList>
+				{ isEligibleForUpgrade && (
+					<ActionList.ActionItem
+						title={ __( 'Upgrade plan' ) }
+						description={ __( 'Find the best fit for your business.' ) }
+						actions={
+							<Button
+								variant="secondary"
+								size="compact"
+								onClick={ () => ( {
+									// FIXME
+								} ) }
+							>
+								{ __( 'Upgrade plan' ) }
+							</Button>
+						}
+					/>
+				) }
+				{ canBeRenewed && (
+					<ActionList.ActionItem
+						title={ __( 'Renew now' ) }
+						description={ __( 'Renew your subscription manually.' ) }
+						actions={
+							<Button
+								variant="secondary"
+								size="compact"
+								onClick={ () => ( {
+									// FIXME
+								} ) }
+							>
+								{ __( 'Renew' ) }
+							</Button>
+						}
+					/>
+				) }
+				{ canCancel && (
+					<ActionList.ActionItem
+						title={ __( 'Downgrade or cancel your subscription' ) }
+						description={ __( "We'll be sorry to see you go!" ) }
+						actions={
+							<Button
+								variant="secondary"
+								size="compact"
+								onClick={ () => ( {
+									// FIXME
+								} ) }
+							>
+								{ __( 'Downgrade or cancel' ) }
+							</Button>
+						}
+					/>
+				) }
+				{ ! canCancel && canBeRemoved && (
+					<ActionList.ActionItem
+						title={ __( 'Remove subscription' ) }
+						description={ __( 'Remove this product.' ) }
+						actions={
+							<Button
+								variant="secondary"
+								size="compact"
+								onClick={ () => ( {
+									// FIXME
+								} ) }
+							>
+								{ __( 'Remove subscription' ) }
+							</Button>
+						}
+					/>
+				) }
+			</ActionList>
+		</VStack>
+	);
+}
+
+function PurchaseSettingsCard( {
+	icon,
+	title,
+	heading,
+	description,
+	link,
+}: {
+	icon?: ReactElement;
+	title: ReactNode;
+	heading?: ReactNode;
+	description?: ReactNode;
+	link?: string;
+} ) {
+	return (
+		<PurchaseSettingsCardLinkWrapper link={ link }>
+			<Card className="purchase-settings-card">
+				<CardBody>
+					<VStack>
+						<HStack justify="space-between">
+							<HStack spacing={ 2 } justify="flex-start" alignment="center">
+								{ icon && <Icon className="dashboard-overview-card__icon" icon={ icon } /> }
+								<Text
+									className="dashboard-overview-card__title"
+									variant="muted"
+									lineHeight="16px"
+									size={ 11 }
+									weight={ 500 }
+									upperCase
+								>
+									{ title }
+								</Text>
+							</HStack>
+							{ link && (
+								<Icon className="dashboard-overview-card__link-icon" icon={ chevronRight } />
+							) }
+						</HStack>
+						<HStack spacing={ 2 } justify="flex-start" alignment="center">
+							<VStack>
+								{ heading && (
+									<Heading level={ 2 } size={ 20 } weight={ 500 }>
+										{ heading }
+									</Heading>
+								) }
+								{ description && (
+									<Text variant="muted" lineHeight="16px" size={ 12 }>
+										{ description }
+									</Text>
+								) }
+							</VStack>
+						</HStack>
+					</VStack>
+				</CardBody>
+			</Card>
+		</PurchaseSettingsCardLinkWrapper>
+	);
+}
+
+function getFields( { isMutationPending }: { isMutationPending?: boolean } ): Field< Purchase >[] {
+	return [
+		{
+			id: 'is_auto_renew_enabled',
+			label: __( 'Enable auto-renew' ),
+			Edit: ( { field, data: purchase, onChange } ) => {
+				const locale = useLocale();
+				const { getValue } = field;
+				const helpText = ( () => {
+					if (
+						purchase.is_auto_renew_enabled &&
+						Boolean( purchase.renew_date ) &&
+						isRenewing( purchase )
+					) {
+						// translators: date is a formatted date string
+						return sprintf( __( 'You will be billed on %(date)s' ), {
+							date: formatDate( new Date( purchase.renew_date ), locale, { dateStyle: 'long' } ),
+						} );
+					}
+					if ( isIncludedWithPlan( purchase ) && purchase.attached_to_purchase_id ) {
+						return (
+							<Link to={ getPurchaseUrlForId( purchase.attached_to_purchase_id ) }>
+								{ __( 'Renews with plan' ) }
+							</Link>
+						);
+					}
+					if ( purchase.is_auto_renew_enabled ) {
+						return __( 'Will not auto-renew because there is no payment method' );
+					}
+					return undefined;
+				} )();
+				return (
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ field.label }
+						checked={ getValue( { item: purchase } ) }
+						disabled={
+							isMutationPending ||
+							isOneTimePurchase( purchase ) ||
+							isExpired( purchase ) ||
+							isIncludedWithPlan( purchase )
+						}
+						onChange={ ( value: boolean ) => onChange( { is_auto_renew_enabled: value } ) }
+						help={ helpText }
+					/>
+				);
+			},
+		},
+	];
+}
+
+const form = {
+	type: 'regular' as const,
+	labelPosition: 'top' as const,
+	fields: [
+		{
+			id: 'autoRenew',
+			label: __( 'Manage subscription' ),
+			children: [ 'is_auto_renew_enabled' ],
+		},
+	],
+};
+
+function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
+	const {
+		mutate: setAutoRenew,
+		error,
+		isPending: isMutationPending,
+	} = useMutation( userPurchaseSetAutoRenewQuery( parseInt( purchase.ID ) ) );
+	return (
+		<Card>
+			<CardBody>
+				<VStack spacing={ 4 } alignment="left">
+					<DataForm< Purchase >
+						data={ purchase }
+						fields={ getFields( { isMutationPending } ) }
+						form={ form }
+						onChange={ ( newData ) => {
+							if ( newData.is_auto_renew_enabled !== purchase.is_auto_renew_enabled ) {
+								setAutoRenew( newData.is_auto_renew_enabled );
+							}
+						} }
+					/>
+
+					{ error && (
+						<Notice status="error" isDismissible={ false }>
+							{ error.message }
+						</Notice>
+					) }
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+}
+
+export default function PurchaseSettings() {
+	const { user } = useAuth();
+	const params = purchaseSettingsRoute.useParams();
+	const purchaseId = params.purchaseId;
+	const { data: purchase } = useQuery( {
+		...purchaseQuery( parseInt( purchaseId ) ),
+		enabled: Boolean( purchaseId ),
+	} );
+	const { data: site } = useQuery( {
+		...siteBySlugQuery( purchase?.site_slug ?? '' ),
+		enabled: Boolean( purchase?.site_slug ),
+	} );
+	const formattedExpiry = useFormattedTime( purchase?.expiry_date ?? '' );
+	const formattedRenewal = useFormattedTime( purchase?.renew_date ?? '' );
+	if ( ! purchase || ! site ) {
+		return null;
+	}
+	// FIXME: figure this out
+	const isEligibleForUpgrade =
+		! isExpired( purchase ) && ! isIncludedWithPlan( purchase ) && purchase.is_plan;
+
+	const subtitle = getSubtitleForDisplay( purchase );
+
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<VStack>
+					<PageHeader
+						prefix={ <BackButton /> }
+						title={ getTitleForDisplay( purchase ) }
+						actions={
+							// FIXME: figure out where to go here
+							site?.options?.admin_url && (
+								<>
+									{ isEligibleForUpgrade && (
+										<Button __next40pxDefaultSize variant="primary" href="#">
+											{ __( 'Upgrade plan' ) }
+										</Button>
+									) }
+									<PurchaseActionMenu />
+								</>
+							)
+						}
+					/>
+					{ subtitle && <Text variant="muted">{ subtitle }</Text> }
+				</VStack>
+			}
+		>
+			<VStack spacing={ 6 }>
+				<HStack spacing={ 6 } justify="flex-start" alignment="center">
+					<PurchaseSettingsCard
+						icon={ calendar }
+						title={
+							purchase.renew_date && ! isExpiring( purchase ) ? __( 'Renews' ) : __( 'Expires' )
+						}
+						heading={ ( () => {
+							if ( isOneTimePurchase( purchase ) ) {
+								return __( 'Never expires' );
+							}
+							if ( purchase.renew_date && ! isExpiring( purchase ) ) {
+								return formattedRenewal;
+							}
+							return formattedExpiry;
+						} )() }
+						description={ ( () => {
+							if ( purchase.is_auto_renew_enabled && isRenewing( purchase ) ) {
+								return __( 'Auto-renew is enabled' );
+							}
+							if ( isIncludedWithPlan( purchase ) && purchase.attached_to_purchase_id ) {
+								return (
+									<Link to={ getPurchaseUrlForId( purchase.attached_to_purchase_id ) }>
+										{ __( 'Renews with plan' ) }
+									</Link>
+								);
+							}
+							if ( purchase.is_auto_renew_enabled ) {
+								return __( 'Will not auto-renew because there is no payment method' );
+							}
+							return __( 'Auto-renew is disabled' );
+						} )() }
+					/>
+					<PurchaseSettingsCard
+						icon={ currencyDollar }
+						title={ __( 'Renewal price' ) }
+						heading={ formatCurrency( purchase.price_integer, purchase.currency_code, {
+							isSmallestUnit: true,
+						} ) }
+						description={ getBillPeriodLabel( purchase ) + ' ' + __( 'Excludes taxes.' ) }
+					/>
+				</HStack>
+				<HStack spacing={ 6 } justify="flex-start" alignment="center">
+					<PurchaseSettingsCard
+						icon={ siteLogo }
+						title={ __( 'Site' ) }
+						heading={ site.name }
+						description={ purchase.site_slug }
+						link={ `/v2/sites/${ purchase.site_slug }` }
+					/>
+					<PurchaseSettingsCard
+						icon={ commentAuthorAvatar }
+						title={ __( 'Owner' ) }
+						heading={
+							String( user.ID ) === String( purchase.user_id )
+								? user.display_name
+								: __( 'Owned by a different user' )
+						}
+						description={
+							String( user.ID ) === String( purchase.user_id ) ? user.email : undefined
+						}
+					/>
+				</HStack>
+				<ManageSubscriptionCard purchase={ purchase } />
+				{ ! isExpired( purchase ) && (
+					<PurchaseSettingsActions
+						purchase={ purchase }
+						isEligibleForUpgrade={ isEligibleForUpgrade }
+					/>
+				) }
+			</VStack>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -809,16 +809,21 @@ function BBEPurchaseDescription( { purchase }: { purchase: Purchase } ) {
 	);
 }
 
-function PurchaseSubtitle( { purchase }: { purchase: Purchase } ) {
+function PurchaseSecondSubtitle( { purchase }: { purchase: Purchase } ) {
 	if ( purchase.is_domain ) {
 		if ( purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD ) {
-			return __(
-				'Your stories, achievements, and memories preserved for generations to come. One payment. One hundred years of legacy.'
+			return (
+				<Text variant="muted">
+					{ ' ' }
+					{ __(
+						'Your stories, achievements, and memories preserved for generations to come. One payment. One hundred years of legacy.'
+					) }
+				</Text>
 			);
 		}
 
 		return (
-			<span>
+			<Text variant="muted">
 				{ createInterpolateElement(
 					// translators: SiteUrl is the URL of the site and Domain is the domain name of the site.
 					__(
@@ -829,14 +834,18 @@ function PurchaseSubtitle( { purchase }: { purchase: Purchase } ) {
 						Domain: <strong>{ purchase.meta }</strong>,
 					}
 				) }
-			</span>
+			</Text>
 		);
 	}
 
 	if ( purchase.product_slug === DomainProductSlugs.TRANSFER_IN ) {
 		// FIXME: render domain transfer status (see resolveDomainStatus)
-		return __(
-			'Transfers an existing domain from another provider to WordPress.com, helping you manage your site and domain in one place.'
+		return (
+			<Text variant="muted">
+				{ __(
+					'Transfers an existing domain from another provider to WordPress.com, helping you manage your site and domain in one place.'
+				) }
+			</Text>
 		);
 	}
 
@@ -851,7 +860,7 @@ function PurchaseSubtitle( { purchase }: { purchase: Purchase } ) {
 
 		if ( purchase.renewal_price_tier_usage_quantity ) {
 			return (
-				<span>
+				<Text variant="muted">
 					{ description }{ ' ' }
 					{ sprintf(
 						// translators: numberOfMailboxes is a number and domain is a domain name
@@ -865,7 +874,7 @@ function PurchaseSubtitle( { purchase }: { purchase: Purchase } ) {
 							domain: purchase.meta,
 						}
 					) }
-				</span>
+				</Text>
 			);
 		}
 		return description;
@@ -874,7 +883,10 @@ function PurchaseSubtitle( { purchase }: { purchase: Purchase } ) {
 	if ( purchase.product_slug === WPCOM_DIFM_LITE ) {
 		return <BBEPurchaseDescription purchase={ purchase } />;
 	}
+	return null;
+}
 
+function PurchaseSubtitle( { purchase }: { purchase: Purchase } ) {
 	const subtitle = getSubtitleForDisplay( purchase );
 	if ( ! subtitle ) {
 		return null;
@@ -935,6 +947,7 @@ export default function PurchaseSettings() {
 						}
 					/>
 					<PurchaseSubtitle purchase={ purchase } />
+					<PurchaseSecondSubtitle purchase={ purchase } />
 					<ProductLink purchase={ purchase } />
 					<DomainRegistrationAgreement purchase={ purchase } />
 				</VStack>

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -1,5 +1,6 @@
-import { domainManagementEdit } from '@automattic/domains-table/src/utils/paths';
+import { domainManagementEdit, domainUseMyDomain } from '@automattic/domains-table/src/utils/paths';
 import { formatCurrency } from '@automattic/number-formatters';
+import { INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS } from '@automattic/urls';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { useRouter, Link } from '@tanstack/react-router';
 import {
@@ -33,6 +34,7 @@ import {
 import { useAnalytics } from '../../../app/analytics';
 import { useAuth } from '../../../app/auth';
 import { useLocale } from '../../../app/locale';
+import { domainsQuery } from '../../../app/queries/domains';
 import { purchaseQuery, userPurchaseSetAutoRenewQuery } from '../../../app/queries/me-purchases';
 import { siteBySlugQuery } from '../../../app/queries/site';
 import { siteDifmWebsiteContentQuery } from '../../../app/queries/site-do-it-for-me';
@@ -49,9 +51,11 @@ import {
 	AkismetUpgradesProductMap,
 	SubscriptionBillPeriod,
 	DomainProductSlugs,
+	useMyDomainInputMode,
 	WPCOM_DIFM_LITE,
 	OFFSITE_REDIRECT,
 } from '../../../data/constants';
+import { DomainTransferStatus } from '../../../data/domains';
 import { formatDate } from '../../../utils/datetime';
 import { getEmailManagementPath } from '../../../utils/email-paths';
 import {
@@ -845,6 +849,158 @@ function BBEPurchaseDescription( { purchase }: { purchase: Purchase } ) {
 	);
 }
 
+function DomainTransferInfo( { purchase }: { purchase: Purchase } ) {
+	const locale = useLocale();
+	const domains = useQuery( domainsQuery() ).data;
+	if ( purchase.product_slug !== DomainProductSlugs.TRANSFER_IN ) {
+		return null;
+	}
+	const domain = domains?.find( ( domain ) => domain.domain === purchase.meta );
+	if ( ! domain ) {
+		return null;
+	}
+
+	let transferEndDate = null;
+	if ( domain.transfer_start_date ) {
+		transferEndDate = new Date( domain.transfer_start_date );
+		transferEndDate.setDate( transferEndDate.getDate() + 7 ); // Add 7 days.
+		transferEndDate = transferEndDate.toISOString();
+	}
+
+	if ( domain.last_transfer_error && purchase.site_slug ) {
+		return (
+			<Text>
+				{ createInterpolateElement(
+					__(
+						'There was an error when initiating your domain transfer. Please <a>see the details or retry</a>.'
+					),
+					{
+						a: <a href={ domainManagementEdit( purchase.site_slug, domain.domain, null ) } />,
+					}
+				) }
+			</Text>
+		);
+	}
+
+	if (
+		domain.transfer_status === DomainTransferStatus.PENDING_START &&
+		purchase.site_slug &&
+		purchase.meta
+	) {
+		return (
+			<Text>
+				{ createInterpolateElement(
+					__( 'You need to <a>start the domain transfer</a> for your domain.' ),
+					{
+						a: (
+							<a
+								href={ domainUseMyDomain(
+									purchase.site_slug,
+									purchase.meta,
+									useMyDomainInputMode.startPendingTransfer
+								) }
+							/>
+						),
+					}
+				) }
+			</Text>
+		);
+	}
+
+	if ( domain.transfer_status === DomainTransferStatus.CANCELLED ) {
+		return (
+			<Text>
+				{ createInterpolateElement( __( 'Transfer failed. Learn the possible <ReasonsWhy />.' ), {
+					LearnMore: (
+						<ExternalLink
+							href={ INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS }
+							rel="noopener noreferrer"
+						>
+							{ __( 'reasons why' ) }
+						</ExternalLink>
+					),
+				} ) }
+			</Text>
+		);
+	}
+
+	if ( domain.transfer_status === DomainTransferStatus.PENDING_REGISTRY && transferEndDate ) {
+		return (
+			<Text>
+				{ createInterpolateElement(
+					__(
+						'The transfer should complete by <TransferFinishDate />. We are waiting for authorization from your current domain provider to proceed. <LearnMore />'
+					),
+					{
+						TransferFinishDate: (
+							<strong>
+								{ formatDate( new Date( transferEndDate ), locale, { dateStyle: 'long' } ) }
+							</strong>
+						),
+						LearnMore: (
+							<ExternalLink
+								href={ INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS }
+								rel="noopener noreferrer"
+							>
+								{ __( 'Learn more' ) }
+							</ExternalLink>
+						),
+					}
+				) }
+			</Text>
+		);
+	}
+
+	if ( domain.transfer_status === DomainTransferStatus.PENDING_REGISTRY ) {
+		return (
+			<Text>
+				{ createInterpolateElement(
+					__(
+						'We are waiting for authorization from your current domain provider to proceed. <LearnMore />'
+					),
+					{
+						LearnMore: (
+							<ExternalLink
+								href={ INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS }
+								rel="noopener noreferrer"
+							>
+								{ __( 'Learn more' ) }
+							</ExternalLink>
+						),
+					}
+				) }
+			</Text>
+		);
+	}
+
+	if ( transferEndDate ) {
+		return (
+			<Text>
+				{ createInterpolateElement(
+					__( 'The transfer should complete by <TransferFinishDate />. <LearnMore />' ),
+					{
+						TransferFinishDate: (
+							<strong>
+								{ formatDate( new Date( transferEndDate ), locale, { dateStyle: 'long' } ) }
+							</strong>
+						),
+						LearnMore: (
+							<ExternalLink
+								href={ INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS }
+								rel="noopener noreferrer"
+							>
+								{ __( 'Learn more' ) }
+							</ExternalLink>
+						),
+					}
+				) }
+			</Text>
+		);
+	}
+
+	return null;
+}
+
 function PurchaseSecondSubtitle( { purchase }: { purchase: Purchase } ) {
 	if ( purchase.is_domain ) {
 		if ( purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD ) {
@@ -875,7 +1031,6 @@ function PurchaseSecondSubtitle( { purchase }: { purchase: Purchase } ) {
 	}
 
 	if ( purchase.product_slug === DomainProductSlugs.TRANSFER_IN ) {
-		// FIXME: render domain transfer status (see resolveDomainStatus)
 		return (
 			<Text variant="muted">
 				{ __(
@@ -982,6 +1137,10 @@ export default function PurchaseSettings() {
 					/>
 					<PurchaseSubtitle purchase={ purchase } />
 					<PurchaseSecondSubtitle purchase={ purchase } />
+
+					{ purchase.product_slug === DomainProductSlugs.TRANSFER_IN && (
+						<DomainTransferInfo purchase={ purchase } />
+					) }
 					<ProductLink purchase={ purchase } />
 					<DomainRegistrationAgreement purchase={ purchase } />
 					{ ! purchase.partner_name && <PluginList purchase={ purchase } /> }

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -54,6 +54,7 @@ import {
 	isIncludedWithPlan,
 	isOneTimePurchase,
 	isMarketplaceTemporarySitePurchase,
+	isJetpackTemporarySitePurchase,
 	isAkismetProduct,
 	isAkismetFreeProduct,
 } from '../../../utils/purchase';
@@ -120,6 +121,14 @@ function getExpiredNewPlanUrl( purchase: Purchase ): string {
 	return `/plans/${ purchase.site_slug }`;
 }
 
+function canPurchaseBeUpgraded( purchase: Purchase ): boolean {
+	return Boolean(
+		purchase.is_upgradable &&
+			getUpgradeUrl( purchase ) &&
+			! isJetpackTemporarySitePurchase( purchase )
+	);
+}
+
 function upgradePurchase( upgradeUrl: string ): void {
 	window.location.href = upgradeUrl;
 }
@@ -152,7 +161,7 @@ function PurchaseActionMenu( { purchase }: { purchase: Purchase } ) {
 		<DropdownMenu icon={ moreVertical } label={ __( 'Quick actions' ) }>
 			{ () => (
 				<MenuGroup>
-					{ purchase.is_upgradable && upgradeUrl && (
+					{ canPurchaseBeUpgraded( purchase ) && upgradeUrl && (
 						<MenuItem
 							onClick={ () => {
 								recordTracksEvent( 'calypso_purchases_upgrade_plan', {
@@ -214,11 +223,10 @@ function PurchaseSettingsActions( {
 	const canCancel = purchase.is_cancelable;
 	const { recordTracksEvent } = useAnalytics();
 	// FIXME: show re-enable button (see subsReEnableText)
-	// FIXME: prevent rendering upgrade button if Jetpack temp site
 	return (
 		<VStack spacing={ 4 }>
 			<ActionList>
-				{ purchase.is_upgradable && upgradeUrl && (
+				{ canPurchaseBeUpgraded( purchase ) && upgradeUrl && (
 					<ActionList.ActionItem
 						title={ __( 'Upgrade subscription' ) }
 						description={ __( 'Find the best fit for your needs.' ) }
@@ -289,7 +297,7 @@ function PurchaseSettingsActions( {
 								variant="secondary"
 								size="compact"
 								onClick={ () => ( {
-									// FIXME
+									// FIXME: add cancel and downgrade action
 								} ) }
 							>
 								{ __( 'Downgrade or cancel' ) }
@@ -306,7 +314,7 @@ function PurchaseSettingsActions( {
 								variant="secondary"
 								size="compact"
 								onClick={ () => ( {
-									// FIXME
+									// FIXME: add remove action
 								} ) }
 							>
 								{ __( 'Remove subscription' ) }
@@ -534,7 +542,7 @@ export default function PurchaseSettings() {
 						actions={
 							site?.options?.admin_url && (
 								<>
-									{ purchase.is_upgradable && upgradeUrl && (
+									{ canPurchaseBeUpgraded( purchase ) && upgradeUrl && (
 										<Button __next40pxDefaultSize variant="primary" href={ upgradeUrl }>
 											{ __( 'Upgrade' ) }
 										</Button>

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -1,3 +1,4 @@
+import { domainManagementEdit } from '@automattic/domains-table/src/utils/paths';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { useRouter, Link } from '@tanstack/react-router';
@@ -47,8 +48,10 @@ import {
 	SubscriptionBillPeriod,
 	DomainProductSlugs,
 	WPCOM_DIFM_LITE,
+	OFFSITE_REDIRECT,
 } from '../../../data/constants';
 import { formatDate } from '../../../utils/datetime';
+import { getEmailManagementPath } from '../../../utils/email-paths';
 import {
 	getBillPeriodLabel,
 	getTitleForDisplay,
@@ -196,6 +199,32 @@ const BackButton = () => {
 		</Button>
 	);
 };
+
+function ProductLink( { purchase }: { purchase: Purchase } ) {
+	if ( purchase.is_plan && purchase.site_slug ) {
+		const url = '/plans/my-plan/' + purchase.site_slug;
+		const text = __( 'Plan features' );
+		return <a href={ url }>{ text }</a>;
+	}
+
+	if (
+		( purchase.is_domain || purchase.product_slug === OFFSITE_REDIRECT ) &&
+		purchase.site_slug &&
+		purchase.meta
+	) {
+		const url = domainManagementEdit( purchase.site_slug, purchase.meta );
+		const text = __( 'Domain settings' );
+		return <a href={ url }>{ text }</a>;
+	}
+
+	if ( isGoogleWorkspace( purchase ) || isTitanMail( purchase ) ) {
+		const url = getEmailManagementPath( purchase.site_slug, purchase.meta );
+		const text = __( 'Email settings' );
+		return <a href={ url }>{ text }</a>;
+	}
+
+	return null;
+}
 
 function PurchaseActionMenu( { purchase }: { purchase: Purchase } ) {
 	const { user } = useAuth();
@@ -883,7 +912,6 @@ export default function PurchaseSettings() {
 	} )();
 
 	// FIXME: render pluginList (see renderPluginLabel and getPluginsForSite)
-	// FIXME: render ProductLink for plan features, domain management, email management, or theme details
 
 	return (
 		<PageLayout
@@ -907,6 +935,7 @@ export default function PurchaseSettings() {
 						}
 					/>
 					<PurchaseSubtitle purchase={ purchase } />
+					<ProductLink purchase={ purchase } />
 					<DomainRegistrationAgreement purchase={ purchase } />
 				</VStack>
 			}

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -248,6 +248,9 @@ function PurchaseSettingsCardLinkWrapper( {
 }
 
 function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
+	// FIXME: render renderWordAdsEligibilityWarningDialog for refund/cancel
+	// FIXME: render renderNonPrimaryDomainWarningDialog for refund/cancel
+	// FIXME: render "Domain transfers can take anywhere from five to seven days to complete." next to cancel button (see domainTransferDuration)
 	if ( purchase.is_cancelable ) {
 		return (
 			<ActionList.ActionItem
@@ -258,7 +261,7 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 						variant="secondary"
 						size="compact"
 						onClick={ () => ( {
-							// FIXME: add cancel and downgrade action
+							// FIXME: add refund, cancel, and downgrade action
 						} ) }
 					>
 						{ __( 'Downgrade or cancel' ) }
@@ -406,7 +409,6 @@ function PurchaseSettingsCard( {
 	description?: ReactNode;
 	link?: string;
 } ) {
-	// FIXME: Add "Please contact partnerName" for partner purchase
 	return (
 		<PurchaseSettingsCardLinkWrapper link={ link }>
 			<Card className="purchase-settings-card">
@@ -552,6 +554,44 @@ function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
 	);
 }
 
+function PurchasePriceCard( { purchase }: { purchase: Purchase } ) {
+	if ( purchase.partner_name ) {
+		return (
+			<PurchaseSettingsCard
+				icon={ currencyDollar }
+				title={
+					// translators: partnerName is the name of a business partner through which this product was sold
+					sprintf( __( 'Please contact %(partnerName)s for details' ), {
+						partnerName: purchase.partner_name,
+					} )
+				}
+			/>
+		);
+	}
+	if ( isOneTimePurchase( purchase ) ) {
+		return (
+			<PurchaseSettingsCard
+				icon={ currencyDollar }
+				title={ __( 'Price' ) }
+				heading={ formatCurrency( purchase.regular_price_integer, purchase.currency_code, {
+					isSmallestUnit: true,
+				} ) }
+				description={ __( 'Excludes taxes.' ) }
+			/>
+		);
+	}
+	return (
+		<PurchaseSettingsCard
+			icon={ currencyDollar }
+			title={ __( 'Renewal price' ) }
+			heading={ formatCurrency( purchase.price_integer, purchase.currency_code, {
+				isSmallestUnit: true,
+			} ) }
+			description={ getBillPeriodLabel( purchase ) + ' ' + __( 'Excludes taxes.' ) }
+		/>
+	);
+}
+
 export default function PurchaseSettings() {
 	const { user } = useAuth();
 	const params = purchaseSettingsRoute.useParams();
@@ -583,14 +623,12 @@ export default function PurchaseSettings() {
 	} )();
 
 	// FIXME: add edit payment method button
-	// FIXME: add Jetpack CRM downloads link
-	// FIXME: render reinstall button
-	// FIXME: render "Domain transfers can take anywhere from five to seven days to complete."
-	// FIXME: render 'Domain Registration Agreement' and link
-	// FIXME: render DIFM content
-	// FIXME: render renderWordAdsEligibilityWarningDialog for refund/cancel
-	// FIXME: render renderNonPrimaryDomainWarningDialog for refund/cancel
-	// FIXME: render "X cheaper than monthly" upsell button
+	// FIXME: add Jetpack CRM downloads link (see renderCrmDownloadsNavItem)
+	// FIXME: render reinstall button (see renderReinstall)
+	// FIXME: render pluginList (see renderPluginLabel and getPluginsForSite)
+	// FIXME: render 'Domain Registration Agreement' and link (see domainRegistrationAgreementLinkText)
+	// FIXME: render DIFM content (BBEPurchaseDescription)
+	// FIXME: render ProductLink for plan features, domain management, email management, or theme details
 
 	return (
 		<PageLayout
@@ -648,14 +686,7 @@ export default function PurchaseSettings() {
 							return __( 'Auto-renew is disabled' );
 						} )() }
 					/>
-					<PurchaseSettingsCard
-						icon={ currencyDollar }
-						title={ __( 'Renewal price' ) }
-						heading={ formatCurrency( purchase.price_integer, purchase.currency_code, {
-							isSmallestUnit: true,
-						} ) }
-						description={ getBillPeriodLabel( purchase ) + ' ' + __( 'Excludes taxes.' ) }
-					/>
+					<PurchasePriceCard purchase={ purchase } />
 				</HStack>
 				<HStack spacing={ 6 } justify="flex-start" alignment="center">
 					<PurchaseSettingsCard

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -251,83 +251,105 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 	return null;
 }
 
-function PurchaseSettingsActions( {
-	purchase,
-	upgradeUrl,
-}: {
-	purchase: Purchase;
-	upgradeUrl: string | undefined;
-} ) {
+function UpgradeActionButton( { purchase }: { purchase: Purchase } ) {
+	const { recordTracksEvent } = useAnalytics();
+	if ( ! canPurchaseBeUpgraded( purchase ) ) {
+		return null;
+	}
+	const upgradeUrl = getUpgradeUrl( purchase );
+	if ( ! upgradeUrl ) {
+		return null;
+	}
+	return (
+		<ActionList.ActionItem
+			title={ __( 'Upgrade subscription' ) }
+			description={ __( 'Find the best fit for your needs.' ) }
+			actions={
+				<Button
+					variant="secondary"
+					size="compact"
+					onClick={ () => {
+						recordTracksEvent( 'calypso_purchases_upgrade_plan', {
+							status: isExpired( purchase ) ? 'expired' : 'active',
+							plan: purchase.product_name,
+						} );
+						upgradePurchase( upgradeUrl );
+					} }
+				>
+					{ __( 'Upgrade subscription' ) }
+				</Button>
+			}
+		/>
+	);
+}
+
+function ReSubscribeActionButton( { purchase }: { purchase: Purchase } ) {
+	const { recordTracksEvent } = useAnalytics();
+	if ( ! isExpired( purchase ) ) {
+		return null;
+	}
+	return (
+		<ActionList.ActionItem
+			title={ purchase.is_plan ? __( 'Pick another plan' ) : __( 'Pick another product' ) }
+			description={ __( 'Find the best fit for your needs.' ) }
+			actions={
+				<Button
+					variant="secondary"
+					size="compact"
+					onClick={ () => {
+						recordTracksEvent( 'calypso_purchases_upgrade_plan', {
+							status: isExpired( purchase ) ? 'expired' : 'active',
+							plan: purchase.product_name,
+						} );
+						window.location.href = getExpiredNewPlanUrl( purchase );
+					} }
+				>
+					{ purchase.is_plan ? __( 'Pick another plan' ) : __( 'Pick another product' ) }
+				</Button>
+			}
+		/>
+	);
+}
+
+function RenewActionButton( { purchase }: { purchase: Purchase } ) {
 	const { user } = useAuth();
 	const canBeRenewed =
 		purchase.can_explicit_renew && String( user.ID ) === String( purchase.user_id );
 	const { recordTracksEvent } = useAnalytics();
+	if ( ! canBeRenewed ) {
+		return null;
+	}
+
+	return (
+		<ActionList.ActionItem
+			title={ __( 'Renew now' ) }
+			description={ __( 'Renew your subscription manually.' ) }
+			actions={
+				<Button
+					variant="secondary"
+					size="compact"
+					onClick={ () => {
+						recordTracksEvent( 'calypso_purchases_renew_now_click', {
+							product_slug: purchase.product_slug,
+						} );
+						renewPurchase( purchase );
+					} }
+				>
+					{ __( 'Renew' ) }
+				</Button>
+			}
+		/>
+	);
+}
+
+function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
 	// FIXME: show re-enable button (see subsReEnableText)
 	return (
 		<VStack spacing={ 4 }>
 			<ActionList>
-				{ canPurchaseBeUpgraded( purchase ) && upgradeUrl && (
-					<ActionList.ActionItem
-						title={ __( 'Upgrade subscription' ) }
-						description={ __( 'Find the best fit for your needs.' ) }
-						actions={
-							<Button
-								variant="secondary"
-								size="compact"
-								onClick={ () => {
-									recordTracksEvent( 'calypso_purchases_upgrade_plan', {
-										status: isExpired( purchase ) ? 'expired' : 'active',
-										plan: purchase.product_name,
-									} );
-									upgradePurchase( upgradeUrl );
-								} }
-							>
-								{ __( 'Upgrade subscription' ) }
-							</Button>
-						}
-					/>
-				) }
-				{ isExpired( purchase ) && (
-					<ActionList.ActionItem
-						title={ purchase.is_plan ? __( 'Pick another plan' ) : __( 'Pick another product' ) }
-						description={ __( 'Find the best fit for your needs.' ) }
-						actions={
-							<Button
-								variant="secondary"
-								size="compact"
-								onClick={ () => {
-									recordTracksEvent( 'calypso_purchases_upgrade_plan', {
-										status: isExpired( purchase ) ? 'expired' : 'active',
-										plan: purchase.product_name,
-									} );
-									window.location.href = getExpiredNewPlanUrl( purchase );
-								} }
-							>
-								{ purchase.is_plan ? __( 'Pick another plan' ) : __( 'Pick another product' ) }
-							</Button>
-						}
-					/>
-				) }
-				{ canBeRenewed && (
-					<ActionList.ActionItem
-						title={ __( 'Renew now' ) }
-						description={ __( 'Renew your subscription manually.' ) }
-						actions={
-							<Button
-								variant="secondary"
-								size="compact"
-								onClick={ () => {
-									recordTracksEvent( 'calypso_purchases_renew_now_click', {
-										product_slug: purchase.product_slug,
-									} );
-									renewPurchase( purchase );
-								} }
-							>
-								{ __( 'Renew' ) }
-							</Button>
-						}
-					/>
-				) }
+				<UpgradeActionButton purchase={ purchase } />
+				<ReSubscribeActionButton purchase={ purchase } />
+				<RenewActionButton purchase={ purchase } />
 				<CancelOrRemoveActionButton purchase={ purchase } />
 			</ActionList>
 		</VStack>
@@ -625,7 +647,7 @@ export default function PurchaseSettings() {
 					/>
 				</HStack>
 				<ManageSubscriptionCard purchase={ purchase } />
-				<PurchaseSettingsActions purchase={ purchase } upgradeUrl={ upgradeUrl } />
+				<PurchaseSettingsActions purchase={ purchase } />
 			</VStack>
 		</PageLayout>
 	);

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -57,7 +57,8 @@ import {
 	isAkismetProduct,
 } from '../../../utils/purchase';
 import { encodeProductForUrl } from '../../../utils/wpcom-checkout';
-import { getPurchaseUrlForId } from '../urls';
+import { PurchasePaymentMethod } from '../purchase-payment-method';
+import { getPurchaseUrlForId, getAddPaymentMethodUrlFor } from '../urls';
 import type { User } from '../../../data/me';
 import type { Purchase } from '../../../data/purchase';
 import type { Field } from '@wordpress/dataviews';
@@ -545,6 +546,11 @@ function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
 							{ error.message }
 						</Notice>
 					) }
+
+					<PurchasePaymentMethod
+						purchase={ purchase }
+						getAddPaymentMethodUrlFor={ getAddPaymentMethodUrlFor }
+					/>
 				</VStack>
 			</CardBody>
 		</Card>
@@ -619,7 +625,6 @@ export default function PurchaseSettings() {
 		return __( 'Expires' );
 	} )();
 
-	// FIXME: add edit payment method button
 	// FIXME: add Jetpack CRM downloads link (see renderCrmDownloadsNavItem)
 	// FIXME: render reinstall button (see renderReinstall)
 	// FIXME: render pluginList (see renderPluginLabel and getPluginsForSite)

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -106,6 +106,13 @@ function getUpgradeUrl( purchase: Purchase ): string | undefined {
 	return `/plans/${ purchase.site_slug }`;
 }
 
+function getExpiredNewPlanUrl( purchase: Purchase ): string {
+	if ( purchase.is_jetpack_backup_t1 ) {
+		return `/plans/storage/${ purchase.site_slug }`;
+	}
+	return `/plans/${ purchase.site_slug }`;
+}
+
 function upgradePurchase( upgradeUrl: string ): void {
 	window.location.href = upgradeUrl;
 }
@@ -129,7 +136,6 @@ const BackButton = () => {
 };
 
 function PurchaseActionMenu( { purchase }: { purchase: Purchase } ) {
-	// FIXME: figure out what other actions to include here
 	const canBeRenewed = purchase.can_explicit_renew;
 	const upgradeUrl = getUpgradeUrl( purchase );
 	const { recordTracksEvent } = useAnalytics();
@@ -192,8 +198,6 @@ function PurchaseSettingsActions( {
 	purchase: Purchase;
 	upgradeUrl: string | undefined;
 } ) {
-	// FIXME: include "Pick another plan"/"Pick another product" if purchase is expired
-	// FIXME: determine what other actions to include
 	const canBeRemoved = ! isExpired( purchase ) && ! isIncludedWithPlan( purchase );
 	const canBeRenewed = purchase.can_explicit_renew;
 	const canCancel = purchase.is_cancelable;
@@ -218,6 +222,27 @@ function PurchaseSettingsActions( {
 								} }
 							>
 								{ __( 'Upgrade subscription' ) }
+							</Button>
+						}
+					/>
+				) }
+				{ isExpired( purchase ) && (
+					<ActionList.ActionItem
+						title={ purchase.is_plan ? __( 'Pick another plan' ) : __( 'Pick another product' ) }
+						description={ __( 'Find the best fit for your needs.' ) }
+						actions={
+							<Button
+								variant="secondary"
+								size="compact"
+								onClick={ () => {
+									recordTracksEvent( 'calypso_purchases_upgrade_plan', {
+										status: isExpired( purchase ) ? 'expired' : 'active',
+										plan: purchase.product_name,
+									} );
+									window.location.href = getExpiredNewPlanUrl( purchase );
+								} }
+							>
+								{ purchase.is_plan ? __( 'Pick another plan' ) : __( 'Pick another product' ) }
 							</Button>
 						}
 					/>

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -32,6 +32,7 @@ import { useAuth } from '../../../app/auth';
 import { useLocale } from '../../../app/locale';
 import { purchaseQuery, userPurchaseSetAutoRenewQuery } from '../../../app/queries/me-purchases';
 import { siteBySlugQuery } from '../../../app/queries/site';
+import { reinstallMarketplacePluginsQuery } from '../../../app/queries/site-marketplace';
 import { purchaseSettingsRoute } from '../../../app/router/me';
 import { ActionList } from '../../../components/action-list';
 import { useFormattedTime } from '../../../components/formatted-time';
@@ -53,6 +54,7 @@ import {
 	isIncludedWithPlan,
 	isOneTimePurchase,
 	isMarketplaceTemporarySitePurchase,
+	isMarketplacePlugin,
 	isJetpackTemporarySitePurchase,
 	isAkismetProduct,
 	isJetpackCrmProduct,
@@ -414,10 +416,53 @@ function JetpackCRMDownloadsButton( { purchase }: { purchase: Purchase } ) {
 	);
 }
 
+function ReinstallButton( { purchase }: { purchase: Purchase } ) {
+	const {
+		mutate: reinstallPlugins,
+		error,
+		isPending: isMutationPending,
+	} = useMutation( reinstallMarketplacePluginsQuery( parseInt( purchase.blog_id ) ) );
+	if ( ! isMarketplacePlugin( purchase ) ) {
+		return null;
+	}
+	if ( isMarketplaceTemporarySitePurchase( purchase ) ) {
+		return null;
+	}
+
+	return (
+		<ActionList.ActionItem
+			title={ __( 'Reinstall plugins' ) }
+			actions={
+				<>
+					<Button
+						variant="secondary"
+						size="compact"
+						disabled={ isMutationPending }
+						onClick={ () => {
+							reinstallPlugins();
+						} }
+					>
+						{ __( 'Reinstall plugins' ) }
+					</Button>
+					{
+						// FIXME: there's probably a better place for this error message
+						error && (
+							<Notice status="error" isDismissible={ false }>
+								{ error.message }
+							</Notice>
+						)
+					}
+				</>
+			}
+		/>
+	);
+}
+
 function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
 	return (
 		<VStack spacing={ 4 }>
 			<ActionList>
+				<ReinstallButton purchase={ purchase } />
 				<JetpackCRMDownloadsButton purchase={ purchase } />
 				<UpgradeActionButton purchase={ purchase } />
 				<ReSubscribeActionButton purchase={ purchase } />
@@ -659,7 +704,6 @@ export default function PurchaseSettings() {
 		return __( 'Expires' );
 	} )();
 
-	// FIXME: render reinstall button (see renderReinstall)
 	// FIXME: render pluginList (see renderPluginLabel and getPluginsForSite)
 	// FIXME: render 'Domain Registration Agreement' and link (see domainRegistrationAgreementLinkText)
 	// FIXME: render DIFM content (BBEPurchaseDescription)

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -55,6 +55,7 @@ import {
 	isMarketplaceTemporarySitePurchase,
 	isJetpackTemporarySitePurchase,
 	isAkismetProduct,
+	isJetpackCrmProduct,
 } from '../../../utils/purchase';
 import { encodeProductForUrl } from '../../../utils/wpcom-checkout';
 import { PurchasePaymentMethod } from '../purchase-payment-method';
@@ -381,10 +382,43 @@ function RenewActionButton( { purchase }: { purchase: Purchase } ) {
 	);
 }
 
+function JetpackCRMDownloadsButton( { purchase }: { purchase: Purchase } ) {
+	const { recordTracksEvent } = useAnalytics();
+
+	// Only show for Jetpack CRM Products
+	if ( ! isJetpackCrmProduct( purchase.product_slug ) ) {
+		return null;
+	}
+
+	// We'll pass the purchase ID in the URL, and the CRM Downloads component will fetch the actual license key
+	const path = `/purchases/crm-downloads/${ purchase.ID }`;
+
+	return (
+		<ActionList.ActionItem
+			title={ __( 'CRM Downloads' ) }
+			actions={
+				<Button
+					variant="secondary"
+					size="compact"
+					onClick={ () => {
+						recordTracksEvent( 'calypso_purchases_crm_downloads_click', {
+							product_slug: purchase.product_slug,
+						} );
+						window.location.href = path;
+					} }
+				>
+					{ __( 'CRM Downloads' ) }
+				</Button>
+			}
+		/>
+	);
+}
+
 function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
 	return (
 		<VStack spacing={ 4 }>
 			<ActionList>
+				<JetpackCRMDownloadsButton purchase={ purchase } />
 				<UpgradeActionButton purchase={ purchase } />
 				<ReSubscribeActionButton purchase={ purchase } />
 				<RenewActionButton purchase={ purchase } />
@@ -625,7 +659,6 @@ export default function PurchaseSettings() {
 		return __( 'Expires' );
 	} )();
 
-	// FIXME: add Jetpack CRM downloads link (see renderCrmDownloadsNavItem)
 	// FIXME: render reinstall button (see renderReinstall)
 	// FIXME: render pluginList (see renderPluginLabel and getPluginsForSite)
 	// FIXME: render 'Domain Registration Agreement' and link (see domainRegistrationAgreementLinkText)

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -27,6 +27,7 @@ import {
 	siteLogo,
 	commentAuthorAvatar,
 } from '@wordpress/icons';
+import { useAnalytics } from '../../../app/analytics';
 import { useAuth } from '../../../app/auth';
 import { useLocale } from '../../../app/locale';
 import { purchaseQuery, userPurchaseSetAutoRenewQuery } from '../../../app/queries/me-purchases';
@@ -46,13 +47,39 @@ import {
 	isRenewing,
 	isIncludedWithPlan,
 	isOneTimePurchase,
+	isMarketplaceTemporarySitePurchase,
+	isAkismetProduct,
 } from '../../../utils/purchase';
+import { encodeProductForUrl } from '../../../utils/wpcom-checkout';
 import { getPurchaseUrlForId } from '../urls';
 import type { Purchase } from '../../../data/purchase';
 import type { Field } from '@wordpress/dataviews';
 import type { ReactNode, ReactElement } from 'react';
 
 import './style.scss';
+
+function getServicePathForCheckoutFromPurchase( purchase: Purchase ): string {
+	if ( isAkismetProduct( purchase ) ) {
+		return 'akismet/';
+	}
+	if ( isMarketplaceTemporarySitePurchase( purchase ) ) {
+		return 'marketplace/';
+	}
+	return '';
+}
+
+function getRenewalUrlFromPurchase( purchase: Purchase ): string {
+	const productSlug = encodeProductForUrl( purchase.product_slug );
+	const productDomain = purchase.meta ? encodeProductForUrl( purchase.meta ) : undefined;
+	const checkoutProductSlug = productDomain ? `${ productSlug }:${ productDomain }` : productSlug;
+	const checkoutSiteSlug = purchase.site_slug || '';
+	const servicePath = getServicePathForCheckoutFromPurchase( purchase );
+	return `/checkout/${ servicePath }${ checkoutProductSlug }/renew/${ purchase.ID }/${ checkoutSiteSlug }`;
+}
+
+function renewPurchase( purchase: Purchase ): void {
+	window.location.href = getRenewalUrlFromPurchase( purchase );
+}
 
 const BackButton = () => {
 	const router = useRouter();
@@ -72,18 +99,31 @@ const BackButton = () => {
 	);
 };
 
-const PurchaseActionMenu = () => {
+function PurchaseActionMenu( { purchase }: { purchase: Purchase } ) {
 	// FIXME: figure out what these actions should be
+	const canBeRenewed = purchase.can_explicit_renew;
+	const { recordTracksEvent } = useAnalytics();
 	return (
 		<DropdownMenu icon={ moreVertical } label={ __( 'Quick actions' ) }>
 			{ () => (
 				<MenuGroup>
-					<MenuItem onClick={ () => ( {} ) }>Do something</MenuItem>
+					{ canBeRenewed && (
+						<MenuItem
+							onClick={ () => {
+								recordTracksEvent( 'calypso_purchases_renew_now_click', {
+									product_slug: purchase.product_slug,
+								} );
+								renewPurchase( purchase );
+							} }
+						>
+							{ __( 'Renew' ) }
+						</MenuItem>
+					) }
 				</MenuGroup>
 			) }
 		</DropdownMenu>
 	);
-};
+}
 
 function PurchaseSettingsCardLinkWrapper( {
 	link,
@@ -113,6 +153,7 @@ function PurchaseSettingsActions( {
 	const canBeRemoved = ! isExpired( purchase ) && ! isIncludedWithPlan( purchase );
 	const canBeRenewed = purchase.can_explicit_renew;
 	const canCancel = purchase.is_cancelable;
+	const { recordTracksEvent } = useAnalytics();
 	return (
 		<VStack spacing={ 4 }>
 			<ActionList>
@@ -141,9 +182,12 @@ function PurchaseSettingsActions( {
 							<Button
 								variant="secondary"
 								size="compact"
-								onClick={ () => ( {
-									// FIXME
-								} ) }
+								onClick={ () => {
+									recordTracksEvent( 'calypso_purchases_renew_now_click', {
+										product_slug: purchase.product_slug,
+									} );
+									renewPurchase( purchase );
+								} }
 							>
 								{ __( 'Renew' ) }
 							</Button>
@@ -381,7 +425,7 @@ export default function PurchaseSettings() {
 											{ __( 'Upgrade plan' ) }
 										</Button>
 									) }
-									<PurchaseActionMenu />
+									<PurchaseActionMenu purchase={ purchase } />
 								</>
 							)
 						}

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -36,9 +36,11 @@ import { useLocale } from '../../../app/locale';
 import { purchaseQuery, userPurchaseSetAutoRenewQuery } from '../../../app/queries/me-purchases';
 import { siteBySlugQuery } from '../../../app/queries/site';
 import { siteDifmWebsiteContentQuery } from '../../../app/queries/site-do-it-for-me';
+import { siteJetpackKeysQuery } from '../../../app/queries/site-jetpack-keys';
 import { reinstallMarketplacePluginsQuery } from '../../../app/queries/site-marketplace';
 import { purchaseSettingsRoute } from '../../../app/router/me';
 import { ActionList } from '../../../components/action-list';
+import ClipboardInputControl from '../../../components/clipboard-input-control';
 import { useFormattedTime } from '../../../components/formatted-time';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
@@ -721,6 +723,40 @@ function DomainRegistrationAgreement( { purchase }: { purchase: Purchase } ) {
 	);
 }
 
+function getPluginLabel( pluginSlug: string ) {
+	switch ( pluginSlug ) {
+		case 'vaultpress':
+			return __( 'Backups and security scanning API key' );
+		case 'akismet':
+			return __( 'Akismet Anti-spam API key' );
+		default:
+			return pluginSlug;
+	}
+}
+
+function PluginList( { purchase }: { purchase: Purchase } ) {
+	const { data: pluginList } = useQuery( siteJetpackKeysQuery( parseInt( purchase.blog_id ) ) );
+	if ( ! pluginList?.length ) {
+		return null;
+	}
+	return (
+		<div>
+			{ pluginList.map( ( plugin ) => {
+				return (
+					<div key={ plugin.slug }>
+						<ClipboardInputControl
+							label={ getPluginLabel( plugin.slug ) }
+							value={ plugin.key }
+							readOnly
+							__next40pxDefaultSize
+						/>
+					</div>
+				);
+			} ) }
+		</div>
+	);
+}
+
 function BBEPurchaseDescription( { purchase }: { purchase: Purchase } ) {
 	const { data: isSubmitted } = useQuery( {
 		...siteDifmWebsiteContentQuery( parseInt( purchase.blog_id ) ),
@@ -923,8 +959,6 @@ export default function PurchaseSettings() {
 		return __( 'Expires' );
 	} )();
 
-	// FIXME: render pluginList (see renderPluginLabel and getPluginsForSite)
-
 	return (
 		<PageLayout
 			size="small"
@@ -950,6 +984,7 @@ export default function PurchaseSettings() {
 					<PurchaseSecondSubtitle purchase={ purchase } />
 					<ProductLink purchase={ purchase } />
 					<DomainRegistrationAgreement purchase={ purchase } />
+					{ ! purchase.partner_name && <PluginList purchase={ purchase } /> }
 				</VStack>
 			}
 		>

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -18,7 +18,8 @@ import {
 	ExternalLink,
 } from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
-import { __, isRTL, sprintf } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, _n, isRTL, sprintf } from '@wordpress/i18n';
 import {
 	moreVertical,
 	chevronLeft,
@@ -33,6 +34,7 @@ import { useAuth } from '../../../app/auth';
 import { useLocale } from '../../../app/locale';
 import { purchaseQuery, userPurchaseSetAutoRenewQuery } from '../../../app/queries/me-purchases';
 import { siteBySlugQuery } from '../../../app/queries/site';
+import { siteDifmWebsiteContentQuery } from '../../../app/queries/site-do-it-for-me';
 import { reinstallMarketplacePluginsQuery } from '../../../app/queries/site-marketplace';
 import { purchaseSettingsRoute } from '../../../app/router/me';
 import { ActionList } from '../../../components/action-list';
@@ -43,6 +45,8 @@ import {
 	ProductUpgradeMap,
 	AkismetUpgradesProductMap,
 	SubscriptionBillPeriod,
+	DomainProductSlugs,
+	WPCOM_DIFM_LITE,
 } from '../../../data/constants';
 import { formatDate } from '../../../utils/datetime';
 import {
@@ -59,6 +63,8 @@ import {
 	isJetpackTemporarySitePurchase,
 	isAkismetProduct,
 	isJetpackCrmProduct,
+	isTitanMail,
+	isGoogleWorkspace,
 } from '../../../utils/purchase';
 import { encodeProductForUrl } from '../../../utils/wpcom-checkout';
 import { PurchasePaymentMethod } from '../purchase-payment-method';
@@ -686,6 +692,167 @@ function DomainRegistrationAgreement( { purchase }: { purchase: Purchase } ) {
 	);
 }
 
+function BBEPurchaseDescription( { purchase }: { purchase: Purchase } ) {
+	const { data: isSubmitted } = useQuery( {
+		...siteDifmWebsiteContentQuery( parseInt( purchase.blog_id ) ),
+		select: ( data ) => data.is_website_content_submitted,
+	} );
+	if ( purchase.product_slug !== WPCOM_DIFM_LITE ) {
+		return null;
+	}
+	if ( ! purchase.site_slug ) {
+		return null;
+	}
+	if ( purchase.price_tier_list.length === 0 || ! purchase.renewal_price_tier_usage_quantity ) {
+		return null;
+	}
+
+	const [ tier0 ] = purchase.price_tier_list;
+	if ( ! tier0.maximum_units ) {
+		return null;
+	}
+	const extraPageCount = purchase.renewal_price_tier_usage_quantity - tier0.maximum_units;
+
+	const BBESupportLink = (
+		<a
+			href={ `mailto:services+express@wordpress.com?subject=${ encodeURIComponent(
+				`I have a question about my project: ${ purchase.site_slug }`
+			) }` }
+		>
+			{ __( 'Contact us' ) }
+		</a>
+	);
+
+	return (
+		<div>
+			<div>
+				{ tier0.maximum_units === 1
+					? __( 'A professionally built single page website in 4 business days or less.' )
+					: sprintf(
+							// translators: numberOfIncludedPages is a number of pages
+							__(
+								'A professionally built %(numberOfIncludedPages)s-page website in 4 business days or less.'
+							),
+							{
+								numberOfIncludedPages: tier0.maximum_units,
+							}
+					  ) }{ ' ' }
+				{ extraPageCount > 0 &&
+					sprintf(
+						// translators: numberofPages is a number of pages
+						_n(
+							'This purchase includes %(numberOfPages)d extra page.',
+							'This purchase includes %(numberOfPages)d extra pages.',
+							extraPageCount ?? 0
+						),
+						{
+							numberOfPages: extraPageCount,
+						}
+					) }
+			</div>
+			<div>
+				{ isSubmitted
+					? createInterpolateElement(
+							// translators: ContactUs is a link to send an email to support
+							__( '<ContactUs /> with any questions or inquiries about your project.' ),
+							{
+								ContactUs: BBESupportLink,
+							}
+					  )
+					: createInterpolateElement(
+							// translators: ContactUs is a link to send an email to support and SubmitContent is a link to the signup flow for site creation
+							__(
+								'<SubmitContent /> for your website build or <ContactUs /> with any questions about your project.'
+							),
+							{
+								SubmitContent: (
+									<a
+										href={ `/start/site-content-collection/website-content?siteSlug=${ purchase.site_slug }` }
+									>
+										{ __( 'Submit content' ) }
+									</a>
+								),
+								ContactUs: BBESupportLink,
+							}
+					  ) }
+			</div>
+		</div>
+	);
+}
+
+function PurchaseSubtitle( { purchase }: { purchase: Purchase } ) {
+	if ( purchase.is_domain ) {
+		if ( purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD ) {
+			return __(
+				'Your stories, achievements, and memories preserved for generations to come. One payment. One hundred years of legacy.'
+			);
+		}
+
+		return (
+			<span>
+				{ createInterpolateElement(
+					// translators: SiteUrl is the URL of the site and Domain is the domain name of the site.
+					__(
+						"When used with a paid plan, your custom domain can replace your site's free address, <SiteUrl />, with <Domain />, making it easier to remember and easier to share."
+					),
+					{
+						SiteUrl: <strong>{ purchase.domain }</strong>,
+						Domain: <strong>{ purchase.meta }</strong>,
+					}
+				) }
+			</span>
+		);
+	}
+
+	if ( purchase.product_slug === DomainProductSlugs.TRANSFER_IN ) {
+		// FIXME: render domain transfer status (see resolveDomainStatus)
+		return __(
+			'Transfers an existing domain from another provider to WordPress.com, helping you manage your site and domain in one place.'
+		);
+	}
+
+	if ( isGoogleWorkspace( purchase ) || isTitanMail( purchase ) ) {
+		const description = isTitanMail( purchase )
+			? __(
+					'Integrated email solution with powerful features. Manage your email and more on any device.'
+			  )
+			: __(
+					'Business email with Gmail. Includes other collaboration and productivity tools from Google.'
+			  );
+
+		if ( purchase.renewal_price_tier_usage_quantity ) {
+			return (
+				<span>
+					{ description }{ ' ' }
+					{ sprintf(
+						// translators: numberOfMailboxes is a number and domain is a domain name
+						_n(
+							'This purchase is for %(numberOfMailboxes)d mailbox for the domain %(domain)s.',
+							'This purchase is for %(numberOfMailboxes)d mailboxes for the domain %(domain)s.',
+							purchase.renewal_price_tier_usage_quantity
+						),
+						{
+							numberOfMailboxes: purchase.renewal_price_tier_usage_quantity,
+							domain: purchase.meta,
+						}
+					) }
+				</span>
+			);
+		}
+		return description;
+	}
+
+	if ( purchase.product_slug === WPCOM_DIFM_LITE ) {
+		return <BBEPurchaseDescription purchase={ purchase } />;
+	}
+
+	const subtitle = getSubtitleForDisplay( purchase );
+	if ( ! subtitle ) {
+		return null;
+	}
+	return <Text variant="muted">{ subtitle }</Text>;
+}
+
 export default function PurchaseSettings() {
 	const { user } = useAuth();
 	const params = purchaseSettingsRoute.useParams();
@@ -704,7 +871,6 @@ export default function PurchaseSettings() {
 		return null;
 	}
 	const upgradeUrl = getUpgradeUrl( purchase );
-	const subtitle = getSubtitleForDisplay( purchase );
 	const willRenew = Boolean( purchase.renew_date && ! isExpiring( purchase ) );
 	const expiryDateTitle = ( () => {
 		if ( purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD ) {
@@ -717,7 +883,6 @@ export default function PurchaseSettings() {
 	} )();
 
 	// FIXME: render pluginList (see renderPluginLabel and getPluginsForSite)
-	// FIXME: render DIFM content (BBEPurchaseDescription)
 	// FIXME: render ProductLink for plan features, domain management, email management, or theme details
 
 	return (
@@ -741,7 +906,7 @@ export default function PurchaseSettings() {
 							)
 						}
 					/>
-					{ subtitle && <Text variant="muted">{ subtitle }</Text> }
+					<PurchaseSubtitle purchase={ purchase } />
 					<DomainRegistrationAgreement purchase={ purchase } />
 				</VStack>
 			}

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -202,6 +202,9 @@ function PurchaseSettingsActions( {
 	const canBeRenewed = purchase.can_explicit_renew;
 	const canCancel = purchase.is_cancelable;
 	const { recordTracksEvent } = useAnalytics();
+	// FIXME: prevent renew if purchase.isLocked
+	// FIXME: prevent renew if not product owner
+	// FIXME: prevent rendering upgrade button if Jetpack temp site
 	return (
 		<VStack spacing={ 4 }>
 			<ActionList>
@@ -319,6 +322,7 @@ function PurchaseSettingsCard( {
 	description?: ReactNode;
 	link?: string;
 } ) {
+	// FIXME: Add "Please contact partnerName" for partner purchase
 	return (
 		<PurchaseSettingsCardLinkWrapper link={ link }>
 			<Card className="purchase-settings-card">
@@ -477,6 +481,18 @@ export default function PurchaseSettings() {
 	}
 	const upgradeUrl = getUpgradeUrl( purchase );
 	const subtitle = getSubtitleForDisplay( purchase );
+	// FIXME: prevent renewal for preventRenewal
+	// FIXME: prevent renewal for isPendingDomainRegistration
+	// FIXME: add edit payment method button
+	// FIXME: add Jetpack CRM downloads link
+	// FIXME: render reinstall button
+	// FIXME: render "100-Year Domain Registration" in place of getTitleForDisplay for 100 year domain
+	// FIXME: render "Domain transfers can take anywhere from five to seven days to complete."
+	// FIXME: render 'Domain Registration Agreement' and link
+	// FIXME: render DIFM content
+	// FIXME: render renderWordAdsEligibilityWarningDialog for refund/cancel
+	// FIXME: render renderNonPrimaryDomainWarningDialog for refund/cancel
+	// FIXME: render "X cheaper than monthly" upsell button
 
 	return (
 		<PageLayout
@@ -567,9 +583,7 @@ export default function PurchaseSettings() {
 					/>
 				</HStack>
 				<ManageSubscriptionCard purchase={ purchase } />
-				{ ! isExpired( purchase ) && (
-					<PurchaseSettingsActions purchase={ purchase } upgradeUrl={ upgradeUrl } />
-				) }
+				<PurchaseSettingsActions purchase={ purchase } upgradeUrl={ upgradeUrl } />
 			</VStack>
 		</PageLayout>
 	);

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -41,6 +41,7 @@ import {
 	ProductUpgradeMap,
 	AkismetUpgradesProductMap,
 	DomainProductSlugs,
+	SubscriptionBillPeriod,
 } from '../../../data/constants';
 import { formatDate } from '../../../utils/datetime';
 import {
@@ -213,7 +214,6 @@ function PurchaseSettingsActions( {
 	const canCancel = purchase.is_cancelable;
 	const { recordTracksEvent } = useAnalytics();
 	// FIXME: show re-enable button (see subsReEnableText)
-	// FIXME: show "Paid until" for date for 100 year plan instead of expiry date title
 	// FIXME: prevent rendering upgrade button if Jetpack temp site
 	return (
 		<VStack spacing={ 4 }>
@@ -502,6 +502,17 @@ export default function PurchaseSettings() {
 	}
 	const upgradeUrl = getUpgradeUrl( purchase );
 	const subtitle = getSubtitleForDisplay( purchase );
+	const willRenew = Boolean( purchase.renew_date && ! isExpiring( purchase ) );
+	const expiryDateTitle = ( () => {
+		if ( purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD ) {
+			return __( 'Paid until' );
+		}
+		if ( willRenew ) {
+			return __( 'Renews' );
+		}
+		return __( 'Expires' );
+	} )();
+
 	// FIXME: add edit payment method button
 	// FIXME: add Jetpack CRM downloads link
 	// FIXME: render reinstall button
@@ -541,14 +552,12 @@ export default function PurchaseSettings() {
 				<HStack spacing={ 6 } justify="flex-start" alignment="center">
 					<PurchaseSettingsCard
 						icon={ calendar }
-						title={
-							purchase.renew_date && ! isExpiring( purchase ) ? __( 'Renews' ) : __( 'Expires' )
-						}
+						title={ expiryDateTitle }
 						heading={ ( () => {
 							if ( isOneTimePurchase( purchase ) ) {
 								return __( 'Never expires' );
 							}
-							if ( purchase.renew_date && ! isExpiring( purchase ) ) {
+							if ( willRenew ) {
 								return formattedRenewal;
 							}
 							return formattedExpiry;

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -37,6 +37,7 @@ import { ActionList } from '../../../components/action-list';
 import { useFormattedTime } from '../../../components/formatted-time';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
+import { ProductUpgradeMap, AkismetUpgradesProductMap } from '../../../data/constants';
 import { formatDate } from '../../../utils/datetime';
 import {
 	getBillPeriodLabel,
@@ -81,6 +82,34 @@ function renewPurchase( purchase: Purchase ): void {
 	window.location.href = getRenewalUrlFromPurchase( purchase );
 }
 
+function getUpgradeUrl( purchase: Purchase ): string | undefined {
+	if ( isAkismetProduct( purchase ) ) {
+		// For the first Iteration of Calypso Akismet checkout we are only suggesting
+		// for immediate upgrades to the next plan. We will change this in the future
+		// with appropriate page.
+		const upgradeProductPath = AkismetUpgradesProductMap[ purchase.product_slug ];
+		if ( upgradeProductPath ) {
+			return upgradeProductPath;
+		}
+		return undefined;
+	}
+
+	const upgradeProductSlug = ProductUpgradeMap[ purchase.product_slug ];
+	if ( upgradeProductSlug ) {
+		return `/checkout/${ purchase.site_slug }/${ upgradeProductSlug }`;
+	}
+
+	if ( purchase.is_jetpack_backup_t1 ) {
+		return `/plans/storage/${ purchase.site_slug }`;
+	}
+
+	return `/plans/${ purchase.site_slug }`;
+}
+
+function upgradePurchase( upgradeUrl: string ): void {
+	window.location.href = upgradeUrl;
+}
+
 const BackButton = () => {
 	const router = useRouter();
 
@@ -100,13 +129,27 @@ const BackButton = () => {
 };
 
 function PurchaseActionMenu( { purchase }: { purchase: Purchase } ) {
-	// FIXME: figure out what these actions should be
+	// FIXME: figure out what other actions to include here
 	const canBeRenewed = purchase.can_explicit_renew;
+	const upgradeUrl = getUpgradeUrl( purchase );
 	const { recordTracksEvent } = useAnalytics();
 	return (
 		<DropdownMenu icon={ moreVertical } label={ __( 'Quick actions' ) }>
 			{ () => (
 				<MenuGroup>
+					{ purchase.is_upgradable && upgradeUrl && (
+						<MenuItem
+							onClick={ () => {
+								recordTracksEvent( 'calypso_purchases_upgrade_plan', {
+									status: isExpired( purchase ) ? 'expired' : 'active',
+									plan: purchase.product_name,
+								} );
+								upgradePurchase( upgradeUrl );
+							} }
+						>
+							{ __( 'Upgrade' ) }
+						</MenuItem>
+					) }
 					{ canBeRenewed && (
 						<MenuItem
 							onClick={ () => {
@@ -144,12 +187,13 @@ function PurchaseSettingsCardLinkWrapper( {
 
 function PurchaseSettingsActions( {
 	purchase,
-	isEligibleForUpgrade,
+	upgradeUrl,
 }: {
 	purchase: Purchase;
-	isEligibleForUpgrade: boolean;
+	upgradeUrl: string | undefined;
 } ) {
-	// FIXME: determine what actions to include
+	// FIXME: include "Pick another plan"/"Pick another product" if purchase is expired
+	// FIXME: determine what other actions to include
 	const canBeRemoved = ! isExpired( purchase ) && ! isIncludedWithPlan( purchase );
 	const canBeRenewed = purchase.can_explicit_renew;
 	const canCancel = purchase.is_cancelable;
@@ -157,19 +201,23 @@ function PurchaseSettingsActions( {
 	return (
 		<VStack spacing={ 4 }>
 			<ActionList>
-				{ isEligibleForUpgrade && (
+				{ purchase.is_upgradable && upgradeUrl && (
 					<ActionList.ActionItem
-						title={ __( 'Upgrade plan' ) }
-						description={ __( 'Find the best fit for your business.' ) }
+						title={ __( 'Upgrade subscription' ) }
+						description={ __( 'Find the best fit for your needs.' ) }
 						actions={
 							<Button
 								variant="secondary"
 								size="compact"
-								onClick={ () => ( {
-									// FIXME
-								} ) }
+								onClick={ () => {
+									recordTracksEvent( 'calypso_purchases_upgrade_plan', {
+										status: isExpired( purchase ) ? 'expired' : 'active',
+										plan: purchase.product_name,
+									} );
+									upgradePurchase( upgradeUrl );
+								} }
 							>
-								{ __( 'Upgrade plan' ) }
+								{ __( 'Upgrade subscription' ) }
 							</Button>
 						}
 					/>
@@ -402,10 +450,7 @@ export default function PurchaseSettings() {
 	if ( ! purchase || ! site ) {
 		return null;
 	}
-	// FIXME: figure this out
-	const isEligibleForUpgrade =
-		! isExpired( purchase ) && ! isIncludedWithPlan( purchase ) && purchase.is_plan;
-
+	const upgradeUrl = getUpgradeUrl( purchase );
 	const subtitle = getSubtitleForDisplay( purchase );
 
 	return (
@@ -417,12 +462,11 @@ export default function PurchaseSettings() {
 						prefix={ <BackButton /> }
 						title={ getTitleForDisplay( purchase ) }
 						actions={
-							// FIXME: figure out where to go here
 							site?.options?.admin_url && (
 								<>
-									{ isEligibleForUpgrade && (
-										<Button __next40pxDefaultSize variant="primary" href="#">
-											{ __( 'Upgrade plan' ) }
+									{ purchase.is_upgradable && upgradeUrl && (
+										<Button __next40pxDefaultSize variant="primary" href={ upgradeUrl }>
+											{ __( 'Upgrade' ) }
 										</Button>
 									) }
 									<PurchaseActionMenu purchase={ purchase } />
@@ -499,10 +543,7 @@ export default function PurchaseSettings() {
 				</HStack>
 				<ManageSubscriptionCard purchase={ purchase } />
 				{ ! isExpired( purchase ) && (
-					<PurchaseSettingsActions
-						purchase={ purchase }
-						isEligibleForUpgrade={ isEligibleForUpgrade }
-					/>
+					<PurchaseSettingsActions purchase={ purchase } upgradeUrl={ upgradeUrl } />
 				) }
 			</VStack>
 		</PageLayout>

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -37,7 +37,11 @@ import { ActionList } from '../../../components/action-list';
 import { useFormattedTime } from '../../../components/formatted-time';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
-import { ProductUpgradeMap, AkismetUpgradesProductMap } from '../../../data/constants';
+import {
+	ProductUpgradeMap,
+	AkismetUpgradesProductMap,
+	DomainProductSlugs,
+} from '../../../data/constants';
 import { formatDate } from '../../../utils/datetime';
 import {
 	getBillPeriodLabel,
@@ -50,9 +54,11 @@ import {
 	isOneTimePurchase,
 	isMarketplaceTemporarySitePurchase,
 	isAkismetProduct,
+	isAkismetFreeProduct,
 } from '../../../utils/purchase';
 import { encodeProductForUrl } from '../../../utils/wpcom-checkout';
 import { getPurchaseUrlForId } from '../urls';
+import type { User } from '../../../data/me';
 import type { Purchase } from '../../../data/purchase';
 import type { Field } from '@wordpress/dataviews';
 import type { ReactNode, ReactElement } from 'react';
@@ -200,11 +206,11 @@ function PurchaseSettingsActions( {
 } ) {
 	const canBeRemoved = ! isExpired( purchase ) && ! isIncludedWithPlan( purchase );
 	const canBeRenewed = purchase.can_explicit_renew;
-	// FIXME: handle all conditions in renderCancelPurchaseNavItem like canAutoRenewBeTurnedOff and hasAmountAvailableToRefund and isDomainTransfer and isHundredYearDomain
 	const canCancel = purchase.is_cancelable;
 	const { recordTracksEvent } = useAnalytics();
-	// FIXME: prevent renew if purchase.isLocked
 	// FIXME: prevent renew if not product owner
+	// FIXME: show re-enable button (see subsReEnableText)
+	// FIXME: show "Paid until" for date for 100 year plan instead of expiry date title
 	// FIXME: prevent rendering upgrade button if Jetpack temp site
 	return (
 		<VStack spacing={ 4 }>
@@ -368,7 +374,13 @@ function PurchaseSettingsCard( {
 	);
 }
 
-function getFields( { isMutationPending }: { isMutationPending?: boolean } ): Field< Purchase >[] {
+function getFields( {
+	isMutationPending,
+	user,
+}: {
+	isMutationPending?: boolean;
+	user: User;
+} ): Field< Purchase >[] {
 	return [
 		{
 			id: 'is_auto_renew_enabled',
@@ -406,6 +418,10 @@ function getFields( { isMutationPending }: { isMutationPending?: boolean } ): Fi
 						checked={ getValue( { item: purchase } ) }
 						disabled={
 							isMutationPending ||
+							purchase.is_iap_purchase ||
+							purchase.product_slug === DomainProductSlugs.TRANSFER_IN ||
+							String( user.ID ) !== String( purchase.user_id ) ||
+							isAkismetFreeProduct( purchase ) ||
 							isOneTimePurchase( purchase ) ||
 							isExpired( purchase ) ||
 							isIncludedWithPlan( purchase )
@@ -437,13 +453,14 @@ function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
 		error,
 		isPending: isMutationPending,
 	} = useMutation( userPurchaseSetAutoRenewQuery( parseInt( purchase.ID ) ) );
+	const { user } = useAuth();
 	return (
 		<Card>
 			<CardBody>
 				<VStack spacing={ 4 } alignment="left">
 					<DataForm< Purchase >
 						data={ purchase }
-						fields={ getFields( { isMutationPending } ) }
+						fields={ getFields( { isMutationPending, user } ) }
 						form={ form }
 						onChange={ ( newData ) => {
 							if ( newData.is_auto_renew_enabled !== purchase.is_auto_renew_enabled ) {

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -142,7 +142,9 @@ const BackButton = () => {
 };
 
 function PurchaseActionMenu( { purchase }: { purchase: Purchase } ) {
-	const canBeRenewed = purchase.can_explicit_renew;
+	const { user } = useAuth();
+	const canBeRenewed =
+		purchase.can_explicit_renew && String( user.ID ) === String( purchase.user_id );
 	const upgradeUrl = getUpgradeUrl( purchase );
 	const { recordTracksEvent } = useAnalytics();
 	return (
@@ -204,11 +206,12 @@ function PurchaseSettingsActions( {
 	purchase: Purchase;
 	upgradeUrl: string | undefined;
 } ) {
+	const { user } = useAuth();
 	const canBeRemoved = ! isExpired( purchase ) && ! isIncludedWithPlan( purchase );
-	const canBeRenewed = purchase.can_explicit_renew;
+	const canBeRenewed =
+		purchase.can_explicit_renew && String( user.ID ) === String( purchase.user_id );
 	const canCancel = purchase.is_cancelable;
 	const { recordTracksEvent } = useAnalytics();
-	// FIXME: prevent renew if not product owner
 	// FIXME: show re-enable button (see subsReEnableText)
 	// FIXME: show "Paid until" for date for 100 year plan instead of expiry date title
 	// FIXME: prevent rendering upgrade button if Jetpack temp site

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -481,12 +481,9 @@ export default function PurchaseSettings() {
 	}
 	const upgradeUrl = getUpgradeUrl( purchase );
 	const subtitle = getSubtitleForDisplay( purchase );
-	// FIXME: prevent renewal for preventRenewal
-	// FIXME: prevent renewal for isPendingDomainRegistration
 	// FIXME: add edit payment method button
 	// FIXME: add Jetpack CRM downloads link
 	// FIXME: render reinstall button
-	// FIXME: render "100-Year Domain Registration" in place of getTitleForDisplay for 100 year domain
 	// FIXME: render "Domain transfers can take anywhere from five to seven days to complete."
 	// FIXME: render 'Domain Registration Agreement' and link
 	// FIXME: render DIFM content

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -74,8 +74,8 @@ import {
 	isJetpackCrmProduct,
 	isTitanMail,
 	isGoogleWorkspace,
+	getRenewalUrlFromPurchase,
 } from '../../../utils/purchase';
-import { encodeProductForUrl } from '../../../utils/wpcom-checkout';
 import { PurchasePaymentMethod } from '../purchase-payment-method';
 import { getPurchaseUrlForId, getAddPaymentMethodUrlFor } from '../urls';
 import type { User } from '../../../data/me';
@@ -84,25 +84,6 @@ import type { Field } from '@wordpress/dataviews';
 import type { ReactNode, ReactElement } from 'react';
 
 import './style.scss';
-
-function getServicePathForCheckoutFromPurchase( purchase: Purchase ): string {
-	if ( isAkismetProduct( purchase ) ) {
-		return 'akismet/';
-	}
-	if ( isMarketplaceTemporarySitePurchase( purchase ) ) {
-		return 'marketplace/';
-	}
-	return '';
-}
-
-function getRenewalUrlFromPurchase( purchase: Purchase ): string {
-	const productSlug = encodeProductForUrl( purchase.product_slug );
-	const productDomain = purchase.meta ? encodeProductForUrl( purchase.meta ) : undefined;
-	const checkoutProductSlug = productDomain ? `${ productSlug }:${ productDomain }` : productSlug;
-	const checkoutSiteSlug = purchase.site_slug || '';
-	const servicePath = getServicePathForCheckoutFromPurchase( purchase );
-	return `/checkout/${ servicePath }${ checkoutProductSlug }/renew/${ purchase.ID }/${ checkoutSiteSlug }`;
-}
 
 function renewPurchase( purchase: Purchase ): void {
 	window.location.href = getRenewalUrlFromPurchase( purchase );

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -15,6 +15,7 @@ import {
 	Icon,
 	ToggleControl,
 	Notice,
+	ExternalLink,
 } from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
 import { __, isRTL, sprintf } from '@wordpress/i18n';
@@ -674,6 +675,17 @@ function PurchasePriceCard( { purchase }: { purchase: Purchase } ) {
 	);
 }
 
+function DomainRegistrationAgreement( { purchase }: { purchase: Purchase } ) {
+	if ( ! purchase.domain_registration_agreement_url ) {
+		return null;
+	}
+	return (
+		<ExternalLink rel="noreferrer" href={ purchase.domain_registration_agreement_url }>
+			{ __( 'Domain Registration Agreement' ) }
+		</ExternalLink>
+	);
+}
+
 export default function PurchaseSettings() {
 	const { user } = useAuth();
 	const params = purchaseSettingsRoute.useParams();
@@ -705,7 +717,6 @@ export default function PurchaseSettings() {
 	} )();
 
 	// FIXME: render pluginList (see renderPluginLabel and getPluginsForSite)
-	// FIXME: render 'Domain Registration Agreement' and link (see domainRegistrationAgreementLinkText)
 	// FIXME: render DIFM content (BBEPurchaseDescription)
 	// FIXME: render ProductLink for plan features, domain management, email management, or theme details
 
@@ -731,6 +742,7 @@ export default function PurchaseSettings() {
 						}
 					/>
 					{ subtitle && <Text variant="muted">{ subtitle }</Text> }
+					<DomainRegistrationAgreement purchase={ purchase } />
 				</VStack>
 			}
 		>

--- a/client/dashboard/me/billing-purchases/purchase-settings/style.scss
+++ b/client/dashboard/me/billing-purchases/purchase-settings/style.scss
@@ -1,0 +1,9 @@
+.purchase-settings-card__link {
+	text-decoration: none;
+	flex-grow: 1;
+	max-width: 318px;
+}
+.purchase-settings-card {
+	flex-grow: 1;
+	max-width: 318px;
+}

--- a/client/dashboard/me/billing-purchases/urls.ts
+++ b/client/dashboard/me/billing-purchases/urls.ts
@@ -10,7 +10,7 @@ export function getPurchaseUrlForId( id: number | string ) {
 		console.error( 'Cannot display manage purchase page for subscription without ID' );
 		throw new Error( 'Cannot display manage purchase page for subscription without ID' );
 	}
-	return `/v2/me/billing/purchases/purchase/${ id }`;
+	return `/me/billing/purchases/purchase/${ id }`;
 }
 
 export function getAddPaymentMethodUrlFor( purchase: Purchase ): string {

--- a/client/dashboard/me/billing-purchases/urls.ts
+++ b/client/dashboard/me/billing-purchases/urls.ts
@@ -1,0 +1,18 @@
+import type { Purchase } from '../../data/purchase';
+
+export function getPurchaseUrl( purchase: Purchase ) {
+	return getPurchaseUrlForId( purchase.ID );
+}
+
+export function getPurchaseUrlForId( id: number | string ) {
+	if ( ! id ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Cannot display manage purchase page for subscription without ID' );
+		throw new Error( 'Cannot display manage purchase page for subscription without ID' );
+	}
+	return `/v2/me/billing/purchases/purchase/${ id }`;
+}
+
+export function getAddPaymentMethodUrlFor( purchase: Purchase ): string {
+	return `/me/purchases/${ purchase.site_slug ?? 'unknown' }/${ purchase.ID }/payment-method/add`;
+}

--- a/client/dashboard/utils/domain.ts
+++ b/client/dashboard/utils/domain.ts
@@ -3,10 +3,9 @@ import { isAfter, subMinutes, subDays } from 'date-fns';
 import { DotcomFeatures } from '../data/constants';
 import { WhoisType } from '../data/domain-whois';
 import { DomainTypes } from '../data/domains';
-import { isAkismetProduct, isMarketplaceTemporarySitePurchase } from './purchase';
+import { getRenewalUrlFromPurchase } from './purchase';
 import { hasPlanFeature } from './site-features';
 import { userHasFlag } from './user';
-import { encodeProductForUrl } from './wpcom-checkout';
 import type { Purchase } from '../data/purchase';
 import type { SiteDomain, DomainSummary, Site, User, WhoisDataEntry } from '../data/types';
 
@@ -16,26 +15,11 @@ export function getDomainSiteSlug( domain: DomainSummary ) {
 
 export function getDomainRenewalUrl( domain: DomainSummary, purchase: Purchase ) {
 	const siteSlug = getDomainSiteSlug( domain );
-
-	const productSlug = [ purchase.product_slug, domain.domain ]
-		.map( ( productSlug ) => encodeProductForUrl( productSlug ) )
-		.join( ':' );
-
 	const backUrl = window.location.href.replace( window.location.origin, '' );
-	let serviceSlug = '';
-	if ( isAkismetProduct( purchase ) ) {
-		serviceSlug = 'akismet/';
-	} else if ( isMarketplaceTemporarySitePurchase( purchase ) ) {
-		serviceSlug = 'marketplace/';
-	}
-
-	return addQueryArgs(
-		`/checkout/${ serviceSlug }${ productSlug }/renew/${ purchase.ID }/${ siteSlug }`,
-		{
-			cancel_to: backUrl,
-			redirect_to: backUrl,
-		}
-	);
+	return addQueryArgs( getRenewalUrlFromPurchase( purchase, siteSlug ), {
+		cancel_to: backUrl,
+		redirect_to: backUrl,
+	} );
 }
 
 export function isRegisteredDomain( domain: DomainSummary ) {

--- a/client/dashboard/utils/email-paths.ts
+++ b/client/dashboard/utils/email-paths.ts
@@ -1,0 +1,283 @@
+import {
+	isUnderDomainManagementAll,
+	isUnderDomainSiteContext,
+	domainManagementRoot,
+	domainSiteContextRoot,
+	domainManagementAllEmailRoot,
+} from '@automattic/domains-table/src/utils/paths';
+
+type QueryStringParameters = { [ key: string ]: string | undefined };
+
+type EmailPathUtilityFunction = (
+	siteName: string | undefined,
+	domainName?: string,
+	relativeTo?: string,
+	urlParameters?: QueryStringParameters,
+	inSiteContext?: boolean
+) => string;
+
+export const emailManagementPrefix = '/email';
+export const emailManagementAllSitesPrefix = '/email/all';
+export const domainsManagementPrefix = '/domains/manage/all/email';
+export const emailSiteContextPrefix = `${ domainSiteContextRoot() }/email`;
+
+function buildQueryString( params: QueryStringParameters | undefined ): string {
+	if ( ! params ) {
+		return '';
+	}
+	const filteredParams: Array< [ string, string ] > = [];
+	Object.entries( params ).forEach( ( [ key, value ] ) => {
+		if ( value !== undefined && value !== null ) {
+			filteredParams.push( [ key, value ] );
+		}
+	} );
+	if ( filteredParams.length === 0 ) {
+		return '';
+	}
+	return '?' + new URLSearchParams( filteredParams ).toString();
+}
+
+export function isUnderEmailManagementAll( path?: string ) {
+	return path?.startsWith( emailManagementAllSitesPrefix + '/' );
+}
+
+export function isUnderCheckoutRoute( path?: string ) {
+	return path?.startsWith( '/checkout' );
+}
+
+function resolveRootPath( relativeTo?: string ) {
+	if ( relativeTo === emailManagementAllSitesPrefix || relativeTo === domainManagementRoot() ) {
+		return emailManagementAllSitesPrefix;
+	}
+
+	if ( isUnderEmailManagementAll( relativeTo ) || isUnderDomainManagementAll( relativeTo ) ) {
+		return emailManagementAllSitesPrefix;
+	}
+
+	return emailManagementPrefix;
+}
+
+function getPath(
+	siteName: string | undefined,
+	domainName: string | undefined,
+	slug?: string,
+	relativeTo?: string,
+	urlParameters?: QueryStringParameters
+) {
+	if ( siteName && domainName ) {
+		// Encodes only real domain names and not parameter placeholders
+		if ( ! domainName.startsWith( ':' ) ) {
+			// Encodes domain names so addresses with slashes in the path (e.g. used in site redirects) don't break routing.
+			// Note they are encoded twice since page.js decodes the path by default.
+			domainName = encodeURIComponent( encodeURIComponent( domainName ) );
+		}
+
+		const slugFragment = slug ? '/' + slug : '';
+
+		return (
+			resolveRootPath( relativeTo ) +
+			'/' +
+			domainName +
+			slugFragment +
+			'/' +
+			siteName +
+			buildQueryString( urlParameters )
+		);
+	}
+
+	if ( siteName ) {
+		return '/email/' + siteName + buildQueryString( urlParameters );
+	}
+
+	return '/email';
+}
+
+// Retrieves the URL of the Add New Mailboxes page for email forwarding
+export const getAddEmailForwardsPath: EmailPathUtilityFunction = (
+	siteName,
+	domainName,
+	relativeTo,
+	urlParameters
+) => {
+	if ( isUnderDomainManagementAll( relativeTo ) ) {
+		const prefix = isUnderDomainSiteContext( relativeTo )
+			? emailSiteContextPrefix
+			: domainsManagementPrefix;
+
+		return `${ prefix }/${ domainName }/forwarding/add/${ siteName }${ buildQueryString(
+			urlParameters
+		) }`;
+	}
+
+	return getPath( siteName, domainName, 'forwarding/add', relativeTo, urlParameters );
+};
+
+// Retrieves the URL of the Add New Mailboxes page either for G Suite or Google Workspace
+export function getAddGSuiteUsersPath(
+	siteName: string | undefined,
+	domainName: string | undefined,
+	productType: string,
+	relativeTo?: string,
+	source?: string
+) {
+	if ( siteName && domainName ) {
+		return getPath( siteName, domainName, productType + '/add-users', relativeTo, {
+			source,
+		} );
+	}
+
+	if ( siteName ) {
+		return '/email/' + productType + '/add-users/' + siteName;
+	}
+
+	return '/email';
+}
+
+export const getManageTitanAccountPath: EmailPathUtilityFunction = (
+	siteName,
+	domainName,
+	relativeTo,
+	urlParameters
+) => getPath( siteName, domainName, 'titan/manage', relativeTo, urlParameters );
+
+export const getManageTitanMailboxesPath: EmailPathUtilityFunction = (
+	siteName,
+	domainName,
+	relativeTo,
+	urlParameters
+) => getPath( siteName, domainName, 'titan/manage-mailboxes', relativeTo, urlParameters );
+
+export const getNewTitanAccountPath: EmailPathUtilityFunction = (
+	siteName,
+	domainName,
+	relativeTo,
+	urlParameters
+) => {
+	if ( relativeTo?.startsWith( '/overview/site-domain/' ) ) {
+		return `/overview/site-domain/email/${ domainName }/titan/new/${ siteName }${ buildQueryString(
+			urlParameters
+		) }`;
+	} else if ( isUnderDomainManagementAll( relativeTo ) ) {
+		return `${ domainsManagementPrefix }/${ domainName }/titan/new/${ siteName }${ buildQueryString(
+			urlParameters
+		) }`;
+	}
+
+	return getPath( siteName, domainName, 'titan/new', relativeTo, urlParameters );
+};
+
+// Retrieves the URL to set up Titan mailboxes
+export const getTitanSetUpMailboxPath: EmailPathUtilityFunction = (
+	siteName,
+	domainName,
+	relativeTo,
+	urlParameters
+) => getPath( siteName, domainName, 'titan/set-up-mailbox', relativeTo, urlParameters );
+
+export const getTitanControlPanelRedirectPath: EmailPathUtilityFunction = (
+	siteName,
+	domainName,
+	relativeTo,
+	urlParameters
+) => getPath( siteName, domainName, 'titan/control-panel', relativeTo, urlParameters );
+
+// Generates URL: /email/:domain/manage/:site
+export const getEmailManagementPath: EmailPathUtilityFunction = (
+	siteName,
+	domainName,
+	relativeTo = undefined,
+	urlParameters = {},
+	inSiteContext = false
+) => {
+	if (
+		inSiteContext ||
+		isUnderDomainManagementAll( relativeTo ) ||
+		isUnderCheckoutRoute( relativeTo )
+	) {
+		const prefix =
+			inSiteContext || isUnderDomainSiteContext( relativeTo )
+				? emailSiteContextPrefix
+				: domainsManagementPrefix;
+
+		return `${ prefix }/${ domainName }/${ siteName }${ buildQueryString( urlParameters ) }`;
+	}
+
+	return getPath( siteName, domainName, 'manage', relativeTo, urlParameters );
+};
+
+export const getForwardingPath: EmailPathUtilityFunction = ( siteName, domainName, relativeTo ) =>
+	getPath( siteName, domainName, 'forwarding', relativeTo );
+
+// Retrieves the URL of the Email Comparison page
+export const getPurchaseNewEmailAccountPath = (
+	siteName: string | undefined,
+	domainName: string | undefined,
+	relativeTo?: string,
+	source?: string,
+	emailProviderSlug?: string,
+	intervalLength?: string
+) =>
+	getPath( siteName, domainName, 'purchase', relativeTo, {
+		interval: intervalLength,
+		provider: emailProviderSlug,
+		source,
+	} );
+
+// Retrieves the URL of the Email In-Depth Comparison page
+export const getEmailInDepthComparisonPath = (
+	siteName: string | undefined,
+	domainName: string | undefined,
+	relativeTo?: string,
+	source?: string,
+	intervalLength?: string
+) => {
+	if ( isUnderDomainManagementAll( relativeTo ) ) {
+		const prefix = isUnderDomainSiteContext( relativeTo )
+			? emailSiteContextPrefix
+			: domainsManagementPrefix;
+
+		return `${ prefix }/${ domainName }/compare/${ siteName }${ buildQueryString( {
+			interval: intervalLength,
+			referrer: relativeTo,
+			source,
+		} ) }`;
+	}
+
+	return getPath( siteName, domainName, 'compare', relativeTo, {
+		interval: intervalLength,
+		referrer: relativeTo,
+		source,
+	} );
+};
+
+export const getProfessionalEmailCheckoutUpsellPath = (
+	siteName: string,
+	domainName: string,
+	receiptId: number | string
+) => `/checkout/offer-professional-email/${ domainName }/${ receiptId }/${ siteName }`;
+
+export const getEmailCheckoutPath = (
+	siteName: string,
+	domainName: string,
+	relativeTo?: string,
+	newEmail?: string
+): string => {
+	let checkoutPath = '/checkout/' + siteName;
+
+	if ( isUnderDomainManagementAll( relativeTo ) ) {
+		let redirectTo = isUnderDomainSiteContext( relativeTo )
+			? `${ domainSiteContextRoot() }/email/${ domainName }/${ siteName }`
+			: `${ domainManagementAllEmailRoot() }/${ domainName }/${ siteName }`;
+
+		if ( newEmail ) {
+			redirectTo += `?new-email=${ newEmail }`;
+		}
+
+		checkoutPath += '?redirect_to=' + encodeURIComponent( redirectTo );
+	}
+
+	return checkoutPath;
+};
+
+export const getMailboxesPath = ( siteName?: string ) =>
+	siteName ? `/mailboxes/${ siteName }` : '/mailboxes';

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -345,3 +345,7 @@ export function isTitanMail( purchase: Purchase ): boolean {
 export function isGoogleWorkspace( purchase: Purchase ): boolean {
 	return ( Object.values( GoogleWorkspaceSlugs ) as string[] ).includes( purchase.product_slug );
 }
+
+export function isSiteRedirect( purchase: Purchase ): boolean {
+	return purchase.product_slug === 'offsite_redirect';
+}

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -193,6 +193,10 @@ export function getBillPeriodLabel( purchase: Purchase ): string {
  * title and the product name as the subtitle (see `getSubtitleForDisplay`).
  */
 export function getTitleForDisplay( purchase: Purchase ): string {
+	if ( purchase.is_hundred_year_domain ) {
+		return __( '100-Year Domain Registration' );
+	}
+
 	if (
 		purchase.is_jetpack_ai_product &&
 		purchase.renewal_price_tier_usage_quantity &&

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -124,10 +124,6 @@ export function creditCardHasAlreadyExpired( purchase: Purchase ): boolean {
 	return false;
 }
 
-export function isAutoRenewEnabled( purchase: Purchase ): boolean {
-	return parseInt( purchase.auto_renew ?? '' ) === 1;
-}
-
 export function isTransferredOwnership(
 	purchaseId: string | number,
 	transferredOwnershipPurchases: Purchase[]

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -317,3 +317,12 @@ export function getSubtitleForDisplay( purchase: Purchase ): string | null {
 
 	return null;
 }
+
+export function isJetpackCrmProduct( keyOrSlug: string ): boolean {
+	return (
+		keyOrSlug.startsWith( 'jetpack-complete' ) ||
+		keyOrSlug.startsWith( 'jetpack_complete' ) ||
+		keyOrSlug.startsWith( 'jetpack-crm' ) ||
+		keyOrSlug.startsWith( 'jetpack_crm' )
+	);
+}

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -1,6 +1,11 @@
 import { formatNumber } from '@automattic/number-formatters';
 import { __, sprintf } from '@wordpress/i18n';
-import { SubscriptionBillPeriod, AkismetPlans } from '../data/constants';
+import {
+	SubscriptionBillPeriod,
+	AkismetPlans,
+	TitanMailSlugs,
+	GoogleWorkspaceSlugs,
+} from '../data/constants';
 import { isWithinLast, isWithinNext, getDateFromCreditCardExpiry } from './datetime';
 import type { Purchase } from '../data/purchase';
 
@@ -331,4 +336,12 @@ export function isJetpackCrmProduct( keyOrSlug: string ): boolean {
 		keyOrSlug.startsWith( 'jetpack-crm' ) ||
 		keyOrSlug.startsWith( 'jetpack_crm' )
 	);
+}
+
+export function isTitanMail( purchase: Purchase ): boolean {
+	return ( Object.values( TitanMailSlugs ) as string[] ).includes( purchase.product_slug );
+}
+
+export function isGoogleWorkspace( purchase: Purchase ): boolean {
+	return ( Object.values( GoogleWorkspaceSlugs ) as string[] ).includes( purchase.product_slug );
 }

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -1,3 +1,5 @@
+import { formatNumber } from '@automattic/number-formatters';
+import { __, sprintf } from '@wordpress/i18n';
 import { SubscriptionBillPeriod, AkismetPlans } from '../data/constants';
 import { isWithinLast, isWithinNext, getDateFromCreditCardExpiry } from './datetime';
 import type { Purchase } from '../data/purchase';
@@ -149,4 +151,169 @@ export function isMarketplaceTemporarySitePurchase( purchase: Purchase ): boolea
 
 export function isJetpackTemporarySitePurchase( purchase: Purchase ): boolean {
 	return isTemporarySitePurchase( purchase ) && purchase.product_type === 'jetpack';
+}
+
+/**
+ * Return the bill period as a sentence case string. Note that Purchae includes
+ * this text already as `bill_period_label` but it is not sentence case and has
+ * no punctuation.
+ */
+export function getBillPeriodLabel( purchase: Purchase ): string {
+	switch ( purchase.bill_period_days ) {
+		case SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD:
+			return __( 'Per month.' );
+		case SubscriptionBillPeriod.PLAN_ANNUAL_PERIOD:
+			return __( 'Per year.' );
+		case SubscriptionBillPeriod.PLAN_BIENNIAL_PERIOD:
+			return __( 'Every two years.' );
+		case SubscriptionBillPeriod.PLAN_TRIENNIAL_PERIOD:
+			return __( 'Every three years.' );
+		case SubscriptionBillPeriod.PLAN_QUADRENNIAL_PERIOD:
+			return __( 'Every four years.' );
+		case SubscriptionBillPeriod.PLAN_QUINQUENNIAL_PERIOD:
+			return __( 'Every five years.' );
+		case SubscriptionBillPeriod.PLAN_SEXENNIAL_PERIOD:
+			return __( 'Every six years.' );
+		case SubscriptionBillPeriod.PLAN_SEPTENNIAL_PERIOD:
+			return __( 'Every seven years.' );
+		case SubscriptionBillPeriod.PLAN_OCTENNIAL_PERIOD:
+			return __( 'Every eight years.' );
+		case SubscriptionBillPeriod.PLAN_NOVENNIAL_PERIOD:
+			return __( 'Every nine years.' );
+		case SubscriptionBillPeriod.PLAN_DECENNIAL_PERIOD:
+			return __( 'Every ten years.' );
+		case SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD:
+			return __( 'Every hundred years.' );
+		default:
+			return purchase.bill_period_label;
+	}
+}
+
+/**
+ * Return the title for a purchase for display.
+ *
+ * Usually this is just the `product_name`, but some products are displayed
+ * differently. For example, domains are displayed with the domain name as the
+ * title and the product name as the subtitle (see `getSubtitleForDisplay`).
+ */
+export function getTitleForDisplay( purchase: Purchase ): string {
+	if (
+		purchase.is_jetpack_ai_product &&
+		purchase.renewal_price_tier_usage_quantity &&
+		purchase.price_tier_list?.length
+	) {
+		// translators: productName is the name of the product and quantity is a number
+		return sprintf( __( '%(productName)s (%(quantity)s requests per month)' ), {
+			productName: purchase.product_name,
+			quantity: formatNumber( purchase.renewal_price_tier_usage_quantity ),
+		} );
+	}
+
+	if (
+		purchase.is_jetpack_stats_product &&
+		! purchase.is_free_jetpack_stats_product &&
+		purchase.renewal_price_tier_usage_quantity &&
+		purchase.price_tier_list?.length
+	) {
+		// translators: productName is the name of the product and quantity is a number
+		return sprintf( __( '%(productName)s (%(quantity)s views per month)' ), {
+			productName: purchase.product_name,
+			quantity: formatNumber( purchase.renewal_price_tier_usage_quantity ),
+		} );
+	}
+
+	if (
+		'wordpress_com_1gb_space_addon_yearly' === purchase.product_slug &&
+		purchase.renewal_price_tier_usage_quantity
+	) {
+		// translators: productName is the name of the product and quantity is a number (GB stands for GigaBytes)
+		return sprintf( __( '%(productName)s %(quantity)s GB' ), {
+			productName: purchase.product_name,
+			quantity: purchase.renewal_price_tier_usage_quantity,
+		} );
+	}
+
+	if ( purchase.meta && ( purchase.is_domain_registration || purchase.is_domain ) ) {
+		return purchase.meta;
+	}
+	return purchase.product_name;
+}
+
+/**
+ * Return a short description of a purchase, usually used as a subtitle for that
+ * purchase's product name (as defined by `getTitleForDisplay`).
+ *
+ * Notably, domains typically have their title as the domain name itself and
+ * the product type as the subtitle.
+ */
+export function getSubtitleForDisplay( purchase: Purchase ): string | null {
+	if ( 'theme' === purchase.product_type ) {
+		return __( 'Premium Theme' );
+	}
+
+	if ( 'concierge-session' === purchase.product_slug ) {
+		return __( 'One-on-one Support' );
+	}
+
+	if ( purchase.partner_name ) {
+		if ( purchase.partner_type && [ 'agency', 'a4a_agency' ].includes( purchase.partner_type ) ) {
+			return __( 'Agency Managed Plan' );
+		}
+
+		return __( 'Host Managed Plan' );
+	}
+
+	if ( purchase.is_plan ) {
+		return __( 'Site Plan' );
+	}
+
+	if ( purchase.is_domain_registration ) {
+		return purchase.product_name;
+	}
+
+	if ( purchase.product_slug === 'domain_map' ) {
+		return purchase.product_name;
+	}
+
+	if ( isTemporarySitePurchase( purchase ) && purchase.product_type === 'akismet' ) {
+		return null;
+	}
+
+	if ( isTemporarySitePurchase( purchase ) && purchase.product_type === 'saas_plugin' ) {
+		return null;
+	}
+
+	if ( isTemporarySitePurchase( purchase ) && isA4ATemporarySitePurchase( purchase ) ) {
+		return null;
+	}
+
+	if ( purchase.is_google_workspace_product && purchase.meta ) {
+		return sprintf(
+			// translators: The domain is the domain name of the site
+			__( 'Mailboxes and Productivity Tools at %(domain)s' ),
+			{
+				domain: purchase.meta,
+			}
+		);
+	}
+
+	if ( purchase.is_titan_mail_product && purchase.meta ) {
+		return sprintf(
+			// translators: The domain is the domain name of the site
+			__( 'Mailboxes at %(domain)s' ),
+			{
+				domain: purchase.meta,
+			}
+		);
+	}
+
+	if ( purchase.product_type === 'marketplace_plugin' || purchase.product_type === 'saas_plugin' ) {
+		return __( 'Plugin' );
+	}
+
+	if ( purchase.meta ) {
+		return purchase.meta;
+	}
+
+	return null;
 }

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -141,6 +141,12 @@ export function isAkismetTemporarySitePurchase( purchase: Purchase ): boolean {
 	return isTemporarySitePurchase( purchase ) && purchase.product_type === 'akismet';
 }
 
+export function isMarketplacePlugin( purchase: Purchase ): boolean {
+	return (
+		purchase.product_type.startsWith( 'marketplace' ) || purchase.product_type === 'saas_plugin'
+	);
+}
+
 export function isMarketplaceTemporarySitePurchase( purchase: Purchase ): boolean {
 	return isTemporarySitePurchase( purchase ) && purchase.product_type === 'saas_plugin';
 }

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -7,6 +7,7 @@ import {
 	GoogleWorkspaceSlugs,
 } from '../data/constants';
 import { isWithinLast, isWithinNext, getDateFromCreditCardExpiry } from './datetime';
+import { encodeProductForUrl } from './wpcom-checkout';
 import type { Purchase } from '../data/purchase';
 
 export function isTemporarySitePurchase( purchase: Purchase ): boolean {
@@ -348,4 +349,26 @@ export function isGoogleWorkspace( purchase: Purchase ): boolean {
 
 export function isSiteRedirect( purchase: Purchase ): boolean {
 	return purchase.product_slug === 'offsite_redirect';
+}
+
+function getServicePathForCheckoutFromPurchase( purchase: Purchase ): string {
+	if ( isAkismetProduct( purchase ) ) {
+		return 'akismet/';
+	}
+	if ( isMarketplaceTemporarySitePurchase( purchase ) ) {
+		return 'marketplace/';
+	}
+	return '';
+}
+
+export function getRenewalUrlFromPurchase(
+	purchase: Purchase,
+	checkoutSiteSlugForUrl?: string
+): string {
+	const productSlug = encodeProductForUrl( purchase.product_slug );
+	const productDomain = purchase.meta ? encodeProductForUrl( purchase.meta ) : undefined;
+	const checkoutProductSlug = productDomain ? `${ productSlug }:${ productDomain }` : productSlug;
+	const checkoutSiteSlug = checkoutSiteSlugForUrl || purchase.site_slug || '';
+	const servicePath = getServicePathForCheckoutFromPurchase( purchase );
+	return `/checkout/${ servicePath }${ checkoutProductSlug }/renew/${ purchase.ID }/${ checkoutSiteSlug }`;
 }

--- a/packages/domains-table/src/utils/paths.ts
+++ b/packages/domains-table/src/utils/paths.ts
@@ -108,7 +108,7 @@ export function domainManagementRoot() {
 	return '/domains/manage';
 }
 
-export function isUnderDomainManagementAll( path: string ) {
+export function isUnderDomainManagementAll( path: string | undefined ) {
 	return path?.startsWith( domainManagementAllRoot() + '/' ) || path === domainManagementRoot();
 }
 
@@ -240,4 +240,16 @@ export function emailManagementEdit(
 		default:
 			return '/email/' + domainName + '/manage/' + siteSlug;
 	}
+}
+
+export function domainSiteContextRoot() {
+	return '/overview/site-domain';
+}
+
+export function domainManagementAllEmailRoot() {
+	return domainManagementAllRoot() + '/email';
+}
+
+export function isUnderDomainSiteContext( path: string | undefined ) {
+	return path?.startsWith( domainSiteContextRoot() + '/' );
 }

--- a/packages/domains-table/src/utils/paths.ts
+++ b/packages/domains-table/src/utils/paths.ts
@@ -168,7 +168,11 @@ export function domainMappingSetup(
 	return path;
 }
 
-export function domainUseMyDomain( siteName: string, domain: string, initialMode: string ) {
+export function domainUseMyDomain(
+	siteName: string,
+	domain: string,
+	initialMode: string | undefined
+) {
 	const path = `/domains/add/use-my-domain/${ siteName }`;
 	const queryArgs = [];
 	if ( domain ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/CHE-234/hosting-dashboard-migrate-existing-purchase-settings-to-dashboard

## Proposed Changes

This PR adds a basic single purchase page (aka: "purchase settings" or "manage purchase") to the Hosting Dashboard based on the preliminary designs (see the Linear issue).

<img width="578" height="680" alt="Screenshot 2025-08-13 at 6 22 33 PM" src="https://github.com/user-attachments/assets/e353d8f2-279b-478f-b723-5ac481beacbf" />

> [!NOTE]
> The UI for this page is far from final. This is just a first draft and a starting place.
>
> In addition, the purchase settings page has very complex logic for the many _many_ different products we sell as well as the myriad combinations of states they can be in. This PR attempts, as best as I could, to cover all that logic, simplifying much of it by relying on server side properties (see [SHILL-1035](https://linear.app/a8c/issue/SHILL-1035/billing-add-properties-to-purchase-endpoint-for-upgradability), [SHILL-1036](https://linear.app/a8c/issue/SHILL-1036/purchases-make-is-refundable-false-for-saas-plugin), [SHILL-1037](https://linear.app/a8c/issue/SHILL-1037/purchases-make-is-cancellable-false-for-expired-included-or-not-can), [SHILL-1038](https://linear.app/a8c/issue/SHILL-1038/purchases-make-can-explicit-renew-false-for-iap), [SHILL-1039](https://linear.app/a8c/issue/SHILL-1039/purchases-add-is-removable-to-each-purchase), [SHILL-1040](https://linear.app/a8c/issue/SHILL-1040/purchases-add-is-jetpack-legacy-plan)). Prior to production launch we should have folks test every product type, especially the ones with a lot more content on this page (eg: vaultpress, akismet, pending domain transfers, marketplace plugins, hundred year plans, hundred year domains).

> [!IMPORTANT]
> This does not implement some key actions of the purchase settings page which are big enough to require their own PRs:
> - Setting the payment method. https://linear.app/a8c/issue/CHE-236/hosting-dashboard-migrate-existing-add-payment-screen-to-dashboard
> - Canceling or refunding the purchase. https://linear.app/a8c/issue/CHE-237/hosting-dashboard-migrate-existing-cancellation-flow-to-dashboard
> - Removing the purchase. https://linear.app/a8c/issue/CHE-237/hosting-dashboard-migrate-existing-cancellation-flow-to-dashboard also

## Testing Instructions

Visit http://calypso.localhost:3000/v2/me/billing/purchases and click on various purchases. Compare them to their calypso version at https://wordpress.com/me/purchases and make sure they are similar (see the above caveats).
