### PR TITLE
Add more tracking information around creating conversations

### DIFF
--- a/packages/odie-client/src/components/message/direct-escalation-link.tsx
+++ b/packages/odie-client/src/components/message/direct-escalation-link.tsx
@@ -31,6 +31,7 @@ export const DirectEscalationLink = ( { messageId }: { messageId: number | undef
 			chat_provider: chat?.provider,
 			conversation_id: chat?.conversationId,
 			has_zendesk_conversation_already_started: hasZendeskConversationAlreadyStarted,
+			force_email_support: forceEmailSupport,
 		} );
 
 		if ( hasZendeskConversationAlreadyStarted ) {

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -83,25 +83,32 @@ export const useCreateZendeskConversation = (): ( ( {
 			status: 'transfer',
 		} ) );
 
-		trackEvent( 'submitting_zendesk_user_fields', {
-			messaging_initial_message: userFieldMessage || undefined,
-			messaging_site_id: selectedSiteId || null,
-			messaging_ai_chat_id: chatId || undefined,
-			messaging_url: selectedSiteURL || window.location.href,
-			messaging_flow: userFieldFlowName || null,
-			messaging_source: sectionName,
-		} );
+		try {
+			trackEvent( 'submitting_zendesk_user_fields', {
+				messaging_initial_message: userFieldMessage || undefined,
+				messaging_site_id: selectedSiteId || null,
+				messaging_ai_chat_id: chatId || undefined,
+				messaging_url: selectedSiteURL || window.location.href,
+				messaging_flow: userFieldFlowName || null,
+				messaging_source: sectionName,
+			} );
 
-		await submitUserFields( {
-			messaging_initial_message: userFieldMessage || undefined,
-			messaging_site_id: selectedSiteId || null,
-			messaging_ai_chat_id: chatId || undefined,
-			messaging_url: selectedSiteURL || window.location.href,
-			messaging_flow: userFieldFlowName || null,
-			messaging_source: sectionName,
-		} );
+			await submitUserFields( {
+				messaging_initial_message: userFieldMessage || undefined,
+				messaging_site_id: selectedSiteId || null,
+				messaging_ai_chat_id: chatId || undefined,
+				messaging_url: selectedSiteURL || window.location.href,
+				messaging_flow: userFieldFlowName || null,
+				messaging_source: sectionName,
+			} );
 
-		trackEvent( 'submitted_zendesk_user_fields' );
+			trackEvent( 'submitted_zendesk_user_fields' );
+		} catch ( error ) {
+			trackEvent( 'error_submitting_zendesk_user_fields', {
+				error_message:
+					error instanceof Error ? error.message : error?.toString?.() ?? 'Unknown error',
+			} );
+		}
 
 		const conversation = await Smooch.createConversation( {
 			metadata: {

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -51,6 +51,18 @@ export const useCreateZendeskConversation = (): ( ( {
 		isFromError?: boolean;
 	} ) => {
 		const currentInteractionID = interactionId || currentSupportInteraction!.uuid;
+
+		trackEvent( 'create_zendesk_conversation', {
+			is_submitting_zendesk_user_fields: isSubmittingZendeskUserFields,
+			chat_conversation_id: chat.conversationId,
+			chat_status: chat.status,
+			chat_provider: chat.provider,
+			interaction_id: currentInteractionID,
+			created_from: createdFrom,
+			avoid_transfer: avoidTransfer,
+			is_from_error: isFromError,
+		} );
+
 		if (
 			isSubmittingZendeskUserFields ||
 			chat.conversationId ||
@@ -71,6 +83,15 @@ export const useCreateZendeskConversation = (): ( ( {
 			status: 'transfer',
 		} ) );
 
+		trackEvent( 'create_submitting_zendesk_user_fields', {
+			messaging_initial_message: userFieldMessage || undefined,
+			messaging_site_id: selectedSiteId || null,
+			messaging_ai_chat_id: chatId || undefined,
+			messaging_url: selectedSiteURL || window.location.href,
+			messaging_flow: userFieldFlowName || null,
+			messaging_source: sectionName,
+		} );
+
 		await submitUserFields( {
 			messaging_initial_message: userFieldMessage || undefined,
 			messaging_site_id: selectedSiteId || null,
@@ -79,6 +100,7 @@ export const useCreateZendeskConversation = (): ( ( {
 			messaging_flow: userFieldFlowName || null,
 			messaging_source: sectionName,
 		} );
+
 		const conversation = await Smooch.createConversation( {
 			metadata: {
 				createdAt: Date.now(),

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -83,7 +83,7 @@ export const useCreateZendeskConversation = (): ( ( {
 			status: 'transfer',
 		} ) );
 
-		trackEvent( 'create_submitting_zendesk_user_fields', {
+		trackEvent( 'submitting_zendesk_user_fields', {
 			messaging_initial_message: userFieldMessage || undefined,
 			messaging_site_id: selectedSiteId || null,
 			messaging_ai_chat_id: chatId || undefined,
@@ -100,6 +100,8 @@ export const useCreateZendeskConversation = (): ( ( {
 			messaging_flow: userFieldFlowName || null,
 			messaging_source: sectionName,
 		} );
+
+		trackEvent( 'submitted_zendesk_user_fields' );
 
 		const conversation = await Smooch.createConversation( {
 			metadata: {

--- a/packages/zendesk-client/src/use-update-zendesk-user-fields.ts
+++ b/packages/zendesk-client/src/use-update-zendesk-user-fields.ts
@@ -11,6 +11,7 @@ import type { UserFields } from './types';
 
 export function useUpdateZendeskUserFields() {
 	return useMutation( {
+		throwOnError: true,
 		mutationFn: ( userFields: UserFields ) => {
 			return canAccessWpcomApis()
 				? wpcomRequest( {


### PR DESCRIPTION
Fixes: DOTCOM-14220

## Proposed Changes

A user recently wasn't able to create a conversation. The issue happened between the two events `calypso_odie_chat_message_direct_escalation_link_click` and `new_zendesk_conversation`.

Many heavy tasks are done between these two events, and I added more logging around them.


## Why are these changes being made?
Make it easier to debug.

## Testing Instructions

1. Smoke test an escalation to human support.
2. All should work.
