### PR TITLE
Domains: Add policy notices

### DIFF
--- a/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
+++ b/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
@@ -262,7 +262,7 @@ class DomainRegistrationSuggestion extends Component {
 
 		if ( notice.type === 'hsts' ) {
 			return translate(
-				'%(message)s When you host this domain at WordPress.com an SSL ' +
+				'%(message)s When you host this domain at WordPress.com, an SSL ' +
 					'certificate is included. {{a}}Learn more{{/a}}.',
 				{
 					args: {

--- a/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
+++ b/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
@@ -296,6 +296,36 @@ class DomainRegistrationSuggestion extends Component {
 		);
 	}
 
+	getPolicyNoticeMessage( notice ) {
+		const { translate } = this.props;
+
+		if ( notice.type === 'hsts' ) {
+			return translate(
+				'%(message)s When you host this domain at WordPress.com an SSL ' +
+					'certificate is included. {{a}}Learn more{{/a}}.',
+				{
+					args: {
+						message: notice.message,
+					},
+					components: {
+						a: (
+							<a
+								href={ localizeUrl( HTTPS_SSL ) }
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ ( event ) => {
+									event.stopPropagation();
+								} }
+							/>
+						),
+					},
+				}
+			);
+		}
+
+		return notice.message;
+	}
+
 	renderNotice() {
 		const { showHstsNotice, showDotGayNotice } = this.props;
 		return (
@@ -310,7 +340,12 @@ class DomainRegistrationSuggestion extends Component {
 
 	renderBadges() {
 		const {
-			suggestion: { isRecommended, isBestAlternative, is_premium: isPremium },
+			suggestion: {
+				isRecommended,
+				isBestAlternative,
+				is_premium: isPremium,
+				policy_notices: policyNotices,
+			},
 			translate,
 			isFeatured,
 			productSaleCost,
@@ -337,6 +372,19 @@ class DomainRegistrationSuggestion extends Component {
 					{ translate( 'Best alternative' ) }
 				</DomainSuggestionBadge>
 			);
+		}
+
+		if ( policyNotices ) {
+			policyNotices.forEach( ( notice ) => {
+				badges.push(
+					<DomainSuggestionBadge
+						key={ notice.type }
+						popover={ this.getPolicyNoticeMessage( notice ) }
+					>
+						{ notice.label }
+					</DomainSuggestionBadge>
+				);
+			} );
 		}
 
 		const skipSaleBadge = isHundredYearPlanFlow( flowName );

--- a/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
+++ b/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
@@ -50,6 +50,13 @@ class DomainRegistrationSuggestion extends Component {
 			cost: PropTypes.string,
 			match_reasons: PropTypes.arrayOf( PropTypes.oneOf( VALID_MATCH_REASONS ) ),
 			currency_code: PropTypes.string,
+			policy_notices: PropTypes.arrayOf(
+				PropTypes.shape( {
+					type: PropTypes.string.isRequired,
+					label: PropTypes.string.isRequired,
+					message: PropTypes.string.isRequired,
+				} )
+			),
 		} ).isRequired,
 		suggestionSelected: PropTypes.bool,
 		domainsWithPlansOnly: PropTypes.bool.isRequired,

--- a/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
+++ b/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
@@ -24,12 +24,7 @@ import {
 	isPaidDomain,
 	DOMAIN_PRICE_RULE,
 } from 'calypso/lib/cart-values/cart-items';
-import {
-	getDomainPrice,
-	getDomainSalePrice,
-	isHstsRequired,
-	isDotGayNoticeRequired,
-} from 'calypso/lib/domains';
+import { getDomainPrice, getDomainSalePrice } from 'calypso/lib/domains';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
@@ -500,8 +495,6 @@ const mapStateToProps = ( state, props ) => {
 
 	return {
 		zeroCost: formatCurrency( 0, currentUserCurrencyCode, { stripZeros: true } ),
-		showHstsNotice: isHstsRequired( productSlug, productsList ),
-		showDotGayNotice: isDotGayNoticeRequired( productSlug, productsList ),
 		productCost,
 		renewCost,
 		productSaleCost,

--- a/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
+++ b/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
@@ -257,45 +257,6 @@ class DomainRegistrationSuggestion extends Component {
 		);
 	}
 
-	getHstsMessage() {
-		const {
-			translate,
-			suggestion: { domain_name: domain },
-		} = this.props;
-
-		return translate(
-			'All domains ending in {{strong}}%(tld)s{{/strong}} require an SSL certificate ' +
-				'to host a website. When you host this domain at WordPress.com an SSL ' +
-				'certificate is included. {{a}}Learn more{{/a}}.',
-			{
-				args: {
-					tld: '.' + getTld( domain ),
-				},
-				components: {
-					a: (
-						<a
-							href={ localizeUrl( HTTPS_SSL ) }
-							target="_blank"
-							rel="noopener noreferrer"
-							onClick={ ( event ) => {
-								event.stopPropagation();
-							} }
-						/>
-					),
-					strong: <strong />,
-				},
-			}
-		);
-	}
-
-	getDotGayMessage() {
-		const { translate } = this.props;
-
-		return translate(
-			'Any anti-LGBTQ content is prohibited and can result in registration termination. The registry will donate 20% of all registration revenue to LGBTQ non-profit organizations.'
-		);
-	}
-
 	getPolicyNoticeMessage( notice ) {
 		const { translate } = this.props;
 
@@ -324,13 +285,6 @@ class DomainRegistrationSuggestion extends Component {
 		}
 
 		return notice.message;
-	}
-
-	renderNotice() {
-		const { showHstsNotice, showDotGayNotice } = this.props;
-		return (
-			( showHstsNotice && this.getHstsMessage() ) || ( showDotGayNotice && this.getDotGayMessage() )
-		);
 	}
 
 	isExactMatch = () => {
@@ -453,7 +407,6 @@ class DomainRegistrationSuggestion extends Component {
 		const [ domainName, ...tld ] = fullDomain.split( '.' );
 
 		const badges = this.renderBadges();
-		const notice = this.renderNotice();
 
 		const SuggestionComponent = isFeatured ? DomainSuggestion.Featured : DomainSuggestion;
 
@@ -502,7 +455,6 @@ class DomainRegistrationSuggestion extends Component {
 				domain={ domainName }
 				isHighlighted={ isFeatured && this.isExactMatch() }
 				matchReasons={ matchReasons }
-				notice={ notice }
 				tld={ tld.join( '.' ) }
 				price={ price }
 				cta={ cta }

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -48,6 +48,13 @@ class DomainRegistrationSuggestion extends Component {
 			cost: PropTypes.string,
 			match_reasons: PropTypes.arrayOf( PropTypes.oneOf( VALID_MATCH_REASONS ) ),
 			currency_code: PropTypes.string,
+			policy_notices: PropTypes.arrayOf(
+				PropTypes.shape( {
+					type: PropTypes.string.isRequired,
+					label: PropTypes.string.isRequired,
+					message: PropTypes.string.isRequired,
+				} )
+			),
 		} ).isRequired,
 		suggestionSelected: PropTypes.bool,
 		onButtonClick: PropTypes.func.isRequired,

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -23,12 +23,7 @@ import {
 	isPaidDomain,
 	DOMAIN_PRICE_RULE,
 } from 'calypso/lib/cart-values/cart-items';
-import {
-	getDomainPrice,
-	getDomainSalePrice,
-	isHstsRequired,
-	isDotGayNoticeRequired,
-} from 'calypso/lib/domains';
+import { getDomainPrice, getDomainSalePrice } from 'calypso/lib/domains';
 import { shouldUseMultipleDomainsInCart } from 'calypso/signup/steps/domains/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
@@ -417,8 +412,6 @@ class DomainRegistrationSuggestion extends Component {
 
 	renderDomain( hasBadges = false ) {
 		const {
-			showHstsNotice,
-			showDotGayNotice,
 			suggestion: { domain_name: domain },
 		} = this.props;
 
@@ -444,7 +437,6 @@ class DomainRegistrationSuggestion extends Component {
 								</span>
 								<span className="domain-registration-suggestion__domain-title-tld">{ tld }</span>
 							</h3>
-							{ ( showHstsNotice || showDotGayNotice ) && this.renderInfoBubble() }
 						</div>
 					</div>
 				</div>
@@ -452,65 +444,44 @@ class DomainRegistrationSuggestion extends Component {
 		);
 	}
 
-	getHstsMessage() {
-		const {
-			translate,
-			suggestion: { domain_name: domain },
-		} = this.props;
-
-		return translate(
-			'All domains ending in {{strong}}%(tld)s{{/strong}} require an SSL certificate ' +
-				'to host a website. When you host this domain at WordPress.com an SSL ' +
-				'certificate is included. {{a}}Learn more{{/a}}.',
-			{
-				args: {
-					tld: '.' + getTld( domain ),
-				},
-				components: {
-					a: (
-						<a
-							href={ localizeUrl( HTTPS_SSL ) }
-							target="_blank"
-							rel="noopener noreferrer"
-							onClick={ ( event ) => {
-								event.stopPropagation();
-							} }
-						/>
-					),
-					strong: <strong />,
-				},
-			}
-		);
-	}
-
-	getDotGayMessage() {
+	getPolicyNoticeMessage( notice ) {
 		const { translate } = this.props;
 
-		return translate(
-			'Any anti-LGBTQ content is prohibited and can result in registration termination. The registry will donate 20% of all registration revenue to LGBTQ non-profit organizations.'
-		);
-	}
+		if ( notice.type === 'hsts' ) {
+			return translate(
+				'%(message)s When you host this domain at WordPress.com, an SSL ' +
+					'certificate is included. {{a}}Learn more{{/a}}.',
+				{
+					args: {
+						message: notice.message,
+					},
+					components: {
+						a: (
+							<a
+								href={ localizeUrl( HTTPS_SSL ) }
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ ( event ) => {
+									event.stopPropagation();
+								} }
+							/>
+						),
+					},
+				}
+			);
+		}
 
-	renderInfoBubble() {
-		const { isFeatured, showHstsNotice, showDotGayNotice } = this.props;
-
-		const infoPopoverSize = isFeatured ? 22 : 18;
-		return (
-			<InfoPopover
-				className="domain-registration-suggestion__hsts-tooltip"
-				iconSize={ infoPopoverSize }
-				position="right"
-				showOnHover
-			>
-				{ ( showHstsNotice && this.getHstsMessage() ) ||
-					( showDotGayNotice && this.getDotGayMessage() ) }
-			</InfoPopover>
-		);
+		return notice.message;
 	}
 
 	renderBadges() {
 		const {
-			suggestion: { isRecommended, isBestAlternative, is_premium: isPremium },
+			suggestion: {
+				isRecommended,
+				isBestAlternative,
+				is_premium: isPremium,
+				policy_notices: policyNotices,
+			},
 			translate,
 			isFeatured,
 			productSaleCost,
@@ -530,6 +501,23 @@ class DomainRegistrationSuggestion extends Component {
 					{ translate( 'Best Alternative' ) }
 				</Badge>
 			);
+		}
+
+		if ( policyNotices ) {
+			policyNotices.forEach( ( notice ) => {
+				badges.push(
+					<Badge
+						key={ notice.type }
+						type="info"
+						className="domain-registration-suggestion__info-badge"
+					>
+						{ notice.label }
+						<InfoPopover iconSize={ 16 } showOnHover>
+							{ this.getPolicyNoticeMessage( notice ) }
+						</InfoPopover>
+					</Badge>
+				);
+			} );
 		}
 
 		const paidDomain = isPaidDomain( this.getPriceRule() );
@@ -661,8 +649,6 @@ const mapStateToProps = ( state, props ) => {
 	}
 
 	return {
-		showHstsNotice: isHstsRequired( productSlug, productsList ),
-		showDotGayNotice: isDotGayNoticeRequired( productSlug, productsList ),
 		productCost,
 		renewCost,
 		productSaleCost,

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -336,6 +336,14 @@
 	}
 }
 
+.domain-registration-suggestion__info-badge {
+	.info-popover {
+		height: 16px;
+		vertical-align: middle;
+		margin: 0 0 2px 4px;
+	}
+}
+
 .domain-product-price {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOMENG-71](https://linear.app/a8c/issue/DOMENG-71/in-domain-registrationa-checkout-and-email-managing-kyc-expectations)

## Proposed Changes

This changes how TLD policy notices are displayed on the domain suggestions screens. After a conversation with @hambai and @gius80, we decided to be proactive and refactor this part. The changes include:

* Serving the notices from the backend. See 191181-ghe-Automattic/wpcom.
* Rendering policy notices as a label containing a popover instead of only having an (i) icon with a popover. This should make the TLD specifics more visible, resulting in better-informed users.

### `/setup/onboarding/domains` (v1)

| Before | After |
| :---:  | :---: |
| <img width="1550" height="566" alt="image" src="https://github.com/user-attachments/assets/6451bf64-e49b-495b-9802-b6dbb73d14e4" /> | <img width="1568" height="524" alt="image" src="https://github.com/user-attachments/assets/f0f92d15-9768-45dc-8e82-547f6e084e88" /> |

| Before | After |
| :---:  | :---: |
| <img width="762" height="261" alt="image" src="https://github.com/user-attachments/assets/753bf8ef-f97d-41a4-8b5e-4be13c40b1f3" /> | <img width="759" height="283" alt="image" src="https://github.com/user-attachments/assets/48cec950-0759-4ef6-b53f-a033b80d70de" /> |

### `/start/domain/domain-only` (v2)

| Before | After |
| :---:  | :---: |
| <img width="1078" height="309" alt="image" src="https://github.com/user-attachments/assets/be09addd-c023-4d59-b5b0-dde62764be67" /> | <img width="1084" height="308" alt="image" src="https://github.com/user-attachments/assets/6f5109a3-8ec9-4edc-bed4-313a9d61fafb" /> |

| Before | After |
| :---:  | :---: |
| <img width="1070" height="256" alt="image" src="https://github.com/user-attachments/assets/0dedb22e-068c-4783-b856-30802f9aef66" /> | <img width="1070" height="256" alt="image" src="https://github.com/user-attachments/assets/73de7fce-e4b4-4288-968f-828ec0a33be9" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This initiative is part of the .in domain registration improvements. It aims to help users be better informed about the requirements for the .in TLD.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox the following wpcom PR: 191181-ghe-Automattic/wpcom
* Go to `/setup/onboarding/domains` and search for a domain with the `.in`, `.dev`, or `.gay` TLD.
* You should see a badge containing the TLD policy notice.
* Make sure the same badge is also visible in the suggestions list.
* Repeat for `/start/domain/domain-only`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?