### PR TITLE
Add domain action Transfer to WP.com

### DIFF
--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -1,8 +1,10 @@
+import { useMyDomainInputMode } from '@automattic/domains-table/src/utils/constants';
 import {
 	domainManagementDNS,
 	domainManagementEditContactInfo,
 	domainManagementLink,
 	domainMappingSetup,
+	domainUseMyDomain,
 } from '@automattic/domains-table/src/utils/paths';
 import { useMutation } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
@@ -21,6 +23,7 @@ import {
 	canSetAsPrimary,
 	getDomainSiteSlug,
 } from '../../utils/domain';
+import { isTransferrableToWpcom } from '../../utils/domain-types';
 import type { DomainSummary, Site, User } from '../../data/types';
 import type { Action } from '@wordpress/dataviews';
 
@@ -158,8 +161,18 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 				id: 'transfer-domain',
 				label: __( 'Transfer to WordPress.com' ),
 				supportsBulk: false,
-				callback: () => {},
-				isEligible: () => false,
+				callback: ( items: DomainSummary[] ) => {
+					const domain = items[ 0 ];
+					const siteSlug = getDomainSiteSlug( domain );
+					window.location.pathname = domainUseMyDomain(
+						siteSlug,
+						domain.domain,
+						useMyDomainInputMode.transferDomain
+					);
+				},
+				isEligible: ( item: DomainSummary ) => {
+					return isTransferrableToWpcom( item );
+				},
 			},
 			{
 				id: 'connect-to-site',


### PR DESCRIPTION
Ref DOTDASH-248

## Proposed Changes

Logic copied from 

https://github.com/Automattic/wp-calypso/blob/607168eabd1cfd05f646a6320ac782da6de9ffdd/packages/domains-table/src/domains-table/domains-table-row-actions.tsx#L148-L155

https://github.com/Automattic/wp-calypso/blob/607168eabd1cfd05f646a6320ac782da6de9ffdd/client/my-sites/domains/domain-management/dataviews/use-actions.tsx#L177-L198

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Site Overview v2 development

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I'm not sure how to test this other than comparing it to the logic it's based on. Given that it's redirecting to the domain transfer flow, checking that the logic is sound should be good enough.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
