### PR TITLE
[DON'T MERGE] Notifications v2: Clone templates folder

### DIFF
--- a/apps/notifications/src/app/templates/action-button.jsx
+++ b/apps/notifications/src/app/templates/action-button.jsx
@@ -1,0 +1,35 @@
+import clsx from 'clsx';
+import PropTypes from 'prop-types';
+import HotkeyContainer from './container-hotkey';
+import Gridicon from './gridicons';
+
+const ActionButton = ( { isActive, hotkey, icon, onToggle, text, title } ) => (
+	<HotkeyContainer shortcuts={ hotkey ? [ { hotkey, action: onToggle } ] : null }>
+		<button
+			className={ clsx( 'wpnc__action-link', {
+				'active-action': isActive,
+				'inactive-action': ! isActive,
+			} ) }
+			title={ title }
+			onClick={ ( event ) => {
+				// Prevent the notification panel from being closed.
+				event.stopPropagation();
+				onToggle();
+			} }
+		>
+			<Gridicon icon={ icon } size={ 24 } />
+			<p>{ text }</p>
+		</button>
+	</HotkeyContainer>
+);
+
+ActionButton.propTypes = {
+	isActive: PropTypes.bool.isRequired,
+	hotkey: PropTypes.number,
+	icon: PropTypes.string,
+	onToggle: PropTypes.func.isRequired,
+	text: PropTypes.string.isRequired,
+	title: PropTypes.string.isRequired,
+};
+
+export default ActionButton;

--- a/apps/notifications/src/app/templates/actions.jsx
+++ b/apps/notifications/src/app/templates/actions.jsx
@@ -1,0 +1,85 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { getActions, getReferenceId } from '../helpers/notes';
+import getIsNoteApproved from '../state/selectors/get-is-note-approved';
+import getIsNoteLiked from '../state/selectors/get-is-note-liked';
+import AnswerPromptButton from './button-answer-prompt';
+import ApproveButton from './button-approve';
+import EditButton from './button-edit';
+import LikeButton from './button-like';
+import SpamButton from './button-spam';
+import TrashButton from './button-trash';
+import ReplyInput from './comment-reply-input';
+
+const getType = ( note ) => ( null === getReferenceId( note, 'comment' ) ? 'post' : 'comment' );
+
+const getInitialReplyValue = ( note, translate ) => {
+	let ranges;
+	let username;
+
+	if ( 'user' === note.subject[ 0 ].ranges[ 0 ].type ) {
+		// Build the username from the subject line
+		ranges = note.subject[ 0 ].ranges[ 0 ].indices;
+		username = note.subject[ 0 ].text.substring( ranges[ 0 ], ranges[ 1 ] );
+	} else if ( 'user' === note.body[ 0 ].type ) {
+		username = note.body[ 0 ].text;
+	} else {
+		username = null;
+	}
+
+	if ( username ) {
+		return translate( 'Reply to %(username)s…', {
+			args: { username },
+		} );
+	}
+
+	return getType( note ) === 'post'
+		? translate( 'Reply to post…' )
+		: translate( 'Reply to comment…' );
+};
+
+const ActionsPane = ( { global, isApproved, isLiked, note, translate } ) => {
+	const actions = getActions( note );
+	const hasAction = ( types ) =>
+		[].concat( types ).some( ( type ) => actions.hasOwnProperty( type ) );
+
+	return (
+		<div className="wpnc__note-actions">
+			<div className="wpnc__note-actions__buttons">
+				{ hasAction( 'approve-comment' ) && <ApproveButton { ...{ note, isApproved } } /> }
+				{ hasAction( 'spam-comment' ) && <SpamButton note={ note } /> }
+				{ hasAction( 'trash-comment' ) && <TrashButton note={ note } /> }
+				{ hasAction( [ 'like-post', 'like-comment' ] ) && <LikeButton { ...{ note, isLiked } } /> }
+				{ hasAction( 'edit-comment' ) && <EditButton note={ note } /> }
+				{ hasAction( 'answer-prompt' ) && <AnswerPromptButton note={ note } /> }
+			</div>
+			{ !! actions[ 'replyto-comment' ] && (
+				<ReplyInput
+					{ ...{
+						note,
+						defaultValue: getInitialReplyValue( note, translate ),
+						global,
+					} }
+				/>
+			) }
+		</div>
+	);
+};
+
+ActionsPane.propTypes = {
+	global: PropTypes.object.isRequired,
+	isApproved: PropTypes.bool.isRequired,
+	isLiked: PropTypes.bool.isRequired,
+	note: PropTypes.object.isRequired,
+	translate: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = ( state, { note } ) => ( {
+	isApproved: getIsNoteApproved( state, note ),
+	isLiked: getIsNoteLiked( state, note ),
+} );
+
+export default connect( mapStateToProps )( localize( ActionsPane ) );

--- a/apps/notifications/src/app/templates/block-comment.jsx
+++ b/apps/notifications/src/app/templates/block-comment.jsx
@@ -1,0 +1,16 @@
+import clsx from 'clsx';
+import { html } from '../indices-to-html';
+import { p } from './functions';
+
+export const CommentBlock = ( { block, meta } ) => (
+	<div
+		className={ clsx( 'wpnc__comment', {
+			'comment-other': meta.ids.comment !== block.meta.ids.comment,
+			'comment-self': meta.ids.comment === block.meta.ids.comment,
+		} ) }
+	>
+		{ p( html( block ) ) }
+	</div>
+);
+
+export default CommentBlock;

--- a/apps/notifications/src/app/templates/block-post.jsx
+++ b/apps/notifications/src/app/templates/block-post.jsx
@@ -1,0 +1,6 @@
+import { html } from '../indices-to-html';
+import { p } from './functions';
+
+const PostBlock = ( { block } ) => <div className="wpnc__post">{ p( html( block ) ) }</div>;
+
+export default PostBlock;

--- a/apps/notifications/src/app/templates/block-prompt.jsx
+++ b/apps/notifications/src/app/templates/block-prompt.jsx
@@ -1,0 +1,6 @@
+import { html } from '../indices-to-html';
+import { p } from './functions';
+
+const PromptBlock = ( { block } ) => <div className="wpnc__prompt">{ p( html( block ) ) }</div>;
+
+export default PromptBlock;

--- a/apps/notifications/src/app/templates/block-user.jsx
+++ b/apps/notifications/src/app/templates/block-user.jsx
@@ -1,0 +1,213 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+import {
+	getRelativeTimeString,
+	getShortDateString,
+	getNumericDateString,
+	getISODateString,
+} from '@automattic/i18n-utils';
+import { localize, getLocaleSlug } from 'i18n-calypso';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+import getIsNoteApproved from '../state/selectors/get-is-note-approved';
+import FollowLink from './follow-link';
+import { linkProps } from './functions';
+
+const aSecond = 1000;
+const aMinute = aSecond * 60;
+const anHour = aMinute * 60;
+const aDay = anHour * 24;
+
+function getDisplayURL( url ) {
+	const parser = document.createElement( 'a' );
+	parser.href = url;
+	return ( parser.hostname + parser.pathname ).replace( /\/$/, '' );
+}
+
+export class UserBlock extends Component {
+	/**
+	 * Format a timestamp for showing how long ago an event occurred.
+	 * Specifically here for showing when a comment was made.
+	 *
+	 * If within the past five days, a relative time
+	 * e.g. "23 sec. ago", "15 min. ago", "4 hrs. ago", "1 day ago"
+	 *
+	 * If older than five days, absolute date
+	 * e.g. "30 Apr 2015"
+	 *
+	 * If anything goes wrong, ISO date
+	 * e.g. "2020-12-20"
+	 * Localized dates are always better, but ISO dates should be broadly recognizable.
+	 * @param {string} timestamp - Timestamp in Date.parse()'able format
+	 * @returns {string} - Timestamp formatted for display or '' if input invalid
+	 */
+	getTimeString = ( timestamp ) => {
+		const MAX_LENGTH = 15;
+		const parsedTime = Date.parse( timestamp );
+		let timeString;
+
+		if ( isNaN( parsedTime ) ) {
+			return '';
+		}
+
+		const localeSlug = getLocaleSlug();
+
+		timeString = getShortDateString( parsedTime, localeSlug );
+
+		// If the localized short date format is too long, use numeric one.
+		if ( timeString.length > MAX_LENGTH ) {
+			timeString = getNumericDateString( parsedTime, localeSlug );
+		}
+
+		// If the localized numeric date format is still too long, use ISO one.
+		if ( timeString.length > MAX_LENGTH ) {
+			timeString = getISODateString( parsedTime );
+		}
+
+		// Use relative time strings (e.g. '2 min. ago') for recent dates.
+		if ( Date.now() - parsedTime < 5 * aDay ) {
+			const relativeTimeString = getRelativeTimeString( {
+				timestamp: parsedTime,
+				locale: localeSlug,
+			} );
+
+			// Only use relative date if it makes sense and is not too long.
+			if ( relativeTimeString && relativeTimeString.length <= MAX_LENGTH ) {
+				timeString = relativeTimeString;
+			}
+		}
+
+		return timeString;
+	};
+
+	render() {
+		const grav = this.props.block.media[ 0 ];
+		let home_url = '';
+		let home_title = '';
+		let timeIndicator;
+		let homeTemplate;
+		let followLink;
+
+		if ( this.props.block.meta ) {
+			if ( this.props.block.meta.links ) {
+				home_url = this.props.block.meta.links.home || '';
+			}
+			if ( this.props.block.meta.titles ) {
+				home_title = this.props.block.meta.titles.home || '';
+			}
+		}
+		if ( ! home_title && home_url ) {
+			home_title = getDisplayURL( home_url );
+		}
+
+		if ( 'comment' === this.props.note.type ) {
+			// if comment is not approved, show the user's url instead of site
+			// title so it's easier to tell if they are a spammer
+			if ( ! this.props.isApproved && home_url ) {
+				home_title = getDisplayURL( home_url );
+			}
+
+			timeIndicator = (
+				<span className="wpnc__user__timeIndicator">
+					<a
+						href={ this.props.note.url }
+						target="_blank"
+						rel="noopener noreferrer"
+						{ ...linkProps( this.props.note ) }
+					>
+						{ this.getTimeString( this.props.note.timestamp ) }
+					</a>
+					<span className="wpnc__user__bullet" />
+				</span>
+			);
+		} else {
+			timeIndicator = '';
+		}
+
+		if ( home_title ) {
+			const homeClassName =
+				timeIndicator !== '' ? 'wpnc__user__meta wpnc__user__bulleted' : 'wpnc__user__meta';
+			homeTemplate = (
+				<div className={ homeClassName }>
+					<span className="wpnc__user__ago">{ timeIndicator }</span>
+					<a
+						className="wpnc__user__site"
+						href={ home_url }
+						target="_blank"
+						rel="noopener noreferrer"
+						{ ...linkProps( this.props.note, this.props.block ) }
+					>
+						{ home_title }
+					</a>
+				</div>
+			);
+		} else {
+			homeTemplate = (
+				<div className="wpnc__user__meta">
+					<span className="wpnc__user__ago">{ timeIndicator }</span>
+				</div>
+			);
+		}
+
+		if (
+			this.props.block.actions &&
+			this.props.block.meta.ids.site !== undefined &&
+			this.props.block.meta.ids.site !== 'undefined'
+		) {
+			followLink = (
+				<FollowLink
+					site={ this.props.block.meta.ids.site }
+					isFollowing={ this.props.block.actions.follow }
+					noteType={ this.props.note.type }
+				/>
+			);
+		}
+
+		const userId = this.props.block?.meta?.ids?.user;
+		const readerProfileUrl = userId
+			? `https://wordpress.com/reader/users/id/${ userId }`
+			: home_url;
+
+		if ( home_url ) {
+			return (
+				<div className="wpnc__user">
+					<a
+						className="wpnc__user__site"
+						href={ readerProfileUrl }
+						target="_blank"
+						rel="noreferrer"
+					>
+						<img src={ grav.url } height={ grav.height } width={ grav.width } alt="Avatar" />
+					</a>
+					<div>
+						<span className="wpnc__user__username">
+							<a
+								className="wpnc__user__home"
+								href={ readerProfileUrl }
+								target="_blank"
+								rel="noreferrer"
+							>
+								{ this.props.block.text }
+							</a>
+						</span>
+					</div>
+					{ homeTemplate }
+					{ followLink }
+				</div>
+			);
+		}
+		return (
+			<div className="wpnc__user">
+				<img src={ grav.url } height={ grav.height } width={ grav.width } alt="Avatar" />
+				<span className="wpnc__user__username">{ this.props.block.text }</span>
+				{ homeTemplate }
+				{ followLink }
+			</div>
+		);
+	}
+}
+
+const mapStateToProps = ( state, { note } ) => ( {
+	isApproved: getIsNoteApproved( state, note ),
+} );
+
+export default connect( mapStateToProps )( localize( UserBlock ) );

--- a/apps/notifications/src/app/templates/body.jsx
+++ b/apps/notifications/src/app/templates/body.jsx
@@ -1,0 +1,172 @@
+import { localize } from 'i18n-calypso';
+import { Component } from 'react';
+import { html } from '../indices-to-html';
+import { bumpStat } from '../rest-client/bump-stat';
+import { wpcom } from '../rest-client/wpcom';
+import NoteActions from './actions';
+import Comment from './block-comment';
+import Post from './block-post';
+import PromptBlock from './block-prompt';
+import User from './block-user';
+import { p, zipWithSignature } from './functions';
+import NotePreface from './preface';
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+function ReplyBlock( { block } ) {
+	// explicitly send className of '' here so we don't get the default of "paragraph"
+	const replyText = p( html( block ), '' );
+
+	return <div className="wpnc__reply">{ replyText }</div>;
+}
+
+export class NoteBody extends Component {
+	state = {
+		reply: null,
+	};
+
+	isMounted = false;
+
+	componentDidMount() {
+		this.isMounted = true;
+
+		const { note } = this.props;
+		bumpStat( 'notes-click-type', note.type );
+
+		if ( note.meta && note.meta.ids.reply_comment ) {
+			const hasReplyBlock = note.body.some(
+				( block ) =>
+					block.ranges &&
+					block.ranges.length > 1 &&
+					block.ranges[ 1 ].id === note.meta.ids.reply_comment
+			);
+
+			if ( ! hasReplyBlock ) {
+				wpcom()
+					.site( note.meta.ids.site )
+					.comment( note.meta.ids.reply_comment )
+					.get( ( error, data ) => {
+						if ( error || ! this.isMounted ) {
+							return;
+						}
+
+						this.setState( { reply: data } );
+					} );
+			}
+		}
+	}
+
+	componentWillUnmount() {
+		this.isMounted = false;
+	}
+
+	render() {
+		let blocks = zipWithSignature( this.props.note.body, this.props.note );
+		let actions = '';
+		let preface = '';
+		let replyBlock = null;
+		let replyMessage;
+		let firstNonTextIndex;
+		let i;
+
+		for ( i = 0; i < blocks.length; i++ ) {
+			if ( 'text' !== blocks[ i ].signature.type ) {
+				firstNonTextIndex = i;
+				break;
+			}
+		}
+
+		if ( firstNonTextIndex ) {
+			preface = <NotePreface blocks={ this.props.note.body.slice( 0, i ) } />;
+			blocks = blocks.slice( i );
+		}
+
+		const body = [];
+		for ( i = 0; i < blocks.length; i++ ) {
+			const block = blocks[ i ];
+			const blockKey = 'block-' + this.props.note.id + '-' + i;
+
+			if ( block.block.actions && 'user' !== block.signature.type ) {
+				actions = (
+					<NoteActions
+						note={ this.props.note }
+						block={ block.block }
+						global={ this.props.global }
+					/>
+				);
+			}
+
+			switch ( block.signature.type ) {
+				case 'user':
+					body.push(
+						<User
+							key={ blockKey }
+							block={ block.block }
+							noteType={ this.props.note.type }
+							note={ this.props.note }
+							timestamp={ this.props.note.timestamp }
+							url={ this.props.note.url }
+						/>
+					);
+					break;
+				case 'comment':
+					body.push(
+						<Comment key={ blockKey } block={ block.block } meta={ this.props.note.meta } />
+					);
+					break;
+				case 'post':
+					body.push(
+						<Post key={ blockKey } block={ block.block } meta={ this.props.note.meta } />
+					);
+					break;
+				case 'reply':
+					replyBlock = <ReplyBlock key={ blockKey } block={ block.block } />;
+					break;
+				case 'prompt':
+					body.push(
+						<PromptBlock key={ blockKey } block={ block.block } meta={ this.props.note.meta } />
+					);
+					break;
+				default:
+					body.push( <div key={ blockKey }>{ p( html( block.block ) ) }</div> );
+					break;
+			}
+		}
+
+		if ( this.state.reply && this.state.reply.URL ) {
+			if ( this.props.note.meta.ids.comment ) {
+				replyMessage = this.props.translate( 'You {{a}}replied{{/a}} to this comment.', {
+					components: {
+						a: <a href={ this.state.reply.URL } target="_blank" rel="noopener noreferrer" />,
+					},
+				} );
+			} else {
+				replyMessage = this.props.translate( 'You {{a}}replied{{/a}} to this post.', {
+					components: {
+						a: <a href={ this.state.reply.URL } target="_blank" rel="noopener noreferrer" />,
+					},
+				} );
+			}
+
+			replyBlock = (
+				<div className="wpnc__reply">
+					<span className="wpnc__gridicon"></span>
+					{ replyMessage }
+				</div>
+			);
+		}
+
+		return (
+			<div className="wpnc__body">
+				{ preface }
+				<div className="wpnc__body-content">{ body }</div>
+				{ replyBlock }
+				{ actions }
+			</div>
+		);
+	}
+}
+
+/* eslint-enable wpcalypso/jsx-classname-namespace */
+
+export default localize( NoteBody );

--- a/apps/notifications/src/app/templates/button-answer-prompt.jsx
+++ b/apps/notifications/src/app/templates/button-answer-prompt.jsx
@@ -1,0 +1,36 @@
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { keys } from '../helpers/input';
+import { getNewPostLink } from '../helpers/notes';
+import { answerPrompt } from '../state/ui/actions';
+import ActionButton from './action-button';
+
+// eslint-disable-next-line no-shadow
+const AnswerPromptButton = ( { answerPrompt, note, translate } ) => {
+	const { site: siteId } = note?.meta?.ids ?? {};
+	// Notifications are hosted on widgets.wp.com on WordPress.com
+	const host =
+		document.location.host === 'widgets.wp.com' ? 'wordpress.com' : document.location.host;
+	const newPostLink = document.location.protocol + '//' + host + getNewPostLink( note );
+	return (
+		<ActionButton
+			{ ...{
+				icon: 'pinned',
+				isActive: false,
+				hotkey: keys.KEY_E,
+				onToggle: () => answerPrompt( siteId, newPostLink ),
+				text: translate( 'Post Answer', { context: 'verb: imperative' } ),
+				title: translate( 'Post Answer', { context: 'verb: imperative' } ),
+			} }
+		/>
+	);
+};
+
+AnswerPromptButton.propTypes = {
+	answerPrompt: PropTypes.func.isRequired,
+	note: PropTypes.object.isRequired,
+	translate: PropTypes.func.isRequired,
+};
+
+export default connect( null, { answerPrompt } )( localize( AnswerPromptButton ) );

--- a/apps/notifications/src/app/templates/button-approve.jsx
+++ b/apps/notifications/src/app/templates/button-approve.jsx
@@ -1,0 +1,51 @@
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { useContext } from 'react';
+import { connect } from 'react-redux';
+import { RestClientContext } from '../Notifications';
+import { keys } from '../helpers/input';
+import { getReferenceId } from '../helpers/notes';
+import { setApproveStatus as setApproveStatusAction } from '../state/notes/thunks';
+import ActionButton from './action-button';
+
+const ApproveButton = ( { isApproved, note, translate, setApproveStatus } ) => {
+	const restClient = useContext( RestClientContext );
+
+	return (
+		<ActionButton
+			icon="checkmark"
+			isActive={ isApproved }
+			hotkey={ keys.KEY_A }
+			onToggle={ () =>
+				setApproveStatus(
+					note.id,
+					getReferenceId( note, 'site' ),
+					getReferenceId( note, 'comment' ),
+					! isApproved,
+					note.type,
+					restClient
+				)
+			}
+			text={
+				isApproved
+					? translate( 'Approved', { context: 'verb: past-tense' } )
+					: translate( 'Approve', { context: 'verb: imperative' } )
+			}
+			title={
+				isApproved
+					? translate( 'Unapprove comment', { context: 'verb: imperative' } )
+					: translate( 'Approve comment', { context: 'verb: imperative' } )
+			}
+		/>
+	);
+};
+
+ApproveButton.propTypes = {
+	isApproved: PropTypes.bool.isRequired,
+	note: PropTypes.object.isRequired,
+	translate: PropTypes.func.isRequired,
+};
+
+export default connect( null, { setApproveStatus: setApproveStatusAction } )(
+	localize( ApproveButton )
+);

--- a/apps/notifications/src/app/templates/button-edit.jsx
+++ b/apps/notifications/src/app/templates/button-edit.jsx
@@ -1,0 +1,32 @@
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { keys } from '../helpers/input';
+import { getEditCommentLink } from '../helpers/notes';
+import { editComment } from '../state/ui/actions';
+import ActionButton from './action-button';
+
+// eslint-disable-next-line no-shadow
+const EditButton = ( { editComment, note, translate } ) => {
+	const { site: siteId, post: postId, comment: commentId } = note?.meta?.ids ?? {};
+	return (
+		<ActionButton
+			{ ...{
+				icon: 'pencil',
+				isActive: false,
+				hotkey: keys.KEY_E,
+				onToggle: () => editComment( siteId, postId, commentId, getEditCommentLink( note ) ),
+				text: translate( 'Edit', { context: 'verb: imperative' } ),
+				title: translate( 'Edit comment', { context: 'verb: imperative' } ),
+			} }
+		/>
+	);
+};
+
+EditButton.propTypes = {
+	editComment: PropTypes.func.isRequired,
+	note: PropTypes.object.isRequired,
+	translate: PropTypes.func.isRequired,
+};
+
+export default connect( null, { editComment } )( localize( EditButton ) );

--- a/apps/notifications/src/app/templates/button-like.jsx
+++ b/apps/notifications/src/app/templates/button-like.jsx
@@ -1,0 +1,61 @@
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { useContext } from 'react';
+import { connect } from 'react-redux';
+import { RestClientContext } from '../Notifications';
+import { keys } from '../helpers/input';
+import { getReferenceId } from '../helpers/notes';
+import { setLikeStatus } from '../state/notes/thunks/index';
+import ActionButton from './action-button';
+
+// eslint-disable-next-line no-shadow
+const LikeButton = ( { commentId, isLiked, note, translate, setLikeStatus } ) => {
+	const restClient = useContext( RestClientContext );
+
+	let title;
+
+	if ( isLiked ) {
+		if ( commentId ) {
+			title = translate( 'Remove like from comment' );
+		} else {
+			title = translate( 'Remove like from post' );
+		}
+	} else if ( commentId ) {
+		title = translate( 'Like comment', { context: 'verb: imperative' } );
+	} else {
+		title = translate( 'Like post', { context: 'verb: imperative' } );
+	}
+
+	return (
+		<ActionButton
+			icon="star"
+			isActive={ isLiked }
+			hotkey={ keys.KEY_L }
+			onToggle={ () =>
+				setLikeStatus(
+					note.id,
+					getReferenceId( note, 'site' ),
+					getReferenceId( note, 'post' ),
+					getReferenceId( note, 'comment' ),
+					! isLiked,
+					restClient
+				)
+			}
+			text={
+				isLiked
+					? translate( 'Liked', { context: 'verb: past-tense' } )
+					: translate( 'Like', { context: 'verb: imperative' } )
+			}
+			title={ title }
+		/>
+	);
+};
+
+LikeButton.propTypes = {
+	commentId: PropTypes.number,
+	isLiked: PropTypes.bool.isRequired,
+	note: PropTypes.object.isRequired,
+	translate: PropTypes.func.isRequired,
+};
+
+export default connect( null, { setLikeStatus } )( localize( LikeButton ) );

--- a/apps/notifications/src/app/templates/button-spam.jsx
+++ b/apps/notifications/src/app/templates/button-spam.jsx
@@ -1,0 +1,31 @@
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { useContext } from 'react';
+import { connect } from 'react-redux';
+import { RestClientContext } from '../Notifications';
+import { keys } from '../helpers/input';
+import { spamNote } from '../state/notes/thunks';
+import ActionButton from './action-button';
+
+// eslint-disable-next-line no-shadow
+const SpamButton = ( { note, translate, spamNote } ) => {
+	const restClient = useContext( RestClientContext );
+
+	return (
+		<ActionButton
+			icon="spam"
+			isActive={ false }
+			hotkey={ keys.KEY_S }
+			onToggle={ () => spamNote( note, restClient ) }
+			text={ translate( 'Spam', { context: 'verb: Mark as Spam' } ) }
+			title={ translate( 'Mark comment as spam', { context: 'verb: imperative' } ) }
+		/>
+	);
+};
+
+SpamButton.propTypes = {
+	note: PropTypes.object.isRequired,
+	translate: PropTypes.func.isRequired,
+};
+
+export default connect( null, { spamNote } )( localize( SpamButton ) );

--- a/apps/notifications/src/app/templates/button-trash.jsx
+++ b/apps/notifications/src/app/templates/button-trash.jsx
@@ -1,0 +1,31 @@
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { useContext } from 'react';
+import { connect } from 'react-redux';
+import { RestClientContext } from '../Notifications';
+import { keys } from '../helpers/input';
+import { trashNote } from '../state/notes/thunks';
+import ActionButton from './action-button';
+
+// eslint-disable-next-line no-shadow
+const TrashButton = ( { note, translate, trashNote } ) => {
+	const restClient = useContext( RestClientContext );
+
+	return (
+		<ActionButton
+			icon="trash"
+			isActive={ false }
+			hotkey={ keys.KEY_T }
+			onToggle={ () => trashNote( note, restClient ) }
+			text={ translate( 'Trash', { context: 'verb: imperative' } ) }
+			title={ translate( 'Trash comment', { context: 'verb: imperative' } ) }
+		/>
+	);
+};
+
+TrashButton.propTypes = {
+	note: PropTypes.object.isRequired,
+	translate: PropTypes.func.isRequired,
+};
+
+export default connect( null, { trashNote } )( localize( TrashButton ) );

--- a/apps/notifications/src/app/templates/comment-reply-input.jsx
+++ b/apps/notifications/src/app/templates/comment-reply-input.jsx
@@ -1,0 +1,354 @@
+import { localize } from 'i18n-calypso';
+import { createRef, Component } from 'react';
+import { connect } from 'react-redux';
+import repliesCache from '../comment-replies-cache';
+import { modifierKeyIsActive } from '../helpers/input';
+import { bumpStat } from '../rest-client/bump-stat';
+import { wpcom } from '../rest-client/wpcom';
+import actions from '../state/actions';
+import getKeyboardShortcutsEnabled from '../state/selectors/get-keyboard-shortcuts-enabled';
+import Suggestions from '../suggestions';
+import { formatString, validURL } from './functions';
+import Spinner from './spinner';
+const debug = require( 'debug' )( 'notifications:reply' );
+const { recordTracksEvent } = require( '../helpers/stats' );
+
+function stopEvent( event ) {
+	event.stopPropagation();
+	event.preventDefault();
+}
+
+class CommentReplyInput extends Component {
+	replyInput = createRef();
+
+	constructor( props ) {
+		super( props );
+
+		this.savedReplyKey = 'reply_' + this.props.note.id;
+
+		const savedReply = repliesCache.getItem( this.savedReplyKey );
+		const savedReplyValue = savedReply ? savedReply[ 0 ] : '';
+
+		this.state = {
+			value: savedReplyValue,
+			hasClicked: false,
+			isSubmitting: false,
+			rowCount: 1,
+			retryCount: 0,
+		};
+	}
+
+	componentDidMount() {
+		window.addEventListener( 'keydown', this.handleKeyDown, false );
+		window.addEventListener( 'keydown', this.handleCtrlEnter, false );
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener( 'keydown', this.handleKeyDown, false );
+		window.removeEventListener( 'keydown', this.handleCtrlEnter, false );
+
+		this.props.enableKeyboardShortcuts();
+	}
+
+	handleKeyDown = ( event ) => {
+		if ( ! this.props.keyboardShortcutsAreEnabled ) {
+			return;
+		}
+
+		if ( modifierKeyIsActive( event ) ) {
+			return;
+		}
+
+		if ( 82 === event.keyCode ) {
+			/* 'r' key */
+			this.replyInput.current.focus();
+			stopEvent( event );
+		}
+	};
+
+	handleCtrlEnter = ( event ) => {
+		if ( this.state.isSubmitting ) {
+			return;
+		}
+
+		if ( ( event.ctrlKey || event.metaKey ) && ( 10 === event.keyCode || 13 === event.keyCode ) ) {
+			stopEvent( event );
+			this.handleSubmit();
+		}
+	};
+
+	handleSendEnter = ( event ) => {
+		if ( this.state.isSubmitting ) {
+			return;
+		}
+
+		if ( 13 === event.keyCode ) {
+			stopEvent( event );
+			this.handleSubmit();
+		}
+	};
+
+	handleChange = ( event ) => {
+		const textarea = this.replyInput.current;
+
+		this.props.disableKeyboardShortcuts();
+
+		this.setState( {
+			value: event.target.value,
+			rowCount: Math.min(
+				4,
+				Math.ceil( ( textarea.scrollHeight * this.state.rowCount ) / textarea.clientHeight )
+			),
+		} );
+
+		// persist the comment reply on local storage
+		if ( this.savedReplyKey ) {
+			repliesCache.setItem( this.savedReplyKey, [ event.target.value, Date.now() ] );
+		}
+	};
+
+	handleClick = () => {
+		this.props.disableKeyboardShortcuts();
+
+		if ( ! this.state.hasClicked ) {
+			this.setState( {
+				hasClicked: true,
+			} );
+		}
+	};
+
+	handleFocus = () => {
+		this.props.disableKeyboardShortcuts();
+	};
+
+	handleBlur = () => {
+		this.props.enableKeyboardShortcuts();
+
+		// Reset the field if there's no valid user input
+		// The regex strips whitespace
+		if ( '' === this.state.value.replace( /^\s+|\s+$/g, '' ) ) {
+			this.setState( {
+				value: '',
+				hasClicked: false,
+				rowCount: 1,
+			} );
+		}
+	};
+
+	handleSubmit = ( event ) => {
+		let wpObject;
+		let submitComment;
+		let statusMessage;
+		const successMessage = this.props.translate( 'Reply posted!' );
+		const linkMessage = this.props.translate( 'View your comment.' );
+
+		if ( event ) {
+			event.preventDefault();
+			event.stopPropagation();
+		}
+
+		if ( '' === this.state.value ) {
+			return;
+		}
+
+		this.props.global.toggleNavigation( false );
+
+		this.setState( {
+			isSubmitting: true,
+		} );
+
+		if ( this.state.retryCount === 0 ) {
+			bumpStat( 'notes-click-action', 'replyto-comment' );
+			recordTracksEvent( 'calypso_notification_note_reply', {
+				note_type: this.props.note.type,
+			} );
+		}
+
+		if ( this.props.note.meta.ids.comment ) {
+			wpObject = wpcom()
+				.site( this.props.note.meta.ids.site )
+				.comment( this.props.note.meta.ids.comment );
+			submitComment = wpObject.reply;
+		} else {
+			wpObject = wpcom()
+				.site( this.props.note.meta.ids.site )
+				.post( this.props.note.meta.ids.post )
+				.comment();
+			submitComment = wpObject.add;
+		}
+
+		submitComment.call( wpObject, this.state.value, ( error, data ) => {
+			if ( error ) {
+				const errorMessageDuplicateComment = this.props.translate(
+					"Duplicate comment; you've already said that!"
+				);
+				const errorMessage = this.props.translate( 'Reply Failed: Please, try again.' );
+
+				// Handle known exceptions
+				if ( 'CommentDuplicateError' === error.name ) {
+					// Reset the reply form
+					this.setState( {
+						isSubmitting: false,
+						retryCount: 0,
+					} );
+					this.replyInput.current.focus();
+
+					this.props.global.updateStatusBar( errorMessageDuplicateComment, [ 'fail' ], 6000 );
+					this.props.unselectNote();
+				} else if ( this.state.retryCount < 3 ) {
+					this.setState( {
+						retryCount: this.state.retryCount + 1,
+					} );
+
+					window.setTimeout( () => this.handleSubmit(), 2000 * this.state.retryCount );
+				} else {
+					this.setState( {
+						isSubmitting: false,
+						retryCount: 0,
+					} );
+
+					/* Flag submission failure */
+					this.props.global.updateStatusBar( errorMessage, [ 'fail' ], 6000 );
+
+					this.props.enableKeyboardShortcuts();
+					this.props.global.toggleNavigation( true );
+
+					debug( 'Failed to submit comment reply: %s', error.message );
+				}
+
+				return;
+			}
+
+			if ( this.props.note.meta.ids.comment ) {
+				// pre-emptively approve the comment if it wasn't already
+				this.props.approveNote( this.props.note.id, true );
+				this.props.global.client.getNote( this.props.note.id );
+			}
+
+			// remove focus from textarea so we can resume using keyboard
+			// shortcuts without typing in the field
+			this.replyInput.current.blur();
+
+			if ( data.URL && validURL.test( data.URL ) ) {
+				statusMessage = formatString(
+					'{0} <a target="_blank" href="{1}">{2}</a>',
+					successMessage,
+					data.URL,
+					linkMessage
+				);
+			} else {
+				statusMessage = successMessage;
+			}
+
+			this.props.global.updateStatusBar( statusMessage, [ 'success' ], 12000 );
+
+			this.props.enableKeyboardShortcuts();
+			this.props.global.toggleNavigation( true );
+
+			this.setState( {
+				value: '',
+				isSubmitting: false,
+				hasClicked: false,
+				rowCount: 1,
+				retryCount: 0,
+			} );
+
+			// remove the comment reply from local storage
+			repliesCache.removeItem( this.savedReplyKey );
+
+			// route back to list after successful comment post
+			this.props.selectNote( this.props.note.id );
+		} );
+	};
+
+	insertSuggestion = ( suggestion, suggestionsQuery ) => {
+		if ( ! suggestion ) {
+			return;
+		}
+
+		const element = this.replyInput.current;
+		const caretPosition = element.selectionStart;
+		const startString = this.state.value.slice(
+			0,
+			Math.max( caretPosition - suggestionsQuery.length, 0 )
+		);
+		const endString = this.state.value.slice( caretPosition );
+
+		this.setState( {
+			value: startString + suggestion.user_login + ' ' + endString,
+		} );
+
+		element.focus();
+
+		// move the caret after the inserted suggestion
+		const insertPosition = startString.length + suggestion.user_login.length + 1;
+		setTimeout( () => element.setSelectionRange( insertPosition, insertPosition ), 0 );
+	};
+
+	render() {
+		const value = this.state.value;
+		let submitLink = '';
+		const sendText = this.props.translate( 'Send', { context: 'verb: imperative' } );
+
+		if ( this.state.isSubmitting ) {
+			submitLink = <Spinner className="wpnc__spinner" />;
+		} else if ( value.length ) {
+			const submitLinkTitle = this.props.translate( 'Submit reply', {
+				context: 'verb: imperative',
+			} );
+			submitLink = (
+				<button
+					title={ submitLinkTitle }
+					className="active"
+					onClick={ this.handleSubmit }
+					onKeyDown={ this.handleSendEnter }
+				>
+					{ sendText }
+				</button>
+			);
+		} else {
+			const submitLinkTitle = this.props.translate( 'Write your response in order to submit' );
+			submitLink = (
+				<button title={ submitLinkTitle } className="inactive">
+					{ sendText }
+				</button>
+			);
+		}
+
+		return (
+			<div className="wpnc__reply-box">
+				<textarea
+					className="form-textarea"
+					ref={ this.replyInput }
+					rows={ this.state.rowCount }
+					value={ value }
+					placeholder={ this.props.defaultValue }
+					onClick={ this.handleClick }
+					onFocus={ this.handleFocus }
+					onBlur={ this.handleBlur }
+					onChange={ this.handleChange }
+				/>
+				{ submitLink }
+				<Suggestions
+					site={ this.props.note.meta.ids.site }
+					onInsertSuggestion={ this.insertSuggestion }
+					getContextEl={ () => this.replyInput.current }
+				/>
+			</div>
+		);
+	}
+}
+
+const mapStateToProps = ( state ) => ( {
+	keyboardShortcutsAreEnabled: getKeyboardShortcutsEnabled( state ),
+} );
+
+const mapDispatchToProps = {
+	approveNote: actions.notes.approveNote,
+	selectNote: actions.ui.selectNote,
+	unselectNote: actions.ui.unselectNote,
+	enableKeyboardShortcuts: actions.ui.enableKeyboardShortcuts,
+	disableKeyboardShortcuts: actions.ui.disableKeyboardShortcuts,
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( CommentReplyInput ) );

--- a/apps/notifications/src/app/templates/container-hotkey.jsx
+++ b/apps/notifications/src/app/templates/container-hotkey.jsx
@@ -1,0 +1,55 @@
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+import { modifierKeyIsActive } from '../helpers/input';
+import getKeyboardShortcutsEnabled from '../state/selectors/get-keyboard-shortcuts-enabled';
+
+const dispatch = ( event, action ) => {
+	event.preventDefault();
+	event.stopPropagation();
+
+	action();
+};
+
+export class HotkeyContainer extends Component {
+	static propTypes = {
+		shortcuts: PropTypes.arrayOf(
+			PropTypes.shape( {
+				action: PropTypes.func.isRequired,
+				hotkey: PropTypes.number.isRequired,
+				withModifiers: PropTypes.bool,
+			} )
+		),
+	};
+
+	componentDidMount() {
+		window.addEventListener( 'keydown', this.handleKeyDown, false );
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener( 'keydown', this.handleKeyDown, false );
+	}
+
+	handleKeyDown = ( event ) => {
+		if ( ! this.props.shortcuts || ! this.props.keyboardShortcutsAreEnabled ) {
+			return;
+		}
+
+		this.props.shortcuts
+			.filter( ( shortcut ) => shortcut.hotkey === event.keyCode )
+			.filter(
+				( shortcut ) => ( shortcut.withModifiers || false ) === modifierKeyIsActive( event )
+			)
+			.forEach( ( shortcut ) => dispatch( event, shortcut.action ) );
+	};
+
+	render() {
+		return this.props.children;
+	}
+}
+
+const mapStateToProps = ( state ) => ( {
+	keyboardShortcutsAreEnabled: getKeyboardShortcutsEnabled( state ),
+} );
+
+export default connect( mapStateToProps )( HotkeyContainer );

--- a/apps/notifications/src/app/templates/follow-link.jsx
+++ b/apps/notifications/src/app/templates/follow-link.jsx
@@ -1,0 +1,77 @@
+import { useTranslate } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { useState } from 'react';
+import useSafe from '../helpers/use-safe';
+import { bumpStat } from '../rest-client/bump-stat';
+import { wpcom } from '../rest-client/wpcom';
+import Gridicon from './gridicons';
+
+const followStatTypes = {
+	comment: 'note_commented_post',
+	comment_like: 'note_liked_comment',
+	like: 'note_liked_post',
+	follow: 'note_followed',
+	reblog: 'note_reblog_post',
+};
+
+export const FollowLink = ( { site, noteType, isFollowing: initialIsFollowing } ) => {
+	const translate = useTranslate();
+
+	const [ isRequestRunning, setIsRequestRunning ] = useState( false );
+	const [ isFollowing, setIsFollowing ] = useState( initialIsFollowing );
+
+	const safeSetIsFollowing = useSafe( setIsFollowing );
+	const safeSetIsRequestRunning = useSafe( setIsRequestRunning );
+
+	function toggleFollowStatus() {
+		if ( isRequestRunning ) {
+			return;
+		}
+
+		const follower = wpcom().site( site ).follow();
+		setIsRequestRunning( true );
+
+		// optimistically update local state
+		const previousState = isFollowing;
+		setIsFollowing( ! isFollowing );
+
+		const updateState = ( error, data ) => {
+			safeSetIsRequestRunning( false );
+			if ( error ) {
+				safeSetIsFollowing( previousState );
+				throw error;
+			}
+			safeSetIsFollowing( data.is_following );
+		};
+
+		if ( isFollowing ) {
+			follower.del( updateState );
+			bumpStat( 'notes-click-action', 'unfollow' );
+		} else {
+			follower.add( updateState );
+
+			const stats = { 'notes-click-action': 'follow' };
+			stats.follow_source = followStatTypes[ noteType ];
+			bumpStat( stats );
+		}
+	}
+
+	const icon = isFollowing ? 'reader-following' : 'reader-follow';
+	const linkText = isFollowing
+		? translate( 'Subscribed', { context: 'you are subscribing' } )
+		: translate( 'Subscribe', { context: 'verb: imperative' } );
+
+	return (
+		<button className="follow-link" onClick={ toggleFollowStatus }>
+			<Gridicon icon={ icon } size={ 18 } />
+			{ linkText }
+		</button>
+	);
+};
+
+FollowLink.propTypes = {
+	site: PropTypes.number,
+	isFollowing: PropTypes.bool,
+};
+
+export default FollowLink;

--- a/apps/notifications/src/app/templates/gridicons.tsx
+++ b/apps/notifications/src/app/templates/gridicons.tsx
@@ -1,0 +1,352 @@
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import { forwardRef } from 'react';
+
+interface GridiconsProps {
+	icon: string;
+	size?: number;
+	onClick?: () => void;
+}
+
+const Gridicons = forwardRef< SVGSVGElement, GridiconsProps >(
+	( { icon, size = 24, onClick }, ref ) => {
+		const translate = useTranslate();
+		const gridiconClass = `gridicons-${ icon }`;
+		const sharedProps = {
+			className: clsx( 'gridicon', gridiconClass ),
+			height: size,
+			width: size,
+			onClick,
+			ref,
+		};
+
+		switch ( gridiconClass ) {
+			default:
+				return <svg height={ size } width={ size } />;
+
+			case 'gridicons-checkmark':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Approve' ) }</title>
+						<path fill="none" d="M0 0h24v24H0z" />
+						<path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414" />
+					</svg>
+				);
+
+			case 'gridicons-spam':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Spam' ) }</title>
+						<path fill="none" d="M0 0h24v24H0z" />
+						<path d="M17 2H7L2 7v10l5 5h10l5-5V7l-5-5zm-4 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z" />
+					</svg>
+				);
+
+			case 'gridicons-star':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Like' ) }</title>
+						<path fill="none" d="M0 0h24v24H0z" />
+						<path d="M12 2l2.582 6.953L22 9.257l-5.822 4.602L18.18 21 12 16.89 5.82 21l2.002-7.14L2 9.256l7.418-.304" />
+					</svg>
+				);
+
+			case 'gridicons-star-outline':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Like' ) }</title>
+						<g>
+							<path d="M12 6.308l1.176 3.167.347.936.997.042 3.374.14-2.647 2.09-.784.62.27.963.91 3.25-2.813-1.872-.83-.553-.83.552-2.814 1.87.91-3.248.27-.962-.783-.62-2.648-2.092 3.374-.14.996-.04.347-.936L12 6.308M12 2L9.418 8.953 2 9.257l5.822 4.602L5.82 21 12 16.89 18.18 21l-2.002-7.14L22 9.256l-7.418-.305L12 2z" />
+						</g>
+					</svg>
+				);
+
+			case 'gridicons-trash':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Trash' ) }</title>
+						<path fill="none" d="M0 0h24v24H0z" />
+						<path d="M6.187 8h11.625l-.695 11.125C17.05 20.18 16.177 21 15.12 21H8.88c-1.057 0-1.93-.82-1.997-1.875L6.187 8zM19 5v2H5V5h3V4c0-1.105.895-2 2-2h4c1.105 0 2 .895 2 2v1h3zm-9 0h4V4h-4v1z" />
+					</svg>
+				);
+
+			case 'gridicons-reader-follow':
+				// Added "title" to the "plus" icon from the "@wordpress/icons" package. Ideally the package should support adding titles to icons.
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Reader Follow' ) }</title>
+						<path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" />
+					</svg>
+				);
+
+			case 'gridicons-reader-following':
+				return (
+					// Added "title" to the "published" icon from the "@wordpress/icons" package. Ideally the package should support adding titles to icons.
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Reader Following' ) }</title>
+						<path
+							fillRule="evenodd"
+							clipRule="evenodd"
+							d="M12 18.5a6.5 6.5 0 1 1 0-13 6.5 6.5 0 0 1 0 13ZM4 12a8 8 0 1 1 16 0 8 8 0 0 1-16 0Zm11.53-1.47-1.06-1.06L11 12.94l-1.47-1.47-1.06 1.06L11 15.06l4.53-4.53Z"
+						/>
+					</svg>
+				);
+
+			case 'gridicons-mention':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Mention' ) }</title>
+						<g>
+							<path d="M12 2a10 10 0 0 0 0 20v-2a8 8 0 1 1 8-8v.5a1.5 1.5 0 0 1-3 0V7h-2v1a5 5 0 1 0 1 7 3.5 3.5 0 0 0 6-2.46V12A10 10 0 0 0 12 2zm0 13a3 3 0 1 1 3-3 3 3 0 0 1-3 3z" />
+						</g>
+					</svg>
+				);
+
+			case 'gridicons-comment':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Comment' ) }</title>
+						<g>
+							<path d="M3 6v9c0 1.105.895 2 2 2h9v5l5.325-3.804c1.05-.75 1.675-1.963 1.675-3.254V6c0-1.105-.895-2-2-2H5c-1.105 0-2 .895-2 2z" />
+						</g>
+					</svg>
+				);
+
+			case 'gridicons-add':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Add' ) }</title>
+						<g>
+							<path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z" />
+						</g>
+					</svg>
+				);
+
+			case 'gridicons-info':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Info' ) }</title>
+						<g>
+							<path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z" />
+						</g>
+					</svg>
+				);
+
+			case 'gridicons-info-outline':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Info' ) }</title>
+						<g>
+							<path d="M13 9h-2V7h2v2zm0 2h-2v6h2v-6zm-1-7c-4.411 0-8 3.589-8 8s3.589 8 8 8 8-3.589 8-8-3.589-8-8-8m0-2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2z" />
+						</g>
+					</svg>
+				);
+
+			case 'gridicons-lock':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Lock' ) }</title>
+						<g>
+							<path d="M18 8h-1V7c0-2.757-2.243-5-5-5S7 4.243 7 7v1H6c-1.105 0-2 .895-2 2v10c0 1.105.895 2 2 2h12c1.105 0 2-.895 2-2V10c0-1.105-.895-2-2-2zM9 7c0-1.654 1.346-3 3-3s3 1.346 3 3v1H9V7zm4 8.723V18h-2v-2.277c-.595-.346-1-.984-1-1.723 0-1.105.895-2 2-2s2 .895 2 2c0 .738-.405 1.376-1 1.723z" />
+						</g>
+					</svg>
+				);
+
+			case 'gridicons-stats-alt':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Stats' ) }</title>
+						<g>
+							<path d="M21 21H3v-2h18v2zM8 10H4v7h4v-7zm6-7h-4v14h4V3zm6 3h-4v11h4V6z" />
+						</g>
+					</svg>
+				);
+
+			case 'gridicons-reblog':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Reblog' ) }</title>
+						<g>
+							<path d="M22.086 9.914L20 7.828V18c0 1.105-.895 2-2 2h-7v-2h7V7.828l-2.086 2.086L14.5 8.5 19 4l4.5 4.5-1.414 1.414zM6 16.172V6h7V4H6c-1.105 0-2 .895-2 2v10.172l-2.086-2.086L.5 15.5 5 20l4.5-4.5-1.414-1.414L6 16.172z" />
+						</g>
+					</svg>
+				);
+
+			case 'gridicons-trophy':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Trophy' ) }</title>
+						<g>
+							<path d="M18 5.062V3H6v2.062H2V8c0 2.525 1.89 4.598 4.324 4.932.7 2.058 2.485 3.61 4.676 3.978V18c0 1.105-.895 2-2 2H8v2h8v-2h-1c-1.105 0-2-.895-2-2v-1.09c2.19-.368 3.976-1.92 4.676-3.978C20.11 12.598 22 10.525 22 8V5.062h-4zM4 8v-.938h2v3.766C4.836 10.416 4 9.304 4 8zm16 0c0 1.304-.836 2.416-2 2.83V7.06h2V8z" />
+						</g>
+					</svg>
+				);
+
+			case 'gridicons-notice':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Notice' ) }</title>
+						<g>
+							<path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z" />
+						</g>
+					</svg>
+				);
+
+			case 'gridicons-time':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Time' ) }</title>
+						<g>
+							<path d="M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm3.8 13.4L13 11.667V7h-2v5.333l3.2 4.266 1.6-1.2z" />
+						</g>
+					</svg>
+				);
+
+			case 'gridicons-reply':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Reply' ) }</title>
+						<g>
+							<path d="M9 16h7.2l-2.6 2.6L15 20l5-5-5-5-1.4 1.4 2.6 2.6H9c-2.2 0-4-1.8-4-4s1.8-4 4-4h2V4H9c-3.3 0-6 2.7-6 6s2.7 6 6 6z" />
+						</g>
+					</svg>
+				);
+
+			case 'gridicons-arrow-up':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Arrow Up' ) }</title>
+						<g>
+							<path d="M13 20V7.83l5.59 5.59L20 12l-8-8-8 8 1.41 1.41L11 7.83V20h2z" />
+						</g>
+					</svg>
+				);
+
+			case 'gridicons-arrow-down':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Arrow Down' ) }</title>
+						<g>
+							<path d="M11 4v12.17l-5.59-5.59L4 12l8 8 8-8-1.41-1.41L13 16.17V4h-2z" />
+						</g>
+					</svg>
+				);
+
+			case 'gridicons-arrow-left':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Arrow Left' ) }</title>
+						<g>
+							<path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z" />
+						</g>
+					</svg>
+				);
+
+			case 'gridicons-arrow-right':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Arrow Right' ) }</title>
+						<g>
+							<path d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8-8-8z" />
+						</g>
+					</svg>
+				);
+
+			case 'gridicons-cross':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Dismiss' ) }</title>
+						<g>
+							<path d="M18.36 19.78L12 13.41l-6.36 6.37-1.42-1.42L10.59 12 4.22 5.64l1.42-1.42L12 10.59l6.36-6.36 1.41 1.41L13.41 12l6.36 6.36z" />
+						</g>
+					</svg>
+				);
+
+			case 'gridicons-cog':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Open notification settings' ) }</title>
+						<g>
+							<path d="M20,12c0-0.568-0.061-1.122-0.174-1.656l1.834-1.612l-2-3.464l-2.322,0.786c-0.819-0.736-1.787-1.308-2.859-1.657L14,2h-4L9.521,4.396c-1.072,0.349-2.04,0.921-2.859,1.657L4.34,5.268l-2,3.464l1.834,1.612C4.061,10.878,4,11.432,4,12s0.061,1.122,0.174,1.656L2.34,15.268l2,3.464l2.322-0.786c0.819,0.736,1.787,1.308,2.859,1.657L10,22h4l0.479-2.396c1.072-0.349,2.039-0.921,2.859-1.657l2.322,0.786l2-3.464l-1.834-1.612C19.939,13.122,20,12.568,20,12z M12,16c-2.209,0-4-1.791-4-4c0-2.209,1.791-4,4-4c2.209,0,4,1.791,4,4C16,14.209,14.209,16,12,16z" />
+						</g>
+					</svg>
+				);
+
+			case 'gridicons-cart':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Cart' ) }</title>
+						<g>
+							<path d="M9 20c0 1.1-.9 2-2 2s-1.99-.9-1.99-2S5.9 18 7 18s2 .9 2 2zm8-2c-1.1 0-1.99.9-1.99 2s.89 2 1.99 2 2-.9 2-2-.9-2-2-2zm.396-5c.937 0 1.75-.65 1.952-1.566L21 5H7V4c0-1.105-.895-2-2-2H3v2h2v11c0 1.105.895 2 2 2h12c0-1.105-.895-2-2-2H7v-2h10.396z" />
+						</g>
+					</svg>
+				);
+
+			case 'gridicons-pencil':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Edit' ) }</title>
+						<g>
+							<path d="M13,6l5,5l-9.507,9.507c-0.686-0.686-0.689-1.794-0.012-2.485l-0.003-0.003c-0.691,0.677-1.799,0.674-2.485-0.012c-0.677-0.677-0.686-1.762-0.036-2.455l-0.008-0.008c-0.693,0.649-1.779,0.64-2.455-0.036L13,6z M20.586,5.586l-2.172-2.172c-0.781-0.781-2.047-0.781-2.828,0L14,5l5,5l1.586-1.586C21.367,7.633,21.367,6.367,20.586,5.586z M3,18v3h3C6,19.343,4.657,18,3,18z" />
+						</g>
+					</svg>
+				);
+
+			case 'gridicons-pinned':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Pinned' ) }</title>
+						<path
+							d="M9.23611 1.82L11.0933 0L17.583 6.35L15.7157 8.17C14.6443 7.49 13.1851 7.6 12.2361 8.53L11.4708 9.28C10.532 10.21 10.4096 11.63 11.1137 12.69L9.24632 14.51L6.78713 12.1L3.92999 14.89C3.50142 15.31 0.48101 17.6 0.0524386 17.18C-0.376133 16.76 1.9504 13.79 2.37897 13.37L5.22591 10.58L2.76672 8.16L4.63407 6.34C5.7055 7.03 7.16468 6.91 8.10346 5.98L8.86876 5.23C9.81774 4.31 9.94019 2.88 9.23611 1.82Z"
+							fill="#8D8F94"
+						/>
+					</svg>
+				);
+
+			case 'gridicons-bell-off':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>{ translate( 'Bell Off' ) }</title>
+						<g opacity="0.48">
+							<mask
+								id="mask0_766_4208"
+								style={ { maskType: 'alpha' } }
+								maskUnits="userSpaceOnUse"
+								x="7"
+								y="5"
+								width="14"
+								height="17"
+							>
+								<path
+									fillRule="evenodd"
+									clipRule="evenodd"
+									d="M20.8003 18.0896L20.8003 17.2575L20.0591 16.7013C19.5511 16.3206 19.1357 15.6341 19.1357 15.1769L19.1357 10.5984C19.1357 7.84064 16.8995 5.60442 14.1418 5.60442C11.384 5.60442 9.14782 7.84064 9.14782 10.5984L9.14723 15.1763C9.14723 15.6335 8.7318 16.32 8.22386 16.7007L7.48199 17.2575L7.48199 18.0896L20.8003 18.0896ZM15.2826 20.5232C15.6078 20.1979 15.7705 19.7713 15.7705 19.3447L12.4376 19.3447C12.4376 19.7713 12.6009 20.1973 12.9255 20.5232C13.5767 21.1743 14.6314 21.1743 15.2826 20.5232Z"
+									fill="white"
+								/>
+							</mask>
+							<g mask="url(#mask0_766_4208)">
+								<rect
+									y="14.1422"
+									width="20"
+									height="20"
+									transform="rotate(-45 0 14.1422)"
+									fill="#797C82"
+								/>
+							</g>
+							<path
+								className="bell"
+								d="M21.1406 6.14215L7.14062 20.1422"
+								stroke="#797C82"
+								strokeWidth="1.5"
+							/>
+							<path d="M20.1406 5.14215L5.14062 20.1421" stroke="white" strokeWidth="1.5" />
+						</g>
+					</svg>
+				);
+		}
+	}
+);
+
+Gridicons.displayName = 'Gridicons';
+
+export default Gridicons;

