### PR TITLE
Revert "Enable dashboard/v2/backport/site-overview in stage and production"

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -38,7 +38,7 @@
 		"cookie-banner": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
-		"dashboard/v2/backport/site-overview": true,
+		"dashboard/v2/backport/site-overview": false,
 		"dashboard/v2/backport/sites-list": true,
 		"dashboard/v2/security-settings": false,
 		"domains/ui-redesign": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -36,7 +36,7 @@
 		"cookie-banner": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
-		"dashboard/v2/backport/site-overview": true,
+		"dashboard/v2/backport/site-overview": false,
 		"dashboard/v2/backport/sites-list": true,
 		"dashboard/v2/security-settings": false,
 		"dev/preferences-helper": true,


### PR DESCRIPTION
Prepare a revert for Automattic/wp-calypso#105273 just in case.