### PR TITLE
Hosting Dashboard: Add notices/warning in DNS records page

### DIFF
--- a/client/dashboard/domains/domain-dns/import-bind-file-button.tsx
+++ b/client/dashboard/domains/domain-dns/import-bind-file-button.tsx
@@ -38,13 +38,13 @@ export default function ImportBindFileButton( {
 
 	return (
 		<FormFileUpload
-			__next40pxDefaultSize
 			accept="text/plain"
 			multiple={ false }
 			onChange={ handleFileChange }
 			render={ ( { openFileDialog } ) => (
 				<Button
 					variant="secondary"
+					__next40pxDefaultSize
 					onClick={ openFileDialog }
 					isBusy={ importDnsBindMutation.isPending }
 				>

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -273,9 +273,9 @@ export default function DomainDns() {
 	};
 
 	const renderExternalNameserversNotice = () => {
-		// if ( hasWpcomNameservers() || ! nameservers || ! nameservers.length ) {
-		// 	return null;
-		// }
+		if ( hasWpcomNameservers() || ! nameservers || ! nameservers.length ) {
+			return null;
+		}
 
 		// TODO: Add a link to the name servers page or connection setup, once we have the pages
 		return (

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -3,6 +3,7 @@ import { useRouter } from '@tanstack/react-router';
 import { __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
@@ -14,6 +15,7 @@ import {
 } from '../../app/queries/domain-dns-records';
 import { domainDnsAddRoute, domainRoute } from '../../app/router/domains';
 import DataViewsCard from '../../components/dataviews-card';
+import InlineSupportLink from '../../components/inline-support-link';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { useDnsActions } from './actions';
@@ -228,6 +230,12 @@ export default function DomainDns() {
 								/>
 							</>
 						}
+						description={ createInterpolateElement(
+							__( 'DNS records change how your domain works. <link>Learn more</link>' ),
+							{
+								link: <InlineSupportLink supportContext="manage-your-dns-records" />,
+							}
+						) }
 					/>
 				</VStack>
 			}

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -197,7 +197,7 @@ export default function DomainDns() {
 			return null;
 		}
 
-		if ( domain?.is_gravatar_domain ) {
+		if ( domain.is_gravatar_domain ) {
 			return (
 				<Notice variant="warning" title={ __( 'Your domain is not using default A records' ) }>
 					{ createInterpolateElement(
@@ -363,7 +363,7 @@ export default function DomainDns() {
 				onConfirm={ handleRestoreDefaultARecords }
 				onCancel={ () => setIsRestoreDefaultARecordsDialogOpen( false ) }
 				isBusy={ updateDnsMutation.isPending }
-				isGravatarDomain={ domain?.is_gravatar_domain ?? false }
+				isGravatarDomain={ domain.is_gravatar_domain ?? false }
 				isOpen={ isRestoreDefaultARecordsDialogOpen }
 			/>
 			<RestoreDefaultCnameRecord

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -212,7 +212,7 @@ export default function DomainDns() {
 				<Notice variant="warning" title={ __( 'Your domain is not using default A records' ) }>
 					{ createInterpolateElement(
 						__(
-							'Your domain is not using default A records. This means it may not be pointing to your Gravatar profile correctly. To restore default A records, click on the three dots menu and select “Restore default A records”. <defaultRecordsLink>Learn more</defaultRecordsLink>'
+							'This means it may not be pointing to your Gravatar profile correctly. To restore default A records, click on the three dots menu and select “Restore default A records”. <defaultRecordsLink>Learn more</defaultRecordsLink>'
 						),
 						{
 							defaultRecordsLink: <InlineSupportLink supportContext="dns_default_records" />,
@@ -225,7 +225,7 @@ export default function DomainDns() {
 			<Notice variant="warning" title={ __( 'Your domain is not using default A records' ) }>
 				{ createInterpolateElement(
 					__(
-						'Your domain is not using default A records. This means it may not be pointing to your WordPress.com site correctly. To restore default A records, click on the three dots menu and select “Restore default A records”. <defaultRecordsLink>Learn more</defaultRecordsLink>.'
+						'This means it may not be pointing to your WordPress.com site correctly. To restore default A records, click on the three dots menu and select “Restore default A records”. <defaultRecordsLink>Learn more</defaultRecordsLink>.'
 					),
 					{
 						defaultRecordsLink: <InlineSupportLink supportContext="dns_default_records" />,
@@ -241,10 +241,13 @@ export default function DomainDns() {
 		}
 
 		return (
-			<Notice title={ __( 'Default CNAME record restored.' ) }>
+			<Notice
+				variant="warning"
+				title={ __( 'Your domain is not using the default WWW CNAME record' ) }
+			>
 				{ createInterpolateElement(
 					__(
-						'Your domain is not using the default WWW CNAME record. This means your WordPress.com site may not be reached correctly using the www prefix. To restore the default WWW CNAME record, click on the three dots menu and select “Restore default CNAME record”. <defaultRecordsLink>Learn more</defaultRecordsLink>.'
+						'This means your WordPress.com site may not be reached correctly using the www prefix. To restore the default WWW CNAME record, click on the three dots menu and select “Restore default CNAME record”. <defaultRecordsLink>Learn more</defaultRecordsLink>.'
 					),
 					{
 						defaultRecordsLink: <InlineSupportLink supportContext="dns_default_records" />,
@@ -278,7 +281,7 @@ export default function DomainDns() {
 		return (
 			<Notice variant="warning" title={ __( 'Your domain is using external name servers' ) }>
 				{ __(
-					'Your domain is using external name servers so the DNS records you are editing will not be in effect until you switch to use WordPress.com name servers.'
+					'This means the DNS records you are editing will not be in effect until you switch to use WordPress.com name servers.'
 				) }
 			</Notice>
 		);

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -212,7 +212,7 @@ export default function DomainDns() {
 				<Notice variant="warning" title={ __( 'Your domain is not using default A records' ) }>
 					{ createInterpolateElement(
 						__(
-							'Your domain is not using default A records. This means it may not be pointing to your Gravatar profile correctly. To restore default A records, click on the three dots menu and select "Restore default A records". <defaultRecordsLink>Learn more</defaultRecordsLink>'
+							'Your domain is not using default A records. This means it may not be pointing to your Gravatar profile correctly. To restore default A records, click on the three dots menu and select “Restore default A records”. <defaultRecordsLink>Learn more</defaultRecordsLink>'
 						),
 						{
 							defaultRecordsLink: <InlineSupportLink supportContext="dns_default_records" />,
@@ -225,7 +225,7 @@ export default function DomainDns() {
 			<Notice variant="warning" title={ __( 'Your domain is not using default A records' ) }>
 				{ createInterpolateElement(
 					__(
-						'Your domain is not using default A records. This means it may not be pointing to your WordPress.com site correctly. To restore default A records, click on the three dots menu and select "Restore default A records". <defaultRecordsLink>Learn more</defaultRecordsLink>.'
+						'Your domain is not using default A records. This means it may not be pointing to your WordPress.com site correctly. To restore default A records, click on the three dots menu and select “Restore default A records”. <defaultRecordsLink>Learn more</defaultRecordsLink>.'
 					),
 					{
 						defaultRecordsLink: <InlineSupportLink supportContext="dns_default_records" />,
@@ -244,7 +244,7 @@ export default function DomainDns() {
 			<Notice title={ __( 'Default CNAME record restored.' ) }>
 				{ createInterpolateElement(
 					__(
-						'Your domain is not using the default WWW CNAME record. This means your WordPress.com site may not be reached correctly using the www prefix. To restore the default WWW CNAME record, click on the three dots menu and select "Restore default CNAME record". <defaultRecordsLink>Learn more</defaultRecordsLink>.'
+						'Your domain is not using the default WWW CNAME record. This means your WordPress.com site may not be reached correctly using the www prefix. To restore the default WWW CNAME record, click on the three dots menu and select “Restore default CNAME record”. <defaultRecordsLink>Learn more</defaultRecordsLink>.'
 					),
 					{
 						defaultRecordsLink: <InlineSupportLink supportContext="dns_default_records" />,

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -20,7 +20,7 @@ import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { WPCOM_DEFAULT_NAMESERVERS_REGEX } from '../name-servers/utils';
+import { areAllWpcomNameServers } from '../name-servers/utils';
 import { useDnsActions } from './actions';
 import DnsActionsMenu from './dns-actions-menu';
 import DnsImportDialog from './dns-import-dialog';
@@ -192,18 +192,8 @@ export default function DomainDns() {
 		} );
 	};
 
-	const hasWpcomNameservers = () => {
-		if ( ! nameservers || nameservers.length === 0 ) {
-			return false;
-		}
-
-		return nameservers.every( ( nameserver ) => {
-			return WPCOM_DEFAULT_NAMESERVERS_REGEX.test( nameserver );
-		} );
-	};
-
 	const renderDefaultARecordsNotice = () => {
-		if ( ! hasWpcomNameservers() || hasDefaultARecordsValue ) {
+		if ( ! areAllWpcomNameServers( nameservers ) || hasDefaultARecordsValue ) {
 			return null;
 		}
 
@@ -236,7 +226,7 @@ export default function DomainDns() {
 	};
 
 	const renderDefaultCnameRecordNotice = () => {
-		if ( ! hasWpcomNameservers() || hasDefaultCnameRecordValue ) {
+		if ( ! areAllWpcomNameServers( nameservers ) || hasDefaultCnameRecordValue ) {
 			return null;
 		}
 
@@ -273,7 +263,7 @@ export default function DomainDns() {
 	};
 
 	const renderExternalNameserversNotice = () => {
-		if ( hasWpcomNameservers() || ! nameservers || ! nameservers.length ) {
+		if ( areAllWpcomNameServers( nameservers ) || ! nameservers || ! nameservers.length ) {
 			return null;
 		}
 

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -13,11 +13,14 @@ import {
 	domainDnsQuery,
 	domainDnsEmailMutation,
 } from '../../app/queries/domain-dns-records';
+import { domainNameServersQuery } from '../../app/queries/domain-name-servers';
 import { domainDnsAddRoute, domainRoute } from '../../app/router/domains';
 import DataViewsCard from '../../components/dataviews-card';
 import InlineSupportLink from '../../components/inline-support-link';
+import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import { WPCOM_DEFAULT_NAMESERVERS_REGEX } from '../name-servers/utils';
 import { useDnsActions } from './actions';
 import DnsActionsMenu from './dns-actions-menu';
 import DnsImportDialog from './dns-import-dialog';
@@ -63,6 +66,7 @@ export default function DomainDns() {
 	const restoreDefaultEmailRecordsMutation = useMutation( domainDnsEmailMutation( domainName ) );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
+	const { data: nameservers } = useSuspenseQuery( domainNameServersQuery( domainName ) );
 	const { data: dnsData, isLoading } = useQuery( domainDnsQuery( domainName ) );
 	const [ isRestoreDefaultARecordsDialogOpen, setIsRestoreDefaultARecordsDialogOpen ] =
 		useState( false );
@@ -188,6 +192,98 @@ export default function DomainDns() {
 		} );
 	};
 
+	const hasWpcomNameservers = () => {
+		if ( ! nameservers || nameservers.length === 0 ) {
+			return false;
+		}
+
+		return nameservers.every( ( nameserver ) => {
+			return WPCOM_DEFAULT_NAMESERVERS_REGEX.test( nameserver );
+		} );
+	};
+
+	const renderDefaultARecordsNotice = () => {
+		if ( ! hasWpcomNameservers() || hasDefaultARecordsValue ) {
+			return null;
+		}
+
+		if ( domain?.is_gravatar_domain ) {
+			return (
+				<Notice variant="warning" title={ __( 'Your domain is not using default A records' ) }>
+					{ createInterpolateElement(
+						__(
+							'Your domain is not using default A records. This means it may not be pointing to your Gravatar profile correctly. To restore default A records, click on the three dots menu and select "Restore default A records". <defaultRecordsLink>Learn more</defaultRecordsLink>'
+						),
+						{
+							defaultRecordsLink: <InlineSupportLink supportContext="dns_default_records" />,
+						}
+					) }
+				</Notice>
+			);
+		}
+		return (
+			<Notice variant="warning" title={ __( 'Your domain is not using default A records' ) }>
+				{ createInterpolateElement(
+					__(
+						'Your domain is not using default A records. This means it may not be pointing to your WordPress.com site correctly. To restore default A records, click on the three dots menu and select "Restore default A records". <defaultRecordsLink>Learn more</defaultRecordsLink>.'
+					),
+					{
+						defaultRecordsLink: <InlineSupportLink supportContext="dns_default_records" />,
+					}
+				) }
+			</Notice>
+		);
+	};
+
+	const renderDefaultCnameRecordNotice = () => {
+		if ( ! hasWpcomNameservers() || hasDefaultCnameRecordValue ) {
+			return null;
+		}
+
+		return (
+			<Notice title={ __( 'Default CNAME record restored.' ) }>
+				{ createInterpolateElement(
+					__(
+						'Your domain is not using the default WWW CNAME record. This means your WordPress.com site may not be reached correctly using the www prefix. To restore the default WWW CNAME record, click on the three dots menu and select "Restore default CNAME record". <defaultRecordsLink>Learn more</defaultRecordsLink>.'
+					),
+					{
+						defaultRecordsLink: <InlineSupportLink supportContext="dns_default_records" />,
+					}
+				) }
+			</Notice>
+		);
+	};
+
+	const renderDnsRecordsExplanationNotice = () => {
+		return (
+			<Notice title={ __( 'What are DNS records used for?' ) }>
+				{ createInterpolateElement(
+					__(
+						'Custom DNS records allow you to connect your domain to third-party services that are not hosted on WordPress.com, such as an email provider. <link>Learn more</link>'
+					),
+					{
+						link: <InlineSupportLink supportContext="manage-your-dns-records" />,
+					}
+				) }
+			</Notice>
+		);
+	};
+
+	const renderExternalNameserversNotice = () => {
+		if ( hasWpcomNameservers() || ! nameservers || ! nameservers.length ) {
+			return null;
+		}
+
+		// TODO: Add a link to the name servers page or connection setup, once we have the pages
+		return (
+			<Notice variant="warning" title={ __( 'Your domain is using external name servers' ) }>
+				{ __(
+					'Your domain is using external name servers so the DNS records you are editing will not be in effect until you switch to use WordPress.com name servers.'
+				) }
+			</Notice>
+		);
+	};
+
 	return (
 		<PageLayout
 			size="small"
@@ -240,6 +336,10 @@ export default function DomainDns() {
 				</VStack>
 			}
 		>
+			{ renderDnsRecordsExplanationNotice() }
+			{ renderExternalNameserversNotice() }
+			{ renderDefaultARecordsNotice() }
+			{ renderDefaultCnameRecordNotice() }
 			<DataViewsCard>
 				{ dnsData?.records?.length === 0 && ! isLoading ? (
 					<div style={ { padding: '20px', textAlign: 'center' } }>

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -225,7 +225,7 @@ export default function DomainDns() {
 			<Notice variant="warning" title={ __( 'Your domain is not using default A records' ) }>
 				{ createInterpolateElement(
 					__(
-						'This means it may not be pointing to your WordPress.com site correctly. To restore default A records, click on the three dots menu and select “Restore default A records”. <defaultRecordsLink>Learn more</defaultRecordsLink>.'
+						'This means it may not be pointing to your WordPress.com site correctly. To restore default A records, click on the three dots menu and select “Restore default A records”. <defaultRecordsLink>Learn more</defaultRecordsLink>'
 					),
 					{
 						defaultRecordsLink: <InlineSupportLink supportContext="dns_default_records" />,
@@ -247,7 +247,7 @@ export default function DomainDns() {
 			>
 				{ createInterpolateElement(
 					__(
-						'This means your WordPress.com site may not be reached correctly using the www prefix. To restore the default WWW CNAME record, click on the three dots menu and select “Restore default CNAME record”. <defaultRecordsLink>Learn more</defaultRecordsLink>.'
+						'This means your WordPress.com site may not be reached correctly using the www prefix. To restore the default WWW CNAME record, click on the three dots menu and select “Restore default CNAME record”. <defaultRecordsLink>Learn more</defaultRecordsLink>'
 					),
 					{
 						defaultRecordsLink: <InlineSupportLink supportContext="dns_default_records" />,
@@ -273,9 +273,9 @@ export default function DomainDns() {
 	};
 
 	const renderExternalNameserversNotice = () => {
-		if ( hasWpcomNameservers() || ! nameservers || ! nameservers.length ) {
-			return null;
-		}
+		// if ( hasWpcomNameservers() || ! nameservers || ! nameservers.length ) {
+		// 	return null;
+		// }
 
 		// TODO: Add a link to the name servers page or connection setup, once we have the pages
 		return (


### PR DESCRIPTION
Closes [DOTDASH-324](https://linear.app/a8c/issue/DOTDASH-324/add-dns-list-messagesinfo)

## Proposed Changes
This PR adds some warning/notices and additional info on DNS list page to improve user experience and provide better guidance.
- Implemented conditional notices for domains not using default A records, CNAME records, and external nameservers
- Added explanatory notice about DNS records purpose with inline support links
- Enhanced page header with DNS records description and support link
- Added nam eservers validation to determine when notices should be displayed

## Why are these changes being made?
This is part on the Hosting Dashboard Domains project.

![Screenshot 2025-08-25 alle 11 04 36](https://github.com/user-attachments/assets/aa785546-dd6c-4ee3-a4f6-f1d17d1ba302)
![Screenshot 2025-08-25 alle 11 57 11](https://github.com/user-attachments/assets/957c1237-8e2e-46e2-afc8-4756073b1253)
![Screenshot 2025-08-25 alle 11 57 28](https://github.com/user-attachments/assets/e7595237-1216-424e-ae20-9dc964723fca)
![Screenshot 2025-08-25 alle 11 59 19](https://github.com/user-attachments/assets/766c2fdb-a75a-422c-89cb-f6e2bb0c5091)


## Testing Instructions
- Test with WordPress.com nameservers:
  - Navigate to a domain using WordPress.com nameservers
  - Verify default A/CNAME notices appear when default records are missing
  - Check that notices disappear when default records are restored
- Test with external nameservers:
  - Use a domain with external nameservers
  - Verify the external nameservers warning appears
  - Confirm other notices don't show (since they're not applicable)
- Test support links:
  - Click on "Learn more" links in notices
  - Verify they open the correct support documentation

## Pre-merge Checklist
<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
