### PR TITLE
Help Center: Redesign the container

### DIFF
--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -4,7 +4,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useWindowDimensions } from '@automattic/viewport';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
-import { Card } from '@wordpress/components';
+import { Card, __experimentalElevation as Elevation } from '@wordpress/components';
 import { useFocusReturn, useMergeRefs } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import clsx from 'clsx';
@@ -117,6 +117,10 @@ const HelpCenterContainer: React.FC< Container > = ( {
 						<HelpCenterHeader onDismiss={ onDismiss } />
 						<HelpCenterContent currentRoute={ currentRoute } />
 						{ ! isMinimized && <HelpCenterFooter /> }
+						<Elevation
+							borderRadius={ isMinimized ? '16px 16px 0 0' : '16px' }
+							value={ 4 }
+						></Elevation>
 					</Card>
 				</OptionalDraggable>
 			</FeatureFlagProvider>

--- a/packages/help-center/src/components/help-center-header.scss
+++ b/packages/help-center/src/components/help-center-header.scss
@@ -31,7 +31,11 @@
 	}
 
 	.help-center__container-header {
-		border: 1px solid $gray-100;
+		border-bottom: 1px solid $gray-100;
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 16px;
+		border-bottom-right-radius: 0;
+		border-bottom-left-radius: 0;
 
 		&.has-unread {
 			background: $help-center-blue;

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -6,7 +6,6 @@ import {
 	Button,
 	Spinner,
 	Flex,
-	__experimentalElevation as Elevation,
 	__experimentalHStack as HStack,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
@@ -264,7 +263,6 @@ const HelpCenterHeader = ( { onDismiss }: Header ) => {
 	if ( isMinimized ) {
 		return (
 			<button className={ classNames } onClick={ () => setIsMinimized( false ) }>
-				<Elevation isInteractive value={ 10 } hover={ 15 } />
 				<HStack alignment="center" justify="space-between" spacing={ 5 }>
 					<HStack justify="flex-start">
 						<HeaderText />

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -109,13 +109,8 @@
 		width: 410px;
 		height: 80vh;
 		max-height: 800px;
-		box-shadow:
-			0 3px 8px 0 rgba(0, 0, 0, 0.12),
-			0 3px 1px 0 rgba(0, 0, 0, 0.04),
-			0 0 0 1px rgba(0, 0, 0, 0.04);
 		/* stylelint-disable-next-line scales/radii */
 		border-radius: 16px;
-		overflow: hidden;
 
 		&.is-minimized {
 			height: $head-foot-height;


### PR DESCRIPTION
Fixes DOTCOM-14182

## Proposed Changes
Implements the container and switches to Core's `Elevation`.

## Why are these changes being made?
Modernize the HC

## Testing Instructions

1. Open the HC.
2. The border shadow should look good.
3. Minimize the HC, the minimized state should look good.

## Screenshots

| Before | After |
|--------|--------|
| <img width="431" height="817" alt="image" src="https://github.com/user-attachments/assets/cdeb040b-f291-47a3-8df3-072f5e8e787f" /> | <img width="431" height="820" alt="image" src="https://github.com/user-attachments/assets/af6f0d0c-4ffe-42df-a3dc-6f9d2cb05b5f" /> | 