### PR TITLE
Help Center: Fix section name in track events

### DIFF
--- a/apps/help-center/help-center-gutenberg.js
+++ b/apps/help-center/help-center-gutenberg.js
@@ -28,7 +28,7 @@ function HelpCenterContent() {
 		recordTracksEvent( `calypso_inlinehelp_${ show ? 'close' : 'show' }`, {
 			force_site_id: true,
 			location: 'help-center',
-			section: 'gutenberg-editor',
+			section: helpCenterData.sectionName || 'gutenberg-editor',
 			editor_type: getEditorType(),
 			canvas_mode: canvasMode,
 		} );

--- a/apps/help-center/help-center-wp-admin-disconnected.js
+++ b/apps/help-center/help-center-wp-admin-disconnected.js
@@ -10,7 +10,7 @@ function initHelpCenterTracking() {
 			recordTracksEvent( 'calypso_inlinehelp_show', {
 				force_site_id: true,
 				location: 'help-center',
-				section: 'wp-admin',
+				section: 'wp-admin-disconnected',
 				jetpack_disconnected_site: true,
 			} );
 		} );

--- a/apps/help-center/help-center-wp-admin.js
+++ b/apps/help-center/help-center-wp-admin.js
@@ -70,7 +70,7 @@ function AdminHelpCenterContent() {
 		recordTracksEvent( `calypso_inlinehelp_${ show ? 'close' : 'show' }`, {
 			force_site_id: true,
 			location: 'help-center',
-			section: 'wp-admin',
+			section: helpCenterData.sectionName || 'wp-admin',
 		} );
 
 		setShowHelpCenter( ! show );

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -14,6 +14,7 @@ import Draggable, { DraggableProps } from 'react-draggable';
  * Internal Dependencies
  */
 import { FeatureFlagProvider } from '../contexts/FeatureFlagContext';
+import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { HELP_CENTER_STORE } from '../stores';
 import { Container } from '../types';
 import HelpCenterContent from './help-center-content';
@@ -63,6 +64,8 @@ const HelpCenterContainer: React.FC< Container > = ( {
 		};
 	}, [] );
 
+	const { sectionName } = useHelpCenterContext();
+
 	const nodeRef = useRef< HTMLDivElement >( null );
 	const { setIsMinimized } = useDispatch( HELP_CENTER_STORE );
 	const isMobile = useMobileBreakpoint();
@@ -72,8 +75,10 @@ const HelpCenterContainer: React.FC< Container > = ( {
 
 	const onDismiss = useCallback( () => {
 		handleClose();
-		recordTracksEvent( 'calypso_inlinehelp_close' );
-	}, [ handleClose ] );
+		recordTracksEvent( 'calypso_inlinehelp_close', {
+			section: sectionName,
+		} );
+	}, [ handleClose, sectionName ] );
 
 	const focusReturnRef = useFocusReturn();
 


### PR DESCRIPTION
Fixes DOTCOM-14219

## Proposed Changes

Passes the correct section to track events.

## Why are these changes being made?
More accurate tracking

## Testing Instructions

1. cd into `apps/help-center`.
2. run `yarn dev --sync`.
3. sandbox widgets.wp.com.
4. open DevTools > Network and filter by `inlinehelp`.
5. visit wordpress.com/support.
6. track events should contain the correct section.
