### PR TITLE
i18n: Fix intl collator to work with BCP 47 language tags

### DIFF
--- a/client/state/selectors/get-current-intl-collator.js
+++ b/client/state/selectors/get-current-intl-collator.js
@@ -12,7 +12,11 @@ const getCurrentIntlCollator = ( state ) => {
 	const sortLocales = [ 'en' ];
 
 	if ( currentLocaleSlug ) {
-		sortLocales.unshift( currentLocaleSlug );
+		/*
+		 * Locale slugs could contain underscores, but Intl.Collator expects them to use dashes
+		 * @see https://developer.mozilla.org/en-US/docs/Glossary/BCP_47_language_tag
+		 */
+		sortLocales.unshift( currentLocaleSlug.replace( '_', '-' ) );
 	}
 
 	return new Intl.Collator( sortLocales );


### PR DESCRIPTION
## Proposed Changes

Changing language slug when using intl collator to use dashes instead of underscores

## Why are these changes being made?

To fix a bug when user is using a languages slug like `en_US`

See p1756028281657679-slack-C02A41GCS

## Testing Instructions

* Make sure you're using such a language slug. Change `getCurrentLocaleSlug()` to return `en_US` if you wanna force it.
* Go to `/me/security/connected-applications`
* Verify it no longer crashes.