### PR TITLE
Connect Refresh: Migrate Jetpack Cloud create-account to unified Signup

### DIFF
--- a/client/blocks/login/social.scss
+++ b/client/blocks/login/social.scss
@@ -102,18 +102,4 @@
 			}
 		}
 	}
-
-	/**
-	* Jetpack Cloud
-	*/
-	@at-root .jetpack-cloud & {
-		max-width: 375px;
-		width: 100%;
-		padding: 16px;
-		margin-bottom: 0;
-
-		@include break-mobile {
-			padding: 24px;
-		}
-	}
 }

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -41,6 +41,7 @@ import {
 	isCrowdsignalOAuth2Client,
 	isGravatarOAuth2Client,
 	isVIPOAuth2Client,
+	isJetpackCloudOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login, lostPassword } from 'calypso/lib/paths';
 import { isExistingAccountError } from 'calypso/lib/signup/is-existing-account-error';
@@ -1043,7 +1044,8 @@ class SignupForm extends Component {
 			this.props.isCrowdsignal ||
 			this.props.isBlazePro ||
 			this.props.isAkismet ||
-			this.props.isVIPClient;
+			this.props.isVIPClient ||
+			this.props.isJetpackCloud;
 		const isGravatar = this.props.isGravatar;
 		const emailErrorMessage = this.getErrorMessagesWithLogin( 'email' );
 		const showSeparator =
@@ -1202,6 +1204,7 @@ export default connect(
 			isCrowdsignal: isCrowdsignalOAuth2Client( oauth2Client ),
 			isAkismet: getIsAkismet( state ),
 			isVIPClient: isVIPOAuth2Client( oauth2Client ),
+			isJetpackCloud: isJetpackCloudOAuth2Client( oauth2Client ),
 		};
 	},
 	{

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -17,6 +17,7 @@ import {
 	isA4AOAuth2Client,
 	isBlazeProOAuth2Client,
 	isCrowdsignalOAuth2Client,
+	isJetpackCloudOAuth2Client,
 	isVIPOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { isWpccFlow } from 'calypso/signup/is-flow';
@@ -106,11 +107,12 @@ class SocialSignupForm extends Component {
 			isAkismet,
 			isCrowdsignal,
 			isVIPClient,
+			isJetpackCloud,
 			setCurrentStep,
 		} = this.props;
 
 		const isUnifiedCreateAccount =
-			isWoo || isA4A || isCrowdsignal || isBlazePro || isAkismet || isVIPClient;
+			isWoo || isA4A || isCrowdsignal || isBlazePro || isAkismet || isVIPClient || isJetpackCloud;
 
 		return (
 			<Card
@@ -169,6 +171,7 @@ export default connect(
 			isCrowdsignal: isCrowdsignalOAuth2Client( oauth2Client ),
 			isAkismet: getIsAkismet( state ),
 			isVIPClient: isVIPOAuth2Client( oauth2Client ),
+			isJetpackCloud: isJetpackCloudOAuth2Client( oauth2Client ),
 		};
 	},
 	{ showErrorNotice: errorNotice }

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -360,22 +360,6 @@ body.is-section-accept-invite {
 			}
 		}
 	}
-
-	/**
-	* Jetpack Cloud
-	*/
-	@at-root .jetpack-cloud & {
-		max-width: 375px;
-		width: 100%;
-		padding: 16px;
-		margin-bottom: 0;
-
-		@include break-mobile {
-			padding: 24px;
-		}
-	}
-
-
 }
 
 // TODO clk remove this. it's handled by .is-unified-create-account

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -15,7 +15,7 @@ import MasterbarLoggedOut from 'calypso/layout/masterbar/logged-out';
 import OauthClientMasterbar from 'calypso/layout/masterbar/oauth-client';
 import { isInStepContainerV2FlowContext } from 'calypso/layout/utils';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
