### PR TITLE
Backups: update backup list automatically after backup is done

### DIFF
--- a/client/dashboard/app/hooks/site-backup-state.ts
+++ b/client/dashboard/app/hooks/site-backup-state.ts
@@ -1,0 +1,67 @@
+import { useQuery } from '@tanstack/react-query';
+import { useCallback, useEffect, useState } from 'react';
+import { type BackupEntry } from '../../data/site-backups';
+import { siteBackupsQuery } from '../queries/site-backups';
+
+export type BackupState = 'default' | 'enqueued' | 'in_progress';
+
+interface BackupStateResult {
+	backupState: BackupState;
+	isBackupActive: boolean;
+	hasRecentlyCompleted: boolean;
+}
+
+export function useBackupState( siteId: number, isEnqueued = false ): BackupStateResult {
+	const [ hasRecentlyCompleted, setHasRecentlyCompleted ] = useState( false );
+	const [ previousBackupState, setPreviousBackupState ] = useState< BackupState >( 'default' );
+
+	// Determine current backup state from backup entries
+	const getBackupState = useCallback(
+		( backups: BackupEntry[] ): BackupState => {
+			const currentBackup = backups[ 0 ];
+			if ( currentBackup?.status === 'started' ) {
+				return 'in_progress';
+			}
+			if ( currentBackup?.status === 'queued' || isEnqueued ) {
+				return 'enqueued';
+			}
+			return 'default';
+		},
+		[ isEnqueued ]
+	);
+
+	// Query backup status with polling during active operations
+	const { data: rewindBackups = [] } = useQuery( {
+		...siteBackupsQuery( siteId ),
+		refetchInterval: ( query ) => {
+			const backups = query.state.data || [];
+			const backupState = getBackupState( backups );
+			// Poll when backup is enqueued or in progress
+			return backupState !== 'default' ? 2000 : false;
+		},
+	} );
+
+	const backupState = getBackupState( rewindBackups );
+	const isBackupActive = backupState !== 'default';
+
+	// Track when backup transitions from in_progress to default (completion)
+	useEffect( () => {
+		if ( previousBackupState === 'in_progress' && backupState === 'default' ) {
+			setHasRecentlyCompleted( true );
+
+			// Stop tracking completion after timeout
+			const timeoutId = setTimeout( () => {
+				setHasRecentlyCompleted( false );
+			}, 30000 );
+
+			return () => clearTimeout( timeoutId );
+		}
+		setPreviousBackupState( backupState );
+	}, [ backupState, previousBackupState ] );
+
+	return {
+		backupState,
+		isBackupActive,
+		hasRecentlyCompleted,
+	};
+}

--- a/client/dashboard/sites/backups/backup-now-button.tsx
+++ b/client/dashboard/sites/backups/backup-now-button.tsx
@@ -1,45 +1,19 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useCallback, useEffect, useState } from 'react';
-import { siteBackupEnqueueMutation, siteBackupsQuery } from '../../app/queries/site-backups';
-import { type BackupEntry } from '../../data/site-backups';
+import { useEffect, useState } from 'react';
+import { useBackupState } from '../../app/hooks/site-backup-state';
+import { siteBackupEnqueueMutation } from '../../app/queries/site-backups';
 import type { Site } from '../../data/types';
 
 interface BackupNowButtonProps {
 	site: Site;
 }
 
-type BackupState = 'default' | 'enqueued' | 'in_progress';
-
 export function BackupNowButton( { site }: BackupNowButtonProps ) {
 	const [ isEnqueued, setIsEnqueued ] = useState( false );
 
-	// Determine current state
-	const getBackupState = useCallback(
-		( backups: BackupEntry[] ): BackupState => {
-			const currentBackup = backups[ 0 ];
-			if ( currentBackup?.status === 'started' ) {
-				return 'in_progress';
-			}
-			if ( currentBackup?.status === 'queued' || isEnqueued ) {
-				return 'enqueued';
-			}
-			return 'default';
-		},
-		[ isEnqueued ]
-	);
-
-	// Check for in-progress backup using rewind/backups endpoint
-	const { data: rewindBackups = [] } = useQuery( {
-		...siteBackupsQuery( site.ID ),
-		refetchInterval: ( query ) => {
-			const backups = query.state.data || [];
-			const backupState = getBackupState( backups );
-			// Poll when backup is enqueued or in progress
-			return backupState !== 'default' ? 2000 : false;
-		},
-	} );
+	const { backupState, isBackupActive } = useBackupState( site.ID, isEnqueued );
 
 	const { mutate: triggerBackup, isPending } = useMutation( {
 		...siteBackupEnqueueMutation( site.ID ),
@@ -47,8 +21,6 @@ export function BackupNowButton( { site }: BackupNowButtonProps ) {
 			setIsEnqueued( true );
 		},
 	} );
-
-	const backupState = getBackupState( rewindBackups );
 
 	// Reset enqueued state when backup actually starts
 	useEffect( () => {
@@ -72,7 +44,7 @@ export function BackupNowButton( { site }: BackupNowButtonProps ) {
 		},
 	};
 
-	const isBusy = backupState !== 'default' || isPending;
+	const isBusy = isBackupActive || isPending;
 
 	return (
 		<Button

--- a/client/dashboard/sites/backups/backups-list.tsx
+++ b/client/dashboard/sites/backups/backups-list.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from 'react';
+import { useBackupState } from '../../app/hooks/site-backup-state';
 import { siteRewindableActivityLogEntriesQuery } from '../../app/queries/site-activity-log';
 import DataViewsCard from '../../components/dataviews-card';
 import { getFields } from './dataviews/fields';
@@ -25,9 +26,12 @@ export function BackupsList( {
 		perPage: 10,
 	} );
 
-	const { data: activityLog = [], isLoading: isLoadingActivityLog } = useQuery(
-		siteRewindableActivityLogEntriesQuery( site.ID )
-	);
+	const { hasRecentlyCompleted } = useBackupState( site.ID );
+
+	const { data: activityLog = [], isLoading: isLoadingActivityLog } = useQuery( {
+		...siteRewindableActivityLogEntriesQuery( site.ID ),
+		refetchInterval: hasRecentlyCompleted ? 3000 : false,
+	} );
 
 	const fields = getFields();
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( activityLog, view, fields );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTDASH-289][1].

## Proposed Changes

What this PR does is:

- Extracts the logic that polls the backup state to update the `Back up now` button to a hook that can be shared between components.
- Adds the required logic to track backup completion, used to start/stop polling the backups list.
- Updates the `Back up now` button to use the new hook.
- Updates the Backups list to make use of it as well.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This ensures that the user is able to see the newly completed backup without refreshing the page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!NOTE]
> Keep the browser Network console open during the test, filtering by Fetch/XHR requests, to see the API polling happening.

- Go to the `/v2/sites/{site}/backups` page for a site that has backups enabled.
- Click on the `Back up now` button.
- Wait until the backup is completed.
- After a few seconds, the new backup should now be shown as the first item in the backups list.

<img width="1278" height="357" alt="image" src="https://github.com/user-attachments/assets/0f095519-3056-4499-b755-17796a3f5ad4" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

[1]: https://linear.app/a8c/issue/DOTDASH-289