### PR TITLE
Dashboard v2: Add NotificationDropdown

### DIFF
--- a/apps/notifications/src/app/README.md
+++ b/apps/notifications/src/app/README.md
@@ -1,0 +1,3 @@
+# Notification App
+
+This is a new app for dashboard v2 Calypso usage.

--- a/apps/notifications/src/app/index.tsx
+++ b/apps/notifications/src/app/index.tsx
@@ -1,0 +1,132 @@
+import { Navigator } from '@wordpress/components';
+import { createContext, useEffect, useState, Suspense, lazy } from 'react';
+import { Provider } from 'react-redux';
+import repliesCache from '../panel/comment-replies-cache';
+import RestClient from '../panel/rest-client';
+import { init as initAPI } from '../panel/rest-client/wpcom';
+import { init as initStore } from '../panel/state';
+import { SET_IS_SHOWING } from '../panel/state/action-types';
+import { addListeners, removeListeners } from '../panel/state/create-listener-middleware';
+import getIsPanelOpen from '../panel/state/selectors/get-is-panel-open';
+
+let client: any;
+
+let store = initStore();
+
+repliesCache.cleanup();
+
+/**
+ * Force a manual refresh of the notes data
+ */
+export const refreshNotes = () => client && client.refreshNotes.call( client );
+
+export const RestClientContext = createContext( client );
+
+const defaultHandlers = {
+	APP_REFRESH_NOTES: [
+		( _store: any, action: any ) => {
+			if ( ! client ) {
+				return;
+			}
+
+			if ( 'boolean' === typeof action.isVisible ) {
+				// Use this.props instead of destructuring isShowing, so that this uses
+				// the value on props at any given time and not only the value that was
+				// present on initial mount.
+				client.setVisibility.call( client, {
+					isShowing: getIsPanelOpen( _store.getState() ),
+					isVisible: action.isVisible,
+				} );
+			}
+
+			client.refreshNotes.call( client );
+		},
+	],
+};
+
+const NotePanel = lazy( () => import( './note-panel' ) );
+
+const Note = lazy( () => import( './note' ) );
+
+const NotificationApp = ( {
+	locale = 'en',
+	customEnhancer,
+	actionHandlers = {},
+	wpcom,
+}: {
+	locale?: string;
+	customEnhancer?: any;
+	actionHandlers?: any;
+	wpcom: any;
+} ) => {
+	const [ isReady, setIsReady ] = useState( !! client );
+
+	useEffect( () => {
+		store.dispatch( { type: 'APP_IS_READY' } );
+		store.dispatch( { type: SET_IS_SHOWING, isShowing: true } );
+		client?.setVisibility( { isShowing: true, isVisible: true } );
+
+		return () => {
+			store.dispatch( { type: SET_IS_SHOWING, isShowing: false } );
+			client?.setVisibility( { isShowing: false, isVisible: false } );
+		};
+	}, [] );
+
+	useEffect( () => {
+		initAPI( wpcom );
+
+		if ( ! client ) {
+			client = new RestClient();
+			client.locale = locale;
+			client?.setVisibility( { isShowing: true, isVisible: true } );
+			setIsReady( true );
+		}
+	}, [ wpcom ] );
+
+	useEffect( () => {
+		if ( customEnhancer ) {
+			store = initStore( { customEnhancer } );
+		}
+	}, [ customEnhancer ] );
+
+	useEffect( () => {
+		if ( client ) {
+			client.locale = locale;
+		}
+	}, [ locale ] );
+
+	useEffect( () => {
+		store.dispatch( addListeners( actionHandlers ) );
+		store.dispatch( addListeners( defaultHandlers ) );
+
+		return () => {
+			store.dispatch( removeListeners( actionHandlers ) );
+			store.dispatch( removeListeners( defaultHandlers ) );
+		};
+	}, [ actionHandlers ] );
+
+	if ( ! isReady ) {
+		return null;
+	}
+
+	return (
+		<Provider store={ store }>
+			<RestClientContext.Provider value={ client }>
+				<Navigator initialPath="/">
+					<Navigator.Screen path="/">
+						<Suspense fallback={ null }>
+							<NotePanel />
+						</Suspense>
+					</Navigator.Screen>
+					<Navigator.Screen path="/notes/:noteId">
+						<Suspense fallback={ null }>
+							<Note />
+						</Suspense>
+					</Navigator.Screen>
+				</Navigator>
+			</RestClientContext.Provider>
+		</Provider>
+	);
+};
+
+export default NotificationApp;

