### PR TITLE
Domain Search Rewrite: Fix Hosting Dashboard cart

### DIFF
--- a/client/dashboard/components/domain-search/index.tsx
+++ b/client/dashboard/components/domain-search/index.tsx
@@ -1,7 +1,13 @@
 // eslint-disable-next-line no-restricted-imports
 import { DomainSearch } from '@automattic/domain-search';
+// eslint-disable-next-line no-restricted-imports
+import { ShoppingCartProvider } from '@automattic/shopping-cart';
 import { __ } from '@wordpress/i18n';
-import { useWPCOMShoppingCartForDomainSearch } from '../../app/shopping-cart';
+import { ComponentProps } from 'react';
+import {
+	shoppingCartManagerClient,
+	useWPCOMShoppingCartForDomainSearch,
+} from '../../app/shopping-cart';
 import { PageHeader } from '../page-header';
 import PageLayout from '../page-layout';
 
@@ -12,11 +18,18 @@ interface DashboardDomainSearchProps {
 	currentSiteUrl?: string;
 }
 
-function DashboardDomainSearch( { currentSiteId, currentSiteUrl }: DashboardDomainSearchProps ) {
+function DomainSearchWithCart( {
+	currentSiteId,
+	...props
+}: Omit< ComponentProps< typeof DomainSearch >, 'cart' > & { currentSiteId?: number } ) {
 	const cart = useWPCOMShoppingCartForDomainSearch( {
 		cartKey: currentSiteId ?? 'no-site',
 	} );
 
+	return <DomainSearch className="dashboard-domain-search" { ...props } cart={ cart } />;
+}
+
+function DashboardDomainSearch( props: DashboardDomainSearchProps ) {
 	return (
 		<PageLayout
 			size="large"
@@ -27,11 +40,9 @@ function DashboardDomainSearch( { currentSiteId, currentSiteUrl }: DashboardDoma
 				/>
 			}
 		>
-			<DomainSearch
-				cart={ cart }
-				className="dashboard-domain-search"
-				currentSiteUrl={ currentSiteUrl }
-			/>
+			<ShoppingCartProvider managerClient={ shoppingCartManagerClient }>
+				<DomainSearchWithCart { ...props } />
+			</ShoppingCartProvider>
 		</PageLayout>
 	);
 }


### PR DESCRIPTION
Follows up on DOMAINS-1597.

## Proposed Changes

Wraps the domain search with the shopping cart provider, something I missed in my last PR.

## Testing Instructions

You should see a functional cart in `/v2/domains/purchase` instead of a general error saying that there's no cart provider on the page.
