### PR TITLE
Domains: Name servers: Improve error handling

### DIFF
--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -3,7 +3,6 @@ import { domainQuery } from '../queries/domain';
 import { domainDnsQuery } from '../queries/domain-dns-records';
 import { domainForwardingQuery } from '../queries/domain-forwarding';
 import { domainGlueRecordsQuery } from '../queries/domain-glue-records';
-import { domainNameServersQuery } from '../queries/domain-name-servers';
 import { sslDetailsQuery } from '../queries/domain-ssl';
 import { domainsQuery } from '../queries/domains';
 import { queryClient } from '../query-client';
@@ -168,8 +167,6 @@ export const domainContactInfoRoute = createRoute( {
 export const domainNameServersRoute = createRoute( {
 	getParentRoute: () => domainRoute,
 	path: 'name-servers',
-	loader: ( { params: { domainName } } ) =>
-		queryClient.ensureQueryData( domainNameServersQuery( domainName ) ),
 } ).lazy( () =>
 	import( '../../domains/name-servers' ).then( ( d ) =>
 		createLazyRoute( 'domain-name-servers' )( {

--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -3,6 +3,7 @@ import { domainQuery } from '../queries/domain';
 import { domainDnsQuery } from '../queries/domain-dns-records';
 import { domainForwardingQuery } from '../queries/domain-forwarding';
 import { domainGlueRecordsQuery } from '../queries/domain-glue-records';
+import { domainNameServersQuery } from '../queries/domain-name-servers';
 import { sslDetailsQuery } from '../queries/domain-ssl';
 import { domainsQuery } from '../queries/domains';
 import { queryClient } from '../query-client';
@@ -167,6 +168,8 @@ export const domainContactInfoRoute = createRoute( {
 export const domainNameServersRoute = createRoute( {
 	getParentRoute: () => domainRoute,
 	path: 'name-servers',
+	loader: ( { params: { domainName } } ) =>
+		queryClient.ensureQueryData( domainNameServersQuery( domainName ) ),
 } ).lazy( () =>
 	import( '../../domains/name-servers' ).then( ( d ) =>
 		createLazyRoute( 'domain-name-servers' )( {

--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -1,8 +1,16 @@
-import { createRoute, createLazyRoute, notFound, redirect } from '@tanstack/react-router';
+import {
+	createRoute,
+	createLazyRoute,
+	notFound,
+	redirect,
+	lazyRouteComponent,
+} from '@tanstack/react-router';
+import { __ } from '@wordpress/i18n';
 import { domainQuery } from '../queries/domain';
 import { domainDnsQuery } from '../queries/domain-dns-records';
 import { domainForwardingQuery } from '../queries/domain-forwarding';
 import { domainGlueRecordsQuery } from '../queries/domain-glue-records';
+import { domainNameServersQuery } from '../queries/domain-name-servers';
 import { sslDetailsQuery } from '../queries/domain-ssl';
 import { domainsQuery } from '../queries/domains';
 import { queryClient } from '../query-client';
@@ -37,8 +45,20 @@ export const domainsPurchaseRoute = createRoute( {
 export const domainRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'domains/$domainName',
-	loader: ( { params: { domainName } } ) => {
-		return queryClient.ensureQueryData( domainQuery( domainName ) );
+	loader: async ( { params: { domainName }, location } ) => {
+		const domain = await queryClient.ensureQueryData( domainQuery( domainName ) );
+		const isNameServersSubRoute = location.pathname.includes( '/name-servers' );
+
+		// If navigating to name-servers sub-route and user doesn't have permission,
+		// throw error and handle it with the global error boundary
+		if ( isNameServersSubRoute && ! domain.can_manage_name_servers ) {
+			throw new Error(
+				domain.cannot_manage_name_servers_reason ||
+					__( 'You do not have permission to manage name servers.' )
+			);
+		}
+
+		return domain;
 	},
 } ).lazy( () =>
 	import( '../../domains/domain' ).then( ( d ) =>
@@ -167,13 +187,11 @@ export const domainContactInfoRoute = createRoute( {
 export const domainNameServersRoute = createRoute( {
 	getParentRoute: () => domainRoute,
 	path: 'name-servers',
-} ).lazy( () =>
-	import( '../../domains/name-servers' ).then( ( d ) =>
-		createLazyRoute( 'domain-name-servers' )( {
-			component: d.default,
-		} )
-	)
-);
+	loader: ( { params: { domainName } } ) =>
+		queryClient.ensureQueryData( domainNameServersQuery( domainName ) ),
+	component: lazyRouteComponent( () => import( '../../domains/name-servers' ) ),
+	errorComponent: lazyRouteComponent( () => import( '../../domains/name-servers/error' ) ),
+} );
 
 export const domainGlueRecordsRoute = createRoute( {
 	getParentRoute: () => domainRoute,

--- a/client/dashboard/domains/domain-error.tsx
+++ b/client/dashboard/domains/domain-error.tsx
@@ -1,0 +1,30 @@
+import { Card, CardBody } from '@wordpress/components';
+import Notice from '../components/notice';
+import { PageHeader } from '../components/page-header';
+import PageLayout from '../components/page-layout';
+
+interface DomainErrorProps {
+	error: Error;
+	title: string;
+}
+
+// In case we need to display a domain-specific error page e.g. Name Servers, Glue Records, etc.
+// this is a domain-specific error component shared between all domain subroutes
+export default function DomainError( { error, title }: DomainErrorProps ) {
+	return (
+		<PageLayout size="small" header={ <PageHeader title={ title } /> }>
+			<Card>
+				<CardBody>
+					<Notice variant="error">{ error.message }</Notice>
+				</CardBody>
+			</Card>
+		</PageLayout>
+	);
+}
+
+// Factory function to create domain-specific error components
+export function createDomainErrorComponent( title: string ) {
+	return function DomainSpecificError( { error }: { error: Error } ) {
+		return <DomainError error={ error } title={ title } />;
+	};
+}

--- a/client/dashboard/domains/name-servers/error.tsx
+++ b/client/dashboard/domains/name-servers/error.tsx
@@ -1,0 +1,17 @@
+import { Card, CardBody } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import Notice from '../../components/notice';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+
+export default function NameServers( { error }: { error: Error } ) {
+	return (
+		<PageLayout size="small" header={ <PageHeader title={ __( 'Name Servers' ) } /> }>
+			<Card>
+				<CardBody>
+					<Notice variant="error">{ error.message }</Notice>
+				</CardBody>
+			</Card>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/domains/name-servers/error.tsx
+++ b/client/dashboard/domains/name-servers/error.tsx
@@ -1,17 +1,4 @@
-import { Card, CardBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import Notice from '../../components/notice';
-import { PageHeader } from '../../components/page-header';
-import PageLayout from '../../components/page-layout';
+import { createDomainErrorComponent } from '../domain-error';
 
-export default function NameServers( { error }: { error: Error } ) {
-	return (
-		<PageLayout size="small" header={ <PageHeader title={ __( 'Name Servers' ) } /> }>
-			<Card>
-				<CardBody>
-					<Notice variant="error">{ error.message }</Notice>
-				</CardBody>
-			</Card>
-		</PageLayout>
-	);
-}
+export default createDomainErrorComponent( __( 'Name Servers' ) );

--- a/client/dashboard/domains/name-servers/form.tsx
+++ b/client/dashboard/domains/name-servers/form.tsx
@@ -1,7 +1,6 @@
 import { CHANGE_NAME_SERVERS_FINDING_OUT_NEW_NS } from '@automattic/urls';
 import {
 	Button,
-	Spinner,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	__experimentalInputControl as InputControl,
@@ -99,7 +98,6 @@ interface Props {
 	showUpsellNudge?: boolean;
 	nameServers?: string[];
 	isBusy?: boolean;
-	isLoading?: boolean;
 	onSubmit: ( nameServers: string[] ) => void;
 }
 
@@ -109,7 +107,6 @@ export default function NameServersForm( {
 	showUpsellNudge,
 	nameServers = [],
 	isBusy,
-	isLoading,
 	onSubmit,
 }: Props ) {
 	const isWpcomNameservers = areAllWpcomNameServers( nameServers );
@@ -210,14 +207,6 @@ export default function NameServersForm( {
 		! isBusy &&
 		isItemValid( formData, fields, form ) &&
 		isNameServersChanged( formData, nameServers );
-
-	if ( isLoading ) {
-		return (
-			<VStack alignment="center">
-				<Spinner />
-			</VStack>
-		);
-	}
 
 	return (
 		<form onSubmit={ handleSubmit }>

--- a/client/dashboard/domains/name-servers/form.tsx
+++ b/client/dashboard/domains/name-servers/form.tsx
@@ -1,6 +1,7 @@
 import { CHANGE_NAME_SERVERS_FINDING_OUT_NEW_NS } from '@automattic/urls';
 import {
 	Button,
+	Spinner,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	__experimentalInputControl as InputControl,
@@ -98,6 +99,7 @@ interface Props {
 	showUpsellNudge?: boolean;
 	nameServers?: string[];
 	isBusy?: boolean;
+	isLoading?: boolean;
 	onSubmit: ( nameServers: string[] ) => void;
 }
 
@@ -107,6 +109,7 @@ export default function NameServersForm( {
 	showUpsellNudge,
 	nameServers = [],
 	isBusy,
+	isLoading,
 	onSubmit,
 }: Props ) {
 	const isWpcomNameservers = areAllWpcomNameServers( nameServers );
@@ -207,6 +210,14 @@ export default function NameServersForm( {
 		! isBusy &&
 		isItemValid( formData, fields, form ) &&
 		isNameServersChanged( formData, nameServers );
+
+	if ( isLoading ) {
+		return (
+			<VStack alignment="center">
+				<Spinner />
+			</VStack>
+		);
+	}
 
 	return (
 		<form onSubmit={ handleSubmit }>

--- a/client/dashboard/domains/name-servers/index.tsx
+++ b/client/dashboard/domains/name-servers/index.tsx
@@ -23,11 +23,7 @@ export default function NameServers() {
 	const { user } = useAuth();
 	const { domainName } = domainRoute.useParams();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const {
-		data: nameServers,
-		error: queryError,
-		isLoading: isNameServersLoading,
-	} = useQuery( domainNameServersQuery( domainName ) );
+	const { data: nameServers, error: queryError } = useQuery( domainNameServersQuery( domainName ) );
 	const { mutate: updateNameServers, isPending: isUpdatingNameServers } = useMutation(
 		domainNameServersMutation( domainName )
 	);
@@ -77,7 +73,6 @@ export default function NameServers() {
 							domainName={ domainName }
 							domainSiteSlug={ getDomainSiteSlug( domain ) }
 							isBusy={ isUpdatingNameServers }
-							isLoading={ isNameServersLoading }
 							nameServers={ nameServers ?? [] }
 							onSubmit={ onSubmit }
 							showUpsellNudge={ showUpsellNudge }

--- a/client/dashboard/domains/name-servers/index.tsx
+++ b/client/dashboard/domains/name-servers/index.tsx
@@ -12,7 +12,6 @@ import {
 } from '../../app/queries/domain-name-servers';
 import { siteByIdQuery } from '../../app/queries/site';
 import { domainRoute } from '../../app/router/domains';
-import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { getDomainSiteSlug } from '../../utils/domain';
@@ -23,11 +22,8 @@ export default function NameServers() {
 	const { user } = useAuth();
 	const { domainName } = domainRoute.useParams();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const {
-		data: nameServers,
-		error: queryError,
-		isLoading: isNameServersLoading,
-	} = useQuery( domainNameServersQuery( domainName ) );
+
+	const { data: nameServers } = useSuspenseQuery( domainNameServersQuery( domainName ) );
 	const { mutate: updateNameServers, isPending: isUpdatingNameServers } = useMutation(
 		domainNameServersMutation( domainName )
 	);
@@ -38,19 +34,6 @@ export default function NameServers() {
 		() => shouldShowUpsellNudge( user, domain, site ),
 		[ domain, site, user ]
 	);
-
-	const errorMsg = useMemo( () => {
-		if ( ! domain?.can_manage_name_servers ) {
-			return (
-				domain?.cannot_manage_name_servers_reason ||
-				__( 'You do not have permission to manage name servers.' )
-			);
-		}
-
-		if ( queryError ) {
-			return queryError.message;
-		}
-	}, [ domain, queryError ] );
 
 	const onSubmit = useCallback(
 		( ns: string[] ) => {
@@ -70,19 +53,14 @@ export default function NameServers() {
 		<PageLayout size="small" header={ <PageHeader title={ __( 'Name Servers' ) } /> }>
 			<Card>
 				<CardBody>
-					{ errorMsg ? (
-						<Notice variant="error">{ errorMsg }</Notice>
-					) : (
-						<NameServersForm
-							domainName={ domainName }
-							domainSiteSlug={ getDomainSiteSlug( domain ) }
-							isBusy={ isUpdatingNameServers }
-							isLoading={ isNameServersLoading }
-							nameServers={ nameServers ?? [] }
-							onSubmit={ onSubmit }
-							showUpsellNudge={ showUpsellNudge }
-						/>
-					) }
+					<NameServersForm
+						domainName={ domainName }
+						domainSiteSlug={ getDomainSiteSlug( domain ) }
+						isBusy={ isUpdatingNameServers }
+						nameServers={ nameServers ?? [] }
+						onSubmit={ onSubmit }
+						showUpsellNudge={ showUpsellNudge }
+					/>
 				</CardBody>
 			</Card>
 		</PageLayout>

--- a/client/dashboard/domains/name-servers/index.tsx
+++ b/client/dashboard/domains/name-servers/index.tsx
@@ -23,7 +23,11 @@ export default function NameServers() {
 	const { user } = useAuth();
 	const { domainName } = domainRoute.useParams();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const { data: nameServers, error: queryError } = useQuery( domainNameServersQuery( domainName ) );
+	const {
+		data: nameServers,
+		error: queryError,
+		isLoading: isNameServersLoading,
+	} = useQuery( domainNameServersQuery( domainName ) );
 	const { mutate: updateNameServers, isPending: isUpdatingNameServers } = useMutation(
 		domainNameServersMutation( domainName )
 	);
@@ -73,6 +77,7 @@ export default function NameServers() {
 							domainName={ domainName }
 							domainSiteSlug={ getDomainSiteSlug( domain ) }
 							isBusy={ isUpdatingNameServers }
+							isLoading={ isNameServersLoading }
 							nameServers={ nameServers ?? [] }
 							onSubmit={ onSubmit }
 							showUpsellNudge={ showUpsellNudge }


### PR DESCRIPTION
Part of DOTDASH-312

## Proposed Changes

- Fetch name-servers data before the component rendering
- Improves error handling

## Why are these changes being made?

* DOTDASH-312

## Testing Instructions

* Open `/v2/domains/{DOMAN_NAME}/name-servers`

General error handling:
<img width="968" height="650" alt="Screenshot 2025-08-27 at 14 38 21" src="https://github.com/user-attachments/assets/75cd8ae5-bf87-4d33-9dfa-47f95ae023e0" />

Specific name servers error handling:
<img width="969" height="512" alt="Screenshot 2025-08-27 at 14 37 52" src="https://github.com/user-attachments/assets/1a552e50-fc10-4a61-afff-f3a52c646f88" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?