### PR TITLE
A4A: Submit the HubSpotutk value during the A4A signup submission.

### DIFF
--- a/.vscode/settings-sample.jsonc
+++ b/.vscode/settings-sample.jsonc
@@ -45,6 +45,5 @@
 	"scss.validate": false,
 	"stylelint.validate": [ "css", "scss", "postcss" ],
 	// Use the installed version of TypeScript, not the ones bundled with VS Code
-	"typescript.tsdk": "node_modules/typescript/lib",
-	"references.preferredLocation": "view"
+	"typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/.vscode/settings-sample.jsonc
+++ b/.vscode/settings-sample.jsonc
@@ -45,5 +45,6 @@
 	"scss.validate": false,
 	"stylelint.validate": [ "css", "scss", "postcss" ],
 	// Use the installed version of TypeScript, not the ones bundled with VS Code
-	"typescript.tsdk": "node_modules/typescript/lib"
+	"typescript.tsdk": "node_modules/typescript/lib",
+	"references.preferredLocation": "view"
 }

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-create-agency-mutation.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-create-agency-mutation.ts
@@ -1,9 +1,13 @@
 import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import cookie from 'cookie';
 import wpcom from 'calypso/lib/wp';
 import { APIError, Agency } from 'calypso/state/a8c-for-agencies/types';
 import { AgencyDetailsPayload } from '../types';
 
 function createAgency( details: AgencyDetailsPayload ): Promise< Agency > {
+	// For Agency signup tracking, we need to submit the hubspotutk cookie.
+	const hubspotutk = cookie.parse( document.cookie ).hubspotutk;
+
 	return wpcom.req.post( {
 		apiNamespace: 'wpcom/v2',
 		path: '/agency',
@@ -28,6 +32,7 @@ function createAgency( details: AgencyDetailsPayload ): Promise< Agency > {
 			address_postal_code: details.postalCode,
 			phone_number: details.phone?.phoneNumber ? details.phone?.phoneNumberFull : '',
 			referral_status: details.referer,
+			hubspotutk,
 		},
 	} );
 }

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-create-agency-mutation.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-create-agency-mutation.ts
@@ -6,7 +6,7 @@ import { AgencyDetailsPayload } from '../types';
 
 function createAgency( details: AgencyDetailsPayload ): Promise< Agency > {
 	// For Agency signup tracking, we need to submit the hubspotutk cookie.
-	const hubspotutk = cookie.parse( document.cookie ).hubspotutk;
+	const hubspotutk = cookie.parse( document.cookie )?.hubspotutk;
 
 	return wpcom.req.post( {
 		apiNamespace: 'wpcom/v2',


### PR DESCRIPTION
This PR updates the Signup mutation to include the hubspotutk value from the cookie during signup submission.

Context: p1755262248595769/1752771442.560369-slack-C047ACYM8UQ


## Proposed Changes

* Parse the `hubspotutk` from Cookie and submit it as part of the signup payload.

## Why are these changes being made?
To properly track signups on HubSpot, we need to pass the `hubspotutk` value from our cookie to the signup endpoint. This allows us to correctly link our forms to our HubSpot records.

## Testing Instructions

* You will need to use Incognito mode on your browser.
* Spin up this branch locally and navigate to `/signup`.
* Finish the signup.
* Inspect the endpoint request.
* Confirm that the hubspotutk is submitted as part of the payload.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?