### PR TITLE
Revert "Experiment streamlining the plans grid + checkout: Enforce the winning solution of the experiment"

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
@@ -1,12 +1,17 @@
 import { getFlowFromURL } from 'calypso/landing/stepper/utils/get-flow-from-url';
 import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
+import { useExperiment, loadExperimentAssignment } from 'calypso/lib/explat';
 import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 
-export function useStreamlinedPriceExperiment(): [ boolean, string | null ] {
-	const variationName = isEligibleForExperiment() ? 'plans_1Y_checkout_radio' : null;
+const STREAMLINED_PRICE_EXPERIMENT_NAME = 'calypso_streamlined_plans_checkout';
 
-	return [ false, variationName ];
+export function useStreamlinedPriceExperiment(): [ boolean, string | null ] {
+	const [ isLoadingExperiment, assignment ] = useExperiment( STREAMLINED_PRICE_EXPERIMENT_NAME, {
+		isEligible: isEligibleForExperiment(),
+	} );
+
+	return [ isLoadingExperiment, assignment?.variationName ?? null ];
 }
 
 function isEligibleForExperiment(): boolean {
@@ -15,6 +20,11 @@ function isEligibleForExperiment(): boolean {
 	const flow = flowFromStorage || flowFromURL;
 	// Only onboarding flow is eligible for streamlined pricing. Akismet/Jetpack checkouts are excluded as well.
 	return flow === 'onboarding' && ! isAkismetCheckout() && ! isJetpackCheckout();
+}
+
+export async function isStreamlinedPriceExperiment() {
+	const assignment = await loadExperimentAssignment( STREAMLINED_PRICE_EXPERIMENT_NAME );
+	return assignment?.variationName !== null;
 }
 
 export function isStreamlinedPricePlansTreatment( variationName?: string | null ) {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -478,12 +478,20 @@ const PlansFeaturesMain = ( {
 	const showStreamlinedPriceExperiment =
 		isInSignup && isStreamlinedPricePlansTreatment( streamlinedPriceExperimentAssignment );
 
-	let hidePlanSelector = false;
-	const enableTermSavingsPriceDisplay = true;
+	let hidePlanSelector = true;
+	let enableTermSavingsPriceDisplay = true;
 	// In the "purchase a plan and free domain" flow we do not want to show
 	// monthly plans because monthly plans do not come with a free domain.
-	if ( redirectToAddDomainFlow !== undefined || hidePlanTypeSelector ) {
-		hidePlanSelector = true;
+	// We are also hiding the plan interval selector and showing terms savings prices
+	// for the compatible streamlined price experiment variations.
+	if (
+		redirectToAddDomainFlow === undefined &&
+		! hidePlanTypeSelector &&
+		! isStreamlinedPriceExperimentLoading &&
+		! showStreamlinedPriceExperiment
+	) {
+		hidePlanSelector = false;
+		enableTermSavingsPriceDisplay = false;
 	}
 
 	let _customerType = chooseDefaultCustomerType( {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#105328