### PR TITLE
Dashboard v2: apply default font size to modals as well

### DIFF
--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -40,6 +40,7 @@ body {
 		'Helvetica Neue', sans-serif;
 	background: var( --dashboard__background-color );
 	color: var( --dashboard__text-color );
+	font-size: $font-size-medium;
 	line-height: $font-line-height-small;
 
 	/* stylelint-disable-next-line unit-allowed-list */
@@ -52,8 +53,4 @@ body {
 
 a {
 	color: var( --wp-admin-theme-color );
-}
-
-#wpcom {
-	font-size: $font-size-medium;
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/pull/105170#discussion_r2275669438

## Proposed Changes

https://github.com/Automattic/wp-calypso/pull/105170 unsets font-size, line height, etc from `<Text>`, which was injected inline by `emotion`, so that we're using the styles from our global CSS:

https://github.com/Automattic/wp-calypso/blob/c5e64fbcc29b5130ddb2398fab45b64d419b62a5/client/dashboard/app/style.scss#L37-L59

However, curiously, only font-size is explicitly set to `#wpcom`:

https://github.com/Automattic/wp-calypso/blob/c5e64fbcc29b5130ddb2398fab45b64d419b62a5/client/dashboard/app/style.scss#L57-L59

This style won't get picked up by modals, because they are not inside it 😬 

This PR "fixes" it by moving the font size to the other styles in `<body>` together. I'm not very sure why it was put inside that. I tested and it seems there is no regressions.

|Before|After|
|-|-|
|<img width="521" height="372" alt="image" src="https://github.com/user-attachments/assets/d15c5cc9-a7f7-4482-ade8-dc53870aea9d" />|<img width="518" height="373" alt="image" src="https://github.com/user-attachments/assets/027503f1-2f8b-43b4-87c9-6adbcf1d8697" />


## Testing Instructions

1. Go to `/v2/sites/:siteSlug/domains` of a Simple site
2. Click the domain action and click `Change site address`
3. Verify the text look good
4. Click around hosting dashboard and verify you see no regressions 😄 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