--- a/apps/notifications/src/app/note-list/dataviews.tsx
+++ b/apps/notifications/src/app/note-list/dataviews.tsx
@@ -1,0 +1,107 @@
+import { __ } from '@wordpress/i18n';
+import { html } from '../../panel/indices-to-html';
+import Gridicon from '../../panel/templates/gridicons';
+import ImagePreloader from '../../panel/templates/image-loader';
+import noticon2gridicon from '../../panel/utils/noticon2gridicon';
+import type { Field } from '@wordpress/dataviews';
+
+const DAY_MILLISECONDS = 24 * 60 * 60 * 1000;
+
+const groupTitles = [
+	__( 'Today' ),
+	__( 'Yesterday' ),
+	__( 'Older than 2 days' ),
+	__( 'Older than a week' ),
+	__( 'Older than a month' ),
+];
+
+export function getFields(): Field< any >[] {
+	return [
+		{
+			id: 'icon',
+			label: __( 'Icon' ),
+			render: ( { item } ) => (
+				<div className="wpnc__note-icon" style={ { position: 'relative' } }>
+					<ImagePreloader
+						src={ item.icon }
+						key={ `image-preloader-${ item.icon }` }
+						placeholder={
+							// eslint-disable-next-line jsx-a11y/alt-text
+							<img src="https://www.gravatar.com/avatar/ad516503a11cd5ca435acc9bb6523536?s=128" />
+						}
+					/>
+					<span
+						className="wpnc__gridicon"
+						style={ {
+							position: 'absolute',
+							bottom: 0,
+							right: 0,
+							border: '1.5px solid #fff',
+							background: '#ddd',
+						} }
+					>
+						<Gridicon icon={ noticon2gridicon( item.noticon ) } size={ 16 } />
+					</span>
+				</div>
+			),
+		},
+		{
+			id: 'title',
+			label: __( 'Title' ),
+			getValue: ( { item } ) =>
+				html( item.subject[ 0 ], {
+					links: false,
+				} ),
+			render: ( { field, item } ) => (
+				<div className="wpnc__text-summary">
+					<div
+						className="wpnc__subject"
+						style={ { whiteSpace: 'pre-wrap' } }
+						/* eslint-disable-next-line react/no-danger */
+						dangerouslySetInnerHTML={ { __html: field.getValue( { item } ) } }
+					/>
+				</div>
+			),
+		},
+		{
+			id: 'date',
+			label: __( 'Date' ),
+			getValue: ( { item } ) => item.timestamp,
+			render: ( { item } ) => {
+				const now = new Date().setHours( 0, 0, 0, 0 );
+				const timeBoundaries = [
+					Infinity,
+					now,
+					new Date( now - DAY_MILLISECONDS ),
+					new Date( now - DAY_MILLISECONDS * 6 ),
+					new Date( now - DAY_MILLISECONDS * 30 ),
+					-Infinity,
+				];
+
+				const timeGroups = timeBoundaries
+					.slice( 0, -1 )
+					.map( ( val, index ) => [ val, timeBoundaries[ index + 1 ] ] );
+
+				const time = new Date( item.timestamp );
+				const groupKey = timeGroups.findIndex(
+					( [ after, before ] ) => before < time && time <= after
+				);
+
+				return <div>{ groupTitles[ groupKey ] }</div>;
+			},
+		},
+		{
+			id: 'content',
+			label: __( 'Content' ),
+			getValue: ( { item } ) => ( item.subject.length > 1 ? item.subject[ 1 ].text : '' ),
+			render: ( { field, item } ) => {
+				const excerpt = field.getValue( { item } );
+				if ( ! excerpt ) {
+					return null;
+				}
+
+				return <div className="wpnc__excerpt">{ excerpt }</div>;
+			},
+		},
+	];
+}

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -1,0 +1,52 @@
+import { useNavigator } from '@wordpress/components';
+import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { useState } from 'react';
+import { useSelector } from 'react-redux';
+import getAllNotes from '../../panel/state/selectors/get-all-notes';
+import getIsLoading from '../../panel/state/selectors/get-is-loading';
+import { getFields } from './dataviews';
+import type { View } from '@wordpress/dataviews';
+
+const NoteList = () => {
+	const { goTo } = useNavigator();
+	const notes = useSelector( ( state ) => getAllNotes( state ) );
+	const isLoading = useSelector( ( state ) => getIsLoading( state ) );
+
+	const [ view, setView ] = useState< View >( {
+		type: 'list',
+		titleField: 'title',
+		mediaField: 'icon',
+		fields: [ 'content', 'date' ],
+		page: 1,
+		perPage: 10,
+	} );
+
+	const fields = getFields();
+
+	const { data: filteredData, paginationInfo } = filterSortAndPaginate( notes, view, fields );
+
+	const onChangeSelection = ( selection: string[] ) => {
+		goTo( `/notes/${ selection[ 0 ] }`, { skipFocus: true } );
+	};
+
+	return (
+		<DataViews< any >
+			data={ filteredData }
+			fields={ fields }
+			view={ view }
+			isLoading={ isLoading }
+			defaultLayouts={ { table: {} } }
+			paginationInfo={ paginationInfo }
+			getItemId={ ( item ) => item.id }
+			onChangeView={ setView }
+			onChangeSelection={ onChangeSelection }
+		>
+			<>
+				<DataViews.Layout />
+				<DataViews.Pagination />
+			</>
+		</DataViews>
+	);
+};
+
+export default NoteList;

