### PR TITLE
A4A: Update VIP Referral success message

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/refer-enterprise-hosting/form.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/refer-enterprise-hosting/form.tsx
@@ -173,9 +173,9 @@ export default function ReferEnterpriseHostingForm() {
 		return (
 			<Form
 				className="refer-enterprise-hosting-form"
-				title={ translate( 'WordPress VIP referral sent' ) }
+				title={ translate( 'Thank you for your WordPress VIP referral' ) }
 				description={ translate(
-					"Your client referral to Enterprise VIP Hosting is appreciated. We'll take it from here and ensure you're updated on our progress."
+					"We value your partnership—thank you for helping us identify great opportunities! Once you submit your referral, our team will move quickly to review it and support you. We’ll keep you updated at each step, so you always know what's happening and can stay connected as the opportunity progresses."
 				) }
 			>
 				<div className="refer-enterprise-hosting-form__footer">


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/A4A-1428/update-wordpress-vip-referral-post-submission-message

## Proposed Changes

This PR updates the success message for VIP referral submission.

<img width="717" height="231" alt="image" src="https://github.com/user-attachments/assets/a123dca3-7c07-4518-8fbd-183524fc4e9b" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Visit `/marketplace/hosting/refer-enterprise-hosting`
- Fill the form
- Verify that the copy of the title and the message is updated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
