### PR TITLE
Hosting Dashboard: Update private site dashboard copy

### DIFF
--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -51,7 +51,7 @@ const visibilityFields: Field< PrivacyFormData >[] = [
 				label: __( 'Private' ),
 				value: 'private',
 				description: __(
-					'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
+					'Your site is only visible to you and to logged-in members you approve. Everyone else will see a login screen.'
 				),
 			},
 		],

--- a/client/sites/settings/site/privacy/form.tsx
+++ b/client/sites/settings/site/privacy/form.tsx
@@ -309,7 +309,7 @@ const SiteSettingPrivacyForm = ( {
 						</FormLabel>
 						<FormSettingExplanation>
 							{ translate(
-								'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
+								'Your site is only visible to you and to logged-in members you approve. Everyone else will see a login screen.'
 							) }
 						</FormSettingExplanation>
 					</>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-34

## Proposed Changes

The original sentence:

> Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.

Suggested edit:

> Your site is only visible to you and to logged-in members you approve. Everyone else will see a login screen.

See also: https://github.com/Automattic/jetpack/pull/44905

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Implementing feedback.

Added “to” for parallel structure.

Changed “log in” to “login” since it’s used as a noun.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Check the copy in the site visibility settings: `/sites/:siteSlug/settings/site-visibility`
I'm not sure whether the un-untangled reader settings view is still available somewhere, but I updated the copy there too for good measure.

Test the wp-admin change in https://github.com/Automattic/jetpack/pull/44905

I'll use string freeze on this PR.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
