### PR TITLE
Disable self-serve plan downgrade from Premium to Personal

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/get-upsell-type.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/get-upsell-type.ts
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import {
 	isWpComMonthlyPlan,
 	isWpComBusinessPlan,
-	isWpComPremiumPlan,
 	isWpComAnnualPlan,
 	isWpComBiennialPlan,
 	isWpComTriennialPlan,
@@ -51,10 +50,6 @@ export function getUpsellType( reason: string, opts: UpsellOptions ): UpsellType
 		case 'budgetConstraints':
 			if ( ! canDowngrade ) {
 				return '';
-			}
-
-			if ( isWpComPremiumPlan( productSlug ) && isWpComAnnualPlan( productSlug ) ) {
-				return 'downgrade-personal';
 			}
 
 			if (


### PR DESCRIPTION
Something on the backend is currently broken leading to AT reverts during downgrade. Disable it temporarily until the backend is fixed

Part of #

## Proposed Changes

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* A report that downgrades to Personal would revert the site if it has the summer special flag

## Testing Instructions


* Get a Premium plan with the Store Sandbox
* Cancel it
* In the cancel flow, select that the plan is too expensive
* Personal offer should not appear

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
