### PR TITLE
Hosting Dashboard: Initial structure for me/security

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -133,6 +133,72 @@ export const securityRoute = createRoute( {
 	)
 );
 
+export const securityPasswordRoute = createRoute( {
+	getParentRoute: () => meRoute,
+	path: 'security/password',
+} ).lazy( () =>
+	import( '../../me/security-password' ).then( ( d ) =>
+		createLazyRoute( 'security-password' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const securityAccountRecoveryRoute = createRoute( {
+	getParentRoute: () => meRoute,
+	path: 'security/account-recovery',
+} ).lazy( () =>
+	import( '../../me/security-account-recovery' ).then( ( d ) =>
+		createLazyRoute( 'security-account-recovery' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const securityTwoStepAuthRoute = createRoute( {
+	getParentRoute: () => meRoute,
+	path: 'security/two-step-auth',
+} ).lazy( () =>
+	import( '../../me/security-two-step-auth' ).then( ( d ) =>
+		createLazyRoute( 'security-two-step-auth' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const securitySshKeyRoute = createRoute( {
+	getParentRoute: () => meRoute,
+	path: 'security/ssh-key',
+} ).lazy( () =>
+	import( '../../me/security-ssh-key' ).then( ( d ) =>
+		createLazyRoute( 'security-ssh-key' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const securityConnectedAppsRoute = createRoute( {
+	getParentRoute: () => meRoute,
+	path: 'security/connected-apps',
+} ).lazy( () =>
+	import( '../../me/security-connected-apps' ).then( ( d ) =>
+		createLazyRoute( 'security-connected-apps' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const securitySocialLoginsRoute = createRoute( {
+	getParentRoute: () => meRoute,
+	path: 'security/social-logins',
+} ).lazy( () =>
+	import( '../../me/security-social-logins' ).then( ( d ) =>
+		createLazyRoute( 'security-social-logins' )( {
+			component: d.default,
+		} )
+	)
+);
+
 export const privacyRoute = createRoute( {
 	getParentRoute: () => meRoute,
 	path: 'privacy',
@@ -180,6 +246,12 @@ export const createMeRoutes = ( config: AppConfig ) => {
 		paymentMethodsRoute,
 		taxDetailsRoute,
 		securityRoute,
+		securityPasswordRoute,
+		securityAccountRecoveryRoute,
+		securityTwoStepAuthRoute,
+		securitySshKeyRoute,
+		securityConnectedAppsRoute,
+		securitySocialLoginsRoute,
 		notificationsRoute,
 	];
 

--- a/client/dashboard/me/security-account-recovery/index.tsx
+++ b/client/dashboard/me/security-account-recovery/index.tsx
@@ -1,0 +1,22 @@
+import { __ } from '@wordpress/i18n';
+import PageLayout from '../../components/page-layout';
+import { Text } from '../../components/text';
+import SecurityPageHeader from '../security-page-header';
+
+export default function SecurityAccountRecovery() {
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<SecurityPageHeader
+					title={ __( 'Account recovery' ) }
+					description={ __(
+						'If you ever have problems accessing your account, WordPress.com will use what you enter here to verify your identity.'
+					) }
+				/>
+			}
+		>
+			<Text>Content goes here</Text>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/me/security-account-recovery/summary.tsx
+++ b/client/dashboard/me/security-account-recovery/summary.tsx
@@ -1,0 +1,15 @@
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { lifesaver } from '@wordpress/icons';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+
+export default function SecurityAccountRecoverySummary() {
+	return (
+		<RouterLinkSummaryButton
+			to="/me/security/account-recovery"
+			title={ __( 'Account recovery' ) }
+			description={ __( 'Set up recovery email & SMS number' ) }
+			decoration={ <Icon icon={ lifesaver } /> }
+		/>
+	);
+}

--- a/client/dashboard/me/security-connected-apps/index.tsx
+++ b/client/dashboard/me/security-connected-apps/index.tsx
@@ -1,0 +1,35 @@
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import InlineSupportLink from '../../components/inline-support-link';
+import PageLayout from '../../components/page-layout';
+import { Text } from '../../components/text';
+import SecurityPageHeader from '../security-page-header';
+
+export default function SecurityConnectedApps() {
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<SecurityPageHeader
+					title={ __( 'Connected applications' ) }
+					description={ createInterpolateElement(
+						__(
+							'Connect with third-party applications that extend your site in new and cool ways. <link>Learn more</link>'
+						),
+						{
+							link: (
+								<InlineSupportLink
+									supportPostId={ 17288 }
+									// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
+									supportLink="https://wordpress.com/support/third-party-applications/"
+								/>
+							),
+						}
+					) }
+				/>
+			}
+		>
+			<Text>Content goes here</Text>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/me/security-connected-apps/summary.tsx
+++ b/client/dashboard/me/security-connected-apps/summary.tsx
@@ -1,0 +1,15 @@
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { connection } from '@wordpress/icons';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+
+export default function SecurityAccountRecoverySummary() {
+	return (
+		<RouterLinkSummaryButton
+			to="/me/security/connected-apps"
+			title={ __( 'Connected applications' ) }
+			description={ __( 'Manage applications connected to your WordPress.com account.' ) }
+			decoration={ <Icon icon={ connection } /> }
+		/>
+	);
+}

--- a/client/dashboard/me/security-page-header/index.tsx
+++ b/client/dashboard/me/security-page-header/index.tsx
@@ -1,0 +1,24 @@
+import { useRouter } from '@tanstack/react-router';
+import { Button } from '@wordpress/components';
+import { __, isRTL } from '@wordpress/i18n';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
+import { PageHeader } from '../../components/page-header';
+import type { PageHeaderProps } from '../../components/page-header/types';
+
+export default function SecurityPageHeader( props: PageHeaderProps ) {
+	const router = useRouter();
+
+	const backButton = (
+		<Button
+			className="dashboard-page-header__back-button"
+			icon={ isRTL() ? chevronRight : chevronLeft }
+			onClick={ () => {
+				router.navigate( { to: '/me/security' } );
+			} }
+		>
+			{ __( 'Security' ) }
+		</Button>
+	);
+
+	return <PageHeader prefix={ backButton } { ...props } />;
+}

--- a/client/dashboard/me/security-password/index.tsx
+++ b/client/dashboard/me/security-password/index.tsx
@@ -1,0 +1,22 @@
+import { __ } from '@wordpress/i18n';
+import PageLayout from '../../components/page-layout';
+import { Text } from '../../components/text';
+import SecurityPageHeader from '../security-page-header';
+
+export default function SecurityPassword() {
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<SecurityPageHeader
+					title={ __( 'Password' ) }
+					description={ __(
+						'Strong passwords have at least six characters, and use upper and lower case letters, numbers, and symbols like ! ” ? $ % ^ & ).'
+					) }
+				/>
+			}
+		>
+			<Text>Content goes here</Text>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/me/security-password/summary.tsx
+++ b/client/dashboard/me/security-password/summary.tsx
@@ -1,0 +1,15 @@
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { lockOutline } from '@wordpress/icons';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+
+export default function SecurityAccountRecoverySummary() {
+	return (
+		<RouterLinkSummaryButton
+			to="/me/security/password"
+			title={ __( 'Password' ) }
+			description={ __( 'Strengthen your account by ensuring your password is strong.' ) }
+			decoration={ <Icon icon={ lockOutline } /> }
+		/>
+	);
+}

--- a/client/dashboard/me/security-social-logins/index.tsx
+++ b/client/dashboard/me/security-social-logins/index.tsx
@@ -1,0 +1,20 @@
+import { __ } from '@wordpress/i18n';
+import PageLayout from '../../components/page-layout';
+import { Text } from '../../components/text';
+import SecurityPageHeader from '../security-page-header';
+
+export default function SecuritySocialLogins() {
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<SecurityPageHeader
+					title={ __( 'Social logins' ) }
+					description={ __( 'Log in faster with the accounts you already use.' ) }
+				/>
+			}
+		>
+			<Text>Content goes here</Text>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/me/security-social-logins/summary.tsx
+++ b/client/dashboard/me/security-social-logins/summary.tsx
@@ -1,0 +1,15 @@
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { commentAuthorAvatar } from '@wordpress/icons';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+
+export default function SecuritySocialLoginsSummary() {
+	return (
+		<RouterLinkSummaryButton
+			to="/me/security/social-logins"
+			title={ __( 'Social logins' ) }
+			description={ __( 'Log in faster with the accounts you already use.' ) }
+			decoration={ <Icon icon={ commentAuthorAvatar } /> }
+		/>
+	);
+}

--- a/client/dashboard/me/security-ssh-key/index.tsx
+++ b/client/dashboard/me/security-ssh-key/index.tsx
@@ -1,0 +1,22 @@
+import { __ } from '@wordpress/i18n';
+import PageLayout from '../../components/page-layout';
+import { Text } from '../../components/text';
+import SecurityPageHeader from '../security-page-header';
+
+export default function SecuritySshKey() {
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<SecurityPageHeader
+					title={ __( 'SSH key' ) }
+					description={ __(
+						'Add an SSH key to your WordPress.com account to make it available for SFTP and SSH authentication.'
+					) }
+				/>
+			}
+		>
+			<Text>Content goes here</Text>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/me/security-ssh-key/summary.tsx
+++ b/client/dashboard/me/security-ssh-key/summary.tsx
@@ -1,0 +1,17 @@
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { key } from '@wordpress/icons';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+
+export default function SecuritySshKeySummary() {
+	return (
+		<RouterLinkSummaryButton
+			to="/me/security/ssh-key"
+			title={ __( 'SSH key' ) }
+			description={ __(
+				'Add a SSH key to your WordPress.com account to make it available for SFTP and SSH authentication.'
+			) }
+			decoration={ <Icon icon={ key } /> }
+		/>
+	);
+}

--- a/client/dashboard/me/security-two-step-auth/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/index.tsx
@@ -1,0 +1,22 @@
+import { __ } from '@wordpress/i18n';
+import PageLayout from '../../components/page-layout';
+import { Text } from '../../components/text';
+import SecurityPageHeader from '../security-page-header';
+
+export default function SecurityTwoStepAuth() {
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<SecurityPageHeader
+					title={ __( 'Two-step authentication' ) }
+					description={ __(
+						'Keep your account extra safe with two-step authentication. You’ll use your password plus a temporary code from your phone to sign in.'
+					) }
+				/>
+			}
+		>
+			<Text>Content goes here</Text>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/me/security-two-step-auth/summary.tsx
+++ b/client/dashboard/me/security-two-step-auth/summary.tsx
@@ -1,0 +1,15 @@
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { mobile } from '@wordpress/icons';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+
+export default function SecurityTwoStepAuthSummary() {
+	return (
+		<RouterLinkSummaryButton
+			to="/me/security/two-step-auth"
+			title={ __( 'Two-step authentication' ) }
+			description={ __( 'Manage two-step authentication and security keys and backup codes.' ) }
+			decoration={ <Icon icon={ mobile } /> }
+		/>
+	);
+}

--- a/client/dashboard/me/security/index.tsx
+++ b/client/dashboard/me/security/index.tsx
@@ -2,21 +2,23 @@ import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import SecurityAccountRecoverySummary from '../security-account-recovery/summary';
+import SecurityConnectedAppsSummary from '../security-connected-apps/summary';
+import SecurityPasswordSummary from '../security-password/summary';
+import SecuritySocialLoginsSummary from '../security-social-logins/summary';
+import SecuritySshKeySummary from '../security-ssh-key/summary';
+import SecurityTwoStepAuthSummary from '../security-two-step-auth/summary';
 
 function Security() {
 	return (
-		<PageLayout
-			size="small"
-			header={
-				<PageHeader
-					title={ __( 'Security' ) }
-					description={ __( 'Manage your security settings.' ) }
-				/>
-			}
-		>
-			<VStack spacing={ 4 }>
-				<RouterLinkSummaryButton title={ __( 'Details' ) } to="/me/security" />
+		<PageLayout size="small" header={ <PageHeader title={ __( 'Security' ) } /> }>
+			<VStack spacing={ 6 }>
+				<SecurityPasswordSummary />
+				<SecurityAccountRecoverySummary />
+				<SecurityTwoStepAuthSummary />
+				<SecuritySshKeySummary />
+				<SecurityConnectedAppsSummary />
+				<SecuritySocialLoginsSummary />
 			</VStack>
 		</PageLayout>
 	);


### PR DESCRIPTION
## Proposed Changes

Sets up the file structure for the account security settings screens.
<img width="707" height="854" alt="SCR-20250825-tmhe" src="https://github.com/user-attachments/assets/cb74c0f4-7ed8-495b-9f8b-291390d3aef8" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Hosting Dashboard development

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure the structure is sound
* Head to /v2/me/security and ensure routes work as intended

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
