### PR TITLE
Fix Wix import in Stepper

### DIFF
--- a/client/blocks/importer/components/importer-drag/config.tsx
+++ b/client/blocks/importer/components/importer-drag/config.tsx
@@ -47,6 +47,12 @@ export function getImportDragConfig( importer: Importer, supportLinkModal?: bool
 				options
 			),
 		},
+		wix: {
+			description: translate(
+				'Import your posts, tags, images, and videos from your %(importerName)s site',
+				options
+			),
+		},
 		squarespace: {
 			description: translate(
 				'Import posts, pages, comments, tags, and images from a %(importerName)s export file.',


### PR DESCRIPTION
Fixes DOTCOM-14258

## Proposed Changes

This fixes the Wix flow in Stepper. It currently fails with 

```
TypeError: Cannot read properties of undefined (reading 'description')
```


## Testing Instructions

1. Go to /setup/site-migration.
2. Enter a Wix URL.
3. Pick a WPCOM site.
4. Import should work.