### PR TITLE
Add download backup implementation

### DIFF
--- a/client/dashboard/app/queries/site-backup-download.ts
+++ b/client/dashboard/app/queries/site-backup-download.ts
@@ -2,7 +2,6 @@ import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import {
 	fetchSiteBackupDownloadProgress,
 	initiateSiteBackupDownload,
-	type DownloadProgress,
 	type DownloadConfig,
 } from '../../data/site-backup-download';
 import { queryClient } from '../query-client';
@@ -17,17 +16,6 @@ export const siteBackupDownloadProgressQuery = ( siteId: number, downloadId: num
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'backup', 'download', downloadId, 'progress' ],
 		queryFn: () => fetchSiteBackupDownloadProgress( siteId, downloadId ),
-		refetchInterval: ( query: { state: { data?: DownloadProgress } } ) => {
-			const { data } = query.state;
-
-			// Poll every 1.5 seconds if download is in progress
-			if ( ! data?.url ) {
-				return 1500;
-			}
-
-			// Stop polling if finished or failed
-			return false;
-		},
 	} );
 
 /**

--- a/client/dashboard/app/queries/site-backup-download.ts
+++ b/client/dashboard/app/queries/site-backup-download.ts
@@ -1,0 +1,51 @@
+import { mutationOptions, queryOptions } from '@tanstack/react-query';
+import {
+	fetchSiteBackupDownloadProgress,
+	initiateSiteBackupDownload,
+	type DownloadProgress,
+	type DownloadConfig,
+} from '../../data/site-backup-download';
+import { queryClient } from '../query-client';
+
+/**
+ * Fetch the download progress for a site backup.
+ * @param siteId - The ID of the site to fetch download progress for.
+ * @param downloadId - The ID of the download to fetch progress for.
+ * @returns A promise that resolves to the download progress.
+ */
+export const siteBackupDownloadProgressQuery = ( siteId: number, downloadId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'backup', 'download', downloadId, 'progress' ],
+		queryFn: () => fetchSiteBackupDownloadProgress( siteId, downloadId ),
+		refetchInterval: ( query: { state: { data?: DownloadProgress } } ) => {
+			const { data } = query.state;
+
+			// Poll every 1.5 seconds if download is in progress
+			if ( ! data?.url ) {
+				return 1500;
+			}
+
+			// Stop polling if finished or failed
+			return false;
+		},
+	} );
+
+/**
+ * Initiate a site backup download.
+ * @param siteId - The ID of the site to initiate a download for.
+ * @returns A promise that resolves to the download ID.
+ */
+export const siteBackupDownloadInitiateMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( {
+			timestamp,
+			config,
+		}: {
+			timestamp: string | number;
+			config?: DownloadConfig;
+		} ) => initiateSiteBackupDownload( siteId, timestamp, config ),
+		onSuccess: ( downloadId ) => {
+			// Start polling download progress
+			queryClient.prefetchQuery( siteBackupDownloadProgressQuery( siteId, downloadId ) );
+		},
+	} );

