### PR TITLE
Newsletter importer: Update billing warning copy

### DIFF
--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -3,9 +3,10 @@ import { Card, ConfettiAnimation } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
 import { ProgressBar, ExternalLink, Notice } from '@wordpress/components';
 import { useReducedMotion } from '@wordpress/compose';
-import { createInterpolateElement } from '@wordpress/element';
+// removed createInterpolateElement in favor of fixMe + translate with components
 import { __, sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
+import { fixMe, translate } from 'i18n-calypso';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import pauseSubstackBillingImg from 'calypso/assets/images/importer/pause-substack-billing.png';
 import { Steps, StepStatus } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
@@ -182,22 +183,41 @@ export default function Summary( {
 				{ showPauseSubstackBillingWarning && (
 					<Notice status="warning" className="importer__notice" isDismissible={ false }>
 						<h2>{ __( 'Action required' ) }</h2>
-						{ createInterpolateElement(
-							__(
-								'To prevent any charges from Substack, go to your <substackPaymentsSettingsLink>Substack Payments Settings</substackPaymentsSettingsLink>, select "Pause billing" and click "<strong>Pause indefinitely</strong>".'
+						{ fixMe( {
+							text: 'To prevent double-charging your subscribers, go to your {{substackPaymentsSettingsLink}}Substack Payments Settings{{/substackPaymentsSettingsLink}} and click "{{strong}}Pause{{/strong}}".',
+							newCopy: translate(
+								'To prevent double-charging your subscribers, go to your {{substackPaymentsSettingsLink}}Substack Payments Settings{{/substackPaymentsSettingsLink}} and click "{{strong}}Pause{{/strong}}".',
+								{
+									components: {
+										strong: <strong />,
+										substackPaymentsSettingsLink: (
+											// @ts-expect-error Used in translate components doesn't need children.
+											<ExternalLink
+												href={ `https://${ normalizeFromSite(
+													fromSite
+												) }/publish/settings?search=Pause%20subscription` }
+											/>
+										),
+									},
+								}
 							),
-							{
-								strong: <strong />,
-								substackPaymentsSettingsLink: (
-									// @ts-expect-error Used in createInterpolateElement doesn't need children.
-									<ExternalLink
-										href={ `https://${ normalizeFromSite(
-											fromSite
-										) }/publish/settings?search=Pause%20subscription` }
-									/>
-								),
-							}
-						) }
+							oldCopy: translate(
+								'To prevent any charges from Substack, go to your {{substackPaymentsSettingsLink}}Substack Payments Settings{{/substackPaymentsSettingsLink}}, select "Pause billing" and click "{{strong}}Pause indefinitely{{/strong}}".',
+								{
+									components: {
+										strong: <strong />,
+										substackPaymentsSettingsLink: (
+											// @ts-expect-error Used in translate components doesn't need children.
+											<ExternalLink
+												href={ `https://${ normalizeFromSite(
+													fromSite
+												) }/publish/settings?search=Pause%20subscription` }
+											/>
+										),
+									},
+								}
+							),
+						} ) }
 						<img
 							src={ pauseSubstackBillingImg }
 							alt={ __( 'Pause Substack billing' ) }

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -183,9 +183,9 @@ export default function Summary( {
 					<Notice status="warning" className="importer__notice" isDismissible={ false }>
 						<h2>{ __( 'Action required' ) }</h2>
 						{ fixMe( {
-							text: 'To prevent double-charging your subscribers, go to your {{substackPaymentsSettingsLink}}Substack Payments Settings{{/substackPaymentsSettingsLink}} and under "Pause subscription billing" click {{strong}}Pause{{/strong}}.',
+							text: 'To prevent double-charging your subscribers, go to your {{substackPaymentsSettingsLink}}Substack Payments Settings{{/substackPaymentsSettingsLink}} and under "Pause subscription billing," click {{strong}}Pause{{/strong}}.',
 							newCopy: translate(
-								'To prevent double-charging your subscribers, go to your {{substackPaymentsSettingsLink}}Substack Payments Settings{{/substackPaymentsSettingsLink}} and under "Pause subscription billing" click {{strong}}Pause{{/strong}}.',
+								'To prevent double-charging your subscribers, go to your {{substackPaymentsSettingsLink}}Substack Payments Settings{{/substackPaymentsSettingsLink}} and under "Pause subscription billing," click {{strong}}Pause{{/strong}}.',
 								{
 									components: {
 										strong: <strong />,

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -3,7 +3,6 @@ import { Card, ConfettiAnimation } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
 import { ProgressBar, ExternalLink, Notice } from '@wordpress/components';
 import { useReducedMotion } from '@wordpress/compose';
-// removed createInterpolateElement in favor of fixMe + translate with components
 import { __, sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { fixMe, translate } from 'i18n-calypso';

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -183,9 +183,9 @@ export default function Summary( {
 					<Notice status="warning" className="importer__notice" isDismissible={ false }>
 						<h2>{ __( 'Action required' ) }</h2>
 						{ fixMe( {
-							text: 'To prevent double-charging your subscribers, go to your {{substackPaymentsSettingsLink}}Substack Payments Settings{{/substackPaymentsSettingsLink}} and click "{{strong}}Pause{{/strong}}".',
+							text: 'To prevent double-charging your subscribers, go to your {{substackPaymentsSettingsLink}}Substack Payments Settings{{/substackPaymentsSettingsLink}} and under "Pause subscription billing" click {{strong}}Pause{{/strong}}.',
 							newCopy: translate(
-								'To prevent double-charging your subscribers, go to your {{substackPaymentsSettingsLink}}Substack Payments Settings{{/substackPaymentsSettingsLink}} and click "{{strong}}Pause{{/strong}}".',
+								'To prevent double-charging your subscribers, go to your {{substackPaymentsSettingsLink}}Substack Payments Settings{{/substackPaymentsSettingsLink}} and under "Pause subscription billing" click {{strong}}Pause{{/strong}}.',
 								{
 									components: {
 										strong: <strong />,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/CML-787/improve-wording-on-substack-subscriber-import-to-prevent-double

## Proposed Changes

* Improve wording on newsletter paid subscriber import to prevent double charging. New copy: 

> To prevent double-charging your subscribers, go to your Substack Payments Settings and under "Pause subscription billing," click **Pause**.

Before | After
---- | -----
<img width="698" height="279" alt="Screenshot 2025-08-13 at 5 10 11 PM" src="https://github.com/user-attachments/assets/e00bd095-9341-4d8c-8fa3-5446789d35fb" /> | <img width="688" height="268" alt="Screenshot 2025-08-14 at 10 53 18 AM" src="https://github.com/user-attachments/assets/f725b935-7299-4f6e-b894-d2f575445f70" />


For reference, here's the settings page we link to:

<img width="1294" height="406" alt="Screenshot 2025-08-13 at 5 17 23 PM" src="https://github.com/user-attachments/assets/b9d219e0-c49c-4364-9205-359067b991e8" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* A user imported paid subscribers and did not understand that they had to cancel the previous paid subscriptions.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You can force the notice to show up by setting `showPauseSubstackBillingWarning` to `true` or copying the `Notice` component into `if ( importerStatus === 'skipped' ) {...`.
* Then start an import at `/import/newsletter/substack/` and get to the summary screen.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
