### PR TITLE
Big Sky: Carry the `spec_id` param through site creation

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
+++ b/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
@@ -108,7 +108,9 @@ const aiSiteBuilder: FlowV2< typeof initialize > = {
 							let promptParam = '';
 
 							const source = queryParams.get( 'source' );
+							const specId = queryParams.get( 'spec_id' );
 							let sourceParam = '';
+							let specIdParam = '';
 
 							addBlogSticker( siteId, 'big-sky-free-trial' );
 
@@ -155,8 +157,12 @@ const aiSiteBuilder: FlowV2< typeof initialize > = {
 							if ( source ) {
 								sourceParam = `&source=${ encodeURIComponent( source ) }`;
 							}
+							if ( specId ) {
+								specIdParam = `&spec_id=${ encodeURIComponent( specId ) }`;
+							}
+
 							window.location.replace(
-								`${ siteURL }/wp-admin/site-editor.php?canvas=edit&referrer=${ AI_SITE_BUILDER_FLOW }${ promptParam }${ sourceParam }`
+								`${ siteURL }/wp-admin/site-editor.php?canvas=edit&referrer=${ AI_SITE_BUILDER_FLOW }${ promptParam }${ sourceParam }${ specIdParam }`
 							);
 						} else if ( providedDependencies.isLaunched ) {
 							const site = await resolveSelect( SITE_STORE ).getSite(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
@@ -113,8 +113,15 @@ const LaunchBigSky: Step = function ( props ) {
 					promptParam = `&prompt=${ encodeURIComponent( prompt ) }`;
 				}
 
+				const specId = urlQuery.get( 'spec_id' );
+				let specIdParam = '';
+
+				if ( specId ) {
+					specIdParam = `&spec_id=${ encodeURIComponent( specId ) }`;
+				}
+
 				window.location.replace(
-					`${ siteURL }/wp-admin/site-editor.php?canvas=edit&referrer=${ flow }${ promptParam }&source=${ flow }`
+					`${ siteURL }/wp-admin/site-editor.php?canvas=edit&referrer=${ flow }${ promptParam }&source=${ flow }${ specIdParam }`
 				);
 			} catch ( error ) {
 				// eslint-disable-next-line no-console


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

Requires Big Sky [PR](https://github.com/Automattic/big-sky-plugin/pull/4154)

## Proposed Changes

Fixes https://linear.app/a8c/issue/BSKY-1023/wp-calypso-carry-the-spec-id-param-through-site-creation

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Big Sky needs `spec_id` to build the site using site spec 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Requires Big Sky [PR](https://github.com/Automattic/big-sky-plugin/pull/4154)

1. Pull this PR and run locally
2. Pull Big Sky [PR](https://github.com/Automattic/big-sky-plugin/pull/4154) and run locally
3. Update this [line](https://github.com/Automattic/wp-calypso/blob/47a4d7854109a6751d2888870dc818bca334de69/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts#L165) to point to your local Big Sky env
4. Reset your site in big sky
5. Navigate to `http://calypso.localhost:3000/setup/ai-site-builder?spec_id=01857933-9394-4a0e-a6b4-c0fb1904c635` or any valid session
6. Verify that you're site is being built 

https://github.com/user-attachments/assets/0dfb1c6d-4d57-4494-bce6-0eb05361e602



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
