### PR TITLE
DataViews: Upgrade to 7.0.0

### DIFF
--- a/apps/design-system-docs/package.json
+++ b/apps/design-system-docs/package.json
@@ -29,7 +29,7 @@
 		"@wordpress/base-styles": "^5.23.0",
 		"@wordpress/browserslist-config": "^6.23.0",
 		"@wordpress/components": "^29.9.0",
-		"@wordpress/dataviews": "^5.0.1-next.719a03cbe.0",
+		"@wordpress/dataviews": "^7.0.0",
 		"docusaurus-plugin-sass": "^0.2.6",
 		"prism-react-renderer": "^2.4.1",
 		"react": "^18.3.1",

--- a/client/dashboard/domains/dns/form.tsx
+++ b/client/dashboard/domains/dns/form.tsx
@@ -14,7 +14,7 @@ import type { DnsRecordTypeFormData, DnsRecordFormData } from './records/dns-rec
 import type { DnsRecord } from '../../data/domain-dns-records';
 
 const typeForm = {
-	type: 'regular' as const,
+	layout: { type: 'regular' as const },
 	fields: [ 'type' ],
 };
 

--- a/client/dashboard/domains/dns/records/a-record.tsx
+++ b/client/dashboard/domains/dns/records/a-record.tsx
@@ -30,7 +30,7 @@ export const ARecordConfig: DnsRecordConfig = {
 		},
 	],
 	form: {
-		type: 'regular',
+		layout: { type: 'regular' as const },
 		fields: [ 'name', 'data', 'ttl' ],
 	},
 	transformData: ( data: DnsRecordFormData ) => ( {

--- a/client/dashboard/domains/dns/records/aaaa-record.tsx
+++ b/client/dashboard/domains/dns/records/aaaa-record.tsx
@@ -26,7 +26,7 @@ export const AAAARecordConfig: DnsRecordConfig = {
 		},
 	],
 	form: {
-		type: 'regular',
+		layout: { type: 'regular' as const },
 		fields: [ 'name', 'data', 'ttl' ],
 	},
 	transformData: ( data: DnsRecordFormData ) => ( {

--- a/client/dashboard/domains/dns/records/alias-record.tsx
+++ b/client/dashboard/domains/dns/records/alias-record.tsx
@@ -22,7 +22,7 @@ export const AliasRecordConfig: DnsRecordConfig = {
 		},
 	],
 	form: {
-		type: 'regular',
+		layout: { type: 'regular' as const },
 		fields: [ 'data', 'ttl' ],
 	},
 	transformData: ( data: DnsRecordFormData, domainName?: string ) => {

--- a/client/dashboard/domains/dns/records/caa-record.tsx
+++ b/client/dashboard/domains/dns/records/caa-record.tsx
@@ -45,7 +45,7 @@ export const CAARecordConfig: DnsRecordConfig = {
 		},
 	],
 	form: {
-		type: 'regular',
+		layout: { type: 'regular' as const },
 		fields: [ 'name', 'flags', 'tag', 'data', 'ttl' ],
 	},
 	transformData: ( data: DnsRecordFormData ) => ( {

--- a/client/dashboard/domains/dns/records/cname-record.tsx
+++ b/client/dashboard/domains/dns/records/cname-record.tsx
@@ -29,7 +29,7 @@ export const CNAMERecordConfig: DnsRecordConfig = {
 		},
 	],
 	form: {
-		type: 'regular',
+		layout: { type: 'regular' as const },
 		fields: [ 'name', 'data', 'ttl' ],
 	},
 	transformData: ( data: DnsRecordFormData ) => {

--- a/client/dashboard/domains/dns/records/dns-record-configs.ts
+++ b/client/dashboard/domains/dns/records/dns-record-configs.ts
@@ -32,7 +32,7 @@ export type DnsRecordConfig = {
 	description?: string;
 	fields: Field< DnsRecordFormData >[];
 	form: {
-		type: 'regular';
+		layout: { type: 'regular' };
 		fields: string[];
 	};
 	// Function to transform the form data into the format expected by the DNS endpoint

--- a/client/dashboard/domains/dns/records/mx-record.tsx
+++ b/client/dashboard/domains/dns/records/mx-record.tsx
@@ -36,7 +36,7 @@ export const MXRecordConfig: DnsRecordConfig = {
 		},
 	],
 	form: {
-		type: 'regular',
+		layout: { type: 'regular' as const },
 		fields: [ 'name', 'data', 'aux', 'ttl' ],
 	},
 	transformData: ( data: DnsRecordFormData ) => {

--- a/client/dashboard/domains/dns/records/ns-record.tsx
+++ b/client/dashboard/domains/dns/records/ns-record.tsx
@@ -29,7 +29,7 @@ export const NSRecordConfig: DnsRecordConfig = {
 		},
 	],
 	form: {
-		type: 'regular',
+		layout: { type: 'regular' as const },
 		fields: [ 'name', 'data', 'ttl' ],
 	},
 	transformData: ( data: DnsRecordFormData ) => {

--- a/client/dashboard/domains/dns/records/srv-record.tsx
+++ b/client/dashboard/domains/dns/records/srv-record.tsx
@@ -67,7 +67,7 @@ export const SRVRecordConfig: DnsRecordConfig = {
 		},
 	],
 	form: {
-		type: 'regular',
+		layout: { type: 'regular' as const },
 		fields: [ 'name', 'service', 'protocol', 'aux', 'weight', 'target', 'port', 'ttl' ],
 	},
 	transformData: ( data: DnsRecordFormData ) => {

--- a/client/dashboard/domains/dns/records/txt-record.tsx
+++ b/client/dashboard/domains/dns/records/txt-record.tsx
@@ -43,7 +43,7 @@ export const TXTRecordConfig: DnsRecordConfig = {
 		},
 	],
 	form: {
-		type: 'regular',
+		layout: { type: 'regular' as const },
 		fields: [ 'name', 'data', 'ttl' ],
 	},
 	transformData: ( data: DnsRecordFormData ) => ( {

--- a/client/dashboard/domains/domain-dns/email-setup-form.tsx
+++ b/client/dashboard/domains/domain-dns/email-setup-form.tsx
@@ -18,7 +18,7 @@ export type EmailSetupFormData = {
 };
 
 const form = {
-	type: 'regular' as const,
+	layout: { type: 'regular' as const },
 	fields: [ 'record' ],
 };
 

--- a/client/dashboard/domains/domain-dnssec/index.tsx
+++ b/client/dashboard/domains/domain-dnssec/index.tsx
@@ -31,7 +31,7 @@ const fields: Field< DNSSECFormData >[] = [
 ];
 
 const form = {
-	type: 'regular' as const,
+	layout: { type: 'regular' as const },
 	fields: [ 'enabled' ],
 };
 

--- a/client/dashboard/domains/domain-forwardings/form.tsx
+++ b/client/dashboard/domains/domain-forwardings/form.tsx
@@ -159,7 +159,7 @@ export default function DomainForwardingForm( {
 	);
 
 	const form = {
-		type: 'regular' as const,
+		layout: { type: 'regular' as const },
 		fields: [ 'sourceType', 'subdomain', 'targetUrl' ],
 	};
 

--- a/client/dashboard/domains/name-servers/form.tsx
+++ b/client/dashboard/domains/name-servers/form.tsx
@@ -126,8 +126,9 @@ export default function NameServersForm( {
 		return initialData as FormData;
 	} );
 
-	const formObj = useMemo(
+	const form = useMemo(
 		() => ( {
+			layout: { type: 'regular' as const },
 			fields: [
 				'useWpcomNameServers',
 				...Array.from(
@@ -204,7 +205,7 @@ export default function NameServersForm( {
 
 	const canSubmit =
 		! isBusy &&
-		isItemValid( formData, fields, formObj ) &&
+		isItemValid( formData, fields, form ) &&
 		isNameServersChanged( formData, nameServers );
 
 	return (
@@ -213,7 +214,7 @@ export default function NameServersForm( {
 				<DataForm< FormData >
 					data={ formData }
 					fields={ fields }
-					form={ formObj }
+					form={ form }
 					onChange={ ( value ) => {
 						setFormData( ( data ) => ( { ...data, ...value } ) );
 					} }

--- a/client/dashboard/me/privacy/do-not-sell-card.tsx
+++ b/client/dashboard/me/privacy/do-not-sell-card.tsx
@@ -66,7 +66,7 @@ export default function DoNotSellCard() {
 	];
 
 	const form = {
-		type: 'regular' as const,
+		layout: { type: 'regular' as const },
 		fields: [ 'advertising_targeting_opt_out' ],
 	};
 

--- a/client/dashboard/me/privacy/usage-information-card.tsx
+++ b/client/dashboard/me/privacy/usage-information-card.tsx
@@ -66,7 +66,7 @@ export default function UsageInformationCard() {
 	];
 
 	const form = {
-		type: 'regular' as const,
+		layout: { type: 'regular' as const },
 		fields: [ 'tracks_opt_out' ],
 	};
 

--- a/client/dashboard/me/profile/index.tsx
+++ b/client/dashboard/me/profile/index.tsx
@@ -100,8 +100,7 @@ const fields: Field< UserProfile >[] = [
 ];
 
 const form = {
-	type: 'regular' as const,
-	labelPosition: 'top' as const,
+	layout: { type: 'regular' as const, labelPosition: 'top' as const },
 	fields: [
 		{
 			id: 'personalInfo',

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -157,7 +157,7 @@ export default function Sites() {
 						onChangeView={ handleViewChange }
 						defaultLayouts={ DEFAULT_LAYOUTS }
 						paginationInfo={ paginationInfo }
-						perPageSizes={ DEFAULT_PER_PAGE_SIZES }
+						config={ { perPageSizes: DEFAULT_PER_PAGE_SIZES } }
 						empty={
 							<DataViewsEmptyState
 								title={ emptyTitle }

--- a/client/dashboard/sites/settings-agency/index.tsx
+++ b/client/dashboard/sites/settings-agency/index.tsx
@@ -52,7 +52,7 @@ const fields: Field< SiteSettings >[] = [
 ];
 
 const form = {
-	type: 'regular' as const,
+	layout: { type: 'regular' as const },
 	fields: [ { id: 'is_fully_managed_agency_site' } as SimpleFormField ],
 };
 

--- a/client/dashboard/sites/settings-caching/index.tsx
+++ b/client/dashboard/sites/settings-caching/index.tsx
@@ -49,7 +49,7 @@ const fields: Field< CachingFormData >[] = [
 ];
 
 const form = {
-	type: 'regular' as const,
+	layout: { type: 'regular' as const },
 	fields: [ 'active' ],
 };
 

--- a/client/dashboard/sites/settings-defensive-mode/index.tsx
+++ b/client/dashboard/sites/settings-defensive-mode/index.tsx
@@ -63,7 +63,7 @@ const fields: Field< { ttl: string } >[] = [
 ];
 
 const form = {
-	type: 'regular' as const,
+	layout: { type: 'regular' as const },
 	fields: [ 'ttl' ],
 };
 

--- a/client/dashboard/sites/settings-hundred-year-plan/index.tsx
+++ b/client/dashboard/sites/settings-hundred-year-plan/index.tsx
@@ -43,7 +43,7 @@ const fields: Field< SiteSettings >[] = [
 ];
 
 const form = {
-	type: 'regular' as const,
+	layout: { type: 'regular' as const },
 	fields: [ { id: 'wpcom_legacy_contact' }, { id: 'wpcom_locked_mode' } ] as SimpleFormField[],
 };
 

--- a/client/dashboard/sites/settings-php/index.tsx
+++ b/client/dashboard/sites/settings-php/index.tsx
@@ -54,7 +54,7 @@ export default function PHPVersionSettings( { siteSlug }: { siteSlug: string } )
 	];
 
 	const form = {
-		type: 'regular' as const,
+		layout: { type: 'regular' as const },
 		fields: [ 'version' ],
 	};
 

--- a/client/dashboard/sites/settings-sftp-ssh/sftp-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/sftp-card.tsx
@@ -128,7 +128,7 @@ export default function SftpCard( {
 	];
 
 	const form = {
-		type: 'regular' as const,
+		layout: { type: 'regular' as const },
 		fields: [ 'url', 'port', 'username', 'password' ],
 	};
 

--- a/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
@@ -275,7 +275,7 @@ export default function SshCard( {
 	];
 
 	const form = {
-		type: 'regular' as const,
+		layout: { type: 'regular' as const },
 		fields: [ 'connection_command', 'ssh_key' ],
 	};
 

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -60,7 +60,7 @@ const visibilityFields: Field< PrivacyFormData >[] = [
 
 const visibilityForm = {
 	layout: {
-		type: 'regular',
+		type: 'regular' as const,
 	},
 	fields: [ { id: 'visibility', layout: { type: 'regular', labelPosition: 'none' } } ],
 } satisfies Form;
@@ -115,7 +115,7 @@ const robotFields: Field< PrivacyFormData & { isPrimaryDomainStaging: boolean } 
 ];
 
 const robotForm = {
-	layout: { type: 'regular' },
+	layout: { type: 'regular' as const },
 	fields: [ 'discourageSearchEngines', 'preventThirdPartySharing' ],
 } satisfies Form;
 

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -59,8 +59,10 @@ const visibilityFields: Field< PrivacyFormData >[] = [
 ];
 
 const visibilityForm = {
-	type: 'regular',
-	fields: [ { id: 'visibility', labelPosition: 'none' } ],
+	layout: {
+		type: 'regular',
+	},
+	fields: [ { id: 'visibility', layout: { type: 'regular', labelPosition: 'none' } } ],
 } satisfies Form;
 
 // This form also has access to `isPrimaryDomainStaging` which isn't a persisted setting, but is data
@@ -113,7 +115,7 @@ const robotFields: Field< PrivacyFormData & { isPrimaryDomainStaging: boolean } 
 ];
 
 const robotForm = {
-	type: 'regular',
+	layout: { type: 'regular' },
 	fields: [ 'discourageSearchEngines', 'preventThirdPartySharing' ],
 } satisfies Form;
 

--- a/client/dashboard/sites/settings-static-file-404/index.tsx
+++ b/client/dashboard/sites/settings-static-file-404/index.tsx
@@ -51,9 +51,8 @@ const fields: Field< { setting: string } >[] = [
 ];
 
 const form = {
-	type: 'regular' as const,
+	layout: { type: 'regular' as const, labelPosition: 'none' as const },
 	fields: [ 'setting' ],
-	labelPosition: 'none' as const,
 };
 
 export default function SiteStaticFile404Settings( { siteSlug }: { siteSlug: string } ) {

--- a/client/dashboard/sites/settings-subscription-gifting/index.tsx
+++ b/client/dashboard/sites/settings-subscription-gifting/index.tsx
@@ -45,7 +45,7 @@ const fields: Field< SiteSettings >[] = [
 ];
 
 const form = {
-	type: 'regular' as const,
+	layout: { type: 'regular' as const },
 	fields: [ { id: 'wpcom_gifting_subscription' } as SimpleFormField ],
 };
 

--- a/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
@@ -29,7 +29,7 @@ const fields: Field< ConfirmNewOwnerFormData >[] = [
 ];
 
 const form = {
-	type: 'regular' as const,
+	layout: { type: 'regular' as const },
 	fields: [ 'email' ],
 };
 

--- a/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
@@ -45,7 +45,7 @@ const fields: Field< StartSiteTransferFormData >[] = [
 ];
 
 const form = {
-	type: 'regular' as const,
+	layout: { type: 'regular' as const },
 	fields: [ 'accept_authorization', 'accept_transfer', 'accept_undone' ],
 };
 

--- a/client/dashboard/sites/settings-web-application-firewall/allow-list-form.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/allow-list-form.tsx
@@ -54,7 +54,7 @@ const fields: Field< JetpackSettings >[] = [
 ];
 
 const form = {
-	type: 'regular' as const,
+	layout: { type: 'regular' as const },
 	fields: [ 'jetpack_waf_ip_allow_list_enabled', 'jetpack_waf_ip_allow_list' ],
 };
 

--- a/client/dashboard/sites/settings-web-application-firewall/automatic-rules-form.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/automatic-rules-form.tsx
@@ -32,7 +32,7 @@ const fields: Field< JetpackSettings >[] = [
 ];
 
 const form = {
-	type: 'regular' as const,
+	layout: { type: 'regular' as const },
 	fields: [ 'jetpack_waf_automatic_rules' ],
 };
 

--- a/client/dashboard/sites/settings-web-application-firewall/block-list-form.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/block-list-form.tsx
@@ -55,7 +55,7 @@ const fields: Field< JetpackSettings >[] = [
 ];
 
 const form = {
-	type: 'regular' as const,
+	layout: { type: 'regular' as const },
 	fields: [ 'jetpack_waf_ip_block_list_enabled', 'jetpack_waf_ip_block_list' ],
 };
 

--- a/client/dashboard/sites/settings-web-application-firewall/protect-form.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/protect-form.tsx
@@ -28,7 +28,7 @@ const fields = [
 ];
 
 const form = {
-	type: 'regular' as const,
+	layout: { type: 'regular' as const },
 	fields: [ 'protect' ],
 };
 

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -54,7 +54,7 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 	];
 
 	const form = {
-		type: 'regular' as const,
+		layout: { type: 'regular' as const },
 		fields: [ 'version' ],
 	};
 

--- a/client/dashboard/sites/settings-wpcom-login/sso-form.tsx
+++ b/client/dashboard/sites/settings-wpcom-login/sso-form.tsx
@@ -76,7 +76,7 @@ const fields: Field< WpcomLoginFormData >[] = [
 ];
 
 const form = {
-	type: 'regular' as const,
+	layout: { type: 'regular' as const },
 	fields: [ 'sso', 'jetpack_sso_match_by_email', 'jetpack_sso_require_two_step' ],
 };
 

--- a/client/dashboard/sites/site-change-address-modal/content.tsx
+++ b/client/dashboard/sites/site-change-address-modal/content.tsx
@@ -88,7 +88,7 @@ const NewSiteAddressForm = ( {
 	];
 
 	const form = {
-		type: 'regular' as const,
+		layout: { type: 'regular' as const },
 		fields: [ 'subdomain' ],
 	};
 
@@ -211,7 +211,7 @@ const ConfirmNewSiteAddressForm = ( {
 	];
 
 	const form = {
-		type: 'regular' as const,
+		layout: { type: 'regular' as const },
 		fields: [ 'accept_undone' ],
 	};
 

--- a/client/dashboard/sites/site-delete-modal/index.tsx
+++ b/client/dashboard/sites/site-delete-modal/index.tsx
@@ -142,7 +142,7 @@ function SiteDeleteConfirmContent( { site, onClose }: { site: Site; onClose: () 
 	];
 
 	const form = {
-		type: 'regular' as const,
+		layout: { type: 'regular' as const },
 		fields: [ 'domain' ],
 	};
 

--- a/client/dashboard/sites/site-leave-modal/content-info.tsx
+++ b/client/dashboard/sites/site-leave-modal/content-info.tsx
@@ -165,7 +165,7 @@ function ContentLeaveSite( { site, onClose }: ContentInfoProps ) {
 							Edit: 'checkbox',
 						},
 					] }
-					form={ { type: 'regular' as const, fields: [ 'confirmed' ] } }
+					form={ { layout: { type: 'regular' as const }, fields: [ 'confirmed' ] } }
 					onChange={ ( edits: Partial< SiteLeaveFormData > ) => {
 						setFormData( ( data ) => ( { ...data, ...edits } ) );
 					} }

--- a/client/dashboard/sites/site-preview-links/index.tsx
+++ b/client/dashboard/sites/site-preview-links/index.tsx
@@ -90,7 +90,7 @@ export default function SitePreviewLinks( { site, title, description }: SitePrev
 		];
 
 		const form = {
-			type: 'regular' as const,
+			layout: { type: 'regular' as const },
 			fields: [ 'enabled' ],
 		};
 

--- a/client/dashboard/sites/site-reset-modal/index.tsx
+++ b/client/dashboard/sites/site-reset-modal/index.tsx
@@ -121,7 +121,7 @@ function SiteResetContent( {
 					<DataForm< SiteResetFormData >
 						data={ formData }
 						fields={ fields }
-						form={ { layout: { type: 'regular' }, fields } }
+						form={ { layout: { type: 'regular' as const }, fields } }
 						onChange={ ( edits: { domain?: string } ) => {
 							setFormData( ( data ) => ( {
 								...data,

--- a/client/dashboard/sites/site-reset-modal/index.tsx
+++ b/client/dashboard/sites/site-reset-modal/index.tsx
@@ -121,7 +121,7 @@ function SiteResetContent( {
 					<DataForm< SiteResetFormData >
 						data={ formData }
 						fields={ fields }
-						form={ { type: 'regular', fields } }
+						form={ { layout: { type: 'regular' }, fields } }
 						onChange={ ( edits: { domain?: string } ) => {
 							setFormData( ( data ) => ( {
 								...data,

--- a/client/me/purchases/vat-info/vat-form.tsx
+++ b/client/me/purchases/vat-info/vat-form.tsx
@@ -167,7 +167,7 @@ export default function VatForm() {
 	];
 
 	const form = {
-		type: 'regular' as const,
+		layout: { type: 'regular' as const },
 		fields: [ 'country', 'id', 'name', 'address' ],
 	};
 

--- a/client/package.json
+++ b/client/package.json
@@ -100,7 +100,7 @@
 		"@wordpress/components": "^29.9.0",
 		"@wordpress/compose": "^7.23.0",
 		"@wordpress/data": "^10.23.0",
-		"@wordpress/dataviews": "^5.0.1-next.719a03cbe.0",
+		"@wordpress/dataviews": "^7.0.0",
 		"@wordpress/date": "^5.23.0",
 		"@wordpress/dom": "^4.23.0",
 		"@wordpress/edit-post": "^8.23.0",

--- a/package.json
+++ b/package.json
@@ -356,7 +356,7 @@
 		"@wordpress/customize-widgets": "5.23.0",
 		"@wordpress/data-controls": "4.23.0",
 		"@wordpress/data": "^10.23.0",
-		"@wordpress/dataviews": "^6.0.0",
+		"@wordpress/dataviews": "^7.0.0",
 		"@wordpress/date": "5.23.0",
 		"@wordpress/dependency-extraction-webpack-plugin": "^6.24.0",
 		"@wordpress/deprecated": "4.23.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1097,7 +1097,7 @@ __metadata:
     "@wordpress/base-styles": "npm:^5.23.0"
     "@wordpress/browserslist-config": "npm:^6.23.0"
     "@wordpress/components": "npm:^29.9.0"
-    "@wordpress/dataviews": "npm:^5.0.1-next.719a03cbe.0"
+    "@wordpress/dataviews": "npm:^7.0.0"
     docusaurus-plugin-sass: "npm:^0.2.6"
     prism-react-renderer: "npm:^2.4.1"
     react: "npm:^18.3.1"
@@ -12011,25 +12011,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/dataviews@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "@wordpress/dataviews@npm:6.0.0"
+"@wordpress/dataviews@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "@wordpress/dataviews@npm:7.0.0"
   dependencies:
     "@ariakit/react": "npm:^0.4.15"
     "@babel/runtime": "npm:7.25.7"
-    "@wordpress/base-styles": "npm:^6.4.0"
-    "@wordpress/components": "npm:^30.1.0"
-    "@wordpress/compose": "npm:^7.28.0"
-    "@wordpress/data": "npm:^10.28.0"
-    "@wordpress/date": "npm:^5.28.0"
-    "@wordpress/element": "npm:^6.28.0"
-    "@wordpress/i18n": "npm:^6.1.0"
-    "@wordpress/icons": "npm:^10.28.0"
-    "@wordpress/keycodes": "npm:^4.28.0"
-    "@wordpress/primitives": "npm:^4.28.0"
-    "@wordpress/private-apis": "npm:^1.28.0"
-    "@wordpress/url": "npm:^4.28.0"
-    "@wordpress/warning": "npm:^3.28.0"
+    "@wordpress/base-styles": "npm:^6.5.0"
+    "@wordpress/components": "npm:^30.2.0"
+    "@wordpress/compose": "npm:^7.29.0"
+    "@wordpress/data": "npm:^10.29.0"
+    "@wordpress/date": "npm:^5.29.0"
+    "@wordpress/element": "npm:^6.29.0"
+    "@wordpress/i18n": "npm:^6.2.0"
+    "@wordpress/icons": "npm:^10.29.0"
+    "@wordpress/keycodes": "npm:^4.29.0"
+    "@wordpress/primitives": "npm:^4.29.0"
+    "@wordpress/private-apis": "npm:^1.29.0"
+    "@wordpress/url": "npm:^4.29.0"
+    "@wordpress/warning": "npm:^3.29.0"
     clsx: "npm:^2.1.1"
     date-fns: "npm:^4.1.0"
     fast-deep-equal: "npm:^3.1.3"
@@ -12037,7 +12037,7 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: a467883e1d57a6bd506372594a68d2e4bfaede1c1e1f9c0690f839931761eba18e83879dbe3d0abd446b8734a64f4a2d23b615e981a4c5fc273ed0e7c58999a7
+  checksum: e472eae31ad9b34b5a686164ad9fe391258f4464faad3ac103b1e59c5f63d008f4e4d264ddda1af29b8ba47607f84599c45e1e1df94f36070e3c9b1f8ce476ff
   languageName: node
   linkType: hard
 
@@ -15002,7 +15002,7 @@ __metadata:
     "@wordpress/components": "npm:^29.9.0"
     "@wordpress/compose": "npm:^7.23.0"
     "@wordpress/data": "npm:^10.23.0"
-    "@wordpress/dataviews": "npm:^5.0.1-next.719a03cbe.0"
+    "@wordpress/dataviews": "npm:^7.0.0"
     "@wordpress/date": "npm:^5.23.0"
     "@wordpress/dom": "npm:^4.23.0"
     "@wordpress/edit-post": "npm:^8.23.0"


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Upgrade to 7.0.0 to get the infinite scroll feature

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We need the infinite scroll feature

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Go through any screens that use either DataViews or DataForms
* Ensure everything still works as before

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
