### PR TITLE
DateCalendar, DateRangeCalendar: use px instead of rem, use theme-ready variables

### DIFF
--- a/packages/ui/src/calendar/styles.module.scss
+++ b/packages/ui/src/calendar/styles.module.scss
@@ -7,9 +7,9 @@
 
 	// Internal variables
 	--a8c-calendar-outline-focus: 1.5px solid #{theme.$components-color-accent};
-	--a8c-calendar-button-height: 2rem;
-	--a8c-calendar-button-width: 2rem;
-	--a8c-calendar-nav-height: 2rem;
+	--a8c-calendar-button-height: 32px;
+	--a8c-calendar-button-width: 32px;
+	--a8c-calendar-nav-height: 32px;
 
 	// TODO: themify / align to DS tokens
 	--a8c-calendar-range-middle-background-color: color-mix(in srgb, #{theme.$components-color-accent} 4%, transparent);
@@ -176,7 +176,7 @@
 	display: flex;
 	justify-content: center;
 	flex-wrap: wrap;
-	gap: 1rem;
+	gap: 16px;
 	max-width: fit-content;
 }
 

--- a/packages/ui/src/calendar/styles.module.scss
+++ b/packages/ui/src/calendar/styles.module.scss
@@ -1,4 +1,5 @@
-@use "@wordpress/base-styles/colors";
+@use '@wordpress/base-styles/mixins';
+@use '@wordpress/base-styles/variables';
 @use '../utils/theme-variables' as theme;
 
 /* Root of the component. */
@@ -7,9 +8,9 @@
 
 	// Internal variables
 	--a8c-calendar-outline-focus: 1.5px solid #{theme.$components-color-accent};
-	--a8c-calendar-button-height: 32px;
-	--a8c-calendar-button-width: 32px;
-	--a8c-calendar-nav-height: 32px;
+	--a8c-calendar-button-height: #{variables.$grid-unit-40};
+	--a8c-calendar-button-width: #{variables.$grid-unit-40};
+	--a8c-calendar-nav-height: #{variables.$grid-unit-40};
 
 	// TODO: themify / align to DS tokens
 	--a8c-calendar-range-middle-background-color: color-mix(in srgb, #{theme.$components-color-accent} 4%, transparent);
@@ -18,10 +19,10 @@
 	position: relative; /* Required to position the navigation toolbar. */
 	box-sizing: border-box;
 	display: inline flow-root;
-	color: colors.$gray-900;
-	background-color: colors.$white;
-	font-size: 13px;
-	font-weight: 400;
+	color: theme.$components-color-foreground;
+	background-color: theme.$components-color-background;
+	font-size: variables.$font-size-medium;
+	font-weight: variables.$font-weight-regular;
 	z-index: 0; // Create a stacking context and render on top of the background.
 
 	*, *::before, *::after {
@@ -38,7 +39,7 @@
 	// date follows the same color as the button's text, since the button
 	// inherits its text color.
 	&:has(.calendar__day-button:disabled) {
-		color: colors.$gray-600;
+		color: theme.$components-color-disabled;
 	}
 	&:has(.calendar__day-button:hover:not(:disabled)),
 	&:has(.calendar__day-button:focus-visible) {
@@ -60,7 +61,7 @@
 	height: var(--a8c-calendar-button-height);
 
 	border: none;
-	border-radius: 2px;
+	border-radius: variables.$radius-small;
 
 	font: inherit;
 	font-variant-numeric: tabular-nums;
@@ -76,7 +77,7 @@
 		z-index: -1;
 		inset: 0;
 		border: none; // No default border to avoid polluting high-contrast mode.
-		border-radius: 2px;
+		border-radius: variables.$radius-small;
 	}
 
 	// Use the button's ::after to show the selection preview.
@@ -120,7 +121,7 @@
 .calendar__button-next,
 .calendar__button-previous {
 	border: none;
-	border-radius: 2px;
+	border-radius: variables.$radius-small;
 	background: none;
 	padding: 0;
 	margin: 0;
@@ -142,7 +143,7 @@
 	&[aria-disabled="true"] {
 		cursor: revert;
 
-		color: colors.$gray-600;
+		color: theme.$components-color-disabled;
 	}
 
 	&:focus-visible {
@@ -153,8 +154,8 @@
 .calendar__chevron {
 	display: inline-block;
 	fill: currentColor;
-	width: 16px;
-	height: 16px;
+	width: variables.$grid-unit-20;
+	height: variables.$grid-unit-20;
 }
 
 .calendar[dir="rtl"] .calendar__nav .calendar__chevron {
@@ -168,7 +169,7 @@
 	align-content: center;
 
 	height: var(--a8c-calendar-nav-height);
-	margin-bottom: 12px;
+	margin-bottom: variables.$grid-unit-15;
 }
 
 .calendar__months {
@@ -176,13 +177,13 @@
 	display: flex;
 	justify-content: center;
 	flex-wrap: wrap;
-	gap: 16px;
+	gap: variables.$grid-unit-20;
 	max-width: fit-content;
 }
 
 .calendar__month-grid {
 	border-collapse: separate;
-	border-spacing: 0 4px;
+	border-spacing: 0 variables.$grid-unit-05;
 }
 
 .calendar__nav {
@@ -203,7 +204,7 @@
 	height: var(--a8c-calendar-button-height);
 	padding: 0;
 
-	color: colors.$gray-700;
+	color: theme.$components-color-gray-700;
 	text-align: center;
 	text-transform: uppercase;
 }
@@ -225,12 +226,12 @@
 // Selected date button (individual date, range start, and range end)
 .calendar__day--selected:not(.calendar__range-middle) {
 	&:has(.calendar__day-button, .calendar__day-button:hover:not(:disabled)) {
-		color: colors.$white;
+		color: theme.$components-color-foreground-inverted;
 	}
 
 	.calendar__day-button {
 		&::before {
-			background-color: colors.$gray-900;
+			background-color: theme.$components-color-foreground;
 			// Render a transparent border to highlight the selected day in
 			// forced-colors (high-contrast) mode, since the background is not
 			// visible.
@@ -238,11 +239,11 @@
 		}
 
 		&:disabled::before {
-			background-color: colors.$gray-600;
+			background-color: theme.$components-color-disabled;
 		}
 
 		&:hover:not(:disabled)::before {
-			background-color: colors.$gray-800;
+			background-color: theme.$components-color-gray-800;
 		}
 	}
 }

--- a/packages/ui/src/utils/_theme-variables.scss
+++ b/packages/ui/src/utils/_theme-variables.scss
@@ -30,3 +30,4 @@ $components-color-gray-800: var(--wp-components-color-gray-800, colors.$gray-800
 
 // Semantic aliases (prefer these over raw gray values when applicable).
 $components-color-border: #{ $components-color-gray-600 };
+$components-color-disabled: #{ $components-color-gray-600 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

**Note: This PR applies the same changes as in https://github.com/WordPress/gutenberg/pull/71248**

Switch from `rem` to `px` units for some internal sizes (day button size, nav height, months gap).


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Until now, the `DateCalendar` and `DateRangeCalendar` components would render in unexpected ways depending on the HTML base font size.

The changes in this PR enforce the same metrics across environments with different base HTML font sizes.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Switch from `rem` to `px`, assuming a `16px` base font size.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Compare Storybook examples on trunk and this PR:

- there shouldn't be any visual differences when the base HTML font size is set to `16px`
- when (manually) changing the HTML base font size, the metrics of the version on trunk are expected to change, while the version from this PR should stay unchanged