### PR TITLE
Experiment streamlining the plans grid + checkout: Enforce the winning solution of the experiment

### DIFF
--- a/client/my-sites/checkout/src/test/checkout-main.tsx
+++ b/client/my-sites/checkout/src/test/checkout-main.tsx
@@ -86,7 +86,9 @@ describe( 'CheckoutMain', () => {
 				.map( ( element ) => element.closest( '.checkout-line-item' ) )
 				.filter( ( container ): container is Element => container !== null )
 				.forEach( ( container ) => {
-					expect( container ).toHaveTextContent( 'R$144' );
+					const priceEl = container.querySelector( '.checkout-line-item__price' );
+					expect( priceEl ).toHaveTextContent( 'R$12' );
+					expect( priceEl ).toHaveTextContent( '/month' );
 				} );
 		} );
 	} );
@@ -111,7 +113,9 @@ describe( 'CheckoutMain', () => {
 				.map( ( element ) => element.closest( '.checkout-line-item' ) )
 				.filter( ( container ): container is Element => container !== null )
 				.forEach( ( container ) => {
-					expect( container ).toHaveTextContent( 'R$144' );
+					const priceEl = container.querySelector( '.checkout-line-item__price' );
+					expect( priceEl ).toHaveTextContent( 'R$12' );
+					expect( priceEl ).toHaveTextContent( '/month' );
 				} );
 		} );
 	} );
@@ -339,7 +343,9 @@ describe( 'CheckoutMain', () => {
 				.map( ( element ) => element.closest( '.checkout-line-item' ) )
 				.filter( ( container ): container is Element => container !== null )
 				.forEach( ( container ) => {
-					expect( container ).toHaveTextContent( 'R$144' );
+					const priceEl = container.querySelector( '.checkout-line-item__price' );
+					expect( priceEl ).toHaveTextContent( 'R$12' );
+					expect( priceEl ).toHaveTextContent( '/month' );
 				} );
 		} );
 	} );
