### PR TITLE
Jetpack Cloud: skip wpcomJetpackScanAtomicTransfer middleware on Cloud and A4A

### DIFF
--- a/client/my-sites/scan/wpcom-atomic-transfer.tsx
+++ b/client/my-sites/scan/wpcom-atomic-transfer.tsx
@@ -1,6 +1,8 @@
 import { WPCOM_FEATURES_SCAN } from '@automattic/calypso-products';
 import { translate } from 'i18n-calypso';
 import JetpackScanSVG from 'calypso/assets/images/illustrations/jetpack-scan.svg';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import wpcomAtomicTransfer from 'calypso/lib/jetpack/wpcom-atomic-transfer';
 import WPCOMScanUpsellPage from 'calypso/my-sites/scan/wpcom-upsell';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -8,6 +10,10 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export function wpcomJetpackScanAtomicTransfer(): ( context: any, next: () => void ) => void {
 	return ( context, next ) => {
+		if ( isJetpackCloud() || isA8CForAgencies() ) {
+			return next();
+		}
+
 		const state = context.store.getState();
 		const siteId = getSelectedSiteId( state );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to https://github.com/Automattic/wp-calypso/pull/105147

## Proposed Changes

* Skip `wpcomJetpackScanAtomicTransfer` middleware on Jetpack Cloud and A4A

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Self-hosted sites with Scan plan (like Jetpack Security) are seeing a WPCOM upgrade prompt introduced in https://github.com/Automattic/wp-calypso/pull/105147. Related discussion: p1755058962064939-slack-C08LSARAWCV

<img width="1142" height="942" alt="CleanShot 2025-08-13 at 00 14 12@2x" src="https://github.com/user-attachments/assets/b5682eb7-a2c9-4ada-b634-264cb0dec86e" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pick a self-hosted site, purchase Jetpack Security
* Navigate to Jetpack Cloud (using live branch)
* Got to Scan page
* You should see the Scan page instead of the upgrade prompt

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?