### PR TITLE
Continue as user: update styling for Woo and Blaze

### DIFF
--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -3,7 +3,6 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import Gravatar from 'calypso/components/gravatar';
 import wpcom from 'calypso/lib/wp';
-import SocialToS from '../authentication/social/social-tos';
 
 import './continue-as-user.scss';
 
@@ -79,22 +78,10 @@ export default function ContinueAsUser( {
 		</div>
 	);
 
-	if ( isWoo ) {
+	if ( isWoo || isBlazePro ) {
 		return (
 			<div className="continue-as-user">
-				<div className="continue-as-user__user-info">
-					{ gravatarLink }
-					<div className="continue-as-user__not-you">
-						<Button
-							variant="tertiary"
-							id="loginAsAnotherUser"
-							className="continue-as-user__change-user-link"
-							onClick={ onChangeAccount }
-						>
-							{ translate( 'Sign in as a different user' ) }
-						</Button>
-					</div>
-				</div>
+				<div className="continue-as-user__user-info">{ gravatarLink }</div>
 				<Button
 					variant="primary"
 					className="continue-as-user__continue-button"
@@ -104,38 +91,14 @@ export default function ContinueAsUser( {
 				>
 					{ translate( 'Continue' ) }
 				</Button>
-			</div>
-		);
-	}
-
-	if ( isBlazePro ) {
-		return (
-			<div className="continue-as-user">
-				<div className="continue-as-user__user-info">
-					{ gravatarLink }
-					<div className="continue-as-user__not-you">
-						<Button
-							variant="tertiary"
-							id="loginAsAnotherUser"
-							className="continue-as-user__change-user-link"
-							onClick={ onChangeAccount }
-						>
-							{ translate( 'Sign in as a different user' ) }
-						</Button>
-					</div>
-				</div>
 				<Button
-					variant="primary"
-					className="continue-as-user__continue-button"
-					isBusy={ validatingPath }
-					href={ validatedPath || '/' }
-					__next40pxDefaultSize
+					variant="link"
+					id="loginAsAnotherUser"
+					className="continue-as-user__change-user-link"
+					onClick={ onChangeAccount }
 				>
-					{ `${ translate( 'Continue as', {
-						context: 'Continue as an existing WordPress.com user',
-					} ) } ${ userName }` }
+					{ translate( 'Login with a different account' ) }
 				</Button>
-				<SocialToS />
 			</div>
 		);
 	}

--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -97,7 +97,7 @@ export default function ContinueAsUser( {
 					className="continue-as-user__change-user-link"
 					onClick={ onChangeAccount }
 				>
-					{ translate( 'Login with a different account' ) }
+					{ translate( 'Log in with a different account' ) }
 				</Button>
 			</div>
 		);

--- a/client/blocks/login/continue-as-user.scss
+++ b/client/blocks/login/continue-as-user.scss
@@ -9,7 +9,7 @@
 	font-size: $font-body-small;
 	text-align: center;
 	height: calc(65vh - 47px); /* The values here are set so that the Not-you line gets pushed to the bottom of the screen on mobile */
-	margin: 48px auto 0;
+	margin: 24px auto 0;
 	position: relative;
 	min-height: 260px;
 

--- a/client/blocks/login/continue-as-user.scss
+++ b/client/blocks/login/continue-as-user.scss
@@ -11,7 +11,6 @@
 	height: calc(65vh - 47px); /* The values here are set so that the Not-you line gets pushed to the bottom of the screen on mobile */
 	margin: 48px auto 0;
 	position: relative;
-	max-width: 400px;
 	min-height: 260px;
 
 	@include break-medium {
@@ -51,5 +50,50 @@
 	}
 	.continue-as-user__not-you {
 		position: static;
+	}
+}
+
+/* For now, limit this to Woo and Blaze Pro. In the future, styles will be applied to all clients. */
+.layout.is-blaze-pro,
+.layout.is-woo-passwordless {
+	.continue-as-user {
+		max-width: 430px;
+		width: 100%;
+	}
+
+	.continue-as-user__user-info {
+		background: #fff;
+		width: 100%;
+		border: 1px solid var( --studio-gray-5 );
+		padding: 24px 0;
+	}
+
+	.continue-as-user__gravatar {
+		width: 80px;
+		height: 80px;
+	}
+
+	.continue-as-user__username {
+		font-size: rem( 15px );
+		font-weight: 500;
+		color: var( --studio-gray-90 );
+		margin-top: 16px;
+	}
+
+	.continue-as-user__email {
+		font-size: rem( 13px );
+	}
+
+	.continue-as-user__continue-button {
+		font-size: rem( 13px );
+		margin-block-start: 24px;
+		margin-block-end: 0;
+	}
+
+	.continue-as-user__change-user-link {
+		font-weight: 500;
+		font-size: rem( 13px );
+		color: var( --studio-gray-90 );
+		margin-top: 24px;
 	}
 }

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -488,20 +488,6 @@ class Login extends Component {
 							isBlazePro={ isBlazePro }
 							isWoo={ isWCCOM }
 						/>
-						<LoginForm
-							disableAutoFocus={ disableAutoFocus }
-							onSuccess={ this.handleValidLogin }
-							socialService={ socialService }
-							socialServiceResponse={ socialServiceResponse }
-							domain={ domain }
-							locale={ locale }
-							userEmail={ userEmail }
-							handleUsernameChange={ handleUsernameChange }
-							signupUrl={ signupUrl }
-							showSocialLoginFormOnly
-							sendMagicLoginLink={ this.sendMagicLoginLink }
-							isFromAutomatticForAgenciesPlugin={ isFromAutomatticForAgenciesPlugin }
-						/>
 					</div>
 				);
 			}

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -98,7 +98,6 @@ export class LoginForm extends Component {
 		translate: PropTypes.func.isRequired,
 		userEmail: PropTypes.string,
 		locale: PropTypes.string,
-		showSocialLoginFormOnly: PropTypes.bool,
 		currentQuery: PropTypes.object,
 		sendMagicLoginLink: PropTypes.func,
 		isSendingEmail: PropTypes.bool,
@@ -930,28 +929,12 @@ export class LoginForm extends Component {
 	render() {
 		const {
 			currentQuery,
-			showSocialLoginFormOnly,
 			isWoo,
 			isBlazePro,
 			isSocialFirst,
-			isJetpack,
 			isOneTapAuth,
 			socialAccountIsLinking: linkingSocialUser,
 		} = this.props;
-
-		if ( showSocialLoginFormOnly ) {
-			return config.isEnabled( 'signup/social' ) ? (
-				<Fragment>
-					<FormDivider />
-					<SocialLoginForm
-						handleLogin={ this.handleSocialLogin }
-						trackLoginAndRememberRedirect={ this.trackLoginAndRememberRedirect }
-						socialServiceResponse={ this.props.socialServiceResponse }
-						isJetpack={ isJetpack }
-					/>
-				</Fragment>
-			) : null;
-		}
 
 		return (
 			<>

--- a/client/layout/masterbar/blaze-pro.scss
+++ b/client/layout/masterbar/blaze-pro.scss
@@ -166,110 +166,19 @@ body.is-section-login {
 		}
 	}
 
+	&.is-section-signup .layout__content,
+	.layout__content {
+		padding-top: 85px;
+
+		@media ( max-width: $break-mobile ) {
+			padding-top: 50px;
+			padding-bottom: 80px;
+		}
+	}
+
 	&.is-section-signup::before,
 	&.is-section-signup .layout__primary::before {
 		display: none;
-	}
-
-	.login__body--continue-as-user {
-		align-items: center;
-		display: flex;
-		flex-direction: column;
-
-		.card.auth-form__social.is-login {
-			width: 326px;
-		}
-
-		.auth-form__separator::before,
-		.auth-form__separator::after {
-			display: none;
-		}
-	}
-
-	.continue-as-user {
-		margin: 0;
-		width: 326px;
-		height: unset;
-
-		~ .auth-form__separator {
-			margin: 32px auto;
-		}
-
-		.continue-as-user__user-info {
-			display: flex;
-			flex-direction: column;
-			justify-content: center;
-			align-items: center;
-			align-self: stretch;
-			border: 1px solid #ccc;
-			width: 100%;
-			box-sizing: border-box;
-			padding: 32px 24px 16px 24px;
-			position: relative;
-		}
-
-		~ .card.auth-form__social.is-login {
-			margin: 0;
-			padding: 0;
-			max-width: initial;
-		}
-
-
-		.continue-as-user__gravatar-link {
-			margin: 0 0 8px;
-			padding: 0;
-			border: 0;
-			border-radius: 0;
-			width: 100%;
-		}
-
-		.gravatar.continue-as-user__gravatar {
-			width: 80px;
-			height: 80px;
-			box-sizing: border-box;
-		}
-
-		.continue-as-user__username {
-			color: var(--color-black);
-			font-family: $inter;
-			font-size: 1rem;
-			font-weight: 600;
-			line-height: 20px;
-		}
-
-		.continue-as-user__email {
-			color: var(--studio-gray-60);
-			font-family: $inter;
-			font-size: 0.875rem;
-			font-weight: 500;
-			line-height: 20px;
-			margin: 0;
-			text-align: center;
-		}
-
-		.continue-as-user__not-you {
-			align-items: center;
-			bottom: auto;
-			display: flex;
-			gap: 4px;
-			height: 32px;
-			justify-content: center;
-			margin-bottom: 0;
-			padding: 4px 16px;
-			position: inherit;
-		}
-
-		.continue-as-user__change-user-link {
-			font-size: 0.875rem;
-			font-weight: 500;
-		}
-
-		.continue-as-user__continue-button {
-			font-size: rem(13px);
-			font-weight: 600;
-			margin-top: 24px;
-			width: 326px;
-		}
 	}
 
 	.card.auth-form__social.is-login {
@@ -302,7 +211,6 @@ body.is-section-login {
 				font-family: $inter;
 				font-size: rem(13px);
 			}
-
 		}
 	}
 
@@ -316,7 +224,7 @@ body.is-section-login {
 
 		a,
 		a:visited {
-			color: var(--studio-gray-60);
+			color: var( --studio-gray-60 );
 			text-decoration: underline;
 		}
 	}
@@ -415,28 +323,5 @@ body.is-section-login {
 
 	.login__lostpassword-subtitle {
 		width: 360px;
-	}
-}
-
-// Hacks for Continue-as-a-user for Sign Up (but user is already logged in)
-.is-blaze-pro {
-	.step-wrapper__content {
-		align-items: center;
-		display: flex;
-		flex-direction: column;
-	}
-
-	&.layout:not(.dops) .step-wrapper .step-wrapper__header {
-		margin-top: 0;
-	}
-
-	// Do not show ToS twice for Sign In...
-	&.layout.is-section-login .continue-as-user .auth-form__social-buttons-tos {
-		display: none;
-	}
-
-	// ... though ToS should be shown for Sign Up (for logged in users)
-	&.layout.is-section-signup.is-logged-in .continue-as-user .auth-form__social-buttons-tos {
-		margin-top: 24px;
 	}
 }

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -381,74 +381,6 @@ $breakpoint-mobile: 660px;
 		}
 	}
 
-	.continue-as-user {
-		max-width: 472px;
-		margin: 54px auto 0;
-		height: unset;
-		min-height: 238px;
-
-		~ .card.auth-form__social.is-login {
-			max-width: 472px;
-		}
-
-		.continue-as-user__gravatar-content {
-			pointer-events: auto;
-			display: grid;
-			grid-template-columns: 56px 1fr;
-			grid-template-areas:
-				'gravatar username'
-				'gravatar email';
-			flex-direction: row;
-			justify-items: flex-start;
-			align-items: center;
-			padding: 16px 24px;
-			border: 1px solid #c3c4c7;
-			border-radius: 4px;
-			text-decoration: none;
-			margin: 0 0 16px;
-
-			.gravatar.continue-as-user__gravatar {
-				width: 40px;
-				height: 40px;
-				grid-area: gravatar;
-			}
-
-			.continue-as-user__username {
-				font-size: 1rem;
-				font-weight: 600;
-				line-height: 24px;
-				color: var( --color-text );
-				grid-area: username;
-				margin-top: 0;
-			}
-
-			.continue-as-user__email {
-				font-size: 1rem;
-				line-height: 24px;
-				font-weight: 400;
-				color: $gray-60;
-				grid-area: email;
-				margin-bottom: 0;
-				text-overflow: ellipsis;
-				width: 100%;
-				overflow: hidden;
-				white-space: nowrap;
-				text-align: left;
-			}
-		}
-
-		.continue-as-user__user-info {
-			.button {
-				margin: 0;
-			}
-		}
-
-		.continue-as-user__not-you {
-			margin-bottom: 32px;
-			position: initial;
-		}
-	}
-
 	.logged-out-form {
 		max-width: 100%;
 		background: inherit;
@@ -900,84 +832,18 @@ $breakpoint-mobile: 660px;
 			margin-top: unset;
 		}
 
-		.login__body--continue-as-user {
-			width: 540px;
-			margin: 0 auto;
-			padding: 0;
-			display: flex;
-			flex-direction: column;
+		.signup-form {
+			// TODO clk remove this. it's handled by .is-unified-create-account
+			input[type='email'].form-text-input {
+				margin-bottom: 0;
+			}
 		}
 
-		.continue-as-user {
-			margin: 0;
-			max-width: initial;
-
-			.continue-as-user__user-info {
-				display: flex;
-				flex-direction: column;
-				justify-content: center;
-				align-items: center;
-				align-self: stretch;
-				border-radius: 8px;
-				border: 1px solid #dcdcde;
-				width: 100%;
-				box-sizing: border-box;
-				padding: 32px 24px 16px 24px;
-				background: #fff;
-			}
-
-			~ .card.auth-form__social.is-login {
-				margin: 0;
-				padding: 0;
-				max-width: initial;
-			}
-
-			.continue-as-user__gravatar-content {
-				display: flex;
-				flex-direction: column;
-				margin: 0 0 8px;
-				padding: 0;
-				border: 0;
-				border-radius: 0;
-				width: 100%;
-			}
-
-			.gravatar.continue-as-user__gravatar {
-				width: 80px;
-				height: 80px;
-				box-sizing: border-box;
-			}
-
-			.continue-as-user__username {
-				font-style: normal;
-				margin-top: 8px;
-			}
-
-			.continue-as-user__email {
-				font-size: 0.875rem;
-				line-height: 21px;
-				color: $gray-50;
-				text-align: center;
-				margin: 0;
-			}
-
-			.continue-as-user__not-you {
-				margin-bottom: 0;
-				display: flex;
-				height: 32px;
-				padding: 4px 16px;
-				justify-content: center;
-				align-items: center;
-				gap: 4px;
-			}
-
-			.continue-as-user__change-user-link {
-				font-size: 0.875rem;
-				font-weight: 500;
-			}
-
-			.continue-as-user__continue-button {
-				margin-top: 24px;
+		div.auth-form__separator {
+			// TODO clk remove this. it's handled by .is-unified-create-account
+			&::before,
+			&::after {
+				border-block-start-color: #e0e0e1;
 			}
 		}
 

--- a/client/login/wp-login/hooks/get-header-text.tsx
+++ b/client/login/wp-login/hooks/get-header-text.tsx
@@ -24,10 +24,31 @@ interface Props {
 	isSocialFirst?: boolean;
 	isWooJPC?: boolean;
 	isWCCOM?: boolean;
+	isBlazePro?: boolean;
 	isFromAkismet?: boolean;
 	isFromAutomatticForAgenciesPlugin?: boolean;
 	isGravPoweredClient?: boolean;
+	isUserLoggedIn?: boolean;
 }
+
+const getLoggedInUserHeaderText = ( {
+	isSocialFirst,
+	isWooJPC,
+	isWCCOM,
+	isBlazePro,
+	translate,
+}: {
+	isSocialFirst?: boolean;
+	isWooJPC?: boolean;
+	isWCCOM?: boolean;
+	isBlazePro?: boolean;
+	translate: ( arg0: string, arg1?: object ) => TranslateResult;
+} ): TranslateResult | null => {
+	if ( isSocialFirst && ( isWooJPC || isWCCOM || isBlazePro ) ) {
+		return translate( 'Connect your account' );
+	}
+	return null;
+};
 
 /**
  * This function is used to get the header text for the login page.
@@ -44,13 +65,28 @@ export function getHeaderText( {
 	isWooJPC,
 	isJetpack,
 	isWCCOM,
+	isBlazePro,
 	isFromAkismet,
 	isFromAutomatticForAgenciesPlugin,
 	isGravPoweredClient,
 	currentQuery,
 	translate,
 	twoStepNonce,
+	isUserLoggedIn,
 }: Props ): TranslateResult {
+	if ( isUserLoggedIn ) {
+		const loggedInText = getLoggedInUserHeaderText( {
+			isSocialFirst,
+			isWooJPC,
+			isWCCOM,
+			isBlazePro,
+			translate,
+		} );
+		if ( loggedInText ) {
+			return loggedInText;
+		}
+	}
+
 	let headerText = translate( 'Log in to your account' );
 
 	if ( isSocialFirst ) {

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -28,6 +28,7 @@ import {
 	recordTracksEventWithClientId as recordTracksEvent,
 	enhanceWithSiteType,
 } from 'calypso/state/analytics/actions';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { wasManualRenewalImmediateLoginAttempted } from 'calypso/state/immediate-login/selectors';
 import { getRedirectToOriginal } from 'calypso/state/login/selectors';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
@@ -104,6 +105,7 @@ export class Login extends Component {
 			'isWooJPC',
 			'isJetpack',
 			'isWCCOM',
+			'isBlazePro',
 			'isFromAkismet',
 			'isFromAutomatticForAgenciesPlugin',
 			'isGravPoweredClient',
@@ -292,11 +294,13 @@ export class Login extends Component {
 			isWooJPC,
 			isJetpack,
 			isWCCOM,
+			isBlazePro,
 			isFromAkismet,
 			isFromAutomatticForAgenciesPlugin,
 			isGravPoweredClient,
 			currentQuery,
 			translate,
+			isUserLoggedIn: isLoggedIn,
 		} = this.props;
 
 		// TODO: remove isGravPoweredClient when login pages are unified.
@@ -313,11 +317,13 @@ export class Login extends Component {
 			isWooJPC,
 			isJetpack,
 			isWCCOM,
+			isBlazePro,
 			isFromAkismet,
 			isFromAutomatticForAgenciesPlugin,
 			isGravPoweredClient,
 			currentQuery,
 			translate,
+			isUserLoggedIn: isLoggedIn,
 		} );
 
 		const headingSubText = getHeadingSubText( {
@@ -444,6 +450,7 @@ export default connect(
 				'automattic-for-agencies-client' ===
 					new URLSearchParams( getRedirectToOriginal( state )?.split( '?' )[ 1 ] ).get( 'from' ),
 			isManualRenewalImmediateLoginAttempt: wasManualRenewalImmediateLoginAttempted( state ),
+			isUserLoggedIn: isUserLoggedIn( state ),
 		};
 	},
 	{


### PR DESCRIPTION
Part of DOTCOM-13852

## Proposed Changes

Update continue as user pages for Woo and Blaze Pro, according to [Figma](https://www.figma.com/design/ZiYj4ukUuFLVXtfHvbXS1c/Login-and-connect?node-id=139-4659&m=dev). 

## Testing Instructions


* Make sure you are logged into WordPress.com
* Visit [WooCommerce.com continue as user page](http://calypso.localhost:3000/log-in?client_id=50916&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D4bd8b0b3edf214402f9f9c7fbb9a24e1c8407044cf9cb0f5c8efc6bbccfe33b2%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26from-calypso%3D1)
    * WooJPC is not updated in this PR as it's tied to Jetpack
* Visit [Blaze Pro continue as user page](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D99370%26state%3D0f0d1f16975b65cf8e9e924461b7c892f78eabeeb190dc03654cef0465786da0%26redirect_uri%3Dhttps%253A%252F%252Fblazepro.tumblr.com%252Fauth%252Fconnected%26blog_id%3D0%26wpcom_connect%3D1%26calypso_env%3Dproduction%26scope%3Dglobal%26from-calypso%3D1&client_id=99370&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D99370%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%253Fresponse_type%253Dcode%2526client_id%253D99370%2526state%253D0f0d1f16975b65cf8e9e924461b7c892f78eabeeb190dc03654cef0465786da0%2526redirect_uri%253Dhttps%25253A%25252F%25252Fblazepro.tumblr.com%25252Fauth%25252Fconnected%2526blog_id%253D0%2526wpcom_connect%253D1%2526calypso_env%253Dproduction%2526scope%253Dglobal%2526from-calypso%253D1)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
