### PR TITLE
Hosting Dashboard: Implement support sessions.

### DIFF
--- a/client/dashboard/app/auth/bypass-local-storage.ts
+++ b/client/dashboard/app/auth/bypass-local-storage.ts
@@ -1,0 +1,148 @@
+import debugModule from 'debug';
+
+const debug = debugModule( 'calypso:support-user' );
+
+type MemoryStore = Record< string, string >;
+
+export const length = ( memoryStore: MemoryStore ) => {
+	return () => {
+		debug( 'Bypassing localStorage', 'length property' );
+		return Object.keys( memoryStore ).length;
+	};
+};
+
+export const key = ( memoryStore: MemoryStore ) => {
+	return ( index: number ) => {
+		debug( 'Bypassing localStorage', 'key' );
+		if ( index >= Object.keys( memoryStore ).length ) {
+			return null;
+		}
+
+		return Object.keys( memoryStore )[ index ];
+	};
+};
+
+export const setItem = (
+	memoryStore: MemoryStore,
+	allowedKeys: string[],
+	original?: typeof localStorage.setItem
+) => {
+	return ( _key: string, value: string ) => {
+		if ( original && allowedKeys.includes( _key ) ) {
+			original( _key, value );
+			return;
+		}
+
+		debug( 'Bypassing localStorage', 'setItem', _key );
+		memoryStore[ _key ] = value;
+	};
+};
+
+export const getItem = (
+	memoryStore: MemoryStore,
+	allowedKeys: string[],
+	original?: typeof localStorage.getItem
+) => {
+	return ( _key: string ) => {
+		if ( original && allowedKeys.includes( _key ) ) {
+			return original( _key );
+		}
+
+		debug( 'Bypassing localStorage', 'getItem', _key );
+		return memoryStore[ _key ] || null;
+	};
+};
+
+export const removeItem = (
+	memoryStore: MemoryStore,
+	allowedKeys: string[],
+	original?: typeof localStorage.removeItem
+) => {
+	return ( _key: string ) => {
+		if ( original && allowedKeys.includes( _key ) ) {
+			original( _key );
+			return;
+		}
+
+		debug( 'Bypassing localStorage', 'removeItem', _key );
+		delete memoryStore[ _key ];
+	};
+};
+
+export const clear = ( memoryStore: MemoryStore ) => {
+	return () => {
+		debug( 'Bypassing localStorage', 'clear' );
+
+		for ( const _key in memoryStore ) {
+			delete memoryStore[ _key ];
+		}
+	};
+};
+
+/**
+ * Overrides localStorage, using an in-memory store instead of the real localStorage.
+ *
+ * This function replaces localStorage with an in-memory store and is useful in the following cases:
+ * 1. Avoiding conflicts caused by shared localStorage across multiple support user sessions.
+ * 2. Providing a working localStorage implementation for older Safari versions that throw errors in Private mode.
+ * @param [args]             An arguments object
+ * @param [args.root]        Allow alternate "window" object to support tests in non-browser environments
+ * @param [args.allowedKeys] An array of localStorage keys that are proxied to the real localStorage
+ */
+export default function bypassLocalStorage( {
+	root = typeof window === 'undefined' ? undefined : window,
+	allowedKeys = [],
+}: {
+	root?: typeof window;
+	allowedKeys?: string[];
+} = {} ) {
+	debug( 'Bypassing localStorage' );
+
+	let _setItem;
+	let _getItem;
+	let _removeItem;
+
+	if ( root && root.localStorage && root.Storage && root.Storage.prototype ) {
+		_setItem = root.Storage.prototype.setItem.bind( root.localStorage );
+		_getItem = root.Storage.prototype.getItem.bind( root.localStorage );
+		_removeItem = root.Storage.prototype.removeItem.bind( root.localStorage );
+	}
+
+	const memoryStore = {};
+	const getMemoryStoreLength = length( memoryStore );
+	const localStorageOverride = {
+		setItem: setItem( memoryStore, allowedKeys, _setItem ),
+		getItem: getItem( memoryStore, allowedKeys, _getItem ),
+		removeItem: removeItem( memoryStore, allowedKeys, _removeItem ),
+		key: key( memoryStore ),
+		clear: clear( memoryStore ),
+	};
+
+	if ( ! root ) {
+		return;
+	}
+
+	try {
+		// Try redefining `window.localStorage` instead of assigning to localStorage methods
+		// like `getItem` and `setItem` because it is not effective in Firefox.
+		// https://github.com/whatwg/html/issues/183#issuecomment-142944605
+		//
+		// NOTE: Based on testing, Safari versions 5-9 throw an error when attempting to redefine localStorage.
+		Object.defineProperty( root, 'localStorage', {
+			value: localStorageOverride,
+			enumerable: true,
+			configurable: true,
+		} );
+		Object.defineProperty( root.localStorage, 'length', { get: getMemoryStoreLength } );
+	} catch ( error ) {
+		// Attempt to assign to localStorage methods as a last effort.
+		// This is necessary in desktop Safari versions 6-9 as they do not allow
+		// window.localStorage to be redefined.
+		Object.assign( root.localStorage, localStorageOverride );
+
+		// ATTENTION: No `length` getter is provided in this case, so
+		// localStorage.length will always be zero. Previous implementations used
+		// localStorage.__defineGetter__ which does not throw but also is ineffective.
+		// This behavior was observed in testing Safari versions 6-12.
+	}
+}

