### PR TITLE
Domain Search Rewrite: Move Skip Purchase button to the package

### DIFF
--- a/client/components/domain-search-v2/domain-search-results/index.jsx
+++ b/client/components/domain-search-v2/domain-search-results/index.jsx
@@ -1,4 +1,8 @@
-import { DomainSuggestionsList, DomainSuggestion } from '@automattic/domain-search';
+import {
+	DomainSuggestionsList,
+	DomainSuggestion,
+	DomainSearchSkipSuggestion,
+} from '@automattic/domain-search';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import { get, times } from 'lodash';
@@ -294,7 +298,7 @@ class DomainSearchResults extends Component {
 			);
 		} else {
 			featuredSuggestionElement = <FeaturedDomainSuggestions showPlaceholders />;
-			domainSkipSuggestion = <DomainSkipSuggestion.Placeholder />;
+			domainSkipSuggestion = <DomainSearchSkipSuggestion.Placeholder />;
 			suggestionElements = this.renderPlaceholders();
 		}
 

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -262,6 +262,17 @@ export const siteDomainsRoute = createRoute( {
 	)
 );
 
+export const siteDomainsPurchaseRoute = createRoute( {
+	getParentRoute: () => siteRoute,
+	path: 'domains/purchase',
+} ).lazy( () =>
+	import( '../../sites/domains/purchase' ).then( ( d ) =>
+		createLazyRoute( 'site-domains-purchase' )( {
+			component: d.default,
+		} )
+	)
+);
+
 export const siteEmailsRoute = createRoute( {
 	getParentRoute: () => siteRoute,
 	path: 'emails',
@@ -662,7 +673,7 @@ export const createSitesRoutes = ( config: AppConfig ) => {
 	}
 
 	if ( config.supports.sites.domains ) {
-		siteRoutes.push( siteDomainsRoute );
+		siteRoutes.push( siteDomainsRoute, siteDomainsPurchaseRoute );
 	}
 
 	if ( config.supports.sites.emails ) {

--- a/client/dashboard/components/domain-search/index.tsx
+++ b/client/dashboard/components/domain-search/index.tsx
@@ -1,6 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
 import { DomainSearch } from '@automattic/domain-search';
 import { __ } from '@wordpress/i18n';
+import { type ComponentProps } from 'react';
 import { PageHeader } from '../page-header';
 import PageLayout from '../page-layout';
 
@@ -27,7 +28,9 @@ const staticCart = {
 	hasItem: () => false,
 };
 
-function DashboardDomainSearch() {
+function DashboardDomainSearch( {
+	currentSiteUrl,
+}: Pick< ComponentProps< typeof DomainSearch >, 'currentSiteUrl' > ) {
 	return (
 		<PageLayout
 			size="large"
@@ -38,7 +41,11 @@ function DashboardDomainSearch() {
 				/>
 			}
 		>
-			<DomainSearch className="dashboard-domain-search" cart={ staticCart } />
+			<DomainSearch
+				className="dashboard-domain-search"
+				cart={ staticCart }
+				currentSiteUrl={ currentSiteUrl }
+			/>
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -5,10 +5,11 @@ import { useState } from 'react';
 import { useAuth } from '../../app/auth';
 import { siteBySlugQuery } from '../../app/queries/site';
 import { siteDomainsQuery } from '../../app/queries/site-domains';
-import { siteRoute } from '../../app/router/sites';
+import { siteDomainsPurchaseRoute, siteRoute } from '../../app/router/sites';
 import DataViewsCard from '../../components/dataviews-card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import RouterLinkButton from '../../components/router-link-button';
 import { useActions, useFields, DEFAULT_VIEW, DEFAULT_LAYOUTS } from '../../domains/dataviews';
 import type { SiteDomain } from '../../data/types';
 import type { DomainsView } from '../../domains/dataviews';
@@ -40,7 +41,22 @@ function SiteDomains() {
 	);
 
 	return (
-		<PageLayout header={ <PageHeader title={ __( 'Domains' ) } /> }>
+		<PageLayout
+			header={
+				<PageHeader
+					title={ __( 'Domains' ) }
+					actions={
+						<RouterLinkButton
+							to={ siteDomainsPurchaseRoute.fullPath }
+							params={ { siteSlug } }
+							variant="primary"
+						>
+							{ __( 'Add New Domain' ) }
+						</RouterLinkButton>
+					}
+				/>
+			}
+		>
 			<DataViewsCard>
 				<DataViews< SiteDomain >
 					data={ filteredData || [] }

--- a/client/dashboard/sites/domains/purchase.tsx
+++ b/client/dashboard/sites/domains/purchase.tsx
@@ -1,0 +1,33 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import { sprintf, __ } from '@wordpress/i18n';
+import { siteBySlugQuery } from '../../app/queries/site';
+import { siteDomainsRoute, siteRoute } from '../../app/router/sites';
+import DomainSearch from '../../components/domain-search';
+import FullScreenOverlay from '../../components/full-screen-overlay';
+
+export default function SiteDomainsPurchase() {
+	const { siteSlug } = siteRoute.useParams();
+	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+	const router = useRouter();
+
+	return (
+		<FullScreenOverlay
+			backLabel={ sprintf(
+				// translators: %s is the site name.
+				__( 'Back to %s' ),
+				site.name
+			) }
+			fallbackCloseRoute={
+				router.buildLocation( {
+					to: siteDomainsRoute.fullPath,
+					params: {
+						siteSlug,
+					},
+				} ).href
+			}
+		>
+			<DomainSearch />
+		</FullScreenOverlay>
+	);
+}

--- a/client/dashboard/sites/domains/purchase.tsx
+++ b/client/dashboard/sites/domains/purchase.tsx
@@ -27,7 +27,7 @@ export default function SiteDomainsPurchase() {
 				} ).href
 			}
 		>
-			<DomainSearch />
+			<DomainSearch currentSiteUrl={ new URL( site.URL ).hostname } />
 		</FullScreenOverlay>
 	);
 }

--- a/packages/domain-search/src/components/featured-search-results/index.tsx
+++ b/packages/domain-search/src/components/featured-search-results/index.tsx
@@ -1,4 +1,4 @@
-import { FeaturedSuggestionWithReason } from '../../helpers/partition-featured-suggestions';
+import { FeaturedSuggestionWithReason } from '../../helpers/partition-suggestions';
 import { FeaturedDomainSuggestionsList } from '../../ui';
 import { FeaturedSearchResultsItem } from './item';
 import { FeaturedSearchResultsPlaceholder } from './placeholder';

--- a/packages/domain-search/src/components/featured-search-results/item.tsx
+++ b/packages/domain-search/src/components/featured-search-results/item.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
-import { type FeaturedSuggestionReason } from '../../helpers/partition-featured-suggestions';
+import { type FeaturedSuggestionReason } from '../../helpers/partition-suggestions';
 import { useSuggestion } from '../../hooks/use-suggestion';
 import { useDomainSuggestionBadges } from '../../hooks/use-suggestion-badges';
 import { useDomainSearch } from '../../page/context';

--- a/packages/domain-search/src/components/skip-suggestion/index.tsx
+++ b/packages/domain-search/src/components/skip-suggestion/index.tsx
@@ -20,6 +20,17 @@ const SkipSuggestion = ( { freeSuggestion }: { freeSuggestion?: string } ) => {
 		},
 	} );
 
+	if ( currentSiteUrl ) {
+		return (
+			<DomainSearchSkipSuggestion
+				existingSiteUrl={ currentSiteUrl }
+				onSkip={ events.onContinue }
+				disabled={ false }
+				isBusy={ false }
+			/>
+		);
+	}
+
 	if ( suggestion ) {
 		return (
 			<DomainSearchSkipSuggestion
@@ -29,17 +40,6 @@ const SkipSuggestion = ( { freeSuggestion }: { freeSuggestion?: string } ) => {
 				} }
 				disabled={ isAddingToCart }
 				isBusy={ isAddingToCart }
-			/>
-		);
-	}
-
-	if ( currentSiteUrl ) {
-		return (
-			<DomainSearchSkipSuggestion
-				existingSiteUrl={ currentSiteUrl }
-				onSkip={ events.onContinue }
-				disabled={ false }
-				isBusy={ false }
 			/>
 		);
 	}

