### PR TITLE
Avoid newsletter redirect for atomic Personal/Premium sites

### DIFF
--- a/client/my-sites/site-settings/settings-controller.js
+++ b/client/my-sites/site-settings/settings-controller.js
@@ -1,3 +1,4 @@
+import { isWpComPersonalPlan, isWpComPremiumPlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import titlecase from 'to-title-case';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
@@ -6,6 +7,7 @@ import { sectionify } from 'calypso/lib/route';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { getSiteOption, getSiteUrl } from 'calypso/state/sites/selectors';
+import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export function redirectToJetpackNewsletterSettingsIfNeeded( context, next ) {
@@ -17,7 +19,14 @@ export function redirectToJetpackNewsletterSettingsIfNeeded( context, next ) {
 	const hasClassicAdminInterfaceStyle =
 		getSiteOption( state, siteId, 'wpcom_admin_interface' ) === 'wp-admin';
 
-	if ( hasClassicAdminInterfaceStyle && isAtomic ) {
+	// Check if site has Personal or Premium plan
+	const sitePlan = getSitePlan( state, siteId );
+	const isPersonalOrPremiumPlan =
+		sitePlan &&
+		( isWpComPersonalPlan( sitePlan.product_slug ) || isWpComPremiumPlan( sitePlan.product_slug ) );
+
+	// Only redirect if it's atomic with classic admin interface AND not Personal/Premium plan
+	if ( hasClassicAdminInterfaceStyle && isAtomic && ! isPersonalOrPremiumPlan ) {
 		navigate( `${ siteUrl }/wp-admin/admin.php?page=jetpack#/newsletter` );
 		return;
 	}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://github.com/Automattic/jetpack/pull/44699

## Proposed Changes

* prevent Newsletter redirect for atomic Personal or Premium plans

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* the Jetpack PR matches the atomic menu items for the Personal/Premium plans with the simple version. For Newsletter, there's a redirect to the wp-admin/Jetpack version of the pages exposes other broken sections

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow https://github.com/Automattic/jetpack/pull/44699
* Checkout this branch
* Using Charles, map `wordpress.com` to your Calypso instance
* In the Atomic site, clicking on the `Jetpack` -> `Newsletter` should land you on the Calyspo Newsletter page

| Before | After |
|--------|--------|
| <img width="480" alt="Screenshot 2025-08-11 at 12 11 10" src="https://github.com/user-attachments/assets/565d4d63-0c39-497e-8133-250de5999fc4" /> | <img width="480" alt="Screenshot 2025-08-11 at 12 09 41" src="https://github.com/user-attachments/assets/a9a99b04-41c0-4b01-8fd6-ea4e634a14d1" /> | 



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
