### PR TITLE
Backups Dashboard: restore page minor adjustments

### DIFF
--- a/client/dashboard/sites/backup-restore/index.tsx
+++ b/client/dashboard/sites/backup-restore/index.tsx
@@ -8,9 +8,11 @@ import {
 	ExternalLink,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement, useState } from '@wordpress/element';
 import { __, isRTL, sprintf } from '@wordpress/i18n';
 import { Icon, cloud, chevronLeft, chevronRight } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
 import { siteBySlugQuery } from '../../app/queries/site';
 import { siteBackupRestoreRoute, siteBackupsRoute } from '../../app/router/sites';
 import { useFormattedTime } from '../../components/formatted-time';
@@ -29,6 +31,7 @@ function SiteBackupRestore() {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const [ currentStep, setCurrentStep ] = useState< RestoreStep >( 'form' );
 	const [ restoreId, setRestoreId ] = useState< number | null >( null );
+	const { createSuccessNotice } = useDispatch( noticesStore );
 
 	const router = useRouter();
 
@@ -39,6 +42,9 @@ function SiteBackupRestore() {
 
 	const handleRestoreComplete = () => {
 		setCurrentStep( 'success' );
+		createSuccessNotice( __( 'Site restore completed.' ), {
+			type: 'snackbar',
+		} );
 	};
 
 	const handleRestoreError = () => {

--- a/client/dashboard/sites/backup-restore/index.tsx
+++ b/client/dashboard/sites/backup-restore/index.tsx
@@ -95,7 +95,7 @@ function SiteBackupRestore() {
 	return (
 		<PageLayout
 			size="small"
-			header={ <PageHeader prefix={ backButton } title={ __( 'Restore your site' ) } /> }
+			header={ <PageHeader prefix={ backButton } title={ __( 'Site restore' ) } /> }
 		>
 			<Card>
 				<CardHeader>

--- a/client/dashboard/sites/backup-restore/index.tsx
+++ b/client/dashboard/sites/backup-restore/index.tsx
@@ -59,7 +59,6 @@ function SiteBackupRestore() {
 	const restorePointDate = useFormattedTime(
 		new Date( parseFloat( rewindId ) * 1000 ).toISOString(),
 		{
-			dateStyle: 'medium',
 			timeStyle: 'short',
 		}
 	);

--- a/client/dashboard/sites/backup-restore/progress.tsx
+++ b/client/dashboard/sites/backup-restore/progress.tsx
@@ -58,7 +58,10 @@ function SiteBackupRestoreProgress( {
 						restoreProgress?.percent ?? 0
 					) }
 				</Text>
-				<ProgressBar value={ restoreProgress?.percent ?? 0 } />
+				<ProgressBar
+					className="dashboard-backups__progress-bar"
+					value={ restoreProgress?.percent ?? 0 }
+				/>
 			</VStack>
 			<Spacer marginTop={ 12 }>
 				<Notice variant="info" title={ __( 'Check your email' ) }>

--- a/client/dashboard/sites/backup-restore/success.tsx
+++ b/client/dashboard/sites/backup-restore/success.tsx
@@ -8,7 +8,6 @@ import {
 import { __ } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
 import { siteBackupsRoute } from '../../app/router/sites';
-import { getSiteDisplayUrl } from '../../utils/site-url';
 import type { Site } from '../../data/types';
 
 const SiteBackupRestoreSuccess = ( {
@@ -19,7 +18,6 @@ const SiteBackupRestoreSuccess = ( {
 	site: Site;
 } ) => {
 	const router = useRouter();
-
 	return (
 		<HStack spacing={ 4 }>
 			<HStack justify="flex-start">
@@ -41,7 +39,7 @@ const SiteBackupRestoreSuccess = ( {
 				/>
 				<Button
 					variant="primary"
-					href={ getSiteDisplayUrl( site ) }
+					href={ site.URL }
 					target="_blank"
 					text={ __( 'View website ↗' ) }
 				/>

--- a/client/dashboard/sites/backups/style.scss
+++ b/client/dashboard/sites/backups/style.scss
@@ -1,9 +1,9 @@
 .dashboard-backups__list-icon {
-    position: relative;
-    top: 50%;
-    inset-inline-start: 50%;
-    transform: translate(-50%, -50%);
-    fill: $gray-700;
+	position: relative;
+	top: 50%;
+	inset-inline-start: 50%;
+	transform: translate(-50%, -50%);
+	fill: $gray-700;
 }
 
 .dashboard-backups__progress-bar{

--- a/client/dashboard/sites/backups/style.scss
+++ b/client/dashboard/sites/backups/style.scss
@@ -5,3 +5,7 @@
     transform: translate(-50%, -50%);
     fill: $gray-700;
 }
+
+.dashboard-backups__progress-bar{
+	--wp-components-color-foreground: var(--wp-admin-theme-color);
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-278

## Proposed Changes
* Update restore page title
* Update progress bar color by defining `--wp-components-color-foreground` on the Backup's pages styles
* Update restore point date to use relative format for today's date
* Add a success snackbar when a restore completes
    <img width="150" alt="CleanShot 2025-08-21 at 19 47 23@2x" src="https://github.com/user-attachments/assets/32547521-0e3c-49f2-842d-19a82b811f4d" />

| Before | After |
|---|---|
| <img width="660" height="236" alt="CleanShot 2025-08-21 at 19 45 50@2x" src="https://github.com/user-attachments/assets/c47f8eb3-8483-4bf5-9ca6-943c04fc7a89" /> | <img width="660" height="236" alt="CleanShot 2025-08-21 at 19 46 15@2x" src="https://github.com/user-attachments/assets/313c69e1-30c0-45b3-873c-050aa4f078a8" /> |
| <img width="440" height="254" alt="CleanShot 2025-08-21 at 20 10 28@2x" src="https://github.com/user-attachments/assets/589d8fed-2119-4638-817b-7c103c7c8f02" /> | <img width="440" height="254" alt="CleanShot 2025-08-21 at 20 10 08@2x" src="https://github.com/user-attachments/assets/67b45050-9a20-412b-8c06-2a3a6430c01f" /> |
| <img width="1386" height="488" alt="CleanShot 2025-08-21 at 20 06 30@2x" src="https://github.com/user-attachments/assets/543b7e6c-3231-4aa1-981d-fe523a4a49da" /> | <img width="1386" height="490" alt="CleanShot 2025-08-21 at 20 03 13@2x" src="https://github.com/user-attachments/assets/33c0c829-60b5-4e20-81ca-e283d31aa5ea" /> |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of Backups in the Hosting Dashboard

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/v2/sites/SITE_SLUG/backups` using a site with the backup feature
* Click on any of the backups on the list, then click on -> Restore to this point
* If it is a backup from today, verify the date says "Today at X"
* Verify the restore page now is "Site restore"
* Run a new restore
* Verify the progress bar looks blue instead of black
* After restore completion, verify the snackbar pops up

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