--- a/client/dashboard/app/auth/support-session.ts
+++ b/client/dashboard/app/auth/support-session.ts
@@ -1,0 +1,87 @@
+import debugModule from 'debug';
+import wpcom from 'calypso/lib/wp';
+import bypassLocalStorage from './bypass-local-storage';
+
+const debug = debugModule( 'calypso:support-user' );
+const STORAGE_KEY = 'boot_support_user';
+
+// `isSupportSession` global is added in client/document/index.jsx
+declare global {
+	interface Window {
+		isSupportSession?: boolean;
+	}
+}
+
+function getStoredSupportUser(): { user?: string; token?: string } {
+	try {
+		const storageValue = window.sessionStorage.getItem( STORAGE_KEY );
+		return storageValue ? JSON.parse( storageValue ) : {};
+	} catch {
+		return {};
+	}
+}
+
+function saveStoredSupportUser( storage: { user: string; token: string } ) {
+	try {
+		window.sessionStorage.setItem( STORAGE_KEY, JSON.stringify( storage ) );
+	} catch {}
+}
+
+// Evaluate isSupportUserSession at module startup time, then freeze it
+// for the remainder of the session. This is needed because the User
+// module clears the store on change; it could return false if called
+// after boot.
+const _isSupportUserSession = ( () => {
+	const supportUser = getStoredSupportUser();
+	return supportUser && supportUser.user && supportUser.token;
+} )();
+
+export function isSupportUserSession() {
+	return _isSupportUserSession;
+}
+
+export function isSupportNextSession() {
+	return !! ( typeof window !== 'undefined' && window.isSupportSession );
+}
+
+export function isSupportSession() {
+	return isSupportUserSession() || isSupportNextSession();
+}
+
+export function maybeInitializeSupportSession() {
+	if ( isSupportUserSession() ) {
+		const { user, token } = getStoredSupportUser();
+		debug( 'Booting hosting dashboard with support user', user );
+
+		window.sessionStorage.removeItem( STORAGE_KEY );
+
+		const handleBeforeUnload = () => {
+			if ( user && token ) {
+				saveStoredSupportUser( { user, token } );
+			}
+		};
+
+		window.addEventListener( 'beforeunload', handleBeforeUnload );
+
+		wpcom.setSupportUserToken( user, token, ( error: Error ) => {
+			debug( 'Deactivating support user and rebooting due to token error', error.message );
+
+			window.sessionStorage.removeItem( STORAGE_KEY );
+			window.removeEventListener( 'beforeunload', handleBeforeUnload );
+			window.location.search = '';
+		} );
+	}
+
+	if ( isSupportNextSession() ) {
+		debug( 'Booting hosting dashboard with support next session' );
+		// "Support next" sessions don't need initializing because the
+		// browser extension handles this case.
+	}
+
+	if ( isSupportSession() ) {
+		// The following keys will not be bypassed as
+		// they are safe to share across user sessions.
+		const allowedKeys = [ 'debug' ];
+		bypassLocalStorage( { allowedKeys } );
+	}
+}

