### PR TITLE
Staging Sites Redesign: Fix Sync Button Showing Too Early

### DIFF
--- a/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
@@ -5,7 +5,9 @@ import { __ } from '@wordpress/i18n';
 import { chevronDown, cloudDownload, cloudUpload } from '@wordpress/icons';
 import { lazy, Suspense } from 'react';
 import { siteBySlugQuery } from '../../app/queries/site';
+import { siteLatestAtomicTransferQuery } from '../../app/queries/site-atomic-transfers';
 import { stagingSiteSyncStateQuery } from '../../app/queries/site-staging-sites';
+import { isAtomicTransferInProgress } from '../../utils/site-atomic-transfers';
 import {
 	getProductionSiteId,
 	getStagingSiteId,
@@ -42,6 +44,16 @@ export default function StagingSiteSyncDropdown( {
 	const productionSiteId = site ? getProductionSiteId( site ) : null;
 	const stagingSiteId = site ? getStagingSiteId( site ) : null;
 
+	// Check atomic transfer status for staging site
+	const { data: atomicTransfer } = useQuery( {
+		...siteLatestAtomicTransferQuery( stagingSiteId ?? 0 ),
+		enabled: !! stagingSiteId,
+	} );
+
+	const isStagingSiteReady = atomicTransfer
+		? ! isAtomicTransferInProgress( atomicTransfer.status )
+		: false;
+
 	const { data: stagingSiteSyncState, refetch: fetchStagingSiteSyncState } = useQuery( {
 		...stagingSiteSyncStateQuery( productionSiteId ?? 0 ),
 		enabled: !! productionSiteId,
@@ -74,7 +86,7 @@ export default function StagingSiteSyncDropdown( {
 
 	// The sync is not allowed if the staging site is in a transition or is deleting.
 	// We should consider this when we start to rewrite the StagingSiteSyncModal.
-	if ( ! productionSiteId || ! stagingSiteId ) {
+	if ( ! productionSiteId || ! stagingSiteId || ! isStagingSiteReady ) {
 		return null;
 	}
 

--- a/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
@@ -47,6 +47,9 @@ export default function StagingSiteSyncDropdown( {
 	// Check atomic transfer status for staging site
 	const { data: atomicTransfer } = useQuery( {
 		...siteLatestAtomicTransferQuery( stagingSiteId ?? 0 ),
+		refetchInterval: ( query ) => {
+			return isAtomicTransferInProgress( query.state.data?.status ?? 'pending' ) ? 3000 : false;
+		},
 		enabled: !! stagingSiteId,
 	} );
 

--- a/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
@@ -6,6 +6,7 @@ import { chevronDown, cloudDownload, cloudUpload } from '@wordpress/icons';
 import { lazy, Suspense } from 'react';
 import { siteBySlugQuery, siteByIdQuery } from '../../app/queries/site';
 import { stagingSiteSyncStateQuery } from '../../app/queries/site-staging-sites';
+import { hasManageOptions } from '../../utils/site-capabilities';
 import {
 	getProductionSiteId,
 	getStagingSiteId,
@@ -41,18 +42,16 @@ export default function StagingSiteSyncDropdown( {
 
 	const productionSiteId = site ? getProductionSiteId( site ) : null;
 	const stagingSiteId = site ? getStagingSiteId( site ) : null;
-	const siteHasManageOptions = ( site: Site ) => site?.capabilities?.manage_options;
 
 	const { data: stagingSite } = useQuery( {
 		...siteByIdQuery( stagingSiteId ?? 0 ),
 		refetchInterval: ( query ) => {
-			return siteHasManageOptions( query.state.data ) ? false : 5000;
+			return hasManageOptions( query.state.data ) ? false : 5000;
 		},
 		enabled: !! stagingSiteId,
 	} );
 
-	const isStagingSite = !! stagingSiteId;
-	const isStagingSiteTransferInProgress = isStagingSite && ! siteHasManageOptions( stagingSite );
+	const isStagingSiteTransferInProgress = !! stagingSiteId && ! hasManageOptions( stagingSite );
 
 	const { data: stagingSiteSyncState, refetch: fetchStagingSiteSyncState } = useQuery( {
 		...stagingSiteSyncStateQuery( productionSiteId ?? 0 ),

--- a/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
@@ -5,7 +5,9 @@ import { __ } from '@wordpress/i18n';
 import { chevronDown, cloudDownload, cloudUpload } from '@wordpress/icons';
 import { lazy, Suspense } from 'react';
 import { siteBySlugQuery, siteByIdQuery } from '../../app/queries/site';
+import { siteLatestAtomicTransferQuery } from '../../app/queries/site-atomic-transfers';
 import { stagingSiteSyncStateQuery } from '../../app/queries/site-staging-sites';
+import { isAtomicTransferInProgress } from '../../utils/site-atomic-transfers';
 import { hasManageOptions } from '../../utils/site-capabilities';
 import {
 	getProductionSiteId,
@@ -43,6 +45,14 @@ export default function StagingSiteSyncDropdown( {
 	const productionSiteId = site ? getProductionSiteId( site ) : null;
 	const stagingSiteId = site ? getStagingSiteId( site ) : null;
 
+	const { data: atomicTransfer } = useQuery( {
+		...siteLatestAtomicTransferQuery( stagingSiteId ?? 0 ),
+		refetchInterval: ( query ) => {
+			return isAtomicTransferInProgress( query.state.data?.status ?? 'pending' ) ? 5000 : false;
+		},
+		enabled: !! stagingSiteId,
+	} );
+
 	const { data: stagingSite } = useQuery( {
 		...siteByIdQuery( stagingSiteId ?? 0 ),
 		refetchInterval: ( query ) => {
@@ -51,7 +61,10 @@ export default function StagingSiteSyncDropdown( {
 		enabled: !! stagingSiteId,
 	} );
 
-	const isStagingSiteTransferInProgress = !! stagingSiteId && ! hasManageOptions( stagingSite );
+	const isStagingSiteReady =
+		!! stagingSiteId &&
+		! isAtomicTransferInProgress( atomicTransfer?.status ?? 'pending' ) &&
+		hasManageOptions( stagingSite );
 
 	const { data: stagingSiteSyncState, refetch: fetchStagingSiteSyncState } = useQuery( {
 		...stagingSiteSyncStateQuery( productionSiteId ?? 0 ),
@@ -85,7 +98,7 @@ export default function StagingSiteSyncDropdown( {
 
 	// The sync is not allowed if the staging site is in a transition or is deleting.
 	// We should consider this when we start to rewrite the StagingSiteSyncModal.
-	if ( ! productionSiteId || ! stagingSiteId || isStagingSiteTransferInProgress ) {
+	if ( ! productionSiteId || ! stagingSiteId || ! isStagingSiteReady ) {
 		return null;
 	}
 

--- a/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
@@ -41,16 +41,18 @@ export default function StagingSiteSyncDropdown( {
 
 	const productionSiteId = site ? getProductionSiteId( site ) : null;
 	const stagingSiteId = site ? getStagingSiteId( site ) : null;
+	const siteHasManageOptions = ( site: Site ) => site?.capabilities?.manage_options;
 
 	const { data: stagingSite } = useQuery( {
 		...siteByIdQuery( stagingSiteId ?? 0 ),
+		refetchInterval: ( query ) => {
+			return siteHasManageOptions( query.state.data ) ? false : 5000;
+		},
 		enabled: !! stagingSiteId,
 	} );
 
 	const isStagingSite = !! stagingSiteId;
-	const stagingSiteHasManageOptions = stagingSite?.capabilities?.manage_options;
-
-	const isStagingSiteTransferInProgress = isStagingSite && ! stagingSiteHasManageOptions;
+	const isStagingSiteTransferInProgress = isStagingSite && ! siteHasManageOptions( stagingSite );
 
 	const { data: stagingSiteSyncState, refetch: fetchStagingSiteSyncState } = useQuery( {
 		...stagingSiteSyncStateQuery( productionSiteId ?? 0 ),

--- a/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
@@ -4,10 +4,8 @@ import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { chevronDown, cloudDownload, cloudUpload } from '@wordpress/icons';
 import { lazy, Suspense } from 'react';
-import { siteBySlugQuery } from '../../app/queries/site';
-import { siteLatestAtomicTransferQuery } from '../../app/queries/site-atomic-transfers';
+import { siteBySlugQuery, siteByIdQuery } from '../../app/queries/site';
 import { stagingSiteSyncStateQuery } from '../../app/queries/site-staging-sites';
-import { isAtomicTransferInProgress } from '../../utils/site-atomic-transfers';
 import {
 	getProductionSiteId,
 	getStagingSiteId,
@@ -44,18 +42,15 @@ export default function StagingSiteSyncDropdown( {
 	const productionSiteId = site ? getProductionSiteId( site ) : null;
 	const stagingSiteId = site ? getStagingSiteId( site ) : null;
 
-	// Check atomic transfer status for staging site
-	const { data: atomicTransfer } = useQuery( {
-		...siteLatestAtomicTransferQuery( stagingSiteId ?? 0 ),
-		refetchInterval: ( query ) => {
-			return isAtomicTransferInProgress( query.state.data?.status ?? 'pending' ) ? 3000 : false;
-		},
+	const { data: stagingSite } = useQuery( {
+		...siteByIdQuery( stagingSiteId ?? 0 ),
 		enabled: !! stagingSiteId,
 	} );
 
-	const isStagingSiteReady = atomicTransfer
-		? ! isAtomicTransferInProgress( atomicTransfer.status )
-		: false;
+	const isStagingSite = !! stagingSiteId;
+	const stagingSiteHasManageOptions = stagingSite?.capabilities?.manage_options;
+
+	const isStagingSiteTransferInProgress = isStagingSite && ! stagingSiteHasManageOptions;
 
 	const { data: stagingSiteSyncState, refetch: fetchStagingSiteSyncState } = useQuery( {
 		...stagingSiteSyncStateQuery( productionSiteId ?? 0 ),
@@ -89,7 +84,7 @@ export default function StagingSiteSyncDropdown( {
 
 	// The sync is not allowed if the staging site is in a transition or is deleting.
 	// We should consider this when we start to rewrite the StagingSiteSyncModal.
-	if ( ! productionSiteId || ! stagingSiteId || ! isStagingSiteReady ) {
+	if ( ! productionSiteId || ! stagingSiteId || isStagingSiteTransferInProgress ) {
 		return null;
 	}
 

--- a/client/dashboard/utils/site-capabilities.ts
+++ b/client/dashboard/utils/site-capabilities.ts
@@ -1,7 +1,7 @@
 import type { Site } from '../data/types';
 
-export const hasManageOptions = ( site: Site ) => {
-	if ( ! site.capabilities ) {
+export const hasManageOptions = ( site: Site | undefined ) => {
+	if ( ! site?.capabilities ) {
 		return false;
 	}
 

--- a/client/dashboard/utils/site-capabilities.ts
+++ b/client/dashboard/utils/site-capabilities.ts
@@ -1,0 +1,9 @@
+import type { Site } from '../data/types';
+
+export const hasManageOptions = ( site: Site ) => {
+	if ( ! site.capabilities ) {
+		return false;
+	}
+
+	return Boolean( site.capabilities.manage_options );
+};

--- a/client/layout/hosting-dashboard/item-view/index.tsx
+++ b/client/layout/hosting-dashboard/item-view/index.tsx
@@ -5,13 +5,13 @@ import { GuidedTourStep } from 'calypso/components/guided-tour/step';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
+import { siteLatestAtomicTransferQuery } from 'calypso/dashboard/app/queries/site-atomic-transfers';
 import { isDeletingStagingSiteQuery } from 'calypso/dashboard/app/queries/site-staging-sites';
 import { queryClient } from 'calypso/dashboard/app/query-client';
+import { isAtomicTransferInProgress } from 'calypso/dashboard/utils/site-atomic-transfers';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import { StagingSiteCreationBanner } from 'calypso/sites/staging-site/components/staging-site-transfer-banner/staging-site-creation-banner';
 import { StagingSiteDeletionBanner } from 'calypso/sites/staging-site/components/staging-site-transfer-banner/staging-site-deletion-banner';
-import { useSelector } from 'calypso/state';
-import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import ItemViewContent from './item-view-content';
 import ItemViewHeader from './item-view-header';
 import ItemViewBreadcrumbsHeader from './item-view-header/breadcrumbs';
@@ -64,11 +64,16 @@ export default function ItemView( {
 	// so it can't be used here to determine if the site is a staging site
 	const isStagingSite = itemData.subtitle?.toString().startsWith( 'staging-' );
 
-	const isAtomicSite = useSelector( ( state ) =>
-		isSiteWpcomAtomic( state, itemData.blogId ?? null )
-	);
+	const { data: atomicTransfer } = useQuery( {
+		...siteLatestAtomicTransferQuery( itemData.blogId ?? 0 ),
+		refetchInterval: ( query ) => {
+			return isAtomicTransferInProgress( query.state.data?.status ?? 'pending' ) ? 5000 : false;
+		},
+		enabled: !! itemData.blogId && isStagingSite,
+	} );
 
-	const isStagingSiteTransferInProgress = isStagingSite && ! isAtomicSite;
+	const isStagingSiteTransferInProgress =
+		isStagingSite && isAtomicTransferInProgress( atomicTransfer?.status ?? 'pending' );
 
 	// Ensure we have features
 	if ( ! features || ! features.length ) {

--- a/client/layout/hosting-dashboard/item-view/index.tsx
+++ b/client/layout/hosting-dashboard/item-view/index.tsx
@@ -5,13 +5,13 @@ import { GuidedTourStep } from 'calypso/components/guided-tour/step';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
-import { siteLatestAtomicTransferQuery } from 'calypso/dashboard/app/queries/site-atomic-transfers';
 import { isDeletingStagingSiteQuery } from 'calypso/dashboard/app/queries/site-staging-sites';
 import { queryClient } from 'calypso/dashboard/app/query-client';
-import { isAtomicTransferInProgress } from 'calypso/dashboard/utils/site-atomic-transfers';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import { StagingSiteCreationBanner } from 'calypso/sites/staging-site/components/staging-site-transfer-banner/staging-site-creation-banner';
 import { StagingSiteDeletionBanner } from 'calypso/sites/staging-site/components/staging-site-transfer-banner/staging-site-deletion-banner';
+import { useSelector } from 'calypso/state';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import ItemViewContent from './item-view-content';
 import ItemViewHeader from './item-view-header';
 import ItemViewBreadcrumbsHeader from './item-view-header/breadcrumbs';
@@ -64,16 +64,11 @@ export default function ItemView( {
 	// so it can't be used here to determine if the site is a staging site
 	const isStagingSite = itemData.subtitle?.toString().startsWith( 'staging-' );
 
-	const { data: atomicTransfer } = useQuery( {
-		...siteLatestAtomicTransferQuery( itemData.blogId ?? 0 ),
-		refetchInterval: ( query ) => {
-			return isAtomicTransferInProgress( query.state.data?.status ?? 'pending' ) ? 5000 : false;
-		},
-		enabled: !! itemData.blogId && isStagingSite,
-	} );
+	const isAtomicSite = useSelector( ( state ) =>
+		isSiteWpcomAtomic( state, itemData.blogId ?? null )
+	);
 
-	const isStagingSiteTransferInProgress =
-		isStagingSite && isAtomicTransferInProgress( atomicTransfer?.status ?? 'pending' );
+	const isStagingSiteTransferInProgress = isStagingSite && ! isAtomicSite;
 
 	// Ensure we have features
 	if ( ! features || ! features.length ) {

--- a/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
@@ -1,10 +1,12 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQueryClient, useQuery } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useMemo, useEffect } from 'react';
+import { siteLatestAtomicTransferQuery } from 'calypso/dashboard/app/queries/site-atomic-transfers';
+import { isAtomicTransferInProgress } from 'calypso/dashboard/utils/site-atomic-transfers';
 import { USE_SITE_EXCERPTS_QUERY_KEY } from 'calypso/data/sites/use-site-excerpts-query';
 import { useAddStagingSiteMutation } from 'calypso/sites/staging-site/hooks/use-add-staging-site';
 import { useCheckStagingSiteStatus } from 'calypso/sites/staging-site/hooks/use-check-staging-site-status';
@@ -67,15 +69,28 @@ export default function HeaderStagingSiteButton( {
 	}, [ stagingSites ] );
 	const transferStatus = useCheckStagingSiteStatus( stagingSiteId );
 
+	// Check atomic transfer status for staging site
+	const { data: atomicTransfer } = useQuery( {
+		...siteLatestAtomicTransferQuery( stagingSiteId ?? 0 ),
+		refetchInterval: ( query ) => {
+			return isAtomicTransferInProgress( query.state.data?.status ?? 'pending' ) ? 3000 : false;
+		},
+		enabled: !! stagingSiteId,
+	} );
+
+	const isStagingSiteReady = atomicTransfer
+		? ! isAtomicTransferInProgress( atomicTransfer.status )
+		: false;
+
 	useEffect( () => {
-		if ( isCreatingStagingSite && transferStatus === transferStates.COMPLETE ) {
+		if ( isCreatingStagingSite && isStagingSiteReady ) {
 			dispatch( setStagingSiteStatus( siteId, StagingSiteStatus.COMPLETE ) );
 			queryClient.invalidateQueries( { queryKey: [ USE_SITE_EXCERPTS_QUERY_KEY ] } );
 			dispatch(
 				successNotice( __( 'Staging site added.' ), { id: stagingSiteAddSuccessNoticeId } )
 			);
 		}
-	}, [ __, dispatch, queryClient, siteId, transferStatus, isCreatingStagingSite ] );
+	}, [ __, dispatch, queryClient, siteId, isCreatingStagingSite, isStagingSiteReady ] );
 
 	const removeAllNotices = useCallback( () => {
 		dispatch( removeNotice( 'staging-site-add-success' ) );

--- a/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
@@ -6,6 +6,8 @@ import { plus } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useMemo, useEffect } from 'react';
 import { siteByIdQuery } from 'calypso/dashboard/app/queries/site';
+import { siteLatestAtomicTransferQuery } from 'calypso/dashboard/app/queries/site-atomic-transfers';
+import { isAtomicTransferInProgress } from 'calypso/dashboard/utils/site-atomic-transfers';
 import { hasManageOptions } from 'calypso/dashboard/utils/site-capabilities';
 import { USE_SITE_EXCERPTS_QUERY_KEY } from 'calypso/data/sites/use-site-excerpts-query';
 import { useAddStagingSiteMutation } from 'calypso/sites/staging-site/hooks/use-add-staging-site';
@@ -69,6 +71,14 @@ export default function HeaderStagingSiteButton( {
 	}, [ stagingSites ] );
 	const transferStatus = useCheckStagingSiteStatus( stagingSiteId );
 
+	const { data: atomicTransfer } = useQuery( {
+		...siteLatestAtomicTransferQuery( stagingSiteId ?? 0 ),
+		refetchInterval: ( query ) => {
+			return isAtomicTransferInProgress( query.state.data?.status ?? 'pending' ) ? 5000 : false;
+		},
+		enabled: !! stagingSiteId,
+	} );
+
 	const { data: stagingSite } = useQuery( {
 		...siteByIdQuery( stagingSiteId ?? 0 ),
 		refetchInterval: ( query ) => {
@@ -77,7 +87,10 @@ export default function HeaderStagingSiteButton( {
 		enabled: !! stagingSiteId,
 	} );
 
-	const isStagingSiteReady = !! stagingSiteId && hasManageOptions( stagingSite );
+	const isStagingSiteReady =
+		!! stagingSiteId &&
+		! isAtomicTransferInProgress( atomicTransfer?.status ?? 'pending' ) &&
+		hasManageOptions( stagingSite );
 
 	useEffect( () => {
 		if ( isCreatingStagingSite && isStagingSiteReady ) {

--- a/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
@@ -5,8 +5,8 @@ import { sprintf } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useMemo, useEffect } from 'react';
-import { siteLatestAtomicTransferQuery } from 'calypso/dashboard/app/queries/site-atomic-transfers';
-import { isAtomicTransferInProgress } from 'calypso/dashboard/utils/site-atomic-transfers';
+import { siteByIdQuery } from 'calypso/dashboard/app/queries/site';
+import { hasManageOptions } from 'calypso/dashboard/utils/site-capabilities';
 import { USE_SITE_EXCERPTS_QUERY_KEY } from 'calypso/data/sites/use-site-excerpts-query';
 import { useAddStagingSiteMutation } from 'calypso/sites/staging-site/hooks/use-add-staging-site';
 import { useCheckStagingSiteStatus } from 'calypso/sites/staging-site/hooks/use-check-staging-site-status';
@@ -69,18 +69,15 @@ export default function HeaderStagingSiteButton( {
 	}, [ stagingSites ] );
 	const transferStatus = useCheckStagingSiteStatus( stagingSiteId );
 
-	// Check atomic transfer status for staging site
-	const { data: atomicTransfer } = useQuery( {
-		...siteLatestAtomicTransferQuery( stagingSiteId ?? 0 ),
+	const { data: stagingSite } = useQuery( {
+		...siteByIdQuery( stagingSiteId ?? 0 ),
 		refetchInterval: ( query ) => {
-			return isAtomicTransferInProgress( query.state.data?.status ?? 'pending' ) ? 3000 : false;
+			return hasManageOptions( query.state.data ) ? false : 5000;
 		},
 		enabled: !! stagingSiteId,
 	} );
 
-	const isStagingSiteReady = atomicTransfer
-		? ! isAtomicTransferInProgress( atomicTransfer.status )
-		: false;
+	const isStagingSiteReady = !! stagingSiteId && hasManageOptions( stagingSite );
 
 	useEffect( () => {
 		if ( isCreatingStagingSite && isStagingSiteReady ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes [DOTCOM-14222 Staging Sites Redesign: Fix Sync Button Showing Too Early](https://linear.app/a8c/issue/DOTCOM-14222/staging-sites-redesign-fix-sync-button-showing-too-early)

## Proposed Changes

* Use a query to fetch the latest atomic transfer result 
* Use the query result to delay rendering the Sync button
* Use the query result to delay showing the success notice

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The staging site was still transferring to Atomic after the success notice and Sync button were shown. Related thread: p1755083115896159/1755077694.787479-slack-C04GESRBWKW

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to a site that doesn't yet have a staging site
* Click the "Add staging site" button
* Wait for the "Staging site added" success notice and Sync button to be shown
* Switch to the staging site using the environment switcher
* Check that the staging site creation banner is only briefly shown, and you can access any tabs for the staging site

https://github.com/user-attachments/assets/6ebc4cca-9491-48d5-83ba-bac1d4c0e180

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?