### PR TITLE
Summer Special banner: only show if Personal and Premium plans are visible

### DIFF
--- a/client/blocks/summer-special-banner/index.jsx
+++ b/client/blocks/summer-special-banner/index.jsx
@@ -1,3 +1,4 @@
+import { isPremiumPlan, isPersonalPlan } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { Icon, close } from '@wordpress/icons';
@@ -12,7 +13,7 @@ import './style.scss';
 
 const SUMMER_SPECIAL_BANNER_PREFERENCE = 'dismissible-card-plugins-offer-2025';
 
-export default function SummerSpecialBanner( { isFixed = false } ) {
+export default function SummerSpecialBanner( { visiblePlans = [], isFixed = false } ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -20,6 +21,11 @@ export default function SummerSpecialBanner( { isFixed = false } ) {
 		const preference = getPreference( state, SUMMER_SPECIAL_BANNER_PREFERENCE );
 		return !! preference;
 	} );
+	// Check if Premium or Personal plans are visible for the banner
+	const hasTargetPlan = visiblePlans?.some(
+		( { planSlug, isVisible } ) =>
+			isVisible && ( isPremiumPlan( planSlug ) || isPersonalPlan( planSlug ) )
+	);
 
 	const dismiss = useCallback(
 		( event ) => {
@@ -31,7 +37,7 @@ export default function SummerSpecialBanner( { isFixed = false } ) {
 	);
 
 	// Don't show if already dismissed or no target plan in grid
-	if ( isDismissed ) {
+	if ( isDismissed || ! hasTargetPlan ) {
 		return null;
 	}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTOBRD-310](https://linear.app/a8c/issue/DOTOBRD-310/banner-visible-on-lps-with-no-personal-or-premium)

## Proposed Changes

* restricts the Summer Special banner to only plans grids that show Personal or Premium

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The banner should not be visible on plan grids that don't show the Personal/Premium plans 
  * `/start/onboarding-affiliate/plans-affiliate`
  * `/setup/onboarding-unified/plans`
  * `/setup/newsletter/plans`
* The banner should not be visible on plans grids that show the Personal/Premium plans 
  * `/setup/onboarding/plans`
  * `/plans/{SITE_SLUG}`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
