### PR TITLE
Backups Dashboard: add back up now button

### DIFF
--- a/client/dashboard/app/queries/site-backups.ts
+++ b/client/dashboard/app/queries/site-backups.ts
@@ -1,6 +1,6 @@
 import { queryOptions } from '@tanstack/react-query';
 import { fetchSiteRewindableActivityLog } from '../../data/site-activity-log';
-import { fetchSiteBackups } from '../../data/site-backup';
+import { fetchSiteBackups } from '../../data/site-backups';
 
 export const siteLastBackupQuery = ( siteId: number ) =>
 	queryOptions( {

--- a/client/dashboard/app/queries/site-backups.ts
+++ b/client/dashboard/app/queries/site-backups.ts
@@ -1,9 +1,16 @@
 import { queryOptions } from '@tanstack/react-query';
 import { fetchSiteRewindableActivityLog } from '../../data/site-activity-log';
+import { fetchSiteBackups } from '../../data/site-backup';
 
 export const siteLastBackupQuery = ( siteId: number ) =>
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'backups', 'last' ],
 		queryFn: () => fetchSiteRewindableActivityLog( siteId, { number: 1 } ),
 		select: ( data ) => data.current?.orderedItems[ 0 ] ?? null,
+	} );
+
+export const siteBackupsQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'rewind', 'backups' ],
+		queryFn: () => fetchSiteBackups( siteId ),
 	} );

--- a/client/dashboard/data/site-backup.ts
+++ b/client/dashboard/data/site-backup.ts
@@ -1,25 +1,5 @@
 import wpcom from 'calypso/lib/wp';
 
-export interface BackupEntry {
-	id: string;
-	started: string;
-	last_updated: string;
-	status:
-		| 'not_started'
-		| 'queued'
-		| 'started'
-		| 'finished'
-		| 'error'
-		| 'error_will_retry'
-		| 'not-accessible'
-		| 'backups-deactivated';
-	period: string;
-	percent: string;
-	discarded: string;
-	is_backup: string;
-	is_scan: string;
-}
-
 /**
  * Enqueue a backup for a site.
  * @param siteId - The ID of the site to enqueue a backup for.
@@ -28,17 +8,6 @@ export interface BackupEntry {
 export function enqueueSiteBackup( siteId: number ): Promise< void > {
 	return wpcom.req.post( {
 		path: `/sites/${ siteId }/rewind/backups/enqueue`,
-		apiNamespace: 'wpcom/v2',
-	} );
-}
-
-/**
- * Fetch the list of backups for a site.
- * @param siteId - The ID of the site to fetch backups for.
- * @returns A promise that resolves to the list of backups.
- */
-export function fetchSiteBackups( siteId: number ): Promise< BackupEntry[] > {
-	return wpcom.req.get( `/sites/${ siteId }/rewind/backups`, {
 		apiNamespace: 'wpcom/v2',
 	} );
 }

