### PR TITLE
Notifications v2: show blue dot on icon on unseen notifications

### DIFF
--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -2,15 +2,25 @@ import { useNavigate } from '@tanstack/react-router';
 import { Button, Dropdown } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { bellUnread, bell } from '@wordpress/icons';
-import { Suspense, lazy } from 'react';
+import clsx from 'clsx';
+import { Suspense, lazy, useState } from 'react';
 import wpcom from 'calypso/lib/wp';
+import { useAuth } from '../auth';
+import './style.scss';
 
 const AsyncNotificationApp = lazy( () => import( '@automattic/notifications/src/app' ) );
 
 export default function Notifications( { className }: { className: string } ) {
 	const navigate = useNavigate();
+	const { user } = useAuth();
+	const [ hasUnseenNotifications, setHasUnseenNotifications ] = useState( user.has_unseen_notes );
 
 	const actionHandlers = ( onClosePanel: () => void ) => ( {
+		APP_RENDER_NOTES: [
+			( store: any, { newNoteCount }: { newNoteCount: number } ) => {
+				setHasUnseenNotifications( newNoteCount > 0 );
+			},
+		],
 		VIEW_SETTINGS: [
 			() => {
 				onClosePanel();
@@ -20,9 +30,6 @@ export default function Notifications( { className }: { className: string } ) {
 		CLOSE_PANEL: [ onClosePanel ],
 	} );
 
-	// TODO: fetch unread notifications count
-	const hasUnreadNotifications = false;
-
 	return (
 		<Dropdown
 			popoverProps={ {
@@ -31,12 +38,12 @@ export default function Notifications( { className }: { className: string } ) {
 			} }
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button
-					className={ className }
+					className={ clsx( className, 'dashboard-notifications__icon' ) }
 					onClick={ onToggle }
 					aria-expanded={ isOpen }
 					variant="tertiary"
 					label={ __( 'Notifications' ) }
-					icon={ hasUnreadNotifications ? bellUnread : bell }
+					icon={ hasUnseenNotifications ? bellUnread : bell }
 				/>
 			) }
 			renderContent={ ( { onClose } ) => (

--- a/client/dashboard/app/notifications/style.scss
+++ b/client/dashboard/app/notifications/style.scss
@@ -1,0 +1,7 @@
+.dashboard-notifications__icon {
+	svg {
+		circle {
+			fill: var(--wp-admin-theme-color);
+		}
+	}
+}

--- a/client/dashboard/data/me.ts
+++ b/client/dashboard/data/me.ts
@@ -10,6 +10,7 @@ export interface User {
 	language: string;
 	locale_variant: string;
 	email: string;
+	has_unseen_notes: boolean;
 	site_count: number;
 	meta: {
 		data: {


### PR DESCRIPTION
Part of DOTDASH-303

## Proposed Changes

This PR shows blue dot marker on the notification bell icon where there's unseen notifications:

|Has no unseen notifications|Has unseen notifications|
|-|-|
|<img width="245" height="67" alt="image" src="https://github.com/user-attachments/assets/c4b34ffa-3f07-41de-8440-c98e838b2b61" />|<img width="243" height="69" alt="image" src="https://github.com/user-attachments/assets/356ab943-8d48-4fce-82da-c9b7002e9aa0" />

## Testing Instructions

1. Go to /v2/sites
2. Trigger notification for yourself, e.g. by commenting on your post as another user in other incognito window
3. Refresh /v2/sites
4. Verify you see the blue dot
5. Click on the icon
6. Verify the blue dot is gone
7. Refresh /v2/sites
4. Verify you see the blue dot is still gone

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
