### PR TITLE
Privacy v2: Implement usage information card

### DIFF
--- a/client/dashboard/data/me-profile.ts
+++ b/client/dashboard/data/me-profile.ts
@@ -1,13 +1,14 @@
 import wpcom from 'calypso/lib/wp';
 
 export interface UserProfile {
-	user_login: string;
-	display_name: string;
-	user_email: string;
-	user_URL: string;
-	description: string;
-	is_dev_account: boolean;
 	avatar_URL: string;
+	description: string;
+	display_name: string;
+	is_dev_account: boolean;
+	tracks_opt_out: boolean;
+	user_email: string;
+	user_login: string;
+	user_URL: string;
 }
 
 export async function fetchProfile(): Promise< UserProfile > {
@@ -17,7 +18,14 @@ export async function fetchProfile(): Promise< UserProfile > {
 export async function updateProfile(
 	data: Partial< UserProfile >
 ): Promise< Partial< UserProfile > > {
-	const saveableKeys = [ 'display_name', 'description', 'is_dev_account', 'user_URL' ];
+	const saveableKeys = [
+		'display_name',
+		'description',
+		'is_dev_account',
+		'tracks_opt_out',
+		'user_URL',
+	];
+
 	for ( const key in data ) {
 		if ( ! saveableKeys.includes( key ) ) {
 			delete data[ key as keyof UserProfile ];

--- a/client/dashboard/me/privacy/index.tsx
+++ b/client/dashboard/me/privacy/index.tsx
@@ -2,24 +2,14 @@ import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import UsageInformationCard from './usage-information-card';
 
-function Privacy() {
+export default function Privacy() {
 	return (
-		<PageLayout
-			size="small"
-			header={
-				<PageHeader
-					title={ __( 'Privacy' ) }
-					description={ __( 'Manage your privacy settings.' ) }
-				/>
-			}
-		>
-			<VStack spacing={ 4 }>
-				<RouterLinkSummaryButton title={ __( 'Details' ) } to="/me/privacy" />
+		<PageLayout size="small" header={ <PageHeader title={ __( 'Privacy' ) } /> }>
+			<VStack spacing={ 8 }>
+				<UsageInformationCard />
 			</VStack>
 		</PageLayout>
 	);
 }
-
-export default Privacy;

--- a/client/dashboard/me/privacy/usage-information-card.tsx
+++ b/client/dashboard/me/privacy/usage-information-card.tsx
@@ -20,14 +20,13 @@ export default function UsageInformationCard() {
 	const mutation = useMutation( profileMutation() );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
-	const handleChange = ( { enabled }: { enabled?: boolean } ) => {
-		const tracksOptOut = ! enabled;
+	const handleChange = ( { tracks_opt_out }: { tracks_opt_out?: boolean } ) => {
 		mutation.mutate(
-			{ tracks_opt_out: tracksOptOut },
+			{ tracks_opt_out },
 			{
 				onSuccess: () => {
 					createSuccessNotice(
-						tracksOptOut
+						tracks_opt_out
 							? __( 'Usage information sharing disabled.' )
 							: __( 'Usage information sharing enabled.' ),
 						{ type: 'snackbar' }
@@ -35,7 +34,7 @@ export default function UsageInformationCard() {
 				},
 				onError: () => {
 					createErrorNotice(
-						tracksOptOut
+						tracks_opt_out
 							? __( 'Failed to disable usage information sharing.' )
 							: __( 'Failed to enable usage information sharing.' ),
 						{ type: 'snackbar' }
@@ -45,9 +44,9 @@ export default function UsageInformationCard() {
 		);
 	};
 
-	const fields: Field< { enabled: boolean } >[] = [
+	const fields: Field< { tracks_opt_out: boolean } >[] = [
 		{
-			id: 'enabled',
+			id: 'tracks_opt_out',
 			label: __(
 				'Share information with our analytics tool about your use of services while logged in to your WordPress.com account.'
 			),
@@ -57,7 +56,7 @@ export default function UsageInformationCard() {
 					<ToggleControl
 						__nextHasNoMarginBottom
 						label={ hideLabelFromVision ? '' : label }
-						checked={ getValue( { item: data } ) }
+						checked={ ! getValue( { item: data } ) }
 						disabled={ mutation.isPending }
 						onChange={ () => onChange( { [ id ]: ! getValue( { item: data } ) } ) }
 					/>
@@ -68,10 +67,10 @@ export default function UsageInformationCard() {
 
 	const form = {
 		type: 'regular' as const,
-		fields: [ 'enabled' ],
+		fields: [ 'tracks_opt_out' ],
 	};
 
-	const data = { enabled: ! userProfile?.tracks_opt_out };
+	const data = { tracks_opt_out: userProfile?.tracks_opt_out ?? true };
 
 	return (
 		<Card>
@@ -120,7 +119,7 @@ export default function UsageInformationCard() {
 						}
 						level={ 3 }
 					/>
-					<DataForm< { enabled: boolean } >
+					<DataForm< { tracks_opt_out: boolean } >
 						data={ data }
 						fields={ fields }
 						form={ form }

--- a/client/dashboard/me/privacy/usage-information-card.tsx
+++ b/client/dashboard/me/privacy/usage-information-card.tsx
@@ -1,0 +1,133 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import {
+	__experimentalVStack as VStack,
+	Card,
+	CardBody,
+	ExternalLink,
+	ToggleControl,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { DataForm, Field } from '@wordpress/dataviews';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { profileMutation, profileQuery } from '../../app/queries/me-profile';
+import { SectionHeader } from '../../components/section-header';
+import { Text } from '../../components/text';
+
+export default function UsageInformationCard() {
+	const { data: userProfile } = useQuery( profileQuery() );
+	const mutation = useMutation( profileMutation() );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const handleChange = ( { enabled }: { enabled?: boolean } ) => {
+		const tracksOptOut = ! enabled;
+		mutation.mutate(
+			{ tracks_opt_out: tracksOptOut },
+			{
+				onSuccess: () => {
+					createSuccessNotice(
+						tracksOptOut
+							? __( 'Usage information sharing disabled.' )
+							: __( 'Usage information sharing enabled.' ),
+						{ type: 'snackbar' }
+					);
+				},
+				onError: () => {
+					createErrorNotice(
+						tracksOptOut
+							? __( 'Failed to disable usage information sharing.' )
+							: __( 'Failed to enable usage information sharing.' ),
+						{ type: 'snackbar' }
+					);
+				},
+			}
+		);
+	};
+
+	const fields: Field< { enabled: boolean } >[] = [
+		{
+			id: 'enabled',
+			label: __(
+				'Share information with our analytics tool about your use of services while logged in to your WordPress.com account.'
+			),
+			Edit: ( { field, onChange, data, hideLabelFromVision } ) => {
+				const { id, label, getValue } = field;
+				return (
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ hideLabelFromVision ? '' : label }
+						checked={ getValue( { item: data } ) }
+						disabled={ mutation.isPending }
+						onChange={ () => onChange( { [ id ]: ! getValue( { item: data } ) } ) }
+					/>
+				);
+			},
+		},
+	];
+
+	const form = {
+		type: 'regular' as const,
+		fields: [ 'enabled' ],
+	};
+
+	const data = { enabled: ! userProfile?.tracks_opt_out };
+
+	return (
+		<Card>
+			<CardBody>
+				<VStack spacing={ 4 }>
+					<SectionHeader
+						title={ __( 'Usage information' ) }
+						description={
+							<VStack spacing={ 4 }>
+								<Text variant="muted" lineHeight="20px">
+									{ __( 'We collect usage information to improve your experience.' ) }
+								</Text>
+								<Text variant="muted" lineHeight="20px">
+									{ createInterpolateElement(
+										__(
+											'The information you choose to share helps us improve our products, make marketing to you more relevant, personalize your WordPress.com experience, and more as detailed in our <privacyLink>privacy policy</privacyLink>'
+										),
+										{
+											privacyLink: (
+												<ExternalLink
+													// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
+													href="https://automattic.com/privacy/"
+													children={ null }
+												/>
+											),
+										}
+									) }
+								</Text>
+								<Text variant="muted" lineHeight="20px">
+									{ createInterpolateElement(
+										__(
+											'In addition to our own analytics tool, we use other tracking tools, including some from third parties. <cookiesLink>Read about these</cookiesLink> and how to control them.'
+										),
+										{
+											cookiesLink: (
+												<ExternalLink
+													// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
+													href="https://automattic.com/cookies/"
+													children={ null }
+												/>
+											),
+										}
+									) }
+								</Text>
+							</VStack>
+						}
+						level={ 3 }
+					/>
+					<DataForm< { enabled: boolean } >
+						data={ data }
+						fields={ fields }
+						form={ form }
+						onChange={ handleChange }
+					/>
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/sites/site-preview-links/index.tsx
+++ b/client/dashboard/sites/site-preview-links/index.tsx
@@ -73,7 +73,7 @@ export default function SitePreviewLinks( { site, title, description }: SitePrev
 		const fields: Field< { enabled: boolean } >[] = [
 			{
 				id: 'enabled',
-				label: 'Enable share link',
+				label: __( 'Enable share link' ),
 				Edit: ( { field, onChange, data, hideLabelFromVision } ) => {
 					const { id, label, getValue } = field;
 					return (


### PR DESCRIPTION
Ref: DOTDASH-176

## Proposed Changes

This PR implements the Usage Information card.

<img width="731" height="392" alt="SCR-20250818-oyeh" src="https://github.com/user-attachments/assets/70d38d73-6aae-4c00-9833-1b6f1eb77c15" />

>[!NOTE]
> Router updates will be address after https://github.com/Automattic/wp-calypso/pull/105244 has merged.

>[!NOTE]
> The "Learn more" link goes to the Cookie Policy page, which is the same as the "Read about these" link. I ended up not adding it since it seems redundant and the toggle label is already too busy.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Hosting Dashboard development

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2/me/privacy
* Ensure that the toggle saves the setting as intended

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
