### PR TITLE
A4A: Update the cancel subscription modal logic in the A4A Client app

### DIFF
--- a/client/a8c-for-agencies/components/a4a-confirmation-dialog/style.scss
+++ b/client/a8c-for-agencies/components/a4a-confirmation-dialog/style.scss
@@ -9,10 +9,10 @@
 
 	& .dialog__content {
 		h1.a4a-confirmation-dialog__heading {
-			font-size: rem(24px);
+			@include heading-x-large;
 		}
 		p, div {
-			font-size: rem(14px);
+			@include body-large;
 		}
 	}
 

--- a/client/a8c-for-agencies/components/a4a-confirmation-dialog/style.scss
+++ b/client/a8c-for-agencies/components/a4a-confirmation-dialog/style.scss
@@ -7,6 +7,15 @@
 		@include heading-large;
 	}
 
+	& .dialog__content {
+		h1.a4a-confirmation-dialog__heading {
+			font-size: rem(24px);
+		}
+		p {
+			font-size: rem(14px);
+		}
+	}
+
 	& .dialog__action-buttons {
 		display: flex;
 		flex-direction: row;

--- a/client/a8c-for-agencies/components/a4a-confirmation-dialog/style.scss
+++ b/client/a8c-for-agencies/components/a4a-confirmation-dialog/style.scss
@@ -11,7 +11,7 @@
 		h1.a4a-confirmation-dialog__heading {
 			font-size: rem(24px);
 		}
-		p {
+		p, div {
 			font-size: rem(14px);
 		}
 	}

--- a/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { isBefore, subDays } from 'date-fns';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { A4AConfirmationDialog } from 'calypso/a8c-for-agencies/components/a4a-confirmation-dialog';
@@ -57,17 +56,18 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 
 	const storeSubscription = subscription.subscription;
 
+	if ( ! storeSubscription ) {
+		return null;
+	}
+
 	const productName =
-		isBillingTypeBD && storeSubscription?.product_name
+		isBillingTypeBD && storeSubscription.product_name
 			? storeSubscription.product_name
 			: products?.find( ( product ) => product.product_id === subscription.product_id )?.name ?? '';
 
-	const refundPeriodDays = storeSubscription?.billing_interval_unit === 'month' ? 7 : 14;
-	const isWithinRefundPeriod =
-		storeSubscription?.subscribed_date &&
-		isBefore( subDays( new Date(), refundPeriodDays ), storeSubscription?.subscribed_date );
+	const refundPeriodDays = storeSubscription.billing_interval_unit === 'month' ? 7 : 14;
 
-	const expiryDate = storeSubscription?.expiry ?? '';
+	const expiryDate = storeSubscription.expiry ?? '';
 
 	return (
 		<>
@@ -90,12 +90,13 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 					) : (
 						<>
 							<div>
-								{ isWithinRefundPeriod
+								{ storeSubscription.is_refundable
 									? translate(
-											'{{b}}%(productName)s{{/b}} will be canceled and removed immediately. Since you are within the money-back period, you will be refunded.',
+											'{{b}}%(productName)s{{/b}} will be canceled and removed immediately. Since you are within the {{b}}%(refundPeriodDays)d money-back{{/b}} period, you will be refunded.',
 											{
 												args: {
 													productName,
+													refundPeriodDays,
 												},
 												components: {
 													b: <b />,
@@ -105,7 +106,7 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 											}
 									  )
 									: translate(
-											'{{b}}%(productName)s{{/b}} will be canceled, but it will remain active until %(expiryDate)s. After that, it will not renew',
+											'{{b}}%(productName)s{{/b}} will be canceled, but it will remain active {{b}}until %(expiryDate)s{{/b}}. After that, it will not renew',
 											{
 												args: {
 													productName,

--- a/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
@@ -1,11 +1,12 @@
 import { Button } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl, useLocale } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { A4AConfirmationDialog } from 'calypso/a8c-for-agencies/components/a4a-confirmation-dialog';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import useCancelClientSubscription from 'calypso/a8c-for-agencies/data/client/use-cancel-client-subscription';
 import useFetchClientProducts from 'calypso/a8c-for-agencies/data/client/use-fetch-client-products';
+import { formatDate } from 'calypso/dashboard/utils/datetime';
 import { useSelector, useDispatch } from 'calypso/state';
 import { getUserBillingType } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -86,6 +87,7 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 
 function A4ACancelSubscriptionContent( { subscription }: { subscription: Subscription } ) {
 	const translate = useTranslate();
+	const locale = useLocale();
 	const { data: products, isFetching: isFetchingProductInfo } = useFetchClientProducts( false );
 	const isBillingTypeBD = useSelector( getUserBillingType ) === 'billingdragon';
 
@@ -101,7 +103,9 @@ function A4ACancelSubscriptionContent( { subscription }: { subscription: Subscri
 			: products?.find( ( product ) => product.product_id === subscription.product_id )?.name ?? '';
 
 	if ( storeSubscription ) {
-		const expiryDate = storeSubscription.expiry ?? '';
+		const expiryDate = storeSubscription.expiry
+			? formatDate( new Date( storeSubscription.expiry ), locale, { dateStyle: 'long' } )
+			: '';
 		return (
 			<>
 				<div>
@@ -120,7 +124,7 @@ function A4ACancelSubscriptionContent( { subscription }: { subscription: Subscri
 								}
 						  )
 						: translate(
-								'{{b}}%(productName)s{{/b}} will be canceled, but it will remain active {{b}}until %(expiryDate)s{{/b}}. After that, it will not renew',
+								'{{b}}%(productName)s{{/b}} will be canceled, but it will remain active until {{b}}%(expiryDate)s{{/b}}. After that, it will not renew',
 								{
 									args: {
 										productName,

--- a/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
@@ -1,4 +1,6 @@
 import { Button } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { isBefore, subDays } from 'date-fns';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { A4AConfirmationDialog } from 'calypso/a8c-for-agencies/components/a4a-confirmation-dialog';
@@ -53,10 +55,19 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 		setIsVisible( false );
 	};
 
+	const storeSubscription = subscription.subscription;
+
 	const productName =
-		isBillingTypeBD && subscription.subscription?.product_name
-			? subscription.subscription.product_name
+		isBillingTypeBD && storeSubscription?.product_name
+			? storeSubscription.product_name
 			: products?.find( ( product ) => product.product_id === subscription.product_id )?.name ?? '';
+
+	const refundPeriodDays = storeSubscription?.billing_interval_unit === 'month' ? 7 : 14;
+	const isWithinRefundPeriod =
+		storeSubscription?.subscribed_date &&
+		isBefore( subDays( new Date(), refundPeriodDays ), storeSubscription?.subscribed_date );
+
+	const expiryDate = storeSubscription?.expiry ?? '';
 
 	return (
 		<>
@@ -77,19 +88,50 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 					{ isFetchingProductInfo ? (
 						<TextPlaceholder />
 					) : (
-						translate(
-							'{{b}}%(productName)s{{/b}} will be canceled, and you will no longer have access to it. Are you sure you want to cancel?',
-							{
-								args: {
-									productName,
-								},
-								components: {
-									b: <b />,
-								},
-								comment:
-									'%(productName)s is the name of the product that the user is about to cancel.',
-							}
-						)
+						<>
+							<div>
+								{ isWithinRefundPeriod
+									? translate(
+											'{{b}}%(productName)s{{/b}} will be canceled and removed immediately. Since you are within the money-back period, you will be refunded.',
+											{
+												args: {
+													productName,
+												},
+												components: {
+													b: <b />,
+												},
+												comment:
+													'%(productName)s is the name of the product that the user is about to cancel.',
+											}
+									  )
+									: translate(
+											'{{b}}%(productName)s{{/b}} will be canceled, but it will remain active until %(expiryDate)s. After that, it will not renew',
+											{
+												args: {
+													productName,
+													expiryDate,
+												},
+												components: {
+													b: <b />,
+												},
+												comment:
+													'%(productName)s is the name of the product that the user is about to cancel.',
+											}
+									  ) }
+							</div>
+							<p>{ translate( 'Are you sure you want to cancel?' ) }</p>
+							<p>
+								<a
+									href={ localizeUrl(
+										'https://wordpress.com/support/manage-purchases/cancel-a-purchase/'
+									) }
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									{ translate( 'Learn more about how product cancellations work.' ) }
+								</a>
+							</p>
+						</>
 					) }
 				</A4AConfirmationDialog>
 			) }

--- a/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
@@ -23,9 +23,6 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 
 	const [ isVisible, setIsVisible ] = useState( false );
 
-	const { data: products, isFetching: isFetchingProductInfo } = useFetchClientProducts( false );
-	const isBillingTypeBD = useSelector( getUserBillingType ) === 'billingdragon';
-
 	const { mutate: cancelSubscription, isPending } = useCancelClientSubscription( {
 		onSuccess: () => {
 			dispatch(
@@ -54,21 +51,6 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 		setIsVisible( false );
 	};
 
-	const storeSubscription = subscription.subscription;
-
-	if ( ! storeSubscription ) {
-		return null;
-	}
-
-	const productName =
-		isBillingTypeBD && storeSubscription.product_name
-			? storeSubscription.product_name
-			: products?.find( ( product ) => product.product_id === subscription.product_id )?.name ?? '';
-
-	const refundPeriodDays = storeSubscription.billing_interval_unit === 'month' ? 7 : 14;
-
-	const expiryDate = storeSubscription.expiry ?? '';
-
 	return (
 		<>
 			<Button compact onClick={ () => setIsVisible( true ) }>
@@ -85,57 +67,91 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 					isLoading={ isPending }
 					isDestructive
 				>
-					{ isFetchingProductInfo ? (
-						<TextPlaceholder />
-					) : (
-						<>
-							<div>
-								{ storeSubscription.is_refundable
-									? translate(
-											'{{b}}%(productName)s{{/b}} will be canceled and removed immediately. Since you are within the {{b}}%(refundPeriodDays)d money-back{{/b}} period, you will be refunded.',
-											{
-												args: {
-													productName,
-													refundPeriodDays,
-												},
-												components: {
-													b: <b />,
-												},
-												comment:
-													'%(productName)s is the name of the product that the user is about to cancel.',
-											}
-									  )
-									: translate(
-											'{{b}}%(productName)s{{/b}} will be canceled, but it will remain active {{b}}until %(expiryDate)s{{/b}}. After that, it will not renew',
-											{
-												args: {
-													productName,
-													expiryDate,
-												},
-												components: {
-													b: <b />,
-												},
-												comment:
-													'%(productName)s is the name of the product that the user is about to cancel.',
-											}
-									  ) }
-							</div>
-							<p>{ translate( 'Are you sure you want to cancel?' ) }</p>
-							<p>
-								<a
-									href={ localizeUrl(
-										'https://wordpress.com/support/manage-purchases/cancel-a-purchase/'
-									) }
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									{ translate( 'Learn more about how product cancellations work.' ) }
-								</a>
-							</p>
-						</>
-					) }
+					<A4ACancelSubscriptionContent subscription={ subscription } />
 				</A4AConfirmationDialog>
 			) }
 		</>
+	);
+}
+
+function A4ACancelSubscriptionContent( { subscription }: { subscription: Subscription } ) {
+	const translate = useTranslate();
+	const { data: products, isFetching: isFetchingProductInfo } = useFetchClientProducts( false );
+	const isBillingTypeBD = useSelector( getUserBillingType ) === 'billingdragon';
+
+	if ( isFetchingProductInfo ) {
+		return <TextPlaceholder />;
+	}
+
+	const storeSubscription = subscription.subscription;
+
+	const productName =
+		isBillingTypeBD && storeSubscription?.product_name
+			? storeSubscription.product_name
+			: products?.find( ( product ) => product.product_id === subscription.product_id )?.name ?? '';
+
+	if ( storeSubscription ) {
+		const refundPeriodDays = storeSubscription.billing_interval_unit === 'month' ? 7 : 14;
+		const expiryDate = storeSubscription.expiry ?? '';
+		return (
+			<>
+				<div>
+					{ storeSubscription.is_refundable
+						? translate(
+								'{{b}}%(productName)s{{/b}} will be canceled and removed immediately. Since you are within the {{b}}%(refundPeriodDays)d money-back{{/b}} period, you will be refunded.',
+								{
+									args: {
+										productName,
+										refundPeriodDays,
+									},
+									components: {
+										b: <b />,
+									},
+									comment:
+										'%(productName)s is the name of the product that the user is about to cancel.',
+								}
+						  )
+						: translate(
+								'{{b}}%(productName)s{{/b}} will be canceled, but it will remain active {{b}}until %(expiryDate)s{{/b}}. After that, it will not renew',
+								{
+									args: {
+										productName,
+										expiryDate,
+									},
+									components: {
+										b: <b />,
+									},
+									comment:
+										'%(productName)s is the name of the product that the user is about to cancel.',
+								}
+						  ) }
+				</div>
+				<p>{ translate( 'Are you sure you want to cancel?' ) }</p>
+				<p>
+					<a
+						href={ localizeUrl(
+							'https://wordpress.com/support/manage-purchases/cancel-a-purchase/'
+						) }
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						{ translate( 'Learn more about how product cancellations work.' ) }
+					</a>
+				</p>
+			</>
+		);
+	}
+
+	return translate(
+		'{{b}}%(productName)s{{/b}} will be canceled, and you will no longer have access to it. Are you sure you want to cancel?',
+		{
+			args: {
+				productName,
+			},
+			components: {
+				b: <b />,
+			},
+			comment: '%(productName)s is the name of the product that the user is about to cancel.',
+		}
 	);
 }

--- a/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
@@ -51,11 +51,21 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 		setIsVisible( false );
 	};
 
+	// Check if auto-renew is enabled to determine if the cancel button should be shown
+	// If subscription.subscription is null, fallback to old behavior (show the button)
+	// If subscription.subscription exists but is_auto_renew_enabled is null/undefined, default to true (show the button)
+	// TODO: Later we might show added details and the ability to actually remove a cancelled subscription that has auto-renew disabled, like on the WPCOM side.
+	const isAutoRenewEnabled = subscription.subscription
+		? subscription.subscription.is_auto_renew_enabled ?? true
+		: true;
+
 	return (
 		<>
-			<Button compact onClick={ () => setIsVisible( true ) }>
-				{ translate( 'Cancel the subscription' ) }
-			</Button>
+			{ isAutoRenewEnabled && (
+				<Button compact onClick={ () => setIsVisible( true ) }>
+					{ translate( 'Cancel the subscription' ) }
+				</Button>
+			) }
 
 			{ isVisible && (
 				<A4AConfirmationDialog

--- a/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
@@ -101,18 +101,16 @@ function A4ACancelSubscriptionContent( { subscription }: { subscription: Subscri
 			: products?.find( ( product ) => product.product_id === subscription.product_id )?.name ?? '';
 
 	if ( storeSubscription ) {
-		const refundPeriodDays = storeSubscription.billing_interval_unit === 'month' ? 7 : 14;
 		const expiryDate = storeSubscription.expiry ?? '';
 		return (
 			<>
 				<div>
 					{ storeSubscription.is_refundable
 						? translate(
-								'{{b}}%(productName)s{{/b}} will be canceled and removed immediately. Since you are within the {{b}}%(refundPeriodDays)d money-back{{/b}} period, you will be refunded.',
+								'{{b}}%(productName)s{{/b}} will be canceled and removed immediately. Since you are within the money-back period, you will be refunded.',
 								{
 									args: {
 										productName,
-										refundPeriodDays,
 									},
 									components: {
 										b: <b />,
@@ -138,15 +136,19 @@ function A4ACancelSubscriptionContent( { subscription }: { subscription: Subscri
 				</div>
 				<p>{ translate( 'Are you sure you want to cancel?' ) }</p>
 				<p>
-					<a
-						href={ localizeUrl(
-							'https://wordpress.com/support/manage-purchases/cancel-a-purchase/'
-						) }
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						{ translate( 'Learn more about how product cancellations work.' ) }
-					</a>
+					{ translate( '{{link}}Learn more{{/link}} about how product cancellations work.', {
+						components: {
+							link: (
+								<a
+									href={ localizeUrl(
+										'https://wordpress.com/support/manage-purchases/cancel-a-purchase/'
+									) }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						},
+					} ) }
 				</p>
 			</>
 		);

--- a/client/a8c-for-agencies/sections/client/types.ts
+++ b/client/a8c-for-agencies/sections/client/types.ts
@@ -12,10 +12,8 @@ export interface ReferralProduct {
 		purchase_currency?: string;
 		billing_interval_unit?: string;
 		status: string;
-		subscribed_date?: string;
 		expiry?: string;
-		auto_renew: boolean;
-		renew_date?: string;
+		is_auto_renew_enabled: boolean;
 		is_refundable?: boolean;
 	};
 	site_assigned: string;

--- a/client/a8c-for-agencies/sections/client/types.ts
+++ b/client/a8c-for-agencies/sections/client/types.ts
@@ -16,6 +16,7 @@ export interface ReferralProduct {
 		expiry?: string;
 		auto_renew: boolean;
 		renew_date?: string;
+		is_refundable?: boolean;
 	};
 	site_assigned: string;
 }

--- a/client/a8c-for-agencies/sections/client/types.ts
+++ b/client/a8c-for-agencies/sections/client/types.ts
@@ -12,6 +12,10 @@ export interface ReferralProduct {
 		purchase_currency?: string;
 		billing_interval_unit?: string;
 		status: string;
+		subscribed_date?: string;
+		expiry?: string;
+		auto_renew: boolean;
+		renew_date?: string;
 	};
 	site_assigned: string;
 }


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/A4A-1394/show-auto-renew-disabled-in-ui

## Proposed Changes

This PR updates the subscription cancellation modal logic in the A4A Client app based on the refund window period.

**Subscription Types:**

- Monthly => 7 days
- Yearly => 14 days

**Within in the refund window period:**

<img width="1081" height="382" alt="image" src="https://github.com/user-attachments/assets/cc637aeb-11db-4b40-be18-d2a9eed1b2de" />

**After the refund window period:**

<img width="797" height="322" alt="image" src="https://github.com/user-attachments/assets/272ba0b6-8271-4c21-a7b0-eee30a2f586a" />

### Follow-up PRs

- Notification after cancellation, based on the refund window period.
- Pop-up in the Canceled label with message `This product was canceled, but it will remain active until {Date}. After that, it will not renew.` (Client and Agency dashboards)


## Testing Instructions

- Ensure that  `public-api.wordpress.com` is pointing to your sandbox.
- If you need to purchase new referrals, be sure to enable the store sandbox on the backend and purchase using a test credit card, and not credits.
- Test the cancellation modal in 3 different scenarios

1. Before the refund window has passed (for a client with BD subscriptions)
<img width="1034" height="306" alt="Screenshot 2025-08-19 at 3 08 13 PM" src="https://github.com/user-attachments/assets/cb06cc29-b5ec-41be-a98b-342403bd6746" />


2. After the refund window has passed (for a client with BD subscriptions)
  * You can change the time the store thinks it is on the backend using the `wpcom_store_time_string` filter. You'll want to set the time to a time in the future when the refund window has passed (7+ days for monthly, 14+ days for yearly)
```
$mock_time = fn() => gmdate( 'Y-m-d H:i:s', strtotime( '+10 days' ) );
add_filter( 'wpcom_store_time_string', $mock_time );
```
<img width="798" height="321" alt="Screenshot 2025-08-19 at 3 16 23 PM" src="https://github.com/user-attachments/assets/c0f84e09-7043-4b58-9037-9fc845ea146b" />


3. Using an old client with non-BD subscriptions. You should see the old, unchanged modal.
<img width="923" height="227" alt="Screenshot 2025-08-19 at 2 51 17 PM" src="https://github.com/user-attachments/assets/4a849010-a757-4661-93dc-b4758a760577" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?