--- a/apps/notifications/src/app/note-panel/index.tsx
+++ b/apps/notifications/src/app/note-panel/index.tsx
@@ -1,0 +1,43 @@
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalHeading as Heading,
+	CardHeader,
+	Icon,
+	TabPanel,
+} from '@wordpress/components';
+import '@wordpress/components/build-style/style.css';
+import { __ } from '@wordpress/i18n';
+import { bell } from '@wordpress/icons';
+import NoteList from '../note-list';
+
+const NOTIFICATION_TABS = [
+	{ name: 'all', title: __( 'All' ) },
+	{ name: 'unread', title: __( 'Unread' ) },
+	{ name: 'alerts', title: __( 'Alerts' ) },
+];
+
+const NotePanel = () => {
+	return (
+		<>
+			<CardHeader size="small" style={ { paddingBottom: 0 } }>
+				<VStack>
+					<HStack justify="flex-start">
+						<Icon icon={ bell } />
+						<Heading level={ 3 } size={ 15 } weight={ 500 }>
+							{ __( 'Notifications' ) }
+						</Heading>
+					</HStack>
+					<TabPanel activeClass="is-active" tabs={ NOTIFICATION_TABS } initialTabName="all">
+						{ () => null /* Placeholder div since content is rendered elsewhere */ }
+					</TabPanel>
+				</VStack>
+			</CardHeader>
+			<div style={ { overflow: 'auto' } }>
+				<NoteList />
+			</div>
+		</>
+	);
+};
+
+export default NotePanel;

