### PR TITLE
Hosting Dashboard: Add domain glue records DataView

### DIFF
--- a/client/dashboard/app/queries/domain-glue-records.ts
+++ b/client/dashboard/app/queries/domain-glue-records.ts
@@ -1,8 +1,17 @@
-import { queryOptions } from '@tanstack/react-query';
-import { fetchDomainGlueRecords } from '../../data/domain-glue-records';
+import { queryOptions, mutationOptions } from '@tanstack/react-query';
+import { deleteDomainGlueRecord, fetchDomainGlueRecords } from '../../data/domain-glue-records';
+import { queryClient } from '../query-client';
 
 export const domainGlueRecordsQuery = ( domainName: string ) =>
 	queryOptions( {
 		queryKey: [ 'domains', domainName, 'domain-glue-records' ],
 		queryFn: () => fetchDomainGlueRecords( domainName ),
+	} );
+
+export const domainGlueRecordDeleteMutation = ( domainName: string ) =>
+	mutationOptions( {
+		mutationFn: ( nameServer: string ) => deleteDomainGlueRecord( domainName, nameServer ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( domainGlueRecordsQuery( domainName ) );
+		},
 	} );

--- a/client/dashboard/app/queries/domain-glue-records.ts
+++ b/client/dashboard/app/queries/domain-glue-records.ts
@@ -1,0 +1,8 @@
+import { queryOptions } from '@tanstack/react-query';
+import { fetchDomainGlueRecords } from '../../data/domain-glue-records';
+
+export const domainGlueRecordsQuery = ( domainName: string ) =>
+	queryOptions( {
+		queryKey: [ 'domains', domainName, 'domain-glue-records' ],
+		queryFn: () => fetchDomainGlueRecords( domainName ),
+	} );

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -63,6 +63,8 @@ import {
 	domainContactInfoRoute,
 	domainNameServersRoute,
 	domainGlueRecordsRoute,
+	domainGlueRecordsAddRoute,
+	domainGlueRecordsEditRoute,
 	domainDnssecRoute,
 	domainTransferRoute,
 } from './routes/domain-routes';
