### PR TITLE
Hosting Callout: Init the transfer status when the callout mounts

### DIFF
--- a/client/dashboard/sites/staging-site-delete-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-delete-modal/index.tsx
@@ -48,7 +48,7 @@ export default function StagingSiteDeleteModal( {
 				} );
 			},
 			onSuccess: () => {
-				navigate( { to: `/sites/${ productionSite?.slug }` } );
+				navigate( { to: `/sites/${ productionSite?.slug ?? productionSiteId }` } );
 				recordTracksEvent( 'calypso_hosting_configuration_staging_site_delete_success' );
 			},
 		} );

--- a/client/dashboard/sites/staging-site-delete-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-delete-modal/index.tsx
@@ -1,6 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { useQuery, useMutation } from '@tanstack/react-query';
-import { useNavigate } from '@tanstack/react-router';
+import { useMutation } from '@tanstack/react-query';
 import {
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
@@ -11,7 +10,6 @@ import {
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { siteByIdQuery } from '../../app/queries/site';
 import { stagingSiteDeleteMutation } from '../../app/queries/site-staging-sites';
 import type { Site } from '../../data/types';
 
@@ -22,15 +20,9 @@ export default function StagingSiteDeleteModal( {
 	site: Site;
 	onClose: () => void;
 } ) {
-	const navigate = useNavigate();
 	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const productionSiteId = site.options?.wpcom_production_blog_id;
-
-	const { data: productionSite } = useQuery( {
-		...siteByIdQuery( productionSiteId ?? 0 ),
-		enabled: !! productionSiteId,
-	} );
 
 	const mutation = useMutation( stagingSiteDeleteMutation( site.ID, productionSiteId ?? 0 ) );
 
@@ -48,8 +40,8 @@ export default function StagingSiteDeleteModal( {
 				} );
 			},
 			onSuccess: () => {
-				navigate( { to: `/sites/${ productionSite?.slug ?? productionSiteId }` } );
 				recordTracksEvent( 'calypso_hosting_configuration_staging_site_delete_success' );
+				onClose();
 			},
 		} );
 	};

--- a/client/dashboard/sites/staging-site-delete-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-delete-modal/index.tsx
@@ -1,5 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { useMutation } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
@@ -10,6 +11,7 @@ import {
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { siteByIdQuery } from '../../app/queries/site';
 import { stagingSiteDeleteMutation } from '../../app/queries/site-staging-sites';
 import type { Site } from '../../data/types';
 
@@ -20,9 +22,16 @@ export default function StagingSiteDeleteModal( {
 	site: Site;
 	onClose: () => void;
 } ) {
+	const navigate = useNavigate();
 	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const productionSiteId = site.options?.wpcom_production_blog_id;
+
+	const { data: productionSite } = useQuery( {
+		...siteByIdQuery( productionSiteId ?? 0 ),
+		enabled: !! productionSiteId,
+	} );
+
 	const mutation = useMutation( stagingSiteDeleteMutation( site.ID, productionSiteId ?? 0 ) );
 
 	if ( ! productionSiteId ) {
@@ -39,6 +48,7 @@ export default function StagingSiteDeleteModal( {
 				} );
 			},
 			onSuccess: () => {
+				navigate( { to: `/sites/${ productionSite?.slug }` } );
 				recordTracksEvent( 'calypso_hosting_configuration_staging_site_delete_success' );
 			},
 		} );

