### PR TITLE
Hosting Dashboard: Add domain overview settings

### DIFF
--- a/client/dashboard/data/domain.ts
+++ b/client/dashboard/data/domain.ts
@@ -4,6 +4,9 @@ import type { DomainSummary } from './domains';
 export interface Domain extends DomainSummary {
 	can_manage_name_servers: boolean;
 	cannot_manage_name_servers_reason: null | string;
+	has_wpcom_nameservers: boolean;
+	is_dnssec_enabled: boolean;
+	is_dnssec_supported: boolean;
 	is_domain_only_site: boolean;
 	is_gravatar_domain: boolean;
 	is_root_domain_registered_with_automattic: boolean;

--- a/client/dashboard/data/domain.ts
+++ b/client/dashboard/data/domain.ts
@@ -9,6 +9,8 @@ export interface Domain extends DomainSummary {
 	is_root_domain_registered_with_automattic: boolean;
 	is_subdomain: boolean;
 	move_to_new_site_pending: boolean;
+	private_domain: boolean;
+	ssl_status: 'active' | 'inactive' | 'newly_registered' | 'pending';
 	subdomain_part: string;
 }
 

--- a/client/dashboard/data/domains.ts
+++ b/client/dashboard/data/domains.ts
@@ -38,6 +38,7 @@ export interface DomainSummary {
 	expired: boolean;
 	expiry: string | false;
 	has_registration: boolean;
+	has_wpcom_nameservers: boolean;
 	is_dnssec_enabled: boolean;
 	is_dnssec_supported: boolean;
 	is_eligible_for_inbound_transfer: boolean;

--- a/client/dashboard/data/domains.ts
+++ b/client/dashboard/data/domains.ts
@@ -38,9 +38,6 @@ export interface DomainSummary {
 	expired: boolean;
 	expiry: string | false;
 	has_registration: boolean;
-	has_wpcom_nameservers: boolean;
-	is_dnssec_enabled: boolean;
-	is_dnssec_supported: boolean;
 	is_eligible_for_inbound_transfer: boolean;
 	is_hundred_year_domain: boolean;
 	is_redeemable: boolean;

--- a/client/dashboard/domains/domain-contact-details/summary.tsx
+++ b/client/dashboard/domains/domain-contact-details/summary.tsx
@@ -1,0 +1,22 @@
+import { __ } from '@wordpress/i18n';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import type { Domain } from '../../data/types';
+import type { SummaryButtonBadgeProps } from '@automattic/components/src/summary-button/types';
+
+export default function DomainContactDetailsSettingsSummary( { domain }: { domain: Domain } ) {
+	const badges: SummaryButtonBadgeProps[] = [];
+	if ( domain.private_domain ) {
+		badges.push( { text: __( 'Privacy protection on' ), intent: 'success' as const } );
+	} else {
+		badges.push( { text: __( 'Privacy protection off' ), intent: 'warning' as const } );
+	}
+
+	return (
+		<RouterLinkSummaryButton
+			to={ `/domains/${ domain.domain }/contact-info` }
+			title={ __( 'Contact details & privacy' ) }
+			badges={ badges }
+			density={ 'medium' as const }
+		/>
+	);
+}

--- a/client/dashboard/domains/domain-contact-details/summary.tsx
+++ b/client/dashboard/domains/domain-contact-details/summary.tsx
@@ -8,7 +8,7 @@ export default function DomainContactDetailsSettingsSummary( { domain }: { domai
 	if ( domain.private_domain ) {
 		badges.push( { text: __( 'Privacy protection on' ), intent: 'success' as const } );
 	} else {
-		badges.push( { text: __( 'Privacy protection off' ), intent: 'warning' as const } );
+		badges.push( { text: __( 'Privacy protection off' ), intent: undefined } );
 	}
 
 	return (

--- a/client/dashboard/domains/domain-dns/summary.tsx
+++ b/client/dashboard/domains/domain-dns/summary.tsx
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 import type { Domain } from '../../data/types';
 
-export default function NameServersSettingsSummary( { domain }: { domain: Domain } ) {
+export default function DnsSettingsSummary( { domain }: { domain: Domain } ) {
 	let badges = [];
 	if ( domain.has_wpcom_nameservers ) {
 		badges = [ { text: __( 'Using WordPress.com name servers' ), intent: 'success' as const } ];
@@ -12,8 +12,8 @@ export default function NameServersSettingsSummary( { domain }: { domain: Domain
 
 	return (
 		<RouterLinkSummaryButton
-			to={ `/domains/${ domain.domain }/name-servers` }
-			title={ __( 'Name servers' ) }
+			to={ `/domains/${ domain.domain }/dns` }
+			title={ __( 'DNS records' ) }
 			badges={ badges }
 		/>
 	);

--- a/client/dashboard/domains/domain-forwardings/summary.tsx
+++ b/client/dashboard/domains/domain-forwardings/summary.tsx
@@ -2,11 +2,11 @@ import { __ } from '@wordpress/i18n';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 import type { Domain } from '../../data/types';
 
-export default function DnsSettingsSummary( { domain }: { domain: Domain } ) {
+export default function DomainForwardingsSettingsSummary( { domain }: { domain: Domain } ) {
 	return (
 		<RouterLinkSummaryButton
-			to={ `/domains/${ domain.domain }/dns` }
-			title={ __( 'DNS records' ) }
+			to={ `/domains/${ domain.domain }/forwardings` }
+			title={ __( 'Domain forwarding' ) }
 			badges={ [] }
 			density={ 'medium' as const }
 		/>

--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -12,6 +12,7 @@ import PageLayout from '../../components/page-layout';
 import { formatDate } from '../../utils/datetime';
 import { getDomainRenewalUrl } from '../../utils/domain';
 import Actions from './actions';
+import DomainOverviewSettings from './settings';
 
 export default function DomainOverview() {
 	const locale = useLocale();
@@ -65,6 +66,7 @@ export default function DomainOverview() {
 				/>
 			}
 		>
+			<DomainOverviewSettings />
 			<Actions />
 		</PageLayout>
 	);

--- a/client/dashboard/domains/domain-overview/settings.tsx
+++ b/client/dashboard/domains/domain-overview/settings.tsx
@@ -5,7 +5,12 @@ import { domainQuery } from '../../app/queries/domain';
 import { domainRoute } from '../../app/router/domains';
 import { SectionHeader } from '../../components/section-header';
 import { SummaryButtonList } from '../../components/summary-button-list';
+import DomainContactDetailsSettingsSummary from '../domain-contact-details/summary';
+import DnsSettingsSummary from '../domain-dns/summary';
+import DomainForwardingsSettingsSummary from '../domain-forwardings/summary';
+import DomainSecuritySettingsSummary from '../domain-security/summary';
 import NameServersSettingsSummary from '../name-servers/summary';
+import DomainGlueRecordsSettingsSummary from '../overview-glue-records/summary';
 
 export default function DomainOverviewSettings() {
 	const { domainName } = domainRoute.useParams();
@@ -14,7 +19,12 @@ export default function DomainOverviewSettings() {
 		<VStack spacing={ 3 }>
 			<SectionHeader title={ __( 'Settings' ) } level={ 3 } />
 			<SummaryButtonList>
+				<DnsSettingsSummary domain={ domain } />
 				<NameServersSettingsSummary domain={ domain } />
+				<DomainForwardingsSettingsSummary domain={ domain } />
+				<DomainContactDetailsSettingsSummary domain={ domain } />
+				<DomainSecuritySettingsSummary domain={ domain } />
+				<DomainGlueRecordsSettingsSummary domain={ domain } />
 			</SummaryButtonList>
 		</VStack>
 	);

--- a/client/dashboard/domains/domain-overview/settings.tsx
+++ b/client/dashboard/domains/domain-overview/settings.tsx
@@ -19,8 +19,8 @@ export default function DomainOverviewSettings() {
 		<VStack spacing={ 3 }>
 			<SectionHeader title={ __( 'Settings' ) } level={ 3 } />
 			<SummaryButtonList>
-				<DnsSettingsSummary domain={ domain } />
 				<NameServersSettingsSummary domain={ domain } />
+				<DnsSettingsSummary domain={ domain } />
 				<DomainForwardingsSettingsSummary domain={ domain } />
 				<DomainContactDetailsSettingsSummary domain={ domain } />
 				<DomainSecuritySettingsSummary domain={ domain } />

--- a/client/dashboard/domains/domain-overview/settings.tsx
+++ b/client/dashboard/domains/domain-overview/settings.tsx
@@ -1,0 +1,21 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { __experimentalVStack as VStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { domainQuery } from '../../app/queries/domain';
+import { domainRoute } from '../../app/router/domains';
+import { SectionHeader } from '../../components/section-header';
+import { SummaryButtonList } from '../../components/summary-button-list';
+import NameServersSettingsSummary from '../name-servers/summary';
+
+export default function DomainOverviewSettings() {
+	const { domainName } = domainRoute.useParams();
+	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
+	return (
+		<VStack spacing={ 3 }>
+			<SectionHeader title={ __( 'Settings' ) } level={ 3 } />
+			<SummaryButtonList>
+				<NameServersSettingsSummary domain={ domain } />
+			</SummaryButtonList>
+		</VStack>
+	);
+}

--- a/client/dashboard/domains/domain-security/summary.tsx
+++ b/client/dashboard/domains/domain-security/summary.tsx
@@ -16,7 +16,7 @@ export default function NameServersSettingsSummary( { domain }: { domain: Domain
 	if ( domain.is_dnssec_enabled ) {
 		badges.push( { text: __( 'DNSSEC enabled' ), intent: 'success' as const } );
 	} else {
-		badges.push( { text: __( 'DNSSEC disabled' ), intent: 'info' as const } );
+		badges.push( { text: __( 'DNSSEC disabled' ), intent: undefined } );
 	}
 
 	return (

--- a/client/dashboard/domains/domain-security/summary.tsx
+++ b/client/dashboard/domains/domain-security/summary.tsx
@@ -1,0 +1,30 @@
+import { __ } from '@wordpress/i18n';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import type { Domain } from '../../data/types';
+import type { SummaryButtonBadgeProps } from '@automattic/components/src/summary-button/types';
+
+export default function NameServersSettingsSummary( { domain }: { domain: Domain } ) {
+	const badges: SummaryButtonBadgeProps[] = [];
+	if ( domain.ssl_status === 'active' ) {
+		badges.push( { text: __( 'SSL active' ), intent: 'success' as const } );
+	} else if ( domain.ssl_status === 'newly_registered' || domain.ssl_status === 'pending' ) {
+		badges.push( { text: __( 'SSL Pending' ), intent: 'warning' as const } );
+	} else {
+		badges.push( { text: __( 'SSL Disabled' ), intent: 'error' as const } );
+	}
+
+	if ( domain.is_dnssec_enabled ) {
+		badges.push( { text: __( 'DNSSEC enabled' ), intent: 'success' as const } );
+	} else {
+		badges.push( { text: __( 'DNSSEC disabled' ), intent: 'info' as const } );
+	}
+
+	return (
+		<RouterLinkSummaryButton
+			to={ `/domains/${ domain.domain }/security` }
+			title={ __( 'Domain security' ) }
+			badges={ badges }
+			density={ 'medium' as const }
+		/>
+	);
+}

--- a/client/dashboard/domains/name-servers/summary.tsx
+++ b/client/dashboard/domains/name-servers/summary.tsx
@@ -7,7 +7,7 @@ export default function NameServersSettingsSummary( { domain }: { domain: Domain
 	if ( domain.has_wpcom_nameservers ) {
 		badges = [ { text: __( 'Using WordPress.com name servers' ), intent: 'success' as const } ];
 	} else {
-		badges = [ { text: __( 'Using custom name servers' ), intent: 'warning' as const } ];
+		badges = [ { text: __( 'Using custom name servers' ), intent: 'info' as const } ];
 	}
 
 	return (

--- a/client/dashboard/domains/name-servers/summary.tsx
+++ b/client/dashboard/domains/name-servers/summary.tsx
@@ -15,6 +15,7 @@ export default function NameServersSettingsSummary( { domain }: { domain: Domain
 			to={ `/domains/${ domain.domain }/name-servers` }
 			title={ __( 'Name servers' ) }
 			badges={ badges }
+			density={ 'medium' as const }
 		/>
 	);
 }

--- a/client/dashboard/domains/name-servers/summary.tsx
+++ b/client/dashboard/domains/name-servers/summary.tsx
@@ -1,0 +1,28 @@
+import { __ } from '@wordpress/i18n';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import type { Domain } from '../../data/types';
+import type { Density } from '@automattic/components/src/summary-button/types';
+
+export default function NameServersSettingsSummary( {
+	domain,
+	density,
+}: {
+	domain: Domain;
+	density?: Density;
+} ) {
+	let badges = [];
+	if ( domain.has_wpcom_nameservers ) {
+		badges = [ { text: __( 'Using WordPress.com name servers' ), intent: 'success' as const } ];
+	} else {
+		badges = [ { text: __( 'Using custom name servers' ), intent: 'warning' as const } ];
+	}
+
+	return (
+		<RouterLinkSummaryButton
+			to={ `/domains/${ domain.domain }/name-servers` }
+			title={ __( 'Name servers' ) }
+			density={ density }
+			badges={ badges }
+		/>
+	);
+}

--- a/client/dashboard/domains/name-servers/summary.tsx
+++ b/client/dashboard/domains/name-servers/summary.tsx
@@ -7,7 +7,7 @@ export default function NameServersSettingsSummary( { domain }: { domain: Domain
 	if ( domain.has_wpcom_nameservers ) {
 		badges = [ { text: __( 'Using WordPress.com name servers' ), intent: 'success' as const } ];
 	} else {
-		badges = [ { text: __( 'Using custom name servers' ), intent: 'info' as const } ];
+		badges = [ { text: __( 'Using custom name servers' ), intent: undefined } ];
 	}
 
 	return (

--- a/client/dashboard/domains/overview-glue-records/summary.tsx
+++ b/client/dashboard/domains/overview-glue-records/summary.tsx
@@ -2,11 +2,11 @@ import { __ } from '@wordpress/i18n';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 import type { Domain } from '../../data/types';
 
-export default function DnsSettingsSummary( { domain }: { domain: Domain } ) {
+export default function DomainGlueRecordsSettingsSummary( { domain }: { domain: Domain } ) {
 	return (
 		<RouterLinkSummaryButton
-			to={ `/domains/${ domain.domain }/dns` }
-			title={ __( 'DNS records' ) }
+			to={ `/domains/${ domain.domain }/glue-records` }
+			title={ __( 'Glue records' ) }
 			badges={ [] }
 			density={ 'medium' as const }
 		/>

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -548,7 +548,7 @@ const Settings = ( {
 		const { privateDomain, isHundredYearDomain } = domain;
 		const titleLabel = translate( 'Contact information', { textOnly: true } );
 		const privacyProtectionLabel = privateDomain
-			? translate( 'Privacy protection on', { textOnly: true } )
+			? translate( 'Privacy protection onaaaa', { textOnly: true } )
 			: translate( 'Privacy protection off', { textOnly: true } );
 
 		if ( ! domain.currentUserCanManage ) {

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -548,7 +548,7 @@ const Settings = ( {
 		const { privateDomain, isHundredYearDomain } = domain;
 		const titleLabel = translate( 'Contact information', { textOnly: true } );
 		const privacyProtectionLabel = privateDomain
-			? translate( 'Privacy protection onaaaa', { textOnly: true } )
+			? translate( 'Privacy protection on', { textOnly: true } )
 			: translate( 'Privacy protection off', { textOnly: true } );
 
 		if ( ! domain.currentUserCanManage ) {


### PR DESCRIPTION
Closes [DOTDASH-314](https://linear.app/a8c/issue/DOTDASH-314/create-the-settings-panel)

## Proposed Changes
This PR implements the **Settings** section on the **Domain Overview** page (in the Hosting Dashboard)

## Why are these changes being made?
This component is part of the HD Domains projects.

![Screenshot 2025-08-22 alle 16 12 00](https://github.com/user-attachments/assets/52f774f7-3ccc-4f21-9fec-2d5b56e569e2)

![Screenshot 2025-08-22 alle 16 08 23](https://github.com/user-attachments/assets/ccb98585-2d68-4d8b-b968-5672cb2192b1)


## Testing Instructions
Apply this PR and verify that the Settings card is rendered correctly.
Ensure that the badges display the correct values, and that each button links to the appropriate page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