--- a/client/dashboard/data/site-backup-download.ts
+++ b/client/dashboard/data/site-backup-download.ts
@@ -1,0 +1,128 @@
+import config from '@automattic/calypso-config';
+import wpcom from 'calypso/lib/wp';
+
+/**
+ * Download configuration options.
+ */
+export interface DownloadConfig {
+	themes?: boolean;
+	plugins?: boolean;
+	roots?: boolean;
+	contents?: boolean;
+	sqls?: boolean;
+	uploads?: boolean;
+}
+
+/**
+ * Download error information.
+ */
+export interface DownloadError {
+	code: string;
+	message: string;
+}
+
+/**
+ * Download progress information.
+ */
+export interface DownloadProgress {
+	download_id: number;
+	rewind_id: string;
+	backup_point: string;
+	started_at: string;
+	progress: number;
+	download_count: number;
+	valid_until: string;
+	url: string;
+	bytes: number;
+	bytes_formatted: string;
+	error?: DownloadError;
+}
+
+/**
+ * Download status response from the API.
+ */
+interface DownloadStatusResponse {
+	downloadId: number;
+	rewindId: string;
+	backupPoint: string;
+	startedAt: string;
+	progress: number;
+	downloadCount: number;
+	validUntil: string;
+	url: string;
+	bytes: number;
+	bytesFormatted: string;
+	// Error fields
+	code: string;
+	message: string;
+}
+
+/**
+ * Initiate a download operation for a site backup at a specific timestamp.
+ * @param siteId - The ID of the site to download backup for.
+ * @param timestamp - Unix timestamp of the backup to download.
+ * @param downloadConfig - Download configuration specifying what to include.
+ * @returns A promise that resolves to the download ID.
+ */
+export async function initiateSiteBackupDownload(
+	siteId: number,
+	timestamp: string | number,
+	downloadConfig: DownloadConfig = {}
+): Promise< number > {
+	const data: DownloadStatusResponse = await wpcom.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: `/sites/${ siteId }/rewind/downloads`,
+		body: {
+			rewindId: timestamp,
+			types: downloadConfig,
+			calypso_env: config( 'env_id' ),
+		},
+	} );
+
+	return data.downloadId;
+}
+
+/**
+ * Fetch the progress of a download operation.
+ * @param siteId - The ID of the site.
+ * @param downloadReqId - The ID of the download operation.
+ * @returns A promise that resolves to the download progress.
+ */
+export async function fetchSiteBackupDownloadProgress(
+	siteId: number,
+	downloadReqId: number
+): Promise< DownloadProgress > {
+	const data: DownloadStatusResponse = await wpcom.req.get( {
+		apiNamespace: 'wpcom/v2',
+		path: `/sites/${ siteId }/rewind/downloads/${ downloadReqId }`,
+	} );
+
+	const {
+		downloadId = 0,
+		rewindId = '',
+		backupPoint = '',
+		startedAt = '',
+		progress = 0,
+		downloadCount = 0,
+		validUntil = '',
+		url = '',
+		bytes = 0,
+		bytesFormatted = '',
+		code = '',
+		message = '',
+	} = data || {};
+
+	return {
+		download_id: downloadId,
+		rewind_id: rewindId,
+		backup_point: backupPoint,
+		started_at: startedAt,
+		progress,
+		download_count: downloadCount,
+		valid_until: validUntil,
+		url,
+		bytes,
+		bytes_formatted: bytesFormatted,
+		error: code ? { code, message } : undefined,
+	};
+}

--- a/client/dashboard/sites/backup-download/error.tsx
+++ b/client/dashboard/sites/backup-download/error.tsx
@@ -1,0 +1,23 @@
+import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import Notice from '../../components/notice';
+
+const SiteBackupDownloadError = ( { onRetry }: { onRetry: () => void } ) => {
+	return (
+		<HStack spacing={ 4 }>
+			<Notice variant="error" title={ __( 'Download failed' ) }>
+				{ createInterpolateElement(
+					__(
+						'An error occurred while preparing your backup download. Please <button>try again</button> or contact our support team to resolve the issue.'
+					),
+					{
+						button: <Button variant="link" onClick={ onRetry } />,
+					}
+				) }
+			</Notice>
+		</HStack>
+	);
+};
+
+export default SiteBackupDownloadError;

--- a/client/dashboard/sites/backup-download/form.tsx
+++ b/client/dashboard/sites/backup-download/form.tsx
@@ -1,5 +1,9 @@
 import { useMutation } from '@tanstack/react-query';