--- a/packages/domain-search/src/components/skip-suggestion/index.tsx
+++ b/packages/domain-search/src/components/skip-suggestion/index.tsx
@@ -1,0 +1,52 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useDomainSearch } from '../../page/context';
+import { DomainSearchSkipSuggestion } from '../../ui';
+
+const SkipSuggestion = ( { freeSuggestion }: { freeSuggestion?: string } ) => {
+	const { cart, queries, query, currentSiteUrl, events } = useDomainSearch();
+
+	const { data: suggestion } = useQuery( {
+		...queries.domainSuggestions( query ),
+		select: ( data ) => data.find( ( suggestion ) => suggestion.domain_name === freeSuggestion ),
+	} );
+
+	const { mutate: addToCart, isPending: isAddingToCart } = useMutation( {
+		mutationFn: ( suggestion: string ) => {
+			return cart.onAddItem( {
+				domain_name: suggestion,
+				cost: 'Free',
+				product_slug: 'free_domain',
+			} );
+		},
+	} );
+
+	if ( suggestion ) {
+		return (
+			<DomainSearchSkipSuggestion
+				freeSuggestion={ suggestion.domain_name }
+				onSkip={ () => {
+					addToCart( suggestion.domain_name );
+				} }
+				disabled={ isAddingToCart }
+				isBusy={ isAddingToCart }
+			/>
+		);
+	}
+
+	if ( currentSiteUrl ) {
+		return (
+			<DomainSearchSkipSuggestion
+				existingSiteUrl={ currentSiteUrl }
+				onSkip={ events.onContinue }
+				disabled={ false }
+				isBusy={ false }
+			/>
+		);
+	}
+
+	return null;
+};
+
+SkipSuggestion.Placeholder = DomainSearchSkipSuggestion.Placeholder;
+
+export { SkipSuggestion };

