### PR TITLE
Notifications v2: Implement infinite scroll

### DIFF
--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -32,6 +32,7 @@
 		"@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^",
 		"@wordpress/components": "^29.9.0",
 		"@wordpress/data": "^10.23.0",
+		"@wordpress/dataviews": "^7.0.0",
 		"@wordpress/i18n": "^5.23.0",
 		"autoprefixer": "^10.4.21",
 		"calypso": "workspace:^",

--- a/apps/notifications/src/app/context.ts
+++ b/apps/notifications/src/app/context.ts
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+import type { Client } from './types';
+
+export const RestClientContext = createContext< Client | null >( null );

--- a/apps/notifications/src/app/index.tsx
+++ b/apps/notifications/src/app/index.tsx
@@ -1,5 +1,5 @@
 import { Navigator } from '@wordpress/components';
-import { createContext, useEffect, useState, Suspense, lazy } from 'react';
+import { useEffect, useState, Suspense, lazy } from 'react';
 import { Provider } from 'react-redux';
 import repliesCache from '../panel/comment-replies-cache';
 import RestClient from '../panel/rest-client';
@@ -8,6 +8,7 @@ import { init as initStore } from '../panel/state';
 import { SET_IS_SHOWING } from '../panel/state/action-types';
 import { addListeners, removeListeners } from '../panel/state/create-listener-middleware';
 import getIsPanelOpen from '../panel/state/selectors/get-is-panel-open';
+import { RestClientContext } from './context';
 
 let client: any;
 
@@ -19,8 +20,6 @@ repliesCache.cleanup();
  * Force a manual refresh of the notes data
  */
 export const refreshNotes = () => client && client.refreshNotes.call( client );
