### PR TITLE
Login/Signup: add optional "No, thanks" button

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -415,6 +415,7 @@ export function signupForm( context, next ) {
 
 		const authorizeUrlWithApproval = addQueryArgs( { auth_approved: true }, context.path );
 		const { woodna_service_name, woodna_help_url, plugin_name } = context.query || {};
+
 		const urlQueryArgs = {
 			redirect_to: authorizeUrlWithApproval,
 			from,

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -496,13 +496,6 @@ $breakpoint-mobile: 660px;
 			padding-top: 24px;
 		}
 
-		&.feature-flag-woocommerce-core-profiler-passwordless-auth {
-			.signup-form {
-				max-width: 515px;
-				margin: 48px auto;
-			}
-		}
-
 		.login__form-userdata label.form-label {
 			line-height: 16px;
 		}
@@ -1077,11 +1070,6 @@ $breakpoint-mobile: 660px;
 				background-color: var( --studio-gray-0 );
 				color: var( --studio-gray-20 );
 			}
-		}
-
-		.signup-form {
-			max-width: 327px;
-			margin-top: 48px;
 		}
 
 		.jetpack-connect__main-logo {

--- a/client/login/wp-login/components/one-login-layout.scss
+++ b/client/login/wp-login/components/one-login-layout.scss
@@ -21,9 +21,14 @@
 	}
 }
 
+.wp-login__one-login-layout-top-right {
+	display: flex;
+	gap: rem( 16px );
+}
+
 .wp-login__one-login-layout-tos {
 	a {
-		color: var(--color-text);
+		color: var( --color-text );
 		text-decoration: underline;
 	}
 }
