### PR TITLE
A4A > WooPayments: Show estimated earnings for previous and current quarters

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/payout-cards.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/payout-cards.tsx
@@ -14,6 +14,7 @@ function PayoutAmount( {
 	isFetching,
 	footerText,
 	popoverTitle,
+	handleHalfQuarter,
 }: {
 	expectedCommission: number;
 	activityWindow: string;
@@ -21,6 +22,7 @@ function PayoutAmount( {
 	isFetching: boolean;
 	footerText: string;
 	popoverTitle: string;
+	handleHalfQuarter?: boolean;
 } ) {
 	const translate = useTranslate();
 
@@ -40,6 +42,18 @@ function PayoutAmount( {
 					<div className="payout-cards__description-item">
 						{ translate( 'Payout range:' ) }
 						<strong>{ activityWindow }</strong>
+						{ handleHalfQuarter && (
+							<div>
+								{ translate( '(Earnings shown up to %(today)s)', {
+									args: {
+										today: new Date().toLocaleString( 'default', {
+											month: 'short',
+											day: 'numeric',
+										} ),
+									},
+								} ) }
+							</div>
+						) }
 					</div>
 
 					<div className="payout-cards__description-item">
@@ -74,10 +88,12 @@ export default function PayoutCards( {
 	isFetching,
 	previousQuarterExpectedCommission,
 	currentQuarterExpectedCommission,
+	isWooPayments,
 }: {
 	isFetching: boolean;
 	previousQuarterExpectedCommission: number;
 	currentQuarterExpectedCommission: number;
+	isWooPayments?: boolean;
 } ) {
 	const translate = useTranslate();
 
@@ -90,7 +106,14 @@ export default function PayoutCards( {
 	} = useGetPayoutData();
 
 	const previousQuarterTitle = translate( 'Estimated earnings in previous quarter' );
-	const currentQuarterTitle = translate( 'Estimated earnings in current quarter' );
+
+	const isFullQuarter = new Date().toISOString().split( 'T' )[ 0 ] === currentCyclePayoutDate;
+
+	const handleHalfQuarter = isWooPayments && ! isFullQuarter;
+
+	const currentQuarterTitle = handleHalfQuarter
+		? translate( 'Estimated current quarter earnings to date' )
+		: translate( 'Estimated earnings in current quarter' );
 
 	return (
 		<>
@@ -111,6 +134,7 @@ export default function PayoutCards( {
 				isFetching={ isFetching }
 				footerText={ currentQuarterTitle }
 				popoverTitle={ currentQuarterTitle }
+				handleHalfQuarter={ handleHalfQuarter }
 			/>
 		</>
 	);

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/payout-cards.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/payout-cards.tsx
@@ -103,11 +103,10 @@ export default function PayoutCards( {
 		currentCyclePayoutDate,
 		currentCycleActivityWindow,
 		areNextAndCurrentPayoutDatesEqual,
+		isFullQuarter,
 	} = useGetPayoutData();
 
 	const previousQuarterTitle = translate( 'Estimated earnings in previous quarter' );
-
-	const isFullQuarter = new Date().toISOString().split( 'T' )[ 0 ] === currentCyclePayoutDate;
 
 	const handleHalfQuarter = isWooPayments && ! isFullQuarter;
 

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/test/payout-cards.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/test/payout-cards.tsx
@@ -31,6 +31,7 @@ describe( 'PayoutCards', () => {
 		currentCyclePayoutDate: '2 Mar',
 		currentCycleActivityWindow: '1 Jan - 31 Mar',
 		areNextAndCurrentPayoutDatesEqual: false,
+		isFullQuarter: true,
 	};
 
 	beforeEach( () => {
@@ -135,5 +136,55 @@ describe( 'PayoutCards', () => {
 		expect( values[ 1 ] ).toHaveTextContent( '$300.50' );
 		expect( footerTexts[ 0 ] ).toHaveTextContent( 'Estimated earnings in previous quarter' );
 		expect( footerTexts[ 1 ] ).toHaveTextContent( 'Estimated earnings in current quarter' );
+	} );
+
+	it( 'should render the correct payout cards when the current quarter is not a full quarter and isWooPayments is false', () => {
+		mockUseGetPayoutData.mockReturnValue( {
+			...mockPayoutData,
+			isFullQuarter: false,
+		} );
+
+		render(
+			<PayoutCards
+				isWooPayments={ false }
+				isFetching={ false }
+				previousQuarterExpectedCommission={ 150.25 }
+				currentQuarterExpectedCommission={ 300.75 }
+			/>
+		);
+
+		const cards = screen.getAllByTestId( 'consolidated-stats-card' );
+		expect( cards ).toHaveLength( 2 );
+
+		// Should show both cards and the current quarter card should have the correct footer text
+		expect( screen.getByText( '$150.25' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Estimated earnings in previous quarter' ) ).toBeInTheDocument();
+		expect( screen.getByText( '$300.75' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Estimated earnings in current quarter' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render the correct payout cards when the current quarter is not a full quarter and isWooPayments is true', () => {
+		mockUseGetPayoutData.mockReturnValue( {
+			...mockPayoutData,
+			isFullQuarter: false,
+		} );
+
+		render(
+			<PayoutCards
+				isWooPayments
+				isFetching={ false }
+				previousQuarterExpectedCommission={ 150.25 }
+				currentQuarterExpectedCommission={ 300.75 }
+			/>
+		);
+
+		const cards = screen.getAllByTestId( 'consolidated-stats-card' );
+		expect( cards ).toHaveLength( 2 );
+
+		// Should show both cards and the current quarter card should have the correct footer text
+		expect( screen.getByText( '$150.25' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Estimated earnings in previous quarter' ) ).toBeInTheDocument();
+		expect( screen.getByText( '$300.75' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Estimated current quarter earnings to date' ) ).toBeInTheDocument();
 	} );
 } );

--- a/client/a8c-for-agencies/sections/referrals/hooks/use-get-payout-data.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-get-payout-data.ts
@@ -39,6 +39,8 @@ export default function useGetPayoutData() {
 			),
 			areNextAndCurrentPayoutDatesEqual:
 				nextPayoutDateRaw.getTime() === currentCyclePayoutDateRaw.getTime(),
+			isFullQuarter:
+				new Date().toLocaleDateString() === currentCycleWindow.finish.toLocaleDateString(),
 		};
 	}, [] );
 }

--- a/client/a8c-for-agencies/sections/referrals/lib/get-next-payout-date.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/get-next-payout-date.ts
@@ -1,3 +1,7 @@
+// We are using these dates on multiple places in the codebase, like Referrals and WooPayments.
+// We also calculate the commissions in the backend for Referrals and WooPayments.
+// TODO: We should probably move this to an API endpoint so that we have a single source of truth.
+// Please ensure to update the dates in the backend as well if you change these dates.
 const PAYOUT_DATES = [
 	{ month: 3, day: 2, activityStart: { month: 10, day: 1 }, activityEnd: { month: 12, day: 31 } }, // March 2 (Q4 activity)
 	{ month: 6, day: 1, activityStart: { month: 1, day: 1 }, activityEnd: { month: 3, day: 31 } }, // June 1 (Q1 activity)

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/consolidated-views.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/consolidated-views.tsx
@@ -4,7 +4,7 @@ import {
 	ConsolidatedStatsCard,
 	ConsolidatedStatsGroup,
 } from 'calypso/a8c-for-agencies/components/consolidated-stats-card';
-import useGetPayoutData from '../../referrals/hooks/use-get-payout-data';
+import PayoutCards from '../../referrals/consolidated-view/payout-cards';
 import { useWooPaymentsContext } from '../context';
 
 const WooPaymentsConsolidatedViews = () => {
@@ -12,9 +12,10 @@ const WooPaymentsConsolidatedViews = () => {
 
 	const { woopaymentsData, isLoadingWooPaymentsData } = useWooPaymentsContext();
 	const totalCommission = woopaymentsData?.data?.total?.payout ?? 0;
-	const expectedCommission = woopaymentsData?.data?.estimated?.payout ?? 0;
-
-	const { nextPayoutActivityWindow, nextPayoutDate } = useGetPayoutData();
+	const previousQuarterExpectedCommission =
+		woopaymentsData?.data?.estimated?.previous_quarter?.payout ?? 0;
+	const currentQuarterExpectedCommission =
+		woopaymentsData?.data?.estimated?.current_quarter?.payout ?? 0;
 
 	const learnMoreLink =
 		'https://agencieshelp.automattic.com/knowledge-base/earn-revenue-share-when-clients-use-woopayments/';
@@ -37,44 +38,11 @@ const WooPaymentsConsolidatedViews = () => {
 				) }
 				isLoading={ isLoadingWooPaymentsData }
 			/>
-			<ConsolidatedStatsCard
-				value={ formatCurrency( expectedCommission, 'USD' ) }
-				footerText={ translate( 'Next estimated payout amount' ) }
-				popoverTitle={ translate( 'Estimated amount' ) }
-				popoverContent={ translate(
-					'When your client buys products or hosting from Automattic for Agencies, they are billed on the first of every month rather than immediately. ' +
-						'We estimate the commission based on the active use for the current month. ' +
-						'{{br/}}{{br}}{{/br}}The next payout range is for:' +
-						'{{br/}}{{b}}%(nextPayoutActivityWindow)s{{/b}}' +
-						'{{br/}}{{br/}}{{a}}Learn more{{/a}} ↗',
-					{
-						components: {
-							a: <a href={ learnMoreLink } target="_blank" rel="noreferrer noopener" />,
-							br: <br />,
-							b: <b />,
-						},
-						args: {
-							nextPayoutActivityWindow,
-						},
-					}
-				) }
-				isLoading={ isLoadingWooPaymentsData }
-			/>
-			<ConsolidatedStatsCard
-				value={ nextPayoutDate + '*' }
-				footerText={ translate( 'Next estimated payout date' ) }
-				popoverTitle={ translate( 'Estimated date' ) }
-				popoverContent={ translate(
-					'*Commissions are paid quarterly, after a 60-day waiting period, excluding refunds and chargebacks. ' +
-						'Payout dates mark the start of processing, which may take a few extra days. Payments scheduled on weekends are processed the next business day. ' +
-						'{{br/}}{{br/}}{{a}}Learn more{{/a}} ↗',
-					{
-						components: {
-							a: <a href={ learnMoreLink } target="_blank" rel="noreferrer noopener" />,
-							br: <br />,
-						},
-					}
-				) }
+			<PayoutCards
+				isWooPayments
+				isFetching={ isLoadingWooPaymentsData }
+				previousQuarterExpectedCommission={ previousQuarterExpectedCommission }
+				currentQuarterExpectedCommission={ currentQuarterExpectedCommission }
 			/>
 		</ConsolidatedStatsGroup>
 	);

--- a/client/a8c-for-agencies/sections/woopayments/types.ts
+++ b/client/a8c-for-agencies/sections/woopayments/types.ts
@@ -17,12 +17,15 @@ export interface SitesWithWooPaymentsState {
 	state: string;
 }
 
+interface WooPaymentsDataObject {
+	payout: number;
+	tpv: number;
+	transactions: number;
+}
+
 export interface WooPaymentsData {
 	data: {
-		total?: {
-			payout: number;
-			tpv: number;
-			transactions: number;
+		total?: WooPaymentsDataObject & {
 			sites?: {
 				[ key: number ]: {
 					tpv?: number;
@@ -31,10 +34,9 @@ export interface WooPaymentsData {
 				};
 			};
 		};
-		estimated?: {
-			payout: number;
-			tpv: number;
-			transactions: number;
+		estimated?: WooPaymentsDataObject & {
+			current_quarter: WooPaymentsDataObject;
+			previous_quarter: WooPaymentsDataObject;
 		};
 	};
 	status: string;


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/A4A-1321/woopayments-we-should-show-the-current-quarters-estimate-payment-like

Resolves https://linear.app/a8c/issue/A4A-1437/frontend

## Proposed Changes

* Reuses the `PayoutCards` component, refactors it a bit to handle the WooPayments case.
* The PayoutCards will display two cards: Estimated earnings in the previous quarter & current quarter. It will hide the previous quarter if the payout date is the same for both the previous and current quarters.
* We have now moved the payout date and range to the tooltip of the cards to show both the cards.

## Why are these changes being made?

* To show the estimated commission for WooPayments in the previous and current quarters.

## Testing Instructions

* Patch the API: 189702-ghe-Automattic/wpcom if not merged yet. 
* Switch to this branch locally so that we can test different scenarios.
* Go to WooPayments: Dashboard >  Verify you can see two new cards, instead of two old ones (compare with https://agencies.automattic.com/woopayments/dashboard)

<img width="1534" height="125" alt="Screenshot 2025-08-11 at 2 06 18 PM" src="https://github.com/user-attachments/assets/beecb2b8-e237-4688-95ef-48c77404d1f5" />

**Previous quarter** 

<img width="516" height="502" alt="Screenshot 2025-08-11 at 2 06 50 PM" src="https://github.com/user-attachments/assets/3c7e0083-16a1-48ab-877f-abd715c40ede" />

**Current quarter**

<img width="516" height="502" alt="Screenshot 2025-08-11 at 2 07 02 PM" src="https://github.com/user-attachments/assets/c60e2019-6a84-474f-98ca-b64805d57682" />

* Go to client/a8c-for-agencies/sections/referrals/hooks/use-get-payout-data.ts > Set the areNextAndCurrentPayoutDatesEqual to true and verify you see only the current quarter card. 
* Update the date in the `isFullQuarter` from `new Date()` to `new Date( '2025-09-30' )` > Verify the card looks like below:

<img width="516" height="502" alt="Screenshot 2025-08-11 at 2 07 55 PM" src="https://github.com/user-attachments/assets/4526f822-ccfc-4443-8588-cd00d776c82e" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