--- a/apps/notifications/src/app/templates/image-loader.jsx
+++ b/apps/notifications/src/app/templates/image-loader.jsx
@@ -1,0 +1,72 @@
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+
+/**
+ * Module variables
+ */
+const LoadStatus = {
+	PENDING: 'PENDING',
+	LOADING: 'LOADING',
+	LOADED: 'LOADED',
+	FAILED: 'FAILED',
+};
+const noop = () => {};
+
+export class ImageLoader extends Component {
+	static propTypes = {
+		src: PropTypes.string.isRequired,
+		placeholder: PropTypes.element.isRequired,
+		children: PropTypes.node,
+	};
+
+	constructor( props ) {
+		super( props );
+
+		this.image = new Image();
+		this.image.src = props.src;
+		this.image.onload = this.onLoadComplete;
+		this.image.onerror = this.onLoadComplete;
+
+		this.state = {
+			status: LoadStatus.LOADING,
+		};
+	}
+
+	componentWillUnmount() {
+		this.destroyLoader();
+	}
+
+	destroyLoader = () => {
+		if ( ! this.image ) {
+			return;
+		}
+
+		this.image.onload = noop;
+		this.image.onerror = noop;
+		delete this.image;
+	};
+
+	onLoadComplete = ( event ) => {
+		this.destroyLoader();
+
+		this.setState( {
+			status: 'load' === event.type ? LoadStatus.LOADED : LoadStatus.FAILED,
+		} );
+	};
+
+	render() {
+		const { children, placeholder, src } = this.props;
+		const { status } = this.state;
+
+		return (
+			<div className="image-preloader">
+				{ status === LoadStatus.LOADING && placeholder }
+				{ /* eslint-disable-next-line jsx-a11y/alt-text */ }
+				{ status === LoadStatus.LOADED && <img src={ src } /> }
+				{ status === LoadStatus.FAILED && children }
+			</div>
+		);
+	}
+}
+
+export default ImageLoader;

--- a/apps/notifications/src/app/templates/preface.jsx
+++ b/apps/notifications/src/app/templates/preface.jsx
@@ -1,0 +1,5 @@
+import { pSoup } from './functions';
+
+export const Preface = ( { blocks } ) => <div className="wpnc__preface">{ pSoup( blocks ) }</div>;
+
+export default Preface;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Clone templates folder to reduce changes for https://github.com/Automattic/wp-calypso/pull/105355

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
