### PR TITLE
Tests: Remove Pay with PayPal block test after hiding the block from inserter

### DIFF
--- a/test/e2e/specs/blocks/blocks__jetpack-earn.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-earn.ts
@@ -4,7 +4,6 @@
  */
 import {
 	BlockFlow,
-	PayWithPaypalBlockFlow,
 	// OpenTableFlow,
 	DonationsFormFlow,
 	AdFlow,
@@ -16,11 +15,6 @@ import {
 import { createBlockTests } from './shared/block-smoke-testing';
 
 const blockFlows: BlockFlow[] = [
-	new PayWithPaypalBlockFlow( {
-		name: 'Test Paypal Block',
-		price: 900,
-		email: 'test@wordpress.com',
-	} ),
 	// Skip OpenTable block test for now, block is broken due to upstream API changes.
 	// https://github.com/Automattic/jetpack/issues/39410
 	// new OpenTableFlow( {


### PR DESCRIPTION
## Proposed Changes

* Following the merge of https://github.com/Automattic/jetpack/pull/44724, the Pay with PayPal block is no longer available via the inserter. Because of this, we should remove this test which was ensuring that the block could be added.

Of note, after a quick look, I think that we can probably remove the entire `PayWithPaypalBlockFlow`. But, going to defer that for now.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We're deprecating the legacy Pay with PayPal block by removing it from the inserter. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn test specs/blocks/blocks__jetpack-earn.ts` and ensure tests pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
