### PR TITLE
Connect Refresh: Clean up `isUnifiedCreateAccount`. Make it the default

### DIFF
--- a/client/blocks/authentication/form-divider/style.scss
+++ b/client/blocks/authentication/form-divider/style.scss
@@ -72,10 +72,7 @@ $breakpoint-mobile: 660px;
 }
 
 // In this case we want the separator to be vertical
-.signup-form,
-.layout:not(.is-grav-powered-client) .is-social-first,
-.login form.is-woo-passwordless,
-.login form.is-blaze-pro {
+.layout:not(.is-grav-powered-client) .is-social-first {
 	.auth-form__separator {
 		@include horizontal-separator;
 		width: calc(100% - 32px);
@@ -88,6 +85,14 @@ $breakpoint-mobile: 660px;
 
 	.auth-form__separator.is-horizontal {
 		@include horizontal-separator;
+	}
+}
+
+.layout:not(.is-grav-powered-client).is-section-login {
+	.login__body--continue-as-user {
+		.auth-form__separator {
+			@include horizontal-separator;
+		}
 	}
 }
 

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1,6 +1,5 @@
-import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
-import { FormInputValidation, FormLabel } from '@automattic/components';
+import { FormInputValidation } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Spinner } from '@wordpress/components';
 import clsx from 'clsx';
@@ -27,23 +26,13 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import { FormDivider } from 'calypso/blocks/authentication';
 import ContinueAsUser from 'calypso/blocks/login/continue-as-user';
-import FormPasswordInput from 'calypso/components/forms/form-password-input';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import FormTextInput from 'calypso/components/forms/form-text-input';
-import LoggedOutForm from 'calypso/components/logged-out-form';
 import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
 import Notice from 'calypso/components/notice';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import formState from 'calypso/lib/form-state';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
-import {
-	isA4AOAuth2Client,
-	isCrowdsignalOAuth2Client,
-	isGravatarOAuth2Client,
-	isVIPOAuth2Client,
-	isJetpackCloudOAuth2Client,
-	isStudioAppOAuth2Client,
-} from 'calypso/lib/oauth2-clients';
+import { isGravatarOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { login, lostPassword } from 'calypso/lib/paths';
 import { isExistingAccountError } from 'calypso/lib/signup/is-existing-account-error';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -55,7 +44,6 @@ import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { createSocialUserFailed } from 'calypso/state/login/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
-import getIsAkismet from 'calypso/state/selectors/get-is-akismet';
 import getIsBlazePro from 'calypso/state/selectors/get-is-blaze-pro';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
 import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
@@ -63,7 +51,6 @@ import isWooJPCFlow from 'calypso/state/selectors/is-woo-jpc-flow';
 import { resetSignup } from 'calypso/state/signup/actions';
 import { getSectionName } from 'calypso/state/ui/selectors';
 import PasswordlessSignupForm from './passwordless';
-import SignupFormSocialFirst from './signup-form-social-first';
 import SignupSubmitButton from './signup-submit-button';
 import SocialSignupForm from './social';
 
@@ -207,10 +194,6 @@ class SignupForm extends Component {
 		const value = this.props.suggestedUsername || '';
 		return merge( form, { username: { value } } );
 	}
-
-	recordBackLinkClick = () => {
-		recordTracksEvent( 'calypso_signup_back_link_click' );
-	};
 
 	getUserExistsError( props ) {
 		const { step } = props;
@@ -632,147 +615,6 @@ class SignupForm extends Component {
 		return this.props.displayUsernameInput && ! this.props.isBlazePro;
 	}
 
-	formFields() {
-		const isEmailValid =
-			! this.props.disableEmailInput && formState.isFieldValid( this.state.form, 'email' );
-
-		return (
-			<div>
-				{ this.props.displayNameInput && (
-					<>
-						<FormLabel htmlFor="firstName">{ this.props.translate( 'Your first name' ) }</FormLabel>
-						<FormTextInput
-							autoCorrect="off"
-							className="signup-form__input"
-							disabled={ this.state.submitting || !! this.props.disabled }
-							id="firstName"
-							name="firstName"
-							value={ formState.getFieldValue( this.state.form, 'firstName' ) }
-							isError={ formState.isFieldInvalid( this.state.form, 'firstName' ) }
-							isValid={ formState.isFieldValid( this.state.form, 'firstName' ) }
-							onBlur={ this.handleBlur }
-							onChange={ this.handleChangeEvent }
-						/>
-
-						{ formState.isFieldInvalid( this.state.form, 'firstName' ) && (
-							<FormInputValidation isError text={ this.getErrorMessagesWithLogin( 'firstName' ) } />
-						) }
-
-						<FormLabel htmlFor="lastName">{ this.props.translate( 'Your last name' ) }</FormLabel>
-						<FormTextInput
-							autoCorrect="off"
-							className="signup-form__input"
-							disabled={ this.state.submitting || !! this.props.disabled }
-							id="lastName"
-							name="lastName"
-							value={ formState.getFieldValue( this.state.form, 'lastName' ) }
-							isError={ formState.isFieldInvalid( this.state.form, 'lastName' ) }
-							isValid={ formState.isFieldValid( this.state.form, 'lastName' ) }
-							onBlur={ this.handleBlur }
-							onChange={ this.handleChangeEvent }
-						/>
-
-						{ formState.isFieldInvalid( this.state.form, 'lastName' ) && (
-							<FormInputValidation isError text={ this.getErrorMessagesWithLogin( 'lastName' ) } />
-						) }
-					</>
-				) }
-
-				<FormLabel htmlFor="email">{ this.props.translate( 'Your email address' ) }</FormLabel>
-				<FormTextInput
-					autoCapitalize="off"
-					autoCorrect="off"
-					className="signup-form__input"
-					disabled={
-						this.state.submitting || !! this.props.disabled || !! this.props.disableEmailInput
-					}
-					id="email"
-					name="email"
-					type="email"
-					value={ this.getEmailValue() }
-					isError={ formState.isFieldInvalid( this.state.form, 'email' ) }
-					isValid={ this.state.validationInitialized && isEmailValid }
-					onBlur={ this.handleBlur }
-					onChange={ this.handleChangeEvent }
-				/>
-				{ this.emailDisableExplanation() }
-
-				{ formState.isFieldInvalid( this.state.form, 'email' ) && (
-					<FormInputValidation isError text={ this.getErrorMessagesWithLogin( 'email' ) } />
-				) }
-
-				{ this.displayUsernameInput() && (
-					<>
-						<FormLabel htmlFor="username">
-							{ this.props.isWoo && ! this.props.isWooJPC
-								? this.props.translate( 'Username' )
-								: this.props.translate( 'Choose a username' ) }
-						</FormLabel>
-						<FormTextInput
-							autoCapitalize="off"
-							autoCorrect="off"
-							className="signup-form__input"
-							disabled={ this.state.submitting || this.props.disabled }
-							id="username"
-							name="username"
-							value={ formState.getFieldValue( this.state.form, 'username' ) }
-							isError={ formState.isFieldInvalid( this.state.form, 'username' ) }
-							isValid={ formState.isFieldValid( this.state.form, 'username' ) }
-							onBlur={ this.handleBlur }
-							onChange={ this.handleChangeEvent }
-						/>
-
-						{ formState.isFieldInvalid( this.state.form, 'username' ) && (
-							<FormInputValidation isError text={ this.getErrorMessagesWithLogin( 'username' ) } />
-						) }
-					</>
-				) }
-				<FormLabel htmlFor="password">{ this.props.translate( 'Choose a password' ) }</FormLabel>
-				<FormPasswordInput
-					className="signup-form__input"
-					disabled={ this.state.submitting || this.props.disabled }
-					id="password"
-					name="password"
-					value={ formState.getFieldValue( this.state.form, 'password' ) }
-					isError={ formState.isFieldInvalid( this.state.form, 'password' ) }
-					isValid={ formState.isFieldValid( this.state.form, 'password' ) }
-					onBlur={ this.handleBlur }
-					onChange={ this.handleChangeEvent }
-					submitting={ this.state.submitting || this.props.submitting }
-				/>
-				{ this.passwordValidationExplanation() }
-			</div>
-		);
-	}
-
-	recordWooCommerceSignupTracks( method ) {
-		const { isWoo, wccomFrom } = this.props;
-		if ( isWoo && 'cart' === wccomFrom ) {
-			recordTracksEvent( 'wcadmin_storeprofiler_payment_create_account', {
-				signup_method: method,
-			} );
-		}
-	}
-
-	handleWooCommerceSocialConnect = ( ...args ) => {
-		this.recordWooCommerceSignupTracks( 'social' );
-		this.props.handleSocialResponse( ...args );
-	};
-
-	handleWooCommerceSubmit = ( event ) => {
-		event.preventDefault();
-		document.activeElement.blur();
-		this.recordWooCommerceSignupTracks( 'email' );
-
-		this.formStateController.handleSubmit( ( hasErrors ) => {
-			if ( hasErrors ) {
-				this.setState( { submitting: false } );
-				return;
-			}
-		} );
-		this.handleSubmit( event );
-	};
-
 	handlePasswordlessSubmit = ( passwordLessData ) => {
 		this.formStateController.handleSubmit( ( hasErrors ) => {
 			if ( hasErrors ) {
@@ -1019,76 +861,55 @@ class SignupForm extends Component {
 		}
 
 		const logInUrl = this.getLoginLink();
-
-		// TODO clk Akismet
-		if ( this.props.isSocialFirst ) {
-			return (
-				<SignupFormSocialFirst
-					stepName={ this.props.stepName }
-					flowName={ this.props.flowName }
-					goToNextStep={ this.props.goToNextStep }
-					logInUrl={ logInUrl }
-					handleSocialResponse={ this.props.handleSocialResponse }
-					socialServiceResponse={ this.props.socialServiceResponse }
-					redirectToAfterLoginUrl={ this.props.redirectToAfterLoginUrl }
-					queryArgs={ this.props.queryArgs }
-					userEmail={ this.getEmailValue() }
-					notice={ this.getNotice( true ) }
-					isSocialFirst={ this.props.isSocialFirst }
-				/>
-			);
-		}
-
-		const isUnifiedCreateAccount =
-			this.props.isWoo ||
-			this.props.isA4A ||
-			this.props.isCrowdsignal ||
-			this.props.isBlazePro ||
-			this.props.isAkismet ||
-			this.props.isVIPClient ||
-			this.props.isJetpackCloud ||
-			isStudioAppOAuth2Client( this.props.oauth2Client );
 		const isGravatar = this.props.isGravatar;
 		const emailErrorMessage = this.getErrorMessagesWithLogin( 'email' );
-		const showSeparator =
-			isUnifiedCreateAccount ||
-			( 'wpcc' !== this.props.flowName && ! config.isEnabled( 'desktop' ) && this.isHorizontal() );
 
-		if (
-			( this.props.isPasswordless &&
-				( 'wpcc' !== this.props.flowName || isUnifiedCreateAccount ) ) ||
-			isGravatar
-		) {
-			let formProps = {
-				submitButtonLabel: this.props.submitButtonLabel,
-				submitButtonLoadingLabel: this.props.submitButtonLoadingLabel,
-			};
+		const formProps = isGravatar
+			? {
+					inputPlaceholder: this.props.translate( 'Enter your email address' ),
+					submitButtonLabel: this.props.translate( 'Continue' ),
+					submitButtonLoadingLabel: this.props.translate( 'Continue' ),
+			  }
+			: {
+					inputPlaceholder: null,
+					submitButtonLabel: this.props.translate( 'Continue' ),
+					submitButtonLoadingLabel: <Spinner />,
+			  };
 
-			switch ( true ) {
-				case isGravatar:
-					formProps = {
-						inputPlaceholder: this.props.translate( 'Enter your email address' ),
-						submitButtonLabel: this.props.translate( 'Continue' ),
-						submitButtonLoadingLabel: this.props.translate( 'Continue' ),
-					};
-					break;
-				case isUnifiedCreateAccount:
-					formProps = {
-						inputPlaceholder: null,
-						submitButtonLabel: this.props.translate( 'Continue' ),
-						submitButtonLoadingLabel: <Spinner />,
-					};
-			}
-
-			// TODO clk woo
-			return (
-				<div
-					className={ clsx( 'signup-form', this.props.className, {
-						'is-horizontal': this.isHorizontal(),
-					} ) }
-				>
-					{ this.getNotice() }
-					{ isGravatar && (
+		return (
+			<div
+				className={ clsx( 'signup-form', this.props.className, {
+					'is-horizontal': this.isHorizontal(),
+				} ) }
+			>
+				{ this.getNotice() }
+				{ isGravatar && (
+					<PasswordlessSignupForm
+						stepName={ this.props.stepName }
+						flowName={ this.props.flowName }
+						goToNextStep={ this.props.goToNextStep }
+						renderTerms={ this.termsOfServiceLink }
+						disableTosText={ this.props.disableTosText }
+						submitForm={ this.handlePasswordlessSubmit }
+						logInUrl={ logInUrl }
+						disabled={ this.props.disabled }
+						disableSubmitButton={ this.props.disableSubmitButton || emailErrorMessage }
+						queryArgs={ this.props.queryArgs }
+						userEmail={ this.getEmailValue() }
+						labelText={ this.props.labelText }
+						onInputBlur={ this.handleBlur }
+						onInputChange={ this.handleChangeEvent }
+						onCreateAccountError={ this.handleCreateAccountError }
+						onCreateAccountSuccess={ this.props.handleCreateAccountSuccess }
+						{ ...formProps }
+					>
+						{ emailErrorMessage && (
+							<ValidationFieldset errorMessages={ [ emailErrorMessage ] }></ValidationFieldset>
+						) }
+					</PasswordlessSignupForm>
+				) }
+				{ ! isGravatar && (
+					<>
 						<PasswordlessSignupForm
 							stepName={ this.props.stepName }
 							flowName={ this.props.flowName }
@@ -1112,76 +933,16 @@ class SignupForm extends Component {
 								<ValidationFieldset errorMessages={ [ emailErrorMessage ] }></ValidationFieldset>
 							) }
 						</PasswordlessSignupForm>
-					) }
-					{ ! isGravatar && (
-						<>
-							<PasswordlessSignupForm
-								stepName={ this.props.stepName }
-								flowName={ this.props.flowName }
-								goToNextStep={ this.props.goToNextStep }
-								renderTerms={ this.termsOfServiceLink }
-								disableTosText={ this.props.disableTosText }
-								submitForm={ this.handlePasswordlessSubmit }
-								logInUrl={ logInUrl }
-								disabled={ this.props.disabled }
-								disableSubmitButton={ this.props.disableSubmitButton || emailErrorMessage }
-								queryArgs={ this.props.queryArgs }
-								userEmail={ this.getEmailValue() }
-								labelText={ this.props.labelText }
-								onInputBlur={ this.handleBlur }
-								onInputChange={ this.handleChangeEvent }
-								onCreateAccountError={ this.handleCreateAccountError }
-								onCreateAccountSuccess={ this.props.handleCreateAccountSuccess }
-								{ ...formProps }
-							>
-								{ emailErrorMessage && (
-									<ValidationFieldset errorMessages={ [ emailErrorMessage ] }></ValidationFieldset>
-								) }
-							</PasswordlessSignupForm>
-							{ showSeparator && <FormDivider /> }
-							{ this.props.isSocialSignupEnabled && (
-								<SocialSignupForm
-									handleResponse={ this.props.handleSocialResponse }
-									socialServiceResponse={ this.props.socialServiceResponse }
-									redirectToAfterLoginUrl={ this.props.redirectToAfterLoginUrl }
-									compact={ isUnifiedCreateAccount }
-								/>
-							) }
-							{ this.props.footerLink || this.footerLink() }
-						</>
-					) }
-				</div>
-			);
-		}
-
-		return (
-			<div
-				className={ clsx( 'signup-form', this.props.className, {
-					'is-horizontal': this.isHorizontal(),
-				} ) }
-			>
-				<LoggedOutForm onSubmit={ this.handleSubmit } noValidate>
-					{ this.getNotice() }
-					{ this.props.formHeader && (
-						<header className="signup-form__header">{ this.props.formHeader }</header>
-					) }
-					{ this.formFields() }
-					{ this.props.formFooter || this.formFooter() }
-				</LoggedOutForm>
-
-				{ showSeparator && <FormDivider /> }
-
-				{ this.props.isSocialSignupEnabled && (
-					<SocialSignupForm
-						handleResponse={ this.props.handleSocialResponse }
-						socialServiceResponse={ this.props.socialServiceResponse }
-						flowName={ this.props.flowName }
-						compact={ this.props.isWoo }
-						redirectToAfterLoginUrl={ this.props.redirectToAfterLoginUrl }
-					/>
+						<FormDivider />
+						<SocialSignupForm
+							handleResponse={ this.props.handleSocialResponse }
+							socialServiceResponse={ this.props.socialServiceResponse }
+							redirectToAfterLoginUrl={ this.props.redirectToAfterLoginUrl }
+							compact
+							disableTosText
+						/>
+					</>
 				) }
-
-				{ this.props.footerLink || this.footerLink() }
 			</div>
 		);
 	}
@@ -1202,11 +963,6 @@ export default connect(
 			isWooJPC,
 			isGravatar: isGravatarOAuth2Client( oauth2Client ),
 			isBlazePro: getIsBlazePro( state ),
-			isA4A: isA4AOAuth2Client( oauth2Client ),
-			isCrowdsignal: isCrowdsignalOAuth2Client( oauth2Client ),
-			isAkismet: getIsAkismet( state ),
-			isVIPClient: isVIPOAuth2Client( oauth2Client ),
-			isJetpackCloud: isJetpackCloudOAuth2Client( oauth2Client ),
 		};
 	},
 	{

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1,5 +1,4 @@
 import page from '@automattic/calypso-router';
-import { FormInputValidation } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Spinner } from '@wordpress/components';
 import clsx from 'clsx';
@@ -26,8 +25,6 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import { FormDivider } from 'calypso/blocks/authentication';
 import ContinueAsUser from 'calypso/blocks/login/continue-as-user';
-import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
 import Notice from 'calypso/components/notice';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import formState from 'calypso/lib/form-state';
@@ -51,7 +48,6 @@ import isWooJPCFlow from 'calypso/state/selectors/is-woo-jpc-flow';
 import { resetSignup } from 'calypso/state/signup/actions';
 import { getSectionName } from 'calypso/state/ui/selectors';
 import PasswordlessSignupForm from './passwordless';
-import SignupSubmitButton from './signup-submit-button';
 import SocialSignupForm from './social';
 
 import './style.scss';
@@ -77,15 +73,11 @@ class SignupForm extends Component {
 		disableBlurValidation: PropTypes.bool,
 		disableContinueAsUser: PropTypes.bool,
 		disabled: PropTypes.bool,
-		disableEmailExplanation: PropTypes.string,
-		disableEmailInput: PropTypes.bool,
 		disableSubmitButton: PropTypes.bool,
 		displayNameInput: PropTypes.bool,
 		displayUsernameInput: PropTypes.bool,
 		email: PropTypes.string,
 		flowName: PropTypes.string,
-		footerLink: PropTypes.node,
-		formHeader: PropTypes.node,
 		goToNextStep: PropTypes.func,
 		handleCreateAccountError: PropTypes.func,
 		handleCreateAccountSuccess: PropTypes.func,
@@ -104,7 +96,6 @@ class SignupForm extends Component {
 		step: PropTypes.object,
 		submitButtonLabel: PropTypes.string,
 		submitButtonLoadingLabel: PropTypes.string,
-		submitButtonText: PropTypes.string,
 		submitForm: PropTypes.func,
 		submitting: PropTypes.bool,
 		suggestedUsername: PropTypes.string.isRequired,
@@ -471,18 +462,10 @@ class SignupForm extends Component {
 		} );
 	};
 
-	isJetpack() {
-		return 'jetpack-connect' === this.props.sectionName;
-	}
-
-	getLoginLinkFrom() {
-		return this.props.from;
-	}
-
 	getLoginLink( { emailAddress } = {} ) {
 		return login( {
 			emailAddress,
-			isJetpack: this.isJetpack(),
+			isJetpack: 'jetpack-connect' === this.props.sectionName,
 			from: this.props.from,
 			redirectTo: this.props.redirectToAfterLoginUrl,
 			locale: this.props.locale,
@@ -612,7 +595,7 @@ class SignupForm extends Component {
 	}
 
 	displayUsernameInput() {
-		return this.props.displayUsernameInput && ! this.props.isBlazePro;
+		return this.props.displayUsernameInput;
 	}
 
 	handlePasswordlessSubmit = ( passwordLessData ) => {
@@ -634,10 +617,6 @@ class SignupForm extends Component {
 	};
 
 	termsOfServiceLink = () => {
-		if ( this.props.isWoo ) {
-			return null;
-		}
-
 		const options = {
 			components: {
 				tosLink: (
@@ -658,31 +637,11 @@ class SignupForm extends Component {
 				),
 			},
 		};
-		let tosText = this.props.translate(
-			'By creating an account you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+
+		const tosText = this.props.translate(
+			'By entering your email address, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
 			options
 		);
-
-		if ( this.props.isGravatar ) {
-			tosText = this.props.translate(
-				'By entering your email address, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
-				options
-			);
-		}
-
-		if ( this.props.isBlazePro ) {
-			tosText = (
-				<>
-					{ this.props.translate(
-						'By creating an account, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and acknowledge you have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
-						options
-					) }{ ' ' }
-					{ this.props.translate(
-						'Blaze Pro uses WordPress.com accounts under the hood. Tumblr, Blaze Pro, and WordPress.com are properties of Automattic, Inc.'
-					) }
-				</>
-			);
-		}
 
 		return <p className="signup-form__terms-of-service-link">{ tosText }</p>;
 	};
@@ -732,81 +691,6 @@ class SignupForm extends Component {
 		}
 
 		return false;
-	}
-
-	emailDisableExplanation() {
-		if ( this.props.disableEmailInput && this.props.disableEmailExplanation ) {
-			return (
-				<FormSettingExplanation>{ this.props.disableEmailExplanation }</FormSettingExplanation>
-			);
-		}
-	}
-
-	passwordValidationExplanation() {
-		const passwordValue = formState.getFieldValue( this.state.form, 'password' );
-
-		if ( formState.isFieldInvalid( this.state.form, 'password' ) ) {
-			return <FormInputValidation isError text={ this.getErrorMessagesWithLogin( 'password' ) } />;
-		}
-
-		if ( passwordValue && passwordValue < 6 ) {
-			return (
-				<FormSettingExplanation>
-					{ this.props.translate( 'Your password must be at least six characters long.' ) }
-				</FormSettingExplanation>
-			);
-		}
-
-		return false;
-	}
-
-	hasFilledInputValues = () => {
-		const userInputFields = [ 'email', 'username', 'password' ];
-		return userInputFields.every( ( field ) => {
-			const value = formState.getFieldValue( this.state.form, field );
-			if ( typeof value === 'string' ) {
-				return value.trim().length > 0;
-			}
-			// eslint-disable-next-line no-console
-			console.warn(
-				`hasFilledInputValues: field ${ field } has a value of type ${ typeof value }. Expected string.`
-			);
-			// If we can't determine if the field is filled, we assume it is so that the user can submit the form.
-			return true;
-		} );
-	};
-
-	formFooter() {
-		const params = new URLSearchParams( window.location.search );
-		const variationName = params.get( 'variationName' );
-
-		return (
-			<LoggedOutFormFooter isBlended={ this.props.isSocialSignupEnabled }>
-				{ ! this.props.disableTosText && this.termsOfServiceLink() }
-				<SignupSubmitButton
-					isDisabled={
-						this.state.submitting ||
-						this.props.disabled ||
-						this.props.disableSubmitButton ||
-						( this.props.isWoo &&
-							( ! this.hasFilledInputValues() || formState.hasErrors( this.state.form ) ) )
-					}
-					variationName={ variationName }
-				>
-					{ this.props.submitButtonText }
-				</SignupSubmitButton>
-			</LoggedOutFormFooter>
-		);
-	}
-
-	footerLink() {
-		const { isWoo } = this.props;
-
-		if ( isWoo ) {
-			return null;
-		}
-
-		return null;
 	}
 
 	handleOnChangeAccount = () => {
@@ -914,8 +798,7 @@ class SignupForm extends Component {
 							stepName={ this.props.stepName }
 							flowName={ this.props.flowName }
 							goToNextStep={ this.props.goToNextStep }
-							renderTerms={ this.termsOfServiceLink }
-							disableTosText={ this.props.disableTosText }
+							disableTosText
 							submitForm={ this.handlePasswordlessSubmit }
 							logInUrl={ logInUrl }
 							disabled={ this.props.disabled }

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -13,21 +13,11 @@ import {
 	GithubSocialButton,
 	UsernameOrEmailButton,
 } from 'calypso/components/social-buttons';
-import {
-	isA4AOAuth2Client,
-	isBlazeProOAuth2Client,
-	isCrowdsignalOAuth2Client,
-	isJetpackCloudOAuth2Client,
-	isStudioAppOAuth2Client,
-	isVIPOAuth2Client,
-} from 'calypso/lib/oauth2-clients';
 import { isWpccFlow } from 'calypso/signup/is-flow';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import getIsAkismet from 'calypso/state/selectors/get-is-akismet';
-import getIsWoo from 'calypso/state/selectors/get-is-woo';
 
 class SocialSignupForm extends Component {
 	static propTypes = {
@@ -102,27 +92,8 @@ class SocialSignupForm extends Component {
 			disableTosText,
 			isSocialFirst,
 			flowName,
-			isWoo,
-			isA4A,
-			isBlazePro,
-			isAkismet,
-			isCrowdsignal,
-			isVIPClient,
-			isJetpackCloud,
-			isStudioApp,
 			setCurrentStep,
 		} = this.props;
-
-		const isUnifiedCreateAccount =
-			isWoo ||
-			isA4A ||
-			isCrowdsignal ||
-			isBlazePro ||
-			isAkismet ||
-			isVIPClient ||
-			isJetpackCloud ||
-			isStudioApp;
-
 		return (
 			<Card
 				className={ clsx( 'auth-form__social', 'is-signup', {
@@ -156,7 +127,7 @@ class SocialSignupForm extends Component {
 							<UsernameOrEmailButton onClick={ () => setCurrentStep( 'email' ) } />
 						) }
 					</div>
-					{ ! isUnifiedCreateAccount && ! disableTosText && <SocialToS /> }
+					{ ! disableTosText && <SocialToS /> }
 				</div>
 			</Card>
 		);
@@ -174,14 +145,6 @@ export default connect(
 			currentRoute: getCurrentRoute( state ),
 			oauth2Client: oauth2Client,
 			isDevAccount: isDevAccount,
-			isWoo: getIsWoo( state ),
-			isA4A: isA4AOAuth2Client( oauth2Client ),
-			isBlazePro: isBlazeProOAuth2Client( oauth2Client ),
-			isCrowdsignal: isCrowdsignalOAuth2Client( oauth2Client ),
-			isAkismet: getIsAkismet( state ),
-			isVIPClient: isVIPOAuth2Client( oauth2Client ),
-			isJetpackCloud: isJetpackCloudOAuth2Client( oauth2Client ),
-			isStudioApp: isStudioAppOAuth2Client( oauth2Client ),
 		};
 	},
 	{ showErrorNotice: errorNotice }

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -55,17 +55,11 @@
 
 .auth-form__social {
 	max-width: 400px;
-	margin: 0 auto;
-	padding: 16px;
 	box-sizing: border-box;
-
-	.is-unified-create-account & {
-		width: 100%;
-		// Below is the same as .card.logged-out-form
-		margin: 0 auto 16px;
-		// max-width: 360px;
-		padding: 16px;
-	}
+	width: 100%;
+	// Below is the same as .card.logged-out-form
+	margin: 0 auto 16px;
+	padding: 16px;
 
 	p {
 		font-size: $font-body-small;
@@ -360,11 +354,6 @@ body.is-section-accept-invite {
 			}
 		}
 	}
-}
-
-// TODO clk remove this. it's handled by .is-unified-create-account
-.is-woo-passwordless .signup-form .auth-form__separator {
-	margin: 32px 0;
 }
 
 .signup-form.is-horizontal .calypso-notice.signup-form__notice {

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -117,120 +117,62 @@ exports[`JetpackSignup should render 1`] = `
         class="signup-form"
       >
         <div
-          class="card logged-out-form"
+          class="signup-form__passwordless-form-wrapper"
         >
-          <form
-            novalidate=""
+          <div
+            class="card logged-out-form"
           >
-            <div>
-              <label
-                class="form-label"
-                for="email"
+            <form
+              novalidate=""
+            >
+              <fieldset
+                class="validation-fieldset form-fieldset"
+                role="group"
               >
-                Your email address
-              </label>
-              <input
-                autocapitalize="off"
-                autocorrect="off"
-                class="form-text-input signup-form__input"
-                id="email"
-                name="email"
-                type="email"
-                value="email@an.example.site"
-              />
-              <label
-                class="form-label"
-                for="username"
-              >
-                Choose a username
-              </label>
-              <input
-                autocapitalize="off"
-                autocorrect="off"
-                class="form-text-input signup-form__input"
-                id="username"
-                name="username"
-                type="text"
-                value=""
-              />
-              <label
-                class="form-label"
-                for="password"
-              >
-                Choose a password
-              </label>
-              <div
-                class="form-password-input"
-              >
-                <input
-                  autocomplete="off"
-                  class="form-text-input signup-form__input"
-                  id="password"
-                  name="password"
-                  type="password"
-                  value=""
-                />
-                <button
-                  aria-label="Show password"
-                  class="components-button form-password-input__toggle form-password-input__toggle-visibility is-small has-icon"
-                  type="button"
+                <label
+                  class="form-label"
+                  for="signup-email"
                 >
-                  <svg
-                    aria-hidden="true"
-                    focusable="false"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M20.7 12.7s0-.1-.1-.2c0-.2-.2-.4-.4-.6-.3-.5-.9-1.2-1.6-1.8-.7-.6-1.5-1.3-2.6-1.8l-.6 1.4c.9.4 1.6 1 2.1 1.5.6.6 1.1 1.2 1.4 1.6.1.2.3.4.3.5v.1l.7-.3.7-.3Zm-5.2-9.3-1.8 4c-.5-.1-1.1-.2-1.7-.2-3 0-5.2 1.4-6.6 2.7-.7.7-1.2 1.3-1.6 1.8-.2.3-.3.5-.4.6 0 0 0 .1-.1.2s0 0 .7.3l.7.3V13c0-.1.2-.3.3-.5.3-.4.7-1 1.4-1.6 1.2-1.2 3-2.3 5.5-2.3H13v.3c-.4 0-.8-.1-1.1-.1-1.9 0-3.5 1.6-3.5 3.5s.6 2.3 1.6 2.9l-2 4.4.9.4 7.6-16.2-.9-.4Zm-3 12.6c1.7-.2 3-1.7 3-3.5s-.2-1.4-.6-1.9L12.4 16Z"
-                    />
-                  </svg>
+                  Enter your email address
+                </label>
+                <input
+                  autocapitalize="off"
+                  autocorrect="off"
+                  class="form-text-input signup-form__passwordless-email"
+                  id="signup-email"
+                  name="email"
+                  type="email"
+                  value="email@an.example.site"
+                />
+                <div
+                  class="validation-fieldset__validation-message"
+                />
+              </fieldset>
+              <div
+                class="card logged-out-form__footer"
+              >
+                <button
+                  class="components-button signup-form__submit is-next-40px-default-size is-primary"
+                  type="submit"
+                >
+                  Continue
                 </button>
               </div>
-            </div>
-            <div
-              class="card logged-out-form__footer is-blended"
-            >
-              <p
-                class="signup-form__terms-of-service-link"
-              >
-                By creating an account you agree to our 
-                <a
-                  href="https://wordpress.com/tos/"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Terms of Service
-                </a>
-                 and have read our 
-                <a
-                  href="https://automattic.com/privacy/"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Privacy Policy
-                </a>
-                .
-              </p>
-              <button
-                class="components-button signup-form__submit is-next-40px-default-size is-primary"
-                type="submit"
-              >
-                Create your account
-              </button>
-            </div>
-          </form>
+            </form>
+          </div>
+        </div>
+        <div
+          class="auth-form__separator"
+        >
+          <div
+            class="auth-form__separator-text"
+          >
+            or
+          </div>
         </div>
         <div
           class="card auth-form__social is-signup"
         >
-          <p
-            class="auth-form__social-text"
-          >
-            Or create an account using:
-          </p>
           <div
             class="auth-form__social-buttons"
           >
@@ -241,46 +183,7 @@ exports[`JetpackSignup should render 1`] = `
               AppleLoginButton
               GitHubLoginButton
             </div>
-            <p
-              class="auth-form__social-buttons-tos"
-            >
-              If you continue with Google, Apple or GitHub, you agree to our 
-              <a
-                href="https://wordpress.com/tos/"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                Terms of Service
-              </a>
-              , and have read our 
-              <a
-                href="https://automattic.com/privacy/"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                Privacy Policy
-              </a>
-              .
-            </p>
           </div>
-        </div>
-        <div
-          class="logged-out-form__links"
-        >
-          <a
-            class="logged-out-form__link-item"
-            href="/log-in/jetpack?site=http%3A%2F%2Fan.example.site&redirect_to=https%3A%2F%2Fexample.com%2F&email_address=email%40an.example.site&from=banner-44-slide-1-dashboard"
-          >
-            Already have an account? Sign in
-          </a>
-          <a
-            class="logged-out-form__link-item jetpack-connect__help-button"
-            href="https://jetpack.com/contact-support?hpi=1"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Get help setting up Jetpack
-          </a>
         </div>
       </div>
     </div>
@@ -405,120 +308,62 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
         class="signup-form"
       >
         <div
-          class="card logged-out-form"
+          class="signup-form__passwordless-form-wrapper"
         >
-          <form
-            novalidate=""
+          <div
+            class="card logged-out-form"
           >
-            <div>
-              <label
-                class="form-label"
-                for="email"
+            <form
+              novalidate=""
+            >
+              <fieldset
+                class="validation-fieldset form-fieldset"
+                role="group"
               >
-                Your email address
-              </label>
-              <input
-                autocapitalize="off"
-                autocorrect="off"
-                class="form-text-input signup-form__input"
-                id="email"
-                name="email"
-                type="email"
-                value="email@an.example.site"
-              />
-              <label
-                class="form-label"
-                for="username"
-              >
-                Choose a username
-              </label>
-              <input
-                autocapitalize="off"
-                autocorrect="off"
-                class="form-text-input signup-form__input"
-                id="username"
-                name="username"
-                type="text"
-                value=""
-              />
-              <label
-                class="form-label"
-                for="password"
-              >
-                Choose a password
-              </label>
-              <div
-                class="form-password-input"
-              >
-                <input
-                  autocomplete="off"
-                  class="form-text-input signup-form__input"
-                  id="password"
-                  name="password"
-                  type="password"
-                  value=""
-                />
-                <button
-                  aria-label="Show password"
-                  class="components-button form-password-input__toggle form-password-input__toggle-visibility is-small has-icon"
-                  type="button"
+                <label
+                  class="form-label"
+                  for="signup-email"
                 >
-                  <svg
-                    aria-hidden="true"
-                    focusable="false"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M20.7 12.7s0-.1-.1-.2c0-.2-.2-.4-.4-.6-.3-.5-.9-1.2-1.6-1.8-.7-.6-1.5-1.3-2.6-1.8l-.6 1.4c.9.4 1.6 1 2.1 1.5.6.6 1.1 1.2 1.4 1.6.1.2.3.4.3.5v.1l.7-.3.7-.3Zm-5.2-9.3-1.8 4c-.5-.1-1.1-.2-1.7-.2-3 0-5.2 1.4-6.6 2.7-.7.7-1.2 1.3-1.6 1.8-.2.3-.3.5-.4.6 0 0 0 .1-.1.2s0 0 .7.3l.7.3V13c0-.1.2-.3.3-.5.3-.4.7-1 1.4-1.6 1.2-1.2 3-2.3 5.5-2.3H13v.3c-.4 0-.8-.1-1.1-.1-1.9 0-3.5 1.6-3.5 3.5s.6 2.3 1.6 2.9l-2 4.4.9.4 7.6-16.2-.9-.4Zm-3 12.6c1.7-.2 3-1.7 3-3.5s-.2-1.4-.6-1.9L12.4 16Z"
-                    />
-                  </svg>
+                  Enter your email address
+                </label>
+                <input
+                  autocapitalize="off"
+                  autocorrect="off"
+                  class="form-text-input signup-form__passwordless-email"
+                  id="signup-email"
+                  name="email"
+                  type="email"
+                  value="email@an.example.site"
+                />
+                <div
+                  class="validation-fieldset__validation-message"
+                />
+              </fieldset>
+              <div
+                class="card logged-out-form__footer"
+              >
+                <button
+                  class="components-button signup-form__submit is-next-40px-default-size is-primary"
+                  type="submit"
+                >
+                  Continue
                 </button>
               </div>
-            </div>
-            <div
-              class="card logged-out-form__footer is-blended"
-            >
-              <p
-                class="signup-form__terms-of-service-link"
-              >
-                By creating an account you agree to our 
-                <a
-                  href="https://wordpress.com/tos/"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Terms of Service
-                </a>
-                 and have read our 
-                <a
-                  href="https://automattic.com/privacy/"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Privacy Policy
-                </a>
-                .
-              </p>
-              <button
-                class="components-button signup-form__submit is-next-40px-default-size is-primary"
-                type="submit"
-              >
-                Create your account
-              </button>
-            </div>
-          </form>
+            </form>
+          </div>
+        </div>
+        <div
+          class="auth-form__separator"
+        >
+          <div
+            class="auth-form__separator-text"
+          >
+            or
+          </div>
         </div>
         <div
           class="card auth-form__social is-signup"
         >
-          <p
-            class="auth-form__social-text"
-          >
-            Or create an account using:
-          </p>
           <div
             class="auth-form__social-buttons"
           >
@@ -529,46 +374,7 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
               AppleLoginButton
               GitHubLoginButton
             </div>
-            <p
-              class="auth-form__social-buttons-tos"
-            >
-              If you continue with Google, Apple or GitHub, you agree to our 
-              <a
-                href="https://wordpress.com/tos/"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                Terms of Service
-              </a>
-              , and have read our 
-              <a
-                href="https://automattic.com/privacy/"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                Privacy Policy
-              </a>
-              .
-            </p>
           </div>
-        </div>
-        <div
-          class="logged-out-form__links"
-        >
-          <a
-            class="logged-out-form__link-item"
-            href="/log-in/jetpack/es?site=http%3A%2F%2Fan.example.site&redirect_to=https%3A%2F%2Fexample.com%2F&email_address=email%40an.example.site&from=banner-44-slide-1-dashboard"
-          >
-            Already have an account? Sign in
-          </a>
-          <a
-            class="logged-out-form__link-item jetpack-connect__help-button"
-            href="https://jetpack.com/contact-support?hpi=1"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Get help setting up Jetpack
-          </a>
         </div>
       </div>
     </div>

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -120,8 +120,6 @@ const LayoutLoggedOut = ( {
 			currentRoute?.startsWith( '/start/do-it-for-me/' ) ) &&
 		userAllowedToHelpCenter;
 
-	const isUnifiedCreateAccount = sectionName === 'signup' && ! isGravatar;
-
 	const classes = {
 		[ 'is-group-' + sectionGroup ]: sectionGroup,
 		[ 'is-section-' + sectionName ]: sectionName,
@@ -147,7 +145,6 @@ const LayoutLoggedOut = ( {
 		woo: isWoo,
 		'feature-flag-woocommerce-core-profiler-passwordless-auth': true,
 		'jetpack-cloud': isJetpackCloud,
-		'is-unified-create-account': isUnifiedCreateAccount,
 	};
 
 	let masterbar = null;

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -26,10 +26,6 @@ import {
 	isBlazeProOAuth2Client,
 	isAndroidOAuth2Client,
 	isIosOAuth2Client,
-	isA4AOAuth2Client,
-	isCrowdsignalOAuth2Client,
-	isVIPOAuth2Client,
-	isStudioAppOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { createAccountUrl } from 'calypso/lib/paths';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
@@ -84,9 +80,6 @@ const LayoutLoggedOut = ( {
 	clearLastActionRequiresLogin,
 	userAllowedToHelpCenter,
 	colorScheme,
-	isA4A,
-	isCrowdsignal,
-	isVIPClient,
 	isJetpackCloud,
 } ) => {
 	const isLoggedIn = useSelector( isUserLoggedIn );
@@ -127,16 +120,7 @@ const LayoutLoggedOut = ( {
 			currentRoute?.startsWith( '/start/do-it-for-me/' ) ) &&
 		userAllowedToHelpCenter;
 
-	const isUnifiedCreateAccount =
-		sectionName === 'signup' &&
-		( isWoo ||
-			isA4A ||
-			isCrowdsignal ||
-			isBlazePro ||
-			isAkismet ||
-			isVIPClient ||
-			isJetpackCloud ||
-			isStudioAppOAuth2Client( oauth2Client ) );
+	const isUnifiedCreateAccount = sectionName === 'signup' && ! isGravatar;
 
 	const classes = {
 		[ 'is-group-' + sectionGroup ]: sectionGroup,
@@ -402,9 +386,6 @@ export default withCurrentRoute(
 				userAllowedToHelpCenter: ! getIsOnboardingAffiliateFlow( state ),
 				twoFactorEnabled,
 				colorScheme,
-				isA4A: isA4AOAuth2Client( oauth2Client ),
-				isCrowdsignal: isCrowdsignalOAuth2Client( oauth2Client ),
-				isVIPClient: isVIPOAuth2Client( oauth2Client ),
 				isJetpackCloud: isJetpackCloudOAuth2Client( oauth2Client ),
 			};
 		},

--- a/client/layout/masterbar/blaze-pro.scss
+++ b/client/layout/masterbar/blaze-pro.scss
@@ -166,16 +166,6 @@ body.is-section-login {
 		}
 	}
 
-	&.is-section-signup .layout__content,
-	.layout__content {
-		padding-top: 85px;
-
-		@media (max-width: $break-mobile) {
-			padding-top: 50px;
-			padding-bottom: 80px;
-		}
-	}
-
 	&.is-section-signup::before,
 	&.is-section-signup .layout__primary::before {
 		display: none;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -380,11 +380,6 @@ $breakpoint-mobile: 660px;
 		height: unset;
 		min-height: 238px;
 
-		~ .auth-form__separator {
-			margin: -10px auto;
-			max-width: 472px;
-		}
-
 		~ .card.auth-form__social.is-login {
 			max-width: 472px;
 		}
@@ -897,13 +892,17 @@ $breakpoint-mobile: 660px;
 			margin-top: unset;
 		}
 
+		.login__body--continue-as-user {
+			width: 540px;
+			margin: 0 auto;
+			padding: 0;
+			display: flex;
+			flex-direction: column;
+		}
+
 		.continue-as-user {
 			margin: 0;
 			max-width: initial;
-
-			~ .auth-form__separator {
-				margin: 32px auto;
-			}
 
 			.continue-as-user__user-info {
 				display: flex;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -335,14 +335,6 @@ $breakpoint-mobile: 660px;
 		}
 	}
 
-
-	&:not(.is-section-login) {
-		.card { // TODO clk remove this. it's handled by .is-unified-create-account
-			box-shadow: none;
-			background-color: initial;
-		}
-	}
-
 	.step-wrapper,
 	.jetpack-connect__main-logo {
 		box-sizing: border-box;
@@ -466,11 +458,6 @@ $breakpoint-mobile: 660px;
 		margin-top: 8px;
 	}
 
-	.auth-form__separator::before,
-	.auth-form__separator::after {
-		border-block-start: $woo-form-divider-border; // TODO clk remove this. it's handled by .is-unified-create-account
-	}
-
 	.login__two-factor-footer {
 		display: flex;
 		flex-direction: column;
@@ -491,32 +478,6 @@ $breakpoint-mobile: 660px;
 
 		@media (max-width: $break-mobile) {
 			align-items: flex-start;
-		}
-	}
-
-	.signup-form {
-		.auth-form__separator { // TODO clk remove this. it's handled by .is-unified-create-account
-			width: 100%;
-			margin-left: 0;
-			margin-right: 0;
-
-			@media (min-width: 782px) {
-				width: 100%;
-			}
-
-			&::before,
-			&::after {
-				position: absolute;
-				border-inline-start: 0;
-				border-block-start: $woo-form-divider-border;
-				inset-block-start: 50%;
-				inset-inline-start: 0;
-				width: 42%;
-			}
-
-			&::after {
-				left: 58%;
-			}
 		}
 	}
 
@@ -934,28 +895,6 @@ $breakpoint-mobile: 660px;
 
 		.login__form-forgot-password {
 			margin-top: unset;
-		}
-
-		.signup-form, // TODO clk remove this. it's handled by .is-unified-create-account
-		.login__body--continue-as-user {
-			width: 540px;
-			margin: 0 auto;
-			padding: 0;
-			display: flex;
-			flex-direction: column;
-		}
-
-		.signup-form { // TODO clk remove this. it's handled by .is-unified-create-account
-			input[type="email"].form-text-input {
-				margin-bottom: 0;
-			}
-		}
-
-		div.auth-form__separator { // TODO clk remove this. it's handled by .is-unified-create-account
-			&::before,
-			&::after {
-				border-block-start-color: #e0e0e1;
-			}
 		}
 
 		.continue-as-user {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -30,7 +30,6 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
-import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import { startedInHostingFlow } from 'calypso/landing/stepper/utils/hosting-flow';
 import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
 import {
@@ -46,12 +45,6 @@ import {
 	isWooOAuth2Client,
 	isGravatarOAuth2Client,
 	isPartnerPortalOAuth2Client,
-	isA4AOAuth2Client,
-	isBlazeProOAuth2Client,
-	isCrowdsignalOAuth2Client,
-	isVIPOAuth2Client,
-	isJetpackCloudOAuth2Client,
-	isStudioAppOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import SignupFlowController from 'calypso/lib/signup/flow-controller';
 import FlowProgressIndicator from 'calypso/signup/flow-progress-indicator';
@@ -66,7 +59,6 @@ import {
 } from 'calypso/state/current-user/selectors';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
-import getIsAkismet from 'calypso/state/selectors/get-is-akismet';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
 import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
@@ -772,7 +764,7 @@ class Signup extends Component {
 		);
 	}
 
-	renderCurrentStep( isUnifiedCreateAccount ) {
+	renderCurrentStep() {
 		const { stepName, flowName } = this.props;
 
 		const flow = flows.getFlow( flowName, this.props.isLoggedIn );
@@ -786,8 +778,6 @@ class Signup extends Component {
 			...flowStepProps,
 		};
 		const stepKey = this.state.shouldShowLoadingScreen ? 'processing' : stepName;
-		const shouldRenderLocaleSuggestions =
-			0 === this.getPositionInFlow() && ! this.props.isLoggedIn && ! isUnifiedCreateAccount;
 
 		let propsForCurrentStep = propsFromConfig;
 		if ( this.props.isManageSiteFlow ) {
@@ -807,9 +797,6 @@ class Signup extends Component {
 		return (
 			<div className="signup__step" key={ stepKey }>
 				<div className={ `signup__step is-${ stepName }` }>
-					{ shouldRenderLocaleSuggestions && (
-						<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
-					) }
 					{ this.state.shouldShowLoadingScreen ? (
 						this.renderProcessingScreen()
 					) : (
@@ -876,20 +863,7 @@ class Signup extends Component {
 		if ( waitToRenderReturnValue && ! this.state.shouldShowLoadingScreen ) {
 			return this.props.siteId && waitToRenderReturnValue;
 		}
-
-		const isUnifiedCreateAccount =
-			0 === this.getPositionInFlow() &&
-			! this.props.isLoggedIn &&
-			( this.props.isWoo ||
-				this.props.isA4A ||
-				this.props.isCrowdsignal ||
-				this.props.isBlazePro ||
-				this.props.isAkismet ||
-				this.props.isVIPClient ||
-				this.props.isJetpackCloud ||
-				isStudioAppOAuth2Client( this.props.oauth2Client ) );
-
-		const showPageHeader = ! this.props.isGravatar && ! isUnifiedCreateAccount;
+		const showPageHeader = ! ( 0 === this.getPositionInFlow() && ! this.props.isLoggedIn );
 		const isGravatarDomain = isDomainForGravatarFlow( this.props.flowName );
 
 		return (
@@ -915,7 +889,7 @@ class Signup extends Component {
 							logoComponent={ isGravatarDomain ? <GravatarTextLogo /> : undefined }
 						/>
 					) }
-					<div className="signup__steps">{ this.renderCurrentStep( isUnifiedCreateAccount ) }</div>
+					<div className="signup__steps">{ this.renderCurrentStep() }</div>
 					{ this.state.bearerToken && (
 						<WpcomLoginForm
 							authorization={ 'Bearer ' + this.state.bearerToken }
@@ -964,12 +938,6 @@ export default connect(
 			wccomFrom: getWccomFrom( state ),
 			hostingFlow,
 			isWoo: getIsWoo( state ),
-			isA4A: isA4AOAuth2Client( oauth2Client ),
-			isBlazePro: isBlazeProOAuth2Client( oauth2Client ),
-			isCrowdsignal: isCrowdsignalOAuth2Client( oauth2Client ),
-			isAkismet: getIsAkismet( state ),
-			isVIPClient: isVIPOAuth2Client( oauth2Client ),
-			isJetpackCloud: isJetpackCloudOAuth2Client( oauth2Client ),
 		};
 	},
 	{

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -1,7 +1,6 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { isHostingSignupFlow, isNewsletterFlow } from '@automattic/onboarding';
-import { isMobile } from '@automattic/viewport';
 import { Button } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize, fixMe } from 'i18n-calypso';
@@ -10,7 +9,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import SignupForm from 'calypso/blocks/signup-form';
-import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import WooCommerceConnectCartHeader from 'calypso/components/woocommerce-connect-cart-header';
 import WPCloudLogo from 'calypso/components/wp-cloud-logo';
 import { initGoogleRecaptcha, recordGoogleRecaptchaAction } from 'calypso/lib/analytics/recaptcha';
@@ -31,7 +29,6 @@ import OneLoginLayout from 'calypso/login/wp-login/components/one-login-layout';
 import getHeadingSubText from 'calypso/login/wp-login/hooks/get-heading-subtext';
 import flows from 'calypso/signup/config/flows';
 import GravatarStepWrapper from 'calypso/signup/gravatar-step-wrapper';
-import StepWrapper from 'calypso/signup/step-wrapper';
 import {
 	getFlowDestination,
 	getFlowSteps,
@@ -544,37 +541,11 @@ export class UserStep extends Component {
 	}
 
 	renderSignupForm() {
-		const {
-			oauth2Client,
-			isWoo,
-			isUnifiedCreateAccount,
-			isA4A,
-			isBlazePro,
-			isCrowdsignal,
-			isAkismet,
-			isVIPClient,
-			isJetpackCloud,
-			isStudioApp,
-		} = this.props;
-		const isPasswordless =
-			isMobile() ||
-			this.props.isPasswordless ||
-			isNewsletterFlow( this.props?.queryObject?.variationName ) ||
-			isWoo ||
-			isA4A ||
-			isCrowdsignal ||
-			isBlazePro ||
-			isAkismet ||
-			isVIPClient ||
-			isJetpackCloud ||
-			isStudioApp;
+		const { oauth2Client, isWoo } = this.props;
+		const isPasswordless = true;
 		let socialService;
 		let socialServiceResponse;
-		let isSocialSignupEnabled = this.props.isSocialSignupEnabled;
-
-		if ( isUnifiedCreateAccount ) {
-			isSocialSignupEnabled = true;
-		}
+		const isSocialSignupEnabled = true;
 
 		const hashObject = this.props.initialContext && this.props.initialContext.hash;
 		if ( isSocialSignupEnabled && ! isEmpty( hashObject ) ) {
@@ -606,13 +577,10 @@ export class UserStep extends Component {
 					recaptchaClientId={ this.state.recaptchaClientId }
 					horizontal
 					shouldDisplayUserExistsError={ ! isWoo && ! isBlazeProOAuth2Client( oauth2Client ) }
-					isSocialFirst={ this.props.isSocialFirst && ! isUnifiedCreateAccount }
-					labelText={ isUnifiedCreateAccount ? this.props.translate( 'Your email' ) : null }
-					disableTosText={ isUnifiedCreateAccount }
+					isSocialFirst={ false }
+					labelText={ this.props.translate( 'Your email' ) }
+					disableTosText
 				/>
-				{ isUnifiedCreateAccount && (
-					<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
-				) }
 				<div id="g-recaptcha"></div>
 			</>
 		);
@@ -676,39 +644,22 @@ export class UserStep extends Component {
 			return null;
 		}
 
-		if ( this.props.isUnifiedCreateAccount ) {
-			return (
-				<LoginContextProvider>
-					<LoginContextWrapper
-						headerText={ this.getHeaderText() }
-						subHeaderText={ getHeadingSubText( {
-							isSocialFirst: true,
-							twoFactorAuthType: false,
-							translate: this.props.translate,
-							isWooJPC: this.props.isWooJPC,
-						} ) }
-					>
-						<OneLoginLayout isJetpack={ false } isSectionSignup loginUrl={ this.getLoginUrl() }>
-							{ this.renderSignupForm() }
-						</OneLoginLayout>
-					</LoginContextWrapper>
-				</LoginContextProvider>
-			);
-		}
-
-		// TODO: decouple hideBack flag from the flow name.
 		return (
-			<StepWrapper
-				flowName={ this.props.flowName }
-				stepName={ this.props.stepName }
-				headerText={ this.getHeaderText() }
-				subHeaderText={ this.getSubHeaderText() }
-				positionInFlow={ this.props.positionInFlow }
-				fallbackHeaderText={ this.props.translate( 'Create your account.' ) }
-				stepContent={ this.renderSignupForm() }
-				customizedActionButtons={ this.getCustomizedActionButtons() }
-				isSticky={ this.getIsSticky() }
-			/>
+			<LoginContextProvider>
+				<LoginContextWrapper
+					headerText={ this.getHeaderText() }
+					subHeaderText={ getHeadingSubText( {
+						isSocialFirst: true,
+						twoFactorAuthType: false,
+						translate: this.props.translate,
+						isWooJPC: this.props.isWooJPC,
+					} ) }
+				>
+					<OneLoginLayout isJetpack={ false } isSectionSignup loginUrl={ this.getLoginUrl() }>
+						{ this.renderSignupForm() }
+					</OneLoginLayout>
+				</LoginContextWrapper>
+			</LoginContextProvider>
 		);
 	}
 }
@@ -724,15 +675,6 @@ const ConnectedUser = connect(
 		const isVIPClient = isVIPOAuth2Client( oauth2Client );
 		const isJetpackCloud = isJetpackCloudOAuth2Client( oauth2Client );
 		const isStudioApp = isStudioAppOAuth2Client( oauth2Client );
-		const isUnifiedCreateAccount =
-			isWoo ||
-			isA4A ||
-			isCrowdsignal ||
-			isBlazePro ||
-			isAkismet ||
-			isVIPClient ||
-			isJetpackCloud ||
-			isStudioApp;
 
 		return {
 			oauth2Client: oauth2Client,
@@ -744,7 +686,6 @@ const ConnectedUser = connect(
 			from: get( getCurrentQueryArguments( state ), 'from' ),
 			userLoggedIn: isUserLoggedIn( state ),
 			isOnboardingAffiliateFlow: getIsOnboardingAffiliateFlow( state ),
-			isUnifiedCreateAccount,
 			isA4A,
 			isCrowdsignal,
 			isAkismet,

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import SignupForm from 'calypso/blocks/signup-form';
+import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import WooCommerceConnectCartHeader from 'calypso/components/woocommerce-connect-cart-header';
 import WPCloudLogo from 'calypso/components/wp-cloud-logo';
 import { initGoogleRecaptcha, recordGoogleRecaptchaAction } from 'calypso/lib/analytics/recaptcha';
@@ -579,8 +580,11 @@ export class UserStep extends Component {
 					shouldDisplayUserExistsError={ ! isWoo && ! isBlazeProOAuth2Client( oauth2Client ) }
 					isSocialFirst={ false }
 					labelText={ this.props.translate( 'Your email' ) }
-					disableTosText
+					disableTosText={ ! isGravatarOAuth2Client( oauth2Client ) }
 				/>
+				{ ! isGravatarOAuth2Client( oauth2Client ) && (
+					<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
+				) }
 				<div id="g-recaptcha"></div>
 			</>
 		);

--- a/client/signup/steps/user/test/index.js
+++ b/client/signup/steps/user/test/index.js
@@ -3,8 +3,7 @@
  */
 
 import { createElement } from 'react';
-import ReactDOM from 'react-dom';
-import TestUtils from 'react-dom/test-utils';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { UserStep as User } from '../';
 
 const noop = () => {};
@@ -30,73 +29,90 @@ jest.mock( 'calypso/signup/utils', () => ( {
 } ) );
 
 describe( '#signupStep User', () => {
-	let testElement;
-	let rendered;
+	const getSubHeaderEl = ( container ) =>
+		container.querySelector( '.wp-login__one-login-layout-heading-subtext' );
 
-	test( 'should show community subheader text if User step is first in the flow', () => {
-		testElement = createElement( User, {
-			subHeaderText: 'first subheader message',
-			flowName: 'userAsFirstStepInFlow',
-			saveSignupStep: noop,
-			translate,
-		} );
-		rendered = TestUtils.renderIntoDocument( testElement );
+	test( 'should show subheader TOS text when using unified login layout', () => {
+		const { container } = renderWithProvider(
+			createElement( User, {
+				subHeaderText: 'first subheader message',
+				flowName: 'userAsFirstStepInFlow',
+				saveSignupStep: noop,
+				translate,
+			} ),
+			{ initialPath: '/start/account' }
+		);
 
-		expect( rendered.getSubHeaderText() ).toBe( 'Welcome to the WordPress.com community.' );
+		expect( getSubHeaderEl( container ) ).toHaveTextContent(
+			'Just a little reminder that by continuing with any of the options below'
+		);
 	} );
 
-	test( 'should show provided subheader text if User step is not first in the flow', () => {
-		testElement = createElement( User, {
-			subHeaderText: 'test subheader message',
-			flowName: 'someOtherFlow',
-			saveSignupStep: noop,
-			translate,
-		} );
-		rendered = TestUtils.renderIntoDocument( testElement );
-
-		expect( rendered.getSubHeaderText() ).toBe( 'test subheader message' );
-	} );
-
-	describe( '#updateSubHeaderText', () => {
-		let node;
-		let component;
-
-		beforeEach( () => {
-			node = document.createElement( 'div' );
-
-			const element = createElement( User, {
+	test( 'should show subheader TOS text for non-first step as well', () => {
+		const { container } = renderWithProvider(
+			createElement( User, {
 				subHeaderText: 'test subheader message',
 				flowName: 'someOtherFlow',
 				saveSignupStep: noop,
 				translate,
-			} );
-			component = ReactDOM.render( element, node );
+			} ),
+			{ initialPath: '/start/account' }
+		);
+
+		expect( getSubHeaderEl( container ) ).toHaveTextContent(
+			'Just a little reminder that by continuing with any of the options below'
+		);
+	} );
+
+	describe( '#updateSubHeaderText', () => {
+		test( 'should keep subheader TOS text when rerendering with user first in flow', () => {
+			const { container, rerender } = renderWithProvider(
+				createElement( User, {
+					subHeaderText: 'test subheader message',
+					flowName: 'someOtherFlow',
+					saveSignupStep: noop,
+					translate,
+				} ),
+				{ initialPath: '/start/account' }
+			);
+
+			rerender(
+				createElement( User, {
+					subHeaderText: 'My test message',
+					flowName: 'userAsFirstStepInFlow',
+					saveSignupStep: noop,
+					translate,
+				} )
+			);
+
+			expect( getSubHeaderEl( container ) ).toHaveTextContent(
+				'Just a little reminder that by continuing with any of the options below'
+			);
 		} );
 
-		test( 'should show community subheader text when new flow has user as first step', () => {
-			const testProps = {
-				subHeaderText: 'My test message',
-				flowName: 'userAsFirstStepInFlow',
-				saveSignupStep: noop,
-				translate,
-			};
+		test( 'should keep subheader TOS text when rerendering with non-first step', () => {
+			const { container, rerender } = renderWithProvider(
+				createElement( User, {
+					subHeaderText: 'test subheader message',
+					flowName: 'someOtherFlow',
+					saveSignupStep: noop,
+					translate,
+				} ),
+				{ initialPath: '/start/account' }
+			);
 
-			ReactDOM.render( createElement( User, testProps ), node );
+			rerender(
+				createElement( User, {
+					subHeaderText: 'My test message',
+					flowName: 'another test message test',
+					saveSignupStep: noop,
+					translate,
+				} )
+			);
 
-			expect( component.getSubHeaderText() ).toBe( 'Welcome to the WordPress.com community.' );
-		} );
-
-		test( "should show provided subheader text when new flow doesn't have user as first step", () => {
-			const testProps = {
-				subHeaderText: 'My test message',
-				flowName: 'another test message test',
-				saveSignupStep: noop,
-				translate,
-			};
-
-			ReactDOM.render( createElement( User, testProps ), node );
-
-			expect( component.getSubHeaderText() ).toBe( 'My test message' );
+			expect( getSubHeaderEl( container ) ).toHaveTextContent(
+				'Just a little reminder that by continuing with any of the options below'
+			);
 		} );
 	} );
 } );

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -32,7 +32,7 @@ body.is-section-signup {
 
 	.layout {
 
-		// this is awakward but we need to remove the padding from the layout__content
+		// this is awkward but we need to remove the padding from the layout__content
 		// to account for the unified top-bar used in Login and User Steps (Signup)
 		// while preserving the content padding for non-user steps
 		.layout__content {

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -30,15 +30,17 @@ body.is-section-signup {
 		}
 	}
 
-	// Adjust the padding as we no longer
-	// show the masterbar.
-	.layout:not(.is-unified-create-account) .layout__content {
-		padding: 48px 0 0;
-	}
+	.layout {
 
-	.layout.is-unified-create-account {
+		// this is awakward but we need to remove the padding from the layout__content
+		// to account for the unified top-bar used in Login and User Steps (Signup)
+		// while preserving the content padding for non-user steps
 		.layout__content {
 			padding: 0;
+
+			.signup__steps > .signup__step > .signup__step:not(.is-oauth2-user):not(.is-user-social) {
+				padding-top: 48px;
+			}
 		}
 
 		.locale-suggestions {
@@ -261,7 +263,7 @@ body.is-section-signup .layout:not(.dops) {
 }
 
 body.is-section-stepper,
-body.is-section-signup .layout:not(.dops):not(.is-wccom-oauth-flow):not(.is-unified-create-account) {
+body.is-section-signup .layout:not(.dops):not(.is-wccom-oauth-flow) {
 	$gray-100: #101517;
 	$gray-60: #50575e;
 	$gray-50: #646970;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-14072/signup-remove-signup-form-style-overrides-and-conditioning-when

## Proposed Changes

The OAuth2 client create-account screens are now unified design-wise. We remove the `isUnifiedCreateAccount` handle and make it the default (with the exception of Gravatar), and clean up surrounding styles.

### Caveats

Cleanup touches Signup flows (Start) layouts in general.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-14072/signup-remove-signup-form-style-overrides-and-conditioning-when

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to several [OAuth2 client signup](https://linear.app/a8c/issue/DOTCOM-13218/signup-update-and-unify-the-create-account-screens) screens and confirm no changes (links are for Login, click on "create an account" from there).
  * Confirm especially Woo and Blaze Pro.
* Confirm no changes to the Gravatar create-account.
* Confirm no changes to the default WP create-account in Start e.g. try `/start/onboarding-pm`
* Confirm no changes to non-user steps in Start e.g. try `/start/onboarding-pm/domains` (concerning main content paddings and top-bar positioning)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
