### PR TITLE
Remove `lodash` dependency from `@automattic/i18n-utils`

### DIFF
--- a/packages/i18n-utils/.eslintrc.js
+++ b/packages/i18n-utils/.eslintrc.js
@@ -1,4 +1,23 @@
 module.exports = {
+	rules: {
+		'no-restricted-imports': [
+			'warn',
+			{
+				paths: [
+					{
+						name: 'lodash',
+						message: 'Please use native JavaScript instead of lodash in this package.',
+					},
+				],
+				patterns: [
+					{
+						group: [ 'lodash/*' ],
+						message: 'Please use native JavaScript instead of lodash in this package.',
+					},
+				],
+			},
+		],
+	},
 	overrides: [
 		{
 			files: [ '*.md.js' ],

--- a/packages/i18n-utils/CHANGELOG.md
+++ b/packages/i18n-utils/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Add `getNumericFirstDayOfWeek` method as a wrapper for native (but not yet fully supported) `new Intl.Locale( locale ).getWeekInfo()`
 
+Get rid of implicit lodash dependency
+
 ## 1.2.3
 
 Get rid of i18n-calypso dependency

--- a/packages/i18n-utils/src/locale-context.tsx
+++ b/packages/i18n-utils/src/locale-context.tsx
@@ -106,7 +106,7 @@ export function useLocale(): string {
  */
 export const withLocale = createHigherOrderComponent(
 	< OuterProps, >( InnerComponent: React.ComponentType< OuterProps & { locale: string } > ) => {
-		return ( props: OuterProps ) => {
+		return function OuterComponent( props: OuterProps ) {
 			const locale = useLocale();
 			const innerProps = { ...props, locale };
 			return <InnerComponent { ...innerProps } />;

--- a/packages/i18n-utils/src/locale-context.tsx
+++ b/packages/i18n-utils/src/locale-context.tsx
@@ -1,7 +1,6 @@
 import { createHigherOrderComponent } from '@wordpress/compose';
 import * as i18n from '@wordpress/i18n';
 import { createContext, useContext, useEffect, useState, useCallback } from 'react';
-import * as React from 'react';
 import { englishLocales } from './locales';
 import type { Locale } from './locales';
 

--- a/packages/i18n-utils/src/test/utils.js
+++ b/packages/i18n-utils/src/test/utils.js
@@ -4,6 +4,7 @@ import {
 	removeLocaleFromPathLocaleInFront,
 	addLocaleToPathLocaleInFront,
 	getLanguage,
+	filterLanguageRevisions,
 } from '../';
 
 jest.mock( '@automattic/calypso-config', () => ( key ) => {
@@ -98,5 +99,58 @@ describe( '#getLanguage', () => {
 		const result = getLanguage( 'EN' );
 		// Should be undefined since locale matching is case-sensitive
 		expect( result ).toBeUndefined();
+	} );
+} );
+
+describe( '#filterLanguageRevisions', () => {
+	test( 'should return empty object for empty input', () => {
+		const result = filterLanguageRevisions( {} );
+		expect( result ).toEqual( {} );
+	} );
+
+	test( 'should filter out non-numeric revision values', () => {
+		const input = {
+			en: 123,
+			fr: 'invalid',
+			de: null,
+			es: undefined,
+			pt: 456,
+		};
+		const result = filterLanguageRevisions( input );
+		expect( result ).toEqual( {
+			en: 123,
+			pt: 456,
+		} );
+	} );
+
+	test( 'should filter out unsupported language slugs', () => {
+		const input = {
+			en: 123,
+			'invalid-lang': 456,
+			fr: 789,
+			'another-invalid': 999,
+		};
+		const result = filterLanguageRevisions( input );
+		// Only keep entries with valid language slugs and numeric revisions
+		expect( result.en ).toBe( 123 );
+		expect( result.fr ).toBe( 789 );
+		expect( result[ 'invalid-lang' ] ).toBeUndefined();
+		expect( result[ 'another-invalid' ] ).toBeUndefined();
+	} );
+
+	test( 'should preserve all valid entries', () => {
+		const input = {
+			en: 123,
+			fr: 456,
+			de: 789,
+			es: 999,
+		};
+		const result = filterLanguageRevisions( input );
+		// All should be preserved if they're valid language slugs
+		expect( Object.keys( result ).length ).toBeGreaterThan( 0 );
+		Object.entries( result ).forEach( ( [ slug, revision ] ) => {
+			expect( typeof revision ).toBe( 'number' );
+			expect( input[ slug ] ).toBe( revision );
+		} );
 	} );
 } );

--- a/packages/i18n-utils/src/test/utils.js
+++ b/packages/i18n-utils/src/test/utils.js
@@ -3,6 +3,7 @@ import {
 	getNumericFirstDayOfWeek,
 	removeLocaleFromPathLocaleInFront,
 	addLocaleToPathLocaleInFront,
+	getLanguage,
 } from '../';
 
 jest.mock( '@automattic/calypso-config', () => ( key ) => {
@@ -46,5 +47,56 @@ describe( '#addLocaleToPathLocaleInFront', () => {
 		expect( addLocaleToPathLocaleInFront( '/themes?thing=stuff', 'en' ) ).toBe(
 			'/themes?thing=stuff'
 		);
+	} );
+} );
+
+describe( '#getLanguage', () => {
+	test( 'should return undefined for undefined input', () => {
+		expect( getLanguage( undefined ) ).toBeUndefined();
+	} );
+
+	test( 'should return undefined for invalid locale format', () => {
+		expect( getLanguage( '123' ) ).toBeUndefined();
+		expect( getLanguage( 'invalid-locale' ) ).toBeUndefined();
+		expect( getLanguage( 'a' ) ).toBeUndefined();
+	} );
+
+	test( 'should handle locale mapping (no -> nb)', () => {
+		const result = getLanguage( 'no' );
+		expect( result ).toBeDefined();
+		expect( result?.langSlug ).toBe( 'nb' );
+	} );
+
+	test( 'should return exact match for valid locale', () => {
+		const result = getLanguage( 'en' );
+		expect( result ).toBeDefined();
+		expect( result?.langSlug ).toBe( 'en' );
+	} );
+
+	test( 'should return exact match for locale with region code', () => {
+		const result = getLanguage( 'pt-br' );
+		expect( result ).toBeDefined();
+		expect( result?.langSlug ).toBe( 'pt-br' );
+	} );
+
+	test( 'should fallback to parent slug when exact match not found', () => {
+		const result = getLanguage( 'en-nz' );
+		expect( result?.langSlug ).toBe( 'en' );
+	} );
+
+	test( 'should handle locale with underscore separator', () => {
+		const result = getLanguage( 'en_nz' );
+		expect( result?.langSlug ).toBe( 'en' );
+	} );
+
+	test( 'should return undefined when neither exact match nor parent slug exists', () => {
+		const result = getLanguage( 'xx-yy' );
+		expect( result ).toBeUndefined();
+	} );
+
+	test( 'should handle case sensitivity', () => {
+		const result = getLanguage( 'EN' );
+		// Should be undefined since locale matching is case-sensitive
+		expect( result ).toBeUndefined();
 	} );
 } );

--- a/packages/i18n-utils/src/utils.ts
+++ b/packages/i18n-utils/src/utils.ts
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
 import languages, { Language, SubLanguage } from '@automattic/languages';
 import { hasTranslation } from '@wordpress/i18n';
-import { includes } from 'lodash';
 import { getWpI18nLocaleSlug } from './locale-context';
 
 /**
@@ -207,7 +206,7 @@ export function filterLanguageRevisions( languageRevisions: Record< string, stri
 				return false;
 			}
 
-			if ( ! includes( langSlugs, slug ) ) {
+			if ( ! langSlugs.includes( slug ) ) {
 				return false;
 			}
 

--- a/packages/i18n-utils/src/utils.ts
+++ b/packages/i18n-utils/src/utils.ts
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
 import languages, { Language, SubLanguage } from '@automattic/languages';
 import { hasTranslation } from '@wordpress/i18n';
-import { map, pickBy, includes } from 'lodash';
+import { pickBy, includes } from 'lodash';
 import { getWpI18nLocaleSlug } from './locale-context';
 
 /**
@@ -84,10 +84,10 @@ export function translationExists( phrase: string ) {
 
 /**
  * Return a list of all supported language slugs
- * @returns {Array} A list of all supported language slugs
+ * @returns A list of all supported language slugs
  */
-export function getLanguageSlugs() {
-	return map( languages, 'langSlug' );
+export function getLanguageSlugs(): string[] {
+	return languages.map( ( language ) => language.langSlug );
 }
 
 /**

--- a/packages/i18n-utils/src/utils.ts
+++ b/packages/i18n-utils/src/utils.ts
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
 import languages, { Language, SubLanguage } from '@automattic/languages';
 import { hasTranslation } from '@wordpress/i18n';
-import { find, map, pickBy, includes } from 'lodash';
+import { map, pickBy, includes } from 'lodash';
 import { getWpI18nLocaleSlug } from './locale-context';
 
 /**
@@ -132,9 +132,14 @@ export function getLanguage( langSlug: string | undefined ): Language | undefine
 	langSlug = getMappedLanguageSlug( langSlug );
 	if ( langSlug && localeOnlyRegex.test( langSlug ) ) {
 		// Find for the langSlug first. If we can't find it, split it and find its parent slug.
+		const foundBySlug = languages.find( ( language ) => language.langSlug === langSlug );
+		if ( foundBySlug ) {
+			return foundBySlug;
+		}
+
 		// Please see the comment above `localeOnlyRegex` to see why we can split by - or _ and find the parent slug.
-		return ( find( languages, { langSlug } ) ||
-			find( languages, { langSlug: langSlug.split( /[-_]/ )[ 0 ] } ) ) as Language | undefined;
+		const parentSlug = langSlug.split( /[-_]/ )[ 0 ];
+		return languages.find( ( language ) => language.langSlug === parentSlug );
 	}
 
 	return undefined;

--- a/packages/i18n-utils/src/utils.ts
+++ b/packages/i18n-utils/src/utils.ts
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
 import languages, { Language, SubLanguage } from '@automattic/languages';
 import { hasTranslation } from '@wordpress/i18n';
-import { pickBy, includes } from 'lodash';
+import { includes } from 'lodash';
 import { getWpI18nLocaleSlug } from './locale-context';
 
 /**
@@ -194,24 +194,26 @@ export function removeLocaleFromPath( path: string ): string {
 /**
  * Filter out unexpected values from the given language revisions object.
  * @param {Object} languageRevisions A candidate language revisions object for filtering.
- * @returns {Object} A valid language revisions object derived from the given one.
+ * @returns valid language revisions object derived from the given one.
  */
 export function filterLanguageRevisions( languageRevisions: Record< string, string > ) {
 	const langSlugs = getLanguageSlugs();
 
 	// Since there is no strong guarantee that the passed-in revisions map will have the identical set of languages as we define in calypso,
 	// simply filtering against what we have here should be sufficient.
-	return pickBy( languageRevisions, ( revision, slug ) => {
-		if ( typeof revision !== 'number' ) {
-			return false;
-		}
+	return Object.fromEntries(
+		Object.entries( languageRevisions ).filter( ( [ slug, revision ] ) => {
+			if ( typeof revision !== 'number' ) {
+				return false;
+			}
 
-		if ( ! includes( langSlugs, slug ) ) {
-			return false;
-		}
+			if ( ! includes( langSlugs, slug ) ) {
+				return false;
+			}
 
-		return true;
-	} );
+			return true;
+		} )
+	);
 }
 
 /**


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->



## Proposed Changes

Removes lodash utility functions that are easily replicated with built-in JS functionality

Had to silence a React eslint warning so that I could commit

Adds AI-assisted test coverage so I'm confident it works the same before and after.

Including Calypso team as code reviewer in case I've missed something subtle about the fact this package is published to the npm registry. Maybe there's some nuance about changing dependencies in this case?

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Related to hosting dashboard work. We may need to pull the `@automattic/i18n-utils` package into the hosting dashboard p1755877947168549-slack-C0982082MSR. We don't want the hosting dashboard to depend on lodash, so this removes that unnecessary dependency.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Make sure to start and stop your development server (at least one of the utility functions is used by the node server)
- Smoke test Calypso, v2, and onboarding. Confirm translations/localisation looks correct
- Switch to a non-english locale
- Smoke test again

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?