--- a/apps/notifications/src/app/note/index.tsx
+++ b/apps/notifications/src/app/note/index.tsx
@@ -1,0 +1,116 @@
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	CardHeader,
+	Navigator,
+	useNavigator,
+} from '@wordpress/components';
+import { __, isRTL } from '@wordpress/i18n';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
+import clsx from 'clsx';
+import { useSelector } from 'react-redux';
+import { getActions } from '../../panel/helpers/notes';
+import getAllNotes from '../../panel/state/selectors/get-all-notes';
+import getIsNoteApproved from '../../panel/state/selectors/get-is-note-approved';
+import getIsNoteRead from '../../panel/state/selectors/get-is-note-read';
+import NoteBody from '../../panel/templates/body';
+import SummaryInSingle from '../../panel/templates/summary-in-single';
+import '../../panel/boot/stylesheets/style.scss';
+import './style.scss';
+
+const hasBadge = ( body: any ) =>
+	body.some(
+		( { media }: { media: any } ) =>
+			media && media.some( ( { type }: { type: string } ) => 'badge' === type )
+	);
+
+const NoteContent = ( { note }: { note: any } ) => {
+	const isApproved = useSelector( ( state ) => getIsNoteApproved( state, note ) );
+	const isRead = useSelector( ( state ) => getIsNoteRead( state, note ) );
+
+	let hasCommentReply = false;
+	let hasUnapprovedComment = false;
+	if ( 'comment' === note.type ) {
+		const noteBody = note.body;
+		const noteActions = getActions( note );
+		if ( noteBody.length > 1 && noteActions ) {
+			/* Check if note has a reply to another comment */
+			if ( noteBody[ 1 ] && noteBody[ 1 ].nest_level && noteBody[ 1 ].nest_level > 0 ) {
+				hasCommentReply = true;
+			}
+
+			/* Check if note has unapproved comment */
+			if ( 'approve-comment' in noteActions && ! isApproved ) {
+				hasUnapprovedComment = true;
+			}
+		}
+	}
+
+	const classes = clsx( 'wpnc__note', `wpnc__${ note.type }`, 'wpnc__current', {
+		'comment-reply': hasCommentReply,
+		read: isRead,
+		unread: ! isRead,
+		wpnc__badge: hasBadge( note.body ),
+		'wpnc__comment-unapproved': hasUnapprovedComment,
+	} );
+
+	return (
+		<div className={ classes }>
+			<div
+				className="wpnc__note-body"
+				role="region"
+				aria-label={ __( 'Notification details' ) }
+				tabIndex={ -1 }
+			>
+				{ note.header && note.header.length > 0 && (
+					<SummaryInSingle key={ 'note-summary-single-' + note.id } note={ note } />
+				) }
+				<NoteBody note={ note } />
+			</div>
+		</div>
+	);
+};
+
+const Note = () => {
+	const { params } = useNavigator();
+	const { noteId } = params;
+	const note = useSelector( ( state ) =>
+		getAllNotes( state ).find( ( note: any ) => String( note.id ) === noteId )
+	);
+
+	return (
+		<>
+			<CardHeader size="small">
+				<HStack>
+					<Navigator.BackButton
+						icon={ isRTL() ? chevronRight : chevronLeft }
+						style={ { padding: 0 } }
+					>
+						{ __( 'Back' ) }
+					</Navigator.BackButton>
+				</HStack>
+			</CardHeader>
+			<VStack>
+				{ note && (
+					<div className="wpnc__main">
+						<div
+							className={ clsx( 'wpnc__single-view', 'wpnc__current' ) }
+							style={ {
+								position: 'relative',
+								left: 0,
+								right: 0,
+								overflow: 'auto',
+								minHeight: '50vh',
+								zIndex: 1,
+							} }
+						>
+							<NoteContent note={ note } />
+						</div>
+					</div>
+				) }
+			</VStack>
+		</>
+	);
+};
+
+export default Note;

--- a/apps/notifications/src/app/note/style.scss
+++ b/apps/notifications/src/app/note/style.scss
@@ -1,0 +1,106 @@
+@import "@wordpress/base-styles/variables";
+
+.wpnc__main {
+	.has-text-align-center {
+		text-align: center;
+	}
+
+	.has-text-align-right {
+		text-align: right;
+	}
+
+	.has-text-align-left {
+		text-align: left;
+	}
+
+	.has-text-align-justify {
+		text-align: justify;
+	}
+
+	.wpnc__h1 {
+		font-size: $font-headline-small;
+	}
+
+	.wpnc__h2 {
+		font-size: $font-title-large;
+	}
+
+	.wpnc__h3 {
+		font-size: $font-title-medium;
+	}
+
+	.uppercase {
+		text-transform: uppercase;
+	}
+
+	.has-drop-cap:not(:focus)::first-letter {
+		font-weight: bold;
+		line-height: 0.66;
+		text-transform: uppercase;
+		font-style: normal;
+		float: left;
+		font-size: calc(2 * 2.25rem);
+		margin: 0.05em 0.1em 0 0;
+	}
+
+	.has-drop-cap:not(:focus)::after {
+		content: "";
+		display: table;
+		clear: both;
+		padding-top: 14px;
+	}
+
+	.wpnc__sub {
+		font-size: smaller;
+		vertical-align: sub;
+	}
+
+	.wpnc__sup {
+		font-size: smaller;
+		vertical-align: super;
+	}
+
+	.wpnc__em {
+		font-style: italic;
+	}
+
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6 {
+		font-weight: bold;
+	}
+
+	.wpnc__note {
+		blockquote {
+			padding: 0 24px 0 32px;
+			margin: 16px 0 32px;
+			border-left: 3px solid var(--color-neutral-0);
+			color: var(--color-neutral-50);
+			font-weight: 400;
+			background: transparent;
+		}
+		ul,
+		ol {
+			margin-left: 1.5em;
+			list-style-position: inside;
+		}
+		ul {
+			list-style-type: disc;
+			ul {
+				list-style-type: circle;
+				ul {
+					list-style-type: square;
+				}
+			}
+		}
+		ol {
+			list-style-type: decimal;
+		}
+		li {
+			margin: auto;
+		}
+	}
+}

