### PR TITLE
Domains: Allow users to disable transfer lock of .uk domains

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-out/select-ips-tag.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/select-ips-tag.jsx
@@ -9,6 +9,7 @@ import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import SearchCard from 'calypso/components/search-card';
 import { saveDomainIpsTag } from 'calypso/state/domains/transfer/actions';
+import { getDomainWapiInfoByDomainName } from 'calypso/state/domains/transfer/selectors';
 import getGainingRegistrar from 'calypso/state/selectors/get-gaining-registrar';
 import getIpsTagSaveStatus from 'calypso/state/selectors/get-ips-tag-save-status';
 
@@ -215,9 +216,9 @@ class SelectIpsTag extends Component {
 	}
 
 	render() {
-		const { translate, saveStatus, redesign } = this.props;
+		const { translate, saveStatus, redesign, isDomainLocked } = this.props;
 
-		const content = (
+		const content = ! isDomainLocked && (
 			<>
 				<p>
 					{ translate(
@@ -244,9 +245,13 @@ class SelectIpsTag extends Component {
 }
 
 export default connect(
-	( state, ownProps ) => ( {
-		gainingRegistrar: getGainingRegistrar( state, ownProps.selectedDomainName ),
-		saveStatus: getIpsTagSaveStatus( state, ownProps.selectedDomainName ),
-	} ),
+	( state, ownProps ) => {
+		const domainInfo = getDomainWapiInfoByDomainName( state, ownProps.selectedDomainName );
+		return {
+			isDomainLocked: domainInfo.data?.locked,
+			gainingRegistrar: getGainingRegistrar( state, ownProps.selectedDomainName ),
+			saveStatus: getIpsTagSaveStatus( state, ownProps.selectedDomainName ),
+		};
+	},
 	{ saveDomainIpsTag }
 )( localize( SelectIpsTag ) );

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/select-ips-tag.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/select-ips-tag.jsx
@@ -134,7 +134,15 @@ class SelectIpsTag extends Component {
 	}
 
 	renderIpsTagSelect() {
-		const { redesign, saveStatus, selectedDomainName, translate } = this.props;
+		const { redesign, saveStatus, selectedDomainName, translate, isDomainLocked } = this.props;
+
+		if ( isDomainLocked ) {
+			return (
+				<div>
+					<p>{ translate( 'The IPS tag cannot be set while the domain is locked.' ) }</p>
+				</div>
+			);
+		}
 
 		return (
 			<div>
@@ -216,9 +224,9 @@ class SelectIpsTag extends Component {
 	}
 
 	render() {
-		const { translate, saveStatus, redesign, isDomainLocked } = this.props;
+		const { translate, saveStatus, redesign } = this.props;
 
-		const content = ! isDomainLocked && (
+		const content = (
 			<>
 				<p>
 					{ translate(

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -339,7 +339,13 @@ const TransferPage = ( props: TransferPageProps ) => {
 	};
 
 	const renderUkTransferOptions = () => {
-		return <SelectIpsTag selectedDomainName={ selectedDomainName } redesign />;
+		return (
+			<>
+				<p>{ renderTransferMessage() }</p>
+				{ renderTransferLock() }
+				<SelectIpsTag selectedDomainName={ selectedDomainName } redesign />
+			</>
+		);
 	};
 
 	const renderCommonTldTransferOptions = () => {


### PR DESCRIPTION
Part of DOMENG-21

## Proposed Changes

This PR:
- Adds the lock toggle to the transfer page for .uk domains
- And updates the UI so that the IPS tag field is hidden if the domain is locked (since the transfer would fail if the user tried to transfer while the domain is locked)

### Screenshots

| Before | After |
| --- | --- |
| <img width="1074" height="578" alt="Screenshot 2025-08-22 at 19 15 43" src="https://github.com/user-attachments/assets/58fc3f23-2305-4417-b1e5-2b766540510b" /> | <img width="741" height="554" alt="Screenshot 2025-08-22 at 19 48 30" src="https://github.com/user-attachments/assets/9e8ebf08-596f-44e2-bb70-503b5fa6d907" /> | 
|    | <img width="1056" height="665" alt="Screenshot 2025-08-22 at 19 23 36" src="https://github.com/user-attachments/assets/366be68a-436c-445d-b9ab-e03b17a59c9f" /> |

https://github.com/user-attachments/assets/543671f3-218e-47a2-8c64-1a1e0b8d8fcb

## Why are these changes being made?

.uk domains could be transfer locked, but users didn't have a way to disable it. This led to issues like p2MSmN-fjL-p2 and p2MSmN-fjR-p2, among others, where Domains Engineering needed to disable the transfer lock manually.

With this PR, users can unlock the domain themselves now.

## Testing Instructions

This PR depends on 191242-ghe-Automattic/wpcom.

- Open the live Calypso link or build this branch locally
- Go to the domain transfer page for a .uk domain
- Ensure the transfer lock toggle is shown and the IPS tag field only appears when the toggle is turned off

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?