### PR TITLE
A4A > Sign up: Show onboarding tour in WC flow

### DIFF
--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/hooks/use-submit-signup.ts
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/hooks/use-submit-signup.ts
@@ -1,5 +1,7 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { useCallback, useEffect } from 'react';
+import { ONBOARDING_TOUR_HASH } from 'calypso/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour';
 import { A4A_OVERVIEW_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useCreateAgencyMutation from 'calypso/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-create-agency-mutation';
 import { saveSignupDataToLocalStorage } from 'calypso/a8c-for-agencies/sections/signup/lib/signup-data-to-local-storage';
@@ -37,7 +39,11 @@ export default function useSubmitSignup() {
 
 	useEffect( () => {
 		if ( currentAgency ) {
-			page.redirect( A4A_OVERVIEW_LINK );
+			if ( isEnabled( 'a4a-unified-onboarding-tour' ) ) {
+				page.redirect( `${ A4A_OVERVIEW_LINK }${ ONBOARDING_TOUR_HASH }` );
+			} else {
+				page.redirect( A4A_OVERVIEW_LINK );
+			}
 		}
 	}, [ createAgency.isSuccess, currentAgency, dispatch ] );
 


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1441/sign-up-through-wc-flow-doesnt-show-the-onboarding-tour

## Proposed Changes

This PR updates the WC sign up flow to show the onboarding tour when redirected to the Overview page.

## Why are these changes being made?

* To show the onboarding tour when signed up to A4A via the WC sign up flow

## Testing Instructions

* Switch to this branch locally.
* Visit https://automattic.com/for-agencies/wordcamp/ and enter a new email ID
* Open the link sent in the email in an incognito window or a new window without WordPress.com logged in. 
* Replace the URL (https://agencies.automattic.com/) with http://agencies.localhost:3000/ > Enter all the details > Verify you are redirected to the Overview page and the onboarding tour is shown.

<img width="751" height="656" alt="Screenshot 2025-08-12 at 3 50 29 PM" src="https://github.com/user-attachments/assets/631e6b2f-ff0c-49ed-ae11-27e7329c2171" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
