### PR TITLE
Backups: avoid activity log API calls when the site has no backups

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -228,7 +228,9 @@ export const siteBackupsIndexRoute = createRoute( {
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		// Preload activity log backup-related entries.
-		queryClient.ensureQueryData( siteRewindableActivityLogEntriesQuery( site.ID ) );
+		if ( hasHostingFeature( site, HostingFeatures.BACKUPS ) ) {
+			queryClient.ensureQueryData( siteRewindableActivityLogEntriesQuery( site.ID ) );
+		}
 	},
 } ).lazy( () =>
 	import( '../../sites/backups' ).then( ( d ) =>

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -73,14 +73,16 @@ export function BackupsListPage() {
 				/>
 			}
 		>
-			<Grid columns={ 2 }>
-				<BackupsList
-					site={ site }
-					selectedBackup={ selectedBackup }
-					setSelectedBackup={ setSelectedBackup }
-				/>
-				{ selectedBackup && <BackupDetails backup={ selectedBackup } site={ site } /> }
-			</Grid>
+			{ hasBackups && (
+				<Grid columns={ 2 }>
+					<BackupsList
+						site={ site }
+						selectedBackup={ selectedBackup }
+						setSelectedBackup={ setSelectedBackup }
+					/>
+					{ selectedBackup && <BackupDetails backup={ selectedBackup } site={ site } /> }
+				</Grid>
+			) }
 		</PageLayout>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTDASH-291][1].

## Proposed Changes

Conditionally preload and avoid unneeded queries to the `/activity/rewindable` endpoint.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

There's no need to make API calls when the site doesn't have backups available.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Select a site that doesn't have backups, like a Simple Site, in the `/v2/sites/` page.
- Check the browser Network console, filtering by `rewindable` Fetch/XHR requests.
- There should be no API calls to `/activity/rewindable` in the `/v2/sites/{site}/backups` page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

[1]: https://linear.app/a8c/issue/DOTDASH-291/