### PR TITLE
Packages: Add domain-search to tsconfig

### DIFF
--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -25,6 +25,7 @@
 		{ "path": "./design-picker" },
 		{ "path": "./design-preview" },
 		{ "path": "./domain-picker" },
+		{ "path": "./domain-search" },
 		{ "path": "./domains-table" },
 		{ "path": "./explat-client" },
 		{ "path": "./explat-client-react-helpers" },


### PR DESCRIPTION
Fixes SHILL-1023

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

I keep getting TS errors when running `yarn typecheck-client` because the `domain-search` package was not added to the tsconfig.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Run `yarn build-packages && yarn typecheck-client` and make sure there are no errors.