### PR TITLE
A4A > Sites & Referrals: Fix the vertical lines cutting through the table columns abruptly

### DIFF
--- a/client/components/dataviews/style.scss
+++ b/client/components/dataviews/style.scss
@@ -146,7 +146,7 @@
 		position: sticky;
 		right: 0;
 		z-index: 1;
-		background: linear-gradient( 90deg, rgba( 255, 255, 255, 0 ) 0, rgb( 255, 255, 255 ) 25% );
+		background: var( --studio-white );
 		padding-left: 48px;
 	}
 }

--- a/client/components/dataviews/style.scss
+++ b/client/components/dataviews/style.scss
@@ -12,7 +12,6 @@
 	}
 
 	tr.dataviews-view-table__row {
-		background: var( --studio-white );
 
 		.components-checkbox-control__input {
 			opacity: 0;
@@ -131,22 +130,5 @@
 	// Color overrides for focus states of Action button
 	.components-button:focus:not( :disabled ) {
 		--wp-components-color-accent: var( --color-primary-light );
-	}
-}
-
-// TODO: remove when this is implemented upstream.
-//
-// https://github.com/WordPress/gutenberg/pull/65086
-.is-section-a8c-for-agencies-referrals .dataviews-view-table tr,
-.is-section-a8c-for-agencies-sites .dataviews-view-table tr {
-	th:last-child,
-	td:last-child {
-		width: 20px;
-		white-space: nowrap;
-		position: sticky;
-		right: 0;
-		z-index: 1;
-		background: var( --studio-white );
-		padding-left: 48px;
 	}
 }


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1480/fix-the-vertical-line-cutting-through-the-a4a-sites-dashboard-columns

## Proposed Changes

This PR fixes the vertical lines cutting through the table columns on the Sites & Referrals dashboard. 

This was added as part of https://github.com/Automattic/wp-calypso/pull/94323.

## Why are these changes being made?

* To fix the visual bug that causes a vertical separator to cut through columns abruptly. 

## Testing Instructions

* Open the A4A live link 
* Go to Sites > Switch to smaller screen size (1024px) > Verify the vertical line added to separate the sticky "Actions" column is not cutting through the columns abruptly.
* Go to Referrals: Dashboard and verify the same.
* Verify the fixes https://github.com/Automattic/wp-calypso/pull/94323 are still there.

| Before | After |
|--------|--------|
| <img width="1003" height="495" alt="Screenshot 2025-08-20 at 9 44 26 AM" src="https://github.com/user-attachments/assets/3907aa98-3b16-4d14-8bda-b4a9eba310f7" /> | <img width="1003" height="495" alt="Screenshot 2025-08-20 at 9 44 53 AM" src="https://github.com/user-attachments/assets/b2ee7da9-d047-497c-82f6-57d894a53df4" /> | 

Also, hover over the rows of the tables below and verify you can see the whole row being highlighted matching the WordPress.com: Sites experience. 

- A4A: Sites > All
- A4A: Sites > Need Setup
- A4A: Referrals > Dashboard
- A4A: Migrations > Commissions
- A4A: WooPayments > Dashboard
- A4A: Plugins. You can see how it looks currently: https://agencies.automattic.com/plugins/manage/sites
- A4A: Plugins > Details view (Installed on X sites table)
- A4A: Reports > Dashboard. You might see a weird screen break here. It is not related.
- A4A: Team > Active member & Invited
- WordPress.com (live link) > Plugins > Manage plugins
- WordPress.com (live link) > Plugins > Manage plugins > Details view (Installed on X sites table)

First row is highlighted here:

<img width="1550" height="231" alt="Screenshot 2025-08-29 at 2 52 22 PM" src="https://github.com/user-attachments/assets/c1ced85e-3eb8-4fb6-b631-ba40639011fd" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
