### PR TITLE
Importers: Use the new progress bar on the Importer page

### DIFF
--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -1,3 +1,4 @@
+import { formatNumber } from '@automattic/number-formatters';
 import { ProgressBar } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import { omit } from 'lodash';
@@ -122,6 +123,21 @@ export class ImportingPane extends PureComponent {
 
 	getSuccessText = () => {
 		return this.props.translate( 'Success! Your content has been imported.' );
+	};
+
+	getImportMessage = ( numResources ) => {
+		if ( 0 === numResources ) {
+			return this.props.translate( 'Finishing up the import.' );
+		}
+
+		return this.props.translate(
+			'%(numResources)s post, page, or media file left to import',
+			'%(numResources)s posts, pages, and media files left to import',
+			{
+				count: numResources,
+				args: { numResources: formatNumber( numResources ) },
+			}
+		);
 	};
 
 	isError = () => {

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -1,6 +1,4 @@
-import { ProgressBar, Spinner } from '@automattic/components';
-import { formatNumber } from '@automattic/number-formatters';
-import clsx from 'clsx';
+import { ProgressBar } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import { omit } from 'lodash';
 import PropTypes from 'prop-types';
@@ -126,21 +124,6 @@ export class ImportingPane extends PureComponent {
 		return this.props.translate( 'Success! Your content has been imported.' );
 	};
 
-	getImportMessage = ( numResources ) => {
-		if ( 0 === numResources ) {
-			return this.props.translate( 'Finishing up the import.' );
-		}
-
-		return this.props.translate(
-			'%(numResources)s post, page, or media file left to import',
-			'%(numResources)s posts, pages, and media files left to import',
-			{
-				count: numResources,
-				args: { numResources: formatNumber( numResources ) },
-			}
-		);
-	};
-
 	isError = () => {
 		return this.isInState( appStates.IMPORT_FAILURE );
 	};
@@ -232,9 +215,6 @@ export class ImportingPane extends PureComponent {
 			site,
 		} = this.props;
 		const { customData } = importerStatus;
-		const progressClasses = clsx( 'importer__import-progress', {
-			'is-complete': this.isFinished(),
-		} );
 
 		let { percentComplete, statusMessage } = this.props.importerStatus;
 		const { progress } = this.props.importerStatus;
@@ -254,9 +234,7 @@ export class ImportingPane extends PureComponent {
 		}
 
 		if ( this.isImporting() && hasProgressInfo( progress ) ) {
-			const remainingResources = resourcesRemaining( progress );
 			percentComplete = calculateProgress( progress );
-			blockingMessage = this.getImportMessage( remainingResources );
 		}
 
 		return (
@@ -278,11 +256,15 @@ export class ImportingPane extends PureComponent {
 				) }
 				{ ( this.isImporting() || this.isProcessing() ) &&
 					( percentComplete >= 0 ? (
-						<ProgressBar className={ progressClasses } value={ percentComplete } />
+						<div className="importer__importing-pane-progress-container">
+							<ProgressBar
+								className="importer__importing-pane-progress"
+								value={ percentComplete }
+							/>
+						</div>
 					) : (
-						<div>
-							<Spinner className="importer__import-spinner" />
-							<br />
+						<div className="importer__importing-pane-progress-container">
+							<ProgressBar className="importer__importing-pane-progress" isPulsing />
 						</div>
 					) ) }
 				{ blockingMessage && (

--- a/client/my-sites/importer/importing-pane.scss
+++ b/client/my-sites/importer/importing-pane.scss
@@ -1,21 +1,3 @@
-.importer__import-progress {
-	&.progress-bar {
-		display: block;
-		margin-bottom: 0.25em;
-		margin-left: auto;
-		margin-right: auto;
-		width: 80%;
-	}
-
-	.progress-bar__progress {
-		background-color: var(--color-accent);
-	}
-
-	&.is-complete .progress-bar__progress {
-		background-color: var(--color-success);
-	}
-}
-
 .importer__import-progress-message {
 	text-align: center;
 	color: var(--color-text-subtle);
@@ -36,4 +18,16 @@
 	color: var(--color-text-subtle);
 	text-align: center;
 	margin: 3em 0;
+}
+
+.importer__importing-pane-progress-container{
+	padding: 3em 0;
+	.importer__importing-pane-progress{
+		width: 100% !important;
+		background: var(--color-neutral-5);
+
+		> div {
+			background: var(--color-accent);
+		}
+	}
 }

--- a/client/my-sites/importer/uploading-pane.scss
+++ b/client/my-sites/importer/uploading-pane.scss
@@ -71,22 +71,15 @@
 	}
 }
 
+.importer__upload-progress-container{
+	padding: 3em 0;
+}
+
 .importer__upload-progress {
-	&.progress-bar {
-		width: 80%;
+	width: 100% !important;
+	background: var(--color-neutral-5);
 
-		&.is-pulsing {
-			.progress-bar__progress {
-				background-image: linear-gradient(-45deg, var(--color-accent) 28%, var(--color-accent-light) 28%, var(--color-accent-light) 72%, var(--color-accent) 72%);
-			}
-		}
-	}
-
-	.progress-bar__progress {
-		background-color: var(--color-accent);
-	}
-
-	&.is-complete .progress-bar__progress {
-		background-color: var(--color-success);
+	> div {
+		background: var(--color-accent);
 	}
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCON-24

## Proposed Changes

* Updates the 3 states during the importing of Squarespace's content:
  * During the uploading of the file, we now display the updated progress bar.
  * Before processing the file, we replaced the spinner to a pulsing progress bar.
  * When the file is being processed, we now use the updated progress bar.

#### After

<img width="746" height="412" alt="Captura de Tela 2025-08-19 às 08 24 42" src="https://github.com/user-attachments/assets/fde6fa3f-ba37-41bd-9138-7d95056865cb" />

<img width="869" height="514" alt="Captura de Tela 2025-08-19 às 08 20 33" src="https://github.com/user-attachments/assets/6d43c113-100d-4eba-8258-cebdaf33595b" />

<img width="825" height="506" alt="Captura de Tela 2025-08-19 às 08 20 39" src="https://github.com/user-attachments/assets/f77d93c5-6168-4461-83cd-8ecc94fab70b" />

#### Before

<img width="705" height="397" alt="Captura de Tela 2025-08-19 às 08 22 34" src="https://github.com/user-attachments/assets/39b8b0c8-e2c3-4c89-820a-2a55b1fe1708" />

<img width="720" height="322" alt="Captura de Tela 2025-08-18 às 17 47 53" src="https://github.com/user-attachments/assets/4420a34c-6c9f-471f-9232-30a3eddbc584" />

<img width="721" height="366" alt="Captura de Tela 2025-08-18 às 17 48 06" src="https://github.com/user-attachments/assets/db8f0170-f720-463e-8c2b-77cee656c47a" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of the Code Blue, we should update the outdated Progress Bar and loading state while importing a Squarespace site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use calypso live or apply this PR in your local environment
* Navigate to `/import/SITE`.
* Click on Squarespace and go through the flow to import the content
* You should see the same component for the 3 loading states

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
