### PR TITLE
Staging Sites: Add new V2 staging site sync modal (without file browser)

### DIFF
--- a/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
@@ -11,12 +11,13 @@ import {
 	getStagingSiteId,
 	isStagingSiteSyncing,
 } from '../../utils/site-staging-site';
+import StagingSiteSyncModal from '../staging-site-sync-modal';
 import type { StagingSiteSyncDirection } from '../../data/types';
 
 // TODO: We need to rewrite the modal, as it’s not compatible with v2.
 // Both the Modal and especially the FileBrowser rely heavily on Redux state
 // which makes integration problematic in the current setup.
-const StagingSiteSyncModal = lazy(
+const StagingSiteSyncModalV1 = lazy(
 	() =>
 		import(
 			/* webpackChunkName: "async-load-staging-site-sync-modal" */ 'calypso/sites/staging-site/components/staging-site-sync-modal'
@@ -78,6 +79,34 @@ export default function StagingSiteSyncDropdown( {
 		return null;
 	}
 
+	const renderModal = () => {
+		if ( window?.location?.pathname?.startsWith( '/v2' ) ) {
+			return (
+				<StagingSiteSyncModal
+					onClose={ handleCloseModal }
+					syncType={ syncDirection }
+					environment={ environment }
+					productionSiteId={ productionSiteId }
+					stagingSiteId={ stagingSiteId }
+					onSyncStart={ handleSyncStart }
+				/>
+			);
+		}
+
+		return (
+			<Suspense fallback={ null }>
+				<StagingSiteSyncModalV1
+					onClose={ handleCloseModal }
+					syncType={ syncDirection }
+					environment={ environment }
+					productionSiteId={ productionSiteId }
+					stagingSiteId={ stagingSiteId }
+					onSyncStart={ handleSyncStart }
+				/>
+			</Suspense>
+		);
+	};
+
 	return (
 		<>
 			<Dropdown
@@ -122,18 +151,7 @@ export default function StagingSiteSyncDropdown( {
 					</div>
 				) }
 			/>
-			{ isModalOpen && (
-				<Suspense fallback={ null }>
-					<StagingSiteSyncModal
-						onClose={ handleCloseModal }
-						syncType={ syncDirection }
-						environment={ environment }
-						productionSiteId={ productionSiteId }
-						stagingSiteId={ stagingSiteId }
-						onSyncStart={ handleSyncStart }
-					/>
-				</Suspense>
-			) }
+			{ isModalOpen && renderModal() }
 		</>
 	);
 }

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -1,0 +1,275 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+	Button,
+	ExternalLink,
+	Modal,
+	Icon,
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalInputControl as InputControl,
+} from '@wordpress/components';
+import { createInterpolateElement, useState, useCallback } from '@wordpress/element';
+import { __, isRTL } from '@wordpress/i18n';
+import { chevronRight, chevronLeft } from '@wordpress/icons';
+import { siteByIdQuery } from '../../app/queries/site';
+import InlineSupportLink from '../../components/inline-support-link';
+import { SectionHeader } from '../../components/section-header';
+import SiteEnvironmentBadge, { EnvironmentType } from '../../components/site-environment-badge';
+
+const DirectionArrow = () => {
+	return (
+		<div style={ { marginTop: '44px' } }>
+			<Icon
+				icon={ isRTL() ? chevronLeft : chevronRight }
+				style={ {
+					fill: '#949494',
+				} }
+			/>
+		</div>
+	);
+};
+
+interface EnvironmentLabelProps {
+	label: string;
+	environmentType: EnvironmentType;
+	siteTitle?: string;
+}
+
+const EnvironmentLabel = ( { label, environmentType, siteTitle }: EnvironmentLabelProps ) => {
+	return (
+		<VStack spacing={ 1 }>
+			<SectionHeader level={ 3 } title={ label } />
+			<HStack spacing={ 2 }>
+				<SiteEnvironmentBadge environmentType={ environmentType } />
+				{ siteTitle && (
+					<Text
+						style={ {
+							whiteSpace: 'nowrap',
+							overflow: 'hidden',
+							textOverflow: 'ellipsis',
+							maxWidth: '190px',
+						} }
+					>
+						{ siteTitle }
+					</Text>
+				) }
+			</HStack>
+		</VStack>
+	);
+};
+
+interface StagingSiteSyncModalProps {
+	onClose: () => void;
+	syncType: 'pull' | 'push';
+	environment: 'production' | 'staging';
+	productionSiteId: number;
+	stagingSiteId: number;
+	onSyncStart: () => void;
+}
+
+interface EnvironmentConfig {
+	title: string;
+	description: string;
+	syncFrom: EnvironmentType;
+	syncTo: EnvironmentType;
+}
+
+interface SyncConfig {
+	staging: EnvironmentConfig;
+	production: EnvironmentConfig;
+	fromLabel: string;
+	toLabel: string;
+	learnMore: string;
+	submit: string;
+}
+
+const getSyncConfig = ( type: 'pull' | 'push' ): SyncConfig => {
+	if ( type === 'pull' ) {
+		return {
+			staging: {
+				title: __( 'Pull from Production' ),
+				description: __(
+					'Pulling will replace the existing files and database of the staging site. An automatic backup of your environment will be created, allowing you to revert changes from the <a>Activity log</a> if needed.'
+				),
+				syncFrom: 'production',
+				syncTo: 'staging',
+			},
+			production: {
+				title: __( 'Pull from Staging' ),
+				description: __(
+					'Pulling will replace the existing files and database of the production site. An automatic backup of your environment will be created, allowing you to revert changes from the <a>Activity log</a> if needed.'
+				),
+				syncFrom: 'staging',
+				syncTo: 'production',
+			},
+			fromLabel: __( 'Pull' ),
+			toLabel: __( 'To' ),
+			learnMore: __( 'Read more about <a>environment pull</a>.' ),
+			submit: __( 'Pull' ),
+		};
+	}
+
+	return {
+		staging: {
+			title: __( 'Push to Production' ),
+			description: __(
+				'Pushing will replace the existing files and database of the production site. An automatic backup of your environment will be created, allowing you to revert changes from the <a>Activity log</a> if needed.'
+			),
+			syncFrom: 'staging',
+			syncTo: 'production',
+		},
+		production: {
+			title: __( 'Push to Staging' ),
+			description: __(
+				'Pushing will replace the existing files and database of the staging site. An automatic backup of your environment will be created, allowing you to revert changes from the <a>Activity log</a> if needed.'
+			),
+			syncFrom: 'production',
+			syncTo: 'staging',
+		},
+		fromLabel: __( 'Push' ),
+		toLabel: __( 'To' ),
+		learnMore: __( 'Read more about <a>environment push</a>.' ),
+		submit: __( 'Push' ),
+	};
+};
+
+export default function StagingSiteSyncModal( {
+	onClose,
+	syncType,
+	environment,
+	productionSiteId,
+	stagingSiteId,
+}: StagingSiteSyncModalProps ) {
+	const syncConfig = getSyncConfig( syncType );
+	const [ domainConfirmation, setDomainConfirmation ] = useState( '' );
+
+	const targetEnvironment = syncConfig[ environment ].syncTo;
+	const sourceEnvironment = syncConfig[ environment ].syncFrom;
+
+	const { data: productionSite } = useQuery( {
+		...siteByIdQuery( productionSiteId ?? 0 ),
+		enabled: !! productionSiteId,
+	} );
+	const productionSiteSlug = productionSite?.slug;
+	const productionSiteTitle = productionSite?.name;
+
+	const { data: stagingSite } = useQuery( {
+		...siteByIdQuery( stagingSiteId ?? 0 ),
+		enabled: !! stagingSiteId,
+	} );
+	const stagingSiteSlug = stagingSite?.slug;
+	const stagingSiteTitle = stagingSite?.name;
+
+	const targetSiteSlug = targetEnvironment === 'production' ? productionSiteSlug : stagingSiteSlug;
+
+	const sourceSiteTitle = sourceEnvironment === 'staging' ? stagingSiteTitle : productionSiteTitle;
+	const targetSiteTitle =
+		targetEnvironment === 'production' ? productionSiteTitle : stagingSiteTitle;
+
+	// TODO: Uncomment once we need it.
+	// const querySiteId = sourceEnvironment === 'staging' ? stagingSiteId : productionSiteId;
+
+	const handleClose = useCallback( () => {
+		onClose();
+	}, [ onClose ] );
+
+	const handleConfirm = () => {
+		// Sync everything
+		// TODO: Uncomment once pullFromStaging and pushToStaging are available
+		// const include_paths = '';
+		// const exclude_paths = '';
+
+		if (
+			( syncType === 'pull' && environment === 'production' ) ||
+			( syncType === 'push' && environment === 'staging' )
+		) {
+			// TODO: Replace with the correct pullFromStaging (once it is moved to V2)
+			// pullFromStaging( { types: 'paths', include_paths, exclude_paths } );
+		} else {
+			// TODO: Replace with the correct pushToStaging (once it is moved to V2)
+			// pushToStaging( { types: 'paths', include_paths, exclude_paths } );
+		}
+	};
+
+	const handleDomainConfirmation = useCallback(
+		( value: string | undefined ) => setDomainConfirmation( value || '' ),
+		[]
+	);
+
+	const showDomainConfirmation = targetEnvironment === 'production';
+
+	const isSubmitDisabled = showDomainConfirmation && domainConfirmation !== productionSiteSlug;
+
+	return (
+		<Modal
+			title={ syncConfig[ environment ].title }
+			onRequestClose={ handleClose }
+			style={ { maxWidth: '668px' } }
+		>
+			<VStack spacing={ 5 }>
+				<Text>
+					{ createInterpolateElement( syncConfig[ environment ].description, {
+						a: <ExternalLink href={ `/backup/${ targetSiteSlug }` } children={ null } />,
+					} ) }
+				</Text>
+				<HStack spacing={ 4 } alignment="left">
+					<EnvironmentLabel
+						label={ syncConfig.fromLabel }
+						environmentType={ sourceEnvironment }
+						siteTitle={ sourceSiteTitle }
+					/>
+					<DirectionArrow />
+					<EnvironmentLabel
+						label={ syncConfig.toLabel }
+						environmentType={ targetEnvironment }
+						siteTitle={ targetSiteTitle }
+					/>
+				</HStack>
+				<VStack spacing={ 6 }>
+					{ showDomainConfirmation && (
+						<InputControl
+							__next40pxDefaultSize
+							label={
+								<HStack style={ { textTransform: 'none' } } alignment="left" spacing={ 1 }>
+									<Text>
+										{ __( 'Enter your site‘s name' ) }{ ' ' }
+										<Text color="var(--dashboard__foreground-color-error)">
+											{ productionSiteSlug }
+										</Text>{ ' ' }
+										{ __( 'to confirm.' ) }
+									</Text>
+								</HStack>
+							}
+							onChange={ handleDomainConfirmation }
+							value={ domainConfirmation }
+						/>
+					) }
+					<HStack>
+						<HStack>
+							<Text className="staging-site-card__footer-text">
+								{ createInterpolateElement( syncConfig.learnMore, {
+									a: (
+										<InlineSupportLink
+											onClick={ handleClose }
+											supportContext="hosting-staging-site"
+										/>
+									),
+								} ) }
+							</Text>
+						</HStack>
+
+						<HStack justify="flex-end" spacing={ 4 }>
+							<Button variant="tertiary" onClick={ handleClose }>
+								{ __( 'Cancel' ) }
+							</Button>
+							<Button variant="primary" onClick={ handleConfirm } disabled={ isSubmitDisabled }>
+								{ syncConfig.submit }
+							</Button>
+						</HStack>
+					</HStack>
+				</VStack>
+			</VStack>
+		</Modal>
+	);
+}

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -210,7 +210,7 @@ export default function StagingSiteSyncModal( {
 			<VStack spacing={ 5 }>
 				<Text>
 					{ createInterpolateElement( syncConfig[ environment ].description, {
-						a: <ExternalLink href={ `/backup/${ targetSiteSlug }` } children={ null } />,
+						a: <ExternalLink href={ `/activity-log/${ targetSiteSlug }` } children={ null } />,
 					} ) }
 				</Text>
 				<HStack spacing={ 4 } alignment="left">

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -401,7 +401,7 @@ export default function SyncModal( {
 			<VStack spacing={ 5 }>
 				<Text>
 					{ createInterpolateElement( syncConfig[ environment ].description, {
-						a: <ExternalLink href={ `/backup/${ targetSiteSlug }` } children={ null } />,
+						a: <ExternalLink href={ `/activity-log/${ targetSiteSlug }` } children={ null } />,
 					} ) }
 				</Text>
 				<HStack spacing={ 4 } alignment="left">


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTCOM-14283

## Proposed Changes

* add new sync modal to the V2 dashboard, using revamped modal (`client/sites/staging-site/components/staging-site-sync-modal/index.tsx`) as a base
  * syncing is not included as this will be worked on in separate tasks
* the current dashboard that users have access to, will still use the complete original revamped modal
  * this PR is also fixing the Activity log link that was incorrectly pointing to the Backup page

<img width="2772" height="1620" alt="Markup on 2025-08-25 at 12:50:10" src="https://github.com/user-attachments/assets/707c35b0-2ca3-4244-ae72-1ee5da857980" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* DOTCOM-14283; The changes are made as a part of the _Hosting Dashboard: Staging Sites_ project.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start` (or use the Calypso Live link below).
2. Ensure you have a WoA production site with related staging site created.
3. Head over to the V2 dashboard and at `http://calypso.localhost:3000/v2/sites/{site-slug}` and try to click the Sync button.
4. Pick one of the two dropdown options.
5. The Sync modal should open.
6. Confirm the following:
  - copy in the modal should match the dropdown option we clicked
  - all links in the modal should be working correctly
  - it should be possible to close the modal with `X` and `Cancel` buttons
  - if you are pushing to production site / pulling from staging site:
    - there should be a domain confirmation text field rendered
    - the Push / Pull button should be disabled until we enter the target site domain address into it 
  - Push / Pull button should not do anything
7. Repeat the steps 4. to 6. with both dropdown options on both sites (production and staging).

**Testing for regressions:**
1. Head over to the current dashboard at `http://calypso.localhost:3000/sites/{site-slug}` and try to click the Sync button.
2. The Sync modal should open.
3. It should look and behave normally. There should be no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
