### PR TITLE
Staging Sites Redesign: Enable env switcher earlier on staging

### DIFF
--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -9,7 +9,6 @@ import HostingFeaturesIcon from 'calypso/sites/hosting/components/hosting-featur
 import { useStagingSite } from 'calypso/sites/staging-site/hooks/use-staging-site';
 import SitesProductionBadge from 'calypso/sites-dashboard/components/sites-production-badge';
 import { useSelector } from 'calypso/state';
-import { canCurrentUserSwitchEnvironment } from 'calypso/state/sites/selectors/can-current-user-switch-environment';
 import { StagingSiteStatus } from 'calypso/state/staging-site/constants';
 import { getStagingSiteStatus } from 'calypso/state/staging-site/selectors';
 import { useBreadcrumbs } from '../../hooks/breadcrumbs/use-breadcrumbs';
@@ -193,9 +192,9 @@ const DotcomPreviewPane = ( {
 		stagingStatus === StagingSiteStatus.NONE ||
 		stagingStatus === StagingSiteStatus.UNSET;
 
-	const hasEnvironmentPermission = useSelector( ( state ) =>
-		canCurrentUserSwitchEnvironment( state, site )
-	);
+	// const hasEnvironmentPermission = useSelector( ( state ) =>
+	// 	canCurrentUserSwitchEnvironment( state, site )
+	// );
 
 	const { breadcrumbs, shouldShowBreadcrumbs } = useBreadcrumbs();
 	useSetTabBreadcrumb( {
@@ -230,7 +229,7 @@ const DotcomPreviewPane = ( {
 						return <SitesProductionBadge>{ __( 'Production' ) }</SitesProductionBadge>;
 					}
 
-					if ( hasEnvironmentPermission && isStagingStatusFinished ) {
+					if ( isStagingStatusFinished ) {
 						return <SiteEnvironmentSwitcher onChange={ changeSitePreviewPane } site={ site } />;
 					}
 				},

--- a/client/sites/components/site-preview-pane/site-environment-switcher.tsx
+++ b/client/sites/components/site-preview-pane/site-environment-switcher.tsx
@@ -1,5 +1,5 @@
 import { SiteExcerptData } from '@automattic/sites';
-import { DropdownMenu, Button } from '@wordpress/components';
+import { DropdownMenu, Button, MenuItem } from '@wordpress/components';
 import { chevronDownSmall } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
@@ -19,24 +19,60 @@ export default function SiteEnvironmentSwitcher( {
 }: SiteEnvironmentSwitcherProps ) {
 	const { __ } = useI18n();
 
-	if (
-		! site.is_wpcom_staging_site &&
-		! (
-			site.is_wpcom_atomic &&
+	// eslint-disable-next-line no-console
+	console.log( 'SiteEnvironmentSwitcher site properties', {
+		siteId: site.ID,
+		is_wpcom_staging_site: site.is_wpcom_staging_site,
+		is_wpcom_atomic: site.is_wpcom_atomic,
+		wpcom_staging_blog_ids: site.options?.wpcom_staging_blog_ids,
+		wpcom_production_blog_id: site.options?.wpcom_production_blog_id,
+	} );
+
+	// Show switcher if:
+	// 1. Site is a staging site, OR
+	// 2. Site is atomic with staging sites, OR
+	// 3. Site has a production blog ID (indicating it's a staging site that may not be fully flagged yet)
+	const hasEnvironmentSwitchingCapability =
+		site.is_wpcom_staging_site ||
+		( site.is_wpcom_atomic &&
 			site.options?.wpcom_staging_blog_ids &&
-			site.options?.wpcom_staging_blog_ids.length > 0
-		)
-	) {
+			site.options.wpcom_staging_blog_ids.length > 0 ) ||
+		( site.options?.wpcom_production_blog_id && site.options.wpcom_production_blog_id > 0 );
+
+	if ( ! hasEnvironmentSwitchingCapability ) {
+		// eslint-disable-next-line no-console
+		console.log( 'SiteEnvironmentSwitcher hidden: not a staging site and no linked staging site', {
+			siteId: site.ID,
+		} );
 		return;
 	}
 
-	const productionSiteId = site.is_wpcom_staging_site
-		? site.options?.wpcom_production_blog_id
-		: site.ID;
+	// Determine if this is actually a staging site - either flagged as staging OR has a production blog ID
+	const isActuallyStaging =
+		site.is_wpcom_staging_site ||
+		( site.options?.wpcom_production_blog_id && site.options.wpcom_production_blog_id > 0 );
 
-	const stagingSiteId = ! site.is_wpcom_staging_site
-		? site.options?.wpcom_staging_blog_ids?.[ 0 ]
-		: undefined;
+	const productionSiteId = isActuallyStaging ? site.options?.wpcom_production_blog_id : site.ID;
+
+	const stagingSiteId = ! isActuallyStaging ? site.options?.wpcom_staging_blog_ids?.[ 0 ] : site.ID; // If we're on staging, the current site IS the staging site
+
+	// eslint-disable-next-line no-console
+	console.log( 'Environment switcher IDs', {
+		siteId: site.ID,
+		isActuallyStaging,
+		productionSiteId,
+		stagingSiteId,
+	} );
+
+	// If we don't have valid site IDs for switching, don't show the switcher
+	if ( ! productionSiteId || productionSiteId === 0 ) {
+		// eslint-disable-next-line no-console
+		console.log( 'SiteEnvironmentSwitcher hidden: invalid production site ID', {
+			siteId: site.ID,
+			productionSiteId,
+		} );
+		return;
+	}
 
 	const setEnvironment = ( siteIdToChange: number | undefined ) => {
 		if ( siteIdToChange === site.ID ) {
@@ -51,27 +87,38 @@ export default function SiteEnvironmentSwitcher( {
 			icon={ chevronDownSmall }
 			label={ __( 'Select environment' ) }
 			toggleProps={ {
-				as: ( props ) => (
-					<ToggleComponent isStaging={ !! site.is_wpcom_staging_site } { ...props } />
-				),
+				as: ( props ) => <ToggleComponent isStaging={ isActuallyStaging } { ...props } />,
 			} }
 			popoverProps={ {
 				placement: 'bottom-start',
 				className: 'site-preview-pane__site-switcher-dropdown-menu',
 			} }
-			controls={ [
-				{
-					title: __( 'Production' ),
-					onClick: () => setEnvironment( productionSiteId ),
-					isActive: ! site.is_wpcom_staging_site,
-				},
-				{
-					title: __( 'Staging' ),
-					onClick: () => setEnvironment( stagingSiteId ),
-					isActive: site.is_wpcom_staging_site,
-				},
-			] }
-		/>
+		>
+			{ ( { onClose } ) => (
+				<>
+					<MenuItem
+						onClick={ () => {
+							setEnvironment( productionSiteId );
+							onClose();
+						} }
+						aria-pressed={ ! isActuallyStaging ? 'true' : 'false' }
+					>
+						{ __( 'Production' ) }
+					</MenuItem>
+					{ stagingSiteId && (
+						<MenuItem
+							onClick={ () => {
+								setEnvironment( stagingSiteId );
+								onClose();
+							} }
+							aria-pressed={ isActuallyStaging ? 'true' : 'false' }
+						>
+							{ __( 'Staging' ) }
+						</MenuItem>
+					) }
+				</>
+			) }
+		</DropdownMenu>
 	);
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->
Related to: p1755092072147569/1755077694.787479-slack-C04GESRBWKW

## Proposed Changes

We considered making the site switcher available earlier on staging sites. This PR is an proof-of-concept/ mvp. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?