### PR TITLE
Gravatar: Adjust login-related screens for Gravatar-owned services

### DIFF
--- a/client/components/gravatar-login-logo/index.tsx
+++ b/client/components/gravatar-login-logo/index.tsx
@@ -22,6 +22,7 @@ export default function GravatarLoginLogo( {
 			{ ! iconUrl ? (
 				// If no `iconUrl` is provided, use the default Gravatar logo.
 				<img
+					className="gravatar-login-logo__logo-img"
 					src={ gravatarClientData.icon }
 					alt={ gravatarClientData.title }
 					width={ width }
@@ -29,10 +30,16 @@ export default function GravatarLoginLogo( {
 				/>
 			) : (
 				<>
-					<img src={ iconUrl } alt={ alt } width={ width } height={ height } />
+					<img
+						className="gravatar-login-logo__logo-img"
+						src={ iconUrl }
+						alt={ alt }
+						width={ width }
+						height={ height }
+					/>
 					{ isCoBrand && (
 						<img
-							className="gravatar-login-logo__gravatar-logo"
+							className="gravatar-login-logo__logo-img gravatar-login-logo__logo-img--with-co-brand"
 							src="https://gravatar.com/images/grav-logo-with-bg.svg"
 							alt="Gravatar"
 							width={ width }

--- a/client/components/gravatar-login-logo/style.scss
+++ b/client/components/gravatar-login-logo/style.scss
@@ -2,7 +2,13 @@
 	display: flex;
 	align-items: center;
 
-	.gravatar-login-logo__gravatar-logo {
-		margin-left: -8px;
+	.gravatar-login-logo__logo-img {
+		width: 32px;
+		height: 32px;
+		border-radius: 50%;
+
+		&.gravatar-login-logo__logo-img--with-co-brand {
+			margin-left: -8px;
+		}
 	}
 }

--- a/client/lib/oauth2-clients.js
+++ b/client/lib/oauth2-clients.js
@@ -6,8 +6,16 @@ export const isAndroidOAuth2Client = ( oauth2Client ) => {
 	return oauth2Client?.id === 2697;
 };
 
+export const isIosOAuth2Client = ( oauth2Client ) => {
+	return oauth2Client?.id === 11;
+};
+
 export const isCrowdsignalOAuth2Client = ( oauth2Client ) => {
 	return oauth2Client?.id === 978;
+};
+
+export const isWPJobManagerOAuth2Client = ( oauth2Client ) => {
+	return oauth2Client?.id === 90057;
 };
 
 export const isGravatarFlowOAuth2Client = ( oauth2Client ) => {
@@ -18,12 +26,11 @@ export const isGravatarOAuth2Client = ( oauth2Client ) => {
 	return oauth2Client?.id === 1854 || isGravatarFlowOAuth2Client( oauth2Client );
 };
 
-export const isIosOAuth2Client = ( oauth2Client ) => {
-	return oauth2Client?.id === 11;
-};
+// Gravatar flow clients owned by Gravatar, e.g., Gravatar iOS app, Gravatar Android app, etc.
+export const isGravatarOwnedOAuth2Client = ( oauth2Client ) => {
+	const isOwnedByGravatar = [ 119371, 119387 ].includes( oauth2Client?.id );
 
-export const isWPJobManagerOAuth2Client = ( oauth2Client ) => {
-	return oauth2Client?.id === 90057;
+	return isGravatarFlowOAuth2Client( oauth2Client ) && isOwnedByGravatar;
 };
 
 export const isGravPoweredOAuth2Client = ( oauth2Client ) => {

--- a/client/login/magic-login/gravatar/index.tsx
+++ b/client/login/magic-login/gravatar/index.tsx
@@ -1263,7 +1263,7 @@ const GravPoweredMagicLogin = ( { path }: { path: string } ) => {
 	}
 
 	const hasSubHeader =
-		( isGravatarFlowOAuth2Client( oauth2Client ) && ! isGravatarOwnedService ) ||
+		( isGravatarFlow && ! isGravatarOwnedService ) ||
 		isFromGravatar3rdPartyApp ||
 		isFromGravatarQuickEditor;
 

--- a/client/login/magic-login/gravatar/index.tsx
+++ b/client/login/magic-login/gravatar/index.tsx
@@ -15,8 +15,9 @@ import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import getGravatarOAuth2Flow from 'calypso/lib/get-gravatar-oauth2-flow';
 import {
-	isGravatarFlowOAuth2Client,
 	isGravatarOAuth2Client,
+	isGravatarFlowOAuth2Client,
+	isGravatarOwnedOAuth2Client,
 	isWPJobManagerOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
@@ -59,8 +60,6 @@ import RequestLoginEmailForm from '../request-login-email-form';
 import './style.scss';
 
 const RESEND_EMAIL_COUNTDOWN_TIME = 90; // In seconds
-const GRAVATAR_FROM_3RD_PARTY = '3rd-party';
-const GRAVATAR_FROM_QUICK_EDITOR = 'quick-editor';
 
 const GravPoweredMagicLoginTos = () => {
 	const translate = useTranslate();
@@ -128,6 +127,7 @@ interface GravPoweredEmailFormProps {
 	currentQueryArguments: Record< string, string > | undefined;
 	isGravatar: boolean;
 	isGravatarFlow: boolean;
+	isGravatarOwnedService: boolean;
 	isWPJobManager: boolean;
 	isFromGravatar3rdPartyApp: boolean;
 	isFromGravatarQuickEditor: boolean;
@@ -152,6 +152,7 @@ const GravPoweredEmailForm = ( {
 	currentQueryArguments,
 	isGravatar,
 	isGravatarFlow,
+	isGravatarOwnedService,
 	isWPJobManager,
 	isFromGravatar3rdPartyApp,
 	isFromGravatarQuickEditor,
@@ -179,7 +180,7 @@ const GravPoweredEmailForm = ( {
 	headerText = isWPJobManager ? translate( 'Sign in with your email' ) : headerText;
 
 	let subHeader: TranslateResult = '';
-	if ( isGravatarFlow ) {
+	if ( isGravatarFlow && ! isGravatarOwnedService ) {
 		subHeader = translate( '%(clientTitle)s profiles are powered by Gravatar.', {
 			args: { clientTitle: oauth2Client?.title ?? '' },
 		} );
@@ -208,7 +209,7 @@ const GravPoweredEmailForm = ( {
 				<GravatarLoginLogo
 					iconUrl={ oauth2Client?.icon }
 					alt={ oauth2Client?.title ?? '' }
-					isCoBrand={ isGravatarFlow }
+					isCoBrand={ isGravatarFlow && ! isGravatarOwnedService }
 				/>
 				<RequestLoginEmailForm
 					flow={ oauth2Client ? getGravatarOAuth2Flow( oauth2Client ) : undefined }
@@ -400,6 +401,7 @@ interface GravPoweredSecondaryEmailOptionsProps {
 	oauth2Client: any;
 	oauth2ClientId: string | number | null;
 	isGravatarFlow: boolean;
+	isGravatarOwnedService: boolean;
 	usernameOrEmail: string;
 	maskedEmailAddress: string;
 	isNewAccount: boolean;
@@ -418,6 +420,7 @@ const GravPoweredSecondaryEmailOptions = ( {
 	oauth2Client,
 	oauth2ClientId,
 	isGravatarFlow,
+	isGravatarOwnedService,
 	usernameOrEmail,
 	maskedEmailAddress,
 	isNewAccount,
@@ -447,7 +450,7 @@ const GravPoweredSecondaryEmailOptions = ( {
 			<GravatarLoginLogo
 				iconUrl={ oauth2Client?.icon }
 				alt={ oauth2Client?.title ?? '' }
-				isCoBrand={ isGravatarFlow }
+				isCoBrand={ isGravatarFlow && ! isGravatarOwnedService }
 			/>
 			<h1 className="grav-powered-magic-login__header">{ translate( 'Important note' ) }</h1>
 			<p className="grav-powered-magic-login__sub-header">
@@ -556,6 +559,7 @@ interface GravPoweredEmailCodeVerificationProps {
 	oauth2Client: any;
 	oauth2ClientId: string | number | null;
 	isGravatarFlow: boolean;
+	isGravatarOwnedService: boolean;
 	isFromGravatar3rdPartyApp: boolean;
 	usernameOrEmail: string;
 	maskedEmailAddress: string;
@@ -578,6 +582,7 @@ const GravPoweredEmailCodeVerification = ( {
 	oauth2Client,
 	oauth2ClientId,
 	isGravatarFlow,
+	isGravatarOwnedService,
 	isFromGravatar3rdPartyApp,
 	usernameOrEmail,
 	maskedEmailAddress,
@@ -655,7 +660,7 @@ const GravPoweredEmailCodeVerification = ( {
 			<GravatarLoginLogo
 				iconUrl={ oauth2Client?.icon }
 				alt={ oauth2Client?.title ?? '' }
-				isCoBrand={ isGravatarFlow }
+				isCoBrand={ isGravatarFlow && ! isGravatarOwnedService }
 			/>
 			<h1 className="grav-powered-magic-login__header">{ translate( 'Check your email' ) }</h1>
 			<p className="grav-powered-magic-login__sub-header">
@@ -758,7 +763,6 @@ const GravPoweredEmailCodeVerification = ( {
 interface GravPoweredEmailLinkVerificationProps {
 	oauth2Client: any;
 	oauth2ClientId: string | number | null;
-	isGravatarFlow: boolean;
 	usernameOrEmail: string;
 	currentQueryArguments: Record< string, string > | undefined;
 	resendEmailCountdown: number;
@@ -770,7 +774,6 @@ interface GravPoweredEmailLinkVerificationProps {
 const GravPoweredEmailLinkVerification = ( {
 	oauth2Client,
 	oauth2ClientId,
-	isGravatarFlow,
 	usernameOrEmail,
 	currentQueryArguments,
 	resendEmailCountdown,
@@ -826,11 +829,7 @@ const GravPoweredEmailLinkVerification = ( {
 
 	return (
 		<div className="grav-powered-magic-login__content">
-			<GravatarLoginLogo
-				iconUrl={ oauth2Client?.icon }
-				alt={ oauth2Client?.title ?? '' }
-				isCoBrand={ isGravatarFlow }
-			/>
+			<GravatarLoginLogo iconUrl={ oauth2Client?.icon } alt={ oauth2Client?.title ?? '' } />
 			<h1 className="grav-powered-magic-login__header">{ translate( 'Check your email!' ) }</h1>
 			<p className="grav-powered-magic-login__sub-header">
 				{ emailAddress
@@ -889,22 +888,17 @@ const GravPoweredMagicLogin = ( { path }: { path: string } ) => {
 	const showCheckYourEmail = useSelector( getMagicLoginCurrentView ) === CHECK_YOUR_EMAIL_PAGE;
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
 	const oauth2ClientId = useSelector( getCurrentOAuth2ClientId );
+	const isWPJobManager = isWPJobManagerOAuth2Client( oauth2Client );
 	const isGravatar = isGravatarOAuth2Client( oauth2Client );
+	const isGravatarOwnedService = isGravatarOwnedOAuth2Client( oauth2Client );
 	const isGravatarFlow = isGravatarFlowOAuth2Client( oauth2Client );
 	const isGravatarFlowWithEmail = !! ( isGravatarFlow && currentQueryArguments?.email_address );
-	const isWPJobManager = isWPJobManagerOAuth2Client( oauth2Client );
 	const isFromGravatar3rdPartyApp =
-		isGravatar && currentQueryArguments?.gravatar_from === GRAVATAR_FROM_3RD_PARTY;
+		isGravatar && currentQueryArguments?.gravatar_from === '3rd-party';
 	const isFromGravatarQuickEditor =
-		isGravatar && currentQueryArguments?.gravatar_from === GRAVATAR_FROM_QUICK_EDITOR;
+		isGravatar && currentQueryArguments?.gravatar_from === 'quick-editor';
 	const shouldShowSwitchEmail =
 		! isFromGravatar3rdPartyApp && ! isFromGravatarQuickEditor && ! isGravatarFlowWithEmail;
-
-	const hasSubHeader =
-		isGravatarFlowOAuth2Client( oauth2Client ) ||
-		( isGravatarOAuth2Client( oauth2Client ) &&
-			( currentQueryArguments?.gravatar_from === GRAVATAR_FROM_3RD_PARTY ||
-				currentQueryArguments?.gravatar_from === GRAVATAR_FROM_QUICK_EDITOR ) );
 
 	useEffect( () => {
 		recordTracksEvent( 'calypso_gravatar_powered_magic_login_email_form', {
@@ -1189,6 +1183,7 @@ const GravPoweredMagicLogin = ( { path }: { path: string } ) => {
 				oauth2Client={ oauth2Client }
 				oauth2ClientId={ oauth2ClientId }
 				isGravatarFlow={ isGravatarFlow }
+				isGravatarOwnedService={ isGravatarOwnedService }
 				usernameOrEmail={ usernameOrEmail }
 				maskedEmailAddress={ maskedEmailAddress }
 				isNewAccount={ isNewAccount }
@@ -1210,6 +1205,7 @@ const GravPoweredMagicLogin = ( { path }: { path: string } ) => {
 				oauth2Client={ oauth2Client }
 				oauth2ClientId={ oauth2ClientId }
 				isGravatarFlow={ isGravatarFlow }
+				isGravatarOwnedService={ isGravatarOwnedService }
 				isFromGravatar3rdPartyApp={ isFromGravatar3rdPartyApp }
 				usernameOrEmail={ usernameOrEmail }
 				maskedEmailAddress={ maskedEmailAddress }
@@ -1232,7 +1228,6 @@ const GravPoweredMagicLogin = ( { path }: { path: string } ) => {
 			<GravPoweredEmailLinkVerification
 				oauth2Client={ oauth2Client }
 				oauth2ClientId={ oauth2ClientId }
-				isGravatarFlow={ isGravatarFlow }
 				usernameOrEmail={ usernameOrEmail }
 				currentQueryArguments={ currentQueryArguments }
 				resendEmailCountdown={ resendEmailCountdown }
@@ -1251,6 +1246,7 @@ const GravPoweredMagicLogin = ( { path }: { path: string } ) => {
 				currentQueryArguments={ currentQueryArguments }
 				isGravatar={ isGravatar }
 				isGravatarFlow={ isGravatarFlow }
+				isGravatarOwnedService={ isGravatarOwnedService }
 				isWPJobManager={ isWPJobManager }
 				isFromGravatar3rdPartyApp={ isFromGravatar3rdPartyApp }
 				isFromGravatarQuickEditor={ isFromGravatarQuickEditor }
@@ -1265,6 +1261,11 @@ const GravPoweredMagicLogin = ( { path }: { path: string } ) => {
 			/>
 		);
 	}
+
+	const hasSubHeader =
+		( isGravatarFlowOAuth2Client( oauth2Client ) && ! isGravatarOwnedService ) ||
+		isFromGravatar3rdPartyApp ||
+		isFromGravatarQuickEditor;
 
 	return (
 		<Main

--- a/client/login/wp-login/gravatar/grav-powered-login-block-header.tsx
+++ b/client/login/wp-login/gravatar/grav-powered-login-block-header.tsx
@@ -2,7 +2,11 @@ import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import VisitSite from 'calypso/blocks/visit-site';
 import GravatarLoginLogo from 'calypso/components/gravatar-login-logo';
-import { isGravatarFlowOAuth2Client, isGravatarOAuth2Client } from 'calypso/lib/oauth2-clients';
+import {
+	isGravatarFlowOAuth2Client,
+	isGravatarOAuth2Client,
+	isGravatarOwnedOAuth2Client,
+} from 'calypso/lib/oauth2-clients';
 import { getHeaderText } from 'calypso/login/wp-login/hooks/get-header-text';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
@@ -81,7 +85,10 @@ const GravPoweredLoginBlockHeader = ( {
 			<GravatarLoginLogo
 				iconUrl={ oauth2Client?.icon }
 				alt={ oauth2Client?.title || '' }
-				isCoBrand={ isGravatarFlowOAuth2Client( oauth2Client ) }
+				isCoBrand={
+					isGravatarFlowOAuth2Client( oauth2Client ) &&
+					! isGravatarOwnedOAuth2Client( oauth2Client )
+				}
 			/>
 			<div className="grav-powered-login__form-header">{ headerText }</div>
 			{ postHeader }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of GRA-636

## Proposed Changes

* Remove the co-brand logo for Gravatar-owned services, e.g., Gravatar iOS, Gravatar Android, etc.
* Remove the subtitle for Gravatar-owned services, e.g., Gravatar iOS, Gravatar Android, etc.
* Make the co-brand logo a circle
* (Extra) Reuse variables
* (Extra) Remove unnecessary prop from the `<GravPoweredEmailLinkVerification>`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See GRA-636

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* [Setup Calypso](https://github.com/Automattic/wp-calypso?tab=readme-ov-file#getting-started) (re-setup it if needed)
* Check out this PR, and run `yarn start`
* Ensure you have logged out of your account
* Go to this [test URL](http://calypso.localhost:3000/log-in/link?client_id=119371&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D119371%26scope%255B1%255D%3Dgravatar-global%26scope%255B0%255D%3Dauth%26response_type%3Dcode%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fios%252Foauth%252Fcallback%26from-calypso%3D1&gravatar_flow=1), and you will see the following changes:

| Before | After |
| - | - |
| <img width="495" height="640" alt="截圖 2025-08-13 下午5 40 21" src="https://github.com/user-attachments/assets/6644130e-87c5-425c-ba8c-fe65a5370741" /> | <img width="498" height="641" alt="截圖 2025-08-13 下午5 39 54" src="https://github.com/user-attachments/assets/a639cddc-6b27-488c-8f6f-82c34fd55c74" /> |
| <img width="498" height="521" alt="截圖 2025-08-13 下午5 42 10" src="https://github.com/user-attachments/assets/1463a6ad-f1a7-4746-a1d6-04cd469f5322" /> | <img width="496" height="520" alt="截圖 2025-08-13 下午5 41 43" src="https://github.com/user-attachments/assets/0e4b7533-d41a-4a9e-81a5-70ca04cf41ce" /> |
| <img width="500" height="692" alt="截圖 2025-08-13 下午5 42 58" src="https://github.com/user-attachments/assets/c3ba26c1-8d9e-4d65-9d6b-a2609b6355bc" /> | <img width="498" height="690" alt="截圖 2025-08-13 下午5 43 21" src="https://github.com/user-attachments/assets/7cf02e27-39fc-44ee-8102-e6835c370772" /> |

- Go to the PW login screen by using [this URL](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D119371%26scope%255B1%255D%3Dgravatar-global%26scope%255B0%255D%3Dauth%26response_type%3Dcode%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fios%252Foauth%252Fcallback%26from-calypso%3D1&client_id=119371&gravatar_flow=1), and you will see the following changes:

| Before | After |
| - | - |
| <img width="497" height="922" alt="截圖 2025-08-13 下午5 40 45" src="https://github.com/user-attachments/assets/45e934cf-8cd0-4dd2-9ebf-c409f718554b" /> | <img width="497" height="923" alt="截圖 2025-08-13 下午5 40 33" src="https://github.com/user-attachments/assets/8833757f-e75e-45dd-ba7a-ea8f19d9fe03" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
