### PR TITLE
Reader: support webp images in feed view

### DIFF
--- a/client/lib/post-normalizer/utils/is-url-likely-an-image.js
+++ b/client/lib/post-normalizer/utils/is-url-likely-an-image.js
@@ -12,5 +12,7 @@ export function isUrlLikelyAnImage( uri ) {
 	}
 
 	const withoutQuery = getUrlParts( uri ).pathname;
-	return some( [ '.jpg', '.jpeg', '.png', '.gif' ], ( ext ) => withoutQuery.endsWith( ext ) );
+	return some( [ '.jpg', '.jpeg', '.png', '.gif', '.webp' ], ( ext ) =>
+		withoutQuery.endsWith( ext )
+	);
 }


### PR DESCRIPTION
Fixes CML-797

## Proposed Changes, why are these changes being made?

Images with the webp extension should be considered like real images in the Reader.

**Before**

<img width="637" height="285" alt="Screenshot 2025-08-15 at 12 45 04" src="https://github.com/user-attachments/assets/9c6336db-2d74-44b4-a13b-46473f01699c" />

**After**

<img width="649" height="216" alt="Screenshot 2025-08-15 at 12 44 53" src="https://github.com/user-attachments/assets/63b56dd8-26e4-420f-a161-63973f30afc7" />

## Testing Instructions

* Go to http://calypso.localhost:3000/reader/feeds/109983028
* You should see featured images displayed next to each entry.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
