### PR TITLE
Hide the Source URL Select item option in the Domain Forwarding form

### DIFF
--- a/client/dashboard/domains/domain-forwardings/form.tsx
+++ b/client/dashboard/domains/domain-forwardings/form.tsx
@@ -17,7 +17,7 @@ import type { DomainForwarding } from '../../data/domain-forwarding';
 import type { Field } from '@wordpress/dataviews';
 
 export interface FormData {
-	sourceType: 'root' | 'subdomain';
+	sourceType: 'root' | '';
 	subdomain: string;
 	targetUrl: string;
 	isPermanent: boolean;
@@ -42,7 +42,7 @@ export default function DomainForwardingForm( {
 	const [ formData, setFormData ] = useState< FormData >( () => {
 		if ( ! initialData ) {
 			return {
-				sourceType: 'subdomain',
+				sourceType: '',
 				subdomain: '',
 				targetUrl: '',
 				isPermanent: false,
@@ -51,7 +51,7 @@ export default function DomainForwardingForm( {
 		}
 		const protocol = initialData.is_secure ? 'https://' : 'http://';
 		return {
-			sourceType: initialData.subdomain ? 'subdomain' : 'root',
+			sourceType: initialData.subdomain ? '' : 'root',
 			subdomain: initialData.subdomain || '',
 			targetUrl: `${ protocol }${ initialData.target_host }${ initialData.target_path || '' }`,
 			isPermanent: initialData.is_permanent,
@@ -113,7 +113,7 @@ export default function DomainForwardingForm( {
 				elements: [
 					{
 						label: `${ domainName } subdomain`,
-						value: 'subdomain',
+						value: '',
 					},
 					{
 						label: `${ domainName } root domain`,
@@ -137,7 +137,7 @@ export default function DomainForwardingForm( {
 					},
 				},
 				isVisible: ( item: FormData ) => {
-					return item.sourceType === 'subdomain';
+					return item.sourceType === '';
 				},
 			},
 			{

--- a/client/dashboard/domains/domain-forwardings/utils.ts
+++ b/client/dashboard/domains/domain-forwardings/utils.ts
@@ -116,8 +116,7 @@ export function formDataToSubmitData(
 	const { target_host, target_path, is_secure } = parseTargetUrl( formData.targetUrl );
 
 	const submitData: DomainForwardingSaveData = {
-		subdomain:
-			formData.sourceType === 'subdomain' ? formData.subdomain.trim() || undefined : undefined,
+		subdomain: formData.sourceType === '' ? formData.subdomain.trim() || undefined : undefined,
 		target_host,
 		target_path,
 		is_secure,


### PR DESCRIPTION
Just hide the "Select item" option from the Domain Forwarding "Source URL" dropdown

Part of [DOTDASH-275: Hide "Select item" option from Source URL in the Domain Forwarding form](https://linear.app/a8c/issue/DOTDASH-275/hide-select-item-option-from-source-url-in-the-domain-forwarding-form)

| before | after |
| --- | --- |
| <img width="706" height="137" alt="Screenshot 2025-08-15 at 14 09 43" src="https://github.com/user-attachments/assets/6be25dd6-cfa3-4fe7-b53b-eef0558900ba" /> |  <img width="695" height="150" alt="Screenshot 2025-08-15 at 14 09 22" src="https://github.com/user-attachments/assets/54d3afc8-56b7-458e-a88a-3230541d8981" /> |


## Proposed Changes

* Change the `sourceType` field to have an empty value for the first option which is Subdomain

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Unnecessary UI element

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the PR and make sure there is no "Select item" option when you click on the "Source URL" dropdown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