--- a/client/dashboard/data/site-backup.ts
+++ b/client/dashboard/data/site-backup.ts
@@ -26,13 +26,10 @@ export interface BackupEntry {
  * @returns A promise that resolves when the backup is enqueued.
  */
 export function enqueueSiteBackup( siteId: number ): Promise< void > {
-	return wpcom.req.post(
-		{
-			path: `/sites/${ siteId }/rewind/backups/enqueue`,
-			apiNamespace: 'wpcom/v2',
-		},
-		{}
-	);
+	return wpcom.req.post( {
+		path: `/sites/${ siteId }/rewind/backups/enqueue`,
+		apiNamespace: 'wpcom/v2',
+	} );
 }
 
 /**

--- a/client/dashboard/data/site-backup.ts
+++ b/client/dashboard/data/site-backup.ts
@@ -1,0 +1,47 @@
+import wpcom from 'calypso/lib/wp';
+
+export interface BackupEntry {
+	id: string;
+	started: string;
+	last_updated: string;
+	status:
+		| 'not_started'
+		| 'queued'
+		| 'started'
+		| 'finished'
+		| 'error'
+		| 'error_will_retry'
+		| 'not-accessible'
+		| 'backups-deactivated';
+	period: string;
+	percent: string;
+	discarded: string;
+	is_backup: string;
+	is_scan: string;
+}
+
+/**
+ * Enqueue a backup for a site.
+ * @param siteId - The ID of the site to enqueue a backup for.
+ * @returns A promise that resolves when the backup is enqueued.
+ */
+export function enqueueSiteBackup( siteId: number ): Promise< void > {
+	return wpcom.req.post(
+		{
+			path: `/sites/${ siteId }/rewind/backups/enqueue`,
+			apiNamespace: 'wpcom/v2',
+		},
+		{}
+	);
+}
+
+/**
+ * Fetch the list of backups for a site.
+ * @param siteId - The ID of the site to fetch backups for.
+ * @returns A promise that resolves to the list of backups.
+ */
+export function fetchSiteBackups( siteId: number ): Promise< BackupEntry[] > {
+	return wpcom.req.get( `/sites/${ siteId }/rewind/backups`, {
+		apiNamespace: 'wpcom/v2',
+	} );
+}

--- a/client/dashboard/data/site-backups.ts
+++ b/client/dashboard/data/site-backups.ts
@@ -1,0 +1,32 @@
+import wpcom from 'calypso/lib/wp';
+
+export interface BackupEntry {
+	id: string;
+	started: string;
+	last_updated: string;
+	status:
+		| 'not_started'
+		| 'queued'
+		| 'started'
+		| 'finished'
+		| 'error'
+		| 'error_will_retry'
+		| 'not-accessible'
+		| 'backups-deactivated';
+	period: string;
+	percent: string;
+	discarded: string;
+	is_backup: string;
+	is_scan: string;
+}
+
+/**
+ * Fetch the list of backups for a site.
+ * @param siteId - The ID of the site to fetch backups for.
+ * @returns A promise that resolves to the list of backups.
+ */
+export function fetchSiteBackups( siteId: number ): Promise< BackupEntry[] > {
+	return wpcom.req.get( `/sites/${ siteId }/rewind/backups`, {
+		apiNamespace: 'wpcom/v2',
+	} );
+}

--- a/client/dashboard/sites/backups/backup-now-button.tsx
+++ b/client/dashboard/sites/backups/backup-now-button.tsx
@@ -1,7 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Button, Tooltip } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { backup } from '@wordpress/icons';
 import { useCallback, useEffect, useState } from 'react';
 import { siteBackupsQuery } from '../../app/queries/site-backups';
 import { enqueueSiteBackup, type BackupEntry } from '../../data/site-backup';
