### PR TITLE
Hosting Dashboard Privacy: Implement Do not sell card

### DIFF
--- a/client/dashboard/app/analytics/country-code-cookie-gdpr.ts
+++ b/client/dashboard/app/analytics/country-code-cookie-gdpr.ts
@@ -1,0 +1,76 @@
+import cookie from 'cookie';
+import { useEffect, useState } from 'react';
+import { isRegionInCcpaZone } from './tracking-preferences';
+
+let refreshRequest: Promise< void > | null = null;
+
+/**
+ * Refreshes the GDPR `country_code` cookie every 6 hours (like A8C_Analytics wpcom plugin).
+ * @param {AbortSignal} signal optional AbortSignal to cancel the request (use if needed)
+ * @returns {Promise<void>} Promise that resolves when the refreshing is done (or immediately)
+ */
+export async function refreshCountryCodeCookieGdpr( signal?: AbortSignal ) {
+	const cookies = cookie.parse( document.cookie );
+	if ( cookies.country_code && cookies.region ) {
+		return;
+	}
+
+	if ( refreshRequest === null ) {
+		refreshRequest = requestGeoData( signal )
+			.then( ( { country_short, region } ) => {
+				setCookie( 'country_code', country_short );
+				// For some IP ranges we don't detect the region and the value returned by the `/geo` endpoint is `"-"`.
+				// In that case set the cookie to `unknown` This cannot happen for `country_short` because the `/geo`
+				// endpoint returns a 404 HTTP status when not even the country can be detected.
+				setCookie( 'region', region === '-' ? 'unknown' : region );
+			} )
+			.catch( () => {
+				// Set the cookies to `unknown` to signal that the `/geo` request already failed and there's no point
+				// sending it again. But set them only if they don't already exist, don't overwrite valid values!
+				if ( ! cookies.country_code ) {
+					setCookie( 'country_code', 'unknown' );
+				}
+				if ( ! cookies.region ) {
+					setCookie( 'region', 'unknown' );
+				}
+			} )
+			.finally( () => {
+				refreshRequest = null;
+			} );
+	}
+
+	await refreshRequest;
+}
+
+async function requestGeoData( signal?: AbortSignal ) {
+	// cache buster
+	const v = new Date().getTime();
+	const res = await fetch( 'https://public-api.wordpress.com/geo/?v=' + v, { signal } );
+	if ( ! res.ok ) {
+		throw new Error( `The /geo endpoint returned an error: ${ res.status } ${ res.statusText }` );
+	}
+	return await res.json();
+}
+
+function setCookie( name: string, value: string ) {
+	const maxAge = 6 * 60 * 60; // 6 hours in seconds
+	document.cookie = cookie.serialize( name, value, { path: '/', maxAge } );
+}
+
+export function useIsRegionInCcpaZone() {
+	const [ isCookieRegionInCcpaZone, setIsCookieRegionInCcpaZone ] = useState( false );
+
+	useEffect( () => {
+		const controller = new AbortController();
+		refreshCountryCodeCookieGdpr( controller.signal )
+			.then( () => {
+				const cookies = cookie.parse( document.cookie );
+				setIsCookieRegionInCcpaZone( isRegionInCcpaZone( cookies.country_code, cookies.region ) );
+			} )
+			.catch( () => {
+				setIsCookieRegionInCcpaZone( true );
+			} );
+	}, [] );
+
+	return isCookieRegionInCcpaZone;
+}

--- a/client/dashboard/app/analytics/country-code-cookie-gdpr.ts
+++ b/client/dashboard/app/analytics/country-code-cookie-gdpr.ts
@@ -1,6 +1,7 @@
 import cookie from 'cookie';
 import { useEffect, useState } from 'react';
-import { isRegionInCcpaZone } from './tracking-preferences';
+import { fetchGeo } from '../../data/geo';
+import { isRegionInCcpaZone } from './geo-privacy';
 
 let refreshRequest: Promise< void > | null = null;
 
