### PR TITLE
Update the default patterns meta description

### DIFF
--- a/client/my-sites/patterns/components/header/index.tsx
+++ b/client/my-sites/patterns/components/header/index.tsx
@@ -381,7 +381,7 @@ export const PatternsHeader = () => {
 
 	let heading: Substitution = CONTENT.default.patternsHeading;
 	let description: Substitution = CONTENT.default.patternsDescription;
-	let metaDescription: Substitution = CONTENT.default.patternsDescription;
+	let metaDescription: Substitution = CONTENT.default.metaDescription;
 
 	if ( categoryConfig ) {
 		if ( patternTypeFilter === PatternTypeFilter.REGULAR ) {


### PR DESCRIPTION

Part of M4R73CH-896

## Proposed Changes

* The meta description is defined but not used when we visit /patterns. It's requested that we use it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* SEO

## Testing Instructions

* Using calypso.live or export DEBUG="calypso:server-render" && yarn start on local instance navigate /patterns
* Confirm the meta description is the one defined as metaDescription
* Click the different patterns, confirm nothing else changes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
