### PR TITLE
Ensure links are called "Preview links"

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -1,8 +1,8 @@
 import { createRoute, redirect, createLazyRoute, lazyRouteComponent } from '@tanstack/react-router';
-import { HostingFeatures } from '../../data/constants';
+import { HostingFeatures, DotcomFeatures } from '../../data/constants';
 import { LogType } from '../../data/site-logs';
 import { canViewHundredYearPlanSettings, canViewWordPressSettings } from '../../sites/features';
-import { hasHostingFeature } from '../../utils/site-features';
+import { hasHostingFeature, hasPlanFeature } from '../../utils/site-features';
 import { hasSiteTrialEnded } from '../../utils/site-trial';
 import { isAutomatticianQuery } from '../queries/me-a8c';
 import { rawUserPreferencesQuery } from '../queries/me-preferences';
@@ -326,9 +326,12 @@ export const siteSettingsSiteVisibilityRoute = createRoute( {
 	path: 'settings/site-visibility',
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		Promise.all( [
+		await Promise.all( [
 			queryClient.ensureQueryData( siteSettingsQuery( site.ID ) ),
 			queryClient.ensureQueryData( siteDomainsQuery( site.ID ) ),
+			site.is_coming_soon &&
+				hasPlanFeature( site, DotcomFeatures.SITE_PREVIEW_LINKS ) &&
+				queryClient.ensureQueryData( sitePreviewLinksQuery( site.ID ) ),
 		] );
 	},
 } ).lazy( () =>

--- a/client/dashboard/sites/site-preview-links/index.tsx
+++ b/client/dashboard/sites/site-preview-links/index.tsx
@@ -28,12 +28,17 @@ interface SitePreviewLinkProps {
 }
 
 export default function SitePreviewLinks( { site, title, description }: SitePreviewLinkProps ) {
-	const { data: links = [] } = useQuery( sitePreviewLinksQuery( site.ID ) );
+	const linksPermitted = hasPlanFeature( site, DotcomFeatures.SITE_PREVIEW_LINKS );
+
+	const { data: links = [] } = useQuery( {
+		...sitePreviewLinksQuery( site.ID ),
+		enabled: linksPermitted,
+	} );
 	const createMutation = useMutation( sitePreviewLinkCreateMutation( site.ID ) );
 	const deleteMutation = useMutation( sitePreviewLinkDeleteMutation( site.ID ) );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
-	if ( ! hasPlanFeature( site, DotcomFeatures.SITE_PREVIEW_LINKS ) ) {
+	if ( ! linksPermitted ) {
 		return null;
 	}
 
@@ -48,7 +53,7 @@ export default function SitePreviewLinks( { site, title, description }: SitePrev
 				},
 			} );
 		} else {
-			links?.forEach( ( { code } ) => {
+			links.forEach( ( { code } ) => {
 				deleteMutation.mutate( code, {
 					onSuccess: () => {
 						createSuccessNotice( __( 'Preview link disabled.' ), { type: 'snackbar' } );
@@ -105,7 +110,7 @@ export default function SitePreviewLinks( { site, title, description }: SitePrev
 						form={ form }
 						onChange={ handleChange }
 					/>
-					{ links?.map( ( link ) => (
+					{ links.map( ( link ) => (
 						<SitePreviewLink
 							key={ link.code }
 							label={ __( 'Preview link' ) }

--- a/client/dashboard/sites/site-preview-links/index.tsx
+++ b/client/dashboard/sites/site-preview-links/index.tsx
@@ -62,7 +62,7 @@ export default function SitePreviewLinks( { site, title, description }: SitePrev
 	};
 
 	const handleCopy = () => {
-		createSuccessNotice( __( 'Copied the share link to clipboard.' ), {
+		createSuccessNotice( __( 'Copied the preview link to clipboard.' ), {
 			type: 'snackbar',
 		} );
 	};
@@ -73,7 +73,7 @@ export default function SitePreviewLinks( { site, title, description }: SitePrev
 		const fields: Field< { enabled: boolean } >[] = [
 			{
 				id: 'enabled',
-				label: __( 'Enable share link' ),
+				label: __( 'Enable preview link' ),
 				Edit: ( { field, onChange, data, hideLabelFromVision } ) => {
 					const { id, label, getValue } = field;
 					return (
@@ -108,7 +108,7 @@ export default function SitePreviewLinks( { site, title, description }: SitePrev
 					{ links?.map( ( link ) => (
 						<SitePreviewLink
 							key={ link.code }
-							label={ __( 'share link' ) }
+							label={ __( 'Preview link' ) }
 							hideLabelFromVision
 							{ ...link }
 							siteUrl={ site.URL }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTDASH-147

## Proposed Changes

* Updates the coming soon site sharing feature so the links are always called "preview links"
* Improve site visibility page's loading behaviour

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The mockups call this feature "share" or "share site" QOBjujZah0UlGDDdLKZhzi-fi-5104_96129

However the links themselves are variously called "share links" and/or "preview links".

This PR makes the verbiage consistent. The feature is for "sharing" or "sharing your site", and the think you are "sharing" is a "preview link".

While I was here, I also tweaked the loading logic for the site visibility page, because it wasn't a nice experience when the cache was empty. The preview link data is needed as soon as the page is loaded to ensure the toggle doesn't appear as disabled and then a second later update to enabled.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test that the share feature works as expected for coming soon sites
* Test I haven't broken the site visibility view for non-coming soon sites
* Test using an a4a site too
  * In particular a4a sites have a card on the over page which links to the site sharing feature
* Test the improved loading experience
  * Navigate to `/v2/sites/:siteSlug/settings/site-visibility`
  * Switch site to coming soon mode
  * Enable preview link
  * Open dev tools and delete `REACT_QUERY_OFFLINE_CACHE` local storage
  * Refresh page
  * The page loads cleanly, the checkbox is immediately in the correct enabled state

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?