### PR TITLE
Reader: Record algo during the like action

### DIFF
--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -16,6 +16,7 @@ import { getPostLikeCount } from 'calypso/state/posts/selectors/get-post-like-co
 import { isLikedPost } from 'calypso/state/posts/selectors/is-liked-post';
 import { markPostSeen } from 'calypso/state/reader/posts/actions';
 import { getPostByKey } from 'calypso/state/reader/posts/selectors';
+import getPreviousPath from 'calypso/state/selectors/get-previous-path';
 
 import './style.scss';
 
@@ -57,7 +58,10 @@ class ReaderLikeButton extends Component {
 		recordTrackForPost(
 			liked ? 'calypso_reader_article_liked' : 'calypso_reader_article_unliked',
 			post,
-			{ context: this.props.fullPost ? 'full-post' : 'card' }
+			{ context: this.props.fullPost ? 'full-post' : 'card' },
+			{
+				...( this.props.fullPost ? { pathnameOverride: this.props.previousPath } : {} ),
+			}
 		);
 		if ( liked && ! this.props.fullPost && ! post._seen ) {
 			this.props.markPostSeen( post, this.props.site );
@@ -129,6 +133,7 @@ export default connect(
 			likeCount: getPostLikeCount( state, siteId, postId ),
 			iLike: isLikedPost( state, siteId, postId ),
 			isLoggedIn: isUserLoggedIn( state ),
+			previousPath: getPreviousPath( state ),
 		};
 	},
 	{ markPostSeen }


### PR DESCRIPTION

Part of CML-805

## Proposed Changes
* Track the `algo` during like actions 

## Why are these changes being made?
* We want to have visibility into the number of posts liked, which comes from the 

## Testing Instructions
Scenario: Like in the freshly-pressed tab
* Go to `/reader?flags=reader/discover/freshly-pressed` 
* Go to /discover >Frehsly pressed tab
* Click on the like button and check if the `calypso_reader_article_liked` with the algo value = 'freshly-pressed'


Scenario: Like in a post from a freshly-pressed tab
* Go to `/reader?flags=reader/discover/freshly-pressed` 
* Go to /discover >Frehsly pressed tab
* Click in any post
* Click on the like button
* Click on the like button and check if the `calypso_reader_article_liked` with the algo value = 'freshly-pressed'





## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?