### PR TITLE
Add Backup details card

### DIFF
--- a/client/dashboard/sites/backups/backup-details.tsx
+++ b/client/dashboard/sites/backups/backup-details.tsx
@@ -12,8 +12,8 @@ import { SectionHeader } from '../../components/section-header';
 import { gridiconToWordPressIcon } from '../../utils/gridicons';
 import type { ActivityLogEntry } from '../../data/types';
 
-export function BackupDetails( { selectedBackup }: { selectedBackup: ActivityLogEntry } ) {
-	const formattedTime = useFormattedTime( selectedBackup.published, {
+export function BackupDetails( { backup }: { backup: ActivityLogEntry } ) {
+	const formattedTime = useFormattedTime( backup.published, {
 		dateStyle: 'medium',
 		timeStyle: 'short',
 	} );
@@ -22,19 +22,19 @@ export function BackupDetails( { selectedBackup }: { selectedBackup: ActivityLog
 		<Card>
 			<CardHeader>
 				<SectionHeader
-					title={ selectedBackup.summary }
-					decoration={ <Icon icon={ gridiconToWordPressIcon( selectedBackup.gridicon ) } /> }
+					title={ backup.summary }
+					decoration={ <Icon icon={ gridiconToWordPressIcon( backup.gridicon ) } /> }
 				/>
 			</CardHeader>
 			<VStack className="dashboard-backups__details">
 				<Text size={ 14 } weight={ 500 }>
-					{ selectedBackup.content.text }
+					{ backup.content.text }
 				</Text>
 				<HStack alignment="left" spacing={ 4 }>
 					<Text variant="muted">{ formattedTime }</Text>
-					{ selectedBackup.actor?.name && (
+					{ backup.actor?.name && (
 						<Text variant="muted">
-							{ __( 'By' ) } { selectedBackup.actor.name }
+							{ __( 'By' ) } { backup.actor.name }
 						</Text>
 					) }
 				</HStack>

--- a/client/dashboard/sites/backups/backup-details.tsx
+++ b/client/dashboard/sites/backups/backup-details.tsx
@@ -7,7 +7,7 @@ import {
 	CardHeader,
 	Icon,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useFormattedTime } from '../../components/formatted-time';
 import { SectionHeader } from '../../components/section-header';
 import { gridiconToWordPressIcon } from '../../utils/gridicons';
@@ -36,7 +36,10 @@ export function BackupDetails( { backup }: { backup: ActivityLogEntry } ) {
 						<Text variant="muted">{ formattedTime }</Text>
 						{ backup.actor?.name && (
 							<Text variant="muted">
-								{ __( 'By' ) } { backup.actor.name }
+								{
+									/* translators: %s is the name of the person/system who performed the backup */
+									sprintf( __( 'By %s' ), backup.actor.name )
+								}
 							</Text>
 						) }
 					</HStack>

--- a/client/dashboard/sites/backups/backup-details.tsx
+++ b/client/dashboard/sites/backups/backup-details.tsx
@@ -1,0 +1,44 @@
+import {
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Card,
+	CardHeader,
+	Icon,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useFormattedTime } from '../../components/formatted-time';
+import { SectionHeader } from '../../components/section-header';
+import { gridiconToWordPressIcon } from '../../utils/gridicons';
+import type { ActivityLogEntry } from '../../data/types';
+
+export function BackupDetails( { selectedBackup }: { selectedBackup: ActivityLogEntry } ) {
+	const formattedTime = useFormattedTime( selectedBackup.published, {
+		dateStyle: 'medium',
+		timeStyle: 'short',
+	} );
+
+	return (
+		<Card>
+			<CardHeader>
+				<SectionHeader
+					title={ selectedBackup.summary }
+					decoration={ <Icon icon={ gridiconToWordPressIcon( selectedBackup.gridicon ) } /> }
+				/>
+			</CardHeader>
+			<VStack className="dashboard-backups__details">
+				<Text size={ 14 } weight={ 500 }>
+					{ selectedBackup.content.text }
+				</Text>
+				<HStack alignment="left" spacing={ 4 }>
+					<Text variant="muted">{ formattedTime }</Text>
+					{ selectedBackup.actor?.name && (
+						<Text variant="muted">
+							{ __( 'By' ) } { selectedBackup.actor.name }
+						</Text>
+					) }
+				</HStack>
+			</VStack>
+		</Card>
+	);
+}

--- a/client/dashboard/sites/backups/backup-details.tsx
+++ b/client/dashboard/sites/backups/backup-details.tsx
@@ -3,6 +3,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	Card,
+	CardBody,
 	CardHeader,
 	Icon,
 } from '@wordpress/components';
@@ -26,19 +27,21 @@ export function BackupDetails( { backup }: { backup: ActivityLogEntry } ) {
 					decoration={ <Icon icon={ gridiconToWordPressIcon( backup.gridicon ) } /> }
 				/>
 			</CardHeader>
-			<VStack className="dashboard-backups__details">
-				<Text size={ 14 } weight={ 500 }>
-					{ backup.content.text }
-				</Text>
-				<HStack alignment="left" spacing={ 4 }>
-					<Text variant="muted">{ formattedTime }</Text>
-					{ backup.actor?.name && (
-						<Text variant="muted">
-							{ __( 'By' ) } { backup.actor.name }
-						</Text>
-					) }
-				</HStack>
-			</VStack>
+			<CardBody>
+				<VStack>
+					<Text size={ 14 } weight={ 500 }>
+						{ backup.content.text }
+					</Text>
+					<HStack alignment="left" spacing={ 4 }>
+						<Text variant="muted">{ formattedTime }</Text>
+						{ backup.actor?.name && (
+							<Text variant="muted">
+								{ __( 'By' ) } { backup.actor.name }
+							</Text>
+						) }
+					</HStack>
+				</VStack>
+			</CardBody>
 		</Card>
 	);
 }

--- a/client/dashboard/sites/backups/backups-list.tsx
+++ b/client/dashboard/sites/backups/backups-list.tsx
@@ -1,0 +1,67 @@
+import { useQuery } from '@tanstack/react-query';
+import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect } from 'react';
+import { siteRewindableActivityLogEntriesQuery } from '../../app/queries/site-activity-log';
+import DataViewsCard from '../../components/dataviews-card';
+import { getFields } from './dataviews/fields';
+import type { ActivityLogEntry, Site } from '../../data/types';
+import type { View } from '@wordpress/dataviews';
+
+export function BackupsList( {
+	site,
+	selectedBackup,
+	setSelectBackup,
+}: {
+	site: Site;
+	selectedBackup: ActivityLogEntry | null;
+	setSelectBackup: ( backup: ActivityLogEntry | null ) => void;
+} ) {
+	const [ view, setView ] = useState< View >( {
+		type: 'list',
+		fields: [ 'date', 'content_text' ],
+		mediaField: 'icon',
+		titleField: 'title',
+		perPage: 10,
+	} );
+
+	const { data: activityLog = [], isLoading: isLoadingActivityLog } = useQuery(
+		siteRewindableActivityLogEntriesQuery( site.ID )
+	);
+
+	const fields = getFields();
+	const { data: filteredData, paginationInfo } = filterSortAndPaginate( activityLog, view, fields );
+
+	useEffect( () => {
+		if ( ! isLoadingActivityLog && activityLog.length > 0 && ! selectedBackup ) {
+			const firstBackup = activityLog[ 0 ];
+			setSelectBackup( firstBackup );
+		}
+	}, [ isLoadingActivityLog, activityLog, selectedBackup, setSelectBackup ] );
+
+	const onChangeSelection = ( selection: string[] ) => {
+		const backup =
+			selection.length > 0
+				? activityLog.find( ( item ) => item.activity_id === selection[ 0 ] ) || null
+				: null;
+		setSelectBackup( backup );
+	};
+
+	return (
+		<DataViewsCard>
+			<DataViews< ActivityLogEntry >
+				getItemId={ ( item ) => item.activity_id }
+				data={ filteredData }
+				fields={ fields }
+				view={ view }
+				onChangeView={ setView }
+				isLoading={ isLoadingActivityLog }
+				defaultLayouts={ { table: {} } }
+				paginationInfo={ paginationInfo }
+				searchLabel={ __( 'Search backups' ) }
+				onChangeSelection={ onChangeSelection }
+				selection={ selectedBackup ? [ selectedBackup.activity_id ] : [] }
+			/>
+		</DataViewsCard>
+	);
+}

--- a/client/dashboard/sites/backups/backups-list.tsx
+++ b/client/dashboard/sites/backups/backups-list.tsx
@@ -11,11 +11,11 @@ import type { View } from '@wordpress/dataviews';
 export function BackupsList( {
 	site,
 	selectedBackup,
-	setSelectBackup,
+	setSelectedBackup,
 }: {
 	site: Site;
 	selectedBackup: ActivityLogEntry | null;
-	setSelectBackup: ( backup: ActivityLogEntry | null ) => void;
+	setSelectedBackup: ( backup: ActivityLogEntry | null ) => void;
 } ) {
 	const [ view, setView ] = useState< View >( {
 		type: 'list',
@@ -35,16 +35,16 @@ export function BackupsList( {
 	useEffect( () => {
 		if ( ! isLoadingActivityLog && activityLog.length > 0 && ! selectedBackup ) {
 			const firstBackup = activityLog[ 0 ];
-			setSelectBackup( firstBackup );
+			setSelectedBackup( firstBackup );
 		}
-	}, [ isLoadingActivityLog, activityLog, selectedBackup, setSelectBackup ] );
+	}, [ isLoadingActivityLog, activityLog, selectedBackup, setSelectedBackup ] );
 
 	const onChangeSelection = ( selection: string[] ) => {
 		const backup =
 			selection.length > 0
 				? activityLog.find( ( item ) => item.activity_id === selection[ 0 ] ) || null
 				: null;
-		setSelectBackup( backup );
+		setSelectedBackup( backup );
 	};
 
 	return (

--- a/client/dashboard/sites/backups/dataviews/fields.tsx
+++ b/client/dashboard/sites/backups/dataviews/fields.tsx
@@ -7,14 +7,32 @@ import type { Field } from '@wordpress/dataviews';
 
 const FormattedTime = ( { timestamp }: { timestamp: string } ) => {
 	const formattedTime = useFormattedTime( timestamp, {
-		dateStyle: 'long',
+		dateStyle: 'medium',
 		timeStyle: 'short',
 	} );
-	return <strong>{ formattedTime }</strong>;
+	return <>{ formattedTime }</>;
 };
 
 export function getFields(): Field< ActivityLogEntry >[] {
 	return [
+		{
+			id: 'icon',
+			render: ( { item } ) => (
+				<Icon
+					icon={ gridiconToWordPressIcon( item.gridicon ) }
+					size={ 32 }
+					className="dashboard-backups__list-icon"
+				/>
+			),
+		},
+		{
+			id: 'title',
+			getValue: ( { item } ) => {
+				const actor = item.actor?.name ? ` by ${ item.actor.name }` : '';
+				return item.summary + actor;
+			},
+			enableGlobalSearch: true,
+		},
 		{
 			id: 'date',
 			label: __( 'Date' ),
@@ -22,22 +40,9 @@ export function getFields(): Field< ActivityLogEntry >[] {
 			render: ( { item } ) => <FormattedTime timestamp={ item.published } />,
 		},
 		{
-			id: 'action',
-			label: __( 'Action' ),
-			getValue: ( { item } ) => `${ item.summary }: ${ item.content.text }`,
-			render: ( { item } ) => (
-				<>
-					<Icon icon={ gridiconToWordPressIcon( item.gridicon ) } />
-					&nbsp;
-					<strong>{ item.summary }</strong>: { item.content.text }
-				</>
-			),
+			id: 'content_text',
+			getValue: ( { item } ) => item.content.text,
 			enableGlobalSearch: true,
-		},
-		{
-			id: 'user',
-			label: __( 'User' ),
-			getValue: ( { item } ) => item.actor.name,
 		},
 	];
 }

--- a/client/dashboard/sites/backups/dataviews/fields.tsx
+++ b/client/dashboard/sites/backups/dataviews/fields.tsx
@@ -17,6 +17,7 @@ export function getFields(): Field< ActivityLogEntry >[] {
 	return [
 		{
 			id: 'icon',
+			label: __( 'Icon' ),
 			render: ( { item } ) => (
 				<Icon
 					icon={ gridiconToWordPressIcon( item.gridicon ) }
@@ -27,6 +28,7 @@ export function getFields(): Field< ActivityLogEntry >[] {
 		},
 		{
 			id: 'title',
+			label: __( 'Title' ),
 			getValue: ( { item } ) => {
 				const actor = item.actor?.name ? ` by ${ item.actor.name }` : '';
 				return item.summary + actor;
@@ -41,6 +43,7 @@ export function getFields(): Field< ActivityLogEntry >[] {
 		},
 		{
 			id: 'content_text',
+			label: __( 'Content' ),
 			getValue: ( { item } ) => item.content.text,
 			enableGlobalSearch: true,
 		},

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -17,7 +17,6 @@ import { HostingFeatures } from '../../data/constants';
 import { hasHostingFeature } from '../../utils/site-features';
 import { BackupNowButton } from './backup-now-button';
 import illustrationUrl from './backups-callout-illustration.svg';
-import { getActions } from './dataviews/actions';
 import { getFields } from './dataviews/fields';
 import type { ActivityLogEntry, Site } from '../../data/types';
 import type { View } from '@wordpress/dataviews';
@@ -61,8 +60,10 @@ export function SiteBackupsCallout( {
 
 function Backups( { site }: { site: Site } ) {
 	const [ view, setView ] = useState< View >( {
-		type: 'table',
-		fields: [ 'date', 'action', 'user' ],
+		type: 'list',
+		fields: [ 'date', 'content_text' ],
+		mediaField: 'icon',
+		titleField: 'title',
 		perPage: 10,
 	} );
 
@@ -71,7 +72,6 @@ function Backups( { site }: { site: Site } ) {
 	);
 
 	const fields = getFields();
-	const actions = getActions( site );
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( activityLog, view, fields );
 
 	return (
@@ -80,7 +80,6 @@ function Backups( { site }: { site: Site } ) {
 				getItemId={ ( item ) => item.activity_id }
 				data={ filteredData }
 				fields={ fields }
-				actions={ actions }
 				view={ view }
 				onChangeView={ setView }
 				isLoading={ isLoadingActivityLog }

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -1,23 +1,35 @@
 import { useQuery } from '@tanstack/react-query';
-import { __experimentalText as Text } from '@wordpress/components';
+import {
+	__experimentalText as Text,
+	__experimentalGrid as Grid,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Card,
+	CardHeader,
+	Icon,
+} from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { siteBySlugQuery } from '../../app/queries/site';
 import { siteRewindableActivityLogEntriesQuery } from '../../app/queries/site-activity-log';
 import { siteRoute } from '../../app/router';
 import { Callout } from '../../components/callout';
 import { CalloutOverlay } from '../../components/callout-overlay';
 import DataViewsCard from '../../components/dataviews-card';
+import { useFormattedTime } from '../../components/formatted-time';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import { SectionHeader } from '../../components/section-header';
 import UpsellCTAButton from '../../components/upsell-cta-button';
 import { HostingFeatures } from '../../data/constants';
+import { gridiconToWordPressIcon } from '../../utils/gridicons';
 import { hasHostingFeature } from '../../utils/site-features';
 import { BackupNowButton } from './backup-now-button';
 import illustrationUrl from './backups-callout-illustration.svg';
 import { getFields } from './dataviews/fields';
+import './style.scss';
 import type { ActivityLogEntry, Site } from '../../data/types';
 import type { View } from '@wordpress/dataviews';
 
@@ -58,7 +70,15 @@ export function SiteBackupsCallout( {
 	);
 }
 
-function Backups( { site }: { site: Site } ) {
+function Backups( {
+	site,
+	selectedBackup,
+	setSelectBackup,
+}: {
+	site: Site;
+	selectedBackup: ActivityLogEntry | null;
+	setSelectBackup: ( backup: ActivityLogEntry | null ) => void;
+} ) {
 	const [ view, setView ] = useState< View >( {
 		type: 'list',
 		fields: [ 'date', 'content_text' ],
@@ -74,6 +94,21 @@ function Backups( { site }: { site: Site } ) {
 	const fields = getFields();
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( activityLog, view, fields );
 
+	useEffect( () => {
+		if ( ! isLoadingActivityLog && activityLog.length > 0 && ! selectedBackup ) {
+			const firstBackup = activityLog[ 0 ];
+			setSelectBackup( firstBackup );
+		}
+	}, [ isLoadingActivityLog, activityLog, selectedBackup, setSelectBackup ] );
+
+	const onChangeSelection = ( selection: string[] ) => {
+		const backup =
+			selection.length > 0
+				? activityLog.find( ( item ) => item.activity_id === selection[ 0 ] ) || null
+				: null;
+		setSelectBackup( backup );
+	};
+
 	return (
 		<DataViewsCard>
 			<DataViews< ActivityLogEntry >
@@ -86,8 +121,56 @@ function Backups( { site }: { site: Site } ) {
 				defaultLayouts={ { table: {} } }
 				paginationInfo={ paginationInfo }
 				searchLabel={ __( 'Search backups' ) }
+				onChangeSelection={ onChangeSelection }
+				selection={ selectedBackup ? [ selectedBackup.activity_id ] : [] }
 			/>
 		</DataViewsCard>
+	);
+}
+
+function BackupDetails( { selectedBackup }: { selectedBackup: ActivityLogEntry } ) {
+	const formattedTime = useFormattedTime( selectedBackup.published, {
+		dateStyle: 'medium',
+		timeStyle: 'short',
+	} );
+
+	return (
+		<Card>
+			<CardHeader>
+				<SectionHeader
+					title={ selectedBackup.summary }
+					decoration={ <Icon icon={ gridiconToWordPressIcon( selectedBackup.gridicon ) } /> }
+				/>
+			</CardHeader>
+			<VStack className="dashboard-backups__details">
+				<Text size={ 14 } weight={ 500 }>
+					{ selectedBackup.content.text }
+				</Text>
+				<HStack alignment="left" spacing={ 4 }>
+					<Text variant="muted">{ formattedTime }</Text>
+					{ selectedBackup.actor?.name && (
+						<Text variant="muted">
+							{ __( 'By' ) } { selectedBackup.actor.name }
+						</Text>
+					) }
+				</HStack>
+			</VStack>
+		</Card>
+	);
+}
+
+function BackupsLayout( { site }: { site: Site } ) {
+	const [ selectedBackup, setSelectedBackup ] = useState< ActivityLogEntry | null >( null );
+
+	return (
+		<Grid columns={ 2 }>
+			<Backups
+				site={ site }
+				selectedBackup={ selectedBackup }
+				setSelectBackup={ setSelectedBackup }
+			/>
+			{ selectedBackup && <BackupDetails selectedBackup={ selectedBackup } /> }
+		</Grid>
 	);
 }
 
@@ -113,7 +196,7 @@ function SiteBackups() {
 			<CalloutOverlay
 				showCallout={ ! hasBackups }
 				callout={ <SiteBackupsCallout siteSlug={ site.slug } /> }
-				main={ <Backups site={ site } /> }
+				main={ <BackupsLayout site={ site } /> }
 			/>
 		</PageLayout>
 	);

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -66,7 +66,7 @@ function BackupsLayout( { site }: { site: Site } ) {
 				selectedBackup={ selectedBackup }
 				setSelectedBackup={ setSelectedBackup }
 			/>
-			{ selectedBackup && <BackupDetails selectedBackup={ selectedBackup } /> }
+			{ selectedBackup && <BackupDetails backup={ selectedBackup } /> }
 		</Grid>
 	);
 }

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -1,37 +1,23 @@
 import { useQuery } from '@tanstack/react-query';
-import {
-	__experimentalText as Text,
-	__experimentalGrid as Grid,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	Card,
-	CardHeader,
-	Icon,
-} from '@wordpress/components';
-import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { __experimentalText as Text, __experimentalGrid as Grid } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { siteBySlugQuery } from '../../app/queries/site';
-import { siteRewindableActivityLogEntriesQuery } from '../../app/queries/site-activity-log';
 import { siteRoute } from '../../app/router';
 import { Callout } from '../../components/callout';
 import { CalloutOverlay } from '../../components/callout-overlay';
-import DataViewsCard from '../../components/dataviews-card';
-import { useFormattedTime } from '../../components/formatted-time';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { SectionHeader } from '../../components/section-header';
 import UpsellCTAButton from '../../components/upsell-cta-button';
 import { HostingFeatures } from '../../data/constants';
-import { gridiconToWordPressIcon } from '../../utils/gridicons';
 import { hasHostingFeature } from '../../utils/site-features';
+import { BackupDetails } from './backup-details';
 import { BackupNowButton } from './backup-now-button';
 import illustrationUrl from './backups-callout-illustration.svg';
-import { getFields } from './dataviews/fields';
+import { BackupsList } from './backups-list';
 import './style.scss';
 import type { ActivityLogEntry, Site } from '../../data/types';
-import type { View } from '@wordpress/dataviews';
 
 export function SiteBackupsCallout( {
 	siteSlug,
@@ -70,101 +56,12 @@ export function SiteBackupsCallout( {
 	);
 }
 
-function Backups( {
-	site,
-	selectedBackup,
-	setSelectBackup,
-}: {
-	site: Site;
-	selectedBackup: ActivityLogEntry | null;
-	setSelectBackup: ( backup: ActivityLogEntry | null ) => void;
-} ) {
-	const [ view, setView ] = useState< View >( {
-		type: 'list',
-		fields: [ 'date', 'content_text' ],
-		mediaField: 'icon',
-		titleField: 'title',
-		perPage: 10,
-	} );
-
-	const { data: activityLog = [], isLoading: isLoadingActivityLog } = useQuery(
-		siteRewindableActivityLogEntriesQuery( site.ID )
-	);
-
-	const fields = getFields();
-	const { data: filteredData, paginationInfo } = filterSortAndPaginate( activityLog, view, fields );
-
-	useEffect( () => {
-		if ( ! isLoadingActivityLog && activityLog.length > 0 && ! selectedBackup ) {
-			const firstBackup = activityLog[ 0 ];
-			setSelectBackup( firstBackup );
-		}
-	}, [ isLoadingActivityLog, activityLog, selectedBackup, setSelectBackup ] );
-
-	const onChangeSelection = ( selection: string[] ) => {
-		const backup =
-			selection.length > 0
-				? activityLog.find( ( item ) => item.activity_id === selection[ 0 ] ) || null
-				: null;
-		setSelectBackup( backup );
-	};
-
-	return (
-		<DataViewsCard>
-			<DataViews< ActivityLogEntry >
-				getItemId={ ( item ) => item.activity_id }
-				data={ filteredData }
-				fields={ fields }
-				view={ view }
-				onChangeView={ setView }
-				isLoading={ isLoadingActivityLog }
-				defaultLayouts={ { table: {} } }
-				paginationInfo={ paginationInfo }
-				searchLabel={ __( 'Search backups' ) }
-				onChangeSelection={ onChangeSelection }
-				selection={ selectedBackup ? [ selectedBackup.activity_id ] : [] }
-			/>
-		</DataViewsCard>
-	);
-}
-
-function BackupDetails( { selectedBackup }: { selectedBackup: ActivityLogEntry } ) {
-	const formattedTime = useFormattedTime( selectedBackup.published, {
-		dateStyle: 'medium',
-		timeStyle: 'short',
-	} );
-
-	return (
-		<Card>
-			<CardHeader>
-				<SectionHeader
-					title={ selectedBackup.summary }
-					decoration={ <Icon icon={ gridiconToWordPressIcon( selectedBackup.gridicon ) } /> }
-				/>
-			</CardHeader>
-			<VStack className="dashboard-backups__details">
-				<Text size={ 14 } weight={ 500 }>
-					{ selectedBackup.content.text }
-				</Text>
-				<HStack alignment="left" spacing={ 4 }>
-					<Text variant="muted">{ formattedTime }</Text>
-					{ selectedBackup.actor?.name && (
-						<Text variant="muted">
-							{ __( 'By' ) } { selectedBackup.actor.name }
-						</Text>
-					) }
-				</HStack>
-			</VStack>
-		</Card>
-	);
-}
-
 function BackupsLayout( { site }: { site: Site } ) {
 	const [ selectedBackup, setSelectedBackup ] = useState< ActivityLogEntry | null >( null );
 
 	return (
 		<Grid columns={ 2 }>
-			<Backups
+			<BackupsList
 				site={ site }
 				selectedBackup={ selectedBackup }
 				setSelectBackup={ setSelectedBackup }

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -64,7 +64,7 @@ function BackupsLayout( { site }: { site: Site } ) {
 			<BackupsList
 				site={ site }
 				selectedBackup={ selectedBackup }
-				setSelectBackup={ setSelectedBackup }
+				setSelectedBackup={ setSelectedBackup }
 			/>
 			{ selectedBackup && <BackupDetails selectedBackup={ selectedBackup } /> }
 		</Grid>

--- a/client/dashboard/sites/backups/style.scss
+++ b/client/dashboard/sites/backups/style.scss
@@ -1,0 +1,7 @@
+.dashboard-backups__list-icon {
+    position: relative;
+    top: 50%;
+    inset-inline-start: 50%;
+    transform: translate(-50%, -50%);
+    fill: $gray-700;
+}

--- a/client/dashboard/sites/backups/style.scss
+++ b/client/dashboard/sites/backups/style.scss
@@ -1,3 +1,7 @@
+.dashboard-backups__details {
+    padding: 24px;
+}
+
 .dashboard-backups__list-icon {
     position: relative;
     top: 50%;

--- a/client/dashboard/sites/backups/style.scss
+++ b/client/dashboard/sites/backups/style.scss
@@ -1,7 +1,3 @@
-.dashboard-backups__details {
-    padding: 24px;
-}
-
 .dashboard-backups__list-icon {
     position: relative;
     top: 50%;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTDASH-258][1].

## Proposed Changes

This PR adds the Backup details card to the Hosting Dashboard at `/v2/sites/{site}/backups`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Based on the latest designs, we'll show the details in the same page where the backups are listed.

> [!NOTE]
> Some components are intentionally left out of this PR, like the Download/Restore buttons and the File Browser. They will be added on future iterations.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using the Calypso Live link below or the development version on your machine, navigate to the new Sites page at `/v2/sites`
- Select one of the sites, ensuring you are redirected to the `Overview` page at `/v2/sites/{site}`
- Click on the `Backups` link in the upper menu.
- The page at `/v2/sites/{site}/backups` should be shown, similar to the screenshot below.

<img width="1279" height="1111" alt="image" src="https://github.com/user-attachments/assets/022b1942-ac6a-4476-a3c9-7118f8a2b713" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

[1]: https://linear.app/a8c/issue/DOTDASH-258/