### PR TITLE
Backups Dashboard: refactor back up now button improving code organization

### DIFF
--- a/client/dashboard/app/queries/site-backups.ts
+++ b/client/dashboard/app/queries/site-backups.ts
@@ -13,7 +13,7 @@ export const siteLastBackupQuery = ( siteId: number ) =>
 
 export const siteBackupsQuery = ( siteId: number ) =>
 	queryOptions( {
-		queryKey: [ 'site', siteId, 'rewind', 'backups' ],
+		queryKey: [ 'site', siteId, 'backups' ],
 		queryFn: () => fetchSiteBackups( siteId ),
 	} );
 

--- a/client/dashboard/app/queries/site-backups.ts
+++ b/client/dashboard/app/queries/site-backups.ts
@@ -1,6 +1,8 @@
-import { queryOptions } from '@tanstack/react-query';
+import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import { fetchSiteRewindableActivityLog } from '../../data/site-activity-log';
+import { enqueueSiteBackup } from '../../data/site-backup';
 import { fetchSiteBackups } from '../../data/site-backups';
+import { queryClient } from '../query-client';
 
 export const siteLastBackupQuery = ( siteId: number ) =>
 	queryOptions( {
@@ -13,4 +15,12 @@ export const siteBackupsQuery = ( siteId: number ) =>
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'rewind', 'backups' ],
 		queryFn: () => fetchSiteBackups( siteId ),
+	} );
+
+export const siteBackupEnqueueMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: () => enqueueSiteBackup( siteId ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( siteBackupsQuery( siteId ) );
+		},
 	} );

--- a/client/dashboard/sites/backups/backup-now-button.tsx
+++ b/client/dashboard/sites/backups/backup-now-button.tsx
@@ -50,9 +50,7 @@ export function BackupNowButton( { site }: BackupNowButtonProps ) {
 		},
 		onSuccess: () => {
 			// Refresh rewind backups to check for new backup status
-			queryClient.invalidateQueries( {
-				queryKey: [ 'site', site.ID, 'rewind', 'backups' ],
-			} );
+			queryClient.invalidateQueries( siteBackupsQuery( site.ID ) );
 		},
 		onError: () => {
 			// Lets decide later what to do here

--- a/client/dashboard/sites/backups/backup-now-button.tsx
+++ b/client/dashboard/sites/backups/backup-now-button.tsx
@@ -1,9 +1,8 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useEffect, useState } from 'react';
-import { siteBackupsQuery } from '../../app/queries/site-backups';
-import { enqueueSiteBackup } from '../../data/site-backup';
+import { siteBackupEnqueueMutation, siteBackupsQuery } from '../../app/queries/site-backups';
 import { type BackupEntry } from '../../data/site-backups';
 import type { Site } from '../../data/types';
 
@@ -15,7 +14,6 @@ type BackupState = 'default' | 'enqueued' | 'in_progress';
 
 export function BackupNowButton( { site }: BackupNowButtonProps ) {
 	const [ isEnqueued, setIsEnqueued ] = useState( false );
-	const queryClient = useQueryClient();
 
 	// Determine current state
 	const getBackupState = useCallback(
@@ -44,16 +42,9 @@ export function BackupNowButton( { site }: BackupNowButtonProps ) {
 	} );
 
 	const { mutate: triggerBackup, isPending } = useMutation( {
-		mutationFn: () => {
+		...siteBackupEnqueueMutation( site.ID ),
+		onMutate: () => {
 			setIsEnqueued( true );
-			return enqueueSiteBackup( site.ID );
-		},
-		onSuccess: () => {
-			// Refresh rewind backups to check for new backup status
-			queryClient.invalidateQueries( siteBackupsQuery( site.ID ) );
-		},
-		onError: () => {
-			// Lets decide later what to do here
 		},
 	} );
 

--- a/client/dashboard/sites/backups/backup-now-button.tsx
+++ b/client/dashboard/sites/backups/backup-now-button.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Button, Tooltip } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useEffect, useState } from 'react';
 import { siteBackupsQuery } from '../../app/queries/site-backups';
