### PR TITLE
Backups: add download page scaffolding

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -251,6 +251,17 @@ export const siteBackupRestoreRoute = createRoute( {
 	)
 );
 
+export const siteBackupDownloadRoute = createRoute( {
+	getParentRoute: () => siteBackupsRoute,
+	path: '$rewindId/download',
+} ).lazy( () =>
+	import( '../../sites/backup-download' ).then( ( d ) =>
+		createLazyRoute( 'site-backup-download' )( {
+			component: d.default,
+		} )
+	)
+);
+
 export const siteDomainsRoute = createRoute( {
 	getParentRoute: () => siteRoute,
 	path: 'domains',
@@ -657,7 +668,11 @@ export const createSitesRoutes = ( config: AppConfig ) => {
 
 	if ( config.supports.sites.backups ) {
 		siteRoutes.push(
-			siteBackupsRoute.addChildren( [ siteBackupsIndexRoute, siteBackupRestoreRoute ] )
+			siteBackupsRoute.addChildren( [
+				siteBackupsIndexRoute,
+				siteBackupRestoreRoute,
+				siteBackupDownloadRoute,
+			] )
 		);
 	}
 

--- a/client/dashboard/sites/backup-download/index.tsx
+++ b/client/dashboard/sites/backup-download/index.tsx
@@ -1,0 +1,58 @@
+import { useRouter } from '@tanstack/react-router';
+import {
+	Button,
+	Card,
+	CardBody,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __, isRTL } from '@wordpress/i18n';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
+import { siteBackupDownloadRoute, siteBackupsRoute } from '../../app/router/sites';
+import Notice from '../../components/notice';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+
+function SiteBackupDownload() {
+	const { siteSlug, rewindId } = siteBackupDownloadRoute.useParams();
+	const router = useRouter();
+
+	const backButton = (
+		<Button
+			className="dashboard-page-header__back-button"
+			icon={ isRTL() ? chevronRight : chevronLeft }
+			onClick={ () => {
+				router.navigate( { to: siteBackupsRoute.fullPath, params: { siteSlug } } );
+			} }
+		>
+			{ __( 'Backups' ) }
+		</Button>
+	);
+
+	return (
+		<PageLayout
+			size="small"
+			header={ <PageHeader prefix={ backButton } title={ __( 'Download backup' ) } /> }
+		>
+			<Card>
+				<CardBody>
+					<VStack spacing={ 4 }>
+						<p>Rewind ID: { rewindId }</p>
+						<Notice variant="info" title={ __( 'Download Information' ) }>
+							{ __(
+								'This backup contains all your site files, database, and settings from the selected restore point. The download will be prepared and made available for download.'
+							) }
+						</Notice>
+						<HStack justify="flex-start">
+							<Button variant="primary" type="submit">
+								{ __( 'Generate download' ) }
+							</Button>
+						</HStack>
+					</VStack>
+				</CardBody>
+			</Card>
+		</PageLayout>
+	);
+}
+
+export default SiteBackupDownload;

--- a/client/dashboard/sites/backups/backup-details.tsx
+++ b/client/dashboard/sites/backups/backup-details.tsx
@@ -10,8 +10,8 @@ import {
 	Icon,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { rotateLeft } from '@wordpress/icons';
-import { siteBackupRestoreRoute } from '../../app/router/sites';
+import { rotateLeft, download } from '@wordpress/icons';
+import { siteBackupRestoreRoute, siteBackupDownloadRoute } from '../../app/router/sites';
 import { useFormattedTime } from '../../components/formatted-time';
 import { SectionHeader } from '../../components/section-header';
 import { gridiconToWordPressIcon } from '../../utils/gridicons';
@@ -31,6 +31,13 @@ export function BackupDetails( { backup, site }: { backup: ActivityLogEntry; sit
 		} );
 	};
 
+	const handleDownloadClick = () => {
+		router.navigate( {
+			to: siteBackupDownloadRoute.fullPath,
+			params: { siteSlug: site.slug, rewindId: backup.rewind_id },
+		} );
+	};
+
 	return (
 		<Card>
 			<CardHeader style={ { flexDirection: 'column', alignItems: 'stretch' } }>
@@ -39,14 +46,24 @@ export function BackupDetails( { backup, site }: { backup: ActivityLogEntry; sit
 					decoration={ <Icon icon={ gridiconToWordPressIcon( backup.gridicon ) } /> }
 					actions={
 						backup.rewind_id && (
-							<Button
-								variant="primary"
-								size="compact"
-								icon={ rotateLeft }
-								onClick={ handleRestoreClick }
-							>
-								{ __( 'Restore to this point' ) }
-							</Button>
+							<HStack spacing={ 2 }>
+								<Button
+									variant="secondary"
+									size="compact"
+									icon={ download }
+									onClick={ handleDownloadClick }
+								>
+									{ __( 'Download backup' ) }
+								</Button>
+								<Button
+									variant="primary"
+									size="compact"
+									icon={ rotateLeft }
+									onClick={ handleRestoreClick }
+								>
+									{ __( 'Restore to this point' ) }
+								</Button>
+							</HStack>
 						)
 					}
 				/>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes [DOTDASH-284][1].

## Proposed Changes

This PR is the download page version of:

- #105221

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is the foundation of the download backup functionality.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to the `/v2/sites/{site}/backups` page of a site that has backups.
- The `Download backup` button should be shown in the details panel, right beside the restore button.
- When clicking on it, you should be redirected to `/v2/sites/{site}/backups/{rewind_id}/download`
- The `Generate download` button shouldn't do anything, but the `< Backups` one should bring you back to the backup listing page.

### Details card

<img width="626" height="272" alt="image" src="https://github.com/user-attachments/assets/8b1696fa-d97d-4f1c-b8df-7cf529195ba9" />

### Download page

<img width="712" height="421" alt="image" src="https://github.com/user-attachments/assets/2341090c-73aa-40ea-b060-ab91b988e0ba" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

[1]: https://linear.app/a8c/issue/DOTDASH-284