### PR TITLE
Staging Sites: Fix site refresh issue

### DIFF
--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -165,7 +165,7 @@ const DotcomPreviewPane = ( {
 		site,
 		selectedSiteFeature,
 		selectedSiteFeaturePreview,
-		isEnabled,
+		isHostingFeaturesCalloutEnabled,
 	] );
 
 	const itemData: ItemData = {

--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -6,6 +6,7 @@ import { isMigrationInProgress } from 'calypso/data/site-migration';
 import ItemView from 'calypso/layout/hosting-dashboard/item-view';
 import { useSetTabBreadcrumb } from 'calypso/sites/hooks/breadcrumbs/use-set-tab-breadcrumb';
 import HostingFeaturesIcon from 'calypso/sites/hosting/components/hosting-features-icon';
+import { useStagingSite } from 'calypso/sites/staging-site/hooks/use-staging-site';
 import SitesProductionBadge from 'calypso/sites-dashboard/components/sites-production-badge';
 import { useSelector } from 'calypso/state';
 import { canCurrentUserSwitchEnvironment } from 'calypso/state/sites/selectors/can-current-user-switch-environment';
@@ -176,6 +177,15 @@ const DotcomPreviewPane = ( {
 		adminUrl: site.options?.admin_url || `${ site.URL }/wp-admin`,
 		withIcon: true,
 	};
+
+	const { data: stagingSites } = useStagingSite( site.ID, {
+		enabled: ! site.is_wpcom_staging_site && site.is_wpcom_atomic,
+	} );
+
+	if ( site.options && site.is_wpcom_atomic ) {
+		site.options.wpcom_staging_blog_ids =
+			stagingSites?.map( ( stagingSite ) => stagingSite.id ) ?? [];
+	}
 
 	const stagingStatus = useSelector( ( state ) => getStagingSiteStatus( state, site.ID ) );
 	const isStagingStatusFinished =

--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -182,10 +182,21 @@ const DotcomPreviewPane = ( {
 		enabled: ! site.is_wpcom_staging_site && site.is_wpcom_atomic,
 	} );
 
-	if ( site.options && site.is_wpcom_atomic ) {
-		site.options.wpcom_staging_blog_ids =
-			stagingSites?.map( ( stagingSite ) => stagingSite.id ) ?? [];
-	}
+	const siteWithStagingIds = useMemo( () => {
+		if ( ! site.options || ! site.is_wpcom_atomic ) {
+			return site;
+		}
+
+		const stagingBlogIds = stagingSites?.map( ( stagingSite ) => stagingSite.id ) ?? [];
+
+		return {
+			...site,
+			options: {
+				...site.options,
+				wpcom_staging_blog_ids: stagingBlogIds,
+			},
+		};
+	}, [ site, stagingSites ] );
 
 	const stagingStatus = useSelector( ( state ) => getStagingSiteStatus( state, site.ID ) );
 	const isStagingStatusFinished =
@@ -204,8 +215,9 @@ const DotcomPreviewPane = ( {
 		selectedFeatureId: selectedSiteFeature,
 	} );
 
-	const isProduction = site.is_wpcom_atomic && ! site.is_wpcom_staging_site;
-	const hasNoStagingSites = ! site.options?.wpcom_staging_blog_ids?.length;
+	const isProduction =
+		siteWithStagingIds.is_wpcom_atomic && ! siteWithStagingIds.is_wpcom_staging_site;
+	const hasNoStagingSites = ! siteWithStagingIds.options?.wpcom_staging_blog_ids?.length;
 
 	const shouldShowProductionBadge =
 		isProduction && ( hasNoStagingSites || ! isStagingStatusFinished );
@@ -215,7 +227,9 @@ const DotcomPreviewPane = ( {
 			itemData={ itemData }
 			closeItemView={ closeSitePreviewPane }
 			features={ features }
-			className={ site.is_wpcom_staging_site && ! stagingSitesRedesign ? 'is-staging-site' : '' }
+			className={
+				siteWithStagingIds.is_wpcom_staging_site && ! stagingSitesRedesign ? 'is-staging-site' : ''
+			}
 			enforceTabsView
 			itemViewHeaderExtraProps={ {
 				externalIconSize: 16,
@@ -231,7 +245,12 @@ const DotcomPreviewPane = ( {
 					}
 
 					if ( hasEnvironmentPermission && isStagingStatusFinished ) {
-						return <SiteEnvironmentSwitcher onChange={ changeSitePreviewPane } site={ site } />;
+						return (
+							<SiteEnvironmentSwitcher
+								onChange={ changeSitePreviewPane }
+								site={ siteWithStagingIds }
+							/>
+						);
 					}
 				},
 			} }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes STU-734

## Proposed Changes

* revert https://github.com/Automattic/wp-calypso/pull/105302
  * and avoid modifying `site.options` object directly to prevent WSOD experienced by this user: p1755767760958729-slack-CRWCHQGUB
  * original PR for context: https://github.com/Automattic/wp-calypso/pull/91504
* fix dependency array

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* STU-734; related discussion: p1755780195794289-slack-C04GESRBWKW

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR and build the app with `yarn start` (or use the Calypso Live link below).
2. Try to reproduce the issue described in STU-734. It should not be possible.
3. SU to the user in p1755780195794289-slack-C04GESRBWKW.
4. Once you have the dashboard opened, change the URL in the address bar to your local `http://calypso.localhost:3000` or Calypso Live URL.
5. Head over to one of the user's sites in the dashboard.
6. It shouldn't be possible to reproduce the WSOD issue described in the p1755780195794289-slack-C04GESRBWKW thread.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?