@@ -16,7 +17,7 @@ export async function refreshCountryCodeCookieGdpr( signal?: AbortSignal ) {
 	}
 
 	if ( refreshRequest === null ) {
-		refreshRequest = requestGeoData( signal )
+		refreshRequest = fetchGeo( signal )
 			.then( ( { country_short, region } ) => {
 				setCookie( 'country_code', country_short );
 				// For some IP ranges we don't detect the region and the value returned by the `/geo` endpoint is `"-"`.
@@ -40,16 +41,6 @@ export async function refreshCountryCodeCookieGdpr( signal?: AbortSignal ) {
 	}
 
 	await refreshRequest;
-}
-
-async function requestGeoData( signal?: AbortSignal ) {
-	// cache buster
-	const v = new Date().getTime();
-	const res = await fetch( 'https://public-api.wordpress.com/geo/?v=' + v, { signal } );
-	if ( ! res.ok ) {
-		throw new Error( `The /geo endpoint returned an error: ${ res.status } ${ res.statusText }` );
-	}
-	return await res.json();
 }
 
 function setCookie( name: string, value: string ) {

--- a/client/dashboard/app/analytics/geo-privacy.ts
+++ b/client/dashboard/app/analytics/geo-privacy.ts
@@ -1,0 +1,82 @@
+/**
+ * Returns a boolean telling whether a country is in the GDPR zone.
+ * @param countryCode The country code to look for.
+ * @returns Whether the country is in the GDPR zone
+ */
+export function isCountryInGdprZone( countryCode: string | undefined ): boolean {
+	if ( 'unknown' === countryCode || undefined === countryCode ) {
+		// Fail safe: if we don't know the countryCode, assume it's in the Gdpr zone.
+		return true;
+	}
+	return [
+		// European Member countries
+		'AT', // Austria
+		'BE', // Belgium
+		'BG', // Bulgaria
+		'CY', // Cyprus
+		'CZ', // Czech Republic
+		'DE', // Germany
+		'DK', // Denmark
+		'EE', // Estonia
+		'ES', // Spain
+		'FI', // Finland
+		'FR', // France
+		'GR', // Greece
+		'HR', // Croatia
+		'HU', // Hungary
+		'IE', // Ireland
+		'IT', // Italy
+		'LT', // Lithuania
+		'LU', // Luxembourg
+		'LV', // Latvia
+		'MT', // Malta
+		'NL', // Netherlands
+		'PL', // Poland
+		'PT', // Portugal
+		'RO', // Romania
+		'SE', // Sweden
+		'SI', // Slovenia
+		'SK', // Slovakia
+		'GB', // United Kingdom
+		// Single Market Countries that GDPR applies to
+		'CH', // Switzerland
+		'IS', // Iceland
+		'LI', // Liechtenstein
+		'NO', // Norway
+	].includes( countryCode );
+}
+
+/**
+ * Returns a boolean telling whether a region is in the CCPA zone.
+ * @param countryCode The country code to check (it needs to be 'US' for CCPA to apply)
+ * @param region The region to look for.
+ * @returns Whether the region is in the GDPR zone
+ */
+export function isRegionInCcpaZone(
+	countryCode: string | undefined,
+	region: string | undefined
+): boolean {
+	if ( 'US' !== countryCode ) {
+		return false;
+	}
+	if ( 'unknown' === region || undefined === region ) {
+		// Fail safe: if we don't know the region, assume it's in the CCPA zone.
+		return true;
+	}
+
+	return [
+		'california', // CA
+		'colorado', // CO
+		'connecticut', // CT
+		'utah', // UT
+		'virginia', // VA
+		'texas', // TX
+		'tennessee', // TN
+		'oregon', // OR
+		'new jersey', // NJ
+		'montana', // MT
+		'iowa', // IA
+		'indiana', // IN
+		'delaware', // DE
+	].includes( region.toLowerCase() );
+}

--- a/client/dashboard/app/analytics/tracking-preferences.ts
+++ b/client/dashboard/app/analytics/tracking-preferences.ts
@@ -1,4 +1,5 @@
 import cookie from 'cookie';
+import { isCountryInGdprZone, isRegionInCcpaZone } from './geo-privacy';
 
 type TrackingPrefs = {
 	ok: boolean;
@@ -43,89 +44,6 @@ const prefsAllowAll: TrackingPrefs = {
 		advertising: true,
 	},
 };
-
-/**
- * Returns a boolean telling whether a country is in the GDPR zone.
- * @param countryCode The country code to look for.
- * @returns Whether the country is in the GDPR zone
- */
-export function isCountryInGdprZone( countryCode: string | undefined ): boolean {
-	if ( 'unknown' === countryCode || undefined === countryCode ) {
-		// Fail safe: if we don't know the countryCode, assume it's in the Gdpr zone.
-		return true;
-	}
-	return [
-		// European Member countries
-		'AT', // Austria
-		'BE', // Belgium
-		'BG', // Bulgaria
-		'CY', // Cyprus
-		'CZ', // Czech Republic
-		'DE', // Germany
-		'DK', // Denmark
-		'EE', // Estonia
-		'ES', // Spain
-		'FI', // Finland
-		'FR', // France
-		'GR', // Greece
-		'HR', // Croatia
-		'HU', // Hungary
-		'IE', // Ireland
-		'IT', // Italy
-		'LT', // Lithuania
-		'LU', // Luxembourg
-		'LV', // Latvia
-		'MT', // Malta
-		'NL', // Netherlands
-		'PL', // Poland
-		'PT', // Portugal
-		'RO', // Romania
-		'SE', // Sweden
-		'SI', // Slovenia
-		'SK', // Slovakia
-		'GB', // United Kingdom
-		// Single Market Countries that GDPR applies to
-		'CH', // Switzerland
-		'IS', // Iceland
-		'LI', // Liechtenstein
-		'NO', // Norway
-	].includes( countryCode );
-}
-
-/**
- * Returns a boolean telling whether a region is in the CCPA zone.
- * @param countryCode The country code to check (it needs to be 'US' for CCPA to apply)
- * @param region The region to look for.
- * @returns Whether the region is in the GDPR zone
- */
-export function isRegionInCcpaZone(
-	countryCode: string | undefined,
-	region: string | undefined
-): boolean {
-	if ( 'US' !== countryCode ) {
-		return false;
-	}
-	if ( 'unknown' === region || undefined === region ) {
-		// Fail safe: if we don't know the region, assume it's in the CCPA zone.
-		return true;
-	}
-
-	return [
-		'california', // CA
-		'colorado', // CO
-		'connecticut', // CT
-		'utah', // UT
-		'virginia', // VA
-		'texas', // TX
-		'tennessee', // TN
-		'oregon', // OR
-		'new jersey', // NJ
-		'montana', // MT
-		'iowa', // IA
-		'indiana', // IN
-		'delaware', // DE
-	].includes( region.toLowerCase() );
-}
 
 export const parseTrackingPrefs = (
 	cookieV2?: string,

--- a/client/dashboard/app/analytics/tracking-preferences.ts
+++ b/client/dashboard/app/analytics/tracking-preferences.ts
@@ -1,0 +1,216 @@
+import cookie from 'cookie';
+
+type TrackingPrefs = {
+	ok: boolean;
+	buckets: {
+		essential: boolean;
+		analytics: boolean;
+		advertising: boolean;
+	};
+};
+
+type TrackingPrefsData = Partial<
+	Omit< TrackingPrefs, 'buckets' > & { buckets: Partial< TrackingPrefs[ 'buckets' ] > }
+>;
+
+const COOKIE_MAX_AGE = 60 * 60 * 24 * ( 365.25 / 2 ); // 365.25 is the average number of days in a year.
+const TRACKING_PREFS_COOKIE_V1 = 'sensitive_pixel_option';
+const TRACKING_PREFS_COOKIE_V2 = 'sensitive_pixel_options';
+
+const prefsDisallowAll: TrackingPrefs = {
+	ok: false,
+	buckets: {
+		essential: true, // essential bucket is always allowed
+		analytics: false,
+		advertising: false,
+	},
+};
+
+const prefsAllowAnalyticsGdpr: TrackingPrefs = {
+	ok: false, // false is important so the cookie banner is shown
+	buckets: {
+		essential: true,
+		analytics: true, // in GDPR zone, analytics is opt-out
+		advertising: false, // in GDPR zone, advertising is opt-in
+	},
+};
+
+const prefsAllowAll: TrackingPrefs = {
+	ok: true,
+	buckets: {
+		essential: true,
+		analytics: true,
+		advertising: true,
+	},
+};
+
+/**
+ * Returns a boolean telling whether a country is in the GDPR zone.
+ * @param countryCode The country code to look for.
+ * @returns Whether the country is in the GDPR zone
+ */
+export function isCountryInGdprZone( countryCode: string | undefined ): boolean {
+	if ( 'unknown' === countryCode || undefined === countryCode ) {
+		// Fail safe: if we don't know the countryCode, assume it's in the Gdpr zone.
+		return true;
+	}
+	return [
+		// European Member countries
+		'AT', // Austria
+		'BE', // Belgium
+		'BG', // Bulgaria
+		'CY', // Cyprus
+		'CZ', // Czech Republic
+		'DE', // Germany
+		'DK', // Denmark
+		'EE', // Estonia
+		'ES', // Spain
+		'FI', // Finland
+		'FR', // France
+		'GR', // Greece
+		'HR', // Croatia
+		'HU', // Hungary
+		'IE', // Ireland
+		'IT', // Italy
+		'LT', // Lithuania
+		'LU', // Luxembourg
+		'LV', // Latvia
+		'MT', // Malta
+		'NL', // Netherlands
+		'PL', // Poland
+		'PT', // Portugal
+		'RO', // Romania
+		'SE', // Sweden
+		'SI', // Slovenia
+		'SK', // Slovakia
+		'GB', // United Kingdom
+		// Single Market Countries that GDPR applies to
+		'CH', // Switzerland
+		'IS', // Iceland
+		'LI', // Liechtenstein
+		'NO', // Norway
+	].includes( countryCode );
+}
+
+/**
+ * Returns a boolean telling whether a region is in the CCPA zone.
+ * @param countryCode The country code to check (it needs to be 'US' for CCPA to apply)
+ * @param region The region to look for.
+ * @returns Whether the region is in the GDPR zone
+ */
+export function isRegionInCcpaZone(
+	countryCode: string | undefined,
+	region: string | undefined
+): boolean {
+	if ( 'US' !== countryCode ) {
+		return false;
+	}
+	if ( 'unknown' === region || undefined === region ) {
+		// Fail safe: if we don't know the region, assume it's in the CCPA zone.
+		return true;
+	}
+
+	return [
+		'california', // CA
+		'colorado', // CO
+		'connecticut', // CT
+		'utah', // UT
+		'virginia', // VA
+		'texas', // TX
+		'tennessee', // TN
+		'oregon', // OR
+		'new jersey', // NJ
+		'montana', // MT
+		'iowa', // IA
+		'indiana', // IN
+		'delaware', // DE
+	].includes( region.toLowerCase() );
+}
+
+export const parseTrackingPrefs = (
+	cookieV2?: string,
+	cookieV1?: string,
+	defaultPrefs = prefsDisallowAll
+): TrackingPrefs => {
+	const { ok, buckets }: Partial< TrackingPrefs > = cookieV2 ? JSON.parse( cookieV2 ) : {};
+
+	if ( typeof ok === 'boolean' ) {
+		return {
+			ok,
+			buckets: {
+				...defaultPrefs.buckets,
+				...buckets,
+			},
+		};
+	} else if ( cookieV1 && [ 'yes', 'no' ].includes( cookieV1 ) ) {
+		return {
+			ok: cookieV1 === 'yes',
+			buckets: prefsAllowAll.buckets,
+		};
+	}
+
+	return defaultPrefs;
+};
+
+export function setTrackingPrefs( newPrefs: TrackingPrefsData ): TrackingPrefs {
+	const { ok, buckets } = getTrackingPrefs();
+
+	const newOptions = {
+		ok: typeof newPrefs.ok === 'boolean' ? newPrefs.ok : ok,
+		buckets: {
+			...buckets,
+			...newPrefs.buckets,
+		},
+	};
+
+	document.cookie = cookie.serialize( TRACKING_PREFS_COOKIE_V2, JSON.stringify( newOptions ), {
+		path: '/',
+		maxAge: COOKIE_MAX_AGE,
+	} );
+
+	return newOptions;
+}
+
+/**
+ * Returns consents for every Cookie Jar bucket based on privacy driven approach
+ *
+ * WARNING: this function is meant to work on the client side. If not called
+ *          from the client side then it defaults to allow all
+ * @returns Whether we may track the current user
+ */
+export function getTrackingPrefs(): TrackingPrefs {
+	if ( typeof document === 'undefined' ) {
+		return prefsAllowAll;
+	}
+
+	const cookies = cookie.parse( document.cookie );
+	const isCountryGdpr = isCountryInGdprZone( cookies.country_code );
+	const isCountryCcpa = isRegionInCcpaZone( cookies.country_code, cookies.region );
+
+	if ( ! isCountryGdpr && ! isCountryCcpa ) {
+		return prefsAllowAll;
+	}
+
+	// Default tracking mechanism for GDPR is opt-in for marketing and opt-out for anaytics, for CCPA is opt-out:
+	const defaultPrefs = isCountryGdpr ? prefsAllowAnalyticsGdpr : prefsAllowAll;
+
+	const { ok, buckets } = parseTrackingPrefs(
+		cookies[ TRACKING_PREFS_COOKIE_V2 ],
+		cookies[ TRACKING_PREFS_COOKIE_V1 ],
+		defaultPrefs
+	);
+
+	if ( isCountryCcpa ) {
+		// For CCPA, only the advertising bucket is relevant, the rest are always true
+		return {
+			ok,
+			buckets: {
+				...prefsAllowAll.buckets,
+				advertising: buckets.advertising,
+			},
+		};
+	}
+
+	// For CCPA, only the advertising bucket is relevant, the rest are always true
+	return { ok, buckets };
+}

--- a/client/dashboard/data/geo.ts
+++ b/client/dashboard/data/geo.ts
@@ -1,0 +1,21 @@
+export interface GeoLocationData {
+	city: string;
+	country_long: string;
+	country_short: string;
+	latitude: string;
+	longitude: string;
+	region: string;
+}
+
+export async function fetchGeo( signal?: AbortSignal ): Promise< GeoLocationData > {
+	const version = new Date().getTime();
+	const response = await fetch( 'https://public-api.wordpress.com/geo/?v=' + version, { signal } );
+
+	if ( ! response.ok ) {
+		throw new Error(
+			`The /geo endpoint returned an error: ${ response.status } ${ response.statusText }`
+		);
+	}
+
+	return await response.json();
+}

--- a/client/dashboard/data/me-profile.ts
+++ b/client/dashboard/data/me-profile.ts
@@ -1,6 +1,7 @@
 import wpcom from 'calypso/lib/wp';
 
 export interface UserProfile {
+	advertising_targeting_opt_out: boolean;
 	avatar_URL: string;
 	description: string;
 	display_name: string;
@@ -19,6 +20,7 @@ export async function updateProfile(
 	data: Partial< UserProfile >
 ): Promise< Partial< UserProfile > > {
 	const saveableKeys = [
+		'advertising_targeting_opt_out',
 		'display_name',
 		'description',
 		'is_dev_account',

--- a/client/dashboard/me/privacy/do-not-sell-card.tsx
+++ b/client/dashboard/me/privacy/do-not-sell-card.tsx
@@ -1,0 +1,153 @@
+import { useMutation } from '@tanstack/react-query';
+import {
+	__experimentalVStack as VStack,
+	Card,
+	CardBody,
+	ExternalLink,
+	ToggleControl,
+} from '@wordpress/components';
+import { DataForm, Field } from '@wordpress/dataviews';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useAnalytics } from '../../app/analytics';
+import { useIsRegionInCcpaZone } from '../../app/analytics/country-code-cookie-gdpr';
+import { getTrackingPrefs, setTrackingPrefs } from '../../app/analytics/tracking-preferences';
+import { profileMutation } from '../../app/queries/me-profile';
+import { SectionHeader } from '../../components/section-header';
+import { Text } from '../../components/text';
+
+export default function DoNotSellCard() {
+	const { recordTracksEvent } = useAnalytics();
+	const isRegionInCcpaZone = useIsRegionInCcpaZone();
+	const mutation = useMutation( profileMutation() );
+
+	if ( ! isRegionInCcpaZone ) {
+		return null;
+	}
+
+	const handleChange = ( {
+		advertising_targeting_opt_out,
+	}: {
+		advertising_targeting_opt_out?: boolean;
+	} ) => {
+		// Update the preferences in the cookie.
+		setTrackingPrefs( { ok: true, buckets: { advertising: ! advertising_targeting_opt_out } } );
+
+		// Should fail quietly in the event they have an expired 2FA token
+		// and a success notification is not standard when accepting or denying cookies.
+		mutation.mutate( { advertising_targeting_opt_out } );
+
+		if ( advertising_targeting_opt_out ) {
+			recordTracksEvent( 'a8c_ccpa_optout', {
+				source: 'calypso',
+				hostname: window.location.hostname,
+				pathname: window.location.pathname,
+			} );
+		}
+	};
+
+	const fields: Field< { advertising_targeting_opt_out: boolean } >[] = [
+		{
+			id: 'advertising_targeting_opt_out',
+			label: __( 'Do not sell or share my data' ),
+			Edit: ( { field, onChange, data, hideLabelFromVision } ) => {
+				const { id, label, getValue } = field;
+				return (
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ hideLabelFromVision ? '' : label }
+						checked={ getValue( { item: data } ) }
+						disabled={ mutation.isPending }
+						onChange={ () => onChange( { [ id ]: ! getValue( { item: data } ) } ) }
+					/>
+				);
+			},
+		},
+	];
+
+	const form = {
+		type: 'regular' as const,
+		fields: [ 'advertising_targeting_opt_out' ],
+	};
+
+	const data = {
+		advertising_targeting_opt_out: ! getTrackingPrefs().buckets.advertising,
+	};
+
+	return (
+		<Card>
+			<CardBody>
+				<VStack spacing={ 4 }>
+					<SectionHeader
+						title={ __( 'Do not sell or share my data' ) }
+						description={
+							<VStack spacing={ 4 }>
+								<Text variant="muted" lineHeight="20px">
+									{ createInterpolateElement(
+										__(
+											'Your privacy is critically important to us so we strive to be transparent in how we are collecting, using, and sharing your information. We use cookies and other technologies to help us identify and track visitors to our sites, to store usage and access preferences for our services, to track and understand email campaign effectiveness, and to deliver targeted ads. Learn more in our <privacyLink>privacy policy</privacyLink> and our <cookiesLink>cookie policy</cookiesLink>'
+										),
+										{
+											privacyLink: (
+												<ExternalLink
+													// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
+													href="https://automattic.com/privacy/"
+													children={ null }
+												/>
+											),
+											cookiesLink: (
+												<ExternalLink
+													// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
+													href="https://automattic.com/cookies/"
+													children={ null }
+												/>
+											),
+										}
+									) }
+								</Text>
+								<Text variant="muted" lineHeight="20px">
+									{ __(
+										'Like many websites, we share some of the data we collect through cookies with certain third party advertising and analytics vendors. The personal information we share includes online identifiers; internet or other network or device activity (such as cookie information, other device identifiers, and IP address); and geolocation data (approximate location information from your IP address). We do not share information that identifies you personally, like your name or contact information.'
+									) }
+								</Text>
+								<Text variant="muted" lineHeight="20px">
+									{ __(
+										'We never directly sell your personal information in the conventional sense (i.e., for money), but in some U.S. states the sharing of your information with advertising/analytics vendors can be considered a “sale” of your information, which you may have the right to opt out of. To opt out, click the link below.'
+									) }
+								</Text>
+								<Text variant="muted" lineHeight="20px">
+									{ __(
+										'Our opt-out is managed through cookies, so if you delete cookies, your browser is set to delete cookies automatically after a certain length of time, or if you visit sites in a different browser, you’ll need to make this selection again.'
+									) }
+								</Text>
+								<Text variant="muted" lineHeight="20px">
+									{ createInterpolateElement(
+										__(
+											'If you have any questions about this opt out, or how we honor your legal rights, you can contact us at <emailLink>contact@automattic.com</emailLink>'
+										),
+										{
+											emailLink: (
+												<ExternalLink
+													// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
+													href="mailto:contact@automattic.com"
+													children={ null }
+												/>
+											),
+										}
+									) }
+								</Text>
+							</VStack>
+						}
+						level={ 3 }
+					/>
+					<DataForm< { advertising_targeting_opt_out: boolean } >
+						data={ data }
+						fields={ fields }
+						form={ form }
+						onChange={ handleChange }
+					/>
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/me/privacy/index.tsx
+++ b/client/dashboard/me/privacy/index.tsx
@@ -1,7 +1,9 @@
+import config from '@automattic/calypso-config';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import DoNotSellCard from './do-not-sell-card';
 import DpaCard from './dpa-card';
 import UsageInformationCard from './usage-information-card';
 
@@ -11,6 +13,7 @@ export default function Privacy() {
 			<VStack spacing={ 8 }>
 				<UsageInformationCard />
 				<DpaCard />
+				{ config.isEnabled( 'cookie-banner' ) && <DoNotSellCard /> }
 			</VStack>
 		</PageLayout>
 	);


### PR DESCRIPTION
Ref DOTDASH-176

## Proposed Changes

This PR implements the "Do not sell or share my data" card. 

<img width="1416" height="1400" alt="SCR-20250819-pglu" src="https://github.com/user-attachments/assets/269e4ad0-239a-4199-b5c7-bfb9d7592e56" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Hosting Dashboard development

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2/me/privacy?flags=cookie-banner
* Update your cookies:
  * country_code: US
  * region: california
* Ensure you can see the card
* Ensure that updating the toggle:
  * Send an API request
  * Updated the cookie defined by TRACKING_PREFS_COOKIE_V2

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
