### PR TITLE
Domains: Name servers: Disable submit button

### DIFF
--- a/client/dashboard/domains/name-servers/form.tsx
+++ b/client/dashboard/domains/name-servers/form.tsx
@@ -19,7 +19,66 @@ import {
 	NameServerKey,
 } from './types';
 import UpsellNudge from './upsell-nudge';
-import { areAllWpcomNameServers, validateHostname, getFormNameServers } from './utils';
+import { areAllWpcomNameServers, validateHostname } from './utils';
+
+const createNameServerField = ( index: number, formData: FormData, isBusy?: boolean ) => {
+	const baseField = {
+		id: `nameServer${ index }` as NameServerKey,
+		type: 'text' as const,
+		label: sprintf(
+			// translators: %s is the name server number (1-4)
+			__( 'Custom name server %s' ),
+			index
+		),
+		placeholder: sprintf(
+			// translators: %s is the name server number (1-4)
+			__( 'ns%s.domain.com' ),
+			index
+		),
+		isValid: {
+			required: index <= MIN_NAME_SERVERS_LENGTH,
+			custom: ( formData: FormData, field: NormalizedField< FormData > ) => {
+				const value = formData[ field.id as NameServerKey ];
+				// Skip validation for empty optional fields
+				if ( ! value && ! field.isValid?.required ) {
+					return null;
+				}
+				return validateHostname( value ) ? null : __( 'Please enter a valid hostname' );
+			},
+		},
+		isVisible: ( item: FormData ) => {
+			// For WP.com nameservers, show field only if it has a value
+			if ( item.useWpcomNameServers ) {
+				return Boolean( item[ `nameServer${ index }` as NameServerKey ] );
+			}
+
+			// For custom nameservers, show fields 3 and 4 only if previous field has value
+			if ( index > MIN_NAME_SERVERS_LENGTH ) {
+				return Boolean( item[ `nameServer${ index - 1 }` as NameServerKey ] );
+			}
+
+			// Always show MIN_NAME_SERVERS_LENGTH fields
+			return true;
+		},
+	};
+
+	return formData.useWpcomNameServers || isBusy
+		? {
+				...baseField,
+				Edit: ( { field }: { field: Field< FormData > } ) => (
+					<InputControl
+						__next40pxDefaultSize
+						disabled
+						label={ field.label }
+						value={ formData[ field.id as NameServerKey ]?.toLowerCase() }
+					/>
+				),
+		  }
+		: baseField;
+};
+
+export const getFormNameServers = ( { useWpcomNameServers, ...nameServers }: FormData ) =>
+	Object.values( nameServers ).filter( Boolean );
 
 interface Props {
 	domainName: string;
@@ -66,65 +125,6 @@ export default function NameServersForm( {
 			],
 		} ),
 		[]
-	);
-
-	const createNameServerField = useCallback(
-		( index: number ) => {
-			const baseField = {
-				id: `nameServer${ index }` as NameServerKey,
-				type: 'text' as const,
-				label: sprintf(
-					// translators: %s is the name server number (1-4)
-					__( 'Custom name server %s' ),
-					index
-				),
-				placeholder: sprintf(
-					// translators: %s is the name server number (1-4)
-					__( 'ns%s.domain.com' ),
-					index
-				),
-				isValid: {
-					required: index <= MIN_NAME_SERVERS_LENGTH,
-					custom: ( formData: FormData, field: NormalizedField< FormData > ) => {
-						const value = formData[ field.id as NameServerKey ];
-						// Skip validation for empty optional fields
-						if ( ! value && ! field.isValid?.required ) {
-							return null;
-						}
-						return validateHostname( value ) ? null : __( 'Please enter a valid hostname' );
-					},
-				},
-				isVisible: ( item: FormData ) => {
-					// For WP.com nameservers, show field only if it has a value
-					if ( item.useWpcomNameServers ) {
-						return Boolean( item[ `nameServer${ index }` as NameServerKey ] );
-					}
-
-					// For custom nameservers, show fields 3 and 4 only if previous field has value
-					if ( index > MIN_NAME_SERVERS_LENGTH ) {
-						return Boolean( item[ `nameServer${ index - 1 }` as NameServerKey ] );
-					}
-
-					// Always show MIN_NAME_SERVERS_LENGTH fields
-					return true;
-				},
-			};
-
-			return formData.useWpcomNameServers || isBusy
-				? {
-						...baseField,
-						Edit: ( { field }: { field: Field< FormData > } ) => (
-							<InputControl
-								__next40pxDefaultSize
-								disabled
-								label={ field.label }
-								value={ formData[ field.id as NameServerKey ]?.toLowerCase() }
-							/>
-						),
-				  }
-				: baseField;
-		},
-		[ formData, isBusy ]
 	);
 
 	const fields = useMemo(
@@ -176,10 +176,10 @@ export default function NameServersForm( {
 				},
 			},
 			...Array.from( { length: MAX_NAME_SERVERS_LENGTH }, ( _, i ) =>
-				createNameServerField( i + 1 )
+				createNameServerField( i + 1, formData, isBusy )
 			),
 		],
