### PR TITLE
Passport/ A4A: Refactor the items usage based on the API response for block stickers 

### DIFF
--- a/client/blocks/blog-stickers/use-blog-stickers-query.js
+++ b/client/blocks/blog-stickers/use-blog-stickers-query.js
@@ -7,12 +7,13 @@ import { getReaderTeams } from 'calypso/state/teams/selectors';
 export const useBlogStickersQuery = ( blogId, queryOptions = {} ) => {
 	const teams = useSelector( getReaderTeams );
 	const isAutomattician = isAutomatticTeamMember( teams );
+	const isBillingContext = queryOptions.billingContext === true;
 
 	return useQuery( {
 		queryKey: [ 'blog-stickers', blogId ],
 		queryFn: () => wp.req.get( `/sites/${ blogId }/blog-stickers` ),
 		...queryOptions,
-		enabled: !! blogId && isAutomattician,
+		enabled: !! blogId && ( isAutomattician || isBillingContext ),
 		staleTime: 1000 * 60 * 5,
 	} );
 };

--- a/client/lib/billing/use-siteless-domain-check.js
+++ b/client/lib/billing/use-siteless-domain-check.js
@@ -1,0 +1,20 @@
+import { useBlogStickersQuery } from 'calypso/blocks/blog-stickers/use-blog-stickers-query';
+
+/**
+ * Hook to check if a site has stickers that indicate it is a siteless domain
+ * @param {string|number} siteId - The site ID to check
+ * @returns {boolean} Whether the site has siteless checkout stickers
+ */
+export const useSitelessDomainCheck = ( siteId ) => {
+	const { data: stickersData } = useBlogStickersQuery( siteId, {
+		billingContext: true,
+	} );
+
+	const stickers = Array.isArray( stickersData ) ? stickersData : stickersData?.stickers || [];
+	const isSiteless = stickers.some(
+		( sticker ) =>
+			sticker === 'a4a-siteless-checkout-site' || sticker === 'marketplace-siteless-checkout-site'
+	);
+
+	return isSiteless;
+};

--- a/client/me/purchases/billing-history/field-definitions.tsx
+++ b/client/me/purchases/billing-history/field-definitions.tsx
@@ -1,10 +1,8 @@
 import { type Fields, type Operator } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
+import { useSitelessDomainCheck } from 'calypso/lib/billing/use-siteless-domain-check';
 import { capitalPDangit } from 'calypso/lib/formatting';