--- a/client/dashboard/app/auth/test/bypass-local-storage.ts
+++ b/client/dashboard/app/auth/test/bypass-local-storage.ts
@@ -1,0 +1,129 @@
+import { key, clear, setItem, getItem, removeItem, length } from '../bypass-local-storage';
+
+describe( 'localstorage-bypass', () => {
+	// Spy on the original localStorage functions
+	const _setItem = jest.fn();
+	const _getItem = jest.fn( ( x ) => x );
+	const _removeItem = jest.fn();
+	let db: Record< string, string >;
+
+	beforeEach( () => {
+		db = {};
+	} );
+
+	describe( 'length', () => {
+		test( 'returns the number of keys in dummy storage', () => {
+			db.one = 'a';
+			db.two = 'b';
+			expect( length( db )() ).toEqual( 2 );
+			db.three = 'c';
+			expect( length( db )() ).toEqual( 3 );
+		} );
+	} );
+
+	describe( 'clear', () => {
+		test( 'clears all keys', () => {
+			db.one = '1';
+			db.two = '2';
+			clear( db )();
+			expect( Object.keys( db ) ).toHaveLength( 0 );
+		} );
+	} );
+
+	describe( 'key', () => {
+		test( 'returns a specific key', () => {
+			db.first = 'a';
+			db.second = 'b';
+
+			expect( key( db )( 0 ) ).toEqual( 'first' );
+			expect( key( db )( 1 ) ).toEqual( 'second' );
+		} );
+
+		test( "returns null for a key that doesn't exist", () => {
+			expect( key( db )( 2 ) ).toBeNull();
+		} );
+	} );
+
+	describe( 'setItem', () => {
+		test( 'sets an item in memory store', () => {
+			setItem( db, [], _setItem )( 'key', 'value' );
+			expect( db.key ).toEqual( 'value' );
+		} );
+
+		test( 'calls the original setItem function for an allowed key', () => {
+			setItem( db, [ 'key' ], _setItem )( 'key', 'value' );
+			expect( db.key ).toBeUndefined();
+			expect( _setItem ).toHaveBeenCalledWith( 'key', 'value' );
+		} );
+
+		test( 'when there is no original setItem, sets an item in the memory store for an allowed key', () => {
+			setItem( db, [ 'key' ], undefined )( 'key', 'value' );
+			expect( db.key ).toEqual( 'value' );
+		} );
+
+		test( 'overrides an existing value', () => {
+			db.existing = 'abc';
+			setItem( db, [], _setItem )( 'existing', 'def' );
+			expect( db ).toEqual( { existing: 'def' } );
+		} );
+	} );
+
+	describe( 'getItem', () => {
+		beforeEach( () => {
+			db.first = 'abc';
+			db.second = 'def';
+		} );
+
+		test( 'gets an item in memory store', () => {
+			expect( getItem( db, [], _getItem )( 'first' ) ).toEqual( 'abc' );
+		} );
+
+		test( 'calls the original getItem function for an allowed key', () => {
+			expect( getItem( db, [ 'first' ], _getItem )( 'first' ) ).toEqual( 'first' );
+			expect( _getItem ).toHaveBeenCalledWith( 'first' );
+		} );
+
+		test( 'when there is no original getItem, gets an item from the memory store for an allowed key', () => {
+			expect( getItem( db, [], undefined )( 'first' ) ).toEqual( 'abc' );
+		} );
+
+		test( "returns null for a key that doesn't exist", () => {
+			expect( getItem( db, [], _getItem )( 'missing' ) ).toBeNull();
+		} );
+	} );
+
+	describe( 'removeItem', () => {
+		beforeEach( () => {
+			db.first = 'abc';
+			db.second = 'def';
+		} );
+
+		test( 'removes an item in memory store', () => {
+			removeItem( db, [], _removeItem )( 'first' );
+			expect( db.first ).toBeUndefined();
+		} );
+
+		test( 'calls the original removeItem function for an allowed key', () => {
+			removeItem( db, [ 'first' ], _removeItem )( 'first' );
+			expect( db.first ).toEqual( 'abc' );
+			expect( _removeItem ).toHaveBeenCalledWith( 'first' );
+		} );
+
+		test( 'when there is no original removeItem, removes an item from the memory store for an allowed key', () => {
+			removeItem( db, [], undefined )( 'first' );
+			expect( db.first ).toBeUndefined();
+		} );
+
+		test( "has no effect when a key doesn't already exist", () => {
+			removeItem( db, [], _removeItem )( 'missing' );
+			expect( db ).toEqual( { first: 'abc', second: 'def' } );
+		} );
+	} );
+
+	test( 'should add a key, read it, then remove it', () => {
+		setItem( db, [], _setItem )( 'test', 'value' );
+		expect( getItem( db, [], _getItem )( 'test' ) ).toEqual( 'value' );
+		removeItem( db, [], _removeItem )( 'test' );
+		expect( getItem( db, [], _getItem )( 'test' ) ).toBeNull();
+	} );
+} );

