### PR TITLE
Hosting dashboard: Domains/Add dns zone import 

### DIFF
--- a/client/dashboard/app/queries/domain-dns-records.ts
+++ b/client/dashboard/app/queries/domain-dns-records.ts
@@ -56,9 +56,7 @@ export const domainDnsApplyTemplateMutation = ( domainName: string ) =>
 			variables: DnsTemplateVariables;
 		} ) => applyDnsTemplate( domainName, provider, service, variables ),
 		onSuccess: () => {
-			queryClient.invalidateQueries( {
-				queryKey: [ 'domains', domainName, 'dns' ],
-			} );
+			queryClient.invalidateQueries( domainDnsQuery( domainName ) );
 		},
 	} );
 

--- a/client/dashboard/app/queries/domain-dns-records.ts
+++ b/client/dashboard/app/queries/domain-dns-records.ts
@@ -6,6 +6,7 @@ import {
 	type DnsRecord,
 	applyDnsTemplate,
 	type DnsTemplateVariables,
+	importDnsBind,
 } from '../../data/domain-dns-records';
 import { queryClient } from '../query-client';
 
@@ -54,6 +55,16 @@ export const domainDnsApplyTemplateMutation = ( domainName: string ) =>
 			service: string;
 			variables: DnsTemplateVariables;
 		} ) => applyDnsTemplate( domainName, provider, service, variables ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( {
+				queryKey: [ 'domains', domainName, 'dns' ],
+			} );
+		},
+	} );
+
+export const domainDnsImportBindMutation = ( domainName: string ) =>
+	mutationOptions( {
+		mutationFn: ( formData: [ string, File, string ][] ) => importDnsBind( domainName, formData ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( {
 				queryKey: [ 'domains', domainName, 'dns' ],

--- a/client/dashboard/app/queries/domain-dns-records.ts
+++ b/client/dashboard/app/queries/domain-dns-records.ts
@@ -64,7 +64,7 @@ export const domainDnsApplyTemplateMutation = ( domainName: string ) =>
 
 export const domainDnsImportBindMutation = ( domainName: string ) =>
 	mutationOptions( {
-		mutationFn: ( formData: [ string, File, string ][] ) => importDnsBind( domainName, formData ),
+		mutationFn: ( file: File ) => importDnsBind( domainName, file ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( {
 				queryKey: [ 'domains', domainName, 'dns' ],

--- a/client/dashboard/app/queries/domain-dns-records.ts
+++ b/client/dashboard/app/queries/domain-dns-records.ts
@@ -66,8 +66,6 @@ export const domainDnsImportBindMutation = ( domainName: string ) =>
 	mutationOptions( {
 		mutationFn: ( file: File ) => importDnsBind( domainName, file ),
 		onSuccess: () => {
-			queryClient.invalidateQueries( {
-				queryKey: [ 'domains', domainName, 'dns' ],
-			} );
+			queryClient.invalidateQueries( domainDnsQuery( domainName ) );
 		},
 	} );

--- a/client/dashboard/data/domain-dns-records.ts
+++ b/client/dashboard/data/domain-dns-records.ts
@@ -81,13 +81,10 @@ export function applyDnsTemplate(
 	} );
 }
 
-export function importDnsBind(
-	domain: string,
-	formData: [ string, File, string ][]
-): Promise< DnsRecord[] > {
+export function importDnsBind( domain: string, file: File ): Promise< DnsRecord[] > {
 	return wpcom.req.post( {
 		path: `/domains/dns/import/bind/${ domain }`,
 		apiNamespace: 'wpcom/v2',
-		formData,
+		formData: [ [ 'files[]', file, file.name ] ],
 	} );
 }

--- a/client/dashboard/data/domain-dns-records.ts
+++ b/client/dashboard/data/domain-dns-records.ts
@@ -80,3 +80,14 @@ export function applyDnsTemplate(
 		},
 	} );
 }
+
+export function importDnsBind(
+	domain: string,
+	formData: [ string, File, string ][]
+): Promise< DnsRecord[] > {
+	return wpcom.req.post( {
+		path: `/domains/dns/import/bind/${ domain }`,
+		apiNamespace: 'wpcom/v2',
+		formData,
+	} );
+}

--- a/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
+++ b/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
@@ -4,8 +4,10 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
+	CheckboxControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useState, useMemo } from 'react';
 import type { DnsRecord } from '../../data/domain-dns-records';
 
 interface DnsImportDialogProps {
@@ -23,55 +25,139 @@ export default function DnsImportDialog( {
 	onCancel,
 	isBusy = false,
 }: DnsImportDialogProps ) {
+	const [ selectedRecords, setSelectedRecords ] = useState< Set< string > >( new Set() );
+
+	// Initialize all records as selected when records change
+	useMemo( () => {
+		if ( records.length > 0 ) {
+			const allRecordIds = new Set( records.map( ( record, index ) => `record-${ index }` ) );
+			setSelectedRecords( allRecordIds );
+		}
+	}, [ records ] );
+
 	if ( ! isOpen ) {
 		return null;
 	}
+
+	const numberOfSelectedRecords = selectedRecords.size;
+
+	const toggleRecord = ( recordId: string ) => {
+		const newSelectedRecords = new Set( selectedRecords );
+		if ( newSelectedRecords.has( recordId ) ) {
+			newSelectedRecords.delete( recordId );
+		} else {
+			newSelectedRecords.add( recordId );
+		}
+		setSelectedRecords( newSelectedRecords );
+	};
+
+	const toggleAllRecords = () => {
+		if ( numberOfSelectedRecords === records.length ) {
+			// If all are selected, unselect all
+			setSelectedRecords( new Set() );
+		} else {
+			// If not all are selected, select all
+			const allRecordIds = new Set( records.map( ( record, index ) => `record-${ index }` ) );
+			setSelectedRecords( allRecordIds );
+		}
+	};
+
+	const handleConfirm = () => {
+		// Filter only selected records
+		const selectedRecordsData = records.filter( ( record, index ) =>
+			selectedRecords.has( `record-${ index }` )
+		);
+
+		// TODO: Process selectedRecordsData
+		// For now, just log to console as requested
+		// eslint-disable-next-line no-console
+		console.log( 'Selected DNS records:', selectedRecordsData );
+
+		onConfirm();
+	};
+
+	const renderRecordAsString = ( record: DnsRecord ) => {
+		const recordAsString = `${ record.name } ${ record.type }`;
+
+		switch ( record.type ) {
+			case 'A':
+			case 'AAAA':
+			case 'CNAME':
+			case 'NS':
+			case 'TXT':
+				return `${ recordAsString } ${ record.data }`;
+			case 'MX':
+				return `${ recordAsString } ${ record.aux } ${ record.data }`;
+			case 'SRV':
+				return `${ record.service }.${ record.protocol }.${ recordAsString } ${ record.aux } ${ record.weight } ${ record.port } ${ record.data }`;
+			default:
+				return recordAsString;
+		}
+	};
+
+	const renderHeader = () => {
+		const headerLabel = `${ numberOfSelectedRecords !== 1 ? 's' : '' } selected`;
+
+		return (
+			<div style={ { marginBottom: '16px' } }>
+				<CheckboxControl
+					__nextHasNoMarginBottom
+					checked={ numberOfSelectedRecords === records.length }
+					indeterminate={ numberOfSelectedRecords > 0 && numberOfSelectedRecords < records.length }
+					onChange={ toggleAllRecords }
+					label={ `${ numberOfSelectedRecords } record${ headerLabel }` }
+				/>
+			</div>
+		);
+	};
+
+	const renderRecordRow = ( record: DnsRecord, index: number ) => {
+		const recordId = `record-${ index }`;
+		const isSelected = selectedRecords.has( recordId );
+
+		return (
+			<div key={ index } style={ { marginBottom: '8px' } }>
+				<CheckboxControl
+					__nextHasNoMarginBottom
+					checked={ isSelected }
+					onChange={ () => toggleRecord( recordId ) }
+					label={ renderRecordAsString( record ) }
+				/>
+			</div>
+		);
+	};
 
 	return (
 		<Modal title={ __( 'Import DNS Records' ) } onRequestClose={ onCancel }>
 			<VStack spacing={ 6 }>
 				<Text>
 					{ __(
-						'The following DNS records will be imported. Please review them before confirming.'
+						'Select the DNS records you want to import. Please review them before confirming.'
 					) }
 				</Text>
 
-				{ records.length > 0 && (
-					<VStack spacing={ 3 }>
-						<Text>{ __( 'Records to import:' ) }</Text>
-						<VStack spacing={ 2 }>
-							{ records.map( ( record, index ) => (
-								<div
-									key={ `${ record.type }-${ record.name }-${ index }` }
-									style={ {
-										padding: '12px',
-										border: '1px solid #ddd',
-										borderRadius: '4px',
-										backgroundColor: '#f9f9f9',
-									} }
-								>
-									<HStack justify="space-between" alignment="flex-start">
-										<VStack spacing={ 2 } style={ { flex: 1 } }>
-											<HStack spacing={ 2 }>
-												<Text>{ record.type }</Text>
-												<Text>{ record.name }</Text>
-											</HStack>
-											<Text>{ record.data || record.value || '-' }</Text>
-											{ record.ttl && <Text>{ `TTL: ${ record.ttl.toString() }` }</Text> }
-										</VStack>
-									</HStack>
-								</div>
-							) ) }
-						</VStack>
-					</VStack>
+				{ records.length > 0 ? (
+					<>
+						{ renderHeader() }
+						<div style={ { maxHeight: '300px', overflowY: 'auto' } }>
+							{ records.map( ( record, index ) => renderRecordRow( record, index ) ) }
+						</div>
+					</>
+				) : (
+					<Text>{ __( "We couldn't find valid DNS records to import." ) }</Text>
 				) }
 
 				<HStack justify="flex-end" spacing={ 2 }>
 					<Button onClick={ onCancel } isBusy={ isBusy }>
 						{ __( 'Cancel' ) }
 					</Button>
-					<Button variant="primary" isBusy={ isBusy } onClick={ onConfirm }>
-						{ __( 'Import Records' ) }
+					<Button
+						variant="primary"
+						isBusy={ isBusy }
+						onClick={ handleConfirm }
+						disabled={ numberOfSelectedRecords === 0 }
+					>
+						{ __( 'Import Selected Records' ) }
 					</Button>
 				</HStack>
 			</VStack>

--- a/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
+++ b/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
@@ -11,7 +11,7 @@ import {
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { useState, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 import { domainDnsMutation } from '../../app/queries/domain-dns-records';
 import type { DnsRecord } from '../../data/domain-dns-records';
 
@@ -36,9 +36,11 @@ export default function DnsImportDialog( {
 	const updateDnsMutation = useMutation( domainDnsMutation( domainName ) );
 
 	// Initialize all records as selected when records change
-	useMemo( () => {
+	useEffect( () => {
 		if ( records.length > 0 ) {
-			const allRecordIds = new Set( records.map( ( record, index ) => `record-${ index }` ) );
+			const allRecordIds = new Set(
+				records.map( ( record, index ) => `${ record.type }-${ record.name }-${ index }` )
+			);
 			setSelectedRecords( allRecordIds );
 		}
 	}, [ records ] );
@@ -65,7 +67,9 @@ export default function DnsImportDialog( {
 			setSelectedRecords( new Set() );
 		} else {
 			// If not all are selected, select all
-			const allRecordIds = new Set( records.map( ( record, index ) => `record-${ index }` ) );
+			const allRecordIds = new Set(
+				records.map( ( record, index ) => `${ record.type }-${ record.name }-${ index }` )
+			);
 			setSelectedRecords( allRecordIds );
 		}
 	};
@@ -73,7 +77,7 @@ export default function DnsImportDialog( {
 	const handleConfirm = () => {
 		// Filter only selected records
 		const selectedRecordsData = records.filter( ( record, index ) =>
-			selectedRecords.has( `record-${ index }` )
+			selectedRecords.has( `${ record.type }-${ record.name }-${ index }` )
 		);
 
 		// Use domainDnsMutation to add the selected records
@@ -134,7 +138,7 @@ export default function DnsImportDialog( {
 	};
 
 	const renderRecordRow = ( record: DnsRecord, index: number ) => {
-		const recordId = `record-${ index }`;
+		const recordId = `${ record.type }-${ record.name }-${ index }`;
 		const isSelected = selectedRecords.has( recordId );
 
 		return (

--- a/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
+++ b/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
@@ -125,15 +125,13 @@ export default function DnsImportDialog( {
 		const headerLabel = `${ numberOfSelectedRecords !== 1 ? 's' : '' } selected`;
 
 		return (
-			<div style={ { marginBottom: '16px' } }>
-				<CheckboxControl
-					__nextHasNoMarginBottom
-					checked={ numberOfSelectedRecords === records.length }
-					indeterminate={ numberOfSelectedRecords > 0 && numberOfSelectedRecords < records.length }
-					onChange={ toggleAllRecords }
-					label={ `${ numberOfSelectedRecords } record${ headerLabel }` }
-				/>
-			</div>
+			<CheckboxControl
+				__nextHasNoMarginBottom
+				checked={ numberOfSelectedRecords === records.length }
+				indeterminate={ numberOfSelectedRecords > 0 && numberOfSelectedRecords < records.length }
+				onChange={ toggleAllRecords }
+				label={ `${ numberOfSelectedRecords } record${ headerLabel }` }
+			/>
 		);
 	};
 
@@ -163,13 +161,11 @@ export default function DnsImportDialog( {
 				</Text>
 
 				{ records.length > 0 ? (
-					<>
+					<VStack spacing={ 2 }>
 						{ renderHeader() }
 						<Divider />
-						<div style={ { maxHeight: '300px', overflowY: 'auto' } }>
-							{ records.map( ( record, index ) => renderRecordRow( record, index ) ) }
-						</div>
-					</>
+						{ records.map( ( record, index ) => renderRecordRow( record, index ) ) }
+					</VStack>
 				) : (
 					<Text>{ __( "We couldn't find valid DNS records to import." ) }</Text>
 				) }

--- a/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
+++ b/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
@@ -1,0 +1,80 @@
+import {
+	Modal,
+	Button,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import type { DnsRecord } from '../../data/domain-dns-records';
+
+interface DnsImportDialogProps {
+	isOpen: boolean;
+	records: DnsRecord[];
+	onConfirm: () => void;
+	onCancel: () => void;
+	isBusy?: boolean;
+}
+
+export default function DnsImportDialog( {
+	isOpen,
+	records,
+	onConfirm,
+	onCancel,
+	isBusy = false,
+}: DnsImportDialogProps ) {
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	return (
+		<Modal title={ __( 'Import DNS Records' ) } onRequestClose={ onCancel }>
+			<VStack spacing={ 6 }>
+				<Text>
+					{ __(
+						'The following DNS records will be imported. Please review them before confirming.'
+					) }
+				</Text>
+
+				{ records.length > 0 && (
+					<VStack spacing={ 3 }>
+						<Text>{ __( 'Records to import:' ) }</Text>
+						<VStack spacing={ 2 }>
+							{ records.map( ( record, index ) => (
+								<div
+									key={ `${ record.type }-${ record.name }-${ index }` }
+									style={ {
+										padding: '12px',
+										border: '1px solid #ddd',
+										borderRadius: '4px',
+										backgroundColor: '#f9f9f9',
+									} }
+								>
+									<HStack justify="space-between" alignment="flex-start">
+										<VStack spacing={ 2 } style={ { flex: 1 } }>
+											<HStack spacing={ 2 }>
+												<Text>{ record.type }</Text>
+												<Text>{ record.name }</Text>
+											</HStack>
+											<Text>{ record.data || record.value || '-' }</Text>
+											{ record.ttl && <Text>{ `TTL: ${ record.ttl.toString() }` }</Text> }
+										</VStack>
+									</HStack>
+								</div>
+							) ) }
+						</VStack>
+					</VStack>
+				) }
+
+				<HStack justify="flex-end" spacing={ 2 }>
+					<Button onClick={ onCancel } isBusy={ isBusy }>
+						{ __( 'Cancel' ) }
+					</Button>
+					<Button variant="primary" isBusy={ isBusy } onClick={ onConfirm }>
+						{ __( 'Import Records' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		</Modal>
+	);
+}

--- a/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
+++ b/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
@@ -1,3 +1,4 @@
+import { useMutation } from '@tanstack/react-query';
 import {
 	Modal,
 	Button,
@@ -5,27 +6,34 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
 	CheckboxControl,
+	__experimentalDivider as Divider,
 } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { useState, useMemo } from 'react';
+import { domainDnsMutation } from '../../app/queries/domain-dns-records';
 import type { DnsRecord } from '../../data/domain-dns-records';
 
 interface DnsImportDialogProps {
 	isOpen: boolean;
+	domainName: string;
 	records: DnsRecord[];
 	onConfirm: () => void;
 	onCancel: () => void;
-	isBusy?: boolean;
 }
 
 export default function DnsImportDialog( {
 	isOpen,
+	domainName,
 	records,
 	onConfirm,
 	onCancel,
-	isBusy = false,
 }: DnsImportDialogProps ) {
 	const [ selectedRecords, setSelectedRecords ] = useState< Set< string > >( new Set() );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const updateDnsMutation = useMutation( domainDnsMutation( domainName ) );
 
 	// Initialize all records as selected when records change
 	useMemo( () => {
@@ -68,12 +76,26 @@ export default function DnsImportDialog( {
 			selectedRecords.has( `record-${ index }` )
 		);
 
-		// TODO: Process selectedRecordsData
-		// For now, just log to console as requested
-		// eslint-disable-next-line no-console
-		console.log( 'Selected DNS records:', selectedRecordsData );
-
-		onConfirm();
+		// Use domainDnsMutation to add the selected records
+		updateDnsMutation.mutate(
+			{
+				recordsToAdd: selectedRecordsData,
+			},
+			{
+				onSuccess: () => {
+					createSuccessNotice( __( 'DNS records imported successfully!' ), {
+						type: 'snackbar',
+					} );
+					onConfirm();
+				},
+				onError: () => {
+					createErrorNotice( __( 'Failed to import DNS records.' ), {
+						type: 'snackbar',
+					} );
+					onCancel();
+				},
+			}
+		);
 	};
 
 	const renderRecordAsString = ( record: DnsRecord ) => {
@@ -139,6 +161,7 @@ export default function DnsImportDialog( {
 				{ records.length > 0 ? (
 					<>
 						{ renderHeader() }
+						<Divider />
 						<div style={ { maxHeight: '300px', overflowY: 'auto' } }>
 							{ records.map( ( record, index ) => renderRecordRow( record, index ) ) }
 						</div>
@@ -148,14 +171,14 @@ export default function DnsImportDialog( {
 				) }
 
 				<HStack justify="flex-end" spacing={ 2 }>
-					<Button onClick={ onCancel } isBusy={ isBusy }>
+					<Button onClick={ onCancel } disabled={ updateDnsMutation.isPending }>
 						{ __( 'Cancel' ) }
 					</Button>
 					<Button
 						variant="primary"
-						isBusy={ isBusy }
+						isBusy={ updateDnsMutation.isPending }
 						onClick={ handleConfirm }
-						disabled={ numberOfSelectedRecords === 0 }
+						disabled={ numberOfSelectedRecords === 0 || updateDnsMutation.isPending }
 					>
 						{ __( 'Import Selected Records' ) }
 					</Button>

--- a/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
+++ b/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
@@ -167,7 +167,7 @@ export default function DnsImportDialog( {
 						{ records.map( ( record, index ) => renderRecordRow( record, index ) ) }
 					</VStack>
 				) : (
-					<Text>{ __( "We couldn't find valid DNS records to import." ) }</Text>
+					<Text>{ __( 'We couldn’t find valid DNS records to import.' ) }</Text>
 				) }
 
 				<HStack justify="flex-end" spacing={ 2 }>

--- a/client/dashboard/domains/domain-dns/import-bind-file-button.tsx
+++ b/client/dashboard/domains/domain-dns/import-bind-file-button.tsx
@@ -24,8 +24,7 @@ export default function ImportBindFileButton( {
 			return;
 		}
 
-		const formData: [ string, File, string ][] = [ [ 'files[]', file, file.name ] ];
-		importDnsBindMutation.mutate( formData, {
+		importDnsBindMutation.mutate( file, {
 			onSuccess: ( data ) => {
 				onRecordsImported( data );
 			},

--- a/client/dashboard/domains/domain-dns/import-bind-file-button.tsx
+++ b/client/dashboard/domains/domain-dns/import-bind-file-button.tsx
@@ -44,7 +44,11 @@ export default function ImportBindFileButton( {
 			multiple={ false }
 			onChange={ handleFileChange }
 			render={ ( { openFileDialog } ) => (
-				<Button variant="secondary" onClick={ openFileDialog }>
+				<Button
+					variant="secondary"
+					onClick={ openFileDialog }
+					isBusy={ importDnsBindMutation.isPending }
+				>
 					{ __( 'Import BIND file' ) }
 				</Button>
 			) }

--- a/client/dashboard/domains/domain-dns/import-bind-file-button.tsx
+++ b/client/dashboard/domains/domain-dns/import-bind-file-button.tsx
@@ -1,0 +1,53 @@
+import { useMutation } from '@tanstack/react-query';
+import { Button, FormFileUpload } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { domainDnsImportBindMutation } from '../../app/queries/domain-dns-records';
+import type { DnsRecord } from '../../data/domain-dns-records';
+
+interface ImportBindFileButtonProps {
+	domainName: string;
+	onRecordsImported: ( data: DnsRecord[] ) => void;
+}
+
+export default function ImportBindFileButton( {
+	domainName,
+	onRecordsImported,
+}: ImportBindFileButtonProps ) {
+	const { createErrorNotice } = useDispatch( noticesStore );
+	const importDnsBindMutation = useMutation( domainDnsImportBindMutation( domainName ) );
+
+	const handleFileChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
+		const file = event.currentTarget.files?.[ 0 ];
+		if ( ! file ) {
+			return;
+		}
+
+		const formData: [ string, File, string ][] = [ [ 'files[]', file, file.name ] ];
+		importDnsBindMutation.mutate( formData, {
+			onSuccess: ( data ) => {
+				onRecordsImported( data );
+			},
+			onError: () => {
+				createErrorNotice( __( 'Failed to import DNS records.' ), {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
+
+	return (
+		<FormFileUpload
+			__next40pxDefaultSize
+			accept="text/plain"
+			multiple={ false }
+			onChange={ handleFileChange }
+			render={ ( { openFileDialog } ) => (
+				<Button variant="secondary" onClick={ openFileDialog }>
+					{ __( 'Import BIND file' ) }
+				</Button>
+			) }
+		/>
+	);
+}

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -18,6 +18,7 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { useDnsActions } from './actions';
 import DnsActionsMenu from './dns-actions-menu';
+import DnsImportDialog from './dns-import-dialog';
 import EmailSetup from './email-setup';
 import { useDnsFields } from './fields';
 import ImportBindFileButton from './import-bind-file-button';
@@ -67,6 +68,8 @@ export default function DomainDns() {
 		useState( false );
 	const [ isRestoreDefaultEmailRecordsDialogOpen, setIsRestoreDefaultEmailRecordsDialogOpen ] =
 		useState( false );
+	const [ isImportDialogOpen, setIsImportDialogOpen ] = useState( false );
+	const [ importedRecords, setImportedRecords ] = useState< DnsRecord[] >( [] );
 
 	const actions = useDnsActions();
 	const fields = useDnsFields( domainName );
@@ -190,8 +193,8 @@ export default function DomainDns() {
 								<ImportBindFileButton
 									domainName={ domainName }
 									onRecordsImported={ ( data ) => {
-										// TO DO: Store the data in the state
-										// Open the dialog to confirm the import
+										setImportedRecords( data );
+										setIsImportDialogOpen( true );
 									} }
 								/>
 								<Button
@@ -268,6 +271,19 @@ export default function DomainDns() {
 				onCancel={ () => setIsRestoreDefaultEmailRecordsDialogOpen( false ) }
 				isBusy={ updateDnsMutation.isPending }
 				isOpen={ isRestoreDefaultEmailRecordsDialogOpen }
+			/>
+			<DnsImportDialog
+				isOpen={ isImportDialogOpen }
+				records={ importedRecords }
+				onConfirm={ () => {
+					// TODO: Implement the actual import logic
+					setIsImportDialogOpen( false );
+					setImportedRecords( [] );
+				} }
+				onCancel={ () => {
+					setIsImportDialogOpen( false );
+					setImportedRecords( [] );
+				} }
 			/>
 		</PageLayout>
 	);

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
-import { __experimentalVStack as VStack, Button, FormFileUpload } from '@wordpress/components';
+import { __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
@@ -11,7 +11,6 @@ import {
 	domainDnsMutation,
 	domainDnsQuery,
 	domainDnsEmailMutation,
-	domainDnsImportBindMutation,
 } from '../../app/queries/domain-dns-records';
 import { domainDnsAddRoute, domainRoute } from '../../app/router/domains';
 import DataViewsCard from '../../components/dataviews-card';
@@ -21,6 +20,7 @@ import { useDnsActions } from './actions';
 import DnsActionsMenu from './dns-actions-menu';
 import EmailSetup from './email-setup';
 import { useDnsFields } from './fields';
+import ImportBindFileButton from './import-bind-file-button';
 import RestoreDefaultARecords from './restore-default-a-records';
 import RestoreDefaultCnameRecord from './restore-default-cname-record';
 import RestoreDefaultEmailRecords from './restore-default-email-records';
@@ -58,7 +58,6 @@ export default function DomainDns() {
 	const router = useRouter();
 	const updateDnsMutation = useMutation( domainDnsMutation( domainName ) );
 	const restoreDefaultEmailRecordsMutation = useMutation( domainDnsEmailMutation( domainName ) );
-	const importDnsBindMutation = useMutation( domainDnsImportBindMutation( domainName ) );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 	const { data: dnsData, isLoading } = useQuery( domainDnsQuery( domainName ) );
@@ -188,36 +187,13 @@ export default function DomainDns() {
 						title={ __( 'DNS Records' ) }
 						actions={
 							<>
-								<FormFileUpload
-									__next40pxDefaultSize
-									accept="text/plain"
-									multiple={ false }
-									onChange={ ( event ) => {
-										const file = event.currentTarget.files?.[ 0 ];
-										if ( ! file ) {
-											return;
-										}
-
-										const formData: [ string, File, string ][] = [ [ 'files[]', file, file.name ] ];
-										importDnsBindMutation.mutate( formData, {
-											onSuccess: () => {
-												createSuccessNotice( __( 'DNS records imported successfully.' ), {
-													type: 'snackbar',
-												} );
-											},
-											onError: () => {
-												createErrorNotice( __( 'Failed to import DNS records.' ), {
-													type: 'snackbar',
-												} );
-											},
-										} );
+								<ImportBindFileButton
+									domainName={ domainName }
+									onRecordsImported={ ( data ) => {
+										// TO DO: Store the data in the state
+										// Open the dialog to confirm the import
 									} }
-									render={ ( { openFileDialog } ) => (
-										<Button variant="secondary" onClick={ openFileDialog }>
-											{ __( 'Import BIND file' ) }
-										</Button>
-									) }
-								></FormFileUpload>
+								/>
 								<Button
 									variant="primary"
 									onClick={ () => {

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -277,13 +277,15 @@ export default function DomainDns() {
 				isBusy={ updateDnsMutation.isPending }
 				isOpen={ isRestoreDefaultEmailRecordsDialogOpen }
 			/>
-			<DnsImportDialog
-				isOpen={ isImportDialogOpen }
-				domainName={ domainName }
-				records={ importedRecords }
-				onConfirm={ closeImportDialog }
-				onCancel={ closeImportDialog }
-			/>
+			{ isImportDialogOpen && (
+				<DnsImportDialog
+					isOpen={ isImportDialogOpen }
+					domainName={ domainName }
+					records={ importedRecords }
+					onConfirm={ closeImportDialog }
+					onCancel={ closeImportDialog }
+				/>
+			) }
 		</PageLayout>
 	);
 }

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -11,6 +11,7 @@ import {
 	domainDnsMutation,
 	domainDnsQuery,
 	domainDnsEmailMutation,
+	domainDnsImportBindMutation,
 } from '../../app/queries/domain-dns-records';
 import { domainDnsAddRoute, domainRoute } from '../../app/router/domains';
 import DataViewsCard from '../../components/dataviews-card';
@@ -57,6 +58,7 @@ export default function DomainDns() {
 	const router = useRouter();
 	const updateDnsMutation = useMutation( domainDnsMutation( domainName ) );
 	const restoreDefaultEmailRecordsMutation = useMutation( domainDnsEmailMutation( domainName ) );
+	const importDnsBindMutation = useMutation( domainDnsImportBindMutation( domainName ) );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 	const { data: dnsData, isLoading } = useQuery( domainDnsQuery( domainName ) );
@@ -186,19 +188,36 @@ export default function DomainDns() {
 						title={ __( 'DNS Records' ) }
 						actions={
 							<>
-								{ /* TODO Implement bind file logic */ }
 								<FormFileUpload
 									__next40pxDefaultSize
+									accept="text/plain"
+									multiple={ false }
 									onChange={ ( event ) => {
 										const file = event.currentTarget.files?.[ 0 ];
 										if ( ! file ) {
 											return;
 										}
-										// const formData = [ [ 'files[]', file, file.name ] ];
+
+										const formData: [ string, File, string ][] = [ [ 'files[]', file, file.name ] ];
+										importDnsBindMutation.mutate( formData, {
+											onSuccess: () => {
+												createSuccessNotice( __( 'DNS records imported successfully.' ), {
+													type: 'snackbar',
+												} );
+											},
+											onError: () => {
+												createErrorNotice( __( 'Failed to import DNS records.' ), {
+													type: 'snackbar',
+												} );
+											},
+										} );
 									} }
-								>
-									{ /* <Button variant="secondary">{ __( 'Import BIND file' ) }</Button> */ }
-								</FormFileUpload>
+									render={ ( { openFileDialog } ) => (
+										<Button variant="secondary" onClick={ openFileDialog }>
+											{ __( 'Import BIND file' ) }
+										</Button>
+									) }
+								></FormFileUpload>
 								<Button
 									variant="primary"
 									onClick={ () => {

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -85,6 +85,11 @@ export default function DomainDns() {
 		fields
 	);
 
+	const closeImportDialog = () => {
+		setIsImportDialogOpen( false );
+		setImportedRecords( [] );
+	};
+
 	const handleRestoreDefaultARecords = () => {
 		const recordsToRemove = dnsData?.records?.filter(
 			( record ) =>
@@ -274,16 +279,10 @@ export default function DomainDns() {
 			/>
 			<DnsImportDialog
 				isOpen={ isImportDialogOpen }
+				domainName={ domainName }
 				records={ importedRecords }
-				onConfirm={ () => {
-					// TODO: Implement the actual import logic
-					setIsImportDialogOpen( false );
-					setImportedRecords( [] );
-				} }
-				onCancel={ () => {
-					setIsImportDialogOpen( false );
-					setImportedRecords( [] );
-				} }
+				onConfirm={ closeImportDialog }
+				onCancel={ closeImportDialog }
 			/>
 		</PageLayout>
 	);


### PR DESCRIPTION
Closes [DOTDASH-263](https://linear.app/a8c/issue/DOTDASH-263/add-dns-bind-import-in-dns-list)

## Proposed Changes
This PR implements the DNS zone file import feature in the new HD/Domains interface.
The logic is the same as the existing implementation in Calypso: after the user uploads a DNS zone file, the backend parses it and identifies the records that can be imported. The user can then review and select which records to import via a modal dialog.


## Why are these changes being made?
This component is part of the HD Domains projects.


https://github.com/user-attachments/assets/374ced77-7157-4f14-ab85-6dafcb538749



## Testing Instructions
**Prerequisites:**
- Access to a domain with DNS management capabilities
- A valid BIND zone file (`.txt` format) Example 38bc9-pb/

**Testing Steps:**

1. **File Upload:**
   - Navigate to Domain DNS management page
   - Click "Import BIND file" button
   - Upload a valid BIND zone file
   - Verify the file is processed and records are displayed

2. **Record Selection:**
   - Verify all records are initially selected
   - Test individual record selection/deselection
   - Test "Select All" functionality when some records are unselected
   - Test "Deselect All" functionality when all records are selected

3. **Import Process:**
   - Select specific records to import
   - Click "Import Selected Records"
   - Verify success notification appears
   - Verify selected records are added to the domain's DNS configuration
   - Verify the dialog closes and returns to the main DNS view

## Pre-merge Checklist 

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?