### PR TITLE
Dashboard v2: Introduce the Notifications popup

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -52,7 +52,7 @@ $with-sidebar-min-page-width: 1114px;
 }
 
 .wpnc__main {
-	background-color: var(--color-surface);
+	background-color: var(--color-surface, #fff);
 
 	font: {
 		family: $sans;
@@ -234,7 +234,7 @@ $with-sidebar-min-page-width: 1114px;
 
 	.wpnc__filter {
 		width: 100%;
-		background-color: var(--color-surface);
+		background-color: var(--color-surface, #fff);
 		color: var(--color-text-subtle);
 		border-bottom: 1px solid var(--color-neutral-5);
 		border-left: 1px solid var(--color-border-inverted);
@@ -580,7 +580,7 @@ $with-sidebar-min-page-width: 1114px;
 			border-left: 1px solid var(--color-neutral-0);
 		}
 
-		background-color: var(--color-neutral-0);
+		background-color: var(--color-neutral-0, #fff);
 		ol {
 			height: 100%;
 			overflow-y: auto;

--- a/client/dashboard/app/secondary-menu/index.tsx
+++ b/client/dashboard/app/secondary-menu/index.tsx
@@ -1,5 +1,4 @@
 import config from '@automattic/calypso-config';
-import { useNavigate } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -11,13 +10,16 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { help, bellUnread, bell, commentAuthorAvatar } from '@wordpress/icons';
-import { Suspense, lazy, useCallback } from 'react';
+import { Suspense, lazy, useCallback, useState, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import ReaderIcon from 'calypso/assets/icons/reader/reader-icon';
 import RouterLinkMenuItem from '../../components/router-link-menu-item';
+import { useAnalytics } from '../analytics';
 import { useAuth } from '../auth';
 import { useOpenCommandPalette } from '../command-palette/utils';
 import { useAppContext } from '../context';
 import { useHelpCenter } from '../help-center';
+import { useLocale } from '../locale';
 
 import './style.scss';
 
@@ -54,6 +56,77 @@ function Help() {
 						onboardingUrl={ config( 'wpcom_signup_url' ) }
 						sectionName="dashboard"
 					/>
+				) }
+			</Suspense>
+		</>
+	);
+}
+
+const AsyncNotificationsApp = lazy( () =>
+	import( 'calypso/notifications' ).then( ( { Notifications } ) => ( { default: Notifications } ) )
+);
+
+function Notifications() {
+	const [ isOpen, setIsOpen ] = useState( false );
+	const isOpenRef = useRef( isOpen );
+	const containerRef = useRef< HTMLDivElement >( null );
+	const locale = useLocale();
+	const { recordTracksEvent } = useAnalytics();
+	const hasUnreadNotifications = false;
+
+	const checkToggleNotes = useCallback(
+		( event: MouseEvent | null, forceToggle = false, forceOpen = false ) => {
+			const target = event ? event.target : false;
+
+			// Ignore clicks or other events which occur inside of the notification panel.
+			if ( target && containerRef.current?.contains( target as Node ) ) {
+				return;
+			}
+
+			// Prevent toggling closed if we are opting to open.
+			if ( forceOpen && isOpenRef.current ) {
+				return;
+			}
+
+			if ( isOpenRef.current || forceToggle === true || forceOpen === true ) {
+				setIsOpen( ( value ) => ! value );
+			}
+		},
+		[]
+	);
+
+	isOpenRef.current = isOpen;
+
+	return (
+		<>
+			<Button
+				className="dashboard-secondary-menu__item"
+				label={ __( 'Notifications' ) }
+				icon={ hasUnreadNotifications ? bellUnread : bell }
+				variant="tertiary"
+				onClick={ ( event: React.MouseEvent ) => {
+					event.stopPropagation();
+					setIsOpen( ( value ) => ! value );
+				} }
+			/>
+			<Suspense fallback={ null }>
+				{ createPortal(
+					<div ref={ containerRef }>
+						<AsyncNotificationsApp
+							isShowing={ isOpen }
+							currentLocaleSlug={ locale }
+							forceRefresh={ false }
+							selectedSiteId={ false }
+							currentRoute={ window.location.pathname }
+							style={ { top: '65px', background: '#fff', zIndex: 3 } }
+							checkToggle={ checkToggleNotes }
+							recordTracksEventAction={ recordTracksEvent }
+							setUnseenCount={ () => {} }
+							didForceRefresh={ () => {} }
+							requestAdminMenu={ () => {} }
+						/>
+					</div>,
+					document.body
 				) }
 			</Suspense>
 		</>
@@ -129,10 +202,7 @@ function UserProfile() {
 }
 
 function SecondaryMenu() {
-	const navigate = useNavigate();
 	const { supports } = useAppContext();
-	const hasUnreadNotifications = false;
-	const notificationsPath = '/me/notifications';
 
 	return (
 		<HStack spacing={ 2 } justify="flex-end">
@@ -146,19 +216,7 @@ function SecondaryMenu() {
 				/>
 			) }
 			{ supports.help && <Help /> }
-			{ supports.notifications && (
-				<Button
-					className="dashboard-secondary-menu__item"
-					label={ __( 'Notifications' ) }
-					icon={ hasUnreadNotifications ? bellUnread : bell }
-					variant="tertiary"
-					onClick={ ( e: React.MouseEvent< HTMLButtonElement > ) => {
-						e.preventDefault();
-						navigate( { to: notificationsPath } );
-					} }
-					href={ notificationsPath }
-				/>
-			) }
+			{ supports.notifications && <Notifications /> }
 			<UserProfile />
 		</HStack>
 	);

--- a/client/dashboard/components/header-bar/style.scss
+++ b/client/dashboard/components/header-bar/style.scss
@@ -5,7 +5,6 @@
 	padding: $grid-unit-15;
 	border-bottom: $border-width solid var( --dashboard-header__border-color );
 	background-color: var( --dashboard-header__background-color );
-	backdrop-filter: blur(4px);
 	color: var( --dashboard-header__color );
 }
 

--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -322,6 +322,7 @@ export class Notifications extends Component {
 						'wpnt-open': this.props.isShowing,
 						'wpnt-closed': ! this.props.isShowing,
 					} ) }
+					style={ this.props.style }
 				>
 					{ isDedicatedReaderPage && (
 						<Notifications3PCNotice className="reader-notifications__3pc-notice-internal" />


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* This PR focuses only on introducing the Notifications popup.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Click the notification icon on the top-right corner
* It should open the Notification
* Click the icon again or any places outside the notification popup
* It should close the Notification

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