-		[ createNameServerField, isBusy, showUpsellNudge, domainName, domainSiteSlug ]
+		[ formData, isBusy, showUpsellNudge, domainName, domainSiteSlug ]
 	);
 
 	const handleSubmit = useCallback(

--- a/client/dashboard/domains/name-servers/form.tsx
+++ b/client/dashboard/domains/name-servers/form.tsx
@@ -202,9 +202,7 @@ export default function NameServersForm( {
 		);
 	}, [ nameServers, formData ] );
 
-	const canSubmit = useMemo( () => {
-		return ! isBusy && isItemValid( formData, fields, formObj ) && isNameServersChanged();
-	}, [ isBusy, formData, fields, formObj, isNameServersChanged ] );
+	const canSubmit = ! isBusy && isItemValid( formData, fields, formObj ) && isNameServersChanged();
 
 	return (
 		<form onSubmit={ handleSubmit }>

--- a/client/dashboard/domains/name-servers/form.tsx
+++ b/client/dashboard/domains/name-servers/form.tsx
@@ -187,21 +187,36 @@ export default function NameServersForm( {
 		[ createNameServerField, isBusy, showUpsellNudge, domainName, domainSiteSlug ]
 	);
 
+	const getFormNameServersValue = useCallback( () => {
+		return Array.from(
+			{ length: MAX_NAME_SERVERS_LENGTH },
+			( _, i ) => formData[ `nameServer${ i + 1 }` as NameServerKey ]
+		).filter( Boolean );
+	}, [ formData ] );
+
 	const handleSubmit = useCallback(
 		( e: React.FormEvent ) => {
 			e.preventDefault();
-
-			// Get all nameServer values dynamically
-			const nameServerValues = Array.from(
-				{ length: MAX_NAME_SERVERS_LENGTH },
-				( _, i ) => formData[ `nameServer${ i + 1 }` as NameServerKey ]
-			).filter( Boolean );
-			onSubmit( nameServerValues );
+			onSubmit( getFormNameServersValue() );
 		},
-		[ formData, onSubmit ]
+		[ onSubmit, getFormNameServersValue ]
 	);
 
-	const isFormValid = isItemValid( formData, fields, formObj );
+	const isNameServersChanged = useCallback( () => {
+		const currentNameServers = getFormNameServersValue();
+		// Different lengths means there's definitely a change
+		if ( currentNameServers.length !== nameServers.length ) {
+			return true;
+		}
+		// Check if every nameserver matches in the same position
+		return currentNameServers.some(
+			( ns, index ) => ns.toLowerCase() !== ( nameServers[ index ] || '' ).toLowerCase()
+		);
+	}, [ getFormNameServersValue, nameServers ] );
+
+	const canSubmit = useMemo( () => {
+		return ! isBusy && isItemValid( formData, fields, formObj ) && isNameServersChanged();
+	}, [ isBusy, formData, fields, formObj, isNameServersChanged ] );
 
 	return (
 		<form onSubmit={ handleSubmit }>
@@ -219,7 +234,7 @@ export default function NameServersForm( {
 						__next40pxDefaultSize
 						variant="primary"
 						type="submit"
-						disabled={ isBusy || ! isFormValid }
+						disabled={ ! canSubmit }
 						isBusy={ isBusy }
 					>
 						{ __( 'Save' ) }

--- a/client/dashboard/domains/name-servers/form.tsx
+++ b/client/dashboard/domains/name-servers/form.tsx
@@ -15,16 +15,11 @@ import {
 	MIN_NAME_SERVERS_LENGTH,
 	MAX_NAME_SERVERS_LENGTH,
 	WPCOM_DEFAULT_NAME_SERVERS,
+	FormData,
 	NameServerKey,
 } from './types';
 import UpsellNudge from './upsell-nudge';
-import { areAllWpcomNameServers, validateHostname } from './utils';
-
-type FormData = {
-	useWpcomNameServers: boolean;
-} & {
-	[ K in NameServerKey ]: string;
-};
+import { areAllWpcomNameServers, validateHostname, getFormNameServersValue } from './utils';
 
 interface Props {
 	domainName: string;
@@ -187,23 +182,16 @@ export default function NameServersForm( {
 		[ createNameServerField, isBusy, showUpsellNudge, domainName, domainSiteSlug ]
 	);
 
-	const getFormNameServersValue = useCallback( () => {
-		return Array.from(
-			{ length: MAX_NAME_SERVERS_LENGTH },
-			( _, i ) => formData[ `nameServer${ i + 1 }` as NameServerKey ]
-		).filter( Boolean );
-	}, [ formData ] );
-
 	const handleSubmit = useCallback(
 		( e: React.FormEvent ) => {
 			e.preventDefault();
-			onSubmit( getFormNameServersValue() );
+			onSubmit( getFormNameServersValue( formData ) );
 		},
-		[ onSubmit, getFormNameServersValue ]
+		[ onSubmit, formData ]
 	);
 
 	const isNameServersChanged = useCallback( () => {
-		const currentNameServers = getFormNameServersValue();
+		const currentNameServers = getFormNameServersValue( formData );
 		// Different lengths means there's definitely a change
 		if ( currentNameServers.length !== nameServers.length ) {
 			return true;
@@ -212,7 +200,7 @@ export default function NameServersForm( {
 		return currentNameServers.some(
 			( ns, index ) => ns.toLowerCase() !== ( nameServers[ index ] || '' ).toLowerCase()
 		);
-	}, [ getFormNameServersValue, nameServers ] );
+	}, [ nameServers, formData ] );
 
 	const canSubmit = useMemo( () => {
 		return ! isBusy && isItemValid( formData, fields, formObj ) && isNameServersChanged();

--- a/client/dashboard/domains/name-servers/form.tsx
+++ b/client/dashboard/domains/name-servers/form.tsx
@@ -77,8 +77,20 @@ const createNameServerField = ( index: number, formData: FormData, isBusy?: bool
 		: baseField;
 };
 
-export const getFormNameServers = ( { useWpcomNameServers, ...nameServers }: FormData ) =>
+const getFormNameServers = ( { useWpcomNameServers, ...nameServers }: FormData ) =>
 	Object.values( nameServers ).filter( Boolean );
+
+const isNameServersChanged = ( formData: FormData, nameServers: string[] ) => {
+	const currentNameServers = getFormNameServers( formData );
+	// Different lengths means there's definitely a change
+	if ( currentNameServers.length !== nameServers.length ) {
+		return true;
+	}
+	// Check if every nameserver matches in the same position
+	return currentNameServers.some(
+		( ns, index ) => ns.toLowerCase() !== ( nameServers[ index ] || '' ).toLowerCase()
+	);
+};
 
 interface Props {
 	domainName: string;
@@ -190,19 +202,10 @@ export default function NameServersForm( {
 		[ onSubmit, formData ]
 	);
 
-	const isNameServersChanged = useCallback( () => {
-		const currentNameServers = getFormNameServers( formData );
-		// Different lengths means there's definitely a change
-		if ( currentNameServers.length !== nameServers.length ) {
-			return true;
-		}
-		// Check if every nameserver matches in the same position
-		return currentNameServers.some(
-			( ns, index ) => ns.toLowerCase() !== ( nameServers[ index ] || '' ).toLowerCase()
-		);
-	}, [ nameServers, formData ] );
-
-	const canSubmit = ! isBusy && isItemValid( formData, fields, formObj ) && isNameServersChanged();
+	const canSubmit =
+		! isBusy &&
+		isItemValid( formData, fields, formObj ) &&
+		isNameServersChanged( formData, nameServers );
 
 	return (
 		<form onSubmit={ handleSubmit }>

--- a/client/dashboard/domains/name-servers/form.tsx
+++ b/client/dashboard/domains/name-servers/form.tsx
@@ -6,7 +6,7 @@ import {
 	__experimentalInputControl as InputControl,
 	ToggleControl,
 } from '@wordpress/components';
-import { Field, DataForm, NormalizedField } from '@wordpress/dataviews';
+import { Field, DataForm, NormalizedField, isItemValid } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useCallback, useMemo } from 'react';
@@ -94,9 +94,9 @@ export default function NameServersForm( {
 						const value = formData[ field.id as NameServerKey ];
 						// Skip validation for empty optional fields
 						if ( ! value && ! field.isValid?.required ) {
-							return '';
+							return null;
 						}
-						return validateHostname( value ) ? '' : __( 'Please enter a valid hostname' );
+						return validateHostname( value ) ? null : __( 'Please enter a valid hostname' );
 					},
 				},
 				isVisible: ( item: FormData ) => {
@@ -201,6 +201,8 @@ export default function NameServersForm( {
 		[ formData, onSubmit ]
 	);
 
+	const isFormValid = isItemValid( formData, fields, formObj );
+
 	return (
 		<form onSubmit={ handleSubmit }>
 			<VStack spacing={ 4 }>
@@ -217,7 +219,7 @@ export default function NameServersForm( {
 						__next40pxDefaultSize
 						variant="primary"
 						type="submit"
-						disabled={ isBusy }
+						disabled={ isBusy || ! isFormValid }
 						isBusy={ isBusy }
 					>
 						{ __( 'Save' ) }

--- a/client/dashboard/domains/name-servers/form.tsx
+++ b/client/dashboard/domains/name-servers/form.tsx
@@ -19,7 +19,7 @@ import {
 	NameServerKey,
 } from './types';
 import UpsellNudge from './upsell-nudge';
-import { areAllWpcomNameServers, validateHostname, getFormNameServersValue } from './utils';
+import { areAllWpcomNameServers, validateHostname, getFormNameServers } from './utils';
 
 interface Props {
 	domainName: string;
@@ -185,13 +185,13 @@ export default function NameServersForm( {
 	const handleSubmit = useCallback(
 		( e: React.FormEvent ) => {
 			e.preventDefault();
-			onSubmit( getFormNameServersValue( formData ) );
+			onSubmit( getFormNameServers( formData ) );
 		},
 		[ onSubmit, formData ]
 	);
 
 	const isNameServersChanged = useCallback( () => {
-		const currentNameServers = getFormNameServersValue( formData );
+		const currentNameServers = getFormNameServers( formData );
 		// Different lengths means there's definitely a change
 		if ( currentNameServers.length !== nameServers.length ) {
 			return true;

--- a/client/dashboard/domains/name-servers/types.ts
+++ b/client/dashboard/domains/name-servers/types.ts
@@ -7,15 +7,21 @@ export const WPCOM_DEFAULT_NAME_SERVERS = [
 	'ns3.wordpress.com',
 ];
 
-export interface NameServerField {
-	value: string;
-	error: string;
-	touched: boolean;
-}
-
 // Create a union type of numbers from 1 to MAX_NAME_SERVERS_LENGTH
 export type Range< N extends number, T extends number[] = [] > = T[ 'length' ] extends N
 	? T[ number ]
 	: Range< N, [ ...T, T[ 'length' ] ] >;
 
 export type NameServerKey = `nameServer${ Range< typeof MAX_NAME_SERVERS_LENGTH > }`;
+
+export type FormData = {
+	useWpcomNameServers: boolean;
+} & {
+	[ K in NameServerKey ]: string;
+};
+
+export interface NameServerField {
+	value: string;
+	error: string;
+	touched: boolean;
+}

--- a/client/dashboard/domains/name-servers/utils.ts
+++ b/client/dashboard/domains/name-servers/utils.ts
@@ -1,4 +1,4 @@
-import { type FormData, type NameServerKey, MAX_NAME_SERVERS_LENGTH } from './types';
+import { type FormData } from './types';
 import type { Domain } from '../../data/domain';
 import type { User } from '../../data/me';
 import type { Site } from '../../data/site';
@@ -22,12 +22,8 @@ export const areAllWpcomNameServers = ( nameservers?: string[] ) => {
 	} );
 };
 
-export const getFormNameServersValue = ( formData: FormData ) => {
-	return Array.from(
-		{ length: MAX_NAME_SERVERS_LENGTH },
-		( _, i ) => formData[ `nameServer${ i + 1 }` as NameServerKey ]
-	).filter( Boolean );
-};
+export const getFormNameServers = ( { useWpcomNameServers, ...nameServers }: FormData ) =>
+	Object.values( nameServers ).filter( Boolean );
 
 export const shouldShowUpsellNudge = ( user: User, domain: Domain, site?: Site ): boolean => {
 	if (

--- a/client/dashboard/domains/name-servers/utils.ts
+++ b/client/dashboard/domains/name-servers/utils.ts
@@ -1,3 +1,4 @@
+import { type FormData, type NameServerKey, MAX_NAME_SERVERS_LENGTH } from './types';
 import type { Domain } from '../../data/domain';
 import type { User } from '../../data/me';
 import type { Site } from '../../data/site';
@@ -19,6 +20,13 @@ export const areAllWpcomNameServers = ( nameservers?: string[] ) => {
 	return nameservers.every( ( nameserver: string ) => {
 		return ! nameserver || WPCOM_DEFAULT_NAMESERVERS_REGEX.test( nameserver );
 	} );
+};
+
+export const getFormNameServersValue = ( formData: FormData ) => {
+	return Array.from(
+		{ length: MAX_NAME_SERVERS_LENGTH },
+		( _, i ) => formData[ `nameServer${ i + 1 }` as NameServerKey ]
+	).filter( Boolean );
 };
 
 export const shouldShowUpsellNudge = ( user: User, domain: Domain, site?: Site ): boolean => {

--- a/client/dashboard/domains/name-servers/utils.ts
+++ b/client/dashboard/domains/name-servers/utils.ts
@@ -1,4 +1,3 @@
-import { type FormData } from './types';
 import type { Domain } from '../../data/domain';
 import type { User } from '../../data/me';
 import type { Site } from '../../data/site';
@@ -21,9 +20,6 @@ export const areAllWpcomNameServers = ( nameservers?: string[] ) => {
 		return ! nameserver || WPCOM_DEFAULT_NAMESERVERS_REGEX.test( nameserver );
 	} );
 };
-
-export const getFormNameServers = ( { useWpcomNameServers, ...nameServers }: FormData ) =>
-	Object.values( nameServers ).filter( Boolean );
 
 export const shouldShowUpsellNudge = ( user: User, domain: Domain, site?: Site ): boolean => {
 	if (


### PR DESCRIPTION
Closes DOTDASH-304

## Proposed Changes

* Disable the submit button if form is not valid and values are not changed

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve UX

## Testing Instructions

* Go to `/v2/domains/{DOMAIN_NAME}/name-servers`
* Check different scenarios with the form

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
