### PR TITLE
Update disable 2FA button and instructions to correctly refer to 'Two-Step Authentication'

### DIFF
--- a/client/me/security-2fa-code-prompt/index.jsx
+++ b/client/me/security-2fa-code-prompt/index.jsx
@@ -143,13 +143,13 @@ class Security2faCodePrompt extends Component {
 		switch ( this.props.action ) {
 			case 'disable-two-step':
 				return this.state.submittingCode
-					? this.props.translate( 'Disabling Two-Step Authentication…' )
-					: this.props.translate( 'Disable Two-Step Authentication' );
+					? this.props.translate( 'Disabling two-step authentication…' )
+					: this.props.translate( 'Disable two-step authentication' );
 
 			case 'enable-two-step':
 				return this.state.submittingCode
-					? this.props.translate( 'Enabling Two-Step Authentication…' )
-					: this.props.translate( 'Enable Two-Step Authentication' );
+					? this.props.translate( 'Enabling two-step authentication…' )
+					: this.props.translate( 'Enable two-step authentication' );
 
 			default:
 				return this.state.submittingCode

--- a/client/me/security-2fa-code-prompt/index.jsx
+++ b/client/me/security-2fa-code-prompt/index.jsx
@@ -143,13 +143,13 @@ class Security2faCodePrompt extends Component {
 		switch ( this.props.action ) {
 			case 'disable-two-step':
 				return this.state.submittingCode
-					? this.props.translate( 'Disabling Two-Step…' )
-					: this.props.translate( 'Disable Two-Step' );
+					? this.props.translate( 'Disabling Two-Step Authentication…' )
+					: this.props.translate( 'Disable Two-Step Authentication' );
 
 			case 'enable-two-step':
 				return this.state.submittingCode
-					? this.props.translate( 'Enabling Two-Step…' )
-					: this.props.translate( 'Enable Two-Step' );
+					? this.props.translate( 'Enabling Two-Step Authentication…' )
+					: this.props.translate( 'Enable Two-Step Authentication' );
 
 			default:
 				return this.state.submittingCode

--- a/client/me/security-2fa-disable/index.jsx
+++ b/client/me/security-2fa-disable/index.jsx
@@ -156,7 +156,7 @@ class Security2faDisable extends Component {
 						{ translate(
 							'To verify that you wish to disable two-step authentication, ' +
 								'enter the verification code from your device or a backup code, ' +
-								'and click "Disable Two-Step Authentication."'
+								'and click “Disable Two-Step Authentication.”'
 						) }
 					</p>
 					<Security2faCodePrompt
@@ -171,7 +171,7 @@ class Security2faDisable extends Component {
 
 		return (
 			<FormButton isPrimary={ false } scary onClick={ this.onRevealCodePrompt }>
-				{ translate( 'Disable Two-Step Authentication' ) }
+				{ translate( 'Disable two-step authentication' ) }
 			</FormButton>
 		);
 	}

--- a/client/me/security-2fa-disable/index.jsx
+++ b/client/me/security-2fa-disable/index.jsx
@@ -156,7 +156,7 @@ class Security2faDisable extends Component {
 						{ translate(
 							'To verify that you wish to disable two-step authentication, ' +
 								'enter the verification code from your device or a backup code, ' +
-								'and click "Disable two-step."'
+								'and click "Disable Two-Step Authentication."'
 						) }
 					</p>
 					<Security2faCodePrompt
@@ -171,7 +171,7 @@ class Security2faDisable extends Component {
 
 		return (
 			<FormButton isPrimary={ false } scary onClick={ this.onRevealCodePrompt }>
-				{ translate( 'Disable two-step authentication' ) }
+				{ translate( 'Disable Two-Step Authentication' ) }
 			</FormButton>
 		);
 	}

--- a/client/me/security-2fa-disable/index.jsx
+++ b/client/me/security-2fa-disable/index.jsx
@@ -156,7 +156,7 @@ class Security2faDisable extends Component {
 						{ translate(
 							'To verify that you wish to disable two-step authentication, ' +
 								'enter the verification code from your device or a backup code, ' +
-								'and click “Disable Two-Step Authentication.”'
+								'and click “Disable two-step authentication.”'
 						) }
 					</p>
 					<Security2faCodePrompt


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/99828

Fixes DOTCOM-12783

## Proposed Changes

* Changes disable button and associated instructions to include the full string 'Two-Step Authentication'

## Why are these changes being made?

For consistency with the rest of the page where the full phrase is used, not the abbreviated 'Two-Step'

## Testing Instructions

1. Go to /me/security/two-step
2. Click 'Disable Two-Step Authentication'
3. Check that the instructions in the panel that appear, and associated button both contain the full string 'Disable Two-Step Authentication'

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?


## Screenshots for Translation

<img width="421" height="72" alt="Screenshot 2025-09-08 at 14 20 02" src="https://github.com/user-attachments/assets/6fc0742c-a7ae-4705-8403-ca45c2a75149" />
<img width="360" height="68" alt="Screenshot 2025-09-08 at 14 21 58" src="https://github.com/user-attachments/assets/bffa2437-d2ee-4d9c-b40b-7832e934861c" />
<img width="385" height="79" alt="Screenshot 2025-09-08 at 14 22 15" src="https://github.com/user-attachments/assets/23655908-9f4e-4487-a10f-24c5ed9f1015" />