-import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import isJetpackCloudEnvironment from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import {
 	isWooOAuth2Client,
@@ -86,6 +86,7 @@ const LayoutLoggedOut = ( {
 	isA4A,
 	isCrowdsignal,
 	isVIPClient,
+	isJetpackCloud,
 } ) => {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const currentRoute = useSelector( getCurrentRoute );
@@ -115,7 +116,7 @@ const LayoutLoggedOut = ( {
 	const isWpcomMagicLogin =
 		isMagicLogin &&
 		! hasGravPoweredClientClass &&
-		! isJetpackCloudOAuth2Client( oauth2Client ) &&
+		! isJetpackCloud &&
 		! isWooOAuth2Client( oauth2Client );
 
 	const loadHelpCenter =
@@ -127,7 +128,7 @@ const LayoutLoggedOut = ( {
 
 	const isUnifiedCreateAccount =
 		sectionName === 'signup' &&
-		( isWoo || isA4A || isCrowdsignal || isBlazePro || isAkismet || isVIPClient );
+		( isWoo || isA4A || isCrowdsignal || isBlazePro || isAkismet || isVIPClient || isJetpackCloud );
 
 	const classes = {
 		[ 'is-group-' + sectionGroup ]: sectionGroup,
@@ -153,7 +154,7 @@ const LayoutLoggedOut = ( {
 		'is-woo-com-oauth': isWooOAuth2Client( oauth2Client ),
 		woo: isWoo,
 		'feature-flag-woocommerce-core-profiler-passwordless-auth': true,
-		'jetpack-cloud': isJetpackCloudOAuth2Client( oauth2Client ),
+		'jetpack-cloud': isJetpackCloud,
 		'is-unified-create-account': isUnifiedCreateAccount,
 	};
 
@@ -264,7 +265,7 @@ const LayoutLoggedOut = ( {
 					<div className="layout__header-section-content">{ renderHeaderSection() }</div>
 				) }
 			</div>
-			{ isJetpackCloud() && (
+			{ isJetpackCloudEnvironment() && (
 				<AsyncLoad require="calypso/jetpack-cloud/style" placeholder={ null } />
 			) }
 			{ isA8CForAgencies() && (
@@ -396,6 +397,7 @@ export default withCurrentRoute(
 				isA4A: isA4AOAuth2Client( oauth2Client ),
 				isCrowdsignal: isCrowdsignalOAuth2Client( oauth2Client ),
 				isVIPClient: isVIPOAuth2Client( oauth2Client ),
+				isJetpackCloud: isJetpackCloudOAuth2Client( oauth2Client ),
 			};
 		},
 		{ clearLastActionRequiresLogin }

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -129,7 +129,6 @@
 	}
 }
 
-.jetpack-cloud,
 .a8c-for-agencies {
 	background: var(--studio-gray-0);
 	min-height: 100%;
@@ -225,71 +224,6 @@
 	.card.two-factor-authentication__actions {
 		border: none;
 		box-shadow: none;
-	}
-}
-
-.jetpack-cloud {
-	--color-link: var(--studio-jetpack-green-50);
-	--color-link-dark: var(--studio-jetpack-green-60);
-
-	input:focus:hover[type],
-	input:focus[type] {
-		&:not(.form-text-input-core-styles) {
-			box-shadow: 0 0 0 2px var(--color-primary-10);
-		}
-	}
-
-	.button {
-		color: var(--studio-jetpack-green-60);
-		background: var(--studio-white);
-		border: 1px solid var(--studio-jetpack-green-40);
-		border-radius: 2px;
-
-		&:hover,
-		&:focus {
-			background: var(--studio-jetpack-green-0);
-		}
-
-		&:active {
-			background: var(--studio-jetpack-green-5);
-			border-color: var(--studio-jetpack-green-40);
-			border-width: 1px;
-		}
-
-		&[disabled]:active {
-			border-width: 1px;
-		}
-
-		&[disabled],
-		&:disabled {
-			color: var(--studio-gray-10);
-			border-color: var(--color-gray-10);
-			background: var(--studio-white);
-		}
-	}
-
-	.button.is-primary {
-		color: var(--studio-white);
-		background: var(--studio-jetpack-green-40);
-		border-color: var(--studio-jetpack-green-40);
-
-		&:hover,
-		&:focus {
-			background: var(--studio-jetpack-green-30);
-			border-color: var(--studio-jetpack-green-30);
-		}
-
-		&:active {
-			background: var(--studio-jetpack-green-50);
-			border-color: var(--studio-jetpack-green-50);
-		}
-
-		&[disabled],
-		&:disabled {
-			color: var(--studio-white);
-			background: var(--studio-gray-10);
-			border-color: var(--studio-gray-10);
-		}
 	}
 }
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -50,6 +50,7 @@ import {
 	isBlazeProOAuth2Client,
 	isCrowdsignalOAuth2Client,
 	isVIPOAuth2Client,
+	isJetpackCloudOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import SignupFlowController from 'calypso/lib/signup/flow-controller';
 import FlowProgressIndicator from 'calypso/signup/flow-progress-indicator';
@@ -883,7 +884,8 @@ class Signup extends Component {
 				this.props.isCrowdsignal ||
 				this.props.isBlazePro ||
 				this.props.isAkismet ||
-				this.props.isVIPClient );
+				this.props.isVIPClient ||
+				this.props.isJetpackCloud );
 
 		const showPageHeader = ! this.props.isGravatar && ! isUnifiedCreateAccount;
 		const isGravatarDomain = isDomainForGravatarFlow( this.props.flowName );
@@ -965,6 +967,7 @@ export default connect(
 			isCrowdsignal: isCrowdsignalOAuth2Client( oauth2Client ),
 			isAkismet: getIsAkismet( state ),
 			isVIPClient: isVIPOAuth2Client( oauth2Client ),
+			isJetpackCloud: isJetpackCloudOAuth2Client( oauth2Client ),
 		};
 	},
 	{

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -12,7 +12,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import SignupForm from 'calypso/blocks/signup-form';
-import JetpackLogo from 'calypso/components/jetpack-logo';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import WooCommerceConnectCartHeader from 'calypso/components/woocommerce-connect-cart-header';
 import WPCloudLogo from 'calypso/components/wp-cloud-logo';
@@ -489,6 +488,7 @@ export class UserStep extends Component {
 			isAkismet,
 			isVIPClient,
 			isA4A,
+			isJetpackCloud,
 		} = this.props;
 
 		if ( userLoggedIn ) {
@@ -505,7 +505,8 @@ export class UserStep extends Component {
 		// TODO clk This will encompass all unified OAuth2 clients,
 		// similar to get-header-text in wp-login (potentially the two being merged too)
 		if (
-			( oauth2Client && ( isCrowdsignal || isVIPClient || isA4A || isBlazePro ) ) ||
+			( oauth2Client &&
+				( isCrowdsignal || isVIPClient || isA4A || isBlazePro || isJetpackCloud ) ) ||
 			isAkismet
 		) {
 			let clientName = oauth2Client?.name;
@@ -518,6 +519,8 @@ export class UserStep extends Component {
 				clientName = 'Blaze Pro';
 			} else if ( isVIPClient ) {
 				clientName = 'VIP';
+			} else if ( isJetpackCloud ) {
+				clientName = 'Jetpack Cloud';
 			}
 
 			return fixMe( {
@@ -544,15 +547,6 @@ export class UserStep extends Component {
 		/**
 		 * END: Unified create account
 		 */
-
-		if ( isJetpackCloudOAuth2Client( oauth2Client ) ) {
-			return (
-				<div className={ clsx( 'signup-form__wrapper' ) }>
-					<JetpackLogo full={ false } size={ 60 } />
-					<h3>{ translate( 'Sign up to Jetpack.com with a WordPress.com account.' ) }</h3>
-				</div>
-			);
-		}
 
 		if ( isPartnerPortalOAuth2Client( oauth2Client ) ) {
 			if ( document.location.search?.includes( 'wpcloud' ) ) {
@@ -610,6 +604,7 @@ export class UserStep extends Component {
 			isCrowdsignal,
 			isAkismet,
 			isVIPClient,
+			isJetpackCloud,
 		} = this.props;
 		const isPasswordless =
 			isMobile() ||
@@ -620,7 +615,8 @@ export class UserStep extends Component {
 			isCrowdsignal ||
 			isBlazePro ||
 			isAkismet ||
-			isVIPClient;
+			isVIPClient ||
+			isJetpackCloud;
 		let socialService;
 		let socialServiceResponse;
 		let isSocialSignupEnabled = this.props.isSocialSignupEnabled;
@@ -775,8 +771,9 @@ const ConnectedUser = connect(
 		const isCrowdsignal = isCrowdsignalOAuth2Client( oauth2Client );
 		const isAkismet = getIsAkismet( state );
 		const isVIPClient = isVIPOAuth2Client( oauth2Client );
+		const isJetpackCloud = isJetpackCloudOAuth2Client( oauth2Client );
 		const isUnifiedCreateAccount =
-			isWoo || isA4A || isCrowdsignal || isBlazePro || isAkismet || isVIPClient;
+			isWoo || isA4A || isCrowdsignal || isBlazePro || isAkismet || isVIPClient || isJetpackCloud;
 
 		return {
 			oauth2Client: oauth2Client,
@@ -794,6 +791,7 @@ const ConnectedUser = connect(
 			isCrowdsignal,
 			isAkismet,
 			isVIPClient,
+			isJetpackCloud,
 		};
 	},
 	{


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13218/signup-update-and-unify-the-account-creation-screens
Builds off the core foundation from Woo Signup unification: https://github.com/Automattic/wp-calypso/pull/104948

## Proposed Changes

- We migrate the Jetpack Cloud Signup (create account) screen to the unified design. This will align it closely to the Login view, so it's all one seamless flow.
- As with others, we bring the **passwordless** form and **social-signup** options.
- Some general styles are being removed from the masterbar. A little hard to trace if these are applicable elsewhere 🤔 

| Before | After |
|--------|--------|
| <img width="1038" height="864" alt="Screenshot 2025-08-12 at 4 46 40 PM" src="https://github.com/user-attachments/assets/86e52f9a-04ec-4176-896f-9461e05456b4" /> | <img width="1026" height="858" alt="Screenshot 2025-08-12 at 4 46 26 PM" src="https://github.com/user-attachments/assets/493ca4dd-6bb9-4fb6-9b20-adb643247c6d" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13218/signup-update-and-unify-the-account-creation-screens


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [JP Cloud signup](https://linear.app/a8c/issue/DOTCOM-13218/signup-update-and-unify-the-account-creation-screens) and confirm changes (this is a list of Login URLs, find the one for Jetpack Cloud and click on "create an account" from top-right once there)
* Confirm other signup (create account) screens aren't affected by the changes e.g. confirm Woo.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
