### PR TITLE
Substack Import: fix flow bug

### DIFF
--- a/client/my-sites/importer/newsletter/utils.tsx
+++ b/client/my-sites/importer/newsletter/utils.tsx
@@ -96,6 +96,10 @@ export function getImporterStatus( steps?: Steps ): StepStatus {
 		return 'skipped';
 	}
 
+	if ( content === 'skipped' && subscribers === 'pending' ) {
+		return 'importing';
+	}
+
 	if ( content === 'importing' || subscribers === 'importing' ) {
 		return 'importing';
 	}


### PR DESCRIPTION
Fixes CML-793

## Proposed Changes

* Add another case to `getImporterStatus`

## Why are these changes being made?

When importing subscribers during the Substack flow the user is getting kicked back to the start. There is a moment where the subscribers status is "pending". Adding this state to the `getImporterStatus` fixes the premature redirect.

## Testing Instructions

1. Go to `/import/YOUR_SITE`
2. Start the Substack import
3. Skip the content import
4. Choose a CSV to import
5. Make sure you get the loading screen and then the summary
6. Test again with a content import as well to be sure

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
