### PR TITLE
Help Center Search: Record the session id when issuing a TrainTracks interact event

### DIFF
--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -280,6 +280,7 @@ function HelpSearchResults( {
 			recordTracksEvent( 'calypso_help_center_search_traintracks_interact', {
 				action: 'click',
 				railcar: result.railcar.railcar,
+				session_id: result.railcar.session_id,
 				href: result.link,
 				search_type: ! contextSearch && ! searchQuery ? 'tailored' : 'search',
 				location,


### PR DESCRIPTION
This is a follow-up to #105059

In that request, we added TrainTracks for calculating search relevancy of the help center. There was one parameter missing though for the interact events - the `session_id`. This adds it.

## Testing Instructions
In your local calypso development environment or in the live link, open wordpress.com and perform a search in the help center. Inspect the network tab and filter for `t.gif` requests. Inspect one of them. You should see it has an eventname of `calypso_help_center_search_traintracks_render`. Note the `session_id`. Now click on one of the search results. You should another `t.gif` request with eventname `calypso_help_center_search_traintracks_interact` Ensure that the `session_id` matches the render event.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
