### PR TITLE
Notifications v2: add Keybord Shortcuts action menu

### DIFF
--- a/apps/notifications/src/app/note-panel/actions.tsx
+++ b/apps/notifications/src/app/note-panel/actions.tsx
@@ -1,26 +1,49 @@
 import { MenuGroup, MenuItem, DropdownMenu } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import actions from '../../panel/state/actions';
+import getIsShortcutsPopoverOpen from '../../panel/state/selectors/get-is-shortcuts-popover-open';
+import NoteShortcuts from '../note-shortcuts';
 
 export default function NotePanelActions() {
 	const dispatch = useDispatch();
 
+	const isShortcutsPopoverOpen = useSelector( getIsShortcutsPopoverOpen );
+
 	return (
-		<DropdownMenu icon={ moreVertical } label={ __( 'Actions' ) }>
-			{ ( { onClose } ) => (
-				<MenuGroup>
-					<MenuItem
-						onClick={ () => {
-							onClose();
-							dispatch( actions.ui.viewSettings() );
-						} }
-					>
-						{ __( 'Settings' ) }
-					</MenuItem>
-				</MenuGroup>
-			) }
+		<DropdownMenu
+			icon={ moreVertical }
+			label={ __( 'Actions' ) }
+			onToggle={ ( willOpen ) => {
+				if ( ! willOpen ) {
+					dispatch( actions.ui.closeShortcutsPopover() );
+				}
+			} }
+		>
+			{ ( { onClose } ) =>
+				isShortcutsPopoverOpen ? (
+					<NoteShortcuts />
+				) : (
+					<MenuGroup>
+						<MenuItem
+							onClick={ () => {
+								dispatch( actions.ui.toggleShortcutsPopover() );
+							} }
+						>
+							{ __( 'Keyboard shortcuts' ) }
+						</MenuItem>
+						<MenuItem
+							onClick={ () => {
+								onClose();
+								dispatch( actions.ui.viewSettings() );
+							} }
+						>
+							{ __( 'Settings' ) }
+						</MenuItem>
+					</MenuGroup>
+				)
+			}
 		</DropdownMenu>
 	);
 }

--- a/apps/notifications/src/app/note-shortcuts/index.tsx
+++ b/apps/notifications/src/app/note-shortcuts/index.tsx
@@ -1,0 +1,47 @@
+import { MenuItem } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useRef, useEffect } from 'react';
+
+import './style.scss';
+
+function ShortcutIcon( { letter }: { letter: string } ) {
+	return <span className="shortcut letter">{ letter }</span>;
+}
+
+function Shortcut( { letter, title }: { letter: string; title: string } ) {
+	return (
+		<MenuItem
+			disabled
+			icon={ <ShortcutIcon letter={ letter } /> }
+			iconPosition="left"
+			style={ { color: 'inherit' } }
+		>
+			{ title }
+		</MenuItem>
+	);
+}
+
+export default function NoteShortcuts() {
+	// Ensure the component has a focused wrapper container
+	// so that event handlers work when it is rendered inside a <Popover>.
+	const focusRef = useRef< HTMLDivElement >( null );
+	useEffect( () => {
+		focusRef.current?.focus();
+	}, [] );
+
+	return (
+		<div tabIndex={ -1 } ref={ focusRef } className="wpnc__keyboard-shortcuts-popover">
+			<Shortcut letter="n" title={ __( 'Toggle panel' ) } />
+			<Shortcut letter="↓" title={ __( 'Next' ) } />
+			<Shortcut letter="↑" title={ __( 'Previous' ) } />
+			<Shortcut letter="←" title={ __( 'Left' ) } />
+			<Shortcut letter="→" title={ __( 'Right' ) } />
+			<Shortcut letter="a" title={ __( 'View all' ) } />
+			<Shortcut letter="u" title={ __( 'View unread' ) } />
+			<Shortcut letter="c" title={ __( 'View comments' ) } />
+			<Shortcut letter="f" title={ __( 'View subscribers' ) } />
+			<Shortcut letter="l" title={ __( 'View likes' ) } />
+			<Shortcut letter="i" title={ __( 'Toggle shortcuts menu' ) } />
+		</div>
+	);
+}

--- a/apps/notifications/src/app/note-shortcuts/style.scss
+++ b/apps/notifications/src/app/note-shortcuts/style.scss
@@ -1,0 +1,15 @@
+.wpnc__keyboard-shortcuts-popover {
+	.shortcut {
+		border: 1px solid #ccc;
+		border-radius: 4px;
+		min-width: 25px;
+		min-height: 25px;
+		text-align: center;
+		margin-right: 5px;
+	}
+
+	.shortcut.letter {
+		font-weight: 600;
+		line-height: 25px;
+	}
+}


### PR DESCRIPTION
Fixes DOTDASH-298

## Proposed Changes

This PR implements the "Keyboard shortcuts" action menu:

|This PR|Notification v1|
|-|-|
|<img width="273" height="177" alt="image" src="https://github.com/user-attachments/assets/a5077b49-2fb5-43f5-9561-c713ff131f40" /><br><br><img width="296" height="557" alt="image" src="https://github.com/user-attachments/assets/e69d2677-694d-4009-9d84-5c054ef46d50" />|<img width="247" height="491" alt="image" src="https://github.com/user-attachments/assets/f3d8c04c-16a4-41e7-a48f-0cc19c3252a5" />

## Implementation Details

Based on the design that the shortcuts renders in the same place as the original dropdown menu items, I made a decision to just use `<MenuItem>` to implement the design. It's so that it's guaranteed that the original dropdown menu items and this shortcuts information have exactly the same styles. `<MenuItem>` also has built-in `icon` property to render something on the left of each item.

However, since none of the menu items have focusable element (I `disabled` all of them), I need to make a small hack to focus the parent component so that it still works well with the parent `<DropdownMenu>`'s mouse events. 😬 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to /v2/sites
2. Click the notification bell icon
3. Click "Keyboard shortcuts"
4. Verify the shortcuts info appear
5. Verify you can dismiss the info

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
