### PR TITLE
Redirect from deletion banner when the staging site is deleted

### DIFF
--- a/client/layout/hosting-dashboard/item-view/index.tsx
+++ b/client/layout/hosting-dashboard/item-view/index.tsx
@@ -133,7 +133,7 @@ export default function ItemView( {
 			<div className={ clsx( 'hosting-dashboard-item-view', className ) }>
 				{ renderHeader() }
 				{ isStagingSiteDeletionInProgress ? (
-					<StagingSiteDeletionBanner />
+					<StagingSiteDeletionBanner siteId={ itemData.blogId ?? 0 } />
 				) : (
 					<StagingSiteCreationBanner />
 				) }

--- a/client/sites/staging-site/components/staging-site-transfer-banner/staging-site-deletion-banner.tsx
+++ b/client/sites/staging-site/components/staging-site-transfer-banner/staging-site-deletion-banner.tsx
@@ -1,15 +1,80 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
 import {
 	__experimentalText as Text,
 	__experimentalHeading as Heading,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useEffect } from 'react';
+import { siteByIdQuery } from 'calypso/dashboard/app/queries/site';
+import {
+	isDeletingStagingSiteQuery,
+	hasStagingSiteQuery,
+} from 'calypso/dashboard/app/queries/site-staging-sites';
+import { getProductionSiteId } from 'calypso/dashboard/utils/site-staging-site';
 import deleteStagingSiteIllustration from './delete-staging-site-illustration.svg';
 import { StagingSiteBannerWrapper } from './staging-site-banner-wrapper';
 
-export function StagingSiteDeletionBanner() {
+interface StagingSiteDeletionBannerProps {
+	siteId: number;
+}
+
+export function StagingSiteDeletionBanner( { siteId }: StagingSiteDeletionBannerProps ) {
 	const heading = __( 'Deleting staging site' );
+
+	const router = useRouter();
+	const queryClient = useQueryClient();
+	const { createSuccessNotice } = useDispatch( noticesStore );
+
+	// Fetch the current site data
+	const { data: site = {} } = useQuery( {
+		...siteByIdQuery( siteId ),
+		enabled: !! siteId,
+	} );
+
+	const productionSiteId = getProductionSiteId( site ) ?? 0;
+
+	// Poll for staging site status
+	const { data: hasStagingSite } = useQuery( {
+		...hasStagingSiteQuery( productionSiteId ),
+		refetchInterval: 3000,
+		enabled: !! productionSiteId,
+	} );
+
+	// Fetch production site data for redirect
+	const { data: productionSite } = useQuery( {
+		...siteByIdQuery( productionSiteId ?? 0 ),
+		enabled: !! productionSiteId,
+	} );
+
+	// Redirect to the production site when the staging site is deleted
+	useEffect( () => {
+		if ( ! hasStagingSite && productionSite?.slug && site ) {
+			queryClient.removeQueries( isDeletingStagingSiteQuery( site.ID ) );
+
+			// Clear the staging site query to stop polling
+			queryClient.removeQueries( hasStagingSiteQuery( productionSiteId ) );
+
+			// Staging site has been deleted, redirect to production site
+			router.navigate( {
+				to: '/overview/$siteSlug',
+				params: { siteSlug: productionSite.slug },
+			} );
+			createSuccessNotice( __( 'Staging site deleted.' ), { type: 'snackbar' } );
+		}
+	}, [
+		hasStagingSite,
+		productionSite,
+		router,
+		queryClient,
+		productionSiteId,
+		createSuccessNotice,
+		site,
+	] );
 
 	return (
 		<StagingSiteBannerWrapper>

--- a/client/sites/staging-site/components/staging-site-transfer-banner/staging-site-deletion-banner.tsx
+++ b/client/sites/staging-site/components/staging-site-transfer-banner/staging-site-deletion-banner.tsx
@@ -1,5 +1,5 @@
+import page from '@automattic/calypso-router';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useRouter } from '@tanstack/react-router';
 import {
 	__experimentalText as Text,
 	__experimentalHeading as Heading,
@@ -26,17 +26,16 @@ interface StagingSiteDeletionBannerProps {
 export function StagingSiteDeletionBanner( { siteId }: StagingSiteDeletionBannerProps ) {
 	const heading = __( 'Deleting staging site' );
 
-	const router = useRouter();
 	const queryClient = useQueryClient();
 	const { createSuccessNotice } = useDispatch( noticesStore );
 
 	// Fetch the current site data
-	const { data: site = {} } = useQuery( {
+	const { data: site } = useQuery( {
 		...siteByIdQuery( siteId ),
 		enabled: !! siteId,
 	} );
 
-	const productionSiteId = getProductionSiteId( site ) ?? 0;
+	const productionSiteId = Number( site ? getProductionSiteId( site ) : 0 );
 
 	// Poll for staging site status
 	const { data: hasStagingSite } = useQuery( {
@@ -53,28 +52,17 @@ export function StagingSiteDeletionBanner( { siteId }: StagingSiteDeletionBanner
 
 	// Redirect to the production site when the staging site is deleted
 	useEffect( () => {
-		if ( ! hasStagingSite && productionSite?.slug && site ) {
+		if ( hasStagingSite !== undefined && ! hasStagingSite && productionSite?.slug && site ) {
 			queryClient.removeQueries( isDeletingStagingSiteQuery( site.ID ) );
 
 			// Clear the staging site query to stop polling
 			queryClient.removeQueries( hasStagingSiteQuery( productionSiteId ) );
 
 			// Staging site has been deleted, redirect to production site
-			router.navigate( {
-				to: '/overview/$siteSlug',
-				params: { siteSlug: productionSite.slug },
-			} );
+			page( `/overview/${ productionSite.slug }` );
 			createSuccessNotice( __( 'Staging site deleted.' ), { type: 'snackbar' } );
 		}
-	}, [
-		hasStagingSite,
-		productionSite,
-		router,
-		queryClient,
-		productionSiteId,
-		createSuccessNotice,
-		site,
-	] );
+	}, [ hasStagingSite, productionSite, queryClient, productionSiteId, createSuccessNotice, site ] );
 
 	return (
 		<StagingSiteBannerWrapper>

--- a/client/sites/staging-site/components/staging-site-transfer-banner/staging-site-deletion-banner.tsx
+++ b/client/sites/staging-site/components/staging-site-transfer-banner/staging-site-deletion-banner.tsx
@@ -6,9 +6,7 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { useEffect } from 'react';
 import { siteByIdQuery } from 'calypso/dashboard/app/queries/site';
 import {
@@ -16,6 +14,8 @@ import {
 	hasStagingSiteQuery,
 } from 'calypso/dashboard/app/queries/site-staging-sites';
 import { getProductionSiteId } from 'calypso/dashboard/utils/site-staging-site';
+import { useDispatch } from 'calypso/state';
+import { successNotice } from 'calypso/state/notices/actions';
 import deleteStagingSiteIllustration from './delete-staging-site-illustration.svg';
 import { StagingSiteBannerWrapper } from './staging-site-banner-wrapper';
 
@@ -27,7 +27,7 @@ export function StagingSiteDeletionBanner( { siteId }: StagingSiteDeletionBanner
 	const heading = __( 'Deleting staging site' );
 
 	const queryClient = useQueryClient();
-	const { createSuccessNotice } = useDispatch( noticesStore );
+	const dispatch = useDispatch();
 
 	// Fetch the current site data
 	const { data: site } = useQuery( {
@@ -60,9 +60,9 @@ export function StagingSiteDeletionBanner( { siteId }: StagingSiteDeletionBanner
 
 			// Staging site has been deleted, redirect to production site
 			page( `/overview/${ productionSite.slug }` );
-			createSuccessNotice( __( 'Staging site deleted.' ), { type: 'snackbar' } );
+			dispatch( successNotice( __( 'Staging site deleted.' ) ) );
 		}
-	}, [ hasStagingSite, productionSite, queryClient, productionSiteId, createSuccessNotice, site ] );
+	}, [ hasStagingSite, productionSite, queryClient, productionSiteId, dispatch, site ] );
 
 	return (
 		<StagingSiteBannerWrapper>

--- a/client/sites/staging-site/components/staging-site-transfer-banner/staging-site-deletion-banner.tsx
+++ b/client/sites/staging-site/components/staging-site-transfer-banner/staging-site-deletion-banner.tsx
@@ -29,7 +29,6 @@ export function StagingSiteDeletionBanner( { siteId }: StagingSiteDeletionBanner
 	const queryClient = useQueryClient();
 	const dispatch = useDispatch();
 
-	// Fetch the current site data
 	const { data: site } = useQuery( {
 		...siteByIdQuery( siteId ),
 		enabled: !! siteId,
@@ -37,28 +36,20 @@ export function StagingSiteDeletionBanner( { siteId }: StagingSiteDeletionBanner
 
 	const productionSiteId = Number( site ? getProductionSiteId( site ) : 0 );
 
-	// Poll for staging site status
 	const { data: hasStagingSite } = useQuery( {
 		...hasStagingSiteQuery( productionSiteId ),
 		refetchInterval: 3000,
 		enabled: !! productionSiteId,
 	} );
-
-	// Fetch production site data for redirect
 	const { data: productionSite } = useQuery( {
 		...siteByIdQuery( productionSiteId ?? 0 ),
 		enabled: !! productionSiteId,
 	} );
 
-	// Redirect to the production site when the staging site is deleted
 	useEffect( () => {
 		if ( hasStagingSite !== undefined && ! hasStagingSite && productionSite?.slug && site ) {
 			queryClient.removeQueries( isDeletingStagingSiteQuery( site.ID ) );
-
-			// Clear the staging site query to stop polling
 			queryClient.removeQueries( hasStagingSiteQuery( productionSiteId ) );
-
-			// Staging site has been deleted, redirect to production site
 			page( `/overview/${ productionSite.slug }` );
 			dispatch( successNotice( __( 'Staging site deleted.' ) ) );
 		}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves [DOTCOM-14207 Staging Site Redesign: Fix missing redirect after staging site deletion](https://linear.app/a8c/issue/DOTCOM-14207/staging-site-redesign-fix-missing-redirect-after-staging-site-deletion)

## Proposed Changes

* Add missing `siteId` prop to `StagingSiteDeletionBanner` component
* Implement automatic redirect to production site after staging site deletion completes
* Add success notification when staging site deletion is completed
* Update `ItemView` component to pass the required `siteId` prop to the deletion banner
* Change the notice shown from the newer snackbar style to the older calypso/state style, as the component is now rendered outside the context of the dashboard notice store

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

In https://github.com/Automattic/wp-calypso/pull/105069 we refactored the staging site creation and deletion banners to reuse common code, and to avoid inconsistent states that were caused by the deletion banner being rendered from only the settings tab.

However, the refactor of the deletion banner was previously incomplete, it missed the redirection when the deletion is done. This PR implements the missing redirect logic, ensuring users have a smooth experience when deleting staging sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the Staging site settings, and click on the "Delete staging site" button
* Click the Delete button on the modal that appears
* Check that the deletion banner is shown
* Switch to the production environment using the environment switcher, and select a tab other than Settings
* Switch back to the staging environment
* Check that the deletion banner is shown, wait for the staging site to be reverted
* Check that after successful deletion:
   - You are redirected to the production site (not the general `/sites` page)
   - The "Staging site deleted." notice is displayed


https://github.com/user-attachments/assets/1be7b72c-fca0-48ac-85c7-f51fcdddb951



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
