### PR TITLE
fix(sites): prevent PreviewSizePicker crash from invalid previewSize values

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useRouter } from '@tanstack/react-router';
 import { Button, Modal } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { useAnalytics } from '../app/analytics';
 import { useAuth } from '../app/auth';
 import { isAutomatticianQuery } from '../app/queries/me-a8c';
@@ -76,7 +76,27 @@ export default function Sites() {
 	const fields = getFields( { isAutomattician, viewType: view.type } );
 	const actions = getActions( router );
 
-	const { data: filteredData, paginationInfo } = filterSortAndPaginate( sites ?? [], view, fields );
+	// Sanitize view to prevent PreviewSizePicker crashes
+	const sanitizedView = useMemo( () => {
+		const sanitized = { ...view };
+		
+		// If we have a grid layout with an invalid previewSize, reset it to a safe default
+		if ( sanitized.type === 'grid' && sanitized.layout?.previewSize ) {
+			const validSizes = [ 230, 290, 350, 430 ]; // From PreviewSizePicker imageSizes
+			if ( ! validSizes.includes( sanitized.layout.previewSize ) ) {
+				console.warn( 'Invalid previewSize detected and fixed:', {
+					invalid: sanitized.layout.previewSize,
+					fixed: 230,
+					validSizes
+				} );
+				sanitized.layout = { ...sanitized.layout, previewSize: 230 };
+			}
+		}
+		
+		return sanitized;
+	}, [ view ] );
+
+	const { data: filteredData, paginationInfo } = filterSortAndPaginate( sites ?? [], sanitizedView, fields );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
 	const handleViewChange = ( nextView: View ) => {
@@ -133,7 +153,7 @@ export default function Sites() {
 						data={ filteredData }
 						fields={ fields }
 						actions={ actions }
-						view={ view }
+						view={ sanitizedView }
 						isLoading={ isLoadingSites }
 						onChangeView={ handleViewChange }
 						defaultLayouts={ DEFAULT_LAYOUTS }


### PR DESCRIPTION
Fixes [DOTCOM-14221: Incorrect previewSize value for the sites dashboard results in sites not being visible](https://linear.app/a8c/issue/DOTCOM-14221/incorrect-previewsize-value-for-the-sites-dashboard-results-in-sites)

## Proposed Changes

* Added defensive sanitization logic to the dashboard sites component (https://wordpress.com/sites) to prevent PreviewSizePicker crashes
* Added validation for `previewSize` values in grid layout view state before passing to DataViews
* Invalid `previewSize` values are automatically reset to safe default (230) with console warnings for debugging

## Before:

<img width="1210" height="620" alt="image" src="https://github.com/user-attachments/assets/676d9b1e-aaca-461b-90ee-ff6d22a23f74" />

## After

<img width="2318" height="1276" alt="image" src="https://github.com/user-attachments/assets/32cb345c-99e7-4b51-ba01-9b6ecd5389aa" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Some users have corrupted `previewSize` values stored in their server-side view preferences for the sites dashboard. When these users click the settings cog wheel icon, the WordPress DataViews PreviewSizePicker component crashes with "Cannot read properties of undefined (reading 'index')" because it expects specific values from [230, 290, 350, 430] but receives invalid data. 

```sh
preview-size-picker.js:55 Uncaught TypeError: Cannot read properties of undefined (reading 'index')
    at PreviewSizePicker (preview-size-picker.js:55:41)
    at renderWithHooks (react-dom.development.js:15486:18)
    at mountIndeterminateComponent (react-dom.development.js:20099:13)
    at beginWork (react-dom.development.js:21622:16)
    at HTMLUnknownElement.callCallback (react-dom.development.js:4164:14)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:4213:16)
    at invokeGuardedCallback (react-dom.development.js:4277:31)
    at beginWork$1 (react-dom.development.js:27486:7)
    at performUnitOfWork (react-dom.development.js:26592:12)
    at workLoopSync (react-dom.development.js:26501:5)
PreviewSizePicker @ preview-size-picker.js:55
renderWithHooks @ react-dom.development.js:15486
mountIndeterminateComponent @ react-dom.development.js:20099
beginWork @ react-dom.development.js:21622
callCallback @ react-dom.development.js:4164
invokeGuardedCallbackDev @ react-dom.development.js:4213
invokeGuardedCallback @ react-dom.development.js:4277
beginWork$1 @ react-dom.development.js:27486
performUnitOfWork @ react-dom.development.js:26592
workLoopSync @ react-dom.development.js:26501
renderRootSync @ react-dom.development.js:26469
performSyncWorkOnRoot @ react-dom.development.js:26120
flushSyncCallbacks @ react-dom.development.js:12042
eval @ react-dom.development.js:25686
```

This crash makes the sites dashboard settings completely inaccessible and persists across sessions, browsers, and machines since the corrupted data is stored server-side. The fix adds defensive validation to sanitize invalid preference data before it can crash the component.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### To reproduce the original issue (before fix):

1. Navigate to http://calypso.localhost:3000/sites
2. Click on the settings cog wheel icon in the DataViews toolbar
3. Observe crash with "Cannot read properties of undefined (reading 'index')" error

### To test the fix:

1. Apply the changes and navigate to http://calypso.localhost:3000/sites
2. Click on the settings cog wheel icon
3. Verify that the settings dropdown opens without crashing
4. Check browser console for any "Invalid previewSize detected and fixed" warning messages
5. Test switching between table and grid views to ensure functionality works correctly

### Additional testing:

- Test with users who previously experienced the crash (like the ticket in the Linear report)
- Verify fix works across different browsers and sessions
- Confirm that valid `previewSize` values continue to work as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

Fixed with [Claude Code](https://www.anthropic.com/claude-code) assistance.