--- a/packages/domain-search/src/helpers/partition-suggestions.ts
+++ b/packages/domain-search/src/helpers/partition-suggestions.ts
@@ -9,10 +9,11 @@ export interface FeaturedSuggestionWithReason {
 
 interface PartitionedSuggestions {
 	featuredSuggestions: FeaturedSuggestionWithReason[];
+	freeSuggestion?: string;
 	regularSuggestions: string[];
 }
 
-export const partitionFeaturedSuggestions = (
+export const partitionSuggestions = (
 	suggestions: DomainSuggestion[],
 	query: string
 ): PartitionedSuggestions => {
@@ -26,8 +27,9 @@ export const partitionFeaturedSuggestions = (
 					reason: 'exact-match',
 				},
 			],
+			freeSuggestion: suggestions.find( ( suggestion ) => suggestion.is_free )?.domain_name,
 			regularSuggestions: suggestions
-				.filter( ( suggestion ) => suggestion.domain_name !== query )
+				.filter( ( suggestion ) => suggestion.domain_name !== query && ! suggestion.is_free )
 				.map( ( suggestion ) => suggestion.domain_name ),
 		};
 	}
@@ -44,13 +46,17 @@ export const partitionFeaturedSuggestions = (
 					suggestion: suggestion.domain_name,
 					reason: 'best-alternative',
 				} );
+			} else if ( suggestion.is_free ) {
+				acc.freeSuggestion = suggestion.domain_name;
 			} else {
 				acc.regularSuggestions.push( suggestion.domain_name );
 			}
+
 			return acc;
 		},
 		{
 			featuredSuggestions: [],
+			freeSuggestion: undefined,
 			regularSuggestions: [],
 		}
 	);

