### PR TITLE
Staging Sites: Ensure that the env switcher becomes available at the same time on prod and staging

### DIFF
--- a/client/sites/components/site-preview-pane/site-environment-switcher.tsx
+++ b/client/sites/components/site-preview-pane/site-environment-switcher.tsx
@@ -19,17 +19,6 @@ export default function SiteEnvironmentSwitcher( {
 }: SiteEnvironmentSwitcherProps ) {
 	const { __ } = useI18n();
 
-	if (
-		! site.is_wpcom_staging_site &&
-		! (
-			site.is_wpcom_atomic &&
-			site.options?.wpcom_staging_blog_ids &&
-			site.options?.wpcom_staging_blog_ids.length > 0
-		)
-	) {
-		return;
-	}
-
 	const productionSiteId = site.is_wpcom_staging_site
 		? site.options?.wpcom_production_blog_id
 		: site.ID;

--- a/packages/sites/src/site-excerpt-constants.ts
+++ b/packages/sites/src/site-excerpt-constants.ts
@@ -22,6 +22,7 @@ export const SITE_EXCERPT_REQUEST_FIELDS = [
 	'lang',
 	'site_owner',
 	'is_a8c',
+	'capabilities',
 ] as const;
 
 export const SITE_EXCERPT_COMPUTED_FIELDS = [ 'slug' ] as const;


### PR DESCRIPTION
Part of STU-736

## Proposed Changes

This PR ensures that the env switcher becomes available as soon as the staging site is ready so that we don't a case when the switcher is ready on staging and is absent on production. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Currently, the switcher on production appears much later than on staging creating inconsistency. 

## Testing Instructions

* Pull the changes from this branch or use the Calypso Live Link
* Ensure that you have an Atomic site
* Navigate to `sites/{yourAtomicSite}`
* Click on `Add staging site` button
* Wait for the site to be created
* Observe that the switcher appears at the same time as the notice that the site was successfully created

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
