### PR TITLE
Add loading state for features when loading JP Scan

### DIFF
--- a/client/my-sites/scan/wpcom-atomic-transfer.tsx
+++ b/client/my-sites/scan/wpcom-atomic-transfer.tsx
@@ -18,6 +18,7 @@ import isRequestingJetpackScan from 'calypso/state/selectors/is-requesting-jetpa
 import isRequestingSiteFeatures from 'calypso/state/selectors/is-requesting-site-features';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import type { AppState } from 'calypso/types';
 
 // Loading placeholder component
 const ScanLoadingPlaceholder = () => {
@@ -43,24 +44,24 @@ const ScanAtomicTransferWrapper = () => {
 	const siteId = useSelector( getSelectedSiteId ) as number;
 
 	const featuresNotLoaded: boolean = useSelector(
-		( state ) =>
+		( state: AppState ) =>
 			null === getFeaturesBySiteId( state, siteId ) && ! isRequestingSiteFeatures( state, siteId )
 	);
 
 	const scanDataNotLoaded: boolean = useSelector(
-		( state ) =>
+		( state: AppState ) =>
 			! getSiteScanState( state, siteId ) &&
 			( isRequestingJetpackScan( state, siteId ) ||
 				getSiteScanRequestStatus( state, siteId ) === 'pending' )
 	);
 
 	// Check if site has scan feature - must be called unconditionally
-	const hasScanFeature = useSelector( ( state ) =>
+	const hasScanFeature = useSelector( ( state: AppState ) =>
 		siteHasFeature( state, siteId, WPCOM_FEATURES_SCAN )
 	);
 
 	// Get scan state to determine if activation is needed
-	const scanState = useSelector( ( state ) => getSiteScanState( state, siteId ) );
+	const scanState = useSelector( ( state: AppState ) => getSiteScanState( state, siteId ) );
 
 	// If features or scan data are not loaded yet, show loading state
 	if ( featuresNotLoaded || scanDataNotLoaded ) {

--- a/client/my-sites/scan/wpcom-atomic-transfer.tsx
+++ b/client/my-sites/scan/wpcom-atomic-transfer.tsx
@@ -1,50 +1,133 @@
 import { WPCOM_FEATURES_SCAN } from '@automattic/calypso-products';
 import { translate } from 'i18n-calypso';
+import React from 'react';
+import { useSelector } from 'react-redux';
 import JetpackScanSVG from 'calypso/assets/images/illustrations/jetpack-scan.svg';
+import QueryJetpackScan from 'calypso/components/data/query-jetpack-scan';
+import QuerySiteFeatures from 'calypso/components/data/query-site-features';
+import FormattedHeader from 'calypso/components/formatted-header';
+import WPCOMBusinessAT from 'calypso/components/jetpack/wpcom-business-at';
+import Main from 'calypso/components/main';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import wpcomAtomicTransfer from 'calypso/lib/jetpack/wpcom-atomic-transfer';
 import WPCOMScanUpsellPage from 'calypso/my-sites/scan/wpcom-upsell';
+import getFeaturesBySiteId from 'calypso/state/selectors/get-site-features';
+import getSiteScanRequestStatus from 'calypso/state/selectors/get-site-scan-request-status';
+import getSiteScanState from 'calypso/state/selectors/get-site-scan-state';
+import isRequestingJetpackScan from 'calypso/state/selectors/is-requesting-jetpack-scan';
+import isRequestingSiteFeatures from 'calypso/state/selectors/is-requesting-site-features';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
+// Loading placeholder component
+const ScanLoadingPlaceholder = () => {
+	const siteId = useSelector( getSelectedSiteId ) as number;
+
+	return (
+		<Main className="business-at-switch__loading">
+			<QuerySiteFeatures siteIds={ [ siteId ] } />
+			<QueryJetpackScan siteId={ siteId } />
+			<FormattedHeader
+				id="wpcom-scan-loading"
+				className="business-at-switch placeholder__header"
+				headerText={ translate( 'Loading…' ) }
+				align="left"
+			/>
+			<div className="business-at-switch placeholder__primary-promo"></div>
+		</Main>
+	);
+};
+
+// Wrapper component that handles the feature loading logic
+const ScanAtomicTransferWrapper = () => {
+	const siteId = useSelector( getSelectedSiteId ) as number;
+
+	const featuresNotLoaded: boolean = useSelector(
+		( state ) =>
+			null === getFeaturesBySiteId( state, siteId ) && ! isRequestingSiteFeatures( state, siteId )
+	);
+
+	const scanDataNotLoaded: boolean = useSelector(
+		( state ) =>
+			! getSiteScanState( state, siteId ) &&
+			( isRequestingJetpackScan( state, siteId ) ||
+				getSiteScanRequestStatus( state, siteId ) === 'pending' )
+	);
+
+	// Check if site has scan feature - must be called unconditionally
+	const hasScanFeature = useSelector( ( state ) =>
+		siteHasFeature( state, siteId, WPCOM_FEATURES_SCAN )
+	);
+
+	// Get scan state to determine if activation is needed
+	const scanState = useSelector( ( state ) => getSiteScanState( state, siteId ) );
+
+	// If features or scan data are not loaded yet, show loading state
+	if ( featuresNotLoaded || scanDataNotLoaded ) {
+		return <ScanLoadingPlaceholder />;
+	}
+
+	// If site doesn't have scan feature, show Business plan upsell instead of activation
+	if ( ! hasScanFeature ) {
+		return <WPCOMScanUpsellPage />;
+	}
+
+	// If scan is already working (not 'unavailable'), let the normal flow continue
+	// This means we should NOT show the atomic transfer UI
+	if ( scanState && scanState.state !== 'unavailable' ) {
+		// Return null to let the normal scan page show through the middleware chain
+		return null;
+	}
+
+	// If scan state is 'unavailable' and site has scan feature, show atomic transfer activation
+	const content = {
+		documentHeadTitle: translate( 'Activate Jetpack Scan now' ) as string,
+		header: translate( 'Jetpack Scan' ) as string,
+		primaryPromo: {
+			title: translate( 'We guard your site. You run your business.' ),
+			image: { path: JetpackScanSVG },
+			content: translate(
+				'Scan gives you automated scanning and one-click fixes to keep your site ahead of security threats.'
+			),
+			promoCTA: {
+				text: translate( 'Activate Jetpack Scan now' ),
+				loadingText: translate( 'Activating Jetpack Scan' ),
+			},
+		},
+
+		getProductUrl: ( siteSlug: string ) => `/scan/${ siteSlug }`,
+	};
+
+	// Render the atomic transfer UI with the scan-specific content
+	return <WPCOMBusinessAT content={ content } />;
+};
+
+// Wrapper component that conditionally renders atomic transfer logic
+const ConditionalScanAtomicTransferWrapper = ( { children }: { children: React.ReactNode } ) => {
+	const wrapperContent = ScanAtomicTransferWrapper();
+
+	// If wrapper returns null, render the children (normal scan page)
+	// Otherwise render the wrapper content (loading, upsell, or atomic transfer)
+	return wrapperContent || children;
+};
+
 export function wpcomJetpackScanAtomicTransfer(): ( context: any, next: () => void ) => void {
-	return ( context, next ) => {
+	const WPCOMJetpackScanAtomicTransfer = ( context: any, next: () => void ) => {
 		if ( isJetpackCloud() || isA8CForAgencies() ) {
 			return next();
 		}
 
-		const state = context.store.getState();
-		const siteId = getSelectedSiteId( state );
-
-		// Check if site has scan feature
-		const hasScanFeature = siteHasFeature( state, siteId, WPCOM_FEATURES_SCAN );
-
-		// If site doesn't have scan feature, show Business plan upsell instead of activation
-		if ( ! hasScanFeature ) {
-			context.primary = <WPCOMScanUpsellPage />;
-			return next();
-		}
-
-		// If site has scan feature, proceed with atomic transfer logic
-		const content = {
-			documentHeadTitle: translate( 'Activate Jetpack Scan now' ) as string,
-			header: translate( 'Jetpack Scan' ) as string,
-			primaryPromo: {
-				title: translate( 'We guard your site. You run your business.' ),
-				image: { path: JetpackScanSVG },
-				content: translate(
-					'Scan gives you automated scanning and one-click fixes to keep your site ahead of security threats.'
-				),
-				promoCTA: {
-					text: translate( 'Activate Jetpack Scan now' ),
-					loadingText: translate( 'Activating Jetpack Scan' ),
-				},
-			},
-
-			getProductUrl: ( siteSlug: string ) => `/scan/${ siteSlug }`,
-		};
-
-		return wpcomAtomicTransfer( WPCOMScanUpsellPage, content )( context, next );
+		// Wrap the existing primary component with conditional logic
+		// This ensures proper React re-rendering when features are loaded
+		const originalPrimary = context.primary;
+		context.primary = (
+			<ConditionalScanAtomicTransferWrapper>
+				{ originalPrimary }
+			</ConditionalScanAtomicTransferWrapper>
+		);
+		return next();
 	};
+
+	WPCOMJetpackScanAtomicTransfer.displayName = 'WPCOMJetpackScanAtomicTransfer';
+	return WPCOMJetpackScanAtomicTransfer;
 }


### PR DESCRIPTION
It currently doesn't quite work if we go to Scan and reload the page because features are not available

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # DOTOBRD-308

## Proposed Changes

* Add a loading state and query for features to Jetpack Scan page so it shows an upsell when we have Personal, and shows the actual screen when we have Business

## Why are these changes being made?

* It currently works but reloads break it

## Testing Instructions

* You'll need two Atomic sites - one with Personal, and one with Business
* On the Personal Atomic, navigate to Jetpack -> Scan, Business is required. Reload the page. Business is required
* On the Business Atomic, navigate to Jetpack -> Scan, all good. Reload the page. All good

<img width="45%" alt="Screenshot 2025-08-20 at 15 13 01" src="https://github.com/user-attachments/assets/598e370f-b69b-424c-a1de-ce8f2a8bf3ff" /> <img width="45%"  alt="Screenshot 2025-08-20 at 15 12 53" src="https://github.com/user-attachments/assets/519ac742-ef50-4417-a524-affb52b14a5f" />

This page is not available to Jetpack users.

<img width="45%" alt="Screenshot 2025-08-20 at 15 30 06" src="https://github.com/user-attachments/assets/c998a7b1-ed1a-4f9a-a42b-79e5a8ccc40b" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
