### PR TITLE
Domain Dashboard: Render registered date and renewal CTA

### DIFF
--- a/client/dashboard/app/routes/domain-routes.ts
+++ b/client/dashboard/app/routes/domain-routes.ts
@@ -62,8 +62,8 @@ export const domainOverviewRoute = createRoute( {
 	getParentRoute: () => domainRoute,
 	path: '/',
 } ).lazy( () =>
-	import( '../../sites/domains/placeholder' ).then( ( d ) =>
-		createLazyRoute( 'domain' )( {
+	import( '../../domains/domain-overview' ).then( ( d ) =>
+		createLazyRoute( 'domain-overview' )( {
 			component: d.default,
 		} )
 	)

--- a/client/dashboard/components/section-header/types.ts
+++ b/client/dashboard/components/section-header/types.ts
@@ -4,7 +4,7 @@ export interface SectionHeaderProps {
 	/**
 	 * The main heading text that identifies the page or section.
 	 */
-	title: string;
+	title: React.ReactNode;
 	/**
 	 * Optional supporting text that provides additional context or
 	 * guidance beneath the title.

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -41,12 +41,15 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 				isPrimary: true,
 				icon: <Icon icon={ payment } />,
 				label: __( 'Renew now' ),
-				callback: ( [ domain ]: DomainSummary[] ) => {
+				callback: ( items: DomainSummary[] ) => {
+					const domain = items[ 0 ];
 					const purchase = purchases?.find( ( p ) => p.ID === domain.subscription_id );
 
-					if ( domain && purchase ) {
-						window.location.href = getDomainRenewalUrl( domain, purchase );
+					if ( ! purchase ) {
+						return;
 					}
+
+					window.location.href = getDomainRenewalUrl( domain, purchase );
 				},
 				isEligible: ( item: DomainSummary ) => isDomainRenewable( item ),
 			},

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -12,7 +12,6 @@ import { useDispatch } from '@wordpress/data';
 import { sprintf, __ } from '@wordpress/i18n';
 import { payment, tool } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
-import { addQueryArgs } from '@wordpress/url';
 import { useMemo } from 'react';
 import { userPurchasesQuery } from '../../app/queries/me-purchases';
 import { siteSetPrimaryDomainMutation } from '../../app/queries/site-domains';
@@ -24,10 +23,9 @@ import {
 	isDomainInGracePeriod,
 	canSetAsPrimary,
 	getDomainSiteSlug,
+	getDomainRenewalUrl,
 } from '../../utils/domain';
 import { isTransferrableToWpcom } from '../../utils/domain-types';
-import { isAkismetProduct, isMarketplaceTemporarySitePurchase } from '../../utils/purchase';
-import { encodeProductForUrl } from '../../utils/wpcom-checkout';
 import type { DomainSummary, Site, User } from '../../data/types';
 import type { Action } from '@wordpress/dataviews';
 
@@ -43,29 +41,11 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 				isPrimary: true,
 				icon: <Icon icon={ payment } />,
 				label: __( 'Renew now' ),
-				callback: ( items: DomainSummary[] ) => {
-					const domain = items[ 0 ];
-					const siteSlug = getDomainSiteSlug( domain );
+				callback: ( [ domain ]: DomainSummary[] ) => {
 					const purchase = purchases?.find( ( p ) => p.ID === domain.subscription_id );
-					if ( purchase ) {
-						const productSlug = [ purchase.product_slug, domain.domain ]
-							.map( ( productSlug ) => encodeProductForUrl( productSlug ) )
-							.join( ':' );
-						const backUrl = window.location.href.replace( window.location.origin, '' );
-						let serviceSlug = '';
-						if ( isAkismetProduct( purchase ) ) {
-							serviceSlug = 'akismet/';
-						} else if ( isMarketplaceTemporarySitePurchase( purchase ) ) {
-							serviceSlug = 'marketplace/';
-						}
 
-						window.location.href = addQueryArgs(
-							`/checkout/${ serviceSlug }${ productSlug }/renew/${ purchase.ID }/${ siteSlug }`,
-							{
-								cancel_to: backUrl,
-								redirect_to: backUrl,
-							}
-						);
+					if ( domain && purchase ) {
+						window.location.href = getDomainRenewalUrl( domain, purchase );
 					}
 				},
 				isEligible: ( item: DomainSummary ) => isDomainRenewable( item ),

--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -1,3 +1,4 @@
+import { formatCurrency } from '@automattic/number-formatters';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
@@ -9,7 +10,7 @@ import { domainRoute } from '../../app/router';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { formatDate } from '../../utils/datetime';
-import { getDomainRenewalUrl, isDomainRenewable } from '../../utils/domain';
+import { getDomainRenewalUrl } from '../../utils/domain';
 
 export default function DomainOverview() {
 	const locale = useLocale();
@@ -42,8 +43,7 @@ export default function DomainOverview() {
 						date: formatDate( new Date( domain.registration_date ), locale, { dateStyle: 'long' } ),
 					} ) }
 					actions={
-						isDomainRenewable( domain ) &&
-						purchase && (
+						purchase?.can_explicit_renew && (
 							<Button
 								variant="primary"
 								__next40pxDefaultSize
@@ -52,7 +52,10 @@ export default function DomainOverview() {
 								{
 									// translators: price is the price of the domain renewal.
 									sprintf( __( 'Renew now for %(price)s' ), {
-										price: purchase.price_text,
+										price: formatCurrency( purchase.price_integer, purchase.currency_code, {
+											isSmallestUnit: true,
+											stripZeros: true,
+										} ),
 									} )
 								}
 							</Button>

--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -1,16 +1,22 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useLocale } from '../../app/locale';
 import { domainQuery } from '../../app/queries/domain';
+import { sitePurchaseQuery } from '../../app/queries/site-purchases';
 import { domainRoute } from '../../app/router';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { formatDate } from '../../utils/datetime';
+import { getDomainRenewalUrl, isDomainRenewable } from '../../utils/domain';
 
 export default function DomainOverview() {
 	const locale = useLocale();
 	const { domainName } = domainRoute.useParams();
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
+	const { data: purchase } = useQuery(
+		sitePurchaseQuery( domain.blog_id, parseInt( domain.subscription_id, 10 ) )
+	);
 
 	return (
 		<PageLayout
@@ -22,6 +28,23 @@ export default function DomainOverview() {
 					description={ sprintf( __( 'Registered on %(date)s' ), {
 						date: formatDate( new Date( domain.registration_date ), locale, { dateStyle: 'long' } ),
 					} ) }
+					actions={
+						isDomainRenewable( domain ) &&
+						purchase && (
+							<Button
+								variant="primary"
+								__next40pxDefaultSize
+								href={ getDomainRenewalUrl( domain, purchase ) }
+							>
+								{
+									// translators: price is the price of the domain renewal.
+									sprintf( __( 'Renew now for %(price)s' ), {
+										price: purchase.price_text,
+									} )
+								}
+							</Button>
+						)
+					}
 				/>
 			}
 		></PageLayout>

--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -1,6 +1,7 @@
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { useMemo } from 'react';
 import { useLocale } from '../../app/locale';
 import { domainQuery } from '../../app/queries/domain';
 import { sitePurchaseQuery } from '../../app/queries/site-purchases';
@@ -18,12 +19,24 @@ export default function DomainOverview() {
 		sitePurchaseQuery( domain.blog_id, parseInt( domain.subscription_id, 10 ) )
 	);
 
+	const wrappableDomainName = useMemo( () => {
+		const [ domainName, ...tlds ] = domain.domain.split( '.' );
+		const tld = tlds.join( '.' );
+
+		return (
+			<span style={ { wordBreak: 'break-word', hyphens: 'none' } }>
+				{ domainName }
+				<span style={ { whiteSpace: 'nowrap' } }>.{ tld }</span>
+			</span>
+		);
+	}, [ domain.domain ] );
+
 	return (
 		<PageLayout
 			size="small"
 			header={
 				<PageHeader
-					title={ domainName }
+					title={ wrappableDomainName }
 					// translators: date is the date the domain was registered.
 					description={ sprintf( __( 'Registered on %(date)s' ), {
 						date: formatDate( new Date( domain.registration_date ), locale, { dateStyle: 'long' } ),

--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -1,0 +1,29 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { __, sprintf } from '@wordpress/i18n';
+import { useLocale } from '../../app/locale';
+import { domainQuery } from '../../app/queries/domain';
+import { domainRoute } from '../../app/router';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import { formatDate } from '../../utils/datetime';
+
+export default function DomainOverview() {
+	const locale = useLocale();
+	const { domainName } = domainRoute.useParams();
+	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
+
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					title={ domainName }
+					// translators: date is the date the domain was registered.
+					description={ sprintf( __( 'Registered on %(date)s' ), {
+						date: formatDate( new Date( domain.registration_date ), locale, { dateStyle: 'long' } ),
+					} ) }
+				/>
+			}
+		></PageLayout>
+	);
+}

--- a/client/dashboard/utils/domain.ts
+++ b/client/dashboard/utils/domain.ts
@@ -1,12 +1,40 @@
+import { addQueryArgs } from '@wordpress/url';
 import { isAfter, subMinutes, subDays } from 'date-fns';
 import { DotcomFeatures } from '../data/constants';
 import { DomainTypes } from '../data/domains';
+import { isAkismetProduct, isMarketplaceTemporarySitePurchase } from './purchase';
 import { hasPlanFeature } from './site-features';
 import { userHasFlag } from './user';
+import { encodeProductForUrl } from './wpcom-checkout';
+import type { Purchase } from '../data/purchase';
 import type { SiteDomain, DomainSummary, Site, User } from '../data/types';
 
 export function getDomainSiteSlug( domain: DomainSummary ) {
 	return domain.primary_domain ? domain.domain : domain.site_slug;
+}
+
+export function getDomainRenewalUrl( domain: DomainSummary, purchase: Purchase ) {
+	const siteSlug = getDomainSiteSlug( domain );
+
+	const productSlug = [ purchase.product_slug, domain.domain ]
+		.map( ( productSlug ) => encodeProductForUrl( productSlug ) )
+		.join( ':' );
+
+	const backUrl = window.location.href.replace( window.location.origin, '' );
+	let serviceSlug = '';
+	if ( isAkismetProduct( purchase ) ) {
+		serviceSlug = 'akismet/';
+	} else if ( isMarketplaceTemporarySitePurchase( purchase ) ) {
+		serviceSlug = 'marketplace/';
+	}
+
+	return addQueryArgs(
+		`/checkout/${ serviceSlug }${ productSlug }/renew/${ purchase.ID }/${ siteSlug }`,
+		{
+			cancel_to: backUrl,
+			redirect_to: backUrl,
+		}
+	);
 }
 
 export function isRegisteredDomain( domain: DomainSummary ) {


### PR DESCRIPTION
Closes DOTDASH-195.

## Proposed Changes

Renders the registered date and the "Renew CTA" on eligible subscriptions.

<img width="650" height="296" alt="image" src="https://github.com/user-attachments/assets/04049001-d98b-45e9-9051-711f29e82665" />

## Testing Instructions

Enter `/domains/%s` with a domain that's eligible to be renewed immediately and verify you get redirected to checkout accordingly.
