### PR TITLE
Show plugins on my plan that have the summer special flag

### DIFF
--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -60,10 +60,12 @@ export class ProductPurchaseFeaturesList extends Component {
 	static propTypes = {
 		plan: PropTypes.oneOf( Object.keys( PLANS_LIST ) ).isRequired,
 		isPlaceholder: PropTypes.bool,
+		isSummerSpecial: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		isPlaceholder: false,
+		isSummerSpecial: false,
 	};
 
 	// TODO: Define feature list.
@@ -161,6 +163,7 @@ export class ProductPurchaseFeaturesList extends Component {
 			plan,
 			planHasDomainCredit,
 			selectedSite,
+			isSummerSpecial,
 		} = this.props;
 
 		return (
@@ -175,6 +178,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
 				{ canActivateWordadsInstant && <MonetizeSite selectedSite={ selectedSite } /> }
 				{ isEnabled( 'themes/premium' ) && <FindNewTheme selectedSite={ selectedSite } /> }
+				{ isSummerSpecial && <UploadPlugins selectedSite={ selectedSite } /> }
 				<SiteActivity />
 				<MobileApps onClick={ this.handleMobileAppsClick } />
 				<SellOnlinePaypal isJetpack={ false } />
@@ -183,7 +187,8 @@ export class ProductPurchaseFeaturesList extends Component {
 	}
 
 	getPersonalFeatures() {
-		const { isPlaceholder, isMonthlyPlan, selectedSite, planHasDomainCredit } = this.props;
+		const { isPlaceholder, isMonthlyPlan, selectedSite, planHasDomainCredit, isSummerSpecial } =
+			this.props;
 
 		return (
 			<Fragment>
@@ -192,6 +197,7 @@ export class ProductPurchaseFeaturesList extends Component {
 					<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
 				) }
 				<AdvertisingRemoved isEligiblePlan selectedSite={ selectedSite } />
+				{ isSummerSpecial && <UploadPlugins selectedSite={ selectedSite } /> }
 				<SiteActivity />
 				<MobileApps onClick={ this.handleMobileAppsClick } />
 			</Fragment>
@@ -441,6 +447,7 @@ export default connect(
 			currentPlan: getCurrentPlan( state, selectedSiteId ),
 			scheduleId: getConciergeScheduleId( state ),
 			isMonthlyPlan: TERM_MONTHLY === getPlan( ownProps.plan )?.term,
+			isSummerSpecial: selectedSite?.options?.is_summer_special_2025 ?? false,
 		};
 	},
 	{

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -34,6 +34,7 @@ import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedu
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { hasDomainCredit, getCurrentPlan } from 'calypso/state/sites/plans/selectors';
+import { getSiteOptions } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import AdvertisingRemoved from './advertising-removed';
 import BusinessOnboarding from './business-onboarding';
@@ -447,7 +448,7 @@ export default connect(
 			currentPlan: getCurrentPlan( state, selectedSiteId ),
 			scheduleId: getConciergeScheduleId( state ),
 			isMonthlyPlan: TERM_MONTHLY === getPlan( ownProps.plan )?.term,
-			isSummerSpecial: selectedSite?.options?.is_summer_special_2025 ?? false,
+			isSummerSpecial: getSiteOptions( state, selectedSiteId )?.is_summer_special_2025 ?? false,
 		};
 	},
 	{

--- a/client/blocks/product-purchase-features-list/test/product-purchase-features-list.jsx
+++ b/client/blocks/product-purchase-features-list/test/product-purchase-features-list.jsx
@@ -338,3 +338,53 @@ describe( '<HappinessSupportCard isEligibleForLiveChat', () => {
 		expect( screen.getByRole( 'button', { name: /ask a question/i } ) ).toBeVisible();
 	} );
 } );
+
+describe( 'ProductPurchaseFeaturesList summer special tests', () => {
+	const props = {
+		plan: PLAN_PERSONAL,
+		isPlaceholder: false,
+		selectedSite: {
+			plan: { product_slug: PLAN_PERSONAL },
+		},
+	};
+
+	test( 'should render UploadPlugins for Personal plan when summer special is enabled', () => {
+		const { container } = render( <ProductPurchaseFeaturesList { ...props } isSummerSpecial /> );
+		expect( container.firstChild ).not.toBeEmptyDOMElement();
+		// The UploadPlugins component should be rendered somewhere in the DOM
+		expect( container.innerHTML ).toContain( 'Add a Plugin' );
+		expect( container.innerHTML ).toContain( 'Upload a plugin now' );
+	} );
+
+	test( 'should not render UploadPlugins for Personal plan when summer special is disabled', () => {
+		const { container } = render(
+			<ProductPurchaseFeaturesList { ...props } isSummerSpecial={ false } />
+		);
+		expect( container.firstChild ).not.toBeEmptyDOMElement();
+		// The UploadPlugins component should not be rendered
+		expect( container.innerHTML ).not.toContain( 'Add a Plugin' );
+		expect( container.innerHTML ).not.toContain( 'Upload a plugin now' );
+	} );
+
+	test( 'should render UploadPlugins for Premium plan when summer special is enabled', () => {
+		const premiumProps = { ...props, plan: PLAN_PREMIUM };
+		const { container } = render(
+			<ProductPurchaseFeaturesList { ...premiumProps } isSummerSpecial />
+		);
+		expect( container.firstChild ).not.toBeEmptyDOMElement();
+		// The UploadPlugins component should be rendered somewhere in the DOM
+		expect( container.innerHTML ).toContain( 'Add a Plugin' );
+		expect( container.innerHTML ).toContain( 'Upload a plugin now' );
+	} );
+
+	test( 'should not render UploadPlugins for Premium plan when summer special is disabled', () => {
+		const premiumProps = { ...props, plan: PLAN_PREMIUM };
+		const { container } = render(
+			<ProductPurchaseFeaturesList { ...premiumProps } isSummerSpecial={ false } />
+		);
+		expect( container.firstChild ).not.toBeEmptyDOMElement();
+		// The UploadPlugins component should not be rendered
+		expect( container.innerHTML ).not.toContain( 'Add a Plugin' );
+		expect( container.innerHTML ).not.toContain( 'Upload a plugin now' );
+	} );
+} );


### PR DESCRIPTION

Part of DOTOBRD-299

## Proposed Changes

* Show the Add a plugin card on my-plan for Personal and Premium with the Summer Special flag

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

* Get a Personal or Premium plan with credits or store sandbox
* Go to Plans -> My Plan
* Confirm the Add plugin card is visible (around the bottom)
* Toggle the Summer Special 2025 flag from Blog RC
* Confirm the card is not visible

<img width="1400" height="857" alt="Screenshot 2025-08-11 at 9 46 34" src="https://github.com/user-attachments/assets/7b7ad91e-959d-4f9b-b001-5273e83ea2e6" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
