### PR TITLE
Site Overview: Implement renew now action

### DIFF
--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -6,13 +6,16 @@ import {
 	domainMappingSetup,
 	domainUseMyDomain,
 } from '@automattic/domains-table/src/utils/paths';
-import { useMutation } from '@tanstack/react-query';
+import { encodeProductForUrl } from '@automattic/wpcom-checkout'; // eslint-disable-line no-restricted-imports
+import { useQuery, useMutation } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { sprintf, __ } from '@wordpress/i18n';
 import { payment, tool } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
+import { addQueryArgs } from '@wordpress/url';
 import { useMemo } from 'react';
+import { userPurchasesQuery } from '../../app/queries/me-purchases';
 import { siteSetPrimaryDomainMutation } from '../../app/queries/site-domains';
 import { DomainTypes, DomainTransferStatus } from '../../data/domains';
 import {
@@ -24,11 +27,13 @@ import {
 	getDomainSiteSlug,
 } from '../../utils/domain';
 import { isTransferrableToWpcom } from '../../utils/domain-types';
+import { isAkismetProduct, isMarketplaceTemporarySitePurchase } from '../../utils/purchase';
 import type { DomainSummary, Site, User } from '../../data/types';
 import type { Action } from '@wordpress/dataviews';
 
 export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const { data: purchases } = useQuery( userPurchasesQuery() );
 	const setPrimaryDomainMutation = useMutation( siteSetPrimaryDomainMutation() );
 	const context = site ? 'site' : 'domains';
 	const actions: Action< DomainSummary >[] = useMemo(
@@ -38,7 +43,31 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 				isPrimary: true,
 				icon: <Icon icon={ payment } />,
 				label: __( 'Renew now' ),
-				callback: () => {},
+				callback: ( items: DomainSummary[] ) => {
+					const domain = items[ 0 ];
+					const siteSlug = getDomainSiteSlug( domain );
+					const purchase = purchases?.find( ( p ) => p.ID === domain.subscription_id );
+					if ( purchase ) {
+						const productSlug = [ purchase.product_slug, domain.domain ]
+							.map( ( productSlug ) => encodeProductForUrl( productSlug ) )
+							.join( ':' );
+						const backUrl = window.location.href.replace( window.location.origin, '' );
+						let serviceSlug = '';
+						if ( isAkismetProduct( purchase ) ) {
+							serviceSlug = 'akismet/';
+						} else if ( isMarketplaceTemporarySitePurchase( purchase ) ) {
+							serviceSlug = 'marketplace/';
+						}
+
+						window.location.pathname = addQueryArgs(
+							`/checkout/${ serviceSlug }${ productSlug }/renew/${ purchase.ID }/${ siteSlug }`,
+							{
+								cancel_to: backUrl,
+								redirect_to: backUrl,
+							}
+						);
+					}
+				},
 				isEligible: ( item: DomainSummary ) => isDomainRenewable( item ),
 			},
 			{
@@ -199,7 +228,15 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 				isEligible: () => false,
 			},
 		],
-		[ user, site, context, setPrimaryDomainMutation, createSuccessNotice, createErrorNotice ]
+		[
+			user,
+			site,
+			context,
+			purchases,
+			setPrimaryDomainMutation,
+			createSuccessNotice,
+			createErrorNotice,
+		]
 	);
 
 	return actions;

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -6,7 +6,6 @@ import {
 	domainMappingSetup,
 	domainUseMyDomain,
 } from '@automattic/domains-table/src/utils/paths';
-import { encodeProductForUrl } from '@automattic/wpcom-checkout'; // eslint-disable-line no-restricted-imports
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
@@ -28,6 +27,7 @@ import {
 } from '../../utils/domain';
 import { isTransferrableToWpcom } from '../../utils/domain-types';
 import { isAkismetProduct, isMarketplaceTemporarySitePurchase } from '../../utils/purchase';
+import { encodeProductForUrl } from '../../utils/wpcom-checkout';
 import type { DomainSummary, Site, User } from '../../data/types';
 import type { Action } from '@wordpress/dataviews';
 

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -59,7 +59,7 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 							serviceSlug = 'marketplace/';
 						}
 
-						window.location.pathname = addQueryArgs(
+						window.location.href = addQueryArgs(
 							`/checkout/${ serviceSlug }${ productSlug }/renew/${ purchase.ID }/${ siteSlug }`,
 							{
 								cancel_to: backUrl,

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -42,6 +42,10 @@ export function isAkismetFreeProduct( product: Purchase ): boolean {
 	);
 }
 
+export function isAkismetProduct( product: Purchase ): boolean {
+	return Object.values( AkismetPlans ).includes( product.product_slug );
+}
+
 /**
  * Determines if this is a recent monthly purchase (bought within the past week).
  *

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -43,7 +43,9 @@ export function isAkismetFreeProduct( product: Purchase ): boolean {
 }
 
 export function isAkismetProduct( product: Purchase ): boolean {
-	return Object.values( AkismetPlans ).includes( product.product_slug );
+	return Object.values( AkismetPlans ).includes(
+		product.product_slug as ( typeof AkismetPlans )[ keyof typeof AkismetPlans ]
+	);
 }
 
 /**

--- a/client/dashboard/utils/wpcom-checkout.ts
+++ b/client/dashboard/utils/wpcom-checkout.ts
@@ -21,6 +21,5 @@ export function encodeProductForUrl( slug: string ): string {
 }
 
 export function decodeProductFromUrl( slug: string ): string {
-	// This should really use String.prototype.replaceAll but it's yet not fully supported
-	return slug.split( slashForDecoding ).join( '/' );
+	return slug.replaceAll( slashForDecoding, '/' );
 }

--- a/client/dashboard/utils/wpcom-checkout.ts
+++ b/client/dashboard/utils/wpcom-checkout.ts
@@ -1,0 +1,26 @@
+// This file is copied from `@automattic/wpcom-checkout`
+
+// Some product slugs or meta contain slashes which will break the URL, so we
+// encode them first. We cannot use encodeURIComponent because the calypso
+// router seems to break if the trailing part of the URL contains an encoded
+// slash (eg: /checkout/example.com/foo%2Fbar breaks routing). We cannot use
+// the same characters for encoding as for decoding if they are UTF-8 encoded
+// because they will already be decoded by the time the decoding takes place.
+//
+// If all of that is confusing, see the tests for these functions to understand
+// how they will be used.
+//
+// If this is ever changed, please make sure to also change the code that
+// generates renewal emails on the backend, because it uses the same encoding!
+
+const slashForEncoding = '%25';
+const slashForDecoding = '%';
+
+export function encodeProductForUrl( slug: string ): string {
+	return slug.replace( /\//g, slashForEncoding );
+}
+
+export function decodeProductFromUrl( slug: string ): string {
+	// This should really use String.prototype.replaceAll but it's yet not fully supported
+	return slug.split( slashForDecoding ).join( '/' );
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-251

## Proposed Changes

* Implement renew now action

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Select any site with the custom domain
* On the domain card, try to renew the custom domain
* Ensure it opens the checkout page directly
* Ensure the domain is included in your cart

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
