### PR TITLE
Hosting Dashboard Privacy: Implement DPA card

### DIFF
--- a/client/dashboard/app/queries/me-dpa.ts
+++ b/client/dashboard/app/queries/me-dpa.ts
@@ -1,0 +1,7 @@
+import { mutationOptions } from '@tanstack/react-query';
+import { requestDpa } from '../../data/me-dpa';
+
+export const requestDpaMutation = () =>
+	mutationOptions( {
+		mutationFn: requestDpa,
+	} );

--- a/client/dashboard/app/snackbars/index.tsx
+++ b/client/dashboard/app/snackbars/index.tsx
@@ -19,10 +19,10 @@ export default function Snackbars() {
 	const snackbarNotices = notices
 		.filter( ( { type } ) => type === 'snackbar' )
 		.map( ( { status, ...notice } ) => ( {
-			...notice,
 			icon: statusIcon[ status ] && (
 				<Icon icon={ statusIcon[ status ] } style={ { fill: 'currentcolor' } } />
 			),
+			...notice,
 		} ) )
 		.slice( MAX_VISIBLE_NOTICES );
 

--- a/client/dashboard/data/me-dpa.ts
+++ b/client/dashboard/data/me-dpa.ts
@@ -1,0 +1,8 @@
+import wpcom from 'calypso/lib/wp';
+
+export async function requestDpa(): Promise< void > {
+	return wpcom.req.post( {
+		path: '/me/request-dpa',
+		apiVersion: '1.1',
+	} );
+}

--- a/client/dashboard/me/privacy/dpa-card.tsx
+++ b/client/dashboard/me/privacy/dpa-card.tsx
@@ -1,0 +1,81 @@
+import { useMutation } from '@tanstack/react-query';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Button,
+	Card,
+	CardBody,
+	Icon,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { envelope } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
+import { requestDpaMutation } from '../../app/queries/me-dpa';
+import { SectionHeader } from '../../components/section-header';
+import { Text } from '../../components/text';
+import { isWpError } from '../../data/error';
+
+export default function DpaCard() {
+	const mutation = useMutation( requestDpaMutation() );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const handleClick = () => {
+		mutation.mutate( undefined, {
+			onSuccess: () => {
+				createSuccessNotice( __( 'We’ve sent you our DPA via email.' ), {
+					icon: <Icon icon={ envelope } style={ { fill: 'currentcolor' } } />,
+					type: 'snackbar',
+				} );
+			},
+			onError: ( e: Error ) => {
+				createErrorNotice(
+					isWpError( e ) && e.error === 'too_many_requests'
+						? e.message
+						: __( 'There was an error requesting a DPA.' ),
+					{ type: 'snackbar' }
+				);
+			},
+		} );
+	};
+
+	return (
+		<Card>
+			<CardBody>
+				<VStack spacing={ 4 }>
+					<SectionHeader
+						title={ __( 'Data processing addendum' ) }
+						description={
+							<VStack spacing={ 4 }>
+								<Text variant="muted" lineHeight="20px">
+									{ __(
+										'A Data Processing Addendum (DPA) allows web sites and companies to assure customers, vendors, and partners that their data handling complies with the law.'
+									) }
+								</Text>
+								<Text variant="muted" lineHeight="20px">
+									{ __( 'Note: Most free site owners or hobbyists do not need a DPA.' ) }
+								</Text>
+								<Text variant="muted" lineHeight="20px">
+									{ __(
+										'Having a DPA does not change any of our privacy and security practices for site visitors. Everyone using our service gets the same high standards of privacy and security.'
+									) }
+								</Text>
+							</VStack>
+						}
+						level={ 3 }
+					/>
+					<HStack justify="flex-start">
+						<Button
+							__next40pxDefaultSize
+							variant="secondary"
+							isBusy={ mutation.isPending }
+							onClick={ handleClick }
+						>
+							{ __( 'Request a DPA' ) }
+						</Button>
+					</HStack>
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/me/privacy/index.tsx
+++ b/client/dashboard/me/privacy/index.tsx
@@ -2,6 +2,7 @@ import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import DpaCard from './dpa-card';
 import UsageInformationCard from './usage-information-card';
 
 export default function Privacy() {
@@ -9,6 +10,7 @@ export default function Privacy() {
 		<PageLayout size="small" header={ <PageHeader title={ __( 'Privacy' ) } /> }>
 			<VStack spacing={ 8 }>
 				<UsageInformationCard />
+				<DpaCard />
 			</VStack>
 		</PageLayout>
 	);


### PR DESCRIPTION
Ref DOTDASH-176

## Proposed Changes

This PR implements the DPA card. 
<img width="689" height="661" alt="SCR-20250819-jubq" src="https://github.com/user-attachments/assets/9b606a15-6e47-4b8b-92df-d068578f537e" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

HD development.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2/me/privacy
* Ensure the DPA card is rendered
* Ensure that clicking the "Request a DPA" button shows a success notice
* Ensure you receive the DPA in your mailbox

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
