### PR TITLE
Site overview v2: implement empty state for Latest Activity card

### DIFF
--- a/client/dashboard/sites/overview-latest-activity-card/index.tsx
+++ b/client/dashboard/sites/overview-latest-activity-card/index.tsx
@@ -89,6 +89,7 @@ export default function LatestActivityCard( {
 						getItemId={ ( item ) => item.activity_id }
 						paginationInfo={ { totalItems: data.length, totalPages: 1 } }
 						defaultLayouts={ { list: {} } }
+						empty={ __( 'No activity yet.' ) }
 					>
 						<DataViews.Layout />
 					</DataViews>

--- a/client/sites/v2/site-overview/style.scss
+++ b/client/sites/v2/site-overview/style.scss
@@ -21,4 +21,15 @@
 			border-top: none;
 		}
 	}
+
+	.dataviews-wrapper {
+		.dataviews-no-results {
+			// In v1 we specify margins for <p> globally in <body>.
+			// Here, we revert them to make <p> look good in DataViews' empty state.
+			p {
+				margin-top: revert;
+				margin-bottom: revert;
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Proposed Changes

This PR (finally) implements empty state for the Latest Activity card.

|||
|-|-|
|Before (v1)|<img width="534" height="116" alt="image" src="https://github.com/user-attachments/assets/51e7748c-bfbd-4f93-8219-d3e23c787bce" />|
|Before (v2)|<img width="579" height="125" alt="image" src="https://github.com/user-attachments/assets/a6617a04-1c4b-41bf-a952-e914bf3267e8" />|
|After|<img width="592" height="130" alt="image" src="https://github.com/user-attachments/assets/ea815549-0528-4cb9-b8ab-b2c2fae66192" />|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a brand new site, or use a site which you haven't actually touched yet
2. Go to HD overview for that site, in v1 and v2
3. Verify they look good as screenshot above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