--- a/client/dashboard/app/boot.tsx
+++ b/client/dashboard/app/boot.tsx
@@ -10,7 +10,6 @@ import type { AppConfig } from './context';
 function boot( config: AppConfig ) {
 	if ( ! isEnabled( 'dashboard/v2' ) ) {
 		throw new Error( 'Dashboard v2 is not enabled' );
-		return;
 	}
 	const rootElement = document.getElementById( 'wpcom' );
 	if ( rootElement === null ) {

--- a/client/dashboard/app/boot.tsx
+++ b/client/dashboard/app/boot.tsx
@@ -2,15 +2,19 @@ import { isEnabled } from '@automattic/calypso-config';
 import { createRoot } from 'react-dom/client';
 import '@wordpress/components/build-style/style.css';
 import '@wordpress/commands/build-style/style.css';
-import './style.scss';
+import { isSupportSession, maybeInitializeSupportSession } from './auth/support-session';
 import Layout from './layout';
 import { persistPromise } from './query-client';
 import type { AppConfig } from './context';
+import './style.scss';
 
 function boot( config: AppConfig ) {
-	if ( ! isEnabled( 'dashboard/v2' ) ) {
+	if ( ! isEnabled( 'dashboard/v2' ) && ! isSupportSession() ) {
 		throw new Error( 'Dashboard v2 is not enabled' );
 	}
+
+	maybeInitializeSupportSession();
+
 	const rootElement = document.getElementById( 'wpcom' );
 	if ( rootElement === null ) {
 		throw new Error( 'No root element found' );

--- a/client/dashboard/app/query-client.ts
+++ b/client/dashboard/app/query-client.ts
@@ -1,6 +1,7 @@
 import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister';
 import { QueryClient, defaultShouldDehydrateQuery } from '@tanstack/react-query';
 import { persistQueryClient } from '@tanstack/react-query-persist-client';
+import { isSupportSession } from './auth/support-session';
 
 export const queryClient = new QueryClient( {
 	defaultOptions: {
@@ -21,7 +22,7 @@ export const queryClient = new QueryClient( {
 } );
 
 const persister = createSyncStoragePersister( {
-	storage: typeof window !== 'undefined' ? window.localStorage : null,
+	storage: typeof window !== 'undefined' && ! isSupportSession() ? window.localStorage : null,
 } );
 
 const maxAge = 1000 * 60 * 60 * 24; // 24 hours


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

- Configures the network layer at boot time so that it will use a support session when present
- Support sessions mock `localStorage` to ensure none of the data gets saved. Perhaps less important for the new-style since it starts an incognito window
- Disables TanStack Query persistence in support session
- Deletes the secret token from `sessionStorage`, but places it back again before leaving the page. That is so page refresh works
- Enables the hosting dashboard in all hosting sessions. Just for testing.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Before we give users access to the hosting dashboard, we want the ability to give them customer support.

## Support session info

**Old style**

Using our support tools, you are taken to a simple server rendered Calypso page: `/support-user`

https://github.com/Automattic/wp-calypso/blob/7cc684db4d1a256ab20ad74f0859a675edc30e14/client/document/support-user.jsx#L22

The query parameters of this page are loaded into `sessionStorage` and the page redirects to the default Calypso landing page.

On app boot we read `sessionStorage` and use it to configure the `lib/wp` library to go into support mode.

**New style**

Using our support tools, a new browser window opens using a browser extension. This extension handles the network traffic. The reason the app can tell it is in a support session is that network requests to the Calypso server contain a `x-support-session` header. The Calypso server sees this header and injects a page global.

https://github.com/Automattic/wp-calypso/blob/7cc684db4d1a256ab20ad74f0859a675edc30e14/client/server/pages/index.js#L95

https://github.com/Automattic/wp-calypso/blob/7cc684db4d1a256ab20ad74f0859a675edc30e14/client/document/index.jsx#L82

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This PR needs the help of 160142-ghe-Automattic/missioncontrol to test.

The new style support session isn't fully testable on localhost. Requests to the Calypso server do not contain the `x-support-session` header. I suspect this is because it can't add the custom header on non-https traffic. The old Calypso interface has the same issue, not just v2.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?