### PR TITLE
Help Center: Implement new homepage conversation

### DIFF
--- a/packages/components/src/summary-button/types.ts
+++ b/packages/components/src/summary-button/types.ts
@@ -43,7 +43,7 @@ export interface SummaryButtonProps {
 	 * For now, this property is only rendered in `low` density variant.
 	 * We might revisit adding this in more variants in the future.
 	 */
-	description?: string;
+	description?: React.ReactNode;
 	/**
 	 * A brief, optional line of text used to highlight important information,
 	 * such as a warning or status.

--- a/packages/help-center/src/components/help-center-recent-conversations.tsx
+++ b/packages/help-center/src/components/help-center-recent-conversations.tsx
@@ -1,6 +1,5 @@
 import { calculateUnread } from '@automattic/odie-client/src/data/use-get-unread-conversations';
 import { ZendeskConversation } from '@automattic/odie-client/src/types';
-import { useI18n } from '@wordpress/react-i18n';
 import React from 'react';
 import { useGetHistoryChats } from '../hooks';
 import { HelpCenterSupportChatMessage } from './help-center-support-chat-message';
@@ -10,7 +9,6 @@ import './help-center-recent-conversations.scss';
 
 const HelpCenterRecentConversations: React.FC = () => {
 	const { recentConversations } = useGetHistoryChats();
-	const { __ } = useI18n();
 
 	if ( ! recentConversations?.length ) {
 		return null;
@@ -31,19 +29,14 @@ const HelpCenterRecentConversations: React.FC = () => {
 	] );
 
 	return (
-		<div className="help-center-homepage-conversations">
-			<h3 className="help-center-search-results__title help-center__section-title">
-				{ __( 'Recent Conversation', __i18n_text_domain__ ) }
-			</h3>
-
-			<HelpCenterSupportChatMessage
-				numberOfUnreadMessages={ numberOfUnreadMessages }
-				sectionName="recent_conversations"
-				key={ recentConversation.id }
-				message={ lastMessage }
-				conversation={ recentConversation }
-			/>
-		</div>
+		<HelpCenterSupportChatMessage
+			numberOfUnreadMessages={ numberOfUnreadMessages }
+			sectionName="recent_conversations"
+			key={ recentConversation.id }
+			message={ lastMessage }
+			conversation={ recentConversation }
+			homePageVersion
+		/>
 	);
 };
 

--- a/packages/help-center/src/components/help-center-search-results.scss
+++ b/packages/help-center/src/components/help-center-search-results.scss
@@ -1,4 +1,5 @@
 @import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/mixins";
 @import "mixins";
 @import "variables";
 
@@ -39,18 +40,6 @@
 
 		@media screen and (min-width: 661px) {
 			font-size: $font-body;
-		}
-	}
-
-	// Homepage conversations section
-	.help-center-homepage-conversations {
-		.help-center-support-chat__conversation-container {
-			border-radius: 4px;
-			border: 1.5px solid #C3C4C7;
-
-			&:hover, &.is-unread-message {
-				border: 1.5px solid $help-center-blue !important;
-			}
 		}
 	}
 }

--- a/packages/help-center/src/components/help-center-search-results.scss
+++ b/packages/help-center/src/components/help-center-search-results.scss
@@ -1,5 +1,4 @@
 @import "@automattic/typography/styles/variables";
-@import "@wordpress/base-styles/mixins";
 @import "mixins";
 @import "variables";
 

--- a/packages/help-center/src/components/help-center-support-chat-message.scss
+++ b/packages/help-center/src/components/help-center-support-chat-message.scss
@@ -1,45 +1,18 @@
-@import "@wordpress/base-styles/variables";
-@import "@wordpress/base-styles/mixins";
 @import "variables";
 
-// Homepage conversations section
-.help-center-homepage-conversations {
-	margin: 0;
-	border-radius: 8px; /* stylelint-disable-line scales/radii */
+.help-center-support-chat__conversation-sub-information {
+	display: flex;
+	align-items: center;
+	gap: 4px;
 
-	&:hover {
-		box-shadow: rgba(0, 0, 0, 0.25) 0 0 0 1px;
+	.help-center-support-chat__conversation-information-name {
+		text-overflow: ellipsis;
+		overflow: hidden;
+		line-clamp: 1;
 	}
 
-	h3.help-center-search-results__title {
-		@include heading-small();
-		display: flex;
-		justify-content: space-between;
-		height: 20px;
-		text-transform: uppercase;
-		color: $gray-700;
-	}
-
-	.help-center-support-chat__open-conversation {
-		fill: $gray-700;
-	}
-
-	.help-center-support-chat__conversation-container {
-		border: none;
-		column-gap: 0;
-		padding: 0;
-
-		&:hover {
-			border: none;
-		}
-
-		.help-center-support-chat__conversation-information-message {
-			padding: 6px 0;
-		}
-	}
-
-	.components-card__body {
-		padding: 0;
+	.help-center-support-chat__conversation-information-time {
+		flex: 0 0 auto;
 	}
 }
 
@@ -67,21 +40,18 @@
 
 	&.is-unread-message {
 		background-color: #EBF2FC;
-
 		.help-center-support-chat__open-conversation {
 			fill: $help-center-blue;
 		}
 	}
 
 	&:not(.is-unread-message) {
-
-		&.is-closed,
-		&.is-solved {
+		&.is-closed, &.is-solved {
 			background-color: var(--studio-gray-0);
 		}
 	}
 
-	&>* {
+	& > * {
 		display: flex;
 	}
 
@@ -136,29 +106,6 @@
 			-webkit-line-clamp: 1;
 			-webkit-box-orient: vertical;
 		}
-
-		.help-center-support-chat__conversation-sub-information {
-			display: flex;
-			color: #787C82;
-			font-weight: 400;
-			font-size: 0.75rem;
-			line-height: 20px;
-			align-items: center;
-			gap: 4px;
-
-			.help-center-support-chat__conversation-information-name {
-				text-overflow: ellipsis;
-				display: -webkit-box;
-				overflow: hidden;
-				line-clamp: 1;
-				-webkit-line-clamp: 1;
-				-webkit-box-orient: vertical;
-			}
-
-			.help-center-support-chat__conversation-information-time {
-				flex: 0 0 auto;
-			}
-		}
 	}
 
 	.help-center-support-chat__open-conversation {
@@ -167,7 +114,6 @@
 		fill: #787C82;
 	}
 }
-
 .help-center-chat-history__no-results {
 	display: flex;
 	flex-direction: row;

--- a/packages/help-center/src/components/help-center-support-chat-message.scss
+++ b/packages/help-center/src/components/help-center-support-chat-message.scss
@@ -1,10 +1,52 @@
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/mixins";
 @import "variables";
+
+// Homepage conversations section
+.help-center-homepage-conversations {
+	margin: 0;
+	border-radius: 8px; /* stylelint-disable-line scales/radii */
+
+	&:hover {
+		box-shadow: rgba(0, 0, 0, 0.25) 0 0 0 1px;
+	}
+
+	h3.help-center-search-results__title {
+		@include heading-small();
+		display: flex;
+		justify-content: space-between;
+		height: 20px;
+		text-transform: uppercase;
+		color: $gray-700;
+	}
+
+	.help-center-support-chat__open-conversation {
+		fill: $gray-700;
+	}
+
+	.help-center-support-chat__conversation-container {
+		border: none;
+		column-gap: 0;
+		padding: 0;
+
+		&:hover {
+			border: none;
+		}
+
+		.help-center-support-chat__conversation-information-message {
+			padding: 6px 0;
+		}
+	}
+
+	.components-card__body {
+		padding: 0;
+	}
+}
 
 .help-center-support-chat__conversation-container {
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
-
 	background-color: transparent;
 	padding: 16px;
 	gap: 6px;
@@ -25,18 +67,21 @@
 
 	&.is-unread-message {
 		background-color: #EBF2FC;
+
 		.help-center-support-chat__open-conversation {
 			fill: $help-center-blue;
 		}
 	}
 
 	&:not(.is-unread-message) {
-		&.is-closed, &.is-solved {
+
+		&.is-closed,
+		&.is-solved {
 			background-color: var(--studio-gray-0);
 		}
 	}
 
-	& > * {
+	&>* {
 		display: flex;
 	}
 
@@ -122,6 +167,7 @@
 		fill: #787C82;
 	}
 }
+
 .help-center-chat-history__no-results {
 	display: flex;
 	flex-direction: row;

--- a/packages/help-center/src/components/help-center-support-chat-message.tsx
+++ b/packages/help-center/src/components/help-center-support-chat-message.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable no-restricted-imports */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Gravatar, TimeSince } from '@automattic/components';
+import { Card, Gravatar, TimeSince } from '@automattic/components';
 import { HumanAvatar, WapuuAvatar } from '@automattic/odie-client/src/assets';
+import { CardBody } from '@wordpress/components';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { chevronRight, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useGetHistoryChats } from '../hooks';
 import { HELP_CENTER_STORE } from '../stores';
@@ -32,15 +33,18 @@ export const HelpCenterSupportChatMessage = ( {
 	sectionName,
 	conversation,
 	numberOfUnreadMessages = 0,
+	homePageVersion = false,
 }: {
 	message: OdieMessage | ZendeskMessage;
 	sectionName?: string;
 	conversation: OdieConversation | ZendeskConversation;
 	numberOfUnreadMessages?: number;
+	homePageVersion?: boolean;
 } ) => {
 	const { __ } = useI18n();
 	const { currentUser } = useHelpCenterContext();
 	const { displayName, received, role, text, altText } = message;
+	const navigate = useNavigate();
 	const messageText =
 		'metadata' in message && message.metadata?.type === 'csat'
 			? __(
@@ -82,6 +86,85 @@ export const HelpCenterSupportChatMessage = ( {
 
 	const receivedDateISO = new Date( received * 1000 ).toISOString();
 
+	function renderMessage() {
+		return (
+			<>
+				{ ! homePageVersion && (
+					<div
+						className={ clsx( 'help-center-support-chat__conversation-avatar', {
+							'has-unread-messages': hasUnreadMessages,
+						} ) }
+					>
+						{ renderAvatar() }
+						{ hasUnreadMessages && (
+							<div className="help-center-support-chat__conversation-badge">
+								+{ numberOfUnreadMessages }
+							</div>
+						) }
+					</div>
+				) }
+				<div className="help-center-support-chat__conversation-information">
+					<div className="help-center-support-chat__conversation-information-message">
+						{ messageText || altText }
+					</div>
+					<div className="help-center-support-chat__conversation-sub-information">
+						<span className="help-center-support-chat__conversation-information-name">
+							{ messageDisplayName }
+						</span>
+						<Icon
+							size={ 2 }
+							icon={
+								<svg
+									width="2"
+									height="2"
+									viewBox="0 0 2 2"
+									fill="none"
+									xmlns="http://www.w3.org/2000/svg"
+								>
+									<circle cx="1" cy="1" r="1" fill="#787C82" />
+								</svg>
+							}
+						/>
+						<span className="help-center-support-chat__conversation-information-time">
+							<TimeSince date={ receivedDateISO } dateFormat="lll" />
+						</span>
+					</div>
+				</div>
+				{ ! homePageVersion && (
+					<div className="help-center-support-chat__open-conversation">
+						<Icon icon={ chevronRight } size={ 24 } />
+					</div>
+				) }
+			</>
+		);
+	}
+
+	if ( homePageVersion ) {
+		return (
+			<Card
+				onClick={ () => {
+					trackContactButtonClicked( sectionName || helpCenterContextSectionName );
+					setCurrentSupportInteraction( supportInteraction );
+					navigate( `/odie?id=${ supportInteraction?.uuid }` );
+				} }
+				role="button"
+				className="help-center-homepage-conversations"
+			>
+				<CardBody>
+					<h3 className="help-center-search-results__title">
+						<span>{ __( 'Recent Conversation', __i18n_text_domain__ ) }</span>
+						<div className="help-center-support-chat__open-conversation">
+							<Icon icon={ chevronRight } size={ 24 } />
+						</div>
+					</h3>
+					<div className="help-center-support-chat__conversation-container">
+						{ renderMessage() }
+					</div>
+				</CardBody>
+			</Card>
+		);
+	}
+
 	return (
 		<Link
 			to={ `/odie?id=${ supportInteraction?.uuid }` }
@@ -94,49 +177,7 @@ export const HelpCenterSupportChatMessage = ( {
 				[ `is-${ supportInteraction?.status }` ]: supportInteraction?.status,
 			} ) }
 		>
-			<div
-				className={ clsx( 'help-center-support-chat__conversation-avatar', {
-					'has-unread-messages': hasUnreadMessages,
-				} ) }
-			>
-				{ renderAvatar() }
-
-				{ hasUnreadMessages && (
-					<div className="help-center-support-chat__conversation-badge">
-						+{ numberOfUnreadMessages }
-					</div>
-				) }
-			</div>
-			<div className="help-center-support-chat__conversation-information">
-				<div className="help-center-support-chat__conversation-information-message">
-					{ messageText || altText }
-				</div>
-				<div className="help-center-support-chat__conversation-sub-information">
-					<span className="help-center-support-chat__conversation-information-name">
-						{ messageDisplayName }
-					</span>
-					<Icon
-						size={ 2 }
-						icon={
-							<svg
-								width="2"
-								height="2"
-								viewBox="0 0 2 2"
-								fill="none"
-								xmlns="http://www.w3.org/2000/svg"
-							>
-								<circle cx="1" cy="1" r="1" fill="#787C82" />
-							</svg>
-						}
-					/>
-					<span className="help-center-support-chat__conversation-information-time">
-						<TimeSince date={ receivedDateISO } dateFormat="lll" />
-					</span>
-				</div>
-			</div>
-			<div className="help-center-support-chat__open-conversation">
-				<Icon icon={ chevronRight } size={ 24 } />
-			</div>
+			{ renderMessage() }
 		</Link>
 	);
 };

--- a/packages/help-center/src/components/help-center-support-chat-message.tsx
+++ b/packages/help-center/src/components/help-center-support-chat-message.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable no-restricted-imports */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Card, Gravatar, TimeSince } from '@automattic/components';
+import { Gravatar, TimeSince } from '@automattic/components';
+import SummaryButton from '@automattic/components/src/summary-button';
 import { HumanAvatar, WapuuAvatar } from '@automattic/odie-client/src/assets';
-import { CardBody } from '@wordpress/components';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { chevronRight, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
@@ -89,20 +89,19 @@ export const HelpCenterSupportChatMessage = ( {
 	function renderMessage() {
 		return (
 			<>
-				{ ! homePageVersion && (
-					<div
-						className={ clsx( 'help-center-support-chat__conversation-avatar', {
-							'has-unread-messages': hasUnreadMessages,
-						} ) }
-					>
-						{ renderAvatar() }
-						{ hasUnreadMessages && (
-							<div className="help-center-support-chat__conversation-badge">
-								+{ numberOfUnreadMessages }
-							</div>
-						) }
-					</div>
-				) }
+				<div
+					className={ clsx( 'help-center-support-chat__conversation-avatar', {
+						'has-unread-messages': hasUnreadMessages,
+					} ) }
+				>
+					{ renderAvatar() }
+					{ hasUnreadMessages && (
+						<div className="help-center-support-chat__conversation-badge">
+							+{ numberOfUnreadMessages }
+						</div>
+					) }
+				</div>
+
 				<div className="help-center-support-chat__conversation-information">
 					<div className="help-center-support-chat__conversation-information-message">
 						{ messageText || altText }
@@ -130,38 +129,49 @@ export const HelpCenterSupportChatMessage = ( {
 						</span>
 					</div>
 				</div>
-				{ ! homePageVersion && (
-					<div className="help-center-support-chat__open-conversation">
-						<Icon icon={ chevronRight } size={ 24 } />
-					</div>
-				) }
+
+				<div className="help-center-support-chat__open-conversation">
+					<Icon icon={ chevronRight } size={ 24 } />
+				</div>
 			</>
 		);
 	}
 
 	if ( homePageVersion ) {
 		return (
-			<Card
+			<SummaryButton
+				strapline={ __( 'Recent Conversation', __i18n_text_domain__ ) }
+				title={ messageText || altText || '' }
+				description={
+					<div className="help-center-support-chat__conversation-sub-information">
+						<span className="help-center-support-chat__conversation-information-name">
+							{ messageDisplayName }
+						</span>
+						<Icon
+							size={ 2 }
+							icon={
+								<svg
+									width="2"
+									height="2"
+									viewBox="0 0 2 2"
+									fill="none"
+									xmlns="http://www.w3.org/2000/svg"
+								>
+									<circle cx="1" cy="1" r="1" fill="#787C82" />
+								</svg>
+							}
+						/>
+						<span className="help-center-support-chat__conversation-information-time">
+							<TimeSince date={ receivedDateISO } dateFormat="lll" />
+						</span>
+					</div>
+				}
 				onClick={ () => {
 					trackContactButtonClicked( sectionName || helpCenterContextSectionName );
 					setCurrentSupportInteraction( supportInteraction );
 					navigate( `/odie?id=${ supportInteraction?.uuid }` );
 				} }
-				role="button"
-				className="help-center-homepage-conversations"
-			>
-				<CardBody>
-					<h3 className="help-center-search-results__title">
-						<span>{ __( 'Recent Conversation', __i18n_text_domain__ ) }</span>
-						<div className="help-center-support-chat__open-conversation">
-							<Icon icon={ chevronRight } size={ 24 } />
-						</div>
-					</h3>
-					<div className="help-center-support-chat__conversation-container">
-						{ renderMessage() }
-					</div>
-				</CardBody>
-			</Card>
+			/>
 		);
 	}
 


### PR DESCRIPTION
Fixes: DOTCOM-14193

Hi @fditrapani! I improvised the hover styles, can you please check them out?

## Proposed Changes

Implements DOTCOM-14193

## Testing Instructions
1. Open the Help Center. If you don't have support history please create a thread.
2. Go to the Help Center home.
3. The summary of the chat should look exactly like the design.

### Regression testing
1. Go to your history tab.
2. The list should look identical to production.
3. Clicking an item should take you to the thread.


## Screenshots

| Before | After |
|--------|--------|
| <img width="414" height="804" alt="image" src="https://github.com/user-attachments/assets/c9bad6eb-8ba5-4d1e-9ae7-6f893ec877c4" /> | <img width="414" height="803" alt="image" src="https://github.com/user-attachments/assets/5b305848-9242-4643-bae2-923ac72adf23" /> |