### PR TITLE
Scan: ensure the delete confirmation is visible only when trying to fix a threat

### DIFF
--- a/client/components/jetpack/threat-dialog/index.tsx
+++ b/client/components/jetpack/threat-dialog/index.tsx
@@ -27,7 +27,8 @@ const ThreatDialog: React.FC< Props > = ( {
 	const isExtensionDeleteFixer =
 		threat.signature === 'Vulnerable.WP.Extension' &&
 		threat.fixable &&
-		threat.fixable.fixer === 'delete';
+		threat.fixable.fixer === 'delete' &&
+		action === 'fix';
 	const [ confirmationInput, setConfirmationInput ] = React.useState( '' );
 	// So we don't share the input value between different threats
 	React.useEffect( () => {
@@ -62,7 +63,7 @@ const ThreatDialog: React.FC< Props > = ( {
 			</Button>,
 		];
 
-		if ( action === 'fix' && isExtensionDeleteFixer ) {
+		if ( isExtensionDeleteFixer ) {
 			const shouldBeDisabled = confirmationInput !== slug;
 			buttons.push(
 				<Button
@@ -124,7 +125,7 @@ const ThreatDialog: React.FC< Props > = ( {
 			<h3 className="threat-dialog__threat-title">
 				<ThreatFixHeader threat={ threat } action={ action } />
 			</h3>
-			{ action === 'fix' && isExtensionDeleteFixer && (
+			{ isExtensionDeleteFixer && (
 				<>
 					{ threat.fixable.extensionStatus === 'active' ? (
 						<Notice variant="error">

--- a/client/components/jetpack/threat-dialog/index.tsx
+++ b/client/components/jetpack/threat-dialog/index.tsx
@@ -62,7 +62,7 @@ const ThreatDialog: React.FC< Props > = ( {
 			</Button>,
 		];
 
-		if ( isExtensionDeleteFixer ) {
+		if ( action === 'fix' && isExtensionDeleteFixer ) {
 			const shouldBeDisabled = confirmationInput !== slug;
 			buttons.push(
 				<Button
@@ -124,7 +124,7 @@ const ThreatDialog: React.FC< Props > = ( {
 			<h3 className="threat-dialog__threat-title">
 				<ThreatFixHeader threat={ threat } action={ action } />
 			</h3>
-			{ isExtensionDeleteFixer && (
+			{ action === 'fix' && isExtensionDeleteFixer && (
 				<>
 					{ threat.fixable.extensionStatus === 'active' ? (
 						<Notice variant="error">


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Fix: ensure the delete confirmation is visible only when trying to fix a threat

If you try to ignore a fix that requires deleting the extension, the fixer confirmation dialog is still shown. This update ensures that the confirmation dialog only appears when the user selects the “Fix threat” option.

| Before | After |
|---|---|
| <img width="1380" height="1326" alt="CleanShot 2025-08-22 at 14 59 31@2x" src="https://github.com/user-attachments/assets/abbe90da-ad21-4312-9964-f2ef3137d75b" /> | <img width="1386" height="786" alt="CleanShot 2025-08-22 at 14 59 06@2x" src="https://github.com/user-attachments/assets/b57c7359-2503-4d94-a656-54f47bb56727" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Related discussion: p1755852959800389-slack-C04E0KTGW9Z

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Similar to https://github.com/Automattic/wp-calypso/pull/104861
* Spin up a Jetpack Cloud live branch
* Grab a test site with a vulnerable dotorg extension that is already at the newest version but vulnerable (e.g. chatra-live-chat)
* Try clicking on "Ignore threat" and ensure you are not seeing any confirmation dialog

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?