--- a/apps/notifications/src/dropdown/index.tsx
+++ b/apps/notifications/src/dropdown/index.tsx
@@ -1,0 +1,35 @@
+import { Button, Dropdown } from '@wordpress/components';
+import '@wordpress/components/build-style/style.css';
+import { __ } from '@wordpress/i18n';
+import { bellUnread, bell } from '@wordpress/icons';
+import NotificationApp from '../app';
+
+const NoteDropdown = ( { className, wpcom }: { className?: string; wpcom: any } ) => {
+	const hasUnreadNotifications = false;
+
+	return (
+		<Dropdown
+			popoverProps={ {
+				placement: 'bottom-end',
+				offset: 8,
+			} }
+			renderToggle={ ( { isOpen, onToggle } ) => (
+				<Button
+					className={ className }
+					onClick={ onToggle }
+					aria-expanded={ isOpen }
+					variant="tertiary"
+					label={ __( 'Notifications' ) }
+					icon={ hasUnreadNotifications ? bellUnread : bell }
+				/>
+			) }
+			renderContent={ () => (
+				<div style={ { width: '480px', margin: '-8px' } }>
+					<NotificationApp wpcom={ wpcom } />
+				</div>
+			) }
+		/>
+	);
+};
+
+export default NoteDropdown;

--- a/apps/notifications/src/panel/state/index.js
+++ b/apps/notifications/src/panel/state/index.js
@@ -32,6 +32,7 @@ function init( { customEnhancer } = {} ) {
 	const create = customEnhancer ? customEnhancer( middle ) : middle;
 
 	store = create( reducer );
+	return store;
 }
 
 export { store, init };

--- a/client/dashboard/app/secondary-menu/index.tsx
+++ b/client/dashboard/app/secondary-menu/index.tsx
@@ -1,5 +1,4 @@
 import config from '@automattic/calypso-config';
-import { useNavigate } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -10,9 +9,10 @@ import {
 	MenuItem,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { help, bellUnread, bell, commentAuthorAvatar } from '@wordpress/icons';
+import { help, commentAuthorAvatar } from '@wordpress/icons';
 import { Suspense, lazy, useCallback } from 'react';
 import ReaderIcon from 'calypso/assets/icons/reader/reader-icon';
+import wpcom from 'calypso/lib/wp';
 import RouterLinkMenuItem from '../../components/router-link-menu-item';
 import { useAuth } from '../auth';
 import { useOpenCommandPalette } from '../command-palette/utils';
@@ -22,6 +22,8 @@ import { useHelpCenter } from '../help-center';
 import './style.scss';
 
 const AsyncHelpCenterApp = lazy( () => import( '../help-center/help-center-app' ) );
+
+const AsyncNoteDropdown = lazy( () => import( '@automattic/notifications/src/dropdown' ) );
 
 function Help() {
 	const { user } = useAuth();
@@ -129,10 +131,7 @@ function UserProfile() {
 }
 
 function SecondaryMenu() {
-	const navigate = useNavigate();
 	const { supports } = useAppContext();
-	const hasUnreadNotifications = false;
-	const notificationsPath = '/me/notifications';
 
 	return (
 		<HStack spacing={ 2 } justify="flex-end">
@@ -147,17 +146,9 @@ function SecondaryMenu() {
 			) }
 			{ supports.help && <Help /> }
 			{ supports.notifications && (
-				<Button
-					className="dashboard-secondary-menu__item"
-					label={ __( 'Notifications' ) }
-					icon={ hasUnreadNotifications ? bellUnread : bell }
-					variant="tertiary"
-					onClick={ ( e: React.MouseEvent< HTMLButtonElement > ) => {
-						e.preventDefault();
-						navigate( { to: notificationsPath } );
-					} }
-					href={ notificationsPath }
-				/>
+				<Suspense fallback={ null }>
+					<AsyncNoteDropdown className="dashboard-secondary-menu__item" wpcom={ wpcom } />
+				</Suspense>
 			) }
 			<UserProfile />
 		</HStack>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Try to add NoteDropdown
* To iterate:
  * Types definition
  * Filter by selected tab
  * Dropdown
    * Overflow styles
  * NoteList
    * Infinite loading
    * Missing fields
    * Media style
  * Note
    * Rewrite components...

<img width="300" src="https://github.com/user-attachments/assets/b5ff800f-3cae-4641-8e8b-6732970b7df8" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Click the notification icon on the top-right corner
* Ensure it opens the notification panel correctly
* Click any notification
* Ensure it navigates to the specific notification
* Click back button
* Ensure it navigates back to the list

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
