### PR TITLE
Hosting Dashboard Purchases: Fix payment method image size

### DIFF
--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -27,6 +27,8 @@ import type { Site } from '../../data/site';
 import type { SortDirection, View, Fields } from '@wordpress/dataviews';
 import type { ReactNode } from 'react';
 
+import './style.scss';
+
 const purchasesWideFields = [ 'status', 'payment-method' ];
 const purchasesDesktopFields = [ 'status' ];
 const purchasesMobileFields: string[] = [];

--- a/client/dashboard/me/billing-purchases/payment-method-image.tsx
+++ b/client/dashboard/me/billing-purchases/payment-method-image.tsx
@@ -50,5 +50,11 @@ export function getPaymentMethodImageURL( paymentMethodType: string ): string {
 }
 
 export function PaymentMethodImage( { paymentMethodType }: { paymentMethodType: string } ) {
-	return <img alt={ paymentMethodType } src={ getPaymentMethodImageURL( paymentMethodType ) } />;
+	return (
+		<img
+			className="payment-method-image"
+			alt={ paymentMethodType }
+			src={ getPaymentMethodImageURL( paymentMethodType ) }
+		/>
+	);
 }

--- a/client/dashboard/me/billing-purchases/payment-method-image.tsx
+++ b/client/dashboard/me/billing-purchases/payment-method-image.tsx
@@ -55,6 +55,8 @@ export function PaymentMethodImage( { paymentMethodType }: { paymentMethodType: 
 			className="payment-method-image"
 			alt={ paymentMethodType }
 			src={ getPaymentMethodImageURL( paymentMethodType ) }
+			width={ 30 }
+			height={ 19 }
 		/>
 	);
 }

--- a/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
@@ -1,3 +1,4 @@
+import { __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { isExpired, isRenewing, isAkismetFreeProduct } from '../../utils/purchase';
 import { PaymentMethodImage } from './payment-method-image';
@@ -58,10 +59,10 @@ export function PurchasePaymentMethod( {
 				: purchase.payment_card_type || purchase.payment_card_processor || '';
 
 			return (
-				<div>
-					<PaymentMethodImage paymentMethodType={ paymentMethodType } />{ ' ' }
-					{ purchase.payment_details }
-				</div>
+				<HStack justify="flex-start">
+					<PaymentMethodImage paymentMethodType={ paymentMethodType } />
+					<span>{ purchase.payment_details }</span>
+				</HStack>
 			);
 		}
 

--- a/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
@@ -58,10 +58,10 @@ export function PurchasePaymentMethod( {
 				: purchase.payment_card_type || purchase.payment_card_processor || '';
 
 			return (
-				<>
+				<div>
 					<PaymentMethodImage paymentMethodType={ paymentMethodType } />{ ' ' }
 					{ purchase.payment_details }
-				</>
+				</div>
 			);
 		}
 

--- a/client/dashboard/me/billing-purchases/purchase-settings/style.scss
+++ b/client/dashboard/me/billing-purchases/purchase-settings/style.scss
@@ -7,8 +7,3 @@
 	flex-grow: 1;
 	max-width: 318px;
 }
-img.payment-method-image {
-	width: 30px;
-	height: 19px;
-	vertical-align: middle;
-}

--- a/client/dashboard/me/billing-purchases/purchase-settings/style.scss
+++ b/client/dashboard/me/billing-purchases/purchase-settings/style.scss
@@ -7,3 +7,8 @@
 	flex-grow: 1;
 	max-width: 318px;
 }
+img.payment-method-image {
+	width: 30px;
+	height: 19px;
+	vertical-align: middle;
+}

--- a/client/dashboard/me/billing-purchases/style.scss
+++ b/client/dashboard/me/billing-purchases/style.scss
@@ -1,0 +1,5 @@
+img.payment-method-image {
+	width: 30px;
+	height: 19px;
+	vertical-align: middle;
+}

--- a/client/dashboard/me/billing-purchases/style.scss
+++ b/client/dashboard/me/billing-purchases/style.scss
@@ -1,5 +1,3 @@
 img.payment-method-image {
-	width: 30px;
-	height: 19px;
 	vertical-align: middle;
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes SHILL-1061

## Proposed Changes

This PR fixes the image size of the credit card logo displayed in the hosting dashboard's purchases list and purchase settings page.

Before             |  After
:-------------------------:|:-------------------------:
<img width="1389" height="106" alt="Screenshot 2025-08-25 at 4 43 56 PM" src="https://github.com/user-attachments/assets/783c6c4f-396c-466c-844e-3049585c6263" /> | <img width="1389" height="124" alt="Screenshot 2025-08-25 at 4 44 09 PM" src="https://github.com/user-attachments/assets/2b4f34a1-eb41-49eb-ac6f-f17c9d361d30" />
<img width="692" height="232" alt="Screenshot 2025-08-25 at 4 44 43 PM" src="https://github.com/user-attachments/assets/1d00b659-8840-4a9c-a50b-2de34b3c2e5a" /> | <img width="686" height="174" alt="Screenshot 2025-08-25 at 4 44 47 PM" src="https://github.com/user-attachments/assets/2c0d4f56-1ee4-4db0-b9d4-dd9a856405a4" />



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit http://calypso.localhost:3000/v2/me/billing/purchases for an account with a credit card saved to a purchase with auto-renew on. Verify that the credit card logo displayed in the list is roughly the same size as the text (the credit card last four digits) and vertically centered.

Click through to the purchase and verify that the same is true on the purchase settings page.
