### PR TITLE
Notifications v2: add Settings menu action

### DIFF
--- a/apps/notifications/src/app/index.tsx
+++ b/apps/notifications/src/app/index.tsx
@@ -53,11 +53,13 @@ const NotificationApp = ( {
 	customEnhancer,
 	actionHandlers = {},
 	wpcom,
+	onNavigate,
 }: {
 	locale?: string;
 	customEnhancer?: any;
 	actionHandlers?: any;
 	wpcom: any;
+	onNavigate: ( path: string ) => void;
 } ) => {
 	const [ isReady, setIsReady ] = useState( !! client );
 
@@ -115,7 +117,7 @@ const NotificationApp = ( {
 				<Navigator initialPath="/">
 					<Navigator.Screen path="/">
 						<Suspense fallback={ null }>
-							<NotePanel />
+							<NotePanel onNavigate={ onNavigate } />
 						</Suspense>
 					</Navigator.Screen>
 					<Navigator.Screen path="/notes/:noteId">

--- a/apps/notifications/src/app/index.tsx
+++ b/apps/notifications/src/app/index.tsx
@@ -53,13 +53,11 @@ const NotificationApp = ( {
 	customEnhancer,
 	actionHandlers = {},
 	wpcom,
-	onNavigate,
 }: {
 	locale?: string;
 	customEnhancer?: any;
 	actionHandlers?: any;
 	wpcom: any;
-	onNavigate: ( path: string ) => void;
 } ) => {
 	const [ isReady, setIsReady ] = useState( !! client );
 
@@ -117,7 +115,7 @@ const NotificationApp = ( {
 				<Navigator initialPath="/">
 					<Navigator.Screen path="/">
 						<Suspense fallback={ null }>
-							<NotePanel onNavigate={ onNavigate } />
+							<NotePanel />
 						</Suspense>
 					</Navigator.Screen>
 					<Navigator.Screen path="/notes/:noteId">

--- a/apps/notifications/src/app/note-panel/actions.tsx
+++ b/apps/notifications/src/app/note-panel/actions.tsx
@@ -1,20 +1,18 @@
 import { MenuGroup, MenuItem, DropdownMenu } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
+import { connect } from 'react-redux';
+import actions from '../../panel/state/actions';
 
-export default function NotePanelActions( {
-	onNavigate,
-}: {
-	onNavigate: ( path: string ) => void;
-} ) {
+function NotePanelActions( { viewSettings }: { viewSettings: () => void } ) {
 	return (
 		<DropdownMenu icon={ moreVertical } label={ __( 'Actions' ) }>
 			{ ( { onClose } ) => (
 				<MenuGroup>
 					<MenuItem
 						onClick={ () => {
-							onNavigate( '/me/notifications' );
 							onClose();
+							viewSettings();
 						} }
 					>
 						{ __( 'Settings' ) }
@@ -24,3 +22,9 @@ export default function NotePanelActions( {
 		</DropdownMenu>
 	);
 }
+
+const mapDispatchToProps = {
+	viewSettings: actions.ui.viewSettings,
+};
+
+export default connect( null, mapDispatchToProps )( NotePanelActions );

--- a/apps/notifications/src/app/note-panel/actions.tsx
+++ b/apps/notifications/src/app/note-panel/actions.tsx
@@ -1,10 +1,12 @@
 import { MenuGroup, MenuItem, DropdownMenu } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
-import { connect } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import actions from '../../panel/state/actions';
 
-function NotePanelActions( { viewSettings }: { viewSettings: () => void } ) {
+export default function NotePanelActions() {
+	const dispatch = useDispatch();
+
 	return (
 		<DropdownMenu icon={ moreVertical } label={ __( 'Actions' ) }>
 			{ ( { onClose } ) => (
@@ -12,7 +14,7 @@ function NotePanelActions( { viewSettings }: { viewSettings: () => void } ) {
 					<MenuItem
 						onClick={ () => {
 							onClose();
-							viewSettings();
+							dispatch( actions.ui.viewSettings() );
 						} }
 					>
 						{ __( 'Settings' ) }
@@ -22,9 +24,3 @@ function NotePanelActions( { viewSettings }: { viewSettings: () => void } ) {
 		</DropdownMenu>
 	);
 }
-
-const mapDispatchToProps = {
-	viewSettings: actions.ui.viewSettings,
-};
-
-export default connect( null, mapDispatchToProps )( NotePanelActions );

--- a/apps/notifications/src/app/note-panel/actions.tsx
+++ b/apps/notifications/src/app/note-panel/actions.tsx
@@ -1,0 +1,26 @@
+import { MenuGroup, MenuItem, DropdownMenu } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { moreVertical } from '@wordpress/icons';
+
+export default function NotePanelActions( {
+	onNavigate,
+}: {
+	onNavigate: ( path: string ) => void;
+} ) {
+	return (
+		<DropdownMenu icon={ moreVertical } label={ __( 'Actions' ) }>
+			{ ( { onClose } ) => (
+				<MenuGroup>
+					<MenuItem
+						onClick={ () => {
+							onNavigate( '/me/notifications' );
+							onClose();
+						} }
+					>
+						{ __( 'Settings' ) }
+					</MenuItem>
+				</MenuGroup>
+			) }
+		</DropdownMenu>
+	);
+}

--- a/apps/notifications/src/app/note-panel/index.tsx
+++ b/apps/notifications/src/app/note-panel/index.tsx
@@ -18,7 +18,7 @@ const NOTIFICATION_TABS = [
 	{ name: 'alerts', title: __( 'Alerts' ) },
 ];
 
-const NotePanel = ( { onNavigate }: { onNavigate: ( path: string ) => void } ) => {
+const NotePanel = () => {
 	return (
 		<>
 			<CardHeader
@@ -32,7 +32,7 @@ const NotePanel = ( { onNavigate }: { onNavigate: ( path: string ) => void } ) =
 							{ __( 'Notifications' ) }
 						</Heading>
 						<div style={ { marginInlineStart: 'auto' } }>
-							<NotePanelActions onNavigate={ onNavigate } />
+							<NotePanelActions />
 						</div>
 					</HStack>
 					<TabPanel activeClass="is-active" tabs={ NOTIFICATION_TABS } initialTabName="all">

--- a/apps/notifications/src/app/note-panel/index.tsx
+++ b/apps/notifications/src/app/note-panel/index.tsx
@@ -10,6 +10,7 @@ import '@wordpress/components/build-style/style.css';
 import { __ } from '@wordpress/i18n';
 import { bell } from '@wordpress/icons';
 import NoteList from '../note-list';
+import NotePanelActions from './actions';
 
 const NOTIFICATION_TABS = [
 	{ name: 'all', title: __( 'All' ) },
@@ -17,16 +18,22 @@ const NOTIFICATION_TABS = [
 	{ name: 'alerts', title: __( 'Alerts' ) },
 ];
 
-const NotePanel = () => {
+const NotePanel = ( { onNavigate }: { onNavigate: ( path: string ) => void } ) => {
 	return (
 		<>
-			<CardHeader size="small" style={ { paddingBottom: 0 } }>
+			<CardHeader
+				size="small"
+				style={ { flexDirection: 'column', alignItems: 'stretch', paddingBottom: 0 } }
+			>
 				<VStack>
-					<HStack justify="flex-start">
+					<HStack>
 						<Icon icon={ bell } />
 						<Heading level={ 3 } size={ 15 } weight={ 500 }>
 							{ __( 'Notifications' ) }
 						</Heading>
+						<div style={ { marginInlineStart: 'auto' } }>
+							<NotePanelActions onNavigate={ onNavigate } />
+						</div>
 					</HStack>
 					<TabPanel activeClass="is-active" tabs={ NOTIFICATION_TABS } initialTabName="all">
 						{ () => null /* Placeholder div since content is rendered elsewhere */ }

--- a/apps/notifications/src/dropdown/index.tsx
+++ b/apps/notifications/src/dropdown/index.tsx
@@ -6,12 +6,12 @@ import NotificationApp from '../app';
 
 const NoteDropdown = ( {
 	className,
+	actionHandlers,
 	wpcom,
-	onNavigate,
 }: {
 	className?: string;
+	actionHandlers: ( onClose: () => void ) => any;
 	wpcom: any;
-	onNavigate: ( path: string ) => void;
 } ) => {
 	const hasUnreadNotifications = false;
 
@@ -31,17 +31,11 @@ const NoteDropdown = ( {
 					icon={ hasUnreadNotifications ? bellUnread : bell }
 				/>
 			) }
-			renderContent={ ( { onClose } ) => {
-				const handleNavigate = ( path: string ) => {
-					onNavigate( path );
-					onClose();
-				};
-				return (
-					<div style={ { width: '480px', margin: '-8px' } }>
-						<NotificationApp wpcom={ wpcom } onNavigate={ handleNavigate } />
-					</div>
-				);
-			} }
+			renderContent={ ( { onClose } ) => (
+				<div style={ { width: '480px', margin: '-8px' } }>
+					<NotificationApp actionHandlers={ actionHandlers( onClose ) } wpcom={ wpcom } />
+				</div>
+			) }
 		/>
 	);
 };

--- a/apps/notifications/src/dropdown/index.tsx
+++ b/apps/notifications/src/dropdown/index.tsx
@@ -4,7 +4,15 @@ import { __ } from '@wordpress/i18n';
 import { bellUnread, bell } from '@wordpress/icons';
 import NotificationApp from '../app';
 
-const NoteDropdown = ( { className, wpcom }: { className?: string; wpcom: any } ) => {
+const NoteDropdown = ( {
+	className,
+	wpcom,
+	onNavigate,
+}: {
+	className?: string;
+	wpcom: any;
+	onNavigate: ( path: string ) => void;
+} ) => {
 	const hasUnreadNotifications = false;
 
 	return (
@@ -23,11 +31,17 @@ const NoteDropdown = ( { className, wpcom }: { className?: string; wpcom: any } 
 					icon={ hasUnreadNotifications ? bellUnread : bell }
 				/>
 			) }
-			renderContent={ () => (
-				<div style={ { width: '480px', margin: '-8px' } }>
-					<NotificationApp wpcom={ wpcom } />
-				</div>
-			) }
+			renderContent={ ( { onClose } ) => {
+				const handleNavigate = ( path: string ) => {
+					onNavigate( path );
+					onClose();
+				};
+				return (
+					<div style={ { width: '480px', margin: '-8px' } }>
+						<NotificationApp wpcom={ wpcom } onNavigate={ handleNavigate } />
+					</div>
+				);
+			} }
 		/>
 	);
 };

--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -1,0 +1,29 @@
+import { useNavigate } from '@tanstack/react-router';
+import { Suspense, lazy } from 'react';
+import wpcom from 'calypso/lib/wp';
+
+const AsyncNoteDropdown = lazy( () => import( '@automattic/notifications/src/dropdown' ) );
+
+export default function Notifications( { className }: { className: string } ) {
+	const navigate = useNavigate();
+
+	const actionHandlers = ( onClosePanel: () => void ) => ( {
+		VIEW_SETTINGS: [
+			() => {
+				onClosePanel();
+				navigate( { to: '/me/notifications' } );
+			},
+		],
+		CLOSE_PANEL: [ onClosePanel ],
+	} );
+
+	return (
+		<Suspense fallback={ null }>
+			<AsyncNoteDropdown
+				className={ className }
+				actionHandlers={ actionHandlers }
+				wpcom={ wpcom }
+			/>
+		</Suspense>
+	);
+}

--- a/client/dashboard/app/secondary-menu/index.tsx
+++ b/client/dashboard/app/secondary-menu/index.tsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { useNavigate } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -132,6 +133,7 @@ function UserProfile() {
 
 function SecondaryMenu() {
 	const { supports } = useAppContext();
+	const navigate = useNavigate();
 
 	return (
 		<HStack spacing={ 2 } justify="flex-end">
@@ -147,7 +149,11 @@ function SecondaryMenu() {
 			{ supports.help && <Help /> }
 			{ supports.notifications && (
 				<Suspense fallback={ null }>
-					<AsyncNoteDropdown className="dashboard-secondary-menu__item" wpcom={ wpcom } />
+					<AsyncNoteDropdown
+						className="dashboard-secondary-menu__item"
+						wpcom={ wpcom }
+						onNavigate={ ( path ) => navigate( { to: path } ) }
+					/>
 				</Suspense>
 			) }
 			<UserProfile />

--- a/client/dashboard/app/secondary-menu/index.tsx
+++ b/client/dashboard/app/secondary-menu/index.tsx
@@ -1,5 +1,4 @@
 import config from '@automattic/calypso-config';
-import { useNavigate } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -13,18 +12,16 @@ import { __ } from '@wordpress/i18n';
 import { help, commentAuthorAvatar } from '@wordpress/icons';
 import { Suspense, lazy, useCallback } from 'react';
 import ReaderIcon from 'calypso/assets/icons/reader/reader-icon';
-import wpcom from 'calypso/lib/wp';
 import RouterLinkMenuItem from '../../components/router-link-menu-item';
 import { useAuth } from '../auth';
 import { useOpenCommandPalette } from '../command-palette/utils';
 import { useAppContext } from '../context';
 import { useHelpCenter } from '../help-center';
+import Notifications from '../notifications';
 
 import './style.scss';
 
 const AsyncHelpCenterApp = lazy( () => import( '../help-center/help-center-app' ) );
-
-const AsyncNoteDropdown = lazy( () => import( '@automattic/notifications/src/dropdown' ) );
 
 function Help() {
 	const { user } = useAuth();
@@ -133,7 +130,6 @@ function UserProfile() {
 
 function SecondaryMenu() {
 	const { supports } = useAppContext();
-	const navigate = useNavigate();
 
 	return (
 		<HStack spacing={ 2 } justify="flex-end">
@@ -147,15 +143,7 @@ function SecondaryMenu() {
 				/>
 			) }
 			{ supports.help && <Help /> }
-			{ supports.notifications && (
-				<Suspense fallback={ null }>
-					<AsyncNoteDropdown
-						className="dashboard-secondary-menu__item"
-						wpcom={ wpcom }
-						onNavigate={ ( path ) => navigate( { to: path } ) }
-					/>
-				</Suspense>
-			) }
+			{ supports.notifications && <Notifications className="dashboard-secondary-menu__item" /> }
 			<UserProfile />
 		</HStack>
 	);


### PR DESCRIPTION
Fixes DOTDASH-299

## Proposed Changes

This PR adds a top-level Settings action to notifications in /v2:

<img width="503" height="245" alt="image" src="https://github.com/user-attachments/assets/bb5fcee6-0bc9-4081-bf71-f0264d1c0b7f" />

~P.S.: I'm not happy with the current `onNavigate` prop drilling... but I don't have any better way. Perhaps we can use React context but I think it's overkill for now.~

## Testing Instructions

1. Go to /v2
2. Click the notification bell icon
3. Click the three-dot menu
4. Click Settings
5. Verify you land in /v2/me/notifications

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