--- a/client/dashboard/utils/site-atomic-transfers.ts
+++ b/client/dashboard/utils/site-atomic-transfers.ts
@@ -1,4 +1,4 @@
-import type { AtomicTransferStatus } from '../data/types';
+import type { AtomicTransferStatus, Site } from '../data/types';
 
 export function isAtomicTransferInProgress( status: AtomicTransferStatus ) {
 	const inProgressStatuses: AtomicTransferStatus[] = [
@@ -9,3 +9,7 @@ export function isAtomicTransferInProgress( status: AtomicTransferStatus ) {
 	];
 	return inProgressStatuses.includes( status );
 }
+
+export const isAtomicTransferredSite = ( site: Partial< Site > ) =>
+	// The capabilities are not immediately propagated to the atomic site
+	site.is_wpcom_atomic && site.capabilities?.manage_options;

--- a/client/layout/hosting-dashboard/item-view/index.tsx
+++ b/client/layout/hosting-dashboard/item-view/index.tsx
@@ -8,7 +8,6 @@ import NavTabs from 'calypso/components/section-nav/tabs';
 import { siteByIdQuery } from 'calypso/dashboard/app/queries/site';
 import { siteLatestAtomicTransferQuery } from 'calypso/dashboard/app/queries/site-atomic-transfers';
 import { isDeletingStagingSiteQuery } from 'calypso/dashboard/app/queries/site-staging-sites';
-import { queryClient } from 'calypso/dashboard/app/query-client';
 import { isAtomicTransferInProgress } from 'calypso/dashboard/utils/site-atomic-transfers';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import { StagingSiteCreationBanner } from 'calypso/sites/staging-site/components/staging-site-transfer-banner/staging-site-creation-banner';
@@ -56,14 +55,14 @@ export default function ItemView( {
 }: ItemViewProps ) {
 	const [ navRef, setNavRef ] = useState< HTMLElement | null >( null );
 
-	const { data: isStagingSiteDeletionInProgress } = useQuery(
-		isDeletingStagingSiteQuery( itemData.blogId ?? 0 ),
-		queryClient
-	);
-
 	// The is_wpcom_staging_site flag isn't site while the site is being transferred
 	// so it can't be used here to determine if the site is a staging site
 	const isStagingSite = itemData.subtitle?.toString().startsWith( 'staging-' );
+
+	const { data: isStagingSiteDeletionInProgress } = useQuery( {
+		...isDeletingStagingSiteQuery( itemData.blogId ?? 0 ),
+		enabled: !! itemData.blogId && isStagingSite,
+	} );
 
 	const { data: atomicTransfer } = useQuery( {
 		...siteLatestAtomicTransferQuery( itemData.blogId ?? 0 ),

--- a/client/layout/hosting-dashboard/item-view/index.tsx
+++ b/client/layout/hosting-dashboard/item-view/index.tsx
@@ -8,6 +8,7 @@ import NavTabs from 'calypso/components/section-nav/tabs';
 import { siteByIdQuery } from 'calypso/dashboard/app/queries/site';
 import { siteLatestAtomicTransferQuery } from 'calypso/dashboard/app/queries/site-atomic-transfers';
 import { isDeletingStagingSiteQuery } from 'calypso/dashboard/app/queries/site-staging-sites';
+import { queryClient } from 'calypso/dashboard/app/query-client';
 import {
 	isAtomicTransferInProgress,
 	isAtomicTransferredSite,
@@ -62,10 +63,13 @@ export default function ItemView( {
 	// so it can't be used here to determine if the site is a staging site
 	const isStagingSite = itemData.subtitle?.toString().startsWith( 'staging-' );
 
-	const { data: isStagingSiteDeletionInProgress } = useQuery( {
-		...isDeletingStagingSiteQuery( itemData.blogId ?? 0 ),
-		enabled: !! itemData.blogId && isStagingSite,
-	} );
+	const { data: isStagingSiteDeletionInProgress } = useQuery(
+		{
+			...isDeletingStagingSiteQuery( itemData.blogId ?? 0 ),
+			enabled: !! itemData.blogId && isStagingSite,
+		},
+		queryClient
+	);
 
 	const { data: atomicTransfer } = useQuery( {
 		...siteLatestAtomicTransferQuery( itemData.blogId ?? 0 ),

--- a/client/layout/hosting-dashboard/item-view/index.tsx
+++ b/client/layout/hosting-dashboard/item-view/index.tsx
@@ -75,17 +75,18 @@ export default function ItemView( {
 	const { data: stagingSite } = useQuery( {
 		...siteByIdQuery( itemData.blogId ?? 0 ),
 		refetchInterval: ( query ) => {
-			return query.state.data?.jetpack_connection ? false : 5000;
+			return query.state.data?.jetpack_connection && query.state.data?.is_wpcom_atomic
+				? false
+				: 5000;
 		},
 		enabled: !! itemData.blogId && isStagingSite,
 	} );
 
-	const hasStagingSiteJetpackConnection = isStagingSite ? stagingSite?.jetpack_connection : false;
-
 	const isStagingSiteTransferInProgress =
 		isStagingSite &&
 		isAtomicTransferInProgress( atomicTransfer?.status ?? 'pending' ) &&
-		! hasStagingSiteJetpackConnection;
+		! stagingSite?.jetpack_connection &&
+		! stagingSite?.is_wpcom_atomic;
 
 	// Ensure we have features
 	if ( ! features || ! features.length ) {

--- a/client/layout/hosting-dashboard/item-view/index.tsx
+++ b/client/layout/hosting-dashboard/item-view/index.tsx
@@ -8,7 +8,10 @@ import NavTabs from 'calypso/components/section-nav/tabs';
 import { siteByIdQuery } from 'calypso/dashboard/app/queries/site';
 import { siteLatestAtomicTransferQuery } from 'calypso/dashboard/app/queries/site-atomic-transfers';
 import { isDeletingStagingSiteQuery } from 'calypso/dashboard/app/queries/site-staging-sites';
-import { isAtomicTransferInProgress } from 'calypso/dashboard/utils/site-atomic-transfers';
+import {
+	isAtomicTransferInProgress,
+	isAtomicTransferredSite,
+} from 'calypso/dashboard/utils/site-atomic-transfers';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import { StagingSiteCreationBanner } from 'calypso/sites/staging-site/components/staging-site-transfer-banner/staging-site-creation-banner';
 import { StagingSiteDeletionBanner } from 'calypso/sites/staging-site/components/staging-site-transfer-banner/staging-site-deletion-banner';
@@ -75,7 +78,15 @@ export default function ItemView( {
 	const { data: stagingSite } = useQuery( {
 		...siteByIdQuery( itemData.blogId ?? 0 ),
 		refetchInterval: ( query ) => {
-			return query.state.data?.jetpack_connection && query.state.data?.is_wpcom_atomic
+			if ( ! isStagingSite ) {
+				return false;
+			}
+
+			if ( ! query.state.data ) {
+				return 0;
+			}
+
+			return query.state.data.jetpack_connection && isAtomicTransferredSite( query.state.data )
 				? false
 				: 5000;
 		},
@@ -84,9 +95,10 @@ export default function ItemView( {
 
 	const isStagingSiteTransferInProgress =
 		isStagingSite &&
+		stagingSite &&
 		isAtomicTransferInProgress( atomicTransfer?.status ?? 'pending' ) &&
 		! stagingSite?.jetpack_connection &&
-		! stagingSite?.is_wpcom_atomic;
+		! isAtomicTransferredSite( stagingSite );
 
 	// Ensure we have features
 	if ( ! features || ! features.length ) {

--- a/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
@@ -6,6 +6,7 @@ import { plus } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useMemo, useEffect } from 'react';
 import { siteByIdQuery } from 'calypso/dashboard/app/queries/site';
+import { isAtomicTransferredSite } from 'calypso/dashboard/utils/site-atomic-transfers';
 import { USE_SITE_EXCERPTS_QUERY_KEY } from 'calypso/data/sites/use-site-excerpts-query';
 import { useAddStagingSiteMutation } from 'calypso/sites/staging-site/hooks/use-add-staging-site';
 import { useCheckStagingSiteStatus } from 'calypso/sites/staging-site/hooks/use-check-staging-site-status';
@@ -46,11 +47,16 @@ export default function HeaderStagingSiteButton( {
 	const isPossibleJetpackConnectionProblem = useIsJetpackConnectionProblem( site?.ID );
 	const stagingSiteStatus =
 		useSelector( ( state ) => getStagingSiteStatus( state, siteId ) ) ?? StagingSiteStatus.UNSET;
+
 	const isCreatingStagingSite = [
 		StagingSiteStatus.INITIATE_TRANSFERRING,
 		StagingSiteStatus.TRANSFERRING,
 	].includes( stagingSiteStatus );
+
+	const isCreatedStagingSite = stagingSiteStatus === StagingSiteStatus.COMPLETE;
+
 	const isA4ADevSite = site?.is_a4a_dev_site || false;
+
 	const {
 		data: hasValidQuota,
 		isLoading: isLoadingQuotaValidation,
@@ -77,21 +83,32 @@ export default function HeaderStagingSiteButton( {
 				return 0;
 			}
 
-			return ! query.state.data.is_wpcom_atomic ? 1000 : false;
+			return ! isAtomicTransferredSite( query.state.data ) ? 2000 : false;
 		},
 		enabled: !! stagingSiteId && transferStatus === transferStates.COMPLETE,
 	} );
 
+	const isStagingSiteReady =
+		isCreatingStagingSite && stagingSite && isAtomicTransferredSite( stagingSite );
+
 	useEffect( () => {
-		if ( isCreatingStagingSite && stagingSite?.is_wpcom_atomic ) {
+		const handleStagingSiteReady = async () => {
+			if ( ! stagingSite ) {
+				return;
+			}
+
+			await dispatch( requestSite( stagingSite.ID ) );
 			dispatch( setStagingSiteStatus( siteId, StagingSiteStatus.COMPLETE ) );
-			dispatch( requestSite( stagingSite.ID ) );
 			queryClient.invalidateQueries( { queryKey: [ USE_SITE_EXCERPTS_QUERY_KEY ] } );
 			dispatch(
 				successNotice( __( 'Staging site added.' ), { id: stagingSiteAddSuccessNoticeId } )
 			);
+		};
+
+		if ( isStagingSiteReady ) {
+			handleStagingSiteReady();
 		}
-	}, [ __, dispatch, queryClient, siteId, isCreatingStagingSite, stagingSite ] );
+	}, [ __, dispatch, queryClient, siteId, isStagingSiteReady, stagingSite ] );
 
 	const removeAllNotices = useCallback( () => {
 		dispatch( removeNotice( 'staging-site-add-success' ) );
@@ -134,7 +151,7 @@ export default function HeaderStagingSiteButton( {
 		isAtomic &&
 		! isStagingSite &&
 		! isLoadingStagingSites &&
-		( stagingSites.length === 0 || isCreatingStagingSite );
+		( stagingSites.length === 0 || ( isCreatingStagingSite && ! isCreatedStagingSite ) );
 
 	const onAddClick = useCallback( () => {
 		dispatch( setStagingSiteStatus( siteId, StagingSiteStatus.INITIATE_TRANSFERRING ) );
@@ -148,7 +165,8 @@ export default function HeaderStagingSiteButton( {
 	}
 
 	const hasCompletedLoading = ! isLoadingQuotaValidation;
-	const isAddingStagingSite = isLoadingAddStagingSite || isCreatingStagingSite;
+	const isAddingStagingSite =
+		isLoadingAddStagingSite || ( isCreatingStagingSite && ! isCreatedStagingSite );
 
 	let disabledReason: string | undefined;
 	if ( ! hasCompletedLoading ) {

--- a/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
@@ -1,10 +1,11 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQueryClient, useQuery } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useMemo, useEffect } from 'react';
+import { siteByIdQuery } from 'calypso/dashboard/app/queries/site';
 import { USE_SITE_EXCERPTS_QUERY_KEY } from 'calypso/data/sites/use-site-excerpts-query';
 import { useAddStagingSiteMutation } from 'calypso/sites/staging-site/hooks/use-add-staging-site';
 import { useCheckStagingSiteStatus } from 'calypso/sites/staging-site/hooks/use-check-staging-site-status';
@@ -17,6 +18,7 @@ import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/a
 import { transferStates } from 'calypso/state/automated-transfer/constants';
 import { useIsJetpackConnectionProblem } from 'calypso/state/jetpack-connection-health/selectors/is-jetpack-connection-problem.js';
 import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
+import { requestSite } from 'calypso/state/sites/actions';
 import { setStagingSiteStatus } from 'calypso/state/staging-site/actions';
 import { StagingSiteStatus } from 'calypso/state/staging-site/constants';
 import { getStagingSiteStatus } from 'calypso/state/staging-site/selectors/get-staging-site-status';
@@ -65,17 +67,31 @@ export default function HeaderStagingSiteButton( {
 	const stagingSiteId = useMemo( () => {
 		return stagingSites?.length ? stagingSites[ 0 ].id : null;
 	}, [ stagingSites ] );
+
 	const transferStatus = useCheckStagingSiteStatus( stagingSiteId );
 
+	const { data: stagingSite } = useQuery( {
+		...siteByIdQuery( stagingSiteId ?? 0 ),
+		refetchInterval: ( query ) => {
+			if ( ! query.state.data ) {
+				return 0;
+			}
+
+			return ! query.state.data.is_wpcom_atomic ? 1000 : false;
+		},
+		enabled: !! stagingSiteId && transferStatus === transferStates.COMPLETE,
+	} );
+
 	useEffect( () => {
-		if ( isCreatingStagingSite && transferStatus === transferStates.COMPLETE ) {
+		if ( isCreatingStagingSite && stagingSite?.is_wpcom_atomic ) {
 			dispatch( setStagingSiteStatus( siteId, StagingSiteStatus.COMPLETE ) );
+			dispatch( requestSite( stagingSite.ID ) );
 			queryClient.invalidateQueries( { queryKey: [ USE_SITE_EXCERPTS_QUERY_KEY ] } );
 			dispatch(
 				successNotice( __( 'Staging site added.' ), { id: stagingSiteAddSuccessNoticeId } )
 			);
 		}
-	}, [ __, dispatch, queryClient, siteId, transferStatus, isCreatingStagingSite ] );
+	}, [ __, dispatch, queryClient, siteId, isCreatingStagingSite, stagingSite ] );
 
 	const removeAllNotices = useCallback( () => {
 		dispatch( removeNotice( 'staging-site-add-success' ) );

--- a/client/sites/hosting/components/hosting-callout/index.tsx
+++ b/client/sites/hosting/components/hosting-callout/index.tsx
@@ -15,12 +15,19 @@ export function HostingActivationCallout( {
 	siteId: number;
 	redirectUrl?: string;
 } ) {
-	const { data: siteTransferData } = useSiteTransferStatusQuery( siteId, {
-		refetchIntervalInBackground: true,
-	} );
+	const { data: siteTransferData, refetch: fetchSiteTransferStatus } = useSiteTransferStatusQuery(
+		siteId,
+		{
+			refetchIntervalInBackground: true,
+		}
+	);
 
 	const isActivating = siteTransferData?.isTransferring;
 	const isActivated = transferStates.COMPLETED;
+
+	useEffect( () => {
+		fetchSiteTransferStatus();
+	}, [ fetchSiteTransferStatus ] );
 
 	useEffect( () => {
 		if ( isActivated && redirectUrl ) {

--- a/client/sites/hosting/components/hosting-callout/index.tsx
+++ b/client/sites/hosting/components/hosting-callout/index.tsx
@@ -1,10 +1,11 @@
 import page from '@automattic/calypso-router';
+import { useQuery } from '@tanstack/react-query';
 import { Button, __experimentalText as Text } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEffect } from 'react';
+import { siteLatestAtomicTransferQuery } from 'calypso/dashboard/app/queries/site-atomic-transfers';
 import { Callout } from 'calypso/dashboard/components/callout';
-import { useSiteTransferStatusQuery } from 'calypso/landing/stepper/hooks/use-site-transfer/query';
-import { transferStates } from 'calypso/state/atomic-transfer/constants';
+import { isAtomicTransferInProgress } from 'calypso/dashboard/utils/site-atomic-transfers';
 import HostingActivationButton from '../hosting-activation-button';
 import illustrationUrl from './hosting-callout-illustration.svg';
 
@@ -15,19 +16,23 @@ export function HostingActivationCallout( {
 	siteId: number;
 	redirectUrl?: string;
 } ) {
-	const { data: siteTransferData, refetch: fetchSiteTransferStatus } = useSiteTransferStatusQuery(
-		siteId,
-		{
-			refetchIntervalInBackground: true,
-		}
-	);
+	const { data: latestAtomicTransfer } = useQuery( {
+		...siteLatestAtomicTransferQuery( siteId ),
+		enabled: !! siteId,
+		refetchInterval: ( query ) => {
+			if ( ! query.state.data ) {
+				return 0;
+			}
 
-	const isActivating = siteTransferData?.isTransferring;
-	const isActivated = transferStates.COMPLETED;
+			return isAtomicTransferInProgress( query.state.data.status ) ? 5000 : false;
+		},
+		refetchIntervalInBackground: true,
+	} );
 
-	useEffect( () => {
-		fetchSiteTransferStatus();
-	}, [ fetchSiteTransferStatus ] );
+	const isActivating =
+		latestAtomicTransfer && isAtomicTransferInProgress( latestAtomicTransfer.status );
+
+	const isActivated = latestAtomicTransfer?.status === 'completed';
 
 	useEffect( () => {
 		if ( isActivated && redirectUrl ) {

--- a/client/sites/hosting/components/hosting-callout/index.tsx
+++ b/client/sites/hosting/components/hosting-callout/index.tsx
@@ -2,10 +2,14 @@ import page from '@automattic/calypso-router';
 import { useQuery } from '@tanstack/react-query';
 import { Button, __experimentalText as Text } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 import { useEffect } from 'react';
+import { siteByIdQuery } from 'calypso/dashboard/app/queries/site';
 import { siteLatestAtomicTransferQuery } from 'calypso/dashboard/app/queries/site-atomic-transfers';
 import { Callout } from 'calypso/dashboard/components/callout';
 import { isAtomicTransferInProgress } from 'calypso/dashboard/utils/site-atomic-transfers';
+import { useDispatch } from 'calypso/state';
+import { requestSite } from 'calypso/state/sites/actions';
 import HostingActivationButton from '../hosting-activation-button';
 import illustrationUrl from './hosting-callout-illustration.svg';
 
@@ -16,6 +20,7 @@ export function HostingActivationCallout( {
 	siteId: number;
 	redirectUrl?: string;
 } ) {
+	const dispatch = useDispatch();
 	const { data: latestAtomicTransfer } = useQuery( {
 		...siteLatestAtomicTransferQuery( siteId ),
 		enabled: !! siteId,
@@ -29,16 +34,41 @@ export function HostingActivationCallout( {
 		refetchIntervalInBackground: true,
 	} );
 
+	const { data: site } = useQuery( {
+		...siteByIdQuery( siteId ),
+		refetchInterval: ( query ) => {
+			if ( ! query.state.data ) {
+				return 0;
+			}
+
+			return ! query.state.data?.is_wpcom_atomic ? 1000 : false;
+		},
+		enabled: !! siteId && latestAtomicTransfer?.status === 'completed',
+	} );
+
 	const isActivating =
 		latestAtomicTransfer && isAtomicTransferInProgress( latestAtomicTransfer.status );
 
-	const isActivated = latestAtomicTransfer?.status === 'completed';
+	const isActivated = latestAtomicTransfer?.status === 'completed' && site?.is_wpcom_atomic;
 
 	useEffect( () => {
-		if ( isActivated && redirectUrl ) {
-			page.replace( redirectUrl );
+		const handleActivated = async () => {
+			await dispatch( requestSite( siteId ) );
+			if ( redirectUrl ) {
+				page.replace( redirectUrl );
+			} else {
+				page.show(
+					addQueryArgs( window.location.href.replace( window.location.origin, '' ), {
+						activated: true,
+					} )
+				);
+			}
+		};
+
+		if ( isActivated ) {
+			handleActivated();
 		}
-	}, [ isActivated, redirectUrl ] );
+	}, [ isActivated, siteId, redirectUrl, dispatch ] );
 
 	return (
 		<Callout

--- a/client/sites/hosting/components/hosting-callout/index.tsx
+++ b/client/sites/hosting/components/hosting-callout/index.tsx
@@ -7,7 +7,10 @@ import { useEffect } from 'react';
 import { siteByIdQuery } from 'calypso/dashboard/app/queries/site';
 import { siteLatestAtomicTransferQuery } from 'calypso/dashboard/app/queries/site-atomic-transfers';
 import { Callout } from 'calypso/dashboard/components/callout';
-import { isAtomicTransferInProgress } from 'calypso/dashboard/utils/site-atomic-transfers';
+import {
+	isAtomicTransferInProgress,
+	isAtomicTransferredSite,
+} from 'calypso/dashboard/utils/site-atomic-transfers';
 import { useDispatch } from 'calypso/state';
 import { requestSite } from 'calypso/state/sites/actions';
 import HostingActivationButton from '../hosting-activation-button';
@@ -41,15 +44,19 @@ export function HostingActivationCallout( {
 				return 0;
 			}
 
-			return ! query.state.data?.is_wpcom_atomic ? 1000 : false;
+			return ! isAtomicTransferredSite( query.state.data ) ? 2000 : false;
 		},
 		enabled: !! siteId && latestAtomicTransfer?.status === 'completed',
 	} );
 
 	const isActivating =
-		latestAtomicTransfer && isAtomicTransferInProgress( latestAtomicTransfer.status );
+		latestAtomicTransfer &&
+		( isAtomicTransferInProgress( latestAtomicTransfer.status ) ||
+			// Keep displaying “Activating…” until the page redirects.
+			latestAtomicTransfer?.status === 'completed' );
 
-	const isActivated = latestAtomicTransfer?.status === 'completed' && site?.is_wpcom_atomic;
+	const isActivated =
+		latestAtomicTransfer?.status === 'completed' && site && isAtomicTransferredSite( site );
 
 	useEffect( () => {
 		const handleActivated = async () => {

--- a/client/sites/hosting/controller.tsx
+++ b/client/sites/hosting/controller.tsx
@@ -22,7 +22,7 @@ export function hostingFeatures( context: PageJSContext, next: () => void ) {
 		const shouldShowActivationCallout = ! site.is_wpcom_atomic && hasSftpFeature;
 
 		let redirectUrl = context.query.redirect_to;
-		if ( redirectUrl ) {
+		if ( ! redirectUrl ) {
 			redirectUrl = hasSftpFeature ? `/sites/${ site.slug }/settings` : `/overview/${ site.slug }`;
 		}
 

--- a/client/sites/staging-site/components/staging-site-card/index.js
+++ b/client/sites/staging-site/components/staging-site-card/index.js
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useQueryClient } from '@tanstack/react-query';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
@@ -35,7 +34,6 @@ import { useGetLockQuery, USE_STAGING_SITE_LOCK_QUERY_KEY } from '../../hooks/us
 import { useHasValidQuotaQuery } from '../../hooks/use-has-valid-quota';
 import { useStagingSite } from '../../hooks/use-staging-site';
 import { usePullFromStagingMutation, usePushToStagingMutation } from '../../hooks/use-staging-sync';
-import StagingSiteManagementMoveInfo from '../staging-site-management-move-info';
 import { CardContentWrapper } from './card-content/card-content-wrapper';
 import { ManageStagingSiteCardContent } from './card-content/manage-staging-site-card-content';
 import { NewStagingSiteCardContent } from './card-content/new-staging-site-card-content';
@@ -185,10 +183,7 @@ export const StagingSiteCard = ( {
 	} );
 
 	useEffect( () => {
-		if (
-			stagingSiteStatus === StagingSiteStatus.COMPLETE &&
-			! isEnabled( 'hosting/staging-sites-redesign' )
-		) {
+		if ( stagingSiteStatus === StagingSiteStatus.COMPLETE ) {
 			queryClient.invalidateQueries( [ USE_SITE_EXCERPTS_QUERY_KEY ] );
 			dispatch( setStagingSiteStatus( siteId, StagingSiteStatus.NONE ) );
 			dispatch(
@@ -516,10 +511,6 @@ export const StagingSiteCard = ( {
 			dispatch( requestJetpackConnectionHealthStatus( siteId ) );
 		}
 	}, [ dispatch, isJetpack, siteId ] );
-
-	if ( isEnabled( 'hosting/staging-sites-redesign' ) ) {
-		return <StagingSiteManagementMoveInfo />;
-	}
 
 	return (
 		<CardContentWrapper>

--- a/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
+++ b/client/sites/staging-site/components/staging-site-management-move-info/index.tsx
@@ -149,9 +149,11 @@ const StagingSiteManagementMoveInfo: FunctionComponent = () => {
 	const isCurrentSiteStaging = currentSite?.is_wpcom_staging_site;
 	const targetSite = isCurrentSiteStaging ? currentSite : stagingSite;
 
-	const settingsLink = targetSite?.URL
-		? `/sites/${ urlToSlug( targetSite.URL ) }/settings`
-		: undefined;
+	// capabilities are not immediately propagated to the Atomic site...
+	const settingsLink =
+		targetSite?.is_wpcom_atomic && targetSite?.capabilities?.manage_options && targetSite?.URL
+			? `/sites/${ urlToSlug( targetSite.URL ) }/settings`
+			: undefined;
 
 	const infoCardItems = getInfoCardItems( settingsLink );
 

--- a/client/sites/staging-site/components/staging-site/index.tsx
+++ b/client/sites/staging-site/components/staging-site/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_SITE_STAGING_SITES } from '@automattic/calypso-products';
 import { useSelector } from 'calypso/state';
 import isRequestingSiteFeatures from 'calypso/state/selectors/is-requesting-site-features';
@@ -6,6 +7,7 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import StagingSiteCard from '../staging-site-card';
 import StagingSiteProductionCard from '../staging-site-card/staging-site-production-card';
+import StagingSiteManagementMoveInfo from '../staging-site-management-move-info';
 import StagingSiteUpsellNudge from '../staging-site-upsell-nudge';
 import './style.scss';
 
@@ -29,6 +31,10 @@ const StagingSite = () => {
 
 	if ( isWpcomStagingSite ) {
 		return <StagingSiteProductionCard siteId={ siteId } />;
+	}
+
+	if ( isEnabled( 'hosting/staging-sites-redesign' ) ) {
+		return <StagingSiteManagementMoveInfo />;
 	}
 
 	return <StagingSiteCard />;

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -200,10 +200,12 @@ export function requestSite( siteFragment ) {
 					 * endpoint returns accurate data.
 					 */
 					if ( hasSiteTransferredToAtomic && hasMismatchingCapabilities ) {
-						setTimeout( () => dispatch( requestSite( siteFragment ) ), 2000 );
-					} else {
-						dispatch( receiveSite( omit( site, '_headers' ) ) );
+						return new Promise( ( resolve ) => {
+							setTimeout( () => resolve( dispatch( requestSite( siteFragment ) ) ), 2000 );
+						} );
 					}
+
+					dispatch( receiveSite( omit( site, '_headers' ) ) );
 				}
 
 				dispatch( { type: SITE_REQUEST_SUCCESS, siteId: siteFragment } );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-14259

## Proposed Changes

* Initialize the transfer status when the callout mounts, so if the site is already transferring to Atomic, we can continue polling the transfer status.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start creating a new staging site with Add staging site button
* As soon as a switcher is available, switch to the staging site
* Observe the staging site creation banner
* Observe after some time that you can see the hosting callout to activate hosting features on some tabs such as Deployments
* Observe that these hosting callouts won't get stuck and you don't need to refresh the page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
