### PR TITLE
Staging Sites: Ensure add staging site button does not show on domains page

### DIFF
--- a/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
@@ -38,7 +38,7 @@ export default function HeaderStagingSiteButton( {
 	siteId,
 	isAtomic,
 	isStagingSite,
-	hideEnvDataInHeader = false,
+	hideEnvDataInHeader,
 }: HeaderStagingSiteButtonProps ) {
 	const dispatch = useDispatch();
 	const { __ } = useI18n();
@@ -148,6 +148,7 @@ export default function HeaderStagingSiteButton( {
 	);
 
 	const showAddStagingButton =
+		! hideEnvDataInHeader &&
 		isAtomic &&
 		! isStagingSite &&
 		! isLoadingStagingSites &&


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes STU-738

## Proposed Changes

This PR ensures that the `Add staging site` button does not show on the domains page when an Atomic site has a custom domain. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch or use the Calypso Live Link
* Ensure that you have an Atomic site with a custom domain 
* Navigate to `/domains/manage/all/overview/{yourCustomDomain}`
* Confirm that the `Add staging site` button is not visible there
* Confirm that  when you navigate to`/sites/{yourAtomicSite}`, you can still see the `Add staging site` button

<img width="1996" height="348" alt="Screenshot 2025-08-22 at 2 08 23 PM" src="https://github.com/user-attachments/assets/ab7f5490-46f0-4cd2-a43c-bcdd8ceafe7f" />
