### PR TITLE
A4A > Marketplace: Implement new endpoint for referral form submission

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/refer-hosting/form.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/refer-hosting/form.tsx
@@ -118,7 +118,7 @@ export default function ReferHostingForm( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const { formTitle, successTitle, ctaText, companyTitle, contactTitle, events, fields, api } =
+	const { formTitle, successTitle, ctaText, companyTitle, contactTitle, events, fields, type } =
 		config;
 
 	const { countryOptions } = useCountriesAndStates();
@@ -135,7 +135,7 @@ export default function ReferHostingForm( {
 		submit,
 		isPending,
 		validate,
-	} = useReferHostingForm( fields, api.endpoint );
+	} = useReferHostingForm( fields, type );
 
 	const [ isSuccess, setIsSuccess ] = useState( false );
 

--- a/client/a8c-for-agencies/sections/marketplace/refer-hosting/hooks/use-refer-hosting-form.ts
+++ b/client/a8c-for-agencies/sections/marketplace/refer-hosting/hooks/use-refer-hosting-form.ts
@@ -3,7 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback } from 'react';
 import { CAPTURE_URL_RGX } from 'calypso/blocks/import/util';
 import useReferHostingMutation from './use-refer-hosting-mutation';
-import type { ReferHostingFormData, FormFieldsConfig } from '../types';
+import type { ReferHostingFormData, FormFieldsConfig, ReferralDestinationBU } from '../types';
 
 const DEFAULT_FORM_DATA: ReferHostingFormData = {
 	companyName: '',
@@ -24,7 +24,7 @@ const DEFAULT_FORM_DATA: ReferHostingFormData = {
 
 export default function useReferHostingForm(
 	fieldsConfig: FormFieldsConfig = {},
-	apiEndpoint: string
+	type: ReferralDestinationBU
 ) {
 	const translate = useTranslate();
 
@@ -34,7 +34,7 @@ export default function useReferHostingForm(
 
 	const [ validationError, setValidationError ] = useState< Record< string, string > >( {} );
 
-	const { mutate: submit, isPending } = useReferHostingMutation( apiEndpoint );
+	const { mutate: submit, isPending } = useReferHostingMutation( type );
 
 	const updateValidationError = useCallback(
 		( newState: Record< string, string > ) => {

--- a/client/a8c-for-agencies/sections/marketplace/refer-hosting/hooks/use-refer-hosting-mutation.ts
+++ b/client/a8c-for-agencies/sections/marketplace/refer-hosting/hooks/use-refer-hosting-mutation.ts
@@ -3,31 +3,32 @@ import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { APIError, Agency } from 'calypso/state/a8c-for-agencies/types';
-import { ReferHostingFormDataPayload } from '../types';
+import { ReferHostingFormDataPayload, ReferralDestinationBU } from '../types';
 
 function referHostingMutation(
 	agencyId: number | undefined,
 	formData: ReferHostingFormDataPayload,
-	apiEndpoint: string
+	type: ReferralDestinationBU
 ): Promise< Agency > {
 	return wpcom.req.post( {
 		apiNamespace: 'wpcom/v2',
-		path: apiEndpoint,
+		path: '/agency/referral-form',
 		body: {
 			agency_id: agencyId,
+			destination_bu: type,
 			...formData,
 		},
 	} );
 }
 
 export default function useReferHostingMutation< TContext = unknown >(
-	apiEndpoint: string,
+	type: ReferralDestinationBU,
 	options?: UseMutationOptions< Agency, APIError, ReferHostingFormDataPayload, TContext >
 ): UseMutationResult< Agency, APIError, ReferHostingFormDataPayload, TContext > {
 	const agencyId = useSelector( getActiveAgencyId );
 
 	return useMutation< Agency, APIError, ReferHostingFormDataPayload, TContext >( {
 		...options,
-		mutationFn: ( formData ) => referHostingMutation( agencyId, formData, apiEndpoint ),
+		mutationFn: ( formData ) => referHostingMutation( agencyId, formData, type ),
 	} );
 }

--- a/client/a8c-for-agencies/sections/marketplace/refer-hosting/lib/get-referral-config.ts
+++ b/client/a8c-for-agencies/sections/marketplace/refer-hosting/lib/get-referral-config.ts
@@ -1,4 +1,4 @@
-import type { ReferHostingType } from '../types';
+import type { ReferHostingType, ReferralDestinationBU } from '../types';
 
 export const getReferralConfig = (
 	translate: ( key: string, options?: unknown ) => string,
@@ -46,10 +46,8 @@ export const getReferralConfig = (
 			enabled: type === 'enterprise',
 		},
 	},
-	api: {
-		endpoint: {
-			enterprise: '/agency/vip/partner-opportunity',
-			premium: '/agency/pressable/premium-plan-referral',
-		}[ type ],
-	},
+	type: {
+		enterprise: 'VIP',
+		premium: 'Pressable',
+	}[ type ] as ReferralDestinationBU,
 } );

--- a/client/a8c-for-agencies/sections/marketplace/refer-hosting/types.ts
+++ b/client/a8c-for-agencies/sections/marketplace/refer-hosting/types.ts
@@ -45,3 +45,5 @@ export type FormFieldsConfig = {
 };
 
 export type ReferHostingType = 'enterprise' | 'premium';
+
+export type ReferralDestinationBU = 'VIP' | 'Pressable';


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/A4A-1478/implement-hubspot-api-to-handle-refer-premium-plan
Resolves https://linear.app/a8c/issue/A4A-1484/frontend

## Proposed Changes

This PR updates the referral hosting form to utilize the new generic endpoint being added.

## Why are these changes being made?

* To keep the implementation generic.

## Testing Instructions

* Patch the API: 191060-ghe-Automattic/wpcom if not merged yet.
* Open the A4A live link
* Go to Marketplace: Hosting > Select "Enterprise" > Toggle the refer mode on > Click the "Refer your client to VIP hosting" button > Fill all the information and submit the form > Verify it works as expected and the form gets submitted > Also, verify the record gets created in HubSpot, and the Lead Submission Destination BU is set as "VIP" (details in the [ticket](https://linear.app/a8c/issue/A4A-1478/implement-hubspot-api-to-handle-refer-premium-plan))
Go to "Premier Agency Hosting" > Select the "Premium Plans" tab > Click the "Refer now and get rewarded" button > Fill all the information and submit the form > Verify it works as expected and the form gets submitted > Also, verify the record gets created in HubSpot, and the Lead Submission Destination BU is set as "Pressable" (details in the [ticket](https://linear.app/a8c/issue/A4A-1478/implement-hubspot-api-to-handle-refer-premium-plan))

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
