### PR TITLE
Increase timeout between atomic transfer and redirect

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -206,7 +206,7 @@ const MarketplaceProductInstall = ( {
 		) {
 			const triggerInstallFlow = () => {
 				setInitializeInstallFlow( true );
-				waitFor( 5 ).then( () => setCurrentStep( 1 ) );
+				waitFor( 1 ).then( () => setCurrentStep( 1 ) );
 			};
 
 			if ( isJetpack || isAtomic ) {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -206,7 +206,7 @@ const MarketplaceProductInstall = ( {
 		) {
 			const triggerInstallFlow = () => {
 				setInitializeInstallFlow( true );
-				waitFor( 1 ).then( () => setCurrentStep( 1 ) );
+				waitFor( 5 ).then( () => setCurrentStep( 1 ) );
 			};
 
 			if ( isJetpack || isAtomic ) {
@@ -295,7 +295,7 @@ const MarketplaceProductInstall = ( {
 				transferStates.COMPLETE === automatedTransferStatus &&
 				canManagePlugins )
 		) {
-			waitFor( 1 ).then( () => {
+			waitFor( 10 ).then( () => {
 				window.location.href = pluginsUrl as string;
 			} );
 		}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* sets a 10 second delay between atomic transfer complete and redirect to the installed plugins page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* this is needed to address the installed plugins pages showing restricted access
<img width="3286" height="1406" alt="scr-20250812-qjiv" src="https://github.com/user-attachments/assets/679d9c99-afd6-4efa-b352-9da7688a7ceb" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a Business site
* Install a plugin
* After install you should see the installed plugins page
<img width="1926" height="1333" alt="Screenshot 2025-08-12 at 13 04 55" src="https://github.com/user-attachments/assets/6d7d1e96-0670-44b1-9618-6e595f82159e" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