@@ -915,6 +917,8 @@ export {
 	domainContactInfoRoute,
 	domainNameServersRoute,
 	domainGlueRecordsRoute,
+	domainGlueRecordsAddRoute,
+	domainGlueRecordsEditRoute,
 	domainDnssecRoute,
 	domainTransferRoute,
 	emailsRoute,

--- a/client/dashboard/app/routes/domain-routes.ts
+++ b/client/dashboard/app/routes/domain-routes.ts
@@ -1,6 +1,7 @@
 import { createRoute, createLazyRoute } from '@tanstack/react-router';
 import { domainQuery } from '../queries/domain';
 import { domainForwardingQuery } from '../queries/domain-forwarding';
+import { domainGlueRecordsQuery } from '../queries/domain-glue-records';
 import { domainsQuery } from '../queries/domains';
 import { queryClient } from '../query-client';
 import type { AnyRoute } from '@tanstack/react-router';
@@ -163,9 +164,33 @@ export const domainNameServersRoute = createRoute( {
 export const domainGlueRecordsRoute = createRoute( {
 	getParentRoute: () => domainRoute,
 	path: 'glue-records',
+	loader: ( { params: { domainName } } ) =>
+		queryClient.ensureQueryData( domainGlueRecordsQuery( domainName ) ),
+} ).lazy( () =>
+	import( '../../domains/overview-glue-records' ).then( ( d ) =>
+		createLazyRoute( 'domain-glue-records' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const domainGlueRecordsAddRoute = createRoute( {
+	getParentRoute: () => domainRoute,
+	path: 'glue-records/add',
 } ).lazy( () =>
 	import( '../../sites/domains/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'domain-glue-records' )( {
+		createLazyRoute( 'domain-glue-records-add' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const domainGlueRecordsEditRoute = createRoute( {
+	getParentRoute: () => domainRoute,
+	path: 'glue-records/edit/$nameServer',
+} ).lazy( () =>
+	import( '../../sites/domains/placeholder' ).then( ( d ) =>
+		createLazyRoute( 'domain-glue-records-edit' )( {
 			component: d.default,
 		} )
 	)
@@ -205,6 +230,8 @@ export const domainChildRoutes: AnyRoute[] = [
 	domainContactInfoRoute,
 	domainNameServersRoute,
 	domainGlueRecordsRoute,
+	domainGlueRecordsAddRoute,
+	domainGlueRecordsEditRoute,
 	domainDnssecRoute,
 	domainTransferRoute,
 ];

--- a/client/dashboard/data/domain-glue-records.ts
+++ b/client/dashboard/data/domain-glue-records.ts
@@ -1,0 +1,13 @@
+import wpcom from 'calypso/lib/wp';
+
+export interface DomainGlueRecord {
+	nameserver: string;
+	ip_addresses: string[];
+}
+
+export function fetchDomainGlueRecords( domainName: string ): Promise< DomainGlueRecord[] > {
+	return wpcom.req.get( {
+		path: `/domains/glue-records/${ domainName }`,
+		apiNamespace: 'wpcom/v2',
+	} );
+}

--- a/client/dashboard/data/domain-glue-records.ts
+++ b/client/dashboard/data/domain-glue-records.ts
@@ -11,3 +11,16 @@ export function fetchDomainGlueRecords( domainName: string ): Promise< DomainGlu
 		apiNamespace: 'wpcom/v2',
 	} );
 }
+
+export function deleteDomainGlueRecord( domainName: string, nameServer: string ): Promise< void > {
+	return wpcom.req.post(
+		{
+			path: `/domains/glue-records/${ domainName }`,
+			apiNamespace: 'wpcom/v2',
+			method: 'DELETE',
+		},
+		{
+			name_server: nameServer,
+		}
+	);
+}

--- a/client/dashboard/domains/overview-glue-records/index.tsx
+++ b/client/dashboard/domains/overview-glue-records/index.tsx
@@ -1,3 +1,4 @@
+import { isMobile } from '@automattic/viewport';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { Link, useRouter } from '@tanstack/react-router';
 import { useDispatch } from '@wordpress/data';
@@ -24,7 +25,7 @@ import type { Action, Field, ViewTable, ViewList, View } from '@wordpress/datavi
 type GlueRecordsView = ViewTable | ViewList;
 
 const DEFAULT_VIEW: GlueRecordsView = {
-	type: 'table',
+	type: isMobile() ? 'list' : 'table',
 	search: '',
 	page: 1,
 	perPage: 20,

--- a/client/dashboard/domains/overview-glue-records/index.tsx
+++ b/client/dashboard/domains/overview-glue-records/index.tsx
@@ -21,9 +21,9 @@ import RouterLinkButton from '../../components/router-link-button';
 import type { DomainGlueRecord } from '../../data/domain-glue-records';
 import type { Action, Field, ViewTable, ViewList, View } from '@wordpress/dataviews';
 
-type ForwardingView = ViewTable | ViewList;
+type GlueRecordsView = ViewTable | ViewList;
 
-const DEFAULT_VIEW: ForwardingView = {
+const DEFAULT_VIEW: GlueRecordsView = {
 	type: 'table',
 	search: '',
 	page: 1,
@@ -120,7 +120,7 @@ function DomainGlueRecords() {
 		[]
 	);
 
-	const [ view, setView ] = useState< ForwardingView >( DEFAULT_VIEW );
+	const [ view, setView ] = useState< GlueRecordsView >( DEFAULT_VIEW );
 
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate(
 		glueRecordsData ?? [],
@@ -156,7 +156,7 @@ function DomainGlueRecords() {
 					<DataViews< DomainGlueRecord >
 						data={ filteredData || [] }
 						fields={ fields }
-						onChangeView={ ( view: View ) => setView( view as ForwardingView ) }
+						onChangeView={ ( view: View ) => setView( view as GlueRecordsView ) }
 						view={ view }
 						actions={ actions }
 						search

--- a/client/dashboard/domains/overview-glue-records/index.tsx
+++ b/client/dashboard/domains/overview-glue-records/index.tsx
@@ -107,7 +107,7 @@ function DomainGlueRecords() {
 			size="small"
 			header={
 				<PageHeader
-					title={ __( 'Domain Forwarding' ) }
+					title={ __( 'Glue Records' ) }
 					actions={
 						<RouterLinkButton
 							to={ domainGlueRecordsAddRoute.fullPath }
@@ -115,7 +115,7 @@ function DomainGlueRecords() {
 							variant="primary"
 							__next40pxDefaultSize
 						>
-							{ __( 'Add Domain Forwarding' ) }
+							{ __( 'Add Glue Records' ) }
 						</RouterLinkButton>
 					}
 				/>
@@ -124,7 +124,7 @@ function DomainGlueRecords() {
 			<DataViewsCard>
 				{ glueRecordsData?.length === 0 && ! isLoading ? (
 					<div style={ { padding: '20px', textAlign: 'center' } }>
-						{ __( 'No forwarding rules found for this domain.' ) }
+						{ __( 'No glue records found for this domain.' ) }
 					</div>
 				) : (
 					<DataViews< DomainGlueRecord >

--- a/client/dashboard/domains/overview-glue-records/index.tsx
+++ b/client/dashboard/domains/overview-glue-records/index.tsx
@@ -1,0 +1,148 @@
+import { useQuery } from '@tanstack/react-query';
+import { Link, useRouter } from '@tanstack/react-router';
+import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { useState, useMemo } from 'react';
+import { domainGlueRecordsQuery } from '../../app/queries/domain-glue-records';
+import {
+	domainRoute,
+	domainGlueRecordsAddRoute,
+	domainGlueRecordsEditRoute,
+} from '../../app/router';
+import DataViewsCard from '../../components/dataviews-card';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import RouterLinkButton from '../../components/router-link-button';
+import type { DomainGlueRecord } from '../../data/domain-glue-records';
+import type { Action, Field, ViewTable, ViewList, View } from '@wordpress/dataviews';
+
+type ForwardingView = ViewTable | ViewList;
+
+const DEFAULT_VIEW: ForwardingView = {
+	type: 'table',
+	search: '',
+	page: 1,
+	perPage: 20,
+	titleField: 'nameServer',
+	sort: {
+		field: 'nameServer',
+		direction: 'asc',
+	},
+	fields: [ 'ipAddress' ],
+	filters: [],
+};
+
+const DEFAULT_LAYOUTS = {
+	table: {},
+	list: {},
+};
+
+function DomainGlueRecords() {
+	const router = useRouter();
+
+	const { domainName } = domainRoute.useParams();
+	const { data: glueRecordsData, isLoading } = useQuery( domainGlueRecordsQuery( domainName ) );
+
+	const actions: Action< DomainGlueRecord >[] = useMemo(
+		() => [
+			{
+				id: 'edit',
+				label: __( 'Edit' ),
+				callback: ( items ) => {
+					const item = items[ 0 ];
+					router.navigate( {
+						to: domainGlueRecordsEditRoute.fullPath,
+						params: { domainName, nameServer: item?.nameserver },
+					} );
+				},
+			},
+		],
+		[]
+	);
+
+	const fields: Field< DomainGlueRecord >[] = useMemo(
+		() => [
+			{
+				id: 'nameServer',
+				label: __( 'Name Server' ),
+				enableHiding: false,
+				enableSorting: true,
+				enableGlobalSearch: true,
+				getValue: ( { item } ) => {
+					return item.nameserver;
+				},
+				render: ( { field, item } ) => (
+					<Link
+						to={ domainGlueRecordsEditRoute.fullPath }
+						params={ { domainName, nameServer: item.nameserver } }
+					>
+						{ field.getValue( { item } ) }
+					</Link>
+				),
+			},
+			{
+				id: 'ipAddress',
+				label: __( 'IP Address' ),
+				enableHiding: false,
+				enableSorting: true,
+				enableGlobalSearch: true,
+				getValue: ( { item } ) => {
+					return item.ip_addresses[ 0 ];
+				},
+			},
+		],
+		[]
+	);
+
+	const [ view, setView ] = useState< ForwardingView >( DEFAULT_VIEW );
+
+	const { data: filteredData, paginationInfo } = filterSortAndPaginate(
+		glueRecordsData ?? [],
+		view,
+		fields
+	);
+
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					title={ __( 'Domain Forwarding' ) }
+					actions={
+						<RouterLinkButton
+							to={ domainGlueRecordsAddRoute.fullPath }
+							params={ { domainName } }
+							variant="primary"
+							__next40pxDefaultSize
+						>
+							{ __( 'Add Domain Forwarding' ) }
+						</RouterLinkButton>
+					}
+				/>
+			}
+		>
+			<DataViewsCard>
+				{ glueRecordsData?.length === 0 && ! isLoading ? (
+					<div style={ { padding: '20px', textAlign: 'center' } }>
+						{ __( 'No forwarding rules found for this domain.' ) }
+					</div>
+				) : (
+					<DataViews< DomainGlueRecord >
+						data={ filteredData || [] }
+						fields={ fields }
+						onChangeView={ ( view: View ) => setView( view as ForwardingView ) }
+						view={ view }
+						actions={ actions }
+						search
+						paginationInfo={ paginationInfo }
+						getItemId={ ( item: DomainGlueRecord ) => item.nameserver }
+						isLoading={ isLoading }
+						defaultLayouts={ DEFAULT_LAYOUTS }
+					/>
+				) }
+			</DataViewsCard>
+		</PageLayout>
+	);
+}
+
+export default DomainGlueRecords;

--- a/client/dashboard/domains/overview-glue-records/index.tsx
+++ b/client/dashboard/domains/overview-glue-records/index.tsx
@@ -1,9 +1,14 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import { Link, useRouter } from '@tanstack/react-router';
+import { useDispatch } from '@wordpress/data';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { useState, useMemo } from 'react';
-import { domainGlueRecordsQuery } from '../../app/queries/domain-glue-records';
+import {
+	domainGlueRecordDeleteMutation,
+	domainGlueRecordsQuery,
+} from '../../app/queries/domain-glue-records';
 import {
 	domainRoute,
 	domainGlueRecordsAddRoute,
@@ -42,6 +47,8 @@ function DomainGlueRecords() {
 
 	const { domainName } = domainRoute.useParams();
 	const { data: glueRecordsData, isLoading } = useQuery( domainGlueRecordsQuery( domainName ) );
+	const deleteMutation = useMutation( domainGlueRecordDeleteMutation( domainName ) );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
 	const actions: Action< DomainGlueRecord >[] = useMemo(
 		() => [
@@ -53,6 +60,25 @@ function DomainGlueRecords() {
 					router.navigate( {
 						to: domainGlueRecordsEditRoute.fullPath,
 						params: { domainName, nameServer: item?.nameserver },
+					} );
+				},
+			},
+			{
+				id: 'delete',
+				label: __( 'Delete' ),
+				callback: ( items ) => {
+					const item = items[ 0 ];
+					deleteMutation.mutate( item.nameserver, {
+						onSuccess: () => {
+							createSuccessNotice( __( 'Glue record was deleted successfully.' ), {
+								type: 'snackbar',
+							} );
+						},
+						onError: () => {
+							createErrorNotice( __( 'Failed to delete glue record.' ), {
+								type: 'snackbar',
+							} );
+						},
 					} );
 				},
 			},


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTDASH-202/add-glue-records-editing-screen

## Proposed Changes

* Add a DataView listing for the domain glue records. It follows the approach in [domain forwarding](https://github.com/Automattic/wp-calypso/pull/105091).

<img width="694" height="382" alt="image" src="https://github.com/user-attachments/assets/76413abc-336b-441b-9b48-c174870d08a9" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is part of the [Hosting Dashboard: Domains](https://linear.app/a8c/project/hosting-dashboard-domains-7a553b8d4a37/overview) project.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Have a domain without glue records.
* Go to `/v2/domains/[domain]/glue-records` and you should see `No glue records found for this domain.`
* Add a few glue records using the old UI - `/domains/manage/all/overview/[domain]/[domain]`.
* Go to `/v2/domains/[domain]/glue-records` and you should see the DataView list of the records.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
