### PR TITLE
Backups Dashboard: add restore feature

### DIFF
--- a/client/dashboard/app/queries/site-backup-restore.ts
+++ b/client/dashboard/app/queries/site-backup-restore.ts
@@ -1,0 +1,47 @@
+import { mutationOptions, queryOptions } from '@tanstack/react-query';
+import {
+	fetchSiteBackupRestoreProgress,
+	initiateSiteBackupRestore,
+	type RestoreProgress,
+	type RestoreConfig,
+} from '../../data/site-backup-restore';
+import { queryClient } from '../query-client';
+
+/**
+ * Fetch the restore progress for a site.
+ * @param siteId - The ID of the site to fetch restore progress for.
+ * @param restoreId - The ID of the restore to fetch progress for.
+ * @returns A promise that resolves to the restore progress.
+ */
+export const siteBackupRestoreProgressQuery = ( siteId: number, restoreId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'backup', 'restore', restoreId, 'progress' ],
+		queryFn: () => fetchSiteBackupRestoreProgress( siteId, restoreId ),
+		enabled: !! restoreId,
+		refetchInterval: ( query: { state: { data?: RestoreProgress } } ) => {
+			const { data } = query.state;
+
+			// Poll every 1.5 seconds if restore is in progress
+			if ( data?.status === 'queued' || data?.status === 'running' ) {
+				return 1500;
+			}
+
+			// Stop polling if finished or failed
+			return false;
+		},
+	} );
+
+/**
+ * Initiate a site restore.
+ * @param siteId - The ID of the site to initiate a restore for.
+ * @returns A promise that resolves to the restore ID.
+ */
+export const siteBackupRestoreInitiateMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( { timestamp, config }: { timestamp: string | number; config?: RestoreConfig } ) =>
+			initiateSiteBackupRestore( siteId, timestamp, config ),
+		onSuccess: ( restoreId ) => {
+			// Start polling restore progress
+			queryClient.prefetchQuery( siteBackupRestoreProgressQuery( siteId, restoreId ) );
+		},
+	} );

--- a/client/dashboard/app/queries/site-backup-restore.ts
+++ b/client/dashboard/app/queries/site-backup-restore.ts
@@ -2,6 +2,7 @@ import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import {
 	fetchSiteBackupRestoreProgress,
 	initiateSiteBackupRestore,
+	type RestoreProgress,
 	type RestoreConfig,
 } from '../../data/site-backup-restore';
 import { queryClient } from '../query-client';
@@ -16,7 +17,7 @@ export const siteBackupRestoreProgressQuery = ( siteId: number, restoreId: numbe
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'backup', 'restore', restoreId, 'progress' ],
 		queryFn: () => fetchSiteBackupRestoreProgress( siteId, restoreId ),