@@ -85,16 +85,18 @@ export function BackupNowButton( { site }: BackupNowButtonProps ) {
 
 	const isBusy = backupState !== 'default' || isPending;
 
-	const button = (
+	return (
 		<Button
 			variant="secondary"
 			onClick={ () => triggerBackup() }
 			disabled={ isBusy }
 			isBusy={ isBusy }
+			accessibleWhenDisabled
+			description={ buttonContent[ backupState ].tooltip }
+			label={ buttonContent[ backupState ].label }
+			showTooltip
 		>
 			{ buttonContent[ backupState ].label }
 		</Button>
 	);
-
-	return <Tooltip text={ buttonContent[ backupState ].tooltip }>{ button }</Tooltip>;
 }

--- a/client/dashboard/sites/backups/backup-now-button.tsx
+++ b/client/dashboard/sites/backups/backup-now-button.tsx
@@ -17,17 +17,17 @@ export function BackupNowButton( { site }: BackupNowButtonProps ) {
 
 	// Determine current state
 	const getBackupState = useCallback(
-		( backups: BackupEntry[], enqueued: boolean ): BackupState => {
+		( backups: BackupEntry[] ): BackupState => {
 			const currentBackup = backups[ 0 ];
 			if ( currentBackup?.status === 'started' ) {
 				return 'in_progress';
 			}
-			if ( currentBackup?.status === 'queued' || enqueued ) {
+			if ( currentBackup?.status === 'queued' || isEnqueued ) {
 				return 'enqueued';
 			}
 			return 'default';
 		},
-		[]
+		[ isEnqueued ]
 	);
 
 	// Check for in-progress backup using rewind/backups endpoint
@@ -35,7 +35,7 @@ export function BackupNowButton( { site }: BackupNowButtonProps ) {
 		...siteBackupsQuery( site.ID ),
 		refetchInterval: ( query ) => {
 			const backups = query.state.data || [];
-			const backupState = getBackupState( backups, isEnqueued );
+			const backupState = getBackupState( backups );
 			// Poll when backup is enqueued or in progress
 			return backupState !== 'default' ? 2000 : false;
 		},
@@ -48,7 +48,7 @@ export function BackupNowButton( { site }: BackupNowButtonProps ) {
 		},
 	} );
 
-	const backupState = getBackupState( rewindBackups, isEnqueued );
+	const backupState = getBackupState( rewindBackups );
 
 	// Reset enqueued state when backup actually starts
 	useEffect( () => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to https://github.com/Automattic/wp-calypso/pull/105190

## Proposed Changes

* Move backup enqueue mutation to centralized queries file.
* Removed the Tooltip component and used the native tooltip on the Button component.
* Simplify backups query invalidation on success.
* Refactor backup state determination by removing unnecessary parameters.
* Removed unnecessary 'rewind' parameter from queryKey.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This PR aims to address post-merge code reviews from https://github.com/Automattic/wp-calypso/pull/105190.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Copy pasting test instructions of https://github.com/Automattic/wp-calypso/pull/105190:

* Navigate to `/v2/sites/SITE_SLUG/backups` using a site with the backup feature
* Ensure you see the `Back up now` button
* Open the developer console to monitor the Network calls
* Click on the `Back up now` button, it should switch to `Enqueued` state saying "Backup enqueued".
* It should start polling the /rewind/backups endpoint to fetch the status of the backup.
* Once the status is "started", the button switches to "Backup in progress".
* Once the status is "finished", the button will switch back to the default state of "Back up now".

After some seconds, you could refresh the Backup dashboard to see the new Backup. In a future iteration we will start polling the `siteRewindableActivityLogEntriesQuery` and handle error scenarios.

https://github.com/user-attachments/assets/ea9fdc89-577e-4dbb-b998-ec8b919df56a

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
