### PR TITLE
Staging sites: Ensure Sync button is not present on production during staging deletion

### DIFF
--- a/client/sites/components/site-preview-pane/preview-pane-header-buttons.tsx
+++ b/client/sites/components/site-preview-pane/preview-pane-header-buttons.tsx
@@ -50,15 +50,17 @@ const PreviewPaneHeaderButtons = ( { focusRef, itemData }: Props ) => {
 		getIsStagingSiteInTransition( state, itemData.blogId ?? 0 )
 	);
 
-	const { data: isStagingSiteDeletionInProgress } = useQuery(
-		isDeletingStagingSiteQuery( itemData.blogId ?? 0 ),
-		queryClient
-	);
-
 	// Get the staging site to check its jetpack_connection
 	const stagingSiteId = isStagingSite
 		? itemData.blogId
 		: site?.options?.wpcom_staging_blog_ids?.[ 0 ];
+
+	// Check for staging site deletion - either on the staging site itself or on the production site
+	const siteToCheckForDeletion = isStagingSite ? itemData.blogId : stagingSiteId;
+	const { data: isStagingSiteDeletionInProgress } = useQuery(
+		isDeletingStagingSiteQuery( siteToCheckForDeletion ?? 0 ),
+		queryClient
+	);
 
 	const { data: stagingSite } = useQuery( {
 		...siteByIdQuery( stagingSiteId ?? 0 ),


### PR DESCRIPTION
Closes STU-731

## Proposed Changes

This PR ensures that we hide the Sync button on production during staging site deletion. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Currently, the `Sync` button on production sites is available after we start the deletion of a corresponding staging site. This means that the user can open the Sync modal and click on Pull and Push buttons which do nothing. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Ensure that you have an Atomic site with a staging site 
* Navigate to `sites/{yourStagingSite/settings}`
* Start the deletion of the staging site
* Using the switcher on the top, switch back to production
* Confirm that you can not see the `Sync` button on production during staging site deletion
* Compare to trunk where the button is present and the Sync dropdown can be opened

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
