### PR TITLE
Products: Update Pay with PayPal to PayPal Payment Buttons

### DIFF
--- a/client/my-sites/checkout/src/lib/get-jetpack-product-features.ts
+++ b/client/my-sites/checkout/src/lib/get-jetpack-product-features.ts
@@ -102,7 +102,7 @@ function getFeatureStrings(
 				translate( 'Stats (10K site views, upgradeable)' ),
 				translate( 'Social' ),
 				translate( 'Display ads with WordAds' ),
-				translate( 'Pay with PayPal' ),
+				translate( 'PayPal Payment Buttons' ),
 				translate( 'Import unlimited subscribers' ),
 				translate( '40+ Jetpack blocks' ),
 				translate( 'Paid content gating' ),
@@ -171,7 +171,7 @@ function getFeatureStrings(
 		case 'creator':
 			return [
 				translate( 'Display ads with WordAds' ),
-				translate( 'Pay with PayPal' ),
+				translate( 'PayPal Payment Buttons' ),
 				translate( 'Import unlimited subscribers' ),
 				translate( '40+ Jetpack blocks' ),
 				translate( 'Paid content gating' ),

--- a/client/my-sites/checkout/src/lib/get-plan-features.ts
+++ b/client/my-sites/checkout/src/lib/get-plan-features.ts
@@ -105,7 +105,7 @@ export default function getPlanFeatures(
 				? String( translate( 'Unlimited access to our library of Premium Themes' ) )
 				: null,
 			isEnabled( 'earn/pay-with-paypal' )
-				? String( translate( 'Subscriber-only content and Pay with PayPal buttons' ) )
+				? String( translate( 'Subscriber-only content and PayPal Payment Buttons' ) )
 				: String( translate( 'Subscriber-only content and payment buttons' ) ),
 			googleAnalytics,
 		].filter( isValueTruthy );

--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -444,10 +444,10 @@ const FEATURES_LIST: FeatureList = {
 		getDescription: () => {
 			return isEnabled( 'themes/premium' )
 				? i18n.translate(
-						'Including premium themes, advanced design and monetization options, Pay with PayPal buttons, and a custom domain name for one year.'
+						'Including premium themes, advanced design and monetization options, PayPal Payment Buttons, and a custom domain name for one year.'
 				  )
 				: i18n.translate(
-						'Including advanced design and monetization options, Pay with PayPal buttons, and a custom domain name for one year.'
+						'Including advanced design and monetization options, PayPal Payment Buttons, and a custom domain name for one year.'
 				  );
 		},
 	},
@@ -763,7 +763,7 @@ const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_SIMPLE_PAYMENTS ]: {
 		getSlug: () => FEATURE_SIMPLE_PAYMENTS,
-		getTitle: () => i18n.translate( 'Pay with PayPal' ),
+		getTitle: () => i18n.translate( 'PayPal Payment Buttons' ),
 		getDescription: () => i18n.translate( 'Sell anything with a simple PayPal button.' ),
 	},
 	[ FEATURE_NO_BRANDING ]: {

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -2484,7 +2484,7 @@ const getPlanJetpackGrowthDetails = (): IncompleteJetpackPlan => ( {
 	getWhatIsIncluded: () => [
 		translate( '40+ Jetpack blocks' ),
 		translate( 'Display ads with WordAds' ),
-		translate( 'Pay with PayPal' ),
+		translate( 'PayPal Payment Buttons' ),
 		translate( 'Paid content gating' ),
 		translate( 'Paywall access' ),
 		translate( 'Newsletter' ),

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -1375,7 +1375,7 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 	const creatorIncludesInfo = [
 		translate( '40+ Jetpack blocks' ),
 		translate( 'Display ads with WordAds' ),
-		translate( 'Pay with PayPal' ),
+		translate( 'PayPal Payment Buttons' ),
 		translate( 'Paid content gating' ),
 		translate( 'Paywall access' ),
 		translate( 'Newsletter' ),
@@ -2848,7 +2848,7 @@ export const getJetpackPlansAlsoIncludedFeatures = (): Record<
 	];
 	const growthPlanIncludesInfo = [
 		translate( 'Display ads with WordAds' ),
-		translate( 'Pay with PayPal' ),
+		translate( 'PayPal Payment Buttons' ),
 		translate( 'Paid content gating' ),
 		translate( 'Paywall access' ),
 		translate( 'Newsletter' ),


### PR DESCRIPTION
Closes PAYPAL-68

## Proposed Changes

* Updates Pay with PayPal references for Jetpack pricing grid and checkout to mention PayPal Payment Buttons. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Launching the PayPal Payment Buttons block and deprecating the Pay with PayPal block. See pfln9p-23y-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that you have `127.0.0.1 calypso.localhost` and `127.0.0.1 jetpack.cloud.localhost` in your `/etc/hosts` file
* Checkout branch
* `yarn install && yarn start-jetpack-cloud`
* Navigate to http://jetpack.cloud.localhost:3000/pricing#jetpack_growth_yearly and ensure reference is correct
* Navigate to http://jetpack.cloud.localhost:3000/pricing#jetpack_creator_yearly and ensure reference is correct
* Navigate to http://jetpack.cloud.localhost:3000/pricing#jetpack_complete and ensure reference is correct
* Restart with `yarn start`
* Navigate to http://calypso.localhost:3000/checkout/jetpack/jetpack_growth_yearly and ensure reference is correct
* Navigate to http://calypso.localhost:3000/checkout/jetpack/jetpack_creator_yearly and ensure reference is correct

<img width="3670" height="2534" alt="CleanShot 2025-08-25 at 16 25 03@2x" src="https://github.com/user-attachments/assets/a04ae69b-b6bc-4168-868d-bc63b792ed71" />
<img width="4084" height="3394" alt="CleanShot 2025-08-25 at 16 02 13@2x" src="https://github.com/user-attachments/assets/43c76113-d97e-40e7-a613-2a10d43f1e64" />
<img width="4084" height="3394" alt="CleanShot 2025-08-25 at 16 02 03@2x" src="https://github.com/user-attachments/assets/bd3aaef2-15c4-4275-b4be-406725ec9df2" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
