### PR TITLE
Site Overview v2: Improve logic to Setup action

### DIFF
--- a/client/dashboard/data/domains.ts
+++ b/client/dashboard/data/domains.ts
@@ -51,7 +51,7 @@ export interface DomainSummary {
 	pending_transfer: boolean;
 	points_to_wpcom: boolean;
 	primary_domain: boolean;
-	registrationDate: string;
+	registration_date: string;
 	site_slug: string;
 	subscription_id: string;
 	transfer_status: ( typeof DomainTransferStatus )[ keyof typeof DomainTransferStatus ] | null;

--- a/client/dashboard/data/domains.ts
+++ b/client/dashboard/data/domains.ts
@@ -49,6 +49,7 @@ export interface DomainSummary {
 	pending_registration_at_registry: boolean;
 	pending_renewal: boolean;
 	pending_transfer: boolean;
+	points_to_wpcom: boolean;
 	primary_domain: boolean;
 	registrationDate: string;
 	site_slug: string;

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -45,13 +45,14 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 				id: 'setup',
 				isPrimary: true,
 				icon: <Icon icon={ tool } />,
-				label: __( 'Setup' ),
+				label: __( 'Connection setup' ),
 				callback: ( items: DomainSummary[] ) => {
 					const domain = items[ 0 ];
 					const siteSlug = getDomainSiteSlug( domain );
 					window.location.pathname = domainMappingSetup( siteSlug, domain.domain );
 				},
-				isEligible: ( item: DomainSummary ) => item.type === DomainTypes.MAPPED,
+				isEligible: ( item: DomainSummary ) =>
+					item.type === DomainTypes.MAPPED && ! item.points_to_wpcom,
 			},
 			{
 				id: 'manage-domain',

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -45,7 +45,7 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 				id: 'setup',
 				isPrimary: true,
 				icon: <Icon icon={ tool } />,
-				label: __( 'Connection setup' ),
+				label: __( 'Set up connection' ),
 				callback: ( items: DomainSummary[] ) => {
 					const domain = items[ 0 ];
 					const siteSlug = getDomainSiteSlug( domain );

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -155,7 +155,7 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 					return (
 						!! site &&
 						canSetAsPrimary( { domain: item, site, user } ) &&
-						! isRecentlyRegistered( item.registrationDate )
+						! isRecentlyRegistered( item.registration_date )
 					);
 				},
 				disabled: setPrimaryDomainMutation.isPending,

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -49,7 +49,9 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 				callback: ( items: DomainSummary[] ) => {
 					const domain = items[ 0 ];
 					const siteSlug = getDomainSiteSlug( domain );
-					window.location.pathname = domainMappingSetup( siteSlug, domain.domain );
+
+					// Use href instead of pathname to preserve query parameters.
+					window.location.href = domainMappingSetup( siteSlug, domain.domain );
 				},
 				isEligible: ( item: DomainSummary ) =>
 					item.type === DomainTypes.MAPPED && ! item.points_to_wpcom,

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -8,8 +8,11 @@ import { useMemo } from 'react';
 import { domainOverviewRoute } from '../../app/router';
 import { Text } from '../../components/text';
 import { DomainTypes } from '../../data/domains';
+import { isRecentlyRegistered } from '../../utils/domain';
 import type { DomainSummary, Site } from '../../data/types';
 import type { Field } from '@wordpress/dataviews';
+
+const THREE_DAYS_IN_MINUTES = 3 * 1440;
 
 const textOverflowStyles = {
 	overflowX: 'hidden',
@@ -176,7 +179,11 @@ export const useFields = ( {
 				getValue: ( { item }: { item: DomainSummary } ) =>
 					item.expiry ? dateI18n( 'F j, Y', item.expiry ) : '',
 				render: ( { field, item } ) => {
-					if ( item.type === DomainTypes.MAPPED && ! item.points_to_wpcom ) {
+					if (
+						item.type === DomainTypes.MAPPED &&
+						! item.points_to_wpcom &&
+						! isRecentlyRegistered( item.registration_date, THREE_DAYS_IN_MINUTES )
+					) {
 						return <Text intent="error">{ __( 'Connection error' ) }</Text>;
 					}
 

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -1,15 +1,12 @@
 import { Badge } from '@automattic/ui';
 import { Link } from '@tanstack/react-router';
-import {
-	Icon,
-	__experimentalText as Text,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
+import { Icon, __experimentalHStack as HStack } from '@wordpress/components';
 import { dateI18n } from '@wordpress/date';
 import { sprintf, __ } from '@wordpress/i18n';
 import { caution, reusableBlock } from '@wordpress/icons';
 import { useMemo } from 'react';
 import { domainOverviewRoute } from '../../app/router';
+import { Text } from '../../components/text';
 import { DomainTypes } from '../../data/domains';
 import type { DomainSummary, Site } from '../../data/types';
 import type { Field } from '@wordpress/dataviews';
@@ -178,13 +175,19 @@ export const useFields = ( {
 				enableSorting: true,
 				getValue: ( { item }: { item: DomainSummary } ) =>
 					item.expiry ? dateI18n( 'F j, Y', item.expiry ) : '',
-				render: ( { field, item } ) => (
-					<DomainExpiry
-						domain={ item }
-						value={ field.getValue( { item } ) }
-						isCompact={ !! site }
-					/>
-				),
+				render: ( { field, item } ) => {
+					if ( item.type === DomainTypes.MAPPED && ! item.points_to_wpcom ) {
+						return <Text intent="error">{ __( 'Connection error' ) }</Text>;
+					}
+
+					return (
+						<DomainExpiry
+							domain={ item }
+							value={ field.getValue( { item } ) }
+							isCompact={ !! site }
+						/>
+					);
+				},
 			},
 			{
 				id: 'domain_status',


### PR DESCRIPTION
## Proposed Changes

This PR updates the logic to show the Connection Setup when the domain does not point to wpcom. This logic is ported from https://github.com/Automattic/wp-calypso/blob/971e0de3c472b8a45884c02d6dc8abbf09bb44e3/packages/domains-table/src/utils/resolve-domain-status.tsx#L141-L143

Which is the code used in the existing Site Overview

<img width="900" height="380" alt="SCR-20250811-ojmm" src="https://github.com/user-attachments/assets/aa46c541-bd58-42dd-9dab-0fdf9bc311c4" />

This PR:
<img width="683" height="266" alt="SCR-20250811-onsr" src="https://github.com/user-attachments/assets/c3ed798c-b588-4aba-b886-25796005c187" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Polish.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
