### PR TITLE
My Jetpack: Updating user connection page header and button text

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -798,7 +798,7 @@ export class JetpackAuthorize extends Component {
 		}
 
 		if ( this.isFromJetpackOnboarding() || this.isFromMyJetpack() ) {
-			return translate( 'Connect my site' );
+			return translate( 'Connect account' );
 		}
 
 		return translate( 'Approve' );
@@ -1309,7 +1309,7 @@ export class JetpackAuthorize extends Component {
 						/>
 						{ ( isFromJetpackOnboarding || isFromMyJetpack ) && (
 							<div className="jetpack-connect__authorize-form-header--left-aligned">
-								<h1>{ translate( "Now let's connect your site" ) }</h1>
+								<h1>{ translate( 'Now let’s connect your account' ) }</h1>
 								<p>
 									{ translate(
 										'Your site connects to Jetpack’s cloud to offload the heavy work, helping it run faster and deliver powerful features.'


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes MYJP-248

## Proposed Changes

* update connection screen strings to reflect the purpose of the page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* site connection happens on a different stage

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open the live branch
* create a JN site that you need to connect
* when redirected to the user connection, replace the beginning of the URL with the live branch address
* verify that the text for the deader and the button was upated

After:
<img width="584" height="650" alt="SCR-20250811-meki" src="https://github.com/user-attachments/assets/8934fe4e-6e1c-4915-817f-fd0fc819af3b" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
