### PR TITLE
Domains: Fix CSS style of the org field explanation notice

### DIFF
--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -116,6 +116,10 @@
 			}
 		}
 	}
+
+	.contact-details-form-fields__field.organization .form-setting-explanation {
+		font-style: normal;
+	}
 }
 
 .contact-details-form-fields__contact-details {


### PR DESCRIPTION
Related to #104936

## Proposed Changes

After deploying #104936 I noticed the text of the organization notice was in italic. This PR fixes that.

### Screenshots

| Before | After |
| --- | --- |
| <img width="707" height="287" alt="Screenshot 2025-08-21 at 20 25 24" src="https://github.com/user-attachments/assets/b2f59e29-3b32-433c-ac4f-10df76162598" /> | <img width="702" height="285" alt="Screenshot 2025-08-21 at 20 29 11" src="https://github.com/user-attachments/assets/65a8b1bf-6a04-4103-8a59-86f4ecdaa044" /> |

## Why are these changes being made?

The explanation text shouldn't be in italic.

## Testing Instructions

Go to the contact info form for a domain and ensure the org field explanation is not in italic.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
