### PR TITLE
Domain Search Rewrite: Assemble the static search UI

### DIFF
--- a/client/components/domain-search-v2/__legacy/domain-search/style.scss
+++ b/client/components/domain-search-v2/__legacy/domain-search/style.scss
@@ -12,4 +12,6 @@
 	--domain-search-success-badge-border-color: #b8e5be;
 	--domain-search-success-badge-background-color: #d1eed5;
 	--domain-search-mini-cart-height: 80px;
+	--domain-search-mini-cart-inline-padding: 1rem;
+	--domain-search-mini-cart-max-width: 64rem;
 }

--- a/client/components/domain-search-v2/domain-cart/index.tsx
+++ b/client/components/domain-search-v2/domain-cart/index.tsx
@@ -33,6 +33,7 @@ const Item = ( { domain }: Pick< ComponentProps< typeof DomainsFullCartItem >, '
 	return (
 		<DomainsFullCartItem
 			domain={ domain }
+			disabled={ isBusy }
 			isBusy={ isBusy }
 			onRemove={ callback }
 			errorMessage={ errorMessage }

--- a/client/components/domains/wpcom-domain-search/index.tsx
+++ b/client/components/domains/wpcom-domain-search/index.tsx
@@ -1,5 +1,15 @@
 import { DomainSearch } from '@automattic/domain-search';
 
 export const WPCOMDomainSearch = () => {
-	return <DomainSearch />;
+	return (
+		<DomainSearch
+			cart={ {
+				items: [],
+				total: '',
+				onAddItem: () => Promise.resolve(),
+				onRemoveItem: () => Promise.resolve(),
+				hasItem: () => false,
+			} }
+		/>
+	);
 };

--- a/client/dashboard/components/domain-search/index.tsx
+++ b/client/dashboard/components/domain-search/index.tsx
@@ -1,30 +1,43 @@
 // eslint-disable-next-line no-restricted-imports
 import { DomainSearch } from '@automattic/domain-search';
+import { __ } from '@wordpress/i18n';
+import { PageHeader } from '../page-header';
+import PageLayout from '../page-layout';
+
+const staticCart = {
+	items: [
+		{
+			uuid: '1',
+			domain: 'example',
+			tld: 'com',
+			price: '$10',
+		},
+		{
+			uuid: '2',
+			domain: 'example',
+			tld: 'org',
+			price: '$10',
+		},
+	],
+	total: '$10',
+	onAddItem: () => Promise.resolve(),
+	onRemoveItem: () => Promise.resolve(),
+	hasItem: () => false,
+};
 
 function DashboardDomainSearch() {
 	return (
-		<DomainSearch
-			cart={ {
-				items: [
-					{
-						uuid: '1',
-						domain: 'example',
-						tld: 'com',
-						price: '$10',
-					},
-					{
-						uuid: '2',
-						domain: 'example',
-						tld: 'org',
-						price: '$10',
-					},
-				],
-				total: '$10',
-				onAddItem: () => Promise.resolve(),
-				onRemoveItem: () => Promise.resolve(),
-				hasItem: () => false,
-			} }
-		/>
+		<PageLayout
+			size="large"
+			header={
+				<PageHeader
+					title={ __( 'Claim your space on the web' ) }
+					description={ __( 'Make it yours with a .com, .blog or one of 350+ domain options.' ) }
+				/>
+			}
+		>
+			<DomainSearch cart={ staticCart } />
+		</PageLayout>
 	);
 }
 

--- a/client/dashboard/components/domain-search/index.tsx
+++ b/client/dashboard/components/domain-search/index.tsx
@@ -1,0 +1,31 @@
+// eslint-disable-next-line no-restricted-imports
+import { DomainSearch } from '@automattic/domain-search';
+
+function DashboardDomainSearch() {
+	return (
+		<DomainSearch
+			cart={ {
+				items: [
+					{
+						uuid: '1',
+						domain: 'example',
+						tld: 'com',
+						price: '$10',
+					},
+					{
+						uuid: '2',
+						domain: 'example',
+						tld: 'org',
+						price: '$10',
+					},
+				],
+				total: '$10',
+				onAddItem: () => Promise.resolve(),
+				onRemoveItem: () => Promise.resolve(),
+				hasItem: () => false,
+			} }
+		/>
+	);
+}
+
+export default DashboardDomainSearch;

--- a/client/dashboard/components/domain-search/index.tsx
+++ b/client/dashboard/components/domain-search/index.tsx
@@ -4,6 +4,8 @@ import { __ } from '@wordpress/i18n';
 import { PageHeader } from '../page-header';
 import PageLayout from '../page-layout';
 
+import './style.scss';
+
 const staticCart = {
 	items: [
 		{
@@ -36,7 +38,7 @@ function DashboardDomainSearch() {
 				/>
 			}
 		>
-			<DomainSearch cart={ staticCart } />
+			<DomainSearch className="dashboard-domain-search" cart={ staticCart } />
 		</PageLayout>
 	);
 }

--- a/client/dashboard/components/domain-search/style.scss
+++ b/client/dashboard/components/domain-search/style.scss
@@ -1,0 +1,9 @@
+@layer module, consumer-styles;
+
+@layer consumer-styles {
+	.dashboard-domain-search {
+		--domain-search-mini-cart-inline-padding: var( --page-layout-inline-padding );
+		--domain-search-mini-cart-max-width: var( --page-layout-max-width );
+		--domain-search-full-cart-z-index: 3;
+	}
+}

--- a/client/dashboard/components/page-layout/index.tsx
+++ b/client/dashboard/components/page-layout/index.tsx
@@ -1,9 +1,10 @@
 import { __experimentalVStack as VStack } from '@wordpress/components';
+import type { CSSProperties } from 'react';
 import './style.scss';
 
-const sizes = {
-	large: { maxWidth: '1344px' },
-	small: { maxWidth: '660px' },
+const PAGE_LAYOUT_SIZES = {
+	large: { '--page-layout-max-width': '1344px' },
+	small: { '--page-layout-max-width': '660px' },
 };
 
 function PageLayout( {
@@ -21,7 +22,7 @@ function PageLayout( {
 		<VStack
 			spacing={ 8 }
 			className={ `dashboard-page-layout is-${ size }` }
-			style={ sizes[ size ] }
+			style={ PAGE_LAYOUT_SIZES[ size ] as CSSProperties }
 		>
 			{ header }
 			{ notices }

--- a/client/dashboard/components/page-layout/style.scss
+++ b/client/dashboard/components/page-layout/style.scss
@@ -1,12 +1,15 @@
 @import '@wordpress/base-styles/variables';
 
 .dashboard-page-layout {
+	--page-layout-block-padding: #{$grid-unit-40};
+	--page-layout-inline-padding: #{$grid-unit-30};
+
 	margin: auto;
-	padding: $grid-unit-40 $grid-unit-30;
+	padding: var( --page-layout-block-padding ) var( --page-layout-inline-padding );
+	max-width: var( --page-layout-max-width );
 
 	// Creates a positioning context for CalloutOverlay components. It needs to
 	// be on the PageLayout so that the blurred overlay can cover the entire
 	// PageLayout, including the padding.
 	position: relative;
 }
-

--- a/client/dashboard/domains/purchase.tsx
+++ b/client/dashboard/domains/purchase.tsx
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { domainsRoute } from '../app/router/domains';
+import DomainSearch from '../components/domain-search';
 import FullScreenOverlay from '../components/full-screen-overlay';
-import PageLayout from '../components/page-layout';
 
 export default function DomainsPurchase() {
 	return (
@@ -9,9 +9,7 @@ export default function DomainsPurchase() {
 			backLabel={ __( 'Back to domains' ) }
 			fallbackCloseRoute={ domainsRoute.fullPath }
 		>
-			<PageLayout size="large">
-				<p>TODO: Domains purchase component</p>
-			</PageLayout>
+			<DomainSearch />
 		</FullScreenOverlay>
 	);
 }

--- a/packages/domain-search/src/components/cart/index.tsx
+++ b/packages/domain-search/src/components/cart/index.tsx
@@ -1,0 +1,61 @@
+import { useDomainSearch } from '../../page/context';
+import {
+	DomainsFullCart,
+	DomainsFullCartItem,
+	DomainsFullCartItems,
+	DomainsMiniCart,
+} from '../../ui';
+import type { SelectedDomain } from '../../page/types';
+
+const CartItem = ( { item }: { item: SelectedDomain } ) => {
+	const { cart } = useDomainSearch();
+
+	return (
+		<DomainsFullCartItem
+			key={ item.uuid }
+			domain={ item }
+			disabled={ false }
+			isBusy={ false }
+			onRemove={ () => cart.onRemoveItem( item.uuid ) }
+			errorMessage={ null }
+			removeErrorMessage={ () => {} }
+		/>
+	);
+};
+
+export const Cart = () => {
+	const { cart, isFullCartOpen, closeFullCart, events, openFullCart, slots } = useDomainSearch();
+
+	const totalItems = cart.items.length;
+	const totalPrice = cart.total;
+
+	const isCartBusy = false;
+
+	return (
+		<>
+			<DomainsMiniCart
+				isMiniCartOpen={ ! isFullCartOpen && totalItems > 0 }
+				totalItems={ totalItems }
+				totalPrice={ totalPrice }
+				openFullCart={ openFullCart }
+				onContinue={ events.onContinue }
+				isCartBusy={ isCartBusy }
+			/>
+			<DomainsFullCart
+				isFullCartOpen={ isFullCartOpen }
+				closeFullCart={ closeFullCart }
+				onContinue={ events.onContinue }
+				isCartBusy={ isCartBusy }
+				totalItems={ totalItems }
+				totalPrice={ totalPrice }
+			>
+				{ slots?.BeforeFullCartItems && <slots.BeforeFullCartItems /> }
+				<DomainsFullCartItems>
+					{ cart.items.map( ( item ) => (
+						<CartItem key={ item.uuid } item={ item } />
+					) ) }
+				</DomainsFullCartItems>
+			</DomainsFullCart>
+		</>
+	);
+};

--- a/packages/domain-search/src/components/domain-search/index.tsx
+++ b/packages/domain-search/src/components/domain-search/index.tsx
@@ -1,3 +1,0 @@
-export const DomainSearch = () => {
-	return <div>TODO: Implement domain search</div>;
-};

--- a/packages/domain-search/src/components/search-bar/index.tsx
+++ b/packages/domain-search/src/components/search-bar/index.tsx
@@ -1,0 +1,45 @@
+import { __experimentalHStack as HStack } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
+import { useEffect, useState } from 'react';
+import { useDomainSearch } from '../../page/context';
+import { DomainSearchControls } from '../../ui';
+
+const DELAY_TIMEOUT = 300;
+
+export const SearchBar = () => {
+	const { __ } = useI18n();
+	const { query, setQuery } = useDomainSearch();
+	const [ localQuery, setLocalQuery ] = useState( query );
+
+	useEffect( () => {
+		const timeout = setTimeout( () => {
+			setQuery( localQuery );
+		}, DELAY_TIMEOUT );
+
+		return () => clearTimeout( timeout );
+	}, [ localQuery, setQuery ] );
+
+	return (
+		<HStack spacing={ 4 }>
+			<DomainSearchControls.Input
+				value={ localQuery }
+				onChange={ ( value ) => {
+					const trimmedValue = value.trim();
+
+					if ( trimmedValue ) {
+						setLocalQuery( trimmedValue );
+					}
+				} }
+				label={ __( 'Search for a domain' ) }
+				// eslint-disable-next-line jsx-a11y/no-autofocus
+				autoFocus={ false }
+				minLength={ 1 }
+				maxLength={ 253 }
+				dir="ltr"
+				onBlur={ () => {} }
+				onKeyDown={ () => {} }
+			/>
+			<DomainSearchControls.FilterButton count={ 3 } onClick={ () => {} } />
+		</HStack>
+	);
+};

--- a/packages/domain-search/src/components/search-form/index.tsx
+++ b/packages/domain-search/src/components/search-form/index.tsx
@@ -1,0 +1,39 @@
+import { __experimentalHStack as HStack } from '@wordpress/components';
+import { useState } from 'react';
+import { useTypedPlaceholder } from '../../hooks/use-typed-placeholder';
+import { useDomainSearch } from '../../page/context';
+import { DomainSearchControls } from '../../ui';
+
+const PLACEHOLDER_PHRASES = [
+	'dailywine.blog',
+	'creatortools.shop',
+	'literatiagency.com',
+	'democratizework.org',
+	'discardedobject.art',
+];
+
+export const SearchForm = () => {
+	const { setQuery } = useDomainSearch();
+	const [ localQuery, setLocalQuery ] = useState( '' );
+	const { placeholder } = useTypedPlaceholder( PLACEHOLDER_PHRASES, false );
+
+	const handleSubmit = ( event: React.FormEvent< HTMLFormElement > ) => {
+		event.preventDefault();
+		setQuery( localQuery );
+	};
+
+	return (
+		<form onSubmit={ handleSubmit }>
+			{ ' ' }
+			<HStack alignment="flex-start" spacing={ 4 }>
+				<DomainSearchControls.Input
+					value={ localQuery }
+					onChange={ ( value ) => setLocalQuery( value.trim() ) }
+					onReset={ () => setLocalQuery( '' ) }
+					placeholder={ placeholder }
+				/>
+				<DomainSearchControls.Submit />
+			</HStack>
+		</form>
+	);
+};

--- a/packages/domain-search/src/components/search-results/index.tsx
+++ b/packages/domain-search/src/components/search-results/index.tsx
@@ -1,0 +1,37 @@
+import { DomainSuggestion, DomainSuggestionPrice, DomainSuggestionsList } from '../../ui';
+import { DomainSuggestionCTA } from '../suggestion-cta';
+import { type DomainSuggestion as DomainSuggestionType } from './types';
+
+export const SearchResults = () => {
+	const suggestions: DomainSuggestionType[] = [
+		{
+			domain_name: 'example.com',
+			cost: '$10',
+			product_slug: 'example',
+			supports_privacy: true,
+		},
+		{
+			domain_name: 'example.org',
+			cost: '$10',
+			product_slug: 'example',
+			supports_privacy: true,
+		},
+	];
+
+	return (
+		<DomainSuggestionsList>
+			{ suggestions?.map( ( suggestion ) => {
+				const [ domain, ...tlds ] = suggestion.domain_name.split( '.' );
+				return (
+					<DomainSuggestion
+						key={ suggestion.domain_name }
+						domain={ domain }
+						tld={ tlds.join( '.' ) }
+						price={ <DomainSuggestionPrice price={ suggestion.cost } /> }
+						cta={ <DomainSuggestionCTA suggestion={ suggestion } /> }
+					/>
+				);
+			} ) }
+		</DomainSuggestionsList>
+	);
+};

--- a/packages/domain-search/src/components/search-results/types.ts
+++ b/packages/domain-search/src/components/search-results/types.ts
@@ -1,0 +1,6 @@
+export interface DomainSuggestion {
+	domain_name: string;
+	cost: string;
+	product_slug: string;
+	supports_privacy: boolean;
+}

--- a/packages/domain-search/src/components/suggestion-cta/index.tsx
+++ b/packages/domain-search/src/components/suggestion-cta/index.tsx
@@ -1,0 +1,36 @@
+import { useDomainSearch } from '../../page/context';
+import {
+	DomainSuggestionContinueCTA,
+	DomainSuggestionErrorCTA,
+	DomainSuggestionPrimaryCTA,
+} from '../../ui';
+import { type DomainSuggestion } from '../search-results/types';
+
+export interface DomainSuggestionCTAProps {
+	suggestion: DomainSuggestion;
+}
+
+export const DomainSuggestionCTA = ( { suggestion }: DomainSuggestionCTAProps ) => {
+	const { cart, events } = useDomainSearch();
+	const isCartBusy = false;
+
+	const isDomainOnCart = cart.hasItem( suggestion.domain_name );
+
+	if ( isDomainOnCart ) {
+		return <DomainSuggestionContinueCTA disabled={ isCartBusy } onClick={ events.onContinue } />;
+	}
+
+	const errorMessage = null;
+
+	if ( errorMessage ) {
+		return <DomainSuggestionErrorCTA errorMessage={ errorMessage } callback={ () => {} } />;
+	}
+
+	return (
+		<DomainSuggestionPrimaryCTA
+			disabled={ isCartBusy }
+			onClick={ () => {} }
+			isBusy={ isCartBusy }
+		/>
+	);
+};

--- a/packages/domain-search/src/index.ts
+++ b/packages/domain-search/src/index.ts
@@ -3,4 +3,4 @@ export * from './ui';
 export { useDomainSuggestionContainer } from './hooks/use-domain-suggestion-container';
 export { useTypedPlaceholder } from './hooks/use-typed-placeholder';
 
-export { DomainSearch } from './components/domain-search';
+export { DomainSearch } from './page';

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -1,0 +1,35 @@
+import { createContext, useContext } from 'react';
+import { type DomainSearchContextType } from './types';
+
+const noop = () => {};
+
+export const DEFAULT_CONTEXT_VALUE: DomainSearchContextType = {
+	events: {
+		onContinue: noop,
+	},
+	cart: {
+		items: [],
+		total: '',
+		hasItem: () => false,
+		onAddItem: () => Promise.resolve(),
+		onRemoveItem: () => Promise.resolve(),
+	},
+	isFullCartOpen: false,
+	closeFullCart: () => {},
+	openFullCart: () => {},
+	query: '',
+	setQuery: () => {},
+};
+
+export const DomainSearchContext =
+	createContext< DomainSearchContextType >( DEFAULT_CONTEXT_VALUE );
+
+export const useDomainSearch = () => {
+	const context = useContext( DomainSearchContext );
+
+	if ( context === DEFAULT_CONTEXT_VALUE ) {
+		throw new Error( 'useDomainSearch must be used within a DomainSearchContext' );
+	}
+
+	return context;
+};

--- a/packages/domain-search/src/page/index.tsx
+++ b/packages/domain-search/src/page/index.tsx
@@ -1,0 +1,76 @@
+import { __experimentalVStack as VStack } from '@wordpress/components';
+import clsx from 'clsx';
+import { useCallback, useState, useMemo, useLayoutEffect } from 'react';
+import { Cart } from '../components/cart';
+import { SearchBar } from '../components/search-bar';
+import { SearchForm } from '../components/search-form';
+import { SearchResults } from '../components/search-results';
+import { DEFAULT_CONTEXT_VALUE, DomainSearchContext } from './context';
+import type { DomainSearchProps } from './types';
+
+import './style.scss';
+
+export const DomainSearch = ( {
+	className,
+	initialQuery,
+	cart,
+	events,
+	slots,
+}: DomainSearchProps ) => {
+	const [ isFullCartOpen, setIsFullCartOpen ] = useState( false );
+	const [ query, setQuery ] = useState( initialQuery ?? '' );
+
+	const closeFullCart = useCallback( () => {
+		setIsFullCartOpen( false );
+	}, [] );
+
+	const openFullCart = useCallback( () => {
+		setIsFullCartOpen( true );
+	}, [] );
+
+	const contextValue: typeof DEFAULT_CONTEXT_VALUE = useMemo(
+		() => ( {
+			events: {
+				...DEFAULT_CONTEXT_VALUE.events,
+				...events,
+			},
+			cart,
+			isFullCartOpen,
+			closeFullCart,
+			openFullCart,
+			query,
+			setQuery,
+			slots,
+		} ),
+		[ isFullCartOpen, closeFullCart, openFullCart, query, setQuery, cart, events, slots ]
+	);
+
+	const cartItemsLength = cart.items.length;
+
+	useLayoutEffect( () => {
+		if ( cartItemsLength === 0 && isFullCartOpen ) {
+			closeFullCart();
+		}
+	}, [ cartItemsLength, isFullCartOpen, closeFullCart ] );
+
+	const getContent = () => {
+		if ( ! query ) {
+			return <SearchForm />;
+		}
+
+		return (
+			<VStack spacing={ 8 }>
+				<SearchBar />
+				{ slots?.BeforeResults && <slots.BeforeResults /> }
+				<SearchResults />
+				<Cart />
+			</VStack>
+		);
+	};
+
+	return (
+		<DomainSearchContext.Provider value={ contextValue }>
+			<div className={ clsx( 'domain-search', className ) }>{ getContent() }</div>
+		</DomainSearchContext.Provider>
+	);
+};

--- a/packages/domain-search/src/page/style.scss
+++ b/packages/domain-search/src/page/style.scss
@@ -15,5 +15,7 @@
 		--domain-search-success-badge-border-color: #b8e5be;
 		--domain-search-success-badge-background-color: #d1eed5;
 		--domain-search-mini-cart-height: 80px;
+		--domain-search-mini-cart-inline-padding: 1rem;
+		--domain-search-mini-cart-max-width: 64rem;
 	}
 }

--- a/packages/domain-search/src/page/style.scss
+++ b/packages/domain-search/src/page/style.scss
@@ -1,0 +1,19 @@
+@import '@wordpress/base-styles/colors';
+
+@layer module, consumer-styles;
+
+@layer module {
+	.domain-search {
+		--domain-search-v2-background-color: #fcfcfc;
+		--domain-search-secondary-action-color: #{$gray-900};
+		--domain-search-secondary-action-box-shadow-color: #{$gray-400};
+		--domain-search-input-size: 56px;
+		--domain-search-input-border-radius: 4px;
+		--domain-search-promotional-price-color: #048015;
+		--domain-search-warning-badge-border-color: #f4df7b;
+		--domain-search-warning-badge-background-color: #f9edb4;
+		--domain-search-success-badge-border-color: #b8e5be;
+		--domain-search-success-badge-background-color: #d1eed5;
+		--domain-search-mini-cart-height: 80px;
+	}
+}

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -1,0 +1,43 @@
+import { DomainSuggestion } from '../components/search-results/types';
+import type { ComponentType } from 'react';
+
+export interface SelectedDomain {
+	uuid: string;
+	domain: string;
+	tld: string;
+	salePrice?: string;
+	price: string;
+}
+
+export interface DomainSearchCart {
+	items: SelectedDomain[];
+	total: string;
+	onAddItem: ( item: DomainSuggestion ) => Promise< unknown >;
+	onRemoveItem: ( item: SelectedDomain[ 'uuid' ] ) => Promise< unknown >;
+	hasItem: ( domain: SelectedDomain[ 'domain' ] ) => boolean;
+}
+
+export interface DomainSearchEvents {
+	onContinue: () => void;
+}
+
+export interface DomainSearchProps {
+	slots?: {
+		BeforeResults?: ComponentType;
+		BeforeFullCartItems?: ComponentType;
+	};
+	cart: DomainSearchCart;
+	className?: string;
+	initialQuery?: string;
+	events?: Partial< DomainSearchEvents >;
+}
+
+export interface DomainSearchContextType
+	extends Omit< DomainSearchProps, 'className' | 'initialQuery' | 'events' > {
+	events: DomainSearchEvents;
+	isFullCartOpen: boolean;
+	closeFullCart: () => void;
+	openFullCart: () => void;
+	query: string;
+	setQuery: ( query: string ) => void;
+}

--- a/packages/domain-search/src/ui/domain-search-controls/input.tsx
+++ b/packages/domain-search/src/ui/domain-search-controls/input.tsx
@@ -17,17 +17,17 @@ export const DomainSearchControlsInput = ( {
 	'aria-describedby': ariaDescribedBy,
 }: {
 	value: string;
-	label: string;
+	label?: string;
 	placeholder?: string;
 	onChange: ( value: string ) => void;
-	onReset: () => void;
-	autoFocus: boolean;
-	onBlur: ( event: React.FocusEvent< HTMLInputElement > ) => void;
-	onKeyDown: ( event: React.KeyboardEvent< HTMLInputElement > ) => void;
-	minLength: number;
-	maxLength: number;
-	dir: 'ltr' | 'rtl';
-	'aria-describedby': string;
+	onReset?: () => void;
+	autoFocus?: boolean;
+	onBlur?: ( event: React.FocusEvent< HTMLInputElement > ) => void;
+	onKeyDown?: ( event: React.KeyboardEvent< HTMLInputElement > ) => void;
+	minLength?: number;
+	maxLength?: number;
+	dir?: 'ltr' | 'rtl';
+	'aria-describedby'?: string;
 } ) => {
 	const { __ } = useI18n();
 
@@ -38,7 +38,7 @@ export const DomainSearchControlsInput = ( {
 			hideLabelFromVision
 			placeholder={ placeholder ?? __( 'Search…' ) }
 			value={ value }
-			label={ label }
+			label={ label ?? __( 'Search' ) }
 			onChange={ onChange }
 			onReset={ onReset }
 			// eslint-disable-next-line jsx-a11y/no-autofocus

--- a/packages/domain-search/src/ui/domain-search-controls/submit.tsx
+++ b/packages/domain-search/src/ui/domain-search-controls/submit.tsx
@@ -3,10 +3,15 @@ import { useI18n } from '@wordpress/react-i18n';
 
 import './submit.scss';
 
-export const DomainSearchControlsSubmit = ( { onClick }: { onClick: () => void } ) => {
+export const DomainSearchControlsSubmit = ( { onClick }: { onClick?: () => void } ) => {
 	const { __ } = useI18n();
 	return (
-		<Button variant="primary" className="domain-search-controls__submit" onClick={ onClick }>
+		<Button
+			variant="primary"
+			type="submit"
+			className="domain-search-controls__submit"
+			onClick={ onClick }
+		>
 			{ __( 'Search domains' ) }
 		</Button>
 	);

--- a/packages/domain-search/src/ui/domains-full-cart-items/item.tsx
+++ b/packages/domain-search/src/ui/domains-full-cart-items/item.tsx
@@ -13,12 +13,14 @@ import type { DomainInCart } from './types';
 
 export const DomainsFullCartItem = ( {
 	domain,
+	disabled,
 	isBusy,
 	onRemove,
 	errorMessage,
 	removeErrorMessage,
 }: {
 	domain: DomainInCart;
+	disabled: boolean;
 	isBusy: boolean;
 	onRemove: () => void;
 	errorMessage: string | null;
@@ -43,7 +45,7 @@ export const DomainsFullCartItem = ( {
 								</Text>
 							</Text>
 							<Button
-								disabled={ isBusy }
+								disabled={ disabled }
 								isBusy={ isBusy }
 								variant="link"
 								className="domains-full-cart-items__remove"

--- a/packages/domain-search/src/ui/domains-full-cart/style.scss
+++ b/packages/domain-search/src/ui/domains-full-cart/style.scss
@@ -9,6 +9,7 @@
 	bottom: 0;
 	width: 100%;
 	height: 100%;
+	z-index: var( --domain-search-full-cart-z-index );
 
 	@include break-small {
 		left: initial;

--- a/packages/domain-search/src/ui/domains-mini-cart/style.scss
+++ b/packages/domain-search/src/ui/domains-mini-cart/style.scss
@@ -17,7 +17,7 @@
 .domains-mini-cart {
 	justify-content: center;
 	align-items: center;
-	padding-inline: 1rem;
+	padding-inline: var( --domain-search-mini-cart-inline-padding );
 	display: flex;
 	box-sizing: border-box;
 	height: 100%;
@@ -26,7 +26,7 @@
 .domains-mini-cart__content {
 	box-sizing: border-box;
 	width: 100%;
-	max-width: 64rem;
+	max-width: var( --domain-search-mini-cart-max-width );
 }
 
 .domains-mini-cart-actions__view-cart {


### PR DESCRIPTION
Part of DOMAINS-1595.

## Proposed Changes

Part 1 of "assemble the static search UI": create a basic page and render it within the Hosting Dashboard.

As a follow up, I'll address any concerns from this PR, as well as add the items described in the original story.

<img width="2032" height="1167" alt="Screenshot 2025-08-20 alle 3 10 01 PM" src="https://github.com/user-attachments/assets/e5d449d1-de0c-4f75-9a86-bfff2869d01f" />


## Testing Instructions

Enter `/v2/domains` and click "Add New Domain". You should see the new page show up as a modal with the search bar. Search for anything and you should see the results and the cart, static for now. Check that the page is responsive and the margin of the page match the margin of the cart.