-		refetchInterval: ( query ) => {
+		refetchInterval: ( query: { state: { data?: RestoreProgress } } ) => {
 			const { data } = query.state;
 
 			// Poll every 1.5 seconds if restore is in progress

--- a/client/dashboard/app/queries/site-backup-restore.ts
+++ b/client/dashboard/app/queries/site-backup-restore.ts
@@ -2,7 +2,6 @@ import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import {
 	fetchSiteBackupRestoreProgress,
 	initiateSiteBackupRestore,
-	type RestoreProgress,
 	type RestoreConfig,
 } from '../../data/site-backup-restore';
 import { queryClient } from '../query-client';
@@ -18,7 +17,7 @@ export const siteBackupRestoreProgressQuery = ( siteId: number, restoreId: numbe
 		queryKey: [ 'site', siteId, 'backup', 'restore', restoreId, 'progress' ],
 		queryFn: () => fetchSiteBackupRestoreProgress( siteId, restoreId ),
 		enabled: !! restoreId,
-		refetchInterval: ( query: { state: { data?: RestoreProgress } } ) => {
+		refetchInterval: ( query ) => {
 			const { data } = query.state;
 
 			// Poll every 1.5 seconds if restore is in progress

--- a/client/dashboard/app/queries/site-backup-restore.ts
+++ b/client/dashboard/app/queries/site-backup-restore.ts
@@ -16,7 +16,6 @@ export const siteBackupRestoreProgressQuery = ( siteId: number, restoreId: numbe
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'backup', 'restore', restoreId, 'progress' ],
 		queryFn: () => fetchSiteBackupRestoreProgress( siteId, restoreId ),
-		enabled: !! restoreId,
 		refetchInterval: ( query ) => {
 			const { data } = query.state;
 

--- a/client/dashboard/data/site-backup-restore.ts
+++ b/client/dashboard/data/site-backup-restore.ts
@@ -1,0 +1,115 @@
+import config from '@automattic/calypso-config';
+import wpcom from 'calypso/lib/wp';
+
+export type RestoreStatus = 'queued' | 'running' | 'finished' | 'fail' | '';
+
+/**
+ * Restore configuration options.
+ */
+export interface RestoreConfig {
+	themes?: boolean;
+	plugins?: boolean;
+	sqls?: boolean;
+	roots?: boolean;
+	contents?: boolean;
+	uploads?: boolean;
+}
+
+/**
+ * Restore progress information.
+ */
+export interface RestoreProgress {
+	percent: number;
+	status: RestoreStatus;
+	rewindId: string;
+	isDismissed: boolean;
+	context: string;
+	message: string;
+	currentEntry: string | null;
+	errorCode: string;
+	failureReason: string;
+}
+
+/**
+ * Restore status response from the API.
+ */
+interface RestoreStatusResponse {
+	ok: boolean;
+	error: string;
+	restore_status: {
+		percent: number;
+		status: RestoreStatus;
+		rewind_id: string;
+		is_dismissed: boolean;
+		context: string;
+		message: string;
+		current_entry: string | null;
+		error_code: string;
+		failure_reason: string;
+	};
+}
+
+/**
+ * Initiate a restore operation for a site to a specific timestamp.
+ * @param siteId - The ID of the site to restore.
+ * @param timestamp - Unix timestamp to restore site to.
+ * @param restoreConfig - Restore configuration specifying what to restore.
+ * @returns A promise that resolves to the restore ID.
+ */
+export async function initiateSiteBackupRestore(
+	siteId: number,
+	timestamp: string | number,
+	restoreConfig: RestoreConfig = {}
+): Promise< number > {
+	const data: { restore_id: string } = await wpcom.req.post( {
+		apiVersion: '1',
+		path: `/activity-log/${ siteId }/rewind/to/${ timestamp }`,
+		body: {
+			types: restoreConfig,
+			calypso_env: config( 'env_id' ),
+			force_rewind: true,
+		},
+	} );
+
+	return Number( data.restore_id );
+}
+
+/**
+ * Fetch the progress of a restore operation.
+ * @param siteId - The ID of the site.
+ * @param restoreId - The ID of the restore operation.
+ * @returns A promise that resolves to the restore progress.
+ */
+export async function fetchSiteBackupRestoreProgress(
+	siteId: number,
+	restoreId: number
+): Promise< RestoreProgress > {
+	const data: RestoreStatusResponse = await wpcom.req.get( {
+		apiVersion: '1',
+		path: `/activity-log/${ siteId }/rewind/${ restoreId }/restore-status`,
+	} );
+
+	const {
+		percent = 0,
+		status = '',
+		rewind_id = '',
+		is_dismissed = false,
+		context = '',
+		message = '',
+		current_entry = null,
+		error_code = '',
+		failure_reason = '',
+	} = data.restore_status || {};
+
+	return {
+		percent,
+		status,
+		rewindId: rewind_id,
+		isDismissed: is_dismissed,
+		context,
+		message,
+		currentEntry: current_entry,
+		errorCode: error_code,
+		failureReason: failure_reason,
+	};
+}

--- a/client/dashboard/sites/backup-restore/error.tsx
+++ b/client/dashboard/sites/backup-restore/error.tsx
@@ -3,7 +3,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import Notice from '../../components/notice';
 
-const SiteBackupRestoreSuccess = ( { onRetry }: { onRetry: () => void } ) => {
+const SiteBackupRestoreError = ( { onRetry }: { onRetry: () => void } ) => {
 	return (
 		<HStack spacing={ 4 }>
 			<Notice variant="error" title={ __( 'Restore failed' ) }>
@@ -20,4 +20,4 @@ const SiteBackupRestoreSuccess = ( { onRetry }: { onRetry: () => void } ) => {
 	);
 };
 
-export default SiteBackupRestoreSuccess;
+export default SiteBackupRestoreError;

--- a/client/dashboard/sites/backup-restore/error.tsx
+++ b/client/dashboard/sites/backup-restore/error.tsx
@@ -1,0 +1,23 @@
+import { __experimentalHStack as HStack, Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import Notice from '../../components/notice';
+
+const SiteBackupRestoreSuccess = ( { onRetry }: { onRetry: () => void } ) => {
+	return (
+		<HStack spacing={ 4 }>
+			<Notice variant="error" title={ __( 'Restore failed' ) }>
+				{ createInterpolateElement(
+					__(
+						'An error occurred while restoring your site. Please <button>try your restore again</button> or contact our support team to resolve the issue.'
+					),
+					{
+						button: <Button variant="link" onClick={ onRetry } />,
+					}
+				) }
+			</Notice>
+		</HStack>
+	);
+};
+
+export default SiteBackupRestoreSuccess;

--- a/client/dashboard/sites/backup-restore/form.tsx
+++ b/client/dashboard/sites/backup-restore/form.tsx
@@ -1,0 +1,149 @@
+import { useMutation } from '@tanstack/react-query';
+import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { DataForm } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { rotateLeft } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
+import { useState } from 'react';
+import { siteBackupRestoreInitiateMutation } from '../../app/queries/site-backup-restore';
+import { siteBackupRestoreRoute } from '../../app/router/sites';
+import Notice from '../../components/notice';
+import type { RestoreConfig } from '../../data/site-backup-restore';
+import type { Field } from '@wordpress/dataviews';
+
+const fields: Field< RestoreConfig >[] = [
+	{
+		id: 'themes',
+		label: __( 'WordPress themes' ),
+		Edit: 'checkbox',
+	},
+	{
+		id: 'plugins',
+		label: __( 'WordPress plugins' ),
+		Edit: 'checkbox',
+	},
+	{
+		id: 'roots',
+		label: __( 'WordPress root' ),
+		description: __( 'Includes wp-config php and any non WordPress files.' ),
+		Edit: 'checkbox',
+	},
+	{
+		id: 'contents',
+		label: __( 'WP-content directory' ),
+		description: __( 'Excludes themes, plugins, and uploads.' ),
+		Edit: 'checkbox',
+	},
+	{
+		id: 'sqls',
+		label: __( 'Site database' ),
+		description: __( 'Includes pages, and posts.' ),
+		Edit: 'checkbox',
+	},
+	{
+		id: 'uploads',
+		label: __( 'Media uploads' ),
+		description: __( 'You must also select Site database for restored media uploads to appear.' ),
+		Edit: 'checkbox',
+	},
+];
+
+function SiteBackupRestoreForm( {
+	siteId,
+	onRestoreInitiate,
+}: {
+	siteId: number;
+	onRestoreInitiate: ( restoreId: number ) => void;
+} ) {
+	const { rewindId } = siteBackupRestoreRoute.useParams();
+	const { mutate: restoreMutation, isPending: isRestoreMutationPending } = useMutation(
+		siteBackupRestoreInitiateMutation( siteId )
+	);
+	const { createErrorNotice } = useDispatch( noticesStore );
+
+	const [ formData, setFormData ] = useState< RestoreConfig >( {
+		themes: true,
+		plugins: true,
+		roots: true,
+		contents: true,
+		sqls: true,
+		uploads: true,
+	} );
+
+	const form = {
+		type: 'regular' as const,
+		fields: [ 'themes', 'plugins', 'roots', 'contents', 'sqls', 'uploads' ],
+	};
+
+	const handleFormChange = ( changes: Partial< RestoreConfig > ) => {
+		setFormData( ( prev ) => ( {
+			...prev,
+			...Object.fromEntries(
+				Object.entries( changes ).map( ( [ key, value ] ) => [
+					key,
+					value !== undefined ? Boolean( value ) : prev[ key as keyof RestoreConfig ],
+				] )
+			),
+		} ) );
+	};
+
+	const handleRestore = () => {
+		restoreMutation(
+			{
+				timestamp: rewindId,
+				config: formData,
+			},
+			{
+				onSuccess: ( restoreId ) => {
+					onRestoreInitiate( restoreId );
+				},
+				onError: () => {
+					createErrorNotice( __( 'Failed to initiate restore. Please try again.' ), {
+						type: 'snackbar',
+					} );
+				},
+			}
+		);
+	};
+
+	const restoreWarning = formData.sqls
+		? __(
+				'This action will replace all settings, posts, pages and other site content with the information from the selected restore point.'
+		  )
+		: __(
+				'This action will replace the selected content with the content from the selected restore point.'
+		  );
+
+	const isFormValid = Object.values( formData ).some( ( value ) => value );
+
+	return (
+		<>
+			<p>{ __( 'Choose the items you wish to restore:' ) }</p>
+			<DataForm< RestoreConfig >
+				data={ formData }
+				fields={ fields }
+				form={ form }
+				onChange={ handleFormChange }
+			/>
+
+			<Notice variant="info" title={ __( 'Important' ) }>
+				{ restoreWarning }
+			</Notice>
+
+			<HStack justify="flex-start">
+				<Button
+					variant="primary"
+					icon={ rotateLeft }
+					onClick={ handleRestore }
+					isBusy={ isRestoreMutationPending }
+					disabled={ ! isFormValid || isRestoreMutationPending }
+				>
+					{ __( 'Restore now' ) }
+				</Button>
+			</HStack>
+		</>
+	);
+}
+
+export default SiteBackupRestoreForm;

--- a/client/dashboard/sites/backup-restore/form.tsx
+++ b/client/dashboard/sites/backup-restore/form.tsx
@@ -77,15 +77,7 @@ function SiteBackupRestoreForm( {
 	};
 
 	const handleFormChange = ( changes: Partial< RestoreConfig > ) => {
-		setFormData( ( prev ) => ( {
-			...prev,
-			...Object.fromEntries(
-				Object.entries( changes ).map( ( [ key, value ] ) => [
-					key,
-					value !== undefined ? Boolean( value ) : prev[ key as keyof RestoreConfig ],
-				] )
-			),
-		} ) );
+		setFormData( ( data ) => ( { ...data, ...changes } ) );
 	};
 
 	const handleRestore = () => {

--- a/client/dashboard/sites/backup-restore/progress.tsx
+++ b/client/dashboard/sites/backup-restore/progress.tsx
@@ -59,7 +59,7 @@ function SiteBackupRestoreProgress( {
 			<Spacer marginTop={ 12 }>
 				<Notice variant="info" title={ __( 'Check your email' ) }>
 					{ __(
-						"Don't want to wait? For your convenience, we'll email you when your site has been fully restored."
+						'Don’t want to wait? For your convenience, we’ll email you when your site has been fully restored.'
 					) }
 				</Notice>
 			</Spacer>

--- a/client/dashboard/sites/backup-restore/progress.tsx
+++ b/client/dashboard/sites/backup-restore/progress.tsx
@@ -1,0 +1,70 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	__experimentalSpacer as Spacer,
+	ProgressBar,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useEffect } from 'react';
+import { siteBackupRestoreProgressQuery } from '../../app/queries/site-backup-restore';
+import Notice from '../../components/notice';
+import noSitesIllustration from '../no-sites-illustration.svg';
+import type { Site } from '../../data/types';
+
+function SiteBackupRestoreProgress( {
+	site,
+	restoreId,
+	onRestoreComplete,
+	onRestoreError,
+}: {
+	site: Site;
+	restoreId: number;
+	onRestoreComplete: () => void;
+	onRestoreError: () => void;
+} ) {
+	const { data: restoreProgress } = useQuery( {
+		...siteBackupRestoreProgressQuery( site.ID, restoreId ),
+		enabled: !! restoreId,
+	} );
+
+	useEffect( () => {
+		if ( restoreProgress?.status === 'finished' ) {
+			onRestoreComplete();
+		} else if ( restoreProgress?.status === 'fail' ) {
+			onRestoreError();
+		}
+	}, [ restoreProgress?.status, onRestoreComplete, onRestoreError ] );
+
+	const isRunning = restoreProgress?.status === 'running';
+
+	return (
+		<>
+			<VStack spacing={ 4 } alignment="center">
+				<img
+					src={ noSitesIllustration }
+					alt=""
+					width={ 408 }
+					height={ 280 }
+					style={ { opacity: 0.2 } }
+				/>
+				<Text size={ 20 }>
+					{ isRunning ? restoreProgress?.message : __( 'Initializing the restore process' ) }
+				</Text>
+				<Text size={ 13 } variant="muted">
+					{ restoreProgress?.percent }% completed
+				</Text>
+				<ProgressBar value={ restoreProgress?.percent ?? 0 } />
+			</VStack>
+			<Spacer marginTop={ 12 }>
+				<Notice variant="info" title={ __( 'Check your email' ) }>
+					{ __(
+						"Don't want to wait? For your convenience, we'll email you when your site has been fully restored."
+					) }
+				</Notice>
+			</Spacer>
+		</>
+	);
+}
+
+export default SiteBackupRestoreProgress;

--- a/client/dashboard/sites/backup-restore/progress.tsx
+++ b/client/dashboard/sites/backup-restore/progress.tsx
@@ -5,7 +5,7 @@ import {
 	__experimentalSpacer as Spacer,
 	ProgressBar,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useEffect } from 'react';
 import { siteBackupRestoreProgressQuery } from '../../app/queries/site-backup-restore';
 import Notice from '../../components/notice';
@@ -52,7 +52,11 @@ function SiteBackupRestoreProgress( {
 					{ isRunning ? restoreProgress?.message : __( 'Initializing the restore process' ) }
 				</Text>
 				<Text size={ 13 } variant="muted">
-					{ restoreProgress?.percent }% completed
+					{ sprintf(
+						/* translators: %d is the restore completion percentage. */
+						__( '%d%% completed' ),
+						restoreProgress?.percent ?? 0
+					) }
 				</Text>
 				<ProgressBar value={ restoreProgress?.percent ?? 0 } />
 			</VStack>

--- a/client/dashboard/sites/backup-restore/success.tsx
+++ b/client/dashboard/sites/backup-restore/success.tsx
@@ -1,0 +1,53 @@
+import { useRouter } from '@tanstack/react-router';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	Button,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Icon, check } from '@wordpress/icons';
+import { siteBackupsRoute } from '../../app/router/sites';
+import { getSiteDisplayUrl } from '../../utils/site-url';
+import type { Site } from '../../data/types';
+
+const SiteBackupRestoreSuccess = ( {
+	restorePointDate,
+	site,
+}: {
+	restorePointDate: string;
+	site: Site;
+} ) => {
+	const router = useRouter();
+
+	return (
+		<HStack spacing={ 4 }>
+			<HStack justify="flex-start">
+				<Icon icon={ check } />
+				<VStack spacing={ 1 }>
+					<Text size={ 15 }>{ __( 'Site successfully restored' ) }</Text>
+					<Text size={ 13 } variant="muted">
+						{ restorePointDate }
+					</Text>
+				</VStack>
+			</HStack>
+			<HStack justify="flex-end">
+				<Button
+					variant="tertiary"
+					text={ __( 'All backups' ) }
+					onClick={ () =>
+						router.navigate( { to: siteBackupsRoute.fullPath, params: { siteSlug: site.slug } } )
+					}
+				/>
+				<Button
+					variant="primary"
+					href={ getSiteDisplayUrl( site ) }
+					target="_blank"
+					text={ __( 'View website ↗' ) }
+				/>
+			</HStack>
+		</HStack>
+	);
+};
+
+export default SiteBackupRestoreSuccess;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the “fixes” keyword. Consider using “part of” instead.
-->

Part of DOTDASH-278

## Proposed Changes

* Add Backup's restore feature to the Hosting Dashboard
  * Add `siteBackupRestoreInitiateMutation` to handle restore initiation
  * Add `siteBackupRestoreProgressQuery` to handle restore progress
  * Add DataForm for selecting the restore configuration
  * Add form, in progress, success and failure steps

> [!NOTE]
> There may be some adjustments to make on the success and failure state design. I will follow up on this in a separate PR.

### Demo

https://github.com/user-attachments/assets/0229413a-ca5f-4573-93f5-2c7ec819683a

### Screenshots

| Screen | Capture |
|---|---|
| Form / Initial state | <img width="500" alt="CleanShot 2025-08-20 at 22 48 30@2x" src="https://github.com/user-attachments/assets/bdb30c76-8793-40f2-884a-d730434a0d8f" /> |
| In progress state | <img width="500" alt="CleanShot 2025-08-20 at 22 49 19@2x" src="https://github.com/user-attachments/assets/d0ede649-5787-4727-b52e-349b40a092df" /> |
| Success state | <img width="500" alt="CleanShot 2025-08-20 at 22 50 20@2x" src="https://github.com/user-attachments/assets/c7813e81-d461-40a0-ae3e-7510bd536687" /> |
| Failure state | <img width="500"  alt="CleanShot 2025-08-20 at 22 49 58@2x" src="https://github.com/user-attachments/assets/72c4e023-f0a3-4bfe-8dd4-7c2bfa45b5d4" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of Backups in the Hosting Dashboard

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
“Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/v2/sites/SITE_SLUG/backups` using a site with the backup feature
* Click on any of the backups on the list, then click on -> Restore to this point
* It should redirect you to /v2/sites/ragostini.com/backups/#####/restore
* Now you are in the initial state (the form)
* Select the items you would like to restore
  * If you deselect “Site dabase” the notice at the bottom changes slightly :)
* When you are ready, click on the `Restore now` button.
* Now you are in the in-progress state.
* Wait for the restore to complete.
* After completion, you should see the `Site successfully restored` message with an option to see all backups (go back to the main Backup page) or an external link to visit your site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the “[Status] String Freeze” label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the “[Status] Needs Privacy Updates” label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
