### PR TITLE
Site settings: add missing learn more links

### DIFF
--- a/client/dashboard/sites/settings-database/index.tsx
+++ b/client/dashboard/sites/settings-database/index.tsx
@@ -15,6 +15,7 @@ import { blockTable } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { siteBySlugQuery } from '../../app/queries/site';
+import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
 import PageLayout from '../../components/page-layout';
 import { HostingFeatures } from '../../data/constants';
@@ -75,8 +76,13 @@ export default function SiteDatabaseSettings( { siteSlug }: { siteSlug: string }
 			header={
 				<SettingsPageHeader
 					title={ __( 'Database' ) }
-					description={ __(
-						'For the tech-savvy, manage your database with phpMyAdmin and run a wide range of operations with MySQL.'
+					description={ createInterpolateElement(
+						__(
+							'For the tech-savvy, manage your database with phpMyAdmin and run a wide range of operations with MySQL. <link>Learn more</link>'
+						),
+						{
+							link: <InlineSupportLink supportContext="hosting-mysql" />,
+						}
 					) }
 				/>
 			}

--- a/client/dashboard/sites/settings-sftp-ssh/sftp-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/sftp-card.tsx
@@ -157,7 +157,7 @@ export default function SftpCard( {
 						title={ __( 'SFTP' ) }
 						description={ createInterpolateElement(
 							__(
-								'Use the credentials below to access and edit your website files using an SFTP client. <link>Learn more</link>.'
+								'Use the credentials below to access and edit your website files using an SFTP client. <link>Learn more</link>'
 							),
 							{
 								link: <InlineSupportLink supportContext="hosting-sftp" />,

--- a/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
@@ -294,7 +294,7 @@ export default function SshCard( {
 						title={ __( 'SSH' ) }
 						description={ createInterpolateElement(
 							__(
-								'SSH lets you access your site’s backend via a terminal, so you can manage files and use <wpCliLink>WP-CLI</wpCliLink> for quick changes and troubleshooting. <learnMoreLink>Learn more</learnMoreLink>.'
+								'SSH lets you access your site’s backend via a terminal, so you can manage files and use <wpCliLink>WP-CLI</wpCliLink> for quick changes and troubleshooting. <learnMoreLink>Learn more</learnMoreLink>'
 							),
 							{
 								wpCliLink: <ExternalLink href="https://wp-cli.org/" children={ null } />,

--- a/client/dashboard/sites/settings-site-visibility/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/index.tsx
@@ -1,10 +1,12 @@
 import { useQuery, useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { useDispatch } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { siteLaunchMutation, siteBySlugQuery } from '../../app/queries/site';
 import { siteSettingsMutation, siteSettingsQuery } from '../../app/queries/site-settings';
+import InlineSupportLink from '../../components/inline-support-link';
 import PageLayout from '../../components/page-layout';
 import SettingsPageHeader from '../settings-page-header';
 import AgencyDevelopmentSiteLaunchModal from './agency-development-site-launch-modal';
@@ -87,7 +89,12 @@ export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string
 			header={
 				<SettingsPageHeader
 					title={ __( 'Site visibility' ) }
-					description={ __( 'Control who can view your site.' ) }
+					description={ createInterpolateElement(
+						__( 'Control who can view your site. <link>Learn more</link>' ),
+						{
+							link: <InlineSupportLink supportContext="privacy" />,
+						}
+					) }
 				/>
 			}
 		>

--- a/client/dashboard/sites/settings-subscription-gifting/index.tsx
+++ b/client/dashboard/sites/settings-subscription-gifting/index.tsx
@@ -10,11 +10,13 @@ import {
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { siteBySlugQuery } from '../../app/queries/site';
 import { siteSettingsMutation, siteSettingsQuery } from '../../app/queries/site-settings';
+import InlineSupportLink from '../../components/inline-support-link';
 import PageLayout from '../../components/page-layout';
 import { DotcomFeatures } from '../../data/constants';
 import { hasPlanFeature } from '../../utils/site-features';
@@ -99,8 +101,13 @@ export default function SubscriptionGiftingSettings( { siteSlug }: { siteSlug: s
 			header={
 				<SettingsPageHeader
 					title={ __( 'Accept a gift subscription' ) }
-					description={ __(
-						'Allow a site visitor to cover the full cost of your site’s WordPress.com plan.'
+					description={ createInterpolateElement(
+						__(
+							'Allow a site visitor to cover the full cost of your site’s WordPress.com plan. <link>Learn more</link>'
+						),
+						{
+							link: <InlineSupportLink supportContext="gift-a-subscription" />,
+						}
 					) }
 				/>
 			}

--- a/client/dashboard/sites/settings-transfer-site/index.tsx
+++ b/client/dashboard/sites/settings-transfer-site/index.tsx
@@ -30,7 +30,7 @@ const SettingsTransferSitePageLayout = ( { children }: { children: React.ReactNo
 					title={ __( 'Transfer site' ) }
 					description={ createInterpolateElement(
 						__(
-							'Transfer this site to a new or existing site member with just a few clicks. <link>Learn more</link>.'
+							'Transfer this site to a new or existing site member with just a few clicks. <link>Learn more</link>'
 						),
 						{
 							link: <InlineSupportLink supportContext="site-transfer" />,


### PR DESCRIPTION
## Proposed Changes

This PR adds missing learn more links to Site Settings. They were in v1 but for some reasons we never added them in v2.

Also makes it consistent by not putting full stop at then end (see: p1753948903478549/1753935125.453589-slack-C08JZTRS6NA)

|Before|After|
|-|-|
|<img width="676" height="154" alt="image" src="https://github.com/user-attachments/assets/b544416b-4754-4856-bdb6-403bda222c8e" />|<img width="673" height="149" alt="image" src="https://github.com/user-attachments/assets/8e4fb29c-54ea-49ee-8921-428becd29470" />
|<img width="672" height="149" alt="image" src="https://github.com/user-attachments/assets/1dfe0ff8-b6e6-4acd-ad96-ddeee3d5ab54" />|<img width="673" height="157" alt="image" src="https://github.com/user-attachments/assets/b220e46d-d39d-4e72-b191-0b1222172fc1" />
|<img width="670" height="93" alt="image" src="https://github.com/user-attachments/assets/bd29db0a-2cc5-446d-b01a-4cb35864b87e" />|<img width="674" height="100" alt="image" src="https://github.com/user-attachments/assets/8ad4bf93-1314-4deb-a0b8-d61a6d8566fb" />
|<img width="668" height="107" alt="image" src="https://github.com/user-attachments/assets/1d89b1e6-f77d-4f5e-8789-1e791c0c9ae2" />|<img width="672" height="113" alt="image" src="https://github.com/user-attachments/assets/e922e7c5-345b-4bf5-ae0c-70579459eb0e" />
|<img width="676" height="161" alt="image" src="https://github.com/user-attachments/assets/a83dc39a-3374-4493-b1e1-a30889cce80b" />|<img width="673" height="171" alt="image" src="https://github.com/user-attachments/assets/c320f699-3158-414a-a493-084440ec0ce7" />
|<img width="679" height="153" alt="image" src="https://github.com/user-attachments/assets/e1fdfccf-f5bc-4cf7-a895-d2c099106e09" />|<img width="678" height="149" alt="image" src="https://github.com/user-attachments/assets/7b1dc037-d8ff-46bf-bc40-3e1b716380de" />|

## Why are these changes being made?

Fit and finish.

## Testing Instructions

1. Visually check the code changes.
2. Click the new Learn more links; verify they open the relevant documents.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?