-import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import {
+	Button,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
@@ -98,30 +102,37 @@ function SiteBackupDownloadForm( {
 		);
 	};
 
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		handleDownload();
+	};
+
 	const isFormValid = Object.values( formData ).some( ( value ) => value );
 
 	return (
-		<>
-			<p>{ __( 'Choose the items you wish to include in the download:' ) }</p>
-			<DataForm< DownloadConfig >
-				data={ formData }
-				fields={ fields }
-				form={ form }
-				onChange={ handleFormChange }
-			/>
+		<form onSubmit={ handleSubmit }>
+			<VStack spacing={ 4 }>
+				<p>{ __( 'Choose the items you wish to include in the download:' ) }</p>
+				<DataForm< DownloadConfig >
+					data={ formData }
+					fields={ fields }
+					form={ form }
+					onChange={ handleFormChange }
+				/>
 
-			<HStack justify="flex-start">
-				<Button
-					variant="primary"
-					icon={ download }
-					onClick={ handleDownload }
-					isBusy={ isDownloadMutationPending }
-					disabled={ ! isFormValid || isDownloadMutationPending }
-				>
-					{ __( 'Generate download' ) }
-				</Button>
-			</HStack>
-		</>
+				<HStack justify="flex-start">
+					<Button
+						variant="primary"
+						icon={ download }
+						type="submit"
+						isBusy={ isDownloadMutationPending }
+						disabled={ ! isFormValid || isDownloadMutationPending }
+					>
+						{ __( 'Generate download' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		</form>
 	);
 }
 

--- a/client/dashboard/sites/backup-download/form.tsx
+++ b/client/dashboard/sites/backup-download/form.tsx
@@ -1,0 +1,128 @@
+import { useMutation } from '@tanstack/react-query';
+import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { DataForm } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { download } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
+import { useState } from 'react';
+import { siteBackupDownloadInitiateMutation } from '../../app/queries/site-backup-download';
+import { siteBackupDownloadRoute } from '../../app/router/sites';
+import type { DownloadConfig } from '../../data/site-backup-download';
+import type { Field } from '@wordpress/dataviews';
+
+const fields: Field< DownloadConfig >[] = [
+	{
+		id: 'themes',
+		label: __( 'WordPress themes' ),
+		Edit: 'checkbox',
+	},
+	{
+		id: 'plugins',
+		label: __( 'WordPress plugins' ),
+		Edit: 'checkbox',
+	},
+	{
+		id: 'roots',
+		label: __( 'WordPress root' ),
+		description: __( 'Includes wp-config.php and any non WordPress files.' ),
+		Edit: 'checkbox',
+	},
+	{
+		id: 'contents',
+		label: __( 'WP-content directory' ),
+		description: __( 'Excludes themes, plugins, and uploads.' ),
+		Edit: 'checkbox',
+	},
+	{
+		id: 'sqls',
+		label: __( 'Site database' ),
+		description: __( 'Includes pages, and posts.' ),
+		Edit: 'checkbox',
+	},
+	{
+		id: 'uploads',
+		label: __( 'Media uploads' ),
+		description: __( 'You must also select Site database for restored media uploads to appear.' ),
+		Edit: 'checkbox',
+	},
+];
+
+function SiteBackupDownloadForm( {
+	siteId,
+	onDownloadInitiate,
+}: {
+	siteId: number;
+	onDownloadInitiate: ( downloadId: number ) => void;
+} ) {
+	const { rewindId } = siteBackupDownloadRoute.useParams();
+	const { mutate: downloadMutation, isPending: isDownloadMutationPending } = useMutation(
+		siteBackupDownloadInitiateMutation( siteId )
+	);
+	const { createErrorNotice } = useDispatch( noticesStore );
+
+	const [ formData, setFormData ] = useState< DownloadConfig >( {
+		themes: true,
+		plugins: true,
+		roots: true,
+		contents: true,
+		sqls: true,
+		uploads: true,
+	} );
+
+	const form = {
+		type: 'regular' as const,
+		fields: [ 'themes', 'plugins', 'roots', 'contents', 'sqls', 'uploads' ],
+	};
+
+	const handleFormChange = ( changes: Partial< DownloadConfig > ) => {
+		setFormData( ( data ) => ( { ...data, ...changes } ) );
+	};
+
+	const handleDownload = () => {
+		downloadMutation(
+			{
+				timestamp: rewindId,
+				config: formData,
+			},
+			{
+				onSuccess: ( downloadId ) => {
+					onDownloadInitiate( downloadId );
+				},
+				onError: () => {
+					createErrorNotice( __( 'Failed to initiate download. Please try again.' ), {
+						type: 'snackbar',
+					} );
+				},
+			}
+		);
+	};
+
+	const isFormValid = Object.values( formData ).some( ( value ) => value );
+
+	return (
+		<>
+			<p>{ __( 'Choose the items you wish to include in the download:' ) }</p>
+			<DataForm< DownloadConfig >
+				data={ formData }
+				fields={ fields }
+				form={ form }
+				onChange={ handleFormChange }
+			/>
+
+			<HStack justify="flex-start">
+				<Button
+					variant="primary"
+					icon={ download }
+					onClick={ handleDownload }
+					isBusy={ isDownloadMutationPending }
+					disabled={ ! isFormValid || isDownloadMutationPending }
+				>
+					{ __( 'Generate download' ) }
+				</Button>
+			</HStack>
+		</>
+	);
+}
+
+export default SiteBackupDownloadForm;

--- a/client/dashboard/sites/backup-download/index.tsx
+++ b/client/dashboard/sites/backup-download/index.tsx
@@ -1,21 +1,105 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import {
 	Button,
 	Card,
 	CardBody,
-	__experimentalHStack as HStack,
+	CardHeader,
+	ExternalLink,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { __, isRTL } from '@wordpress/i18n';
-import { chevronLeft, chevronRight } from '@wordpress/icons';
+import { useDispatch } from '@wordpress/data';
+import { createInterpolateElement, useState } from '@wordpress/element';
+import { __, isRTL, sprintf } from '@wordpress/i18n';
+import { Icon, cloud, chevronLeft, chevronRight } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
+import { siteBySlugQuery } from '../../app/queries/site';
 import { siteBackupDownloadRoute, siteBackupsRoute } from '../../app/router/sites';
-import Notice from '../../components/notice';
+import { useFormattedTime } from '../../components/formatted-time';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import { SectionHeader } from '../../components/section-header';
+import SiteBackupDownloadError from './error';
+import SiteBackupDownloadForm from './form';
+import SiteBackupDownloadProgress from './progress';
+import SiteBackupDownloadSuccess from './success';
+
+type DownloadStep = 'form' | 'progress' | 'success' | 'error';
 
 function SiteBackupDownload() {
 	const { siteSlug, rewindId } = siteBackupDownloadRoute.useParams();
+	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+	const [ currentStep, setCurrentStep ] = useState< DownloadStep >( 'form' );
+	const [ downloadId, setDownloadId ] = useState< number | null >( null );
+	const [ downloadUrl, setDownloadUrl ] = useState< string | null >( null );
+	const [ fileSizeBytes, setFileSizeBytes ] = useState< string | undefined >();
+	const { createSuccessNotice } = useDispatch( noticesStore );
+
 	const router = useRouter();
+
+	const handleDownloadInitiate = ( newDownloadId: number ) => {
+		setCurrentStep( 'progress' );
+		setDownloadId( newDownloadId );
+	};
+
+	const handleDownloadComplete = ( newDownloadUrl: string, newFileSizeBytes?: string ) => {
+		setCurrentStep( 'success' );
+		setDownloadUrl( newDownloadUrl );
+		setFileSizeBytes( newFileSizeBytes );
+		createSuccessNotice( __( 'Backup download file is ready.' ), {
+			type: 'snackbar',
+		} );
+	};
+
+	const handleDownloadError = () => {
+		setCurrentStep( 'error' );
+	};
+
+	const handleRetry = () => {
+		setCurrentStep( 'form' );
+		setDownloadId( null );
+		setDownloadUrl( null );
+		setFileSizeBytes( undefined );
+	};
+
+	const downloadPointDate = useFormattedTime(
+		new Date( parseFloat( rewindId ) * 1000 ).toISOString(),
+		{
+			timeStyle: 'short',
+		}
+	);
+
+	const renderStep = () => {
+		switch ( currentStep ) {
+			case 'form':
+				return (
+					<SiteBackupDownloadForm
+						siteId={ site.ID }
+						onDownloadInitiate={ handleDownloadInitiate }
+					/>
+				);
+			case 'progress':
+				return downloadId ? (
+					<SiteBackupDownloadProgress
+						site={ site }
+						downloadId={ downloadId }
+						onDownloadComplete={ handleDownloadComplete }
+						onDownloadError={ handleDownloadError }
+					/>
+				) : null;
+			case 'success':
+				return downloadUrl ? (
+					<SiteBackupDownloadSuccess
+						site={ site }
+						downloadPointDate={ downloadPointDate }
+						downloadUrl={ downloadUrl }
+						fileSizeBytes={ fileSizeBytes }
+					/>
+				) : null;
+			case 'error':
+				return <SiteBackupDownloadError onRetry={ handleRetry } />;
+		}
+	};
 
 	const backButton = (
 		<Button
@@ -35,20 +119,28 @@ function SiteBackupDownload() {
 			header={ <PageHeader prefix={ backButton } title={ __( 'Download backup' ) } /> }
 		>
 			<Card>
+				<CardHeader>
+					<SectionHeader
+						title={ __( 'Download point' ) }
+						level={ 3 }
+						description={ createInterpolateElement(
+							/* translators: %s is the date of the download point */
+							sprintf( __( '%(downloadPointDate)s. <LearnMore />' ), {
+								downloadPointDate,
+							} ),
+							{
+								LearnMore: (
+									<ExternalLink href="https://jetpack.com/support/backup/">
+										{ __( 'Learn more' ) }
+									</ExternalLink>
+								),
+							}
+						) }
+						decoration={ <Icon icon={ cloud } /> }
+					/>
+				</CardHeader>
 				<CardBody>
-					<VStack spacing={ 4 }>
-						<p>Rewind ID: { rewindId }</p>
-						<Notice variant="info" title={ __( 'Download Information' ) }>
-							{ __(
-								'This backup contains all your site files, database, and settings from the selected restore point. The download will be prepared and made available for download.'
-							) }
-						</Notice>
-						<HStack justify="flex-start">
-							<Button variant="primary" type="submit">
-								{ __( 'Generate download' ) }
-							</Button>
-						</HStack>
-					</VStack>
+					<VStack spacing={ 4 }>{ renderStep() }</VStack>
 				</CardBody>
 			</Card>
 		</PageLayout>

--- a/client/dashboard/sites/backup-download/progress.tsx
+++ b/client/dashboard/sites/backup-download/progress.tsx
@@ -1,0 +1,77 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	__experimentalSpacer as Spacer,
+	ProgressBar,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { useEffect } from 'react';
+import { siteBackupDownloadProgressQuery } from '../../app/queries/site-backup-download';
+import Notice from '../../components/notice';
+import backupDownloadIllustration from '../backups/backup-download-illustration.svg';
+import type { Site } from '../../data/types';
+
+function SiteBackupDownloadProgress( {
+	site,
+	downloadId,
+	onDownloadComplete,
+	onDownloadError,
+}: {
+	site: Site;
+	downloadId: number;
+	onDownloadComplete: ( downloadUrl: string, fileSizeBytes?: string ) => void;
+	onDownloadError: () => void;
+} ) {
+	const { data: downloadProgress } = useQuery( {
+		...siteBackupDownloadProgressQuery( site.ID, downloadId ),
+		enabled: !! downloadId,
+	} );
+
+	useEffect( () => {
+		if ( downloadProgress?.url ) {
+			onDownloadComplete( downloadProgress.url, downloadProgress.bytes_formatted );
+		} else if ( downloadProgress?.error ) {
+			onDownloadError();
+		}
+	}, [
+		downloadProgress?.url,
+		downloadProgress?.bytes_formatted,
+		downloadProgress?.error,
+		onDownloadComplete,
+		onDownloadError,
+	] );
+
+	return (
+		<>
+			<VStack spacing={ 4 } alignment="center">
+				<img
+					src={ backupDownloadIllustration }
+					alt=""
+					width={ 408 }
+					height={ 280 }
+					style={ { opacity: 0.2 } }
+				/>
+				<Text size={ 20 }> { __( 'Initializing the download process' ) } </Text>
+				<Text size={ 13 } variant="muted">
+					{ sprintf(
+						/* translators: %d is the download completion percentage. */
+						__( '%d%% completed' ),
+						downloadProgress?.progress ?? 0
+					) }
+				</Text>
+				<ProgressBar
+					className="dashboard-backups__progress-bar"
+					value={ downloadProgress?.progress ?? 0 }
+				/>
+			</VStack>
+			<Spacer marginTop={ 12 }>
+				<Notice variant="info" title={ __( 'Check your email' ) }>
+					{ __( 'For your convenience, we’ll email you when your file is ready.' ) }
+				</Notice>
+			</Spacer>
+		</>
+	);
+}
+
+export default SiteBackupDownloadProgress;

--- a/client/dashboard/sites/backup-download/progress.tsx
+++ b/client/dashboard/sites/backup-download/progress.tsx
@@ -26,6 +26,17 @@ function SiteBackupDownloadProgress( {
 	const { data: downloadProgress } = useQuery( {
 		...siteBackupDownloadProgressQuery( site.ID, downloadId ),
 		enabled: !! downloadId,
+		refetchInterval: ( query ) => {
+			const { data } = query.state;
+
+			// Poll every 1.5 seconds if download is in progress
+			if ( ! data?.url ) {
+				return 1500;
+			}
+
+			// Stop polling if finished or failed
+			return false;
+		},
 	} );
 
 	useEffect( () => {

--- a/client/dashboard/sites/backup-download/success.tsx
+++ b/client/dashboard/sites/backup-download/success.tsx
@@ -1,0 +1,69 @@
+import { useRouter } from '@tanstack/react-router';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	Button,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Icon, download, check } from '@wordpress/icons';
+import { siteBackupsRoute } from '../../app/router/sites';
+import Notice from '../../components/notice';
+import type { Site } from '../../data/types';
+
+function SiteBackupDownloadSuccess( {
+	site,
+	downloadPointDate,
+	downloadUrl,
+	fileSizeBytes,
+}: {
+	site: Site;
+	downloadPointDate: string;
+	downloadUrl: string;
+	fileSizeBytes?: string;
+} ) {
+	const router = useRouter();
+
+	const handleAllBackupsClick = () => {
+		router.navigate( { to: siteBackupsRoute.fullPath, params: { siteSlug: site.slug } } );
+	};
+
+	const handleDownloadClick = () => {
+		window.open( downloadUrl, '_blank' );
+	};
+
+	return (
+		<>
+			<HStack spacing={ 4 }>
+				<HStack justify="flex-start">
+					<Icon icon={ check } />
+					<VStack spacing={ 1 }>
+						<Text size={ 15 }>{ __( 'Backup download file is ready' ) }</Text>
+						<Text size={ 13 } variant="muted">
+							{ downloadPointDate }
+						</Text>
+					</VStack>
+				</HStack>
+				<HStack justify="flex-end">
+					<Button
+						variant="tertiary"
+						text={ __( 'All backups' ) }
+						onClick={ handleAllBackupsClick }
+					/>
+					<Button
+						variant="primary"
+						icon={ download }
+						text={ __( 'Download file' ) + ( fileSizeBytes ? ` (${ fileSizeBytes })` : '' ) }
+						onClick={ handleDownloadClick }
+					/>
+				</HStack>
+			</HStack>
+
+			<Notice variant="info" title={ __( 'Check your email' ) }>
+				{ __( 'For your convenience, we’ve emailed you a link to your downloadable backup file.' ) }
+			</Notice>
+		</>
+	);
+}
+
+export default SiteBackupDownloadSuccess;

--- a/client/dashboard/sites/backups/backup-download-illustration.svg
+++ b/client/dashboard/sites/backups/backup-download-illustration.svg
@@ -1,0 +1,28 @@
+<svg width="408" height="280" viewBox="0 0 408 280" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="408" height="280" fill="white"/>
+<rect x="82" y="43" width="189" height="126" rx="6" fill="white" stroke="#F0F0F0"/>
+<rect x="96" y="57" width="189" height="126" rx="6" fill="white" stroke="#DDDDDD"/>
+<rect x="110" y="71" width="189" height="126" rx="6" fill="white" stroke="url(#paint0_linear_5209_83348)"/>
+<circle cx="124" cy="85" r="3" stroke="#3858E9"/>
+<circle cx="136" cy="85" r="3" stroke="#3858E9"/>
+<circle cx="148" cy="85" r="3" stroke="#3858E9"/>
+<path d="M233.911 128.817C233.911 115.285 222.555 105 207.958 105C196.063 105 185.79 112.578 183.088 122.862H182.008C171.191 122.862 162 132.063 162 143.432C162 154.8 171.191 164 182.006 164H230.666C240.399 164 247.968 155.88 247.968 146.138C248.51 137.478 242.022 130.442 233.911 128.817Z" stroke="url(#paint1_linear_5209_83348)"/>
+<rect x="194" y="156" width="22" height="15" fill="white"/>
+<path d="M289 218.687L299.607 229.293C299.997 229.684 299.997 230.317 299.607 230.707L289 241.314" stroke="#069E08" stroke-linecap="round"/>
+<path d="M327 230H211C207.686 230 205 227.314 205 224V135" stroke="url(#paint2_linear_5209_83348)" stroke-linecap="round"/>
+<circle cx="205" cy="140" r="8" fill="#3858E9"/>
+<defs>
+<linearGradient id="paint0_linear_5209_83348" x1="123.263" y1="121.4" x2="282.468" y2="122.198" gradientUnits="userSpaceOnUse">
+<stop stop-color="#3858E9"/>
+<stop offset="1" stop-color="#069E08"/>
+</linearGradient>
+<linearGradient id="paint1_linear_5209_83348" x1="168.035" y1="128.6" x2="240.477" y2="128.953" gradientUnits="userSpaceOnUse">
+<stop stop-color="#3858E9"/>
+<stop offset="1" stop-color="#069E08"/>
+</linearGradient>
+<linearGradient id="paint2_linear_5209_83348" x1="213.256" y1="173.4" x2="306.335" y2="173.758" gradientUnits="userSpaceOnUse">
+<stop stop-color="#3858E9"/>
+<stop offset="1" stop-color="#069E08"/>
+</linearGradient>
+</defs>
+</svg>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes [DOTDASH-283][1].

## Proposed Changes

This PR is the download backup version of:

- https://github.com/Automattic/wp-calypso/pull/105301

With the follow-up changes from:

- https://github.com/Automattic/wp-calypso/pull/105318

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is the implementation of the download backup feature.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/v2/sites/{site}/backups`
- Test the flow from the `Download backup` button.

https://github.com/user-attachments/assets/11bd1868-963c-4037-8137-bab31e83f5c3

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

[1]: https://linear.app/a8c/issue/DOTDASH-283/