### PR TITLE
Retain the existing site list data when you start searching

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -71,7 +71,11 @@ export default function Sites() {
 		viewSearchParams,
 	} );
 
-	const { data: sites, isLoading: isLoadingSites } = useQuery( {
+	const {
+		data: sites,
+		isLoading: isLoadingSites,
+		isPlaceholderData,
+	} = useQuery( {
 		...sitesQuery( getFetchSitesOptions( view, isRestoringAccount ) ),
 		placeholderData: keepPreviousData,
 	} );
@@ -154,7 +158,7 @@ export default function Sites() {
 						fields={ fields }
 						actions={ actions }
 						view={ view }
-						isLoading={ isLoadingSites }
+						isLoading={ isLoadingSites || ( isPlaceholderData && filteredData.length === 0 ) }
 						onChangeView={ handleViewChange }
 						defaultLayouts={ DEFAULT_LAYOUTS }
 						paginationInfo={ paginationInfo }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -1,4 +1,4 @@
-import { useQuery, useSuspenseQuery, useMutation } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery, useMutation, keepPreviousData } from '@tanstack/react-query';
 import { useNavigate, useRouter } from '@tanstack/react-router';
 import { Button, Modal } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
@@ -71,9 +71,10 @@ export default function Sites() {
 		viewSearchParams,
 	} );
 
-	const { data: sites, isLoading: isLoadingSites } = useQuery(
-		sitesQuery( getFetchSitesOptions( view, isRestoringAccount ) )
-	);
+	const { data: sites, isLoading: isLoadingSites } = useQuery( {
+		...sitesQuery( getFetchSitesOptions( view, isRestoringAccount ) ),
+		placeholderData: keepPreviousData,
+	} );
 
 	const fields = getFields( { isAutomattician, viewType: view.type } );
 	const actions = getActions( router );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->



## Proposed Changes

The site list search box doesn't just search visible sites, it also searches sites which have been hidden. That is the site list empties when you start searching: it changes from a `?site_visibility=visible` fetch, to a `?site_visibility=all` fetch.

This PR changes the site list component so that retains the old data in the dataview when the new fetch is initiated. It is much less disruptive for most users who probably aren't looking for a hidden site.

**Before**


https://github.com/user-attachments/assets/a7564c2d-31d6-4bb4-b9fa-4d12090902eb



**After**


https://github.com/user-attachments/assets/048b3c55-a352-49b3-a0b9-2e8cdfa72f5c


**When you _do_ have a hidden site**


https://github.com/user-attachments/assets/b0300f97-f559-42ed-ab9c-805acdaadb3c




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Related to some product feedback pc4f5j-5KC-p2#comment-4989

While we can't improve the list performance until we've switched to elastic search, we can still improve the perceived performance.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Search using the site list in v2 and the backport
* You may want to clear out the react query cache between tests so you are confident of when it is fetching new data
* You can manage your hidden sites here: https://dashboard.wordpress.com/wp-admin/index.php?page=my-blogs

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?