### PR TITLE
Revert "Increase timeout between atomic transfer and redirect"

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -295,7 +295,7 @@ const MarketplaceProductInstall = ( {
 				transferStates.COMPLETE === automatedTransferStatus &&
 				canManagePlugins )
 		) {
-			waitFor( 10 ).then( () => {
+			waitFor( 1 ).then( () => {
 				window.location.href = pluginsUrl as string;
 			} );
 		}


### PR DESCRIPTION
Reverts Automattic/wp-calypso#105174

Undoing the changes because the issue has been addressed.