@@ -36,21 +41,21 @@
 
 .wp-login__one-login-layout-heading-subtext {
 	text-wrap: balance;
-	color: var(--studio-gray-50, #646970);
+	color: var( --studio-gray-50, #646970 );
 	margin-block: 0.5rem 0;
 	font-size: $font-body;
 
 	a {
-		color: var(--studio-gray-50, #646970);
+		color: var( --studio-gray-50, #646970 );
 		text-decoration: underline;
 	}
 
 	&.is-secondary {
 		font-size: $font-body-extra-small;
-		color: var(--studio-gray-30);
+		color: var( --studio-gray-30 );
 
 		a {
-			color: var(--studio-gray-30);
+			color: var( --studio-gray-30 );
 		}
 	}
 }

--- a/client/login/wp-login/components/one-login-layout.tsx
+++ b/client/login/wp-login/components/one-login-layout.tsx
@@ -22,6 +22,7 @@ interface OneLoginLayoutProps {
 	isSectionSignup?: boolean;
 	loginUrl?: string;
 	isLostPasswordView?: boolean;
+	noThanksRedirectUrl?: string;
 }
 
 const OneLoginLayout = ( {
@@ -31,6 +32,7 @@ const OneLoginLayout = ( {
 	isSectionSignup,
 	loginUrl,
 	isLostPasswordView,
+	noThanksRedirectUrl,
 }: OneLoginLayoutProps ) => {
 	const translate = useTranslate();
 	const locale = useSelector( getCurrentUserLocale );
@@ -79,17 +81,39 @@ const OneLoginLayout = ( {
 		);
 	};
 
+	const NoThanksLink = () => {
+		if ( ! noThanksRedirectUrl ) {
+			return null;
+		}
+
+		const handleClick = () => {
+			recordTracksEvent( 'calypso_login_no_thanks_click', {
+				page: currentRoute,
+			} );
+		};
+
+		const href = noThanksRedirectUrl;
+
+		return (
+			<Step.LinkButton href={ href } key="no-thanks-link" rel="external" onClick={ handleClick }>
+				{ translate( 'No, thanks' ) }
+			</Step.LinkButton>
+		);
+	};
+
+	const topBar = (): JSX.Element => {
+		const rightElement = (
+			<nav className="wp-login__one-login-layout-top-right">
+				{ isSectionSignup ? <LoginLink /> : <SignUpLink /> }
+				{ noThanksRedirectUrl && <NoThanksLink /> }
+			</nav>
+		);
+
+		return <Step.TopBar rightElement={ rightElement } compactLogo="always" />;
+	};
+
 	return (
-		<Step.CenteredColumnLayout
-			columnWidth={ 6 }
-			topBar={
-				<Step.TopBar
-					rightElement={ isSectionSignup ? <LoginLink /> : <SignUpLink /> }
-					compactLogo="always"
-				/>
-			}
-			verticalAlign="center"
-		>
+		<Step.CenteredColumnLayout columnWidth={ 6 } topBar={ topBar() } verticalAlign="center">
 			<div className="wp-login__one-login-layout-content-wrapper">
 				<div className="wp-login__one-login-layout-heading">
 					<HeadingLogo isJetpack={ isJetpack } />

--- a/client/login/wp-login/hooks/get-no-thanks-redirect.ts
+++ b/client/login/wp-login/hooks/get-no-thanks-redirect.ts
@@ -1,0 +1,44 @@
+import { getQueryArg } from '@wordpress/url';
+import { isWebUri } from 'valid-url';
+
+interface NoThanksRedirectParams {
+	currentRoute: string;
+	currentQuery: {
+		from?: string;
+		redirect_to?: string;
+		lostpassword_flow?: string;
+	};
+}
+
+export default function getNoThanksRedirectUrl( {
+	currentRoute = '',
+	currentQuery,
+}: NoThanksRedirectParams ): string | null {
+	// Hide for specific routes/flows
+	if ( currentQuery.from !== 'woocommerce-core-profiler' ) {
+		return null;
+	}
+
+	if (
+		currentRoute === '/log-in/jetpack/lostpassword' ||
+		currentRoute === '/log-in/jetpack/link' ||
+		currentQuery?.lostpassword_flow
+	) {
+		return null;
+	}
+
+	let noThanksRedirectUrl: string | null = null;
+
+	// WooCommerce Core Profiler, URL for the "No, thanks" is always found int eh redirect_to param.
+	if ( currentQuery.redirect_to ) {
+		const extracted = getQueryArg( currentQuery.redirect_to, 'redirect_uri' );
+		noThanksRedirectUrl = typeof extracted === 'string' ? extracted : null;
+	}
+
+	// Only return if we have a valid redirect URL
+	if ( typeof noThanksRedirectUrl === 'string' && isWebUri( noThanksRedirectUrl ) ) {
+		return noThanksRedirectUrl;
+	}
+
+	return null;
+}

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -354,15 +354,8 @@ export class Login extends Component {
 	}
 
 	render() {
-		const {
-			locale,
-			translate,
-			isGenericOauth,
-			isGravPoweredClient,
-			isJetpack,
-			isFromAkismet,
-			action,
-		} = this.props;
+		const { locale, translate, isGenericOauth, isGravPoweredClient, isJetpack, action } =
+			this.props;
 
 		const canonicalUrl = localizeUrl( 'https://wordpress.com/log-in', locale );
 

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -39,13 +39,16 @@ import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-
 import getIsBlazePro from 'calypso/state/selectors/get-is-blaze-pro';
 import getIsWCCOM from 'calypso/state/selectors/get-is-wccom';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
-import isWooJPCFlow from 'calypso/state/selectors/is-woo-jpc-flow';
+import isWooJPCFlow, {
+	isWooCommercePaymentsOnboardingFlow,
+} from 'calypso/state/selectors/is-woo-jpc-flow';
 import { withEnhancers } from 'calypso/state/utils';
 import { LoginContext } from '../login-context';
 import OneLoginFooter from './components/one-login-footer';
 import OneLoginLayout from './components/one-login-layout';
 import GravPoweredLoginBlockFooter from './gravatar/grav-powered-login-block-footer';
 import getHeadingSubText from './hooks/get-heading-subtext';
+import getNoThanksRedirectUrl from './hooks/get-no-thanks-redirect';
 
 import './style.scss';
 
@@ -341,6 +344,15 @@ export class Login extends Component {
 		} );
 	}
 
+	getNoThanksRedirectUrl() {
+		const { currentRoute, currentQuery } = this.props;
+
+		return getNoThanksRedirectUrl( {
+			currentRoute,
+			currentQuery,
+		} );
+	}
+
 	render() {
 		const {
 			locale,
@@ -393,9 +405,9 @@ export class Login extends Component {
 				{ ! isGravPoweredClient && (
 					<OneLoginLayout
 						isJetpack={ isJetpack }
-						isFromAkismet={ isFromAkismet }
 						signupUrl={ this.props.signupUrl }
 						isLostPasswordView={ isLostPasswordView }
+						noThanksRedirectUrl={ this.getNoThanksRedirectUrl() }
 					>
 						{ mainContent }
 					</OneLoginLayout>
@@ -451,6 +463,7 @@ export default connect(
 					new URLSearchParams( getRedirectToOriginal( state )?.split( '?' )[ 1 ] ).get( 'from' ),
 			isManualRenewalImmediateLoginAttempt: wasManualRenewalImmediateLoginAttempted( state ),
 			isUserLoggedIn: isUserLoggedIn( state ),
+			isWooPaymentsFlow: isWooCommercePaymentsOnboardingFlow( state ),
 		};
 	},
 	{

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -28,6 +28,7 @@ import { login } from 'calypso/lib/paths';
 import LoginContextProvider, { useLoginContext } from 'calypso/login/login-context';
 import OneLoginLayout from 'calypso/login/wp-login/components/one-login-layout';
 import getHeadingSubText from 'calypso/login/wp-login/hooks/get-heading-subtext';
+import getNoThanksRedirectUrl from 'calypso/login/wp-login/hooks/get-no-thanks-redirect';
 import flows from 'calypso/signup/config/flows';
 import GravatarStepWrapper from 'calypso/signup/gravatar-step-wrapper';
 import {
@@ -133,6 +134,7 @@ function isOauth2RedirectValid( oauth2Redirect ) {
 		return false;
 	}
 }
+
 export class UserStep extends Component {
 	static propTypes = {
 		flowName: PropTypes.string,
@@ -648,6 +650,10 @@ export class UserStep extends Component {
 			return null;
 		}
 
+		// Check for "No, thanks" URL in WooCommerce flows
+		const query = this.props.initialContext?.query || {};
+		const noThanksRedirectUrl = getNoThanksRedirectUrl( { currentQuery: query } );
+
 		return (
 			<LoginContextProvider>
 				<LoginContextWrapper
@@ -659,7 +665,12 @@ export class UserStep extends Component {
 						isWooJPC: this.props.isWooJPC,
 					} ) }
 				>
-					<OneLoginLayout isJetpack={ false } isSectionSignup loginUrl={ this.getLoginUrl() }>
+					<OneLoginLayout
+						isJetpack={ false }
+						isSectionSignup
+						loginUrl={ this.getLoginUrl() }
+						noThanksRedirectUrl={ noThanksRedirectUrl }
+					>
 						{ this.renderSignupForm() }
 					</OneLoginLayout>
 				</LoginContextWrapper>


### PR DESCRIPTION
This button is used in the Woo Core profiler, to skip Jetpack connection step in the flow, in case user doesn't want to connect their store to Jetpack.

Clicking the link will take users to `redirect_to` or `redirect_after_auth` arguments (depends on the flow).

## Proposed Changes
**Adding the No, Thanks** link
<img width="1272" height="1031" alt="image" src="https://github.com/user-attachments/assets/ca0d0005-edf4-4fec-9f5b-0d6fe63f1570" />

## Testing Instructions

* Start the WooJPC flow from this [URL](http://calypso.localhost:3000/start/account/user-social?redirect_to=%2Fjetpack%2Fconnect%2Fauthorize%3Fclient_id%3D247517477%26redirect_uri%3Dhttps%253A%252F%252Fnormal-aurora-toucan.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fhandler%253Djetpack-connection-webhooks%2526action%253Dauthorize%2526_wpnonce%253D03730d2cf1%2526redirect%253Dhttps%25253A%25252F%25252Fnormal-aurora-toucan.jurassic.ninja%25252Fwp-admin%25252Fadmin.php%25253Fpage%25253Dwc-admin%26state%3D1%26scope%3Dadministrator%253Abf585a08a59b53c4400e7bf149a6af59%26user_email%3Dcem.unalan%2540a8c.com%26user_login%3Draicem%26jp_version%3D15.0-a.5%26secret%3DonbO2coMLK4AfJwPij2Av5O88UOnQe1Y%26blogname%3DNormal%2BAurora%2BToucan%26site_url%3Dhttps%253A%252F%252Fnormal-aurora-toucan.jurassic.ninja%26home_url%3Dhttps%253A%252F%252Fnormal-aurora-toucan.jurassic.ninja%26site_icon%3D%26site_lang%3Den_US%26site_created%3D2025-08-18%2B20%253A11%253A00%26allow_site_connection%3D1%26calypso_env%3Dproduction%26source%3D%26_as%3Dwp-cli%26locale%3Den%26from%3Dwoocommerce-core-profiler%26installed_ext_success%3D1%26plugin_name%3D%26color_scheme%3Dfresh%26_ui%3D11140294%26_ut%3Dwpcom%253Auser_id%26purchase_nonce%3D1TWx1axw%26_wp_nonce%3D9aeaa2cf0e%26redirect_after_auth%3Dhttps%253A%252F%252Fnormal-aurora-toucan.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin%26site%3Dhttps%253A%252F%252Fnormal-aurora-toucan.jurassic.ninja%26auth_approved%3Dtrue&from=woocommerce-core-profiler). Confirm you get the **No, thanks** links. Clicking it will take you to my jurassic.ninja store.
* Click on **Log in** and confirm that page also has the **No, thanks** link. Clicking it should again take you to the store.
* Visit [WooPayments flow](http://calypso.localhost:3000/start/account/user-social?redirect_to=%2Fjetpack%2Fconnect%2Fauthorize%3Fclient_id%3D246264896%26redirect_uri%3Dhttps%253A%252F%252Fspeedily-net-pilot.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fhandler%253Djetpack-connection-webhooks%2526action%253Dauthorize%2526_wpnonce%253Dedf5d23f00%2526redirect%253Dhttps%25253A%25252F%25252Fspeedily-net-pilot.jurassic.ninja%25252Fwp-admin%25252Fadmin.php%25253Fpage%25253Dwc-settings%252526tab%25253Dcheckout%252526path%25253D%25252Fwoopayments%25252Fonboarding%252526wpcom_connection_return%25253D1%26state%3D1%26scope%3Dadministrator%253Aab2a50f6f685a4e260ac5dc2c989ba66%26user_email%3Dcem.unalan%2540a8c.com%26user_login%3Draicem%26jp_version%3D14.8%26secret%3DB18GR6Jlp2MnfaL1p9k6MRrhNU9ibPlU%26blogname%3DSpeedily%2BNet%2BPilot%26site_url%3Dhttps%253A%252F%252Fspeedily-net-pilot.jurassic.ninja%26home_url%3Dhttps%253A%252F%252Fspeedily-net-pilot.jurassic.ninja%26site_icon%3D%26site_lang%3Den_US%26site_created%3D2025-07-08%2B10%253A26%253A50%26allow_site_connection%3D1%26calypso_env%3Dproduction%26source%3D%26_as%3Dwp-cli%26locale%3Den%26from%3Dwoocommerce-onboarding%26plugin_name%3Dwoocommerce-payments%26color_scheme%3Dfresh%26_ui%3D11140294%26_ut%3Dwpcom%253Auser_id%26purchase_nonce%3DpNl6uQzx%26_wp_nonce%3Dbd530adf67%26redirect_after_auth%3Dhttps%253A%252F%252Fspeedily-net-pilot.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-settings%2526tab%253Dcheckout%2526path%253D%252Fwoopayments%252Fonboarding%2526wpcom_connection_return%253D1%26site%3Dhttps%253A%252F%252Fspeedily-net-pilot.jurassic.ninja%26auth_approved%3Dtrue&from=woocommerce-onboarding&plugin_name=woocommerce-payments&redirect_after_auth=https%3A%2F%2Fspeedily-net-pilot.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-settings%26tab%3Dcheckout%26path%3D%2Fwoopayments%2Fonboarding%26wpcom_connection_return%3D1). Confirm there is no **No, thanks** link.
* Visit Woo, WPCOM and Jetpack login, and some other clients (links in [Linear](https://linear.app/a8c/issue/DOTCOM-13220/login-make-the-two-columnwhite-layout-the-default-across-all-contexts)). Confirm **No, thanks** is not offered.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
