### PR TITLE
Dashboard v2: render expiring purchase in color

### DIFF
--- a/client/dashboard/components/text/index.tsx
+++ b/client/dashboard/components/text/index.tsx
@@ -8,13 +8,16 @@ export interface TextProps extends React.ComponentProps< typeof WPText > {
 }
 
 function UnforwardedText(
-	{ intent, ...props }: TextProps,
+	{ intent, lineHeight, size, weight, ...props }: TextProps,
 	ref: React.ForwardedRef< HTMLElement >
 ) {
 	return (
 		<WPText
 			ref={ ref }
 			{ ...props }
+			lineHeight={ lineHeight || 'unset' }
+			size={ size || 'unset' }
+			weight={ weight || 'unset' }
 			className={ clsx( intent && `dashboard-text--${ intent }`, props.className ) }
 		/>
 	);

--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -9,6 +9,7 @@ import akismetIcon from 'calypso/assets/images/icons/akismet-icon.svg';
 import jetpackIcon from 'calypso/assets/images/icons/jetpack-icon.svg';
 import passportIcon from 'calypso/assets/images/icons/passport-icon.svg';
 import { useAuth } from '../../app/auth';
+import { PurchaseExpiryStatus } from '../../components/purchase-expiry-status';
 import SiteIcon from '../../sites/site-icon';
 import {
 	isRenewing,
@@ -18,7 +19,6 @@ import {
 } from '../../utils/purchase';
 import { PurchasePaymentMethod } from './purchase-payment-method';
 import { PurchaseProduct } from './purchase-product';
-import { PurchaseStatus } from './purchase-status';
 import type { StoredPaymentMethod } from '../../data/me-payment-methods';
 import type { Purchase } from '../../data/purchase';
 import type { Site } from '../../data/site';
@@ -445,7 +445,7 @@ export function getFields( {
 				const site = sites.find( ( site ) => String( site.ID ) === item.blog_id );
 				return (
 					<div>
-						<PurchaseStatus purchase={ item } isDisconnectedSite={ ! site } />
+						<PurchaseExpiryStatus purchase={ item } isDisconnectedSite={ ! site } />
 					</div>
 				);
 			},

--- a/client/dashboard/sites/overview-card/index.tsx
+++ b/client/dashboard/sites/overview-card/index.tsx
@@ -24,7 +24,7 @@ export interface OverviewCardProps {
 	icon?: ReactElement;
 	title: string;
 	heading?: ReactNode;
-	description?: string;
+	description?: ReactNode;
 	progress?: {
 		value: number;
 		max: number;

--- a/client/dashboard/sites/overview-plan-card/index.tsx
+++ b/client/dashboard/sites/overview-plan-card/index.tsx
@@ -12,6 +12,7 @@ import { wordpress } from '@wordpress/icons';
 import { siteByIdQuery } from '../../app/queries/site';
 import { siteCurrentPlanQuery } from '../../app/queries/site-plans';
 import { sitePurchaseQuery } from '../../app/queries/site-purchases';
+import { PurchaseExpiryStatus } from '../../components/purchase-expiry-status';
 import { DotcomPlans } from '../../data/constants';
 import {
 	getJetpackProductsForSite,
@@ -208,16 +209,8 @@ function getCardDescription( site: Site, purchase?: Purchase ) {
 			: __( 'Upgrade to access more Jetpack tools.' );
 	}
 
-	if ( purchase?.expiry_message ) {
-		return purchase.expiry_message;
-	}
-
-	if ( purchase?.partner_name ) {
-		return sprintf(
-			/* translators: %s: the partner name, e.g.: "Jetpack" */
-			__( 'Managed by %s.' ),
-			purchase.partner_name
-		);
+	if ( purchase ) {
+		return <PurchaseExpiryStatus purchase={ purchase } />;
 	}
 
 	return undefined;


### PR DESCRIPTION
## Proposed Changes

This PR (finally) implements color-coded expiry status based on Figma: QOBjujZah0UlGDDdLKZhzi-fi-6654_206386.

This works by sharing the logic between purchases list and plan overview card. They should really be showing the same thing. So I extracted the component to `dashboard/components/purchase-expiry-status`.

The following logic is ported from v1:

- Renders purchases expiring in 7 days as "warning", and in 30 days as "error":

https://github.com/Automattic/wp-calypso/blob/0e3fcd04101ab7f88de39cc78cc583f42b5f4689/client/me/purchases/purchase-item/index.tsx#L553-L557

- Renders the dates in inline-block so that they don't wrap:

https://github.com/Automattic/wp-calypso/blob/0e3fcd04101ab7f88de39cc78cc583f42b5f4689/client/me/purchases/purchase-item/index.tsx#L566-L568

https://github.com/Automattic/wp-calypso/blob/0e3fcd04101ab7f88de39cc78cc583f42b5f4689/client/me/purchases/style.scss#L222-L225

#### /v2/me/billing/purchases

|Before|After|
|-|-|
|<img width="804" height="352" alt="image" src="https://github.com/user-attachments/assets/7ebdd37f-7170-4dc2-85a5-1c1e9a46b009" />|<img width="821" height="364" alt="image" src="https://github.com/user-attachments/assets/9bad66e8-437f-4063-8cd9-c4b62fbeec98" />


#### /v2/sites/:slug

|Before|After|
|-|-|
|<img width="326" height="149" alt="image" src="https://github.com/user-attachments/assets/08c2cc5c-b8a3-4bdf-9226-77635088b79b" />|<img width="327" height="153" alt="image" src="https://github.com/user-attachments/assets/0703ecd5-722d-44ab-b6f6-c755d50f4184" />|
|<img width="326" height="150" alt="image" src="https://github.com/user-attachments/assets/35501037-d410-4c06-9470-7cc7b25c02b3" />|<img width="328" height="150" alt="image" src="https://github.com/user-attachments/assets/bea406df-c9f6-49fb-9a32-976f2ce92b80" />|
|<img width="327" height="150" alt="image" src="https://github.com/user-attachments/assets/33ccf1d4-bc65-496a-ba79-c0b2a06a18c3" />|<img width="329" height="154" alt="image" src="https://github.com/user-attachments/assets/4aa6a45c-65a0-420e-89e4-a04ba9683d18" />|

## Implementation Details

- The font size in purchase list, and in plan overview card are different. However, `<Text>` by default inserts inline CSS to set font size based on a default `emotion`'s `<ThemeProvider>`. Because we're not using that, I worked it around by passing `unset` unless it's specified.
   - This is just a hack. We should be really using the new DS token if it's out.

## Caveat

- The descriptions in the plan overview card should end in period (`.`)... however they shouldn't in purchases list. I don't know how to best deal with it. Should we add dot manually in overview card? Seems ugly. I leave them inconsistent for now. 😅 

## Testing Instructions

Test all the cases in the screenshots by manually adjusting your plan expiry.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?