### PR TITLE
Add Backups date filter

### DIFF
--- a/client/dashboard/sites/backups/dataviews/fields.tsx
+++ b/client/dashboard/sites/backups/dataviews/fields.tsx
@@ -1,6 +1,7 @@
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useFormattedTime } from '../../../components/formatted-time';
+import { formatYmd } from '../../../utils/datetime';
 import { gridiconToWordPressIcon } from '../../../utils/gridicons';
 import type { ActivityLogEntry } from '../../../data/types';
 import type { Field } from '@wordpress/dataviews';
@@ -38,7 +39,14 @@ export function getFields(): Field< ActivityLogEntry >[] {
 		{
 			id: 'date',
 			label: __( 'Date' ),
-			getValue: ( { item } ) => item.published,
+			type: 'date',
+			filterBy: {
+				operators: [ 'on' ],
+			},
+			getValue: ( { item } ) => {
+				const date = new Date( item.published );
+				return formatYmd( date );
+			},
 			render: ( { item } ) => <FormattedTime timestamp={ item.published } />,
 		},
 		{


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes [DOTDASH-319][1].

## Proposed Changes

Add a date filter to the Backups list.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Users need to be able to quickly switch between dates for faster navigation between backups.

> [!NOTE]
> It's important to highlight that the filter isn't perfect. It works fine for specific dates, but it doesn't automatically switch to ranges when selecting `Past week` or `Past month`, for instance.
>
> I've tried different `filterBy` operators, but it wasn't clear to me how to handle that.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/v2/sites/{site}/backups`
- Try the date filter right beside the search bar.

### Date picker

<img width="626" height="685" alt="image" src="https://github.com/user-attachments/assets/3960ec66-e392-48b1-917a-c8c781dc1d81" />

### Result

<img width="631" height="317" alt="image" src="https://github.com/user-attachments/assets/adda493d-249a-41a8-81c7-48b611a5e670" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

[1]: https://linear.app/a8c/issue/DOTDASH-319