### PR TITLE
Staging Sites: Add success notice and redirect to production site after successful staging site deletion

### DIFF
--- a/client/dashboard/app/router/index.tsx
+++ b/client/dashboard/app/router/index.tsx
@@ -65,5 +65,6 @@ export const getRouter = ( config: AppConfig ) => {
 		// "default", we can still customize it in CSS and add more transition
 		// areas.
 		defaultViewTransition: true,
+		scrollRestoration: true,
 	} );
 };

--- a/client/dashboard/sites/staging-site-delete-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-delete-modal/index.tsx
@@ -1,5 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useMutation } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
@@ -10,7 +11,9 @@ import {
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { siteByIdQuery } from '../../app/queries/site';
 import { stagingSiteDeleteMutation } from '../../app/queries/site-staging-sites';
+import { queryClient } from '../../app/query-client';
 import type { Site } from '../../data/types';
 
 export default function StagingSiteDeleteModal( {
@@ -20,7 +23,8 @@ export default function StagingSiteDeleteModal( {
 	site: Site;
 	onClose: () => void;
 } ) {
-	const { createErrorNotice } = useDispatch( noticesStore );
+	const { createErrorNotice, createSuccessNotice } = useDispatch( noticesStore );
+	const router = useRouter();
 
 	const productionSiteId = site.options?.wpcom_production_blog_id;
 
@@ -41,7 +45,17 @@ export default function StagingSiteDeleteModal( {
 			},
 			onSuccess: () => {
 				recordTracksEvent( 'calypso_hosting_configuration_staging_site_delete_success' );
+				createSuccessNotice( __( 'Staging site deleted.' ), { type: 'snackbar' } );
 				onClose();
+				queryClient
+					.ensureQueryData( siteByIdQuery( productionSiteId ) )
+					.then( ( productionSite ) => {
+						if ( productionSite?.slug ) {
+							router.navigate( {
+								to: `/sites/${ productionSite.slug }`,
+							} );
+						}
+					} );
 			},
 		} );
 	};

--- a/client/dashboard/sites/staging-site-delete-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-delete-modal/index.tsx
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { useRouter } from '@tanstack/react-router';
+import { useNavigate } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
@@ -23,7 +23,7 @@ export default function StagingSiteDeleteModal( {
 	onClose: () => void;
 } ) {
 	const { createErrorNotice, createSuccessNotice } = useDispatch( noticesStore );
-	const router = useRouter();
+	const navigate = useNavigate();
 
 	const productionSiteId = site.options?.wpcom_production_blog_id;
 	const { data: productionSite } = useQuery( {
@@ -52,7 +52,7 @@ export default function StagingSiteDeleteModal( {
 				createSuccessNotice( __( 'Staging site deleted.' ), { type: 'snackbar' } );
 				onClose();
 				if ( productionSiteSlug ) {
-					router.navigate( {
+					navigate( {
 						to: '/sites/$siteSlug',
 						params: { siteSlug: productionSiteSlug },
 					} );

--- a/client/dashboard/sites/staging-site-delete-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-delete-modal/index.tsx
@@ -53,7 +53,8 @@ export default function StagingSiteDeleteModal( {
 				onClose();
 				if ( productionSiteSlug ) {
 					router.navigate( {
-						to: `/sites/${ productionSiteSlug }`,
+						to: '/sites/$siteSlug',
+						params: { siteSlug: productionSiteSlug },
 					} );
 				}
 			},

--- a/client/dashboard/sites/staging-site-delete-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-delete-modal/index.tsx
@@ -11,9 +11,8 @@ import {
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { siteByIdQuery } from '../../app/queries/site';
 import { stagingSiteDeleteMutation } from '../../app/queries/site-staging-sites';
-import { queryClient } from '../../app/query-client';
+import { siteRoute } from '../../app/router/sites';
 import type { Site } from '../../data/types';
 
 export default function StagingSiteDeleteModal( {
@@ -27,6 +26,7 @@ export default function StagingSiteDeleteModal( {
 	const router = useRouter();
 
 	const productionSiteId = site.options?.wpcom_production_blog_id;
+	const { siteSlug } = siteRoute.useParams();
 
 	const mutation = useMutation( stagingSiteDeleteMutation( site.ID, productionSiteId ?? 0 ) );
 
@@ -47,15 +47,9 @@ export default function StagingSiteDeleteModal( {
 				recordTracksEvent( 'calypso_hosting_configuration_staging_site_delete_success' );
 				createSuccessNotice( __( 'Staging site deleted.' ), { type: 'snackbar' } );
 				onClose();
-				queryClient
-					.ensureQueryData( siteByIdQuery( productionSiteId ) )
-					.then( ( productionSite ) => {
-						if ( productionSite?.slug ) {
-							router.navigate( {
-								to: `/sites/${ productionSite.slug }`,
-							} );
-						}
-					} );
+				router.navigate( {
+					to: `/sites/${ siteSlug }`,
+				} );
 			},
 		} );
 	};

--- a/client/dashboard/sites/staging-site-delete-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-delete-modal/index.tsx
@@ -38,6 +38,8 @@ export default function StagingSiteDeleteModal( {
 		return null;
 	}
 
+	const isV2 = window?.location?.pathname?.startsWith( '/v2' );
+
 	const handleDelete = () => {
 		recordTracksEvent( 'calypso_hosting_configuration_staging_site_delete_click' );
 		mutation.mutate( undefined, {
@@ -49,13 +51,15 @@ export default function StagingSiteDeleteModal( {
 			},
 			onSuccess: () => {
 				recordTracksEvent( 'calypso_hosting_configuration_staging_site_delete_success' );
-				createSuccessNotice( __( 'Staging site deleted.' ), { type: 'snackbar' } );
-				onClose();
-				if ( productionSiteSlug ) {
-					navigate( {
-						to: '/sites/$siteSlug',
-						params: { siteSlug: productionSiteSlug },
-					} );
+				if ( isV2 ) {
+					createSuccessNotice( __( 'Staging site deleted.' ), { type: 'snackbar' } );
+					onClose();
+					if ( productionSiteSlug ) {
+						navigate( {
+							to: '/sites/$siteSlug',
+							params: { siteSlug: productionSiteSlug },
+						} );
+					}
 				}
 			},
 		} );

--- a/client/dashboard/sites/staging-site-delete-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-delete-modal/index.tsx
@@ -1,5 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
@@ -11,8 +11,8 @@ import {
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { siteByIdQuery } from '../../app/queries/site';
 import { stagingSiteDeleteMutation } from '../../app/queries/site-staging-sites';
-import { siteRoute } from '../../app/router/sites';
 import type { Site } from '../../data/types';
 
 export default function StagingSiteDeleteModal( {
@@ -26,7 +26,11 @@ export default function StagingSiteDeleteModal( {
 	const router = useRouter();
 
 	const productionSiteId = site.options?.wpcom_production_blog_id;
-	const { siteSlug } = siteRoute.useParams();
+	const { data: productionSite } = useQuery( {
+		...siteByIdQuery( productionSiteId ?? 0 ),
+		enabled: !! productionSiteId,
+	} );
+	const productionSiteSlug = productionSite?.slug;
 
 	const mutation = useMutation( stagingSiteDeleteMutation( site.ID, productionSiteId ?? 0 ) );
 
@@ -47,9 +51,11 @@ export default function StagingSiteDeleteModal( {
 				recordTracksEvent( 'calypso_hosting_configuration_staging_site_delete_success' );
 				createSuccessNotice( __( 'Staging site deleted.' ), { type: 'snackbar' } );
 				onClose();
-				router.navigate( {
-					to: `/sites/${ siteSlug }`,
-				} );
+				if ( productionSiteSlug ) {
+					router.navigate( {
+						to: `/sites/${ productionSiteSlug }`,
+					} );
+				}
 			},
 		} );
 	};

--- a/client/dashboard/sites/staging-site-delete-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-delete-modal/index.tsx
@@ -38,8 +38,6 @@ export default function StagingSiteDeleteModal( {
 		return null;
 	}
 
-	const isV2 = window?.location?.pathname?.startsWith( '/v2' );
-
 	const handleDelete = () => {
 		recordTracksEvent( 'calypso_hosting_configuration_staging_site_delete_click' );
 		mutation.mutate( undefined, {
@@ -51,7 +49,7 @@ export default function StagingSiteDeleteModal( {
 			},
 			onSuccess: () => {
 				recordTracksEvent( 'calypso_hosting_configuration_staging_site_delete_success' );
-				if ( isV2 ) {
+				if ( window?.location?.pathname?.startsWith( '/v2' ) ) {
 					createSuccessNotice( __( 'Staging site deleted.' ), { type: 'snackbar' } );
 					onClose();
 					if ( productionSiteSlug ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTDASH-261

## Proposed Changes

* add success notice and redirect to production site after successful staging site deletion
* set `scrollRestoration` to `true` for the Hosting Dashboard Router

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* DOTDASH-261

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR and build the app with `yarn start` (or use the Calypso Live link below).
2. Ensure you have a WoA production site with staging site created.
3. Head over to the new V2 dashboard and initiate the staging site deletion from the Settings tab (`http://calypso.localhost:3000/v2/sites/{staging-site-slug}/settings`).
4. As soon as we confirm the deletion in the modal, the deletion should initiate.
5. Once the deletion is complete, a success notice should display, modal should autocomplete and we should be redirected to the Overview tab of the related production site.

Testing for regressions:
1. Try to delete the staging site from the current dashboard (`http://calypso.localhost:3000/sites/{staging-site-slug}/settings`).
2. The process should still work correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
