### PR TITLE
Hosting Dashboard: Add DataViewsCard to PurchasesList

### DIFF
--- a/client/dashboard/me/billing-purchases/index.tsx
+++ b/client/dashboard/me/billing-purchases/index.tsx
@@ -6,6 +6,7 @@ import { useState, useMemo } from 'react';
 import { userPaymentMethodsQuery } from '../../app/queries/me-payment-methods';
 import { userPurchasesQuery, userTransferredPurchasesQuery } from '../../app/queries/me-purchases';
 import { sitesQuery } from '../../app/queries/sites';
+import DataViewsCard from '../../components/dataviews-card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { isTransferredOwnership } from '../../utils/purchase';
@@ -69,17 +70,19 @@ export default function PurchasesList() {
 	return (
 		<PageLayout size="large" header={ <PageHeader title={ __( 'Active Upgrades' ) } /> }>
 			<div ref={ ref }>
-				<DataViews
-					isLoading={ isLoadingPurchases || isLoadingTransferredPurchases || isLoadingSites }
-					data={ filteredSubscriptions ?? [] }
-					fields={ purchasesDataFields }
-					view={ currentView }
-					onChangeView={ setView }
-					defaultLayouts={ { table: {} } }
-					actions={ actions }
-					getItemId={ getItemId }
-					paginationInfo={ paginationInfo }
-				/>
+				<DataViewsCard>
+					<DataViews
+						isLoading={ isLoadingPurchases || isLoadingTransferredPurchases || isLoadingSites }
+						data={ filteredSubscriptions ?? [] }
+						fields={ purchasesDataFields }
+						view={ currentView }
+						onChangeView={ setView }
+						defaultLayouts={ { table: {} } }
+						actions={ actions }
+						getItemId={ getItemId }
+						paginationInfo={ paginationInfo }
+					/>
+				</DataViewsCard>
 			</div>
 		</PageLayout>
 	);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/CHE-229/hosting-dashboard-migrate-existing-purchases-list-to-dashboard

## Proposed Changes

A follow-up to #104914 to make sure that we use `DataViewsCard` to wrap the purchases list, which better unifies its appearance with the other DataViews in the dashboard.

Before             |  After
:-------------------------:|:-------------------------:
<img width="750" height="434" alt="Screenshot 2025-08-11 at 1 08 29 PM" src="https://github.com/user-attachments/assets/f8bc250c-19f5-4c33-90e9-3c39a523f0e3" /> | <img width="747" height="447" alt="Screenshot 2025-08-11 at 1 08 04 PM" src="https://github.com/user-attachments/assets/de2aeacb-b4fd-4b5a-987d-023830ef7a61" />


## Testing Instructions

View http://calypso.localhost:3000/v2/me/billing/purchases and verify that the DataView is on a "card" UI element (like http://calypso.localhost:3000/v2/sites).