--- a/packages/domain-search/src/page/index.tsx
+++ b/packages/domain-search/src/page/index.tsx
@@ -11,6 +11,7 @@ import './style.scss';
 
 export const DomainSearch = ( {
 	className,
+	currentSiteUrl,
 	initialQuery,
 	cart,
 	events,
@@ -44,8 +45,19 @@ export const DomainSearch = ( {
 			query,
 			setQuery,
 			slots,
+			currentSiteUrl,
 		} ),
-		[ isFullCartOpen, closeFullCart, openFullCart, query, setQuery, cart, events, slots ]
+		[
+			isFullCartOpen,
+			closeFullCart,
+			openFullCart,
+			query,
+			setQuery,
+			cart,
+			events,
+			slots,
+			currentSiteUrl,
+		]
 	);
 
 	const cartItemsLength = cart.items.length;

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -5,7 +5,8 @@ import { Cart } from '../components/cart';
 import { FeaturedSearchResults } from '../components/featured-search-results';
 import { SearchBar } from '../components/search-bar';
 import { SearchResults } from '../components/search-results';
-import { partitionFeaturedSuggestions } from '../helpers/partition-featured-suggestions';
+import { SkipSuggestion } from '../components/skip-suggestion';
+import { partitionSuggestions } from '../helpers/partition-suggestions';
 import { useDomainSearch } from './context';
 
 export const ResultsPage = () => {
@@ -29,8 +30,8 @@ export const ResultsPage = () => {
 		isLoadingQueryAvailability ||
 		domainAvailabilityQueries.some( ( query ) => query.isLoading );
 
-	const { featuredSuggestions, regularSuggestions } = useMemo( () => {
-		return partitionFeaturedSuggestions( suggestions ?? [], query );
+	const { featuredSuggestions, freeSuggestion, regularSuggestions } = useMemo( () => {
+		return partitionSuggestions( suggestions ?? [], query );
 	}, [ suggestions, query ] );
 
 	return (
@@ -42,6 +43,11 @@ export const ResultsPage = () => {
 					<FeaturedSearchResults.Placeholder />
 				) : (
 					<FeaturedSearchResults suggestions={ featuredSuggestions } />
+				) }
+				{ isLoading ? (
+					<SkipSuggestion.Placeholder />
+				) : (
+					<SkipSuggestion freeSuggestion={ freeSuggestion } />
 				) }
 				{ isLoading ? (
 					<SearchResults.Placeholder />

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -31,6 +31,7 @@ export interface DomainSearchProps {
 	className?: string;
 	initialQuery?: string;
 	events?: Partial< DomainSearchEvents >;
+	currentSiteUrl?: string;
 }
 
 export interface DomainSearchContextType

--- a/packages/domain-search/src/queries/suggestions.ts
+++ b/packages/domain-search/src/queries/suggestions.ts
@@ -3,6 +3,7 @@ export interface DomainSuggestion {
 	cost: string;
 	product_slug: string;
 	is_premium?: boolean;
+	is_free?: boolean;
 }
 
 const fetchDomainSuggestions = async (): Promise< DomainSuggestion[] > => {
@@ -35,6 +36,12 @@ const fetchDomainSuggestions = async (): Promise< DomainSuggestion[] > => {
 			domain_name: 'best-alternative-example.org',
 			cost: '$10',
 			product_slug: 'dotorg_domain',
+		},
+		{
+			domain_name: 'free.wordpress.com',
+			cost: 'Free',
+			product_slug: 'free_domain',
+			is_free: true,
 		},
 	];
 };

--- a/packages/domain-search/src/ui/domain-search-skip-suggestion/index.placeholder.tsx
+++ b/packages/domain-search/src/ui/domain-search-skip-suggestion/index.placeholder.tsx
@@ -1,9 +1,9 @@
 import { LoadingPlaceholder } from '@automattic/components';
-import { DomainSkipSkeleton } from './index.skeleton';
+import { DomainSearchSkipSuggestionSkeleton } from './index.skeleton';
 
-export const DomainSkipSuggestionPlaceholder = () => {
+export const DomainSearchSkipSuggestionPlaceholder = () => {
 	return (
-		<DomainSkipSkeleton
+		<DomainSearchSkipSuggestionSkeleton
 			title={ <LoadingPlaceholder width="11.625rem" height="1.25rem" /> }
 			subtitle={ <LoadingPlaceholder width="14.3125rem" height="0.5rem" /> }
 			right={ <LoadingPlaceholder width="7.4375rem" height="2.5rem" /> }

--- a/packages/domain-search/src/ui/domain-search-skip-suggestion/index.skeleton.tsx
+++ b/packages/domain-search/src/ui/domain-search-skip-suggestion/index.skeleton.tsx
@@ -1,5 +1,5 @@
-import { useDomainSuggestionContainer } from '@automattic/domain-search';
 import { Card, CardBody } from '@wordpress/components';
+import { useDomainSuggestionContainer } from '../../hooks/use-domain-suggestion-container';
 
 interface Props {
 	title: React.ReactNode;
@@ -7,17 +7,17 @@ interface Props {
 	right?: React.ReactNode;
 }
 
-export const DomainSkipSkeleton = ( { title, subtitle, right }: Props ) => {
+export const DomainSearchSkipSuggestionSkeleton = ( { title, subtitle, right }: Props ) => {
 	const { containerRef, activeQuery } = useDomainSuggestionContainer();
 
 	return (
 		<Card
-			className="subdomain-skip-suggestion"
+			className="domain-search-skip-suggestion"
 			ref={ containerRef }
 			size={ activeQuery === 'large' ? 'medium' : 'small' }
 		>
 			<CardBody>
-				<div className="subdomain-skip-suggestion__content">
+				<div className="domain-search-skip-suggestion__content">
 					{ title }
 					{ subtitle }
 				</div>

--- a/packages/domain-search/src/ui/domain-search-skip-suggestion/index.tsx
+++ b/packages/domain-search/src/ui/domain-search-skip-suggestion/index.tsx
@@ -1,0 +1,99 @@
+import {
+	Button,
+	__experimentalHeading as Heading,
+	__experimentalText as Text,
+} from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { DomainSearchSkipSuggestionPlaceholder } from './index.placeholder';
+import { DomainSearchSkipSuggestionSkeleton } from './index.skeleton';
+
+import './style.scss';
+
+interface Props {
+	freeSuggestion?: string;
+	existingSiteUrl?: string;
+	onSkip: () => void;
+	disabled: boolean;
+	isBusy: boolean;
+}
+
+const DomainSearchSkipSuggestion = ( {
+	freeSuggestion,
+	existingSiteUrl,
+	onSkip,
+	disabled,
+	isBusy,
+}: Props ) => {
+	let title;
+	let subtitle;
+
+	if ( existingSiteUrl ) {
+		const [ domain, ...tld ] = existingSiteUrl.split( '.' );
+
+		title = __( 'Current address' );
+		subtitle = createInterpolateElement(
+			sprintf(
+				// translators: %(domain)s is the domain name, %(tld)s is the top-level domain
+				__( 'Keep <domain>%(domain)s<tld>.%(tld)s</tld></domain> as your site address' ),
+				{
+					domain,
+					tld: tld.join( '.' ),
+				}
+			),
+			{
+				domain: <span style={ { wordBreak: 'break-word', hyphens: 'none' } } />,
+				tld: <strong style={ { whiteSpace: 'nowrap' } } />,
+			}
+		);
+	} else if ( freeSuggestion ) {
+		const [ domain, ...tld ] = freeSuggestion.split( '.' );
+
+		title = __( 'WordPress.com subdomain' );
+		subtitle = createInterpolateElement(
+			sprintf(
+				// translators: %(domain)s is the domain name, %(tld)s is the top-level domain
+				__( '<domain>%(domain)s<tld>.%(tld)s</tld></domain> is included' ),
+				{
+					domain,
+					tld: tld.join( '.' ),
+				}
+			),
+			{
+				domain: <span style={ { wordBreak: 'break-word', hyphens: 'none' } } />,
+				tld: <strong style={ { whiteSpace: 'nowrap' } } />,
+			}
+		);
+	}
+
+	if ( ! title || ! subtitle ) {
+		return null;
+	}
+
+	return (
+		<DomainSearchSkipSuggestionSkeleton
+			title={
+				<Heading level="4" weight="normal">
+					{ title }
+				</Heading>
+			}
+			subtitle={ <Text>{ subtitle }</Text> }
+			right={
+				<Button
+					className="domain-search-skip-suggestion__btn"
+					variant="secondary"
+					onClick={ onSkip }
+					disabled={ disabled }
+					isBusy={ isBusy }
+					__next40pxDefaultSize
+				>
+					{ __( 'Skip purchase' ) }
+				</Button>
+			}
+		/>
+	);
+};
+
+DomainSearchSkipSuggestion.Placeholder = DomainSearchSkipSuggestionPlaceholder;
+
+export { DomainSearchSkipSuggestion };

--- a/packages/domain-search/src/ui/domain-search-skip-suggestion/style.scss
+++ b/packages/domain-search/src/ui/domain-search-skip-suggestion/style.scss
@@ -1,6 +1,4 @@
-@import '@wordpress/base-styles/breakpoints';
-
-.subdomain-skip-suggestion {
+.domain-search-skip-suggestion {
 	.components-card__body {
 		display: flex;
 		flex-direction: row;
@@ -9,7 +7,7 @@
 		gap: 1.5rem;
 	}
 
-	.subdomain-skip-suggestion__content {
+	.domain-search-skip-suggestion__content {
 		display: flex;
 		flex-direction: column;
 		gap: 0.25rem;
@@ -21,7 +19,7 @@
 		}
 	}
 
-	.subdomain-skip-suggestion__btn {
+	.domain-search-skip-suggestion__btn {
 		color: var( --domain-search-secondary-action-color );
 		box-shadow: inset 0 0 0 1px var( --domain-search-secondary-action-box-shadow-color );
 	}

--- a/packages/domain-search/src/ui/index.ts
+++ b/packages/domain-search/src/ui/index.ts
@@ -13,3 +13,4 @@ export * from './domain-suggestion-cta';
 export { DomainSuggestionLoadMore } from './domain-suggestion-load-more';
 export { DomainSuggestionFilterReset } from './domain-suggestion-filter-reset';
 export * as DomainSearchControls from './domain-search-controls';
+export { DomainSearchSkipSuggestion } from './domain-search-skip-suggestion';


### PR DESCRIPTION
Part of DOMAINS-1595.

## Proposed Changes

- Makes the 'skip purchase' suggestion generic
- Uses it in the rewritten version
- Adds a site-specific domain search page

## Testing Instructions

Enter `/v2/sites/%s/domains` and click the "Add New Domain" button. Type anything and observe the "Skip purchase" button shows up (after a while) with the site name, below the featured suggestions.
