### PR TITLE
Support link in difm redirect screen open help center

### DIFF
--- a/client/dashboard/sites/difm-lite-in-progress/index.tsx
+++ b/client/dashboard/sites/difm-lite-in-progress/index.tsx
@@ -1,8 +1,10 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import { addDays, isPast } from 'date-fns';
 import { useAnalytics } from '../../app/analytics';
+import { useHelpCenter } from '../../app/help-center';
 import { useLocale } from '../../app/locale';
 import { siteBySlugQuery } from '../../app/queries/site';
 import { siteDifmWebsiteContentQuery } from '../../app/queries/site-do-it-for-me';
@@ -15,6 +17,30 @@ import { WPCOM_DIFM_LITE } from '../../data/constants';
 import { formatDate } from '../../utils/datetime';
 import { hasGSuiteWithUs, hasTitanMailWithUs } from '../../utils/domain';
 import type { Site } from '../../data/types';
+
+function ContactSupport() {
+	const { setNavigateToRoute, setShowHelpCenter, setSubject } = useHelpCenter();
+
+	// Create URLSearchParams for send feedback by email command
+	const emailUrl = `/contact-form?${ new URLSearchParams( {
+		mode: 'EMAIL',
+		'disable-gpt': 'true',
+		'skip-resources': 'true',
+	} ).toString() }`;
+
+	return createInterpolateElement( __( '<a>Contact support</a> if you have any questions.' ), {
+		a: (
+			<Button
+				variant="link"
+				onClick={ () => {
+					setNavigateToRoute( emailUrl );
+					setSubject( __( 'I have a question about my project' ) );
+					setShowHelpCenter( true );
+				} }
+			/>
+		),
+	} );
+}
 
 function WebsiteContentSubmitted( { site }: { site: Site } ) {
 	const { recordTracksEvent } = useAnalytics();
@@ -41,13 +67,19 @@ function WebsiteContentSubmitted( { site }: { site: Site } ) {
 			header={
 				<PageHeader
 					title={ __( 'Your content submission was successful!' ) }
-					description={ sprintf(
-						// translators: %d is the number of business days it will take to build the site. Always greater than 1.
-						__(
-							'We are currently building your site and will send you an email when it’s ready, within %d business days.'
-						),
-						4
-					) }
+					description={
+						<>
+							{ sprintf(
+								// translators: %d is the number of business days it will take to build the site. Always greater than 1.
+								__(
+									'We are currently building your site and will send you an email when it’s ready, within %d business days.'
+								),
+								4
+							) }
+							<br />
+							<ContactSupport />
+						</>
+					}
 				/>
 			}
 			size="small"
@@ -91,19 +123,25 @@ function WebsiteContentSubmissionPending( { site }: { site: Site } ) {
 				<PageHeader
 					title={ __( 'Website content not submitted' ) }
 					description={
-						contentSubmissionDueDate
-							? sprintf(
-									// translators: contentSubmissionDueDate includes a date, month, and year e.g. "January 1, 2023".
-									__(
-										'Click the button below to provide the content we need to build your site by %(contentSubmissionDueDate)s.'
-									),
-									{
-										contentSubmissionDueDate: formatDate( contentSubmissionDueDate, locale, {
-											dateStyle: 'long',
-										} ),
-									}
-							  )
-							: __( 'Click the button below to provide the content we need to build your site.' )
+						<>
+							{ contentSubmissionDueDate
+								? sprintf(
+										// translators: contentSubmissionDueDate includes a date, month, and year e.g. "January 1, 2023".
+										__(
+											'Click the button below to provide the content we need to build your site by %(contentSubmissionDueDate)s.'
+										),
+										{
+											contentSubmissionDueDate: formatDate( contentSubmissionDueDate, locale, {
+												dateStyle: 'long',
+											} ),
+										}
+								  )
+								: __(
+										'Click the button below to provide the content we need to build your site.'
+								  ) }
+							<br />
+							<ContactSupport />
+						</>
 					}
 				/>
 			}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTDASH-242

## Proposed Changes

*

<img width="1758" height="886" alt="CleanShot 2025-08-11 at 20 39 41@2x" src="https://github.com/user-attachments/assets/76b8d879-d3cb-4f03-a757-f60b90de7a46" />

<img width="1996" height="1074" alt="CleanShot 2025-08-11 at 20 39 57@2x" src="https://github.com/user-attachments/assets/3c1836b2-c9b8-4220-9246-7961604ac6e2" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
