### PR TITLE
Connect Refresh: Remove extended margin from email+continue form

### DIFF
--- a/client/signup/validation-fieldset/style.scss
+++ b/client/signup/validation-fieldset/style.scss
@@ -12,8 +12,4 @@
 
 .validation-fieldset + .logged-out-form__footer {
 	margin-top: 0;
-
-	@include breakpoint-deprecated( ">480px" ) {
-		margin-top: 20px;
-	}
 }

--- a/client/signup/validation-fieldset/style.scss
+++ b/client/signup/validation-fieldset/style.scss
@@ -9,7 +9,3 @@
 		margin: 0;
 	}
 }
-
-.validation-fieldset + .logged-out-form__footer {
-	margin-top: 0;
-}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13218/signup-update-and-unify-the-create-account-screens

## Proposed Changes

The default Unified Signup (create-account) form contains some extra margin between email field and "continue" btn below. It looks unnatural and misplaced.

### Before

| Default | with error |
|--------|--------|
| <img width="842" height="729" alt="Screenshot 2025-08-18 at 2 08 50 PM" src="https://github.com/user-attachments/assets/d31ca1f9-0b9b-49ba-b9fc-fb1c749e6369" /> | <img width="844" height="755" alt="Screenshot 2025-08-18 at 2 08 56 PM" src="https://github.com/user-attachments/assets/cf484e29-15bf-475b-a40f-6606089af113" /> |

### After

| Default | with error |
|--------|--------|
| <img width="843" height="730" alt="Screenshot 2025-08-18 at 2 08 20 PM" src="https://github.com/user-attachments/assets/9118d165-cf9c-4e17-8219-8e7520331f4e" /> | <img width="850" height="720" alt="Screenshot 2025-08-18 at 2 08 27 PM" src="https://github.com/user-attachments/assets/2acb1d1f-5058-455a-a908-7082095bc9fe" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Signup form fixes

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to a flow that renders the default WP Signup form e.g. `/start/onboarding` (and click on "create an account")
* Confirm above
* Go to default not-unidifed WP Signup form and confirm no canges e.g. `/start` (and click on "create an account")
* Go to any OAuth  2 client Signup forms and confirm no related changes e.g. [Studio](http://calypso.localhost:3000/log-in?client_id=95109&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dtoken%26client_id%3D95109%26redirect_uri%3Dwpcom-local-dev%253A%252F%252Fauth%26scope%3Dglobal%26client_source%26jetpack-code%26jetpack-user-id%3D0%26action%3Doauth2-login%26from-calypso%3D1)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
