### PR TITLE
Fix crash when switching environments

### DIFF
--- a/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
@@ -1,4 +1,4 @@
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -36,12 +36,11 @@ export default function StagingSiteSyncDropdown( {
 }: StagingSiteSyncDropdownProps ) {
 	const [ isModalOpen, setIsModalOpen ] = useState< boolean >( false );
 	const [ syncDirection, setSyncDirection ] = useState< StagingSiteSyncDirection >( 'pull' );
-	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const environment = site.is_wpcom_staging_site ? 'staging' : 'production';
+	const { data: site } = useQuery( siteBySlugQuery( siteSlug ) );
+	const environment = site?.is_wpcom_staging_site ? 'staging' : 'production';
 
-	const productionSiteId = getProductionSiteId( site );
-
-	const stagingSiteId = getStagingSiteId( site );
+	const productionSiteId = site ? getProductionSiteId( site ) : null;
+	const stagingSiteId = site ? getStagingSiteId( site ) : null;
 
 	const { data: stagingSiteSyncState, refetch: fetchStagingSiteSyncState } = useQuery( {
 		...stagingSiteSyncStateQuery( productionSiteId ?? 0 ),


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes [DOTCOM-14202](https://linear.app/a8c/issue/DOTCOM-14202)

## Proposed Changes

* Changed from `useSuspenseQuery` to `useQuery` in `StagingSiteSyncDropdown` component to prevent crashes when site data is not immediately available
* Added proper null checking for site data before accessing properties like `is_wpcom_staging_site`
* Add fallbacks to `productionSiteId` and `stagingSiteId`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The page was crashing when switching between production and staging sites

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to a site with a staging site and open the dev console
* Switch between the production and staging sites
* Check that the site is switched as expected
* Check that none of the below errors are thrown:
<img width="1554" height="777" alt="image" src="https://github.com/user-attachments/assets/e8a4101c-747b-40af-9498-6f75c483b600" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