@@ -93,7 +92,6 @@ export function BackupNowButton( { site }: BackupNowButtonProps ) {
 	const button = (
 		<Button
 			variant="secondary"
-			icon={ backup }
 			onClick={ () => triggerBackup() }
 			disabled={ isBusy }
 			isBusy={ isBusy }

--- a/client/dashboard/sites/backups/backup-now-button.tsx
+++ b/client/dashboard/sites/backups/backup-now-button.tsx
@@ -3,7 +3,8 @@ import { Button, Tooltip } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useEffect, useState } from 'react';
 import { siteBackupsQuery } from '../../app/queries/site-backups';
-import { enqueueSiteBackup, type BackupEntry } from '../../data/site-backup';
+import { enqueueSiteBackup } from '../../data/site-backup';
+import { type BackupEntry } from '../../data/site-backups';
 import type { Site } from '../../data/types';
 
 interface BackupNowButtonProps {

--- a/client/dashboard/sites/backups/backup-now-button.tsx
+++ b/client/dashboard/sites/backups/backup-now-button.tsx
@@ -1,0 +1,106 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Button, Tooltip } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { backup } from '@wordpress/icons';
+import { useCallback, useEffect, useState } from 'react';
+import { siteBackupsQuery } from '../../app/queries/site-backups';
+import { enqueueSiteBackup, type BackupEntry } from '../../data/site-backup';
+import type { Site } from '../../data/types';
+
+interface BackupNowButtonProps {
+	site: Site;
+}
+
+type BackupState = 'default' | 'enqueued' | 'in_progress';
+
+export function BackupNowButton( { site }: BackupNowButtonProps ) {
+	const [ isEnqueued, setIsEnqueued ] = useState( false );
+	const queryClient = useQueryClient();
+
+	// Determine current state
+	const getBackupState = useCallback(
+		( backups: BackupEntry[], enqueued: boolean ): BackupState => {
+			const currentBackup = backups[ 0 ];
+			if ( currentBackup?.status === 'started' ) {
+				return 'in_progress';
+			}
+			if ( currentBackup?.status === 'queued' || enqueued ) {
+				return 'enqueued';
+			}
+			return 'default';
+		},
+		[]
+	);
+
+	// Check for in-progress backup using rewind/backups endpoint
+	const { data: rewindBackups = [] } = useQuery( {
+		...siteBackupsQuery( site.ID ),
+		refetchInterval: ( query ) => {
+			const backups = query.state.data || [];
+			const backupState = getBackupState( backups, isEnqueued );
+			// Poll when backup is enqueued or in progress
+			return backupState !== 'default' ? 2000 : false;
+		},
+	} );
+
+	const { mutate: triggerBackup, isPending } = useMutation( {
+		mutationFn: () => enqueueSiteBackup( site.ID ),
+		onSuccess: () => {
+			setIsEnqueued( true );
+			// Refresh rewind backups to check for new backup status
+			queryClient.invalidateQueries( {
+				queryKey: [ 'site', site.ID, 'rewind', 'backups' ],
+			} );
+		},
+		onError: () => {
+			// Lets decide later what to do here
+		},
+	} );
+
+	const backupState = getBackupState( rewindBackups, isEnqueued );
+
+	// Reset enqueued state when backup actually starts
+	useEffect( () => {
+		if ( backupState === 'in_progress' && isEnqueued ) {
+			setIsEnqueued( false );
+		}
+	}, [ backupState, isEnqueued ] );
+
+	const getButtonContent = useCallback( ( state: BackupState ) => {
+		switch ( state ) {
+			case 'in_progress':
+				return __( 'Backup in progress' );
+			case 'enqueued':
+				return __( 'Backup queued' );
+			default:
+				return __( 'Back up now' );
+		}
+	}, [] );
+
+	const getTooltipText = useCallback( ( state: BackupState ) => {
+		switch ( state ) {
+			case 'in_progress':
+				return __( 'A backup is currently in progress.' );
+			case 'enqueued':
+				return __( 'A backup has been queued and will start shortly.' );
+			default:
+				return __( 'Create a backup of your site now.' );
+		}
+	}, [] );
+
+	const isBusy = backupState !== 'default' || isPending;
+
+	const button = (
+		<Button
+			variant="secondary"
+			icon={ backup }
+			onClick={ () => triggerBackup() }
+			disabled={ isBusy }
+			isBusy={ isBusy }
+		>
+			{ getButtonContent( backupState ) }
+		</Button>
+	);
+
+	return <Tooltip text={ getTooltipText( backupState ) }>{ button }</Tooltip>;
+}

--- a/client/dashboard/sites/backups/backup-now-button.tsx
+++ b/client/dashboard/sites/backups/backup-now-button.tsx
@@ -43,9 +43,11 @@ export function BackupNowButton( { site }: BackupNowButtonProps ) {
 	} );
 
 	const { mutate: triggerBackup, isPending } = useMutation( {
-		mutationFn: () => enqueueSiteBackup( site.ID ),
-		onSuccess: () => {
+		mutationFn: () => {
 			setIsEnqueued( true );
+			return enqueueSiteBackup( site.ID );
+		},
+		onSuccess: () => {
 			// Refresh rewind backups to check for new backup status
 			queryClient.invalidateQueries( {
 				queryKey: [ 'site', site.ID, 'rewind', 'backups' ],
@@ -65,27 +67,20 @@ export function BackupNowButton( { site }: BackupNowButtonProps ) {
 		}
 	}, [ backupState, isEnqueued ] );
 
-	const getButtonContent = useCallback( ( state: BackupState ) => {
-		switch ( state ) {
-			case 'in_progress':
-				return __( 'Backup in progress' );
-			case 'enqueued':
-				return __( 'Backup queued' );
-			default:
-				return __( 'Back up now' );
-		}
-	}, [] );
-
-	const getTooltipText = useCallback( ( state: BackupState ) => {
-		switch ( state ) {
-			case 'in_progress':
-				return __( 'A backup is currently in progress.' );
-			case 'enqueued':
-				return __( 'A backup has been queued and will start shortly.' );
-			default:
-				return __( 'Create a backup of your site now.' );
-		}
-	}, [] );
+	const buttonContent = {
+		enqueued: {
+			label: __( 'Backup enqueued' ),
+			tooltip: __( 'A backup has been queued and will start shortly.' ),
+		},
+		in_progress: {
+			label: __( 'Backup in progress' ),
+			tooltip: __( 'A backup is currently in progress.' ),
+		},
+		default: {
+			label: __( 'Back up now' ),
+			tooltip: __( 'Create a backup of your site now.' ),
+		},
+	};
 
 	const isBusy = backupState !== 'default' || isPending;
 
@@ -96,9 +91,9 @@ export function BackupNowButton( { site }: BackupNowButtonProps ) {
 			disabled={ isBusy }
 			isBusy={ isBusy }
 		>
-			{ getButtonContent( backupState ) }
+			{ buttonContent[ backupState ].label }
 		</Button>
 	);
 
-	return <Tooltip text={ getTooltipText( backupState ) }>{ button }</Tooltip>;
+	return <Tooltip text={ buttonContent[ backupState ].tooltip }>{ button }</Tooltip>;
 }

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -15,6 +15,7 @@ import PageLayout from '../../components/page-layout';
 import UpsellCTAButton from '../../components/upsell-cta-button';
 import { HostingFeatures } from '../../data/constants';
 import { hasHostingFeature } from '../../utils/site-features';
+import { BackupNowButton } from './backup-now-button';
 import illustrationUrl from './backups-callout-illustration.svg';
 import { getActions } from './dataviews/actions';
 import { getFields } from './dataviews/fields';
@@ -99,10 +100,19 @@ function SiteBackups() {
 		return;
 	}
 
+	const hasBackups = hasHostingFeature( site, HostingFeatures.BACKUPS );
+
 	return (
-		<PageLayout header={ <PageHeader title={ __( 'Backups' ) } /> }>
+		<PageLayout
+			header={
+				<PageHeader
+					title={ __( 'Backups' ) }
+					actions={ hasBackups && <BackupNowButton site={ site } /> }
+				/>
+			}
+		>
 			<CalloutOverlay
-				showCallout={ ! hasHostingFeature( site, HostingFeatures.BACKUPS ) }
+				showCallout={ ! hasBackups }
 				callout={ <SiteBackupsCallout siteSlug={ site.slug } /> }
 				main={ <Backups site={ site } /> }
 			/>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-234

## Proposed Changes

* Add back up now button to the Backups section of the Hosting Dashboard
* Implement `rewind/backups/enqueue` and `rewind/backups` endpoints
* Implement `siteBackupsQuery` query
* Implement polling of the `rewind/backups` endpoint once we enqueue the backup, so we can grab the progress of the backup.

This is an initial iteration. Next steps will include:  
- Polling `siteRewindableActivityLogEntriesQuery` once the new backup is completed, so we can reflect it in the backups list. I didn’t include this in the PR to keep it simpler and because we are working on updating the dashboard to align with the designs.  
- Showing a panel with the backup progress.  
- Showing backup errors.  

<img width="1998" height="1284" alt="CleanShot 2025-08-13 at 19 37 59@2x" src="https://github.com/user-attachments/assets/45c5dccd-32a1-4104-b73f-0fa6296f9ce1" />

| Default | Enqueued | In progress |
|---|---|---|
| <img width="184" height="78" alt="CleanShot 2025-08-13 at 19 29 49@2x" src="https://github.com/user-attachments/assets/76551086-afa0-46f1-98c6-53b976ac6c1d" /> | <img width="222" height="74" alt="CleanShot 2025-08-13 at 19 30 03@2x" src="https://github.com/user-attachments/assets/074a2e3a-c51d-4b1f-8300-0a1822d17a02" /> | <img width="244" height="76" alt="CleanShot 2025-08-13 at 19 30 11@2x" src="https://github.com/user-attachments/assets/b88d523a-3d35-4a96-98d2-9cf417695903" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of Backups in the Hosting Dashboard

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/v2/sites/SITE_SLUG/backups` using a site with the backup feature
* Ensure you see the `Back up now` button
* Open the developer console to monitor the Network calls
* Click on the `Back up now` button, it should switch to `Enqueued` state saying "Backup enqueued".
* It should start polling the /rewind/backups endpoint to fetch the status of the backup.
* Once the status is "started", the button switches to "Backup in progress".
* Once the status is "finished", the button will switch back to the default state of "Back up now".

After some seconds, you could refresh the Backup dashboard to see the new Backup. In a future iteration we will start polling the `siteRewindableActivityLogEntriesQuery` and handle error scenarios.

https://github.com/user-attachments/assets/ea9fdc89-577e-4dbb-b998-ec8b919df56a

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