-
-export const RestClientContext = createContext( client );
 
 const defaultHandlers = {
 	APP_REFRESH_NOTES: [
@@ -112,13 +111,19 @@ const NotificationApp = ( {
 	return (
 		<Provider store={ store }>
 			<RestClientContext.Provider value={ client }>
-				<Navigator initialPath="/">
-					<Navigator.Screen path="/">
+				<Navigator initialPath="/" style={ { maxHeight: 'inherit', height: '100%' } }>
+					<Navigator.Screen
+						path="/"
+						style={ { display: 'flex', flexDirection: 'column', height: '100%' } }
+					>
 						<Suspense fallback={ null }>
 							<NotePanel />
 						</Suspense>
 					</Navigator.Screen>
-					<Navigator.Screen path="/notes/:noteId">
+					<Navigator.Screen
+						path="/notes/:noteId"
+						style={ { display: 'flex', flexDirection: 'column', height: '100%' } }
+					>
 						<Suspense fallback={ null }>
 							<Note />
 						</Suspense>

--- a/apps/notifications/src/app/note-list/dataviews.tsx
+++ b/apps/notifications/src/app/note-list/dataviews.tsx
@@ -21,7 +21,7 @@ export function getFields(): Field< any >[] {
 			id: 'icon',
 			label: __( 'Icon' ),
 			render: ( { item } ) => (
-				<div className="wpnc__note-icon" style={ { position: 'relative' } }>
+				<div className="wpnc__note-icon" style={ { position: 'relative', height: '100%' } }>
 					<ImagePreloader
 						src={ item.icon }
 						key={ `image-preloader-${ item.icon }` }
@@ -34,9 +34,9 @@ export function getFields(): Field< any >[] {
 						className="wpnc__gridicon"
 						style={ {
 							position: 'absolute',
-							bottom: 0,
+							bottom: '-5px',
 							right: 0,
-							border: '1.5px solid #fff',
+							border: '1px solid #fff',
 							background: '#ddd',
 						} }
 					>

--- a/apps/notifications/src/app/note-panel/index.tsx
+++ b/apps/notifications/src/app/note-panel/index.tsx
@@ -40,9 +40,7 @@ const NotePanel = () => {
 					</TabPanel>
 				</VStack>
 			</CardHeader>
-			<div style={ { overflow: 'auto' } }>
-				<NoteList />
-			</div>
+			<NoteList />
 		</>
 	);
 };

--- a/apps/notifications/src/app/note/index.tsx
+++ b/apps/notifications/src/app/note/index.tsx
@@ -90,7 +90,7 @@ const Note = () => {
 					</Navigator.BackButton>
 				</HStack>
 			</CardHeader>
-			<VStack>
+			<VStack justify="flex-start">
 				{ note && (
 					<div className="wpnc__main">
 						<div
@@ -99,8 +99,6 @@ const Note = () => {
 								position: 'relative',
 								left: 0,
 								right: 0,
-								overflow: 'auto',
-								minHeight: '50vh',
 								zIndex: 1,
 							} }
 						>

--- a/apps/notifications/src/app/types.ts
+++ b/apps/notifications/src/app/types.ts
@@ -1,0 +1,77 @@
+type Range = {
+	type: string;
+	indices: [ number, number ];
+	id: number | string;
+	parent: number | string | null;
+	url?: string;
+	site_id?: number;
+};
+
+export type Note = {
+	id: number;
+	type: string;
+	read: number;
+	noticon: string;
+	timestamp: string; // ISO datetime string
+	icon: string;
+	url: string;
+	subject: Array< {
+		text: string;
+		ranges?: Range[];
+	} >;
+	body: Array< {
+		text: string;
+		media?: Array< {
+			type: string;
+			indices: [ number, number ];
+			url: string;
+		} >;
+		ranges?: Range[];
+		meta?: {
+			is_mobile_button?: boolean;
+		};
+	} >;
+	meta: {
+		ids: {
+			site: number;
+		};
+		links: {
+			site: string;
+		};
+	};
+	title: string;
+	note_hash: number;
+};
+
+type Inbox = {
+	note_id: number;
+	action: 'push';
+};
+
+export interface Client {
+	noteList: Note[];
+	gettingNotes: boolean;
+	timeout: boolean;
+	isVisible: boolean;
+	isShowing: boolean;
+	lastSeenTime: number;
+	noteRequestLimit: number;
+	retries: number;
+	subscribeTry: number;
+	subscribeTries: number;
+	subscribing: boolean;
+	subscribed: boolean;
+	firstRender: boolean;
+	locale: string | null;
+	inbox: Inbox[];
+
+	main: () => void;
+	reschedule: ( refresh_ms?: number ) => void;
+	getNote: ( note_id: number ) => void;
+	getNotes: () => void;
+	getNotesList: () => void;
+	updateLastSeenTime: ( proposedTime: number, fromStorage: boolean ) => boolean;
+	loadMore: () => void;
+	refreshNotes: () => void;
+	setVisibility: ( { isShowing, isVisible }: { isShowing: boolean; isVisible: boolean } ) => void;
+}

--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -1,6 +1,5 @@
 import { useNavigate } from '@tanstack/react-router';
 import { Button, Dropdown } from '@wordpress/components';
-import '@wordpress/components/build-style/style.css';
 import { __ } from '@wordpress/i18n';
 import { bellUnread, bell } from '@wordpress/icons';
 import { Suspense, lazy } from 'react';
@@ -41,7 +40,7 @@ export default function Notifications( { className }: { className: string } ) {
 				/>
 			) }
 			renderContent={ ( { onClose } ) => (
-				<div style={ { width: '480px', margin: '-8px' } }>
+				<div style={ { width: '480px', height: '100vh', maxHeight: 'inherit', margin: '-8px' } }>
 					<Suspense fallback={ null }>
 						<AsyncNotificationApp actionHandlers={ actionHandlers( onClose ) } wpcom={ wpcom } />
 					</Suspense>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1663,6 +1663,7 @@ __metadata:
     "@automattic/wp-babel-makepot": "workspace:^"
     "@wordpress/components": "npm:^29.9.0"
     "@wordpress/data": "npm:^10.23.0"
+    "@wordpress/dataviews": "npm:^7.0.0"
     "@wordpress/i18n": "npm:^5.23.0"
     autoprefixer: "npm:^10.4.21"
     calypso: "workspace:^"


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Upgrade `@wordpress/dataviews` to `v7.0.0` to support infinite scroll
* Implement infinite scroll on notification v2
* Add some types
* Adjust some styles

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Click the notifications icon on the top-right corner
* Scroll down to the bottom
* Ensure it loads new notifications

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