-import {
-	isInternalA4AAgencyDomain,
-	isSitelessDomainForBillingAndReceipts,
-} from 'calypso/me/purchases/utils';
+import { isInternalA4AAgencyDomain } from 'calypso/me/purchases/utils';
 import {
 	getTransactionTermLabel,
 	groupDomainProducts,
@@ -19,16 +17,28 @@ import type {
 	BillingTransactionItem,
 } from 'calypso/state/billing-transactions/types';
 
+function ServiceNameWrapper( {
+	transaction,
+	translate,
+}: {
+	transaction: BillingTransactionItem;
+	translate: ReturnType< typeof useTranslate >;
+} ) {
+	// Check if the site is a siteless domain (Passport URL (siteless.marketplace.wp.com), A4A agency, and a4a purchases)
+	// These are internal/system domains that don't represent user sites
+	const isSitelessDomain = useSitelessDomainCheck( transaction.site_id );
+
+	return renderServiceNameDescription( transaction, translate, isSitelessDomain );
+}
+
 function renderServiceNameDescription(
 	transaction: BillingTransactionItem,
-	translate: ReturnType< typeof useTranslate >
+	translate: ReturnType< typeof useTranslate >,
+	isSitelessDomain: boolean
 ) {
 	const plan = capitalPDangit( transaction.variation );
 	const termLabel = getTransactionTermLabel( transaction, translate );
 
-	// Hide domains for siteless transactions (Passport URL (siteless.marketplace.wp.com), A4A agency, and a4a purchases)
-	// These are internal/system domains that don't represent user sites
-	const isSitelessDomain = isSitelessDomainForBillingAndReceipts( transaction.domain );
 	const shouldShowDomain =
 		transaction.domain && ! isSitelessDomain && ! isInternalA4AAgencyDomain( transaction.domain );
 	return (
@@ -60,7 +70,7 @@ function renderServiceName(
 		return transactionItem.product;
 	}
 
-	return renderServiceNameDescription( transactionItem, translate );
+	return <ServiceNameWrapper transaction={ transactionItem } translate={ translate } />;
 }
 
 function getUniqueMonths(

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -22,12 +22,10 @@ import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import TextareaAutosize from 'calypso/components/textarea-autosize';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { useSitelessDomainCheck } from 'calypso/lib/billing/use-siteless-domain-check';
 import { billingHistory, vatDetails as vatDetailsPath } from 'calypso/me/purchases/paths';
 import titles from 'calypso/me/purchases/titles';
-import {
-	isInternalA4AAgencyDomain,
-	isSitelessDomainForBillingAndReceipts,
-} from 'calypso/me/purchases/utils';
+import { isInternalA4AAgencyDomain } from 'calypso/me/purchases/utils';
 import useVatDetails from 'calypso/me/purchases/vat-info/use-vat-details';
 import { useTaxName } from 'calypso/my-sites/checkout/src/hooks/use-country-list';
 import { useDispatch } from 'calypso/state';
@@ -551,12 +549,31 @@ function ReceiptItemTaxes( { transaction }: { transaction: BillingTransaction } 
 	);
 }
 
-function ReceiptLineItem( {
+function ReceiptLineItemWrapper( {
 	item,
 	transaction,
 }: {
 	item: BillingTransactionItem;
 	transaction: BillingTransaction;
+} ) {
+	const isSitelessDomain = useSitelessDomainCheck( item.site_id );
+	return (
+		<ReceiptLineItem
+			item={ item }
+			transaction={ transaction }
+			isSitelessDomain={ isSitelessDomain }
+		/>
+	);
+}
+
+function ReceiptLineItem( {
+	item,
+	transaction,
+	isSitelessDomain,
+}: {
+	item: BillingTransactionItem;
+	transaction: BillingTransaction;
+	isSitelessDomain: boolean;
 } ) {
 	const translate = useTranslate();
 	const termLabel = getTransactionTermLabel( item, translate );
@@ -569,7 +586,6 @@ function ReceiptLineItem( {
 		stripZeros: true,
 	} );
 
-	const isSitelessDomain = isSitelessDomainForBillingAndReceipts( item.domain );
 	const shouldShowDomain =
 		item.domain && ! isSitelessDomain && ! isInternalA4AAgencyDomain( item.domain );
 
@@ -629,7 +645,7 @@ function ReceiptLineItems( { transaction }: { transaction: BillingTransaction } 
 				</thead>
 				<tbody>
 					{ groupedTransactionItems.map( ( item ) => (
-						<ReceiptLineItem key={ item.id } transaction={ transaction } item={ item } />
+						<ReceiptLineItemWrapper key={ item.id } transaction={ transaction } item={ item } />
 					) ) }
 					<tr>
 						<td colSpan={ 2 }>

--- a/client/me/purchases/utils.ts
+++ b/client/me/purchases/utils.ts
@@ -53,20 +53,6 @@ export function getTemporarySiteType( purchase: Purchase ): string | null {
 	return isTemporarySitePurchase( purchase ) ? productType : null;
 }
 
-/**
- * Checks if a domain string is a siteless domain for billing/receipts
- * Matches: siteless.marketplace.wp.com, siteless.agencies.automattic.com, siteless.a4a.com
- * (with or without paths)
- */
-export function isSitelessDomainForBillingAndReceipts(
-	domain: string | undefined | null
-): boolean {
-	if ( ! domain ) {
-		return false;
-	}
-	return /^siteless\.(marketplace\.wp|agencies\.automattic|a4a)\.com/.test( domain );
-}
-
 export function isAkismetTemporarySitePurchase( purchase: Purchase ): boolean {
 	const { productType } = purchase;
 	return isTemporarySitePurchase( purchase ) && productType === 'akismet';


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to https://github.com/Automattic/wp-calypso/pull/104273/files#r2254599161 and p1754477208305629-slack-C03Q2D22DGV

## Proposed Changes

This PR changes the approach for hiding siteless domains. Instead of relying on the Regex matching rules, we are relying on the data from the API for the blog stickers that are added to a specific site. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

See: https://github.com/Automattic/wp-calypso/pull/104273/files#r2254599161

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch or use the Calypso Live Link
* First, ensure that you have passport.online subscription. To do that, you need to:
* Navigate to https://passportproduction.wordpress.com/pricing/
* Choose any plan
* Complete WP.com checkout
* Once the product is purchased, navigate to /me/purchases/billing
* Confirm that the URL/ domain is hidden
* Compare to trunk and observe that the URL is visible
* Also, try navigating to a specific receipt with Passport purchase
* Observe that the URL is also hidden there

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?