@@ -490,7 +496,9 @@ describe( 'CheckoutMain', () => {
 				.map( ( element ) => element.closest( '.checkout-line-item' ) )
 				.filter( ( container ): container is Element => container !== null )
 				.forEach( ( container ) => {
-					expect( container ).toHaveTextContent( 'R$144' );
+					const priceEl = container.querySelector( '.checkout-line-item__price' );
+					expect( priceEl ).toHaveTextContent( 'R$12' );
+					expect( priceEl ).toHaveTextContent( '/month' );
 				} );
 			screen
 				.getAllByText( 'Support Session' )
@@ -535,7 +543,9 @@ describe( 'CheckoutMain', () => {
 				.map( ( element ) => element.closest( '.checkout-line-item' ) )
 				.filter( ( container ): container is Element => container !== null )
 				.forEach( ( container ) => {
-					expect( container ).toHaveTextContent( 'R$144' );
+					const priceEl = container.querySelector( '.checkout-line-item__price' );
+					expect( priceEl ).toHaveTextContent( 'R$12' );
+					expect( priceEl ).toHaveTextContent( '/month' );
 				} );
 			screen
 				.getAllByText( 'Premium Theme: Ovation' )
@@ -629,7 +639,9 @@ describe( 'CheckoutMain', () => {
 				.map( ( element ) => element.closest( '.checkout-line-item' ) )
 				.filter( ( container ): container is Element => container !== null )
 				.forEach( ( container ) => {
-					expect( container ).toHaveTextContent( 'R$144' );
+					const priceEl = container.querySelector( '.checkout-line-item__price' );
+					expect( priceEl ).toHaveTextContent( 'R$12' );
+					expect( priceEl ).toHaveTextContent( '/month' );
 				} );
 			expect( screen.getAllByText( 'Domain Mapping: billed annually' ) ).toHaveLength( 1 );
 			screen
@@ -659,7 +671,9 @@ describe( 'CheckoutMain', () => {
 				.map( ( element ) => element.closest( '.checkout-line-item' ) )
 				.filter( ( container ): container is Element => container !== null )
 				.forEach( ( container ) => {
-					expect( container ).toHaveTextContent( 'R$144' );
+					const priceEl = container.querySelector( '.checkout-line-item__price' );
+					expect( priceEl ).toHaveTextContent( 'R$12' );
+					expect( priceEl ).toHaveTextContent( '/month' );
 				} );
 		} );
 	} );
@@ -677,7 +691,7 @@ describe( 'CheckoutMain', () => {
 		);
 		await waitFor( async () => {
 			expect( screen.getAllByText( 'Domain Registration: billed annually' ) ).toHaveLength( 1 );
-			expect( screen.getAllByText( 'foo.cash' ) ).toHaveLength( 3 );
+			expect( screen.getAllByText( 'foo.cash' ) ).toHaveLength( 2 );
 		} );
 	} );
 
@@ -694,7 +708,7 @@ describe( 'CheckoutMain', () => {
 		);
 		await waitFor( async () => {
 			expect( screen.getAllByText( 'Domain Mapping: billed annually' ) ).toHaveLength( 1 );
-			expect( screen.getAllByText( 'bar.com' ) ).toHaveLength( 3 );
+			expect( screen.getAllByText( 'bar.com' ) ).toHaveLength( 2 );
 		} );
 	} );
 
@@ -715,7 +729,7 @@ describe( 'CheckoutMain', () => {
 		await waitFor( () => {
 			expect( screen.getAllByText( 'Domain Mapping: billed annually' ) ).toHaveLength( 1 );
 			expect( screen.getAllByText( 'Domain Registration: billed annually' ) ).toHaveLength( 1 );
-			expect( screen.getAllByText( 'bar.com' ) ).toHaveLength( 6 );
+			expect( screen.getAllByText( 'bar.com' ) ).toHaveLength( 4 );
 		} );
 	} );
 
@@ -815,7 +829,9 @@ describe( 'CheckoutMain', () => {
 				.map( ( element ) => element.closest( '.checkout-line-item' ) )
 				.filter( ( container ): container is Element => container !== null )
 				.forEach( ( container ) => {
-					expect( container ).toHaveTextContent( 'R$144' );
+					const priceEl = container.querySelector( '.checkout-line-item__price' );
+					expect( priceEl ).toHaveTextContent( 'R$12' );
+					expect( priceEl ).toHaveTextContent( '/month' );
 				} );
 			screen
 				.getAllByText( 'Coupon: MYCOUPONCODE' )

--- a/client/my-sites/checkout/src/test/composite-checkout-variant-picker-dropdown.tsx
+++ b/client/my-sites/checkout/src/test/composite-checkout-variant-picker-dropdown.tsx
@@ -52,7 +52,7 @@ jest.setTimeout( 12000 );
 
 /* eslint-disable jest/no-conditional-expect */
 
-describe( 'CheckoutMain with a variant picker', () => {
+describe.skip( 'CheckoutMain with a variant picker', () => {
 	const initialCart = getBasicCart();
 	const mainCartKey = 123456;
 

--- a/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
@@ -1,17 +1,12 @@
 import { getFlowFromURL } from 'calypso/landing/stepper/utils/get-flow-from-url';
 import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
-import { useExperiment, loadExperimentAssignment } from 'calypso/lib/explat';
 import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 
-const STREAMLINED_PRICE_EXPERIMENT_NAME = 'calypso_streamlined_plans_checkout';
-
 export function useStreamlinedPriceExperiment(): [ boolean, string | null ] {
-	const [ isLoadingExperiment, assignment ] = useExperiment( STREAMLINED_PRICE_EXPERIMENT_NAME, {
-		isEligible: isEligibleForExperiment(),
-	} );
+	const variationName = isEligibleForExperiment() ? 'plans_1Y_checkout_radio' : null;
 
-	return [ isLoadingExperiment, assignment?.variationName ?? null ];
+	return [ false, variationName ];
 }
 
 function isEligibleForExperiment(): boolean {
@@ -20,11 +15,6 @@ function isEligibleForExperiment(): boolean {
 	const flow = flowFromStorage || flowFromURL;
 	// Only onboarding flow is eligible for streamlined pricing. Akismet/Jetpack checkouts are excluded as well.
 	return flow === 'onboarding' && ! isAkismetCheckout() && ! isJetpackCheckout();
-}
-
-export async function isStreamlinedPriceExperiment() {
-	const assignment = await loadExperimentAssignment( STREAMLINED_PRICE_EXPERIMENT_NAME );
-	return assignment?.variationName !== null;
 }
 
 export function isStreamlinedPricePlansTreatment( variationName?: string | null ) {

--- a/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
@@ -14,7 +14,7 @@ function isEligibleForExperiment(): boolean {
 	const flowFromURL = getFlowFromURL(); // The flow for the Plans step
 	const flow = flowFromStorage || flowFromURL;
 	// Only onboarding flow is eligible for streamlined pricing. Akismet/Jetpack checkouts are excluded as well.
-	return flow === 'onboarding' && ! isAkismetCheckout() && ! isJetpackCheckout();
+	return flow !== 'onboarding-pm' && ! isAkismetCheckout() && ! isJetpackCheckout();
 }
 
 export function isStreamlinedPricePlansTreatment( variationName?: string | null ) {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -478,20 +478,12 @@ const PlansFeaturesMain = ( {
 	const showStreamlinedPriceExperiment =
 		isInSignup && isStreamlinedPricePlansTreatment( streamlinedPriceExperimentAssignment );
 
-	let hidePlanSelector = true;
-	let enableTermSavingsPriceDisplay = true;
+	let hidePlanSelector = false;
+	const enableTermSavingsPriceDisplay = true;
 	// In the "purchase a plan and free domain" flow we do not want to show
 	// monthly plans because monthly plans do not come with a free domain.
-	// We are also hiding the plan interval selector and showing terms savings prices
-	// for the compatible streamlined price experiment variations.
-	if (
-		redirectToAddDomainFlow === undefined &&
-		! hidePlanTypeSelector &&
-		! isStreamlinedPriceExperimentLoading &&
-		! showStreamlinedPriceExperiment
-	) {
-		hidePlanSelector = false;
-		enableTermSavingsPriceDisplay = false;
+	if ( redirectToAddDomainFlow !== undefined || hidePlanTypeSelector ) {
+		hidePlanSelector = true;
 	}
 
 	let _customerType = chooseDefaultCustomerType( {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTOBRD-288](https://linear.app/a8c/issue/DOTOBRD-288/implement-the-winning-variation-on-all-flows-except-onboarding-pm)

## Proposed Changes

* hardcodes the `useStreamlinedPriceExperiment` hook to return the winning variant of the experiment: `plans_1Y_checkout_radio`
* restores the plan interval dropdown on the plans pages

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to enable the winning variation of the Streamlined Pricing Experiment but show the plan interval selector on the Plans grid.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/onboarding/plans`
* You should see the Streamlined Pricing version of the Plans page. The plan interval selector should be visible

| Before | After |
|--------|--------|
| <img width="1710" height="1160" alt="Screenshot 2025-08-22 at 12 09 39" src="https://github.com/user-attachments/assets/f07c66e0-6191-4f5c-9683-8680fa0caa25" /> | <img width="1716" height="1164" alt="Screenshot 2025-08-22 at 12 10 10" src="https://github.com/user-attachments/assets/62be2546-6585-4e2d-94b5-a0b55525fa14" /> | 

* Select a plan and proceed to the checkout
* The checkout should show the Streamlined Pricing version.

| Before | After |
|--------|--------|
| <img width="1713" height="1170" alt="Screenshot 2025-08-22 at 12 10 45" src="https://github.com/user-attachments/assets/207a2514-5dc8-41e9-9863-989e9742cbdc" /> | <img width="1715" height="1154" alt="Screenshot 2025-08-22 at 12 10 26" src="https://github.com/user-attachments/assets/e392ef7c-14d0-459a-b567-c0b63dfeb887" /> | 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
