### PR TITLE
Hosting Dashboard: Add app support checks in me routes

### DIFF
--- a/client/dashboard/app-a4a/index.tsx
+++ b/client/dashboard/app-a4a/index.tsx
@@ -23,6 +23,8 @@ boot( {
 		reader: false,
 		help: true,
 		notifications: false,
-		me: true,
+		me: {
+			privacy: false,
+		},
 	},
 } );

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -22,6 +22,8 @@ boot( {
 		reader: true,
 		help: true,
 		notifications: true,
-		me: true,
+		me: {
+			privacy: true,
+		},
 	},
 } );

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -10,6 +10,10 @@ export type SiteFeatureSupports = {
 	emails: boolean;
 };
 
+export type MeSupports = {
+	privacy: boolean;
+};
+
 export type AppConfig = {
 	basePath: string;
 	mainRoute: string;
@@ -23,7 +27,7 @@ export type AppConfig = {
 		reader: boolean;
 		help: boolean;
 		notifications: boolean;
-		me: boolean;
+		me: MeSupports | false;
 	};
 };
 

--- a/client/dashboard/app/router/index.tsx
+++ b/client/dashboard/app/router/index.tsx
@@ -45,7 +45,7 @@ const createRouteTree = ( config: AppConfig ) => {
 	}
 
 	if ( config.supports.me ) {
-		children.push( ...createMeRoutes() );
+		children.push( ...createMeRoutes( config ) );
 	}
 
 	return rootRoute.addChildren( children );

--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -5,6 +5,8 @@ import { userPurchasesQuery } from '../queries/me-purchases';
 import { sitesQuery } from '../queries/sites';
 import { queryClient } from '../query-client';
 import { rootRoute } from './root';
+import type { AppConfig } from '../context';
+import type { AnyRoute } from '@tanstack/react-router';
 
 export const meRoute = createRoute( {
 	getParentRoute: () => rootRoute,
@@ -137,18 +139,25 @@ export const notificationsRoute = createRoute( {
 	)
 );
 
-export const createMeRoutes = () => {
-	return [
-		meRoute.addChildren( [
-			profileRoute,
-			billingRoute,
-			billingHistoryRoute,
-			purchasesRoute,
-			paymentMethodsRoute,
-			taxDetailsRoute,
-			securityRoute,
-			privacyRoute,
-			notificationsRoute,
-		] ),
+export const createMeRoutes = ( config: AppConfig ) => {
+	if ( ! config.supports.me ) {
+		return [];
+	}
+
+	const meRoutes: AnyRoute[] = [
+		profileRoute,
+		billingRoute,
+		billingHistoryRoute,
+		purchasesRoute,
+		paymentMethodsRoute,
+		taxDetailsRoute,
+		securityRoute,
+		notificationsRoute,
 	];
+
+	if ( config.supports.me.privacy ) {
+		meRoutes.push( privacyRoute );
+	}
+
+	return [ meRoute.addChildren( meRoutes ) ];
 };

--- a/client/dashboard/me/me-menu/index.tsx
+++ b/client/dashboard/me/me-menu/index.tsx
@@ -1,6 +1,11 @@
 import { __ } from '@wordpress/i18n';
 import { useAppContext } from '../../app/context';
 import ResponsiveMenu from '../../components/responsive-menu';
+import type { AppConfig, MeSupports } from '../../app/context';
+
+const hasAppSupport = ( supports: AppConfig[ 'supports' ], feature: keyof MeSupports ) => {
+	return supports.me && supports.me[ feature ];
+};
 
 const MeMenu = () => {
 	const { supports } = useAppContext();
@@ -10,7 +15,9 @@ const MeMenu = () => {
 			<ResponsiveMenu.Item to="/me/profile">{ __( 'Profile' ) }</ResponsiveMenu.Item>
 			<ResponsiveMenu.Item to="/me/billing">{ __( 'Billing' ) }</ResponsiveMenu.Item>
 			<ResponsiveMenu.Item to="/me/security">{ __( 'Security' ) }</ResponsiveMenu.Item>
-			<ResponsiveMenu.Item to="/me/privacy">{ __( 'Privacy' ) }</ResponsiveMenu.Item>
+			{ hasAppSupport( supports, 'privacy' ) && (
+				<ResponsiveMenu.Item to="/me/privacy">{ __( 'Privacy' ) }</ResponsiveMenu.Item>
+			) }
 			{ supports.notifications && (
 				<ResponsiveMenu.Item to="/me/notifications">{ __( 'Notifications' ) }</ResponsiveMenu.Item>
 			) }


### PR DESCRIPTION
Ref DOTDASH-176

## Proposed Changes

This PR adds app-level checks to determine whether to enable the me privacy route or not.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Hosting Dashboard development.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
