### PR TITLE
Site overview v2: show v1 migration status in retrofitted overview

### DIFF
--- a/client/sites/overview/controller.tsx
+++ b/client/sites/overview/controller.tsx
@@ -1,9 +1,12 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { isMigrationInProgress } from 'calypso/data/site-migration';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { getRouteFromContext } from 'calypso/utils';
 import DashboardBackportSiteOverview from '../v2/site-overview';
 import HostingOverview from './components/hosting-overview';
 import type { Context as PageJSContext } from '@automattic/calypso-router';
+import type { SiteExcerptData } from '@automattic/sites';
 
 export function overview( context: PageJSContext, next: () => void ) {
 	context.primary = (
@@ -20,6 +23,14 @@ export function overview( context: PageJSContext, next: () => void ) {
  */
 export async function dashboardBackportSiteOverview( context: PageJSContext, next: () => void ) {
 	const { site: siteSlug } = context.params;
+	const site = getSelectedSite( context.store.getState() ) as SiteExcerptData;
+
+	if ( isMigrationInProgress( site ) ) {
+		// Temporarily show the v1 site migration overview page.
+		// @todo implement the page in v2.
+		return overview( context, next );
+	}
+
 	if ( ! isEnabled( 'dashboard/v2/backport/site-overview' ) ) {
 		return overview( context, next );
 	}


### PR DESCRIPTION
Part of DOTDASH-228

## Proposed Changes

This PR shows the site migration overview, for sites that are still in migration process.

This only applies in v1 retrofitted Site Overview and not in v2 yet.

This is as a workaround until it's implemented in v2, as the whole logic is very complicated.

|Before|After|
|-|-|
|<img width="1134" height="784" alt="image" src="https://github.com/user-attachments/assets/3c30a5f5-ffe7-4b34-bd9b-68b165130cdc" />|<img width="1133" height="783" alt="image" src="https://github.com/user-attachments/assets/f3e57b54-86ee-4d70-a962-a77e286723b6" />|

## Testing Instructions

1. Go to /sites.
1. Click "Add new site" -> "Migrate".
1. Click "Or pick your current platform from a list".
1. In the site picker, pick one of your site.
1. In "Let us migrate your site", click "I'll do it myself" at the top right.
1. Pick a plan.
1. Complete the checkout.
1. Go to `/v2/sites?flags=dashboard/v2/backport/site-overview`
2. Click that site
3. Verify you see the migration overview.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
