### PR TITLE
Site Overview: Update the upsell link for performance and backups

### DIFF
--- a/client/dashboard/sites/hosting-feature-gated-with-overview-card/index.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-overview-card/index.tsx
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { upsell } from '../../components/icons';
+import { isRelativeUrl } from '../../utils/url';
 import HostingFeatureGate from '../hosting-feature-gate';
 import OverviewCard from '../overview-card';
 import type { HostingFeatureGateProps } from '../hosting-feature-gate';
@@ -10,16 +11,14 @@ interface HostingFeatureGatedWithOverviewCardProps
 	featureIcon: OverviewCardProps[ 'icon' ];
 	upsellHeading: OverviewCardProps[ 'heading' ];
 	upsellDescription: OverviewCardProps[ 'description' ];
-	upsellLink?: OverviewCardProps[ 'link' ];
-	upsellExternalLink?: OverviewCardProps[ 'externalLink' ];
+	upsellLink: OverviewCardProps[ 'link' ];
 }
 
 export default function HostingFeatureGatedWithOverviewCard( {
 	featureIcon,
 	upsellHeading,
 	upsellDescription,
-	upsellLink,
-	upsellExternalLink,
+	upsellLink = '',
 	...props
 }: HostingFeatureGatedWithOverviewCardProps ) {
 	const { tracksFeatureId } = props;
@@ -29,6 +28,7 @@ export default function HostingFeatureGatedWithOverviewCard( {
 		icon: upsell,
 		description: upsellDescription,
 		variant: 'upsell' as const,
+		...( isRelativeUrl( upsellLink ) ? { link: upsellLink } : { externalLink: upsellLink } ),
 	};
 
 	return (
@@ -38,8 +38,6 @@ export default function HostingFeatureGatedWithOverviewCard( {
 				<OverviewCard
 					{ ...cardProps }
 					title={ __( 'Upgrade to unlock' ) }
-					link={ upsellLink }
-					externalLink={ upsellExternalLink }
 					tracksId={ tracksFeatureId }
 					onClick={ onClick }
 				/>

--- a/client/dashboard/sites/hosting-feature-gated-with-overview-card/index.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-overview-card/index.tsx
@@ -10,13 +10,15 @@ interface HostingFeatureGatedWithOverviewCardProps
 	featureIcon: OverviewCardProps[ 'icon' ];
 	upsellHeading: OverviewCardProps[ 'heading' ];
 	upsellDescription: OverviewCardProps[ 'description' ];
-	upsellExternalLink: OverviewCardProps[ 'externalLink' ];
+	upsellLink?: OverviewCardProps[ 'link' ];
+	upsellExternalLink?: OverviewCardProps[ 'externalLink' ];
 }
 
 export default function HostingFeatureGatedWithOverviewCard( {
 	featureIcon,
 	upsellHeading,
 	upsellDescription,
+	upsellLink,
 	upsellExternalLink,
 	...props
 }: HostingFeatureGatedWithOverviewCardProps ) {
@@ -36,6 +38,7 @@ export default function HostingFeatureGatedWithOverviewCard( {
 				<OverviewCard
 					{ ...cardProps }
 					title={ __( 'Upgrade to unlock' ) }
+					link={ upsellLink }
 					externalLink={ upsellExternalLink }
 					tracksId={ tracksFeatureId }
 					onClick={ onClick }

--- a/client/dashboard/sites/overview-backup-card/index.tsx
+++ b/client/dashboard/sites/overview-backup-card/index.tsx
@@ -58,7 +58,7 @@ export default function BackupCard( { site }: { site: Site } ) {
 			tracksFeatureId={ CARD_PROPS.tracksId }
 			upsellHeading={ __( 'Back up your site' ) }
 			upsellDescription={ __( 'Get back online quickly with one-click restores.' ) }
-			upsellExternalLink={ getBackupUrl( site ) }
+			upsellLink={ getBackupUrl( site ) }
 		>
 			<BackupCardContent site={ site } />
 		</HostingFeatureGatedWithOverviewCard>

--- a/client/dashboard/sites/overview-performance-card/index.tsx
+++ b/client/dashboard/sites/overview-performance-card/index.tsx
@@ -19,7 +19,7 @@ const CARD_PROPS = {
 
 function getPerformanceUrl( site: Site, device?: string ) {
 	const url = window?.location?.pathname?.startsWith( '/v2' )
-		? `https://wordpress.com/sites/performance/${ site.slug }`
+		? `/sites/${ site.slug }/performance`
 		: `/sites/performance/${ site.slug }`;
 
 	return device && device !== 'mobile' ? addQueryArgs( url, { initialTab: device } ) : url;
@@ -159,7 +159,7 @@ export default function PerformanceCard( { site }: { site: Site } ) {
 			tracksFeatureId={ CARD_PROPS.tracksId }
 			upsellHeading={ __( 'Test site performance' ) }
 			upsellDescription={ __( 'Get detailed metrics and recommendations.' ) }
-			upsellExternalLink={ getPerformanceUrl( site ) }
+			upsellLink={ getPerformanceUrl( site ) }
 		>
 			<PerformanceCardContent site={ site } />
 		</HostingFeatureGatedWithOverviewCard>

--- a/client/dashboard/sites/overview-scan-card/index.tsx
+++ b/client/dashboard/sites/overview-scan-card/index.tsx
@@ -91,7 +91,7 @@ export default function ScanCard( { site }: { site: Site } ) {
 			tracksFeatureId={ CARD_PROPS.tracksId }
 			upsellHeading={ __( 'Scan for security threats' ) }
 			upsellDescription={ __( 'We guard your site. You run your business.' ) }
-			upsellExternalLink={ getScanURL( site ) }
+			upsellLink={ getScanURL( site ) }
 		>
 			<ScanCardContent site={ site } />
 		</HostingFeatureGatedWithOverviewCard>

--- a/client/dashboard/utils/site-backup.ts
+++ b/client/dashboard/utils/site-backup.ts
@@ -2,7 +2,11 @@ import { isSelfHostedJetpackConnected } from './site-types';
 import type { Site } from '../data/types';
 
 export function getBackupUrl( site: Site ) {
-	return isSelfHostedJetpackConnected( site )
-		? `https://cloud.jetpack.com/backup/${ site.slug }`
+	if ( isSelfHostedJetpackConnected( site ) ) {
+		return `https://cloud.jetpack.com/backup/${ site.slug }`;
+	}
+
+	return window?.location?.pathname?.startsWith( '/v2' )
+		? `/sites/${ site.slug }/backups`
 		: `https://wordpress.com/backup/${ site.slug }`;
 }

--- a/client/dashboard/utils/url.ts
+++ b/client/dashboard/utils/url.ts
@@ -1,0 +1,7 @@
+export function isRelativeUrl( url: string ) {
+	try {
+		return new URL( url, window.location.href ).origin === window.location.origin;
+	} catch {
+		return false;
+	}
+}

--- a/client/dashboard/utils/url.ts
+++ b/client/dashboard/utils/url.ts
@@ -1,7 +1,5 @@
+import { getProtocol } from '@wordpress/url';
+
 export function isRelativeUrl( url: string ) {
-	try {
-		return new URL( url, window.location.href ).origin === window.location.origin;
-	} catch {
-		return false;
-	}
+	return ! url.startsWith( '//' ) && ! getProtocol( url );
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* On v2, we have performance tab and backups tab, so it would be better to navigate to those tabs for the upsell instead of opening the external page on the new tab
* On v1, we have performance tab, so it would be better to navigate to that tab directly instead of opening it on the new tab

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

V2
* Go to /v2
* Select any simple site
* Click the performance card or backups card
* Ensure it opens the corresponding tab correctly

V1
* Go to /sites
* Select any simple site
* Click the performance card
* Ensure it opens the corresponding tab correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
