### PR TITLE
Summer special banner: Fix position on free domains upsell flow

### DIFF
--- a/client/blocks/summer-special-banner/style.scss
+++ b/client/blocks/summer-special-banner/style.scss
@@ -37,12 +37,12 @@
 		z-index: 100001;
 		margin: 0;
 
-		.layout__secondary:not(:empty) ~ .layout__primary & {
+		.layout:not(.has-no-sidebar) .layout__secondary:not(:empty) ~ .layout__primary & {
 			left: var( --sidebar-width-max );
 		}
 
 		@media ( max-width: 781px ) {
-			.layout.focus-content .layout__secondary:not(:empty) ~ .layout__primary & {
+			.layout.focus-content:not(.has-no-sidebar) .layout__secondary:not(:empty) ~ .layout__primary & {
 				left: 0;
 			}
 		}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* fixes the CSS selector for positioning the Summer special banner when the sidebar is not empty but hidden

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* needed to fix the position of the banner on the Free domain flow

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/yearly/{SITE_SLUG}?domainAndPlanPackage=true`
* The Summer special banner should be properly positioned

| Before | After |
|--------|--------|
| <img width="1651" height="1228" alt="Screenshot 2025-08-22 at 15 52 48" src="https://github.com/user-attachments/assets/846b70c4-915d-42cc-8f3a-f9a093d3ef31" /> | <img width="1649" height="1223" alt="Screenshot 2025-08-22 at 15 52 56" src="https://github.com/user-attachments/assets/c9001864-7e71-4106-8b98-d0d6320a1ba9" /> | 

* Go to `/plans/{SITE_SLUG}`
* The Summer special banner should be properly positioned across all screen sizes

<img width="480" height="1224" alt="Screenshot 2025-08-22 at 15 52 35" src="https://github.com/user-attachments/assets/44a2f16f-11fd-4cda-9178-aee7fe412dda" />
<img width="320" height="964" alt="Screenshot 2025-08-22 at 15 58 13" src="https://github.com/user-attachments/assets/061964ae-8a4c-4ef5-87ca-0402cef4a0f1" />




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
