### PR TITLE
Domains Hosting Dashboard: Add validation to the DNS records form

### DIFF
--- a/client/dashboard/domains/dns/add.tsx
+++ b/client/dashboard/domains/dns/add.tsx
@@ -27,7 +27,7 @@ export default function DomainAddDNS() {
 
 	const handleSubmit = ( typeFormData: DnsRecordTypeFormData, formData: DnsRecordFormData ) => {
 		const config = DNS_RECORD_CONFIGS[ typeFormData.type ];
-		const formattedData = config.transformData( formData, domainName );
+		const formattedData = config.transformData( formData, domainName, typeFormData.type );
 
 		const recordsToAdd: DnsRecord[] = [ formattedData ];
 

--- a/client/dashboard/domains/dns/add.tsx
+++ b/client/dashboard/domains/dns/add.tsx
@@ -51,6 +51,7 @@ export default function DomainAddDNS() {
 	return (
 		<PageLayout size="small" header={ <PageHeader title={ __( 'Add a new DNS record' ) } /> }>
 			<DNSRecordForm
+				domainName={ domainName }
 				isBusy={ mutation.isPending }
 				submitButtonText={ __( 'Add DNS record' ) }
 				onSubmit={ handleSubmit }

--- a/client/dashboard/domains/dns/edit.tsx
+++ b/client/dashboard/domains/dns/edit.tsx
@@ -9,6 +9,7 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import DNSRecordForm from './form';
 import { DNS_RECORD_CONFIGS } from './records/dns-record-configs';
+import { getProcessedRecord } from './utils';
 import type { DnsRecordTypeFormData, DnsRecordFormData } from './records/dns-record-configs';
 import type { DnsRecord } from '../../data/domain-dns-records';
 
@@ -20,8 +21,10 @@ export default function DomainEditDNS() {
 	const mutation = useMutation( domainDnsMutation( domainName ) );
 
 	const { data: dnsRecords } = useSuspenseQuery( domainDnsQuery( domainName ) );
-	// This record's existence is checked in the `beforeLoad` function in the route
-	const recordToEdit = dnsRecords.records.find( ( record ) => record.id === recordId )!;
+	const recordToEdit = getProcessedRecord(
+		// This record's existence is checked in the `beforeLoad` function in the route
+		dnsRecords.records.find( ( record ) => record.id === recordId )!
+	);
 
 	const navigateToDNSOverviewPage = () => {
 		navigate( {
@@ -32,7 +35,7 @@ export default function DomainEditDNS() {
 
 	const handleSubmit = ( typeFormData: DnsRecordTypeFormData, formData: DnsRecordFormData ) => {
 		const config = DNS_RECORD_CONFIGS[ typeFormData.type ];
-		const recordToAdd = config.transformData( formData, domainName );
+		const recordToAdd = config.transformData( formData, domainName, typeFormData.type );
 
 		const recordsToAdd: DnsRecord[] = [ recordToAdd ];
 		const recordsToRemove: DnsRecord[] = [ recordToEdit ];

--- a/client/dashboard/domains/dns/edit.tsx
+++ b/client/dashboard/domains/dns/edit.tsx
@@ -57,6 +57,7 @@ export default function DomainEditDNS() {
 	return (
 		<PageLayout size="small" header={ <PageHeader title={ __( 'Edit DNS record' ) } /> }>
 			<DNSRecordForm
+				domainName={ domainName }
 				isBusy={ mutation.isPending }
 				submitButtonText={ __( 'Update DNS record' ) }
 				onSubmit={ handleSubmit }

--- a/client/dashboard/domains/dns/form.tsx
+++ b/client/dashboard/domains/dns/form.tsx
@@ -43,6 +43,7 @@ export default function DNSRecordForm( {
 		ttl: 3600,
 		flags: 0, // CAA
 		tag: 'issue', // CAA
+		value: '', // CAA
 		aux: 10, // MX, SRV
 		service: 'sip', // SRV
 		protocol: '_tcp', // SRV
@@ -67,6 +68,7 @@ export default function DNSRecordForm( {
 				data: recordToEdit.data || '',
 				flags: recordToEdit.flags || 0,
 				tag: recordToEdit.tag || '',
+				value: recordToEdit.value || '',
 				aux: recordToEdit.aux || 0,
 				service: recordToEdit.service || '',
 				protocol: recordToEdit.protocol || '',

--- a/client/dashboard/domains/dns/form.tsx
+++ b/client/dashboard/domains/dns/form.tsx
@@ -126,6 +126,9 @@ export default function DNSRecordForm( {
 							} }
 						/>
 						<DataForm< DnsRecordFormData >
+							// This key prop is used to force a form re-render when the record type is changed
+							// Othewise, the fields that have validation errors will not have validation reset
+							key={ typeFormData.type }
 							data={ formData }
 							fields={ config.fields }
 							form={ config.form }

--- a/client/dashboard/domains/dns/form.tsx
+++ b/client/dashboard/domains/dns/form.tsx
@@ -11,29 +11,15 @@ import { useState } from 'react';
 import RequiredSelect from '../../components/required-select';
 import { DNS_RECORD_CONFIGS } from './records/dns-record-configs';
 import type { DnsRecordTypeFormData, DnsRecordFormData } from './records/dns-record-configs';
-import type { DnsRecord } from '../../data/domain-dns-records';
+import type { DnsRecord, DnsRecordType } from '../../data/domain-dns-records';
 
 const typeForm = {
 	layout: { type: 'regular' as const },
 	fields: [ 'type' ],
 };
 
-const defaultFormData = {
-	type: 'A',
-	name: '',
-	data: '',
-	ttl: 3600,
-	flags: 0, // CAA
-	tag: 'issue', // CAA
-	aux: 10, // MX, SRV
-	service: 'sip', // SRV
-	protocol: '_tcp', // SRV
-	weight: 10, // SRV
-	target: '', // SRV
-	port: 5060, // SRV
-};
-
 interface DNSRecordFormProps {
+	domainName: string;
 	isBusy: boolean;
 	recordToEdit?: DnsRecord;
 	submitButtonText: string;
@@ -42,12 +28,29 @@ interface DNSRecordFormProps {
 }
 
 export default function DNSRecordForm( {
+	domainName,
 	isBusy,
 	recordToEdit,
 	submitButtonText,
 	onSubmit,
 	navigateToDNSOverviewPage,
 }: DNSRecordFormProps ) {
+	const defaultFormData = {
+		type: 'A' as DnsRecordType,
+		domain: domainName,
+		name: '',
+		data: '',
+		ttl: 3600,
+		flags: 0, // CAA
+		tag: 'issue', // CAA
+		aux: 10, // MX, SRV
+		service: 'sip', // SRV
+		protocol: '_tcp', // SRV
+		weight: 10, // SRV
+		target: '', // SRV
+		port: 5060, // SRV
+	};
+
 	const [ typeFormData, setTypeFormData ] = useState< DnsRecordTypeFormData >( () => {
 		if ( recordToEdit ) {
 			return { type: recordToEdit.type };
@@ -57,6 +60,8 @@ export default function DNSRecordForm( {
 	const [ formData, setFormData ] = useState< DnsRecordFormData >( () => {
 		if ( recordToEdit ) {
 			return {
+				type: recordToEdit.type || ( 'A' as DnsRecordType ),
+				domain: domainName,
 				ttl: recordToEdit.ttl || 3600,
 				name: recordToEdit.name || '',
 				data: recordToEdit.data || '',

--- a/client/dashboard/domains/dns/records/a-record.tsx
+++ b/client/dashboard/domains/dns/records/a-record.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { ipv4Validator, optionalHostnameValidator, ttlValidator } from './validators';
 import type { DnsRecordFormData, DnsRecordConfig } from './dns-record-configs';
 
 export const ARecordConfig: DnsRecordConfig = {
@@ -9,17 +10,23 @@ export const ARecordConfig: DnsRecordConfig = {
 		{
 			id: 'name',
 			type: 'text',
-			label: __( 'Name (optional)' ),
+			label: __( 'Name' ),
 			/* translators: This is a placeholder for a DNS A record `name` property */
 			placeholder: __( 'Enter subdomain' ),
+			isValid: {
+				custom: optionalHostnameValidator(),
+			},
 		},
 		{
-			// TODO: Add validation for IPv4 address
 			id: 'data',
 			type: 'text',
 			label: __( 'Points to' ),
 			/* translators: This is a placeholder for a DNS A record `data` property */
 			placeholder: __( 'e.g. 123.45.67.89' ),
+			isValid: {
+				required: true,
+				custom: ipv4Validator(),
+			},
 		},
 		{
 			id: 'ttl',
@@ -27,6 +34,10 @@ export const ARecordConfig: DnsRecordConfig = {
 			label: __( 'TTL (time to live)' ),
 			/* translators: This is a placeholder for a DNS A record `ttl` property */
 			placeholder: __( 'e.g. 3600' ),
+			isValid: {
+				required: true,
+				custom: ttlValidator(),
+			},
 		},
 	],
 	form: {

--- a/client/dashboard/domains/dns/records/a-record.tsx
+++ b/client/dashboard/domains/dns/records/a-record.tsx
@@ -1,6 +1,8 @@
 import { __ } from '@wordpress/i18n';
+import { getNormalizedName } from '../utils';
 import { hostnameValidator, ipv4Validator, ttlValidator } from './validators';
 import type { DnsRecordFormData, DnsRecordConfig } from './dns-record-configs';
+import type { DnsRecordType } from '../../../data/domain-dns-records';
 
 export const ARecordConfig: DnsRecordConfig = {
 	description: __(
@@ -44,9 +46,9 @@ export const ARecordConfig: DnsRecordConfig = {
 		layout: { type: 'regular' as const },
 		fields: [ 'name', 'data', 'ttl' ],
 	},
-	transformData: ( data: DnsRecordFormData ) => ( {
+	transformData: ( data: DnsRecordFormData, domainName: string, type: DnsRecordType ) => ( {
 		type: 'A',
-		name: data.name,
+		name: getNormalizedName( data.name, type, domainName ),
 		data: data.data,
 		ttl: data.ttl,
 	} ),

--- a/client/dashboard/domains/dns/records/a-record.tsx
+++ b/client/dashboard/domains/dns/records/a-record.tsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { ipv4Validator, optionalHostnameValidator, ttlValidator } from './validators';
+import { hostnameValidator, ipv4Validator, ttlValidator } from './validators';
 import type { DnsRecordFormData, DnsRecordConfig } from './dns-record-configs';
 
 export const ARecordConfig: DnsRecordConfig = {
@@ -14,7 +14,7 @@ export const ARecordConfig: DnsRecordConfig = {
 			/* translators: This is a placeholder for a DNS A record `name` property */
 			placeholder: __( 'Enter subdomain' ),
 			isValid: {
-				custom: optionalHostnameValidator(),
+				custom: hostnameValidator(),
 			},
 		},
 		{

--- a/client/dashboard/domains/dns/records/aaaa-record.tsx
+++ b/client/dashboard/domains/dns/records/aaaa-record.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { ipv6Validator, optionalHostnameValidator, ttlValidator } from './validators';
 import type { DnsRecordFormData, DnsRecordConfig } from './dns-record-configs';
 
 export const AAAARecordConfig: DnsRecordConfig = {
@@ -6,9 +7,12 @@ export const AAAARecordConfig: DnsRecordConfig = {
 		{
 			id: 'name',
 			type: 'text',
-			label: __( 'Name (optional)' ),
+			label: __( 'Name' ),
 			/* translators: This is a placeholder for a DNS AAAA record `name` property */
 			placeholder: __( 'Enter subdomain' ),
+			isValid: {
+				custom: optionalHostnameValidator(),
+			},
 		},
 		{
 			id: 'data',
@@ -16,6 +20,10 @@ export const AAAARecordConfig: DnsRecordConfig = {
 			label: __( 'Points to' ),
 			/* translators: This is a placeholder for a DNS AAAA record `data` property */
 			placeholder: __( 'e.g. 2001:500:84::b' ),
+			isValid: {
+				required: true,
+				custom: ipv6Validator(),
+			},
 		},
 		{
 			id: 'ttl',
@@ -23,6 +31,10 @@ export const AAAARecordConfig: DnsRecordConfig = {
 			label: __( 'TTL (time to live)' ),
 			/* translators: This is a placeholder for a DNS AAAA record `ttl` property */
 			placeholder: __( 'e.g. 3600' ),
+			isValid: {
+				required: true,
+				custom: ttlValidator(),
+			},
 		},
 	],
 	form: {

--- a/client/dashboard/domains/dns/records/aaaa-record.tsx
+++ b/client/dashboard/domains/dns/records/aaaa-record.tsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { ipv6Validator, optionalHostnameValidator, ttlValidator } from './validators';
+import { hostnameValidator, ipv6Validator, ttlValidator } from './validators';
 import type { DnsRecordFormData, DnsRecordConfig } from './dns-record-configs';
 
 export const AAAARecordConfig: DnsRecordConfig = {
@@ -11,7 +11,7 @@ export const AAAARecordConfig: DnsRecordConfig = {
 			/* translators: This is a placeholder for a DNS AAAA record `name` property */
 			placeholder: __( 'Enter subdomain' ),
 			isValid: {
-				custom: optionalHostnameValidator(),
+				custom: hostnameValidator(),
 			},
 		},
 		{

--- a/client/dashboard/domains/dns/records/aaaa-record.tsx
+++ b/client/dashboard/domains/dns/records/aaaa-record.tsx
@@ -1,6 +1,8 @@
 import { __ } from '@wordpress/i18n';
+import { getNormalizedName } from '../utils';
 import { hostnameValidator, ipv6Validator, ttlValidator } from './validators';
 import type { DnsRecordFormData, DnsRecordConfig } from './dns-record-configs';
+import type { DnsRecordType } from '../../../data/domain-dns-records';
 
 export const AAAARecordConfig: DnsRecordConfig = {
 	fields: [
@@ -41,9 +43,9 @@ export const AAAARecordConfig: DnsRecordConfig = {
 		layout: { type: 'regular' as const },
 		fields: [ 'name', 'data', 'ttl' ],
 	},
-	transformData: ( data: DnsRecordFormData ) => ( {
+	transformData: ( data: DnsRecordFormData, domainName: string, type: DnsRecordType ) => ( {
 		type: 'AAAA',
-		name: data.name,
+		name: getNormalizedName( data.name, type, domainName ),
 		data: data.data,
 		ttl: data.ttl,
 	} ),

--- a/client/dashboard/domains/dns/records/alias-record.tsx
+++ b/client/dashboard/domains/dns/records/alias-record.tsx
@@ -15,7 +15,7 @@ export const AliasRecordConfig: DnsRecordConfig = {
 			placeholder: __( 'e.g. example.com' ),
 			isValid: {
 				required: true,
-				custom: domainValidator( 'ALIAS', __( 'Please enter a valid target host.' ) ),
+				custom: domainValidator( __( 'Please enter a valid target host.' ) ),
 			},
 		},
 		{

--- a/client/dashboard/domains/dns/records/alias-record.tsx
+++ b/client/dashboard/domains/dns/records/alias-record.tsx
@@ -1,6 +1,8 @@
 import { __ } from '@wordpress/i18n';
+import { getFieldWithDot, getNormalizedName } from '../utils';
 import { domainValidator, ttlValidator } from './validators';
 import type { DnsRecordFormData, DnsRecordConfig } from './dns-record-configs';
+import type { DnsRecordType } from '../../../data/domain-dns-records';
 
 export const AliasRecordConfig: DnsRecordConfig = {
 	description: __(
@@ -34,15 +36,10 @@ export const AliasRecordConfig: DnsRecordConfig = {
 		layout: { type: 'regular' as const },
 		fields: [ 'data', 'ttl' ],
 	},
-	transformData: ( data: DnsRecordFormData, domainName?: string ) => {
-		// Remove trailing dot from the hostname
-		const hostName = data.data.endsWith( '.' ) ? data.data.slice( 0, -1 ) : data.data;
-
-		return {
-			type: 'ALIAS',
-			name: domainName + '.', // We limit ALIAS records to be set only at the root
-			data: hostName + '.', // we're appending a dot to make the host name a FQDN
-			ttl: data.ttl,
-		};
-	},
+	transformData: ( data: DnsRecordFormData, domainName: string, type: DnsRecordType ) => ( {
+		type: 'ALIAS',
+		name: getNormalizedName( data.name, type, domainName ),
+		data: getFieldWithDot( data.data ),
+		ttl: data.ttl,
+	} ),
 };

--- a/client/dashboard/domains/dns/records/alias-record.tsx
+++ b/client/dashboard/domains/dns/records/alias-record.tsx
@@ -17,6 +17,7 @@ export const AliasRecordConfig: DnsRecordConfig = {
 			placeholder: __( 'e.g. example.com' ),
 			isValid: {
 				required: true,
+				/* translators: This is the error message when the `data` field of a DNS ALIAS record is invalid */
 				custom: domainValidator( __( 'Please enter a valid target host.' ) ),
 			},
 		},

--- a/client/dashboard/domains/dns/records/alias-record.tsx
+++ b/client/dashboard/domains/dns/records/alias-record.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { domainValidator, ttlValidator } from './validators';
 import type { DnsRecordFormData, DnsRecordConfig } from './dns-record-configs';
 
 export const AliasRecordConfig: DnsRecordConfig = {
@@ -12,6 +13,10 @@ export const AliasRecordConfig: DnsRecordConfig = {
 			label: __( 'Alias of (points to)' ),
 			/* translators: This is a placeholder for a DNS ALIAS record `data` property */
 			placeholder: __( 'e.g. example.com' ),
+			isValid: {
+				required: true,
+				custom: domainValidator( 'ALIAS', __( 'Please enter a valid target host.' ) ),
+			},
 		},
 		{
 			id: 'ttl',
@@ -19,6 +24,10 @@ export const AliasRecordConfig: DnsRecordConfig = {
 			label: __( 'TTL (time to live)' ),
 			/* translators: This is a placeholder for a DNS ALIAS record `ttl` property */
 			placeholder: __( 'e.g. 3600' ),
+			isValid: {
+				required: true,
+				custom: ttlValidator(),
+			},
 		},
 	],
 	form: {

--- a/client/dashboard/domains/dns/records/caa-record.tsx
+++ b/client/dashboard/domains/dns/records/caa-record.tsx
@@ -1,9 +1,9 @@
 import { __ } from '@wordpress/i18n';
 import RequiredSelect from '../../../components/required-select';
 import {
+	hostnameValidator,
 	numberRangeValidator,
-	optionalHostnameValidator,
-	requiredHostnameValidator,
+	stringLengthValidator,
 	ttlValidator,
 } from './validators';
 import type { DnsRecordFormData, DnsRecordConfig } from './dns-record-configs';
@@ -17,7 +17,7 @@ export const CAARecordConfig: DnsRecordConfig = {
 			/* translators: This is a placeholder for a DNS CAA record `name` property */
 			placeholder: __( 'Enter subdomain' ),
 			isValid: {
-				custom: optionalHostnameValidator(),
+				custom: hostnameValidator(),
 			},
 		},
 		{
@@ -53,7 +53,7 @@ export const CAARecordConfig: DnsRecordConfig = {
 			placeholder: __( 'e.g. "letsencrypt.org"' ),
 			isValid: {
 				required: true,
-				custom: requiredHostnameValidator( __( 'Please enter a valid value.' ) ),
+				custom: stringLengthValidator( __( 'Please enter a valid value.' ) ),
 			},
 		},
 		{

--- a/client/dashboard/domains/dns/records/caa-record.tsx
+++ b/client/dashboard/domains/dns/records/caa-record.tsx
@@ -49,14 +49,14 @@ export const CAARecordConfig: DnsRecordConfig = {
 			},
 		},
 		{
-			id: 'data',
+			id: 'value',
 			type: 'text',
 			label: __( 'Value' ),
-			/* translators: This is a placeholder for a DNS CAA record `data` property */
+			/* translators: This is a placeholder for a DNS CAA record `value` property */
 			placeholder: __( 'e.g. "letsencrypt.org"' ),
 			isValid: {
 				required: true,
-				/* translators: This is the error message when the `data` field of a DNS CAA record is invalid */
+				/* translators: This is the error message when the `value` field of a DNS CAA record is invalid */
 				custom: stringLengthValidator( __( 'Please enter a valid value.' ) ),
 			},
 		},
@@ -74,14 +74,14 @@ export const CAARecordConfig: DnsRecordConfig = {
 	],
 	form: {
 		layout: { type: 'regular' as const },
-		fields: [ 'name', 'flags', 'tag', 'data', 'ttl' ],
+		fields: [ 'name', 'flags', 'tag', 'value', 'ttl' ],
 	},
 	transformData: ( data: DnsRecordFormData, domainName: string, type: DnsRecordType ) => ( {
 		type: 'CAA',
 		name: getNormalizedName( data.name, type, domainName ),
 		flags: data.flags,
 		tag: data.tag,
-		value: data.data,
+		value: data.value,
 		ttl: data.ttl,
 	} ),
 };

--- a/client/dashboard/domains/dns/records/caa-record.tsx
+++ b/client/dashboard/domains/dns/records/caa-record.tsx
@@ -1,5 +1,11 @@
 import { __ } from '@wordpress/i18n';
 import RequiredSelect from '../../../components/required-select';
+import {
+	numberRangeValidator,
+	optionalHostnameValidator,
+	requiredHostnameValidator,
+	ttlValidator,
+} from './validators';
 import type { DnsRecordFormData, DnsRecordConfig } from './dns-record-configs';
 
 export const CAARecordConfig: DnsRecordConfig = {
@@ -10,6 +16,9 @@ export const CAARecordConfig: DnsRecordConfig = {
 			label: __( 'Name (optional)' ),
 			/* translators: This is a placeholder for a DNS CAA record `name` property */
 			placeholder: __( 'Enter subdomain' ),
+			isValid: {
+				custom: optionalHostnameValidator(),
+			},
 		},
 		{
 			id: 'flags',
@@ -17,6 +26,10 @@ export const CAARecordConfig: DnsRecordConfig = {
 			label: __( 'Flag' ),
 			/* translators: This is a placeholder for a DNS CAA record `flags` property */
 			placeholder: __( 'e.g. 0' ),
+			isValid: {
+				required: true,
+				custom: numberRangeValidator( 0, 255, __( 'Please enter a valid flags value.' ) ),
+			},
 		},
 		{
 			id: 'tag',
@@ -28,6 +41,9 @@ export const CAARecordConfig: DnsRecordConfig = {
 				{ label: 'issueemail', value: 'issueemail' },
 				{ label: 'iodef', value: 'iodef' },
 			],
+			isValid: {
+				required: true,
+			},
 		},
 		{
 			id: 'data',
@@ -35,6 +51,10 @@ export const CAARecordConfig: DnsRecordConfig = {
 			label: __( 'Value' ),
 			/* translators: This is a placeholder for a DNS CAA record `data` property */
 			placeholder: __( 'e.g. "letsencrypt.org"' ),
+			isValid: {
+				required: true,
+				custom: requiredHostnameValidator( __( 'Please enter a valid value.' ) ),
+			},
 		},
 		{
 			id: 'ttl',
@@ -42,6 +62,10 @@ export const CAARecordConfig: DnsRecordConfig = {
 			label: __( 'TTL (time to live)' ),
 			/* translators: This is a placeholder for a DNS CAA record `ttl` property */
 			placeholder: __( 'e.g. 3600' ),
+			isValid: {
+				required: true,
+				custom: ttlValidator(),
+			},
 		},
 	],
 	form: {

--- a/client/dashboard/domains/dns/records/caa-record.tsx
+++ b/client/dashboard/domains/dns/records/caa-record.tsx
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import RequiredSelect from '../../../components/required-select';
+import { getNormalizedName } from '../utils';
 import {
 	hostnameValidator,
 	numberRangeValidator,
@@ -7,6 +8,7 @@ import {
 	ttlValidator,
 } from './validators';
 import type { DnsRecordFormData, DnsRecordConfig } from './dns-record-configs';
+import type { DnsRecordType } from '../../../data/domain-dns-records';
 
 export const CAARecordConfig: DnsRecordConfig = {
 	fields: [
@@ -72,9 +74,9 @@ export const CAARecordConfig: DnsRecordConfig = {
 		layout: { type: 'regular' as const },
 		fields: [ 'name', 'flags', 'tag', 'data', 'ttl' ],
 	},
-	transformData: ( data: DnsRecordFormData ) => ( {
+	transformData: ( data: DnsRecordFormData, domainName: string, type: DnsRecordType ) => ( {
 		type: 'CAA',
-		name: data.name,
+		name: getNormalizedName( data.name, type, domainName ),
 		flags: data.flags,
 		tag: data.tag,
 		value: data.data,

--- a/client/dashboard/domains/dns/records/caa-record.tsx
+++ b/client/dashboard/domains/dns/records/caa-record.tsx
@@ -30,6 +30,7 @@ export const CAARecordConfig: DnsRecordConfig = {
 			placeholder: __( 'e.g. 0' ),
 			isValid: {
 				required: true,
+				/* translators: This is the error message when the `flags` field of a DNS CAA record is invalid */
 				custom: numberRangeValidator( 0, 255, __( 'Please enter a valid flags value.' ) ),
 			},
 		},
@@ -55,6 +56,7 @@ export const CAARecordConfig: DnsRecordConfig = {
 			placeholder: __( 'e.g. "letsencrypt.org"' ),
 			isValid: {
 				required: true,
+				/* translators: This is the error message when the `data` field of a DNS CAA record is invalid */
 				custom: stringLengthValidator( __( 'Please enter a valid value.' ) ),
 			},
 		},

--- a/client/dashboard/domains/dns/records/cname-record.tsx
+++ b/client/dashboard/domains/dns/records/cname-record.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { domainValidator, requiredHostnameValidator, ttlValidator } from './validators';
 import type { DnsRecordFormData, DnsRecordConfig } from './dns-record-configs';
 
 export const CNAMERecordConfig: DnsRecordConfig = {
@@ -12,6 +13,10 @@ export const CNAMERecordConfig: DnsRecordConfig = {
 			label: __( 'Name (host)' ),
 			/* translators: This is a placeholder for a DNS CNAME record `name` property */
 			placeholder: __( 'Enter subdomain (required)' ),
+			isValid: {
+				required: true,
+				custom: requiredHostnameValidator(),
+			},
 		},
 		{
 			id: 'data',
@@ -19,6 +24,10 @@ export const CNAMERecordConfig: DnsRecordConfig = {
 			label: __( 'Alias of (points to)' ),
 			/* translators: This is a placeholder for a DNS CNAME record `data` property */
 			placeholder: __( 'e.g. example.com' ),
+			isValid: {
+				required: true,
+				custom: domainValidator( 'CNAME', __( 'Please enter a valid target host.' ) ),
+			},
 		},
 		{
 			id: 'ttl',
@@ -26,6 +35,10 @@ export const CNAMERecordConfig: DnsRecordConfig = {
 			label: __( 'TTL (time to live)' ),
 			/* translators: This is a placeholder for a DNS CNAME record `ttl` property */
 			placeholder: __( 'e.g. 3600' ),
+			isValid: {
+				required: true,
+				custom: ttlValidator(),
+			},
 		},
 	],
 	form: {

--- a/client/dashboard/domains/dns/records/cname-record.tsx
+++ b/client/dashboard/domains/dns/records/cname-record.tsx
@@ -1,6 +1,8 @@
 import { __ } from '@wordpress/i18n';
+import { getFieldWithDot, getNormalizedName } from '../utils';
 import { domainValidator, hostnameValidator, ttlValidator } from './validators';
 import type { DnsRecordFormData, DnsRecordConfig } from './dns-record-configs';
+import type { DnsRecordType } from '../../../data/domain-dns-records';
 
 export const CNAMERecordConfig: DnsRecordConfig = {
 	description: __(
@@ -45,15 +47,10 @@ export const CNAMERecordConfig: DnsRecordConfig = {
 		layout: { type: 'regular' as const },
 		fields: [ 'name', 'data', 'ttl' ],
 	},
-	transformData: ( data: DnsRecordFormData ) => {
-		// Remove trailing dot from the hostname
-		const hostName = data.data.endsWith( '.' ) ? data.data.slice( 0, -1 ) : data.data;
-
-		return {
-			type: 'CNAME',
-			name: data.name,
-			data: hostName + '.', // we're appending a dot to make the host name a FQDN
-			ttl: data.ttl,
-		};
-	},
+	transformData: ( data: DnsRecordFormData, domainName: string, type: DnsRecordType ) => ( {
+		type: 'CNAME',
+		name: getNormalizedName( data.name, type, domainName ),
+		data: getFieldWithDot( data.data ),
+		ttl: data.ttl,
+	} ),
 };

--- a/client/dashboard/domains/dns/records/cname-record.tsx
+++ b/client/dashboard/domains/dns/records/cname-record.tsx
@@ -28,6 +28,7 @@ export const CNAMERecordConfig: DnsRecordConfig = {
 			placeholder: __( 'e.g. example.com' ),
 			isValid: {
 				required: true,
+				/* translators: This is the error message when the `data` field of a DNS CNAME record is invalid */
 				custom: domainValidator( __( 'Please enter a valid target host.' ) ),
 			},
 		},

--- a/client/dashboard/domains/dns/records/cname-record.tsx
+++ b/client/dashboard/domains/dns/records/cname-record.tsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { domainValidator, requiredHostnameValidator, ttlValidator } from './validators';
+import { domainValidator, hostnameValidator, ttlValidator } from './validators';
 import type { DnsRecordFormData, DnsRecordConfig } from './dns-record-configs';
 
 export const CNAMERecordConfig: DnsRecordConfig = {
@@ -15,7 +15,7 @@ export const CNAMERecordConfig: DnsRecordConfig = {
 			placeholder: __( 'Enter subdomain (required)' ),
 			isValid: {
 				required: true,
-				custom: requiredHostnameValidator(),
+				custom: hostnameValidator(),
 			},
 		},
 		{
@@ -26,7 +26,7 @@ export const CNAMERecordConfig: DnsRecordConfig = {
 			placeholder: __( 'e.g. example.com' ),
 			isValid: {
 				required: true,
-				custom: domainValidator( 'CNAME', __( 'Please enter a valid target host.' ) ),
+				custom: domainValidator( __( 'Please enter a valid target host.' ) ),
 			},
 		},
 		{

--- a/client/dashboard/domains/dns/records/dns-record-configs.ts
+++ b/client/dashboard/domains/dns/records/dns-record-configs.ts
@@ -15,6 +15,8 @@ export type DnsRecordTypeFormData = {
 };
 
 export type DnsRecordFormData = {
+	type: DnsRecordType;
+	domain: string;
 	name: string;
 	data: string;
 	ttl: number;

--- a/client/dashboard/domains/dns/records/dns-record-configs.ts
+++ b/client/dashboard/domains/dns/records/dns-record-configs.ts
@@ -22,6 +22,7 @@ export type DnsRecordFormData = {
 	ttl: number;
 	flags: number; // CAA
 	tag: string; // CAA
+	value: string; // CAA
 	aux: number; // MX, SRV
 	service: string; // SRV
 	protocol: string; // SRV

--- a/client/dashboard/domains/dns/records/dns-record-configs.ts
+++ b/client/dashboard/domains/dns/records/dns-record-configs.ts
@@ -38,7 +38,7 @@ export type DnsRecordConfig = {
 		fields: string[];
 	};
 	// Function to transform the form data into the format expected by the DNS endpoint
-	transformData: ( data: DnsRecordFormData, domainName?: string ) => DnsRecord;
+	transformData: ( data: DnsRecordFormData, domainName: string, type: DnsRecordType ) => DnsRecord;
 };
 
 export const DNS_RECORD_CONFIGS: Record< DnsRecordType, DnsRecordConfig > = {

--- a/client/dashboard/domains/dns/records/mx-record.tsx
+++ b/client/dashboard/domains/dns/records/mx-record.tsx
@@ -1,4 +1,10 @@
 import { __ } from '@wordpress/i18n';
+import {
+	domainValidator,
+	numberRangeValidator,
+	optionalHostnameValidator,
+	ttlValidator,
+} from './validators';
 import type { DnsRecordFormData, DnsRecordConfig } from './dns-record-configs';
 
 export const MXRecordConfig: DnsRecordConfig = {
@@ -9,9 +15,12 @@ export const MXRecordConfig: DnsRecordConfig = {
 		{
 			id: 'name',
 			type: 'text',
-			label: __( 'Name (optional)' ),
+			label: __( 'Name' ),
 			/* translators: This is a placeholder for a DNS MX record `name` property */
 			placeholder: __( 'Enter subdomain' ),
+			isValid: {
+				custom: optionalHostnameValidator(),
+			},
 		},
 		{
 			id: 'data',
@@ -19,6 +28,10 @@ export const MXRecordConfig: DnsRecordConfig = {
 			label: __( 'Handled by' ),
 			/* translators: This is a placeholder for a DNS MX record `data` property */
 			placeholder: __( 'e.g. mail.your-provider.com' ),
+			isValid: {
+				required: true,
+				custom: domainValidator( 'MX', __( 'Please enter a valid mail server.' ) ),
+			},
 		},
 		{
 			id: 'aux',
@@ -26,6 +39,10 @@ export const MXRecordConfig: DnsRecordConfig = {
 			label: __( 'Priority' ),
 			/* translators: This is a placeholder for a DNS MX record `aux` property */
 			placeholder: __( 'e.g. 10' ),
+			isValid: {
+				required: true,
+				custom: numberRangeValidator( 0, 65535, __( 'Please enter a valid priority value.' ) ),
+			},
 		},
 		{
 			id: 'ttl',
@@ -33,6 +50,10 @@ export const MXRecordConfig: DnsRecordConfig = {
 			label: __( 'TTL (time to live)' ),
 			/* translators: This is a placeholder for a DNS MX record `ttl` property */
 			placeholder: __( 'e.g. 3600' ),
+			isValid: {
+				required: true,
+				custom: ttlValidator(),
+			},
 		},
 	],
 	form: {

--- a/client/dashboard/domains/dns/records/mx-record.tsx
+++ b/client/dashboard/domains/dns/records/mx-record.tsx
@@ -1,8 +1,8 @@
 import { __ } from '@wordpress/i18n';
 import {
 	domainValidator,
+	hostnameValidator,
 	numberRangeValidator,
-	optionalHostnameValidator,
 	ttlValidator,
 } from './validators';
 import type { DnsRecordFormData, DnsRecordConfig } from './dns-record-configs';
@@ -19,7 +19,7 @@ export const MXRecordConfig: DnsRecordConfig = {
 			/* translators: This is a placeholder for a DNS MX record `name` property */
 			placeholder: __( 'Enter subdomain' ),
 			isValid: {
-				custom: optionalHostnameValidator(),
+				custom: hostnameValidator(),
 			},
 		},
 		{
@@ -30,7 +30,7 @@ export const MXRecordConfig: DnsRecordConfig = {
 			placeholder: __( 'e.g. mail.your-provider.com' ),
 			isValid: {
 				required: true,
-				custom: domainValidator( 'MX', __( 'Please enter a valid mail server.' ) ),
+				custom: domainValidator( __( 'Please enter a valid mail server.' ) ),
 			},
 		},
 		{

--- a/client/dashboard/domains/dns/records/mx-record.tsx
+++ b/client/dashboard/domains/dns/records/mx-record.tsx
@@ -32,6 +32,7 @@ export const MXRecordConfig: DnsRecordConfig = {
 			placeholder: __( 'e.g. mail.your-provider.com' ),
 			isValid: {
 				required: true,
+				/* translators: This is the error message when the `data` field of a DNS MX record is invalid */
 				custom: domainValidator( __( 'Please enter a valid mail server.' ) ),
 			},
 		},
@@ -43,6 +44,7 @@ export const MXRecordConfig: DnsRecordConfig = {
 			placeholder: __( 'e.g. 10' ),
 			isValid: {
 				required: true,
+				/* translators: This is the error message when the `aux` field of a DNS MX record is invalid */
 				custom: numberRangeValidator( 0, 65535, __( 'Please enter a valid priority value.' ) ),
 			},
 		},

--- a/client/dashboard/domains/dns/records/mx-record.tsx
+++ b/client/dashboard/domains/dns/records/mx-record.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { getFieldWithDot, getNormalizedName } from '../utils';
 import {
 	domainValidator,
 	hostnameValidator,
@@ -6,6 +7,7 @@ import {
 	ttlValidator,
 } from './validators';
 import type { DnsRecordFormData, DnsRecordConfig } from './dns-record-configs';
+import type { DnsRecordType } from '../../../data/domain-dns-records';
 
 export const MXRecordConfig: DnsRecordConfig = {
 	description: __(
@@ -60,16 +62,11 @@ export const MXRecordConfig: DnsRecordConfig = {
 		layout: { type: 'regular' as const },
 		fields: [ 'name', 'data', 'aux', 'ttl' ],
 	},
-	transformData: ( data: DnsRecordFormData ) => {
-		// Remove trailing dot from the hostname
-		const hostName = data.data.endsWith( '.' ) ? data.data.slice( 0, -1 ) : data.data;
-
-		return {
-			type: 'MX',
-			name: data.name,
-			data: hostName + '.', // we're appending a dot to make the host name a FQDN
-			aux: data.aux,
-			ttl: data.ttl,
-		};
-	},
+	transformData: ( data: DnsRecordFormData, domainName: string, type: DnsRecordType ) => ( {
+		type: 'MX',
+		name: getNormalizedName( data.name, type, domainName ),
+		data: getFieldWithDot( data.data ),
+		aux: data.aux,
+		ttl: data.ttl,
+	} ),
 };

--- a/client/dashboard/domains/dns/records/ns-record.tsx
+++ b/client/dashboard/domains/dns/records/ns-record.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { domainValidator, requiredHostnameValidator, ttlValidator } from './validators';
 import type { DnsRecordFormData, DnsRecordConfig } from './dns-record-configs';
 
 export const NSRecordConfig: DnsRecordConfig = {
@@ -9,9 +10,13 @@ export const NSRecordConfig: DnsRecordConfig = {
 		{
 			id: 'name',
 			type: 'text',
-			label: __( 'Name (optional)' ),
+			label: __( 'Name' ),
 			/* translators: This is a placeholder for a DNS NS record `name` property */
 			placeholder: __( 'Enter subdomain' ),
+			isValid: {
+				required: true,
+				custom: requiredHostnameValidator(),
+			},
 		},
 		{
 			id: 'data',
@@ -19,6 +24,10 @@ export const NSRecordConfig: DnsRecordConfig = {
 			label: __( 'Host' ),
 			/* translators: This is a placeholder for a DNS NS record `data` property */
 			placeholder: __( 'e.g. ns1.your-provider.com' ),
+			isValid: {
+				required: true,
+				custom: domainValidator( 'NS', __( 'Please enter a valid host.' ) ),
+			},
 		},
 		{
 			id: 'ttl',
@@ -26,6 +35,10 @@ export const NSRecordConfig: DnsRecordConfig = {
 			label: __( 'TTL (time to live)' ),
 			/* translators: This is a placeholder for a DNS NS record `ttl` property */
 			placeholder: __( 'e.g. 3600' ),
+			isValid: {
+				required: true,
+				custom: ttlValidator(),
+			},
 		},
 	],
 	form: {

--- a/client/dashboard/domains/dns/records/ns-record.tsx
+++ b/client/dashboard/domains/dns/records/ns-record.tsx
@@ -1,6 +1,8 @@
 import { __ } from '@wordpress/i18n';
+import { getFieldWithDot, getNormalizedName } from '../utils';
 import { domainValidator, hostnameValidator, ttlValidator } from './validators';
 import type { DnsRecordFormData, DnsRecordConfig } from './dns-record-configs';
+import type { DnsRecordType } from '../../../data/domain-dns-records';
 
 export const NSRecordConfig: DnsRecordConfig = {
 	description: __(
@@ -45,15 +47,10 @@ export const NSRecordConfig: DnsRecordConfig = {
 		layout: { type: 'regular' as const },
 		fields: [ 'name', 'data', 'ttl' ],
 	},
-	transformData: ( data: DnsRecordFormData ) => {
-		// Remove trailing dot from the hostname
-		const hostName = data.data.endsWith( '.' ) ? data.data.slice( 0, -1 ) : data.data;
-
-		return {
-			type: 'NS',
-			name: data.name,
-			data: hostName + '.', // we're appending a dot to make the host name a FQDN
-			ttl: data.ttl,
-		};
-	},
+	transformData: ( data: DnsRecordFormData, domainName: string, type: DnsRecordType ) => ( {
+		type: 'NS',
+		name: getNormalizedName( data.name, type, domainName ),
+		data: getFieldWithDot( data.data ),
+		ttl: data.ttl,
+	} ),
 };

--- a/client/dashboard/domains/dns/records/ns-record.tsx
+++ b/client/dashboard/domains/dns/records/ns-record.tsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { domainValidator, requiredHostnameValidator, ttlValidator } from './validators';
+import { domainValidator, hostnameValidator, ttlValidator } from './validators';
 import type { DnsRecordFormData, DnsRecordConfig } from './dns-record-configs';
 
 export const NSRecordConfig: DnsRecordConfig = {
@@ -15,7 +15,7 @@ export const NSRecordConfig: DnsRecordConfig = {
 			placeholder: __( 'Enter subdomain' ),
 			isValid: {
 				required: true,
-				custom: requiredHostnameValidator(),
+				custom: hostnameValidator(),
 			},
 		},
 		{
@@ -26,7 +26,7 @@ export const NSRecordConfig: DnsRecordConfig = {
 			placeholder: __( 'e.g. ns1.your-provider.com' ),
 			isValid: {
 				required: true,
-				custom: domainValidator( 'NS', __( 'Please enter a valid host.' ) ),
+				custom: domainValidator( __( 'Please enter a valid host.' ) ),
 			},
 		},
 		{

--- a/client/dashboard/domains/dns/records/ns-record.tsx
+++ b/client/dashboard/domains/dns/records/ns-record.tsx
@@ -28,6 +28,7 @@ export const NSRecordConfig: DnsRecordConfig = {
 			placeholder: __( 'e.g. ns1.your-provider.com' ),
 			isValid: {
 				required: true,
+				/* translators: This is the error message when the `data` field of a DNS NS record is invalid */
 				custom: domainValidator( __( 'Please enter a valid host.' ) ),
 			},
 		},

--- a/client/dashboard/domains/dns/records/srv-record.tsx
+++ b/client/dashboard/domains/dns/records/srv-record.tsx
@@ -57,6 +57,7 @@ export const SRVRecordConfig: DnsRecordConfig = {
 			placeholder: __( 'e.g. 10' ),
 			isValid: {
 				required: true,
+				/* translators: This is the error message when the `aux` field of a DNS SRV record is invalid */
 				custom: numberRangeValidator( 0, 65535, __( 'Please enter a valid priority value.' ) ),
 			},
 		},
@@ -68,6 +69,7 @@ export const SRVRecordConfig: DnsRecordConfig = {
 			placeholder: __( 'e.g. 10' ),
 			isValid: {
 				required: true,
+				/* translators: This is the error message when the `weight` field of a DNS SRV record is invalid */
 				custom: numberRangeValidator( 0, 65535, __( 'Please enter a valid weight value.' ) ),
 			},
 		},
@@ -79,6 +81,7 @@ export const SRVRecordConfig: DnsRecordConfig = {
 			placeholder: __( 'e.g. sip.your-provider.com' ),
 			isValid: {
 				required: true,
+				/* translators: This is the error message when the `target` field of a DNS SRV record is invalid */
 				custom: domainValidator( __( 'Please enter a valid target host.' ) ),
 			},
 		},
@@ -90,6 +93,7 @@ export const SRVRecordConfig: DnsRecordConfig = {
 			placeholder: __( 'e.g. 5060' ),
 			isValid: {
 				required: true,
+				/* translators: This is the error message when the `port` field of a DNS SRV record is invalid */
 				custom: numberRangeValidator( 0, 65535, __( 'Please enter a valid port value.' ) ),
 			},
 		},

--- a/client/dashboard/domains/dns/records/srv-record.tsx
+++ b/client/dashboard/domains/dns/records/srv-record.tsx
@@ -1,9 +1,10 @@
 import { __ } from '@wordpress/i18n';
 import RequiredSelect from '../../../components/required-select';
 import {
+	domainValidator,
+	hostnameValidator,
 	numberRangeValidator,
-	optionalHostnameValidator,
-	requiredHostnameValidator,
+	serviceValidator,
 	ttlValidator,
 } from './validators';
 import type { DnsRecordFormData, DnsRecordConfig } from './dns-record-configs';
@@ -19,7 +20,7 @@ export const SRVRecordConfig: DnsRecordConfig = {
 			label: __( 'Name' ),
 			placeholder: __( 'Enter subdomain' ),
 			isValid: {
-				custom: optionalHostnameValidator(),
+				custom: hostnameValidator(),
 			},
 		},
 		{
@@ -30,6 +31,7 @@ export const SRVRecordConfig: DnsRecordConfig = {
 			placeholder: __( 'e.g. sip' ),
 			isValid: {
 				required: true,
+				custom: serviceValidator(),
 			},
 		},
 		{
@@ -75,7 +77,7 @@ export const SRVRecordConfig: DnsRecordConfig = {
 			placeholder: __( 'e.g. sip.your-provider.com' ),
 			isValid: {
 				required: true,
-				custom: requiredHostnameValidator( __( 'Please enter a valid target host.' ) ),
+				custom: domainValidator( __( 'Please enter a valid target host.' ) ),
 			},
 		},
 		{

--- a/client/dashboard/domains/dns/records/srv-record.tsx
+++ b/client/dashboard/domains/dns/records/srv-record.tsx
@@ -1,5 +1,11 @@
 import { __ } from '@wordpress/i18n';
 import RequiredSelect from '../../../components/required-select';
+import {
+	numberRangeValidator,
+	optionalHostnameValidator,
+	requiredHostnameValidator,
+	ttlValidator,
+} from './validators';
 import type { DnsRecordFormData, DnsRecordConfig } from './dns-record-configs';
 
 export const SRVRecordConfig: DnsRecordConfig = {
@@ -10,8 +16,11 @@ export const SRVRecordConfig: DnsRecordConfig = {
 		{
 			id: 'name',
 			type: 'text',
-			label: __( 'Name (optional)' ),
+			label: __( 'Name' ),
 			placeholder: __( 'Enter subdomain' ),
+			isValid: {
+				custom: optionalHostnameValidator(),
+			},
 		},
 		{
 			id: 'service',
@@ -19,6 +28,9 @@ export const SRVRecordConfig: DnsRecordConfig = {
 			label: __( 'Service' ),
 			/* translators: This is a placeholder for a DNS SRV record `service` property */
 			placeholder: __( 'e.g. sip' ),
+			isValid: {
+				required: true,
+			},
 		},
 		{
 			id: 'protocol',
@@ -29,6 +41,9 @@ export const SRVRecordConfig: DnsRecordConfig = {
 				{ label: '_udp', value: '_udp' },
 				{ label: '_tls', value: '_tls' },
 			],
+			isValid: {
+				required: true,
+			},
 		},
 		{
 			id: 'aux',
@@ -36,6 +51,10 @@ export const SRVRecordConfig: DnsRecordConfig = {
 			label: __( 'Priority' ),
 			/* translators: This is a placeholder for a DNS SRV record `priority` property */
 			placeholder: __( 'e.g. 10' ),
+			isValid: {
+				required: true,
+				custom: numberRangeValidator( 0, 65535, __( 'Please enter a valid priority value.' ) ),
+			},
 		},
 		{
 			id: 'weight',
@@ -43,6 +62,10 @@ export const SRVRecordConfig: DnsRecordConfig = {
 			label: __( 'Weight' ),
 			/* translators: This is a placeholder for a DNS SRV record `weight` property */
 			placeholder: __( 'e.g. 10' ),
+			isValid: {
+				required: true,
+				custom: numberRangeValidator( 0, 65535, __( 'Please enter a valid weight value.' ) ),
+			},
 		},
 		{
 			id: 'target',
@@ -50,6 +73,10 @@ export const SRVRecordConfig: DnsRecordConfig = {
 			label: __( 'Target host' ),
 			/* translators: This is a placeholder for a DNS SRV record `target` property */
 			placeholder: __( 'e.g. sip.your-provider.com' ),
+			isValid: {
+				required: true,
+				custom: requiredHostnameValidator( __( 'Please enter a valid target host.' ) ),
+			},
 		},
 		{
 			id: 'port',
@@ -57,6 +84,10 @@ export const SRVRecordConfig: DnsRecordConfig = {
 			label: __( 'Target port' ),
 			/* translators: This is a placeholder for a DNS SRV record `port` property */
 			placeholder: __( 'e.g. 5060' ),
+			isValid: {
+				required: true,
+				custom: numberRangeValidator( 0, 65535, __( 'Please enter a valid port value.' ) ),
+			},
 		},
 		{
 			id: 'ttl',
@@ -64,6 +95,10 @@ export const SRVRecordConfig: DnsRecordConfig = {
 			label: __( 'TTL (time to live)' ),
 			/* translators: This is a placeholder for a DNS SRV record `ttl` property */
 			placeholder: __( 'e.g. 3600' ),
+			isValid: {
+				required: true,
+				custom: ttlValidator(),
+			},
 		},
 	],
 	form: {

--- a/client/dashboard/domains/dns/records/srv-record.tsx
+++ b/client/dashboard/domains/dns/records/srv-record.tsx
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import RequiredSelect from '../../../components/required-select';
+import { getFieldWithDot, getNormalizedName } from '../utils';
 import {
 	domainValidator,
 	hostnameValidator,
@@ -8,6 +9,7 @@ import {
 	ttlValidator,
 } from './validators';
 import type { DnsRecordFormData, DnsRecordConfig } from './dns-record-configs';
+import type { DnsRecordType } from '../../../data/domain-dns-records';
 
 export const SRVRecordConfig: DnsRecordConfig = {
 	description: __(
@@ -107,20 +109,15 @@ export const SRVRecordConfig: DnsRecordConfig = {
 		layout: { type: 'regular' as const },
 		fields: [ 'name', 'service', 'protocol', 'aux', 'weight', 'target', 'port', 'ttl' ],
 	},
-	transformData: ( data: DnsRecordFormData ) => {
-		// Remove trailing dot from the hostname
-		const target = data.target.endsWith( '.' ) ? data.target.slice( 0, -1 ) : data.target;
-
-		return {
-			type: 'SRV',
-			name: data.name,
-			service: data.service,
-			aux: data.aux,
-			weight: data.weight,
-			target: target + '.', // we're appending a dot to make the host name a FQDN
-			port: data.port,
-			protocol: data.protocol,
-			ttl: data.ttl,
-		};
-	},
+	transformData: ( data: DnsRecordFormData, domainName: string, type: DnsRecordType ) => ( {
+		type: 'SRV',
+		name: getNormalizedName( data.name, type, domainName ),
+		service: data.service,
+		aux: data.aux,
+		weight: data.weight,
+		target: getFieldWithDot( data.target ),
+		port: data.port,
+		protocol: data.protocol,
+		ttl: data.ttl,
+	} ),
 };

--- a/client/dashboard/domains/dns/records/txt-record.tsx
+++ b/client/dashboard/domains/dns/records/txt-record.tsx
@@ -1,5 +1,6 @@
 import { TextareaControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { optionalHostnameValidator, ttlValidator } from './validators';
 import type { DnsRecordFormData, DnsRecordConfig } from './dns-record-configs';
 
 export const TXTRecordConfig: DnsRecordConfig = {
@@ -10,9 +11,12 @@ export const TXTRecordConfig: DnsRecordConfig = {
 		{
 			id: 'name',
 			type: 'text',
-			label: __( 'Name (optional)' ),
+			label: __( 'Name' ),
 			/* translators: This is a placeholder for a DNS TXT record `name` property */
 			placeholder: __( 'Enter subdomain' ),
+			isValid: {
+				custom: optionalHostnameValidator(),
+			},
 		},
 		{
 			id: 'data',
@@ -33,6 +37,9 @@ export const TXTRecordConfig: DnsRecordConfig = {
 					/>
 				);
 			},
+			isValid: {
+				required: true,
+			},
 		},
 		{
 			id: 'ttl',
@@ -40,6 +47,10 @@ export const TXTRecordConfig: DnsRecordConfig = {
 			label: __( 'TTL (time to live)' ),
 			/* translators: This is a placeholder for a DNS TXT record `ttl` property */
 			placeholder: __( 'e.g. 3600' ),
+			isValid: {
+				required: true,
+				custom: ttlValidator(),
+			},
 		},
 	],
 	form: {

--- a/client/dashboard/domains/dns/records/txt-record.tsx
+++ b/client/dashboard/domains/dns/records/txt-record.tsx
@@ -1,6 +1,6 @@
 import { TextareaControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { optionalHostnameValidator, ttlValidator } from './validators';
+import { hostnameValidator, stringLengthValidator, ttlValidator } from './validators';
 import type { DnsRecordFormData, DnsRecordConfig } from './dns-record-configs';
 
 export const TXTRecordConfig: DnsRecordConfig = {
@@ -15,7 +15,7 @@ export const TXTRecordConfig: DnsRecordConfig = {
 			/* translators: This is a placeholder for a DNS TXT record `name` property */
 			placeholder: __( 'Enter subdomain' ),
 			isValid: {
-				custom: optionalHostnameValidator(),
+				custom: hostnameValidator(),
 			},
 		},
 		{
@@ -39,6 +39,7 @@ export const TXTRecordConfig: DnsRecordConfig = {
 			},
 			isValid: {
 				required: true,
+				custom: stringLengthValidator(),
 			},
 		},
 		{

--- a/client/dashboard/domains/dns/records/txt-record.tsx
+++ b/client/dashboard/domains/dns/records/txt-record.tsx
@@ -1,7 +1,9 @@
 import { TextareaControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { getNormalizedName } from '../utils';
 import { hostnameValidator, stringLengthValidator, ttlValidator } from './validators';
 import type { DnsRecordFormData, DnsRecordConfig } from './dns-record-configs';
+import type { DnsRecordType } from '../../../data/domain-dns-records';
 
 export const TXTRecordConfig: DnsRecordConfig = {
 	description: __(
@@ -58,9 +60,9 @@ export const TXTRecordConfig: DnsRecordConfig = {
 		layout: { type: 'regular' as const },
 		fields: [ 'name', 'data', 'ttl' ],
 	},
-	transformData: ( data: DnsRecordFormData ) => ( {
+	transformData: ( data: DnsRecordFormData, domainName: string, type: DnsRecordType ) => ( {
 		type: 'TXT',
-		name: data.name,
+		name: getNormalizedName( data.name, type, domainName ),
 		data: data.data,
 		ttl: data.ttl,
 	} ),

--- a/client/dashboard/domains/dns/records/validators.ts
+++ b/client/dashboard/domains/dns/records/validators.ts
@@ -3,68 +3,74 @@ import { __ } from '@wordpress/i18n';
 import type { DnsRecordFormData } from './dns-record-configs';
 import type { DnsRecordType } from '../../../data/domain-dns-records';
 
-const isValidHostname = ( value: string ): boolean => {
-	return /^([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)*[a-z0-9]([a-z0-9-]*[a-z0-9])?$/i.test( value );
+/**
+ * Check if the provided name is the root domain name
+ *
+ * @param name - The name to check
+ * @param domainName - The domain name
+ * @returns True if the name is the root domain name, false otherwise
+ */
+const isRootDomain = ( name: string, domainName: string ): boolean => {
+	if ( name === '' ) {
+		return true;
+	}
+
+	const rootDomainVariations = [
+		'@',
+		domainName,
+		domainName + '.',
+		'@.' + domainName,
+		'@.' + domainName + '.',
+	];
+	return rootDomainVariations.includes( name );
 };
 
-// const isRootDomain = ( name: string, domainName: string ): boolean => {
-// 	const rootDomainVariations = [
-// 		'@',
-// 		domainName,
-// 		domainName + '.',
-// 		'@.' + domainName,
-// 		'@.' + domainName + '.',
-// 	];
-// 	return ! name || rootDomainVariations.includes( name );
-// };
+/**
+ * Check if the DNS record type supports a root domain `name` value
+ *
+ * @param type - The DNS record type
+ * @returns True if the record type supports a root domain `name`, false otherwise
+ */
+const isRootDomainNameSupported = ( type: DnsRecordType ): boolean => {
+	// TODO: Root NS records can be edited only for subdomains, but we don't have the domain object here.
+	// It's not reliable to determine whether a domain is a subdomain in the frontend, so we'll need
+	// to get this information from the backend.
+	return [ 'A', 'AAAA', 'ALIAS', 'CAA', 'MX', 'SRV', 'TXT' ].includes( type );
+};
 
-// const canBeRootDomain = ( type: DnsRecordType, domain: string ): boolean => {
-// 	// Root NS records can be edited only for subdomains
-// 	if ( type === 'NS' && domain?.isSubdomain ) {
-// 		return true;
-// 	}
+/**
+ * Check if the provided `name` is a valid hostname according to the record type
+ *
+ * @param name - The name of the DNS record
+ * @param type - The type of the DNS record
+ * @param domainName - The domain name
+ * @returns True if the name is valid, false otherwise
+ */
+const isValidName = ( name: string, type: DnsRecordType, domainName: string ): boolean => {
+	if ( isRootDomain( name, domainName ) && isRootDomainNameSupported( type ) ) {
+		return true;
+	}
 
-// 	return [ 'A', 'AAAA', 'ALIAS', 'CAA', 'MX', 'SRV', 'TXT' ].includes( type );
-// };
+	switch ( type ) {
+		case 'A':
+		case 'AAAA':
+			return /^([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)*[a-z0-9]([a-z0-9-]*[a-z0-9])?$/i.test( name );
+		case 'CNAME':
+			return /^([a-z0-9-_]{1,63}\.)*([a-z0-9-_]{1,63})$/i.test( name ) || name === '*';
+		case 'TXT':
+			return /^(\*\.|)([a-z0-9-_]{1,63}\.)*([a-z0-9-_]{1,63})$/i.test( name );
+		default:
+			return /^([a-z0-9-_]{1,63}\.)*([a-z0-9-_]{1,63})$/i.test( name );
+	}
+};
 
-// const isValidName = (
-// 	name: string,
-// 	type: DnsRecordType,
-// 	domainName: string,
-// 	domain: string
-// ): boolean => {
-// 	if ( isRootDomain( name, domainName ) && canBeRootDomain( type, domain ) ) {
-// 		return true;
-// 	}
-
-// 	switch ( type ) {
-// 		case 'A':
-// 		case 'AAAA':
-// 			return /^([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)*[a-z0-9]([a-z0-9-]*[a-z0-9])?$/i.test( name );
-// 		case 'CNAME':
-// 			return /^([a-z0-9-_]{1,63}\.)*([a-z0-9-_]{1,63})$/i.test( name ) || name === '*';
-// 		case 'TXT':
-// 			return /^(\*\.|)([a-z0-9-_]{1,63}\.)*([a-z0-9-_]{1,63})$/i.test( name );
-// 		default:
-// 			return /^([a-z0-9-_]{1,63}\.)*([a-z0-9-_]{1,63})$/i.test( name );
-// 	}
-// };
-
-export const requiredHostnameValidator =
+export const hostnameValidator =
 	( errorMessage: string = __( 'Please enter a valid name.' ) ) =>
 	( formData: DnsRecordFormData, field: NormalizedField< DnsRecordFormData > ) => {
 		const value = formData[ field.id as keyof DnsRecordFormData ] as string;
-		return isValidHostname( value ) ? null : errorMessage;
-	};
-
-export const optionalHostnameValidator =
-	( errorMessage: string = __( 'Please enter a valid name.' ) ) =>
-	( formData: DnsRecordFormData, field: NormalizedField< DnsRecordFormData > ) => {
-		const value = formData[ field.id as keyof DnsRecordFormData ] as string;
-		if ( value === '' ) {
-			return null;
-		}
-		return isValidHostname( value ) ? null : errorMessage;
+		const type = formData.type;
+		const domain = formData.domain;
+		return isValidName( value, type, domain ) ? null : errorMessage;
 	};
 
 const isValidIPv4 = ( value: string ): boolean => {
@@ -111,9 +117,10 @@ const isValidDomain = ( value: string, recordType: DnsRecordType ): boolean => {
 };
 
 export const domainValidator =
-	( recordType: DnsRecordType, errorMessage: string = __( 'Please enter a valid domain.' ) ) =>
+	( errorMessage: string = __( 'Please enter a valid domain.' ) ) =>
 	( formData: DnsRecordFormData, field: NormalizedField< DnsRecordFormData > ) => {
 		const value = formData[ field.id as keyof DnsRecordFormData ] as string;
+		const recordType = formData.type;
 		return isValidDomain( value, recordType ) ? null : errorMessage;
 	};
 
@@ -124,5 +131,27 @@ export const numberRangeValidator =
 		return min <= value && value <= max ? null : errorMessage;
 	};
 
-export const ttlValidator = () =>
-	numberRangeValidator( 300, 86400, __( 'Please enter a TTL value between 300 and 86400.' ) );
+export const ttlValidator = () => {
+	return numberRangeValidator(
+		300,
+		86400,
+		__( 'Please enter a TTL value between 300 and 86400.' )
+	);
+};
+
+export const stringLengthValidator =
+	( errorMessage: string = __( 'Please enter a string between 0 and 2048 characters.' ) ) =>
+	( formData: DnsRecordFormData, field: NormalizedField< DnsRecordFormData > ) => {
+		const value = formData[ field.id as keyof DnsRecordFormData ] as string;
+		return 0 < value.length && value.length <= 2048 ? null : errorMessage;
+	};
+
+/**
+ * Checks if the provided `value` doesn't start with a space or a dot
+ */
+export const serviceValidator =
+	( errorMessage: string = __( 'Please enter a value.' ) ) =>
+	( formData: DnsRecordFormData, field: NormalizedField< DnsRecordFormData > ) => {
+		const value = formData[ field.id as keyof DnsRecordFormData ] as string;
+		return /^[^\s.]+$/.test( value ) ? null : errorMessage;
+	};

--- a/client/dashboard/domains/dns/records/validators.ts
+++ b/client/dashboard/domains/dns/records/validators.ts
@@ -1,0 +1,128 @@
+import { NormalizedField } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import type { DnsRecordFormData } from './dns-record-configs';
+import type { DnsRecordType } from '../../../data/domain-dns-records';
+
+const isValidHostname = ( value: string ): boolean => {
+	return /^([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)*[a-z0-9]([a-z0-9-]*[a-z0-9])?$/i.test( value );
+};
+
+// const isRootDomain = ( name: string, domainName: string ): boolean => {
+// 	const rootDomainVariations = [
+// 		'@',
+// 		domainName,
+// 		domainName + '.',
+// 		'@.' + domainName,
+// 		'@.' + domainName + '.',
+// 	];
+// 	return ! name || rootDomainVariations.includes( name );
+// };
+
+// const canBeRootDomain = ( type: DnsRecordType, domain: string ): boolean => {
+// 	// Root NS records can be edited only for subdomains
+// 	if ( type === 'NS' && domain?.isSubdomain ) {
+// 		return true;
+// 	}
+
+// 	return [ 'A', 'AAAA', 'ALIAS', 'CAA', 'MX', 'SRV', 'TXT' ].includes( type );
+// };
+
+// const isValidName = (
+// 	name: string,
+// 	type: DnsRecordType,
+// 	domainName: string,
+// 	domain: string
+// ): boolean => {
+// 	if ( isRootDomain( name, domainName ) && canBeRootDomain( type, domain ) ) {
+// 		return true;
+// 	}
+
+// 	switch ( type ) {
+// 		case 'A':
+// 		case 'AAAA':
+// 			return /^([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)*[a-z0-9]([a-z0-9-]*[a-z0-9])?$/i.test( name );
+// 		case 'CNAME':
+// 			return /^([a-z0-9-_]{1,63}\.)*([a-z0-9-_]{1,63})$/i.test( name ) || name === '*';
+// 		case 'TXT':
+// 			return /^(\*\.|)([a-z0-9-_]{1,63}\.)*([a-z0-9-_]{1,63})$/i.test( name );
+// 		default:
+// 			return /^([a-z0-9-_]{1,63}\.)*([a-z0-9-_]{1,63})$/i.test( name );
+// 	}
+// };
+
+export const requiredHostnameValidator =
+	( errorMessage: string = __( 'Please enter a valid name.' ) ) =>
+	( formData: DnsRecordFormData, field: NormalizedField< DnsRecordFormData > ) => {
+		const value = formData[ field.id as keyof DnsRecordFormData ] as string;
+		return isValidHostname( value ) ? null : errorMessage;
+	};
+
+export const optionalHostnameValidator =
+	( errorMessage: string = __( 'Please enter a valid name.' ) ) =>
+	( formData: DnsRecordFormData, field: NormalizedField< DnsRecordFormData > ) => {
+		const value = formData[ field.id as keyof DnsRecordFormData ] as string;
+		if ( value === '' ) {
+			return null;
+		}
+		return isValidHostname( value ) ? null : errorMessage;
+	};
+
+const isValidIPv4 = ( value: string ): boolean => {
+	return (
+		/^(\d{1,3}\.){3}\d{1,3}$/.test( value ) &&
+		value.split( '.' ).every( ( octet ) => {
+			const num = parseInt( octet, 10 );
+			return num >= 0 && num <= 255;
+		} )
+	);
+};
+
+export const ipv4Validator =
+	( errorMessage: string = __( 'Please enter a valid IPv4 address.' ) ) =>
+	( formData: DnsRecordFormData, field: NormalizedField< DnsRecordFormData > ) => {
+		const value = formData[ field.id as keyof DnsRecordFormData ] as string;
+		return isValidIPv4( value ) ? null : errorMessage;
+	};
+
+const isValidIPv6 = ( value: string ): boolean => {
+	// TODO: This was copied from `client/state/domains/dns/utils.js`, but I don't think this is correct
+	return /^[a-f0-9:]+$/i.test( value );
+};
+
+export const ipv6Validator =
+	( errorMessage: string = __( 'Please enter a valid IPv6 address.' ) ) =>
+	( formData: DnsRecordFormData, field: NormalizedField< DnsRecordFormData > ) => {
+		const value = formData[ field.id as keyof DnsRecordFormData ] as string;
+		return isValidIPv6( value ) ? null : errorMessage;
+	};
+
+const isValidDomain = ( value: string, recordType: DnsRecordType ): boolean => {
+	const maxLength = value.endsWith( '.' ) ? 254 : 253;
+
+	if ( value.length > maxLength ) {
+		return false;
+	}
+
+	if ( recordType === 'SRV' && value === '.' ) {
+		return true;
+	}
+
+	return /^([a-z0-9-_]{1,63}\.)*[a-z0-9-]{1,63}\.[a-z]{2,63}(\.)?$/i.test( value );
+};
+
+export const domainValidator =
+	( recordType: DnsRecordType, errorMessage: string = __( 'Please enter a valid domain.' ) ) =>
+	( formData: DnsRecordFormData, field: NormalizedField< DnsRecordFormData > ) => {
+		const value = formData[ field.id as keyof DnsRecordFormData ] as string;
+		return isValidDomain( value, recordType ) ? null : errorMessage;
+	};
+
+export const numberRangeValidator =
+	( min: number, max: number, errorMessage: string ) =>
+	( formData: DnsRecordFormData, field: NormalizedField< DnsRecordFormData > ) => {
+		const value = formData[ field.id as keyof DnsRecordFormData ] as number;
+		return min <= value && value <= max ? null : errorMessage;
+	};
+
+export const ttlValidator = () =>
+	numberRangeValidator( 300, 86400, __( 'Please enter a TTL value between 300 and 86400.' ) );

--- a/client/dashboard/domains/dns/records/validators.ts
+++ b/client/dashboard/domains/dns/records/validators.ts
@@ -30,14 +30,15 @@ const isValidName = ( name: string, type: DnsRecordType, domainName: string ): b
 	}
 };
 
-export const hostnameValidator =
-	( errorMessage: string = __( 'Please enter a valid name.' ) ) =>
-	( formData: DnsRecordFormData, field: NormalizedField< DnsRecordFormData > ) => {
+/* translators: This is the error message when the `name` field of a DNS record is invalid */
+export const hostnameValidator = ( errorMessage: string = __( 'Please enter a valid name.' ) ) => {
+	return ( formData: DnsRecordFormData, field: NormalizedField< DnsRecordFormData > ) => {
 		const value = formData[ field.id as keyof DnsRecordFormData ] as string;
 		const type = formData.type;
 		const domain = formData.domain;
 		return isValidName( value, type, domain ) ? null : errorMessage;
 	};
+};
 
 const isValidIPv4 = ( value: string ): boolean => {
 	return (
@@ -49,24 +50,30 @@ const isValidIPv4 = ( value: string ): boolean => {
 	);
 };
 
-export const ipv4Validator =
-	( errorMessage: string = __( 'Please enter a valid IPv4 address.' ) ) =>
-	( formData: DnsRecordFormData, field: NormalizedField< DnsRecordFormData > ) => {
+export const ipv4Validator = (
+	/* translators: This is the error message when the `data` field of a DNS A record is invalid */
+	errorMessage: string = __( 'Please enter a valid IPv4 address.' )
+) => {
+	return ( formData: DnsRecordFormData, field: NormalizedField< DnsRecordFormData > ) => {
 		const value = formData[ field.id as keyof DnsRecordFormData ] as string;
 		return isValidIPv4( value ) ? null : errorMessage;
 	};
+};
 
 const isValidIPv6 = ( value: string ): boolean => {
 	// TODO: This was copied from `client/state/domains/dns/utils.js`, but I don't think this is correct
 	return /^[a-f0-9:]+$/i.test( value );
 };
 
-export const ipv6Validator =
-	( errorMessage: string = __( 'Please enter a valid IPv6 address.' ) ) =>
-	( formData: DnsRecordFormData, field: NormalizedField< DnsRecordFormData > ) => {
+export const ipv6Validator = (
+	/* translators: This is the error message when the `data` field of a DNS AAAA record is invalid */
+	errorMessage: string = __( 'Please enter a valid IPv6 address.' )
+) => {
+	return ( formData: DnsRecordFormData, field: NormalizedField< DnsRecordFormData > ) => {
 		const value = formData[ field.id as keyof DnsRecordFormData ] as string;
 		return isValidIPv6( value ) ? null : errorMessage;
 	};
+};
 
 const isValidDomain = ( value: string, recordType: DnsRecordType ): boolean => {
 	const maxLength = value.endsWith( '.' ) ? 254 : 253;
@@ -82,13 +89,13 @@ const isValidDomain = ( value: string, recordType: DnsRecordType ): boolean => {
 	return /^([a-z0-9-_]{1,63}\.)*[a-z0-9-]{1,63}\.[a-z]{2,63}(\.)?$/i.test( value );
 };
 
-export const domainValidator =
-	( errorMessage: string = __( 'Please enter a valid domain.' ) ) =>
-	( formData: DnsRecordFormData, field: NormalizedField< DnsRecordFormData > ) => {
+export const domainValidator = ( errorMessage: string ) => {
+	return ( formData: DnsRecordFormData, field: NormalizedField< DnsRecordFormData > ) => {
 		const value = formData[ field.id as keyof DnsRecordFormData ] as string;
 		const recordType = formData.type;
 		return isValidDomain( value, recordType ) ? null : errorMessage;
 	};
+};
 
 export const numberRangeValidator =
 	( min: number, max: number, errorMessage: string ) =>
@@ -101,25 +108,30 @@ export const ttlValidator = () => {
 	return numberRangeValidator(
 		300,
 		86400,
+		/* translators: This is the error message when the `ttl` field of a DNS record is invalid */
 		__( 'Please enter a TTL value between 300 and 86400.' )
 	);
 };
 
-export const stringLengthValidator =
-	( errorMessage: string = __( 'Please enter a string between 0 and 2048 characters.' ) ) =>
-	( formData: DnsRecordFormData, field: NormalizedField< DnsRecordFormData > ) => {
+export const stringLengthValidator = (
+	/* translators: This is the error message when the `data` field of a DNS CAA or TXT record is invalid */
+	errorMessage: string = __( 'Please enter a string between 0 and 2048 characters.' )
+) => {
+	return ( formData: DnsRecordFormData, field: NormalizedField< DnsRecordFormData > ) => {
 		const value = formData[ field.id as keyof DnsRecordFormData ] as string;
 		return 0 < value.length && value.length <= 2048 ? null : errorMessage;
 	};
+};
 
 /**
- * Checks if the provided `value` starts with a space or a dot
+ * Checks if the provided value starts with a space or a dot
  *
  * This is used to validate the `service` field of an SRV record.
  */
-export const serviceValidator =
-	( errorMessage: string = __( 'Please enter a value.' ) ) =>
-	( formData: DnsRecordFormData, field: NormalizedField< DnsRecordFormData > ) => {
+/* translators: This is the error message when the `service` field of a DNS SRV record is invalid */
+export const serviceValidator = ( errorMessage: string = __( 'Please enter a value.' ) ) => {
+	return ( formData: DnsRecordFormData, field: NormalizedField< DnsRecordFormData > ) => {
 		const value = formData[ field.id as keyof DnsRecordFormData ] as string;
 		return /^[^\s.]+$/.test( value ) ? null : errorMessage;
 	};
+};

--- a/client/dashboard/domains/dns/records/validators.ts
+++ b/client/dashboard/domains/dns/records/validators.ts
@@ -1,42 +1,8 @@
 import { NormalizedField } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
+import { isRootDomain, isRootDomainNameSupported } from '../utils';
 import type { DnsRecordFormData } from './dns-record-configs';
 import type { DnsRecordType } from '../../../data/domain-dns-records';
-
-/**
- * Check if the provided name is the root domain name
- *
- * @param name - The name to check
- * @param domainName - The domain name
- * @returns True if the name is the root domain name, false otherwise
- */
-const isRootDomain = ( name: string, domainName: string ): boolean => {
-	if ( name === '' ) {
-		return true;
-	}
-
-	const rootDomainVariations = [
-		'@',
-		domainName,
-		domainName + '.',
-		'@.' + domainName,
-		'@.' + domainName + '.',
-	];
-	return rootDomainVariations.includes( name );
-};
-
-/**
- * Check if the DNS record type supports a root domain `name` value
- *
- * @param type - The DNS record type
- * @returns True if the record type supports a root domain `name`, false otherwise
- */
-const isRootDomainNameSupported = ( type: DnsRecordType ): boolean => {
-	// TODO: Root NS records can be edited only for subdomains, but we don't have the domain object here.
-	// It's not reliable to determine whether a domain is a subdomain in the frontend, so we'll need
-	// to get this information from the backend.
-	return [ 'A', 'AAAA', 'ALIAS', 'CAA', 'MX', 'SRV', 'TXT' ].includes( type );
-};
 
 /**
  * Check if the provided `name` is a valid hostname according to the record type

--- a/client/dashboard/domains/dns/records/validators.ts
+++ b/client/dashboard/domains/dns/records/validators.ts
@@ -1,6 +1,6 @@
 import { NormalizedField } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { isRootDomain, isRootDomainNameSupported } from '../utils';
+import { isRootDomainNameSupported } from '../utils';
 import type { DnsRecordFormData } from './dns-record-configs';
 import type { DnsRecordType } from '../../../data/domain-dns-records';
 
@@ -13,7 +13,7 @@ import type { DnsRecordType } from '../../../data/domain-dns-records';
  * @returns True if the name is valid, false otherwise
  */
 const isValidName = ( name: string, type: DnsRecordType, domainName: string ): boolean => {
-	if ( isRootDomain( name, domainName ) && isRootDomainNameSupported( type ) ) {
+	if ( isRootDomainNameSupported( name, type, domainName ) ) {
 		return true;
 	}
 
@@ -113,7 +113,9 @@ export const stringLengthValidator =
 	};
 
 /**
- * Checks if the provided `value` doesn't start with a space or a dot
+ * Checks if the provided `value` starts with a space or a dot
+ *
+ * This is used to validate the `service` field of an SRV record.
  */
 export const serviceValidator =
 	( errorMessage: string = __( 'Please enter a value.' ) ) =>

--- a/client/dashboard/domains/dns/utils.ts
+++ b/client/dashboard/domains/dns/utils.ts
@@ -110,6 +110,12 @@ export const getProcessedRecord = ( record: DnsRecord ): DnsRecord => {
 		record.data = record.data ? record.data.replace( /\.$/, '' ) : '';
 	}
 
+	// The `data` property for CAA records contains `flags`, `tag` and `value`,
+	// and we want to show only the `value` for the user
+	if ( record.type === 'CAA' ) {
+		record.data = record.value;
+	}
+
 	// Make sure we can handle protocols with and without a leading underscore
 	if ( record.type === 'SRV' && record.protocol !== undefined ) {
 		record.protocol = record.protocol.replace( /^_*/, '_' );

--- a/client/dashboard/domains/dns/utils.ts
+++ b/client/dashboard/domains/dns/utils.ts
@@ -3,11 +3,14 @@ import type { DnsRecord, DnsRecordType } from '../../data/domain-dns-records';
 /**
  * Check if the provided name is the root domain name
  *
+ * This checks a few different variations of the root domain name, such as
+ * `@`, `@.example.com`, `@.example.com.`, `example.com` and `example.com.`.
+ *
  * @param name - The name to check
  * @param domainName - The domain name
  * @returns True if the name is the root domain name, false otherwise
  */
-export const isRootDomain = ( name: string, domainName: string ): boolean => {
+const isRootDomainName = ( name: string, domainName: string ): boolean => {
 	if ( name === '' ) {
 		return true;
 	}
@@ -28,34 +31,75 @@ export const isRootDomain = ( name: string, domainName: string ): boolean => {
  * @param type - The DNS record type
  * @returns True if the record type supports a root domain `name`, false otherwise
  */
-export const isRootDomainNameSupported = ( type: DnsRecordType ): boolean => {
+const doesRecordTypeSupportRootDomainName = ( type: DnsRecordType ): boolean => {
 	// TODO: Root NS records can be edited only for subdomains, but we don't have the domain object here.
 	// It's not reliable to determine whether a domain is a subdomain in the frontend, so we'll need
 	// to get this information from the backend.
 	return [ 'A', 'AAAA', 'ALIAS', 'CAA', 'MX', 'SRV', 'TXT' ].includes( type );
 };
 
-export const getFieldWithDot = ( field: string ) => {
-	// something that looks like domain but doesn't end with a dot
-	return typeof field === 'string' && field.match( /^([a-z0-9-_]+\.)+\.?[a-z]+$/i )
-		? field + '.'
-		: field;
+/**
+ * Check if the provided name is the root domain name and the record type supports those
+ *
+ * @param name - The name of the DNS record
+ * @param type - The type of the DNS record
+ * @param domainName - The domain name
+ * @returns True if the name is the root domain name and the record type supports it, false otherwise
+ */
+export const isRootDomainNameSupported = (
+	name: string,
+	type: DnsRecordType,
+	domainName: string
+): boolean => {
+	return isRootDomainName( name, domainName ) && doesRecordTypeSupportRootDomainName( type );
 };
 
-export const getNormalizedName = ( name: string, type: DnsRecordType, domainName: string ) => {
-	const endsWithDomain = name.endsWith( '.' + domainName );
+/**
+ * Add a dot to the end of the field if it doesn't have one to make it a FQDN
+ *
+ * @param field - The field to add a dot to
+ * @returns The field with a dot
+ */
+export const getFieldWithDot = ( field: string ) => {
+	if ( field.endsWith( '.' ) ) {
+		return field;
+	}
+	return field + '.';
+};
 
-	if ( isRootDomain( name, domainName ) && isRootDomainNameSupported( type ) ) {
+/**
+ * Normalizes the `name` field of a DNS record
+ *
+ * This is done before persisting a DNS record.
+ * For example, if the `name` field is `@`, it will be normalized to `example.com.`.
+ *
+ * @param name - The `name` field of the DNS record
+ * @param type - The type of the DNS record
+ * @param domainName - The domain name
+ * @returns The normalized `name` field
+ */
+export const getNormalizedName = ( name: string, type: DnsRecordType, domainName: string ) => {
+	if ( isRootDomainNameSupported( name, type, domainName ) ) {
 		return domainName + '.';
 	}
 
-	if ( endsWithDomain ) {
+	// If `name` is a subdomain, e.g. `www.example.com`, return only `www`
+	if ( name.endsWith( '.' + domainName ) ) {
 		return name.replace( new RegExp( '\\.+' + domainName + '\\.?$', 'i' ), '' );
 	}
 
 	return name;
 };
 
+/**
+ * Processes the record data to show it in a more readable format
+ *
+ * This is done after loading a DNS record from the backend.
+ * For example, `name` fields that are the root domain name are replaced with an empty string.
+ *
+ * @param record
+ * @returns
+ */
 export const getProcessedRecord = ( record: DnsRecord ): DnsRecord => {
 	const isRootDomainRecord = record.name === `${ record.domain }.`;
 	if ( isRootDomainRecord ) {

--- a/client/dashboard/domains/dns/utils.ts
+++ b/client/dashboard/domains/dns/utils.ts
@@ -1,0 +1,81 @@
+import type { DnsRecord, DnsRecordType } from '../../data/domain-dns-records';
+
+/**
+ * Check if the provided name is the root domain name
+ *
+ * @param name - The name to check
+ * @param domainName - The domain name
+ * @returns True if the name is the root domain name, false otherwise
+ */
+export const isRootDomain = ( name: string, domainName: string ): boolean => {
+	if ( name === '' ) {
+		return true;
+	}
+
+	const rootDomainVariations = [
+		'@',
+		domainName,
+		domainName + '.',
+		'@.' + domainName,
+		'@.' + domainName + '.',
+	];
+	return rootDomainVariations.includes( name );
+};
+
+/**
+ * Check if the DNS record type supports a root domain `name` value
+ *
+ * @param type - The DNS record type
+ * @returns True if the record type supports a root domain `name`, false otherwise
+ */
+export const isRootDomainNameSupported = ( type: DnsRecordType ): boolean => {
+	// TODO: Root NS records can be edited only for subdomains, but we don't have the domain object here.
+	// It's not reliable to determine whether a domain is a subdomain in the frontend, so we'll need
+	// to get this information from the backend.
+	return [ 'A', 'AAAA', 'ALIAS', 'CAA', 'MX', 'SRV', 'TXT' ].includes( type );
+};
+
+export const getFieldWithDot = ( field: string ) => {
+	// something that looks like domain but doesn't end with a dot
+	return typeof field === 'string' && field.match( /^([a-z0-9-_]+\.)+\.?[a-z]+$/i )
+		? field + '.'
+		: field;
+};
+
+export const getNormalizedName = ( name: string, type: DnsRecordType, domainName: string ) => {
+	const endsWithDomain = name.endsWith( '.' + domainName );
+
+	if ( isRootDomain( name, domainName ) && isRootDomainNameSupported( type ) ) {
+		return domainName + '.';
+	}
+
+	if ( endsWithDomain ) {
+		return name.replace( new RegExp( '\\.+' + domainName + '\\.?$', 'i' ), '' );
+	}
+
+	return name;
+};
+
+export const getProcessedRecord = ( record: DnsRecord ): DnsRecord => {
+	const isRootDomainRecord = record.name === `${ record.domain }.`;
+	if ( isRootDomainRecord ) {
+		record.name = '';
+	}
+
+	if ( record.type !== 'TXT' ) {
+		record.data = record.data ? record.data.replace( /\.$/, '' ) : '';
+	}
+
+	// Make sure we can handle protocols with and without a leading underscore
+	if ( record.type === 'SRV' && record.protocol !== undefined ) {
+		record.protocol = record.protocol.replace( /^_*/, '_' );
+	}
+
+	// SRV records can have a target of '.', which means that service is unavailable.
+	// This condition prevents that dot from being removed in those cases.
+	if ( ! ( record.type === 'SRV' && record.target === '.' ) ) {
+		record.target = record.target ? record.target.replace( /\.$/, '' ) : '';
+	}
+
+	return record;
+};

--- a/client/dashboard/domains/dns/utils.ts
+++ b/client/dashboard/domains/dns/utils.ts
@@ -110,12 +110,6 @@ export const getProcessedRecord = ( record: DnsRecord ): DnsRecord => {
 		record.data = record.data ? record.data.replace( /\.$/, '' ) : '';
 	}
 
-	// The `data` property for CAA records contains `flags`, `tag` and `value`,
-	// and we want to show only the `value` for the user
-	if ( record.type === 'CAA' ) {
-		record.data = record.value;
-	}
-
 	// Make sure we can handle protocols with and without a leading underscore
 	if ( record.type === 'SRV' && record.protocol !== undefined ) {
 		record.protocol = record.protocol.replace( /^_*/, '_' );


### PR DESCRIPTION
Part of DOTDASH-316

## Proposed Changes

This PR:
- Adds validation to the DNS records add/edit form
- Performs additional processing when loading and persisting the record information

### Screenshots

<img width="701" height="631" alt="Screenshot 2025-08-21 at 18 11 57" src="https://github.com/user-attachments/assets/58d57659-2a62-414b-9773-293e24773982" />
<img width="700" height="625" alt="Screenshot 2025-08-21 at 18 16 52" src="https://github.com/user-attachments/assets/0d206022-45ec-4b1f-a9f4-4315df52798e" />

## Why are these changes being made?

The DNS form needs validation so users know that they're not adding invalid properties for DNS records. Also, additional processing is done to process and persist some fields correctly, e.g. the `data` field for some record types require a domain name that ends in a period, i.e. a FQDN.

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Go to `/v2/domains/<your domain>/dns
- Add and edit existing records
  - Try to add invalid values to all the fields of all DNS record types
- Ensure validation is working correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
