### PR TITLE
Domains: Handle name-servers management access

### DIFF
--- a/client/dashboard/data/domain.ts
+++ b/client/dashboard/data/domain.ts
@@ -3,6 +3,8 @@ import type { DomainSummary } from './domains';
 
 export interface Domain extends DomainSummary {
 	is_gravatar_domain: boolean;
+	can_manage_name_servers: boolean;
+	cannot_manage_name_servers_reason: null | string;
 }
 
 export function fetchDomain( domainName: string ): Promise< Domain > {

--- a/client/dashboard/data/domains.ts
+++ b/client/dashboard/data/domains.ts
@@ -26,8 +26,10 @@ export interface DomainSummary {
 	blog_id: number;
 	blog_name: string;
 	can_manage_dns_records: boolean;
+	can_manage_name_servers: boolean;
 	can_update_contact_info: boolean;
 	can_set_as_primary: boolean;
+	cannot_manage_name_servers_reason: null | string;
 	current_user_can_create_site_from_domain_only: boolean;
 	current_user_can_manage: boolean;
 	current_user_is_owner: boolean | null;

--- a/client/dashboard/data/domains.ts
+++ b/client/dashboard/data/domains.ts
@@ -26,10 +26,8 @@ export interface DomainSummary {
 	blog_id: number;
 	blog_name: string;
 	can_manage_dns_records: boolean;
-	can_manage_name_servers: boolean;
 	can_update_contact_info: boolean;
 	can_set_as_primary: boolean;
-	cannot_manage_name_servers_reason: null | string;
 	current_user_can_create_site_from_domain_only: boolean;
 	current_user_can_manage: boolean;
 	current_user_is_owner: boolean | null;

--- a/client/dashboard/domains/name-servers/form.stories.tsx
+++ b/client/dashboard/domains/name-servers/form.stories.tsx
@@ -66,14 +66,3 @@ export const IsBusy: Story = {
 		onSubmit: action( 'onSubmit' ),
 	},
 };
-
-export const WithError: Story = {
-	args: {
-		domainName: 'example.com',
-		nameServers: [],
-		isBusy: false,
-		showUpsellNudge: false,
-		error: 'Name servers management is forbidden on mapped domains',
-		onSubmit: action( 'onSubmit' ),
-	},
-};

--- a/client/dashboard/domains/name-servers/form.stories.tsx
+++ b/client/dashboard/domains/name-servers/form.stories.tsx
@@ -73,7 +73,7 @@ export const WithError: Story = {
 		nameServers: [],
 		isBusy: false,
 		showUpsellNudge: false,
-		queryError: 'An error occurred while fetching name servers.',
+		error: 'Name servers management is forbidden on mapped domains',
 		onSubmit: action( 'onSubmit' ),
 	},
 };

--- a/client/dashboard/domains/name-servers/form.tsx
+++ b/client/dashboard/domains/name-servers/form.tsx
@@ -32,7 +32,7 @@ interface Props {
 	showUpsellNudge?: boolean;
 	nameServers?: string[];
 	isBusy?: boolean;
-	queryError?: string;
+	error?: string;
 	onSubmit: ( nameServers: string[] ) => void;
 }
 
@@ -41,7 +41,7 @@ export default function NameServersForm( {
 	showUpsellNudge,
 	nameServers = [],
 	isBusy,
-	queryError,
+	error,
 	onSubmit,
 }: Props ) {
 	const isWpcomNameservers = areAllWpcomNameServers( nameServers );
@@ -203,8 +203,8 @@ export default function NameServersForm( {
 	return (
 		<form onSubmit={ handleSubmit }>
 			<VStack spacing={ 4 }>
-				{ queryError && <Notice variant="error">{ queryError }</Notice> }
-				{ ! queryError && (
+				{ error && <Notice variant="error">{ error }</Notice> }
+				{ ! error && (
 					<>
 						<DataForm< FormData >
 							data={ formData }

--- a/client/dashboard/domains/name-servers/form.tsx
+++ b/client/dashboard/domains/name-servers/form.tsx
@@ -11,7 +11,6 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useCallback, useMemo } from 'react';
 import InlineSupportLink from '../../components/inline-support-link';
-import Notice from '../../components/notice';
 import {
 	MIN_NAME_SERVERS_LENGTH,
 	MAX_NAME_SERVERS_LENGTH,
@@ -32,7 +31,6 @@ interface Props {
 	showUpsellNudge?: boolean;
 	nameServers?: string[];
 	isBusy?: boolean;
-	error?: string;
 	onSubmit: ( nameServers: string[] ) => void;
 }
 
@@ -41,7 +39,6 @@ export default function NameServersForm( {
 	showUpsellNudge,
 	nameServers = [],
 	isBusy,
-	error,
 	onSubmit,
 }: Props ) {
 	const isWpcomNameservers = areAllWpcomNameServers( nameServers );
@@ -203,30 +200,25 @@ export default function NameServersForm( {
 	return (
 		<form onSubmit={ handleSubmit }>
 			<VStack spacing={ 4 }>
-				{ error && <Notice variant="error">{ error }</Notice> }
-				{ ! error && (
-					<>
-						<DataForm< FormData >
-							data={ formData }
-							fields={ fields }
-							form={ formObj }
-							onChange={ ( value ) => {
-								setFormData( ( data ) => ( { ...data, ...value } ) );
-							} }
-						/>
-						<div>
-							<Button
-								__next40pxDefaultSize
-								variant="primary"
-								type="submit"
-								disabled={ isBusy }
-								isBusy={ isBusy }
-							>
-								{ __( 'Save' ) }
-							</Button>
-						</div>
-					</>
-				) }
+				<DataForm< FormData >
+					data={ formData }
+					fields={ fields }
+					form={ formObj }
+					onChange={ ( value ) => {
+						setFormData( ( data ) => ( { ...data, ...value } ) );
+					} }
+				/>
+				<div>
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						type="submit"
+						disabled={ isBusy }
+						isBusy={ isBusy }
+					>
+						{ __( 'Save' ) }
+					</Button>
+				</div>
 			</VStack>
 		</form>
 	);

--- a/client/dashboard/domains/name-servers/index.tsx
+++ b/client/dashboard/domains/name-servers/index.tsx
@@ -10,6 +10,7 @@ import {
 	domainNameServersMutation,
 } from '../../app/queries/domain-name-servers';
 import { domainRoute } from '../../app/router';
+import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import NameServersForm from './form';
@@ -54,13 +55,16 @@ export default function NameServers() {
 		<PageLayout size="small" header={ <PageHeader title={ __( 'Name Servers' ) } /> }>
 			<Card>
 				<CardBody>
-					<NameServersForm
-						domainName={ domainName }
-						error={ errorMsg }
-						isBusy={ isUpdatingNameServers }
-						nameServers={ nameServers ?? [] }
-						onSubmit={ onSubmit }
-					/>
+					{ errorMsg ? (
+						<Notice variant="error">{ errorMsg }</Notice>
+					) : (
+						<NameServersForm
+							domainName={ domainName }
+							isBusy={ isUpdatingNameServers }
+							nameServers={ nameServers ?? [] }
+							onSubmit={ onSubmit }
+						/>
+					) }
 				</CardBody>
 			</Card>
 		</PageLayout>

--- a/client/dashboard/domains/name-servers/index.tsx
+++ b/client/dashboard/domains/name-servers/index.tsx
@@ -1,9 +1,10 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { Card, CardBody } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { useCallback } from 'react';
+import { useMemo, useCallback } from 'react';
+import { domainQuery } from '../../app/queries/domain';
 import {
 	domainNameServersQuery,
 	domainNameServersMutation,
@@ -20,6 +21,20 @@ export default function NameServers() {
 	const { mutate: updateNameServers, isPending: isUpdatingNameServers } = useMutation(
 		domainNameServersMutation( domainName )
 	);
+	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
+
+	const errorMsg = useMemo( () => {
+		if ( ! domain?.can_manage_name_servers ) {
+			return (
+				domain?.cannot_manage_name_servers_reason ||
+				__( 'You do not have permission to manage name servers.' )
+			);
+		}
+
+		if ( queryError ) {
+			return queryError.message;
+		}
+	}, [ domain, queryError ] );
 
 	const onSubmit = useCallback(
 		( ns: string[] ) => {
@@ -41,7 +56,7 @@ export default function NameServers() {
 				<CardBody>
 					<NameServersForm
 						domainName={ domainName }
-						queryError={ queryError?.message }
+						error={ errorMsg }
 						isBusy={ isUpdatingNameServers }
 						nameServers={ nameServers ?? [] }
 						onSubmit={ onSubmit }


### PR DESCRIPTION
Part of DOTDASH-254

## Proposed Changes

* Handle NameServers permission management

## Why are these changes being made?

* DOTDASH-254

## Testing Instructions

* Go to `/v2/domains/{DOMAIN_NAME}/name-servers`
* {DOMAIN_NAME} should be one without permission, example: `a8c.tv`
* Check if there is an error
* You can also check the story book

<img width="750" height="228" alt="Screenshot 2025-08-14 at 12 23 50" src="https://github.com/user-attachments/assets/181cdb19-04d5-4133-83f7-41781e9e309e" />

**Storybook:**
<img width="1070" height="248" alt="Screenshot 2025-08-14 at 12 30 37" src="https://github.com/user-attachments/assets/54f4932b-5c23-4bb5-b94f-3e3f21dfc000" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
