### PR TITLE
[WIP] Backups Dashboard: implement backup progress display in the dashboard

### DIFF
--- a/client/dashboard/sites/backups/backup-details.tsx
+++ b/client/dashboard/sites/backups/backup-details.tsx
@@ -11,14 +11,17 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { rotateLeft, download } from '@wordpress/icons';
+import { useBackupState } from '../../app/hooks/site-backup-state';
 import { siteBackupRestoreRoute, siteBackupDownloadRoute } from '../../app/router/sites';
 import { useFormattedTime } from '../../components/formatted-time';
 import { SectionHeader } from '../../components/section-header';
 import { gridiconToWordPressIcon } from '../../utils/gridicons';
+import SiteBackupProgress from './backup-progress';
 import type { ActivityLogEntry, Site } from '../../data/types';
 
 export function BackupDetails( { backup, site }: { backup: ActivityLogEntry; site: Site } ) {
 	const router = useRouter();
+	const { backupState } = useBackupState( site.ID );
 	const formattedTime = useFormattedTime( backup.published, {
 		dateStyle: 'medium',
 		timeStyle: 'short',
@@ -37,6 +40,17 @@ export function BackupDetails( { backup, site }: { backup: ActivityLogEntry; sit
 			params: { siteSlug: site.slug, rewindId: backup.rewind_id },
 		} );
 	};
+
+	// Show backup progress when backup is active
+	if ( backupState !== 'default' ) {
+		return (
+			<Card>
+				<CardBody>
+					<SiteBackupProgress site={ site } />
+				</CardBody>
+			</Card>
+		);
+	}
 
 	return (
 		<Card>

--- a/client/dashboard/sites/backups/backup-details.tsx
+++ b/client/dashboard/sites/backups/backup-details.tsx
@@ -11,17 +11,14 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { rotateLeft, download } from '@wordpress/icons';
-import { useBackupState } from '../../app/hooks/site-backup-state';
 import { siteBackupRestoreRoute, siteBackupDownloadRoute } from '../../app/router/sites';
 import { useFormattedTime } from '../../components/formatted-time';
 import { SectionHeader } from '../../components/section-header';
 import { gridiconToWordPressIcon } from '../../utils/gridicons';
-import SiteBackupProgress from './backup-progress';
 import type { ActivityLogEntry, Site } from '../../data/types';
 
 export function BackupDetails( { backup, site }: { backup: ActivityLogEntry; site: Site } ) {
 	const router = useRouter();
-	const { backupState } = useBackupState( site.ID );
 	const formattedTime = useFormattedTime( backup.published, {
 		dateStyle: 'medium',
 		timeStyle: 'short',
@@ -40,17 +37,6 @@ export function BackupDetails( { backup, site }: { backup: ActivityLogEntry; sit
 			params: { siteSlug: site.slug, rewindId: backup.rewind_id },
 		} );
 	};
-
-	// Show backup progress when backup is active
-	if ( backupState !== 'default' ) {
-		return (
-			<Card>
-				<CardBody>
-					<SiteBackupProgress site={ site } />
-				</CardBody>
-			</Card>
-		);
-	}
 
 	return (
 		<Card>

--- a/client/dashboard/sites/backups/backup-progress.tsx
+++ b/client/dashboard/sites/backups/backup-progress.tsx
@@ -4,6 +4,8 @@ import {
 	__experimentalText as Text,
 	__experimentalSpacer as Spacer,
 	ProgressBar,
+	CardBody,
+	Card,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useEffect } from 'react';
@@ -51,25 +53,29 @@ function SiteBackupProgress( {
 
 	return (
 		<>
-			<VStack spacing={ 4 } alignment="center">
-				<img src={ backupProgressIllustration } alt="" width={ 408 } height={ 280 } />
-				<Text size={ 20 }>{ getMessage() }</Text>
-				<Text size={ 13 } variant="muted">
-					{ sprintf(
-						/* translators: %d is the backup completion percentage. */
-						__( '%d%% completed' ),
-						progress
-					) }
-				</Text>
-				<ProgressBar className="dashboard-backups__progress-bar" value={ progress } />
-			</VStack>
-			<Spacer marginTop={ 12 }>
-				<Notice variant="info" title={ __( 'Did you know?' ) }>
-					{ __(
-						'We store your site backups securely in the cloud, with multiple copies saved across our global server network, so you will never lose your content.'
-					) }
-				</Notice>
-			</Spacer>
+			<Card>
+				<CardBody>
+					<VStack spacing={ 4 } alignment="center">
+						<img src={ backupProgressIllustration } alt="" width={ 408 } height={ 280 } />
+						<Text size={ 20 }>{ getMessage() }</Text>
+						<Text size={ 13 } variant="muted">
+							{ sprintf(
+								/* translators: %d is the backup completion percentage. */
+								__( '%d%% completed' ),
+								progress
+							) }
+						</Text>
+						<ProgressBar className="dashboard-backups__progress-bar" value={ progress } />
+					</VStack>
+					<Spacer marginTop={ 12 }>
+						<Notice variant="info" title={ __( 'Did you know?' ) }>
+							{ __(
+								'We store your site backups securely in the cloud, with multiple copies saved across our global server network, so you will never lose your content.'
+							) }
+						</Notice>
+					</Spacer>
+				</CardBody>
+			</Card>
 		</>
 	);
 }

--- a/client/dashboard/sites/backups/backup-progress.tsx
+++ b/client/dashboard/sites/backups/backup-progress.tsx
@@ -8,38 +8,27 @@ import {
 	Card,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { useEffect } from 'react';
 import { siteBackupsQuery } from '../../app/queries/site-backups';
+import { useFormattedTime } from '../../components/formatted-time';
 import Notice from '../../components/notice';
 import backupProgressIllustration from './backups-progress-illustration.svg';
 import type { Site } from '../../data/types';
 
-function SiteBackupProgress( {
-	site,
-	onBackupComplete,
-	onBackupError,
-}: {
-	site: Site;
-	onBackupComplete?: () => void;
-	onBackupError?: () => void;
-} ) {
+function SiteBackupProgress( { site }: { site: Site } ) {
 	const { data: backups = [] } = useQuery( {
 		...siteBackupsQuery( site.ID ),
 		refetchInterval: 2000,
 	} );
 
 	const currentBackup = backups[ 0 ];
+
+	const backupDate = useFormattedTime( currentBackup.started, {
+		timeStyle: 'short',
+	} );
+
 	const isRunning = currentBackup?.status === 'started';
 	const isQueued = currentBackup?.status === 'queued';
 	const progress = currentBackup ? parseInt( currentBackup.percent, 10 ) : 0;
-
-	useEffect( () => {
-		if ( currentBackup?.status === 'finished' ) {
-			onBackupComplete?.();
-		} else if ( currentBackup?.status === 'error' ) {
-			onBackupError?.();
-		}
-	}, [ currentBackup?.status, onBackupComplete, onBackupError ] );
 
 	const getMessage = () => {
 		if ( isQueued ) {
@@ -55,9 +44,16 @@ function SiteBackupProgress( {
 		<>
 			<Card>
 				<CardBody>
-					<VStack spacing={ 4 } alignment="center">
+					<VStack spacing={ 2 } alignment="center">
 						<img src={ backupProgressIllustration } alt="" width={ 408 } height={ 280 } />
 						<Text size={ 20 }>{ getMessage() }</Text>
+						<Text size={ 13 } variant="muted">
+							{ sprintf(
+								/* translators: %s is the date the backup was initiated. */
+								__( 'We’re making a backup of your site from %s' ),
+								backupDate
+							) }
+						</Text>
 						<Text size={ 13 } variant="muted">
 							{ sprintf(
 								/* translators: %d is the backup completion percentage. */

--- a/client/dashboard/sites/backups/backup-progress.tsx
+++ b/client/dashboard/sites/backups/backup-progress.tsx
@@ -1,0 +1,77 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	__experimentalSpacer as Spacer,
+	ProgressBar,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { useEffect } from 'react';
+import { siteBackupsQuery } from '../../app/queries/site-backups';
+import Notice from '../../components/notice';
+import backupProgressIllustration from './backups-progress-illustration.svg';
+import type { Site } from '../../data/types';
+
+function SiteBackupProgress( {
+	site,
+	onBackupComplete,
+	onBackupError,
+}: {
+	site: Site;
+	onBackupComplete?: () => void;
+	onBackupError?: () => void;
+} ) {
+	const { data: backups = [] } = useQuery( {
+		...siteBackupsQuery( site.ID ),
+		refetchInterval: 2000,
+	} );
+
+	const currentBackup = backups[ 0 ];
+	const isRunning = currentBackup?.status === 'started';
+	const isQueued = currentBackup?.status === 'queued';
+	const progress = currentBackup ? parseInt( currentBackup.percent, 10 ) : 0;
+
+	useEffect( () => {
+		if ( currentBackup?.status === 'finished' ) {
+			onBackupComplete?.();
+		} else if ( currentBackup?.status === 'error' ) {
+			onBackupError?.();
+		}
+	}, [ currentBackup?.status, onBackupComplete, onBackupError ] );
+
+	const getMessage = () => {
+		if ( isQueued ) {
+			return __( 'Backup queued and will start shortly' );
+		}
+		if ( isRunning ) {
+			return __( 'Backup in progress' );
+		}
+		return __( 'Initializing the backup process' );
+	};
+
+	return (
+		<>
+			<VStack spacing={ 4 } alignment="center">
+				<img src={ backupProgressIllustration } alt="" width={ 408 } height={ 280 } />
+				<Text size={ 20 }>{ getMessage() }</Text>
+				<Text size={ 13 } variant="muted">
+					{ sprintf(
+						/* translators: %d is the backup completion percentage. */
+						__( '%d%% completed' ),
+						progress
+					) }
+				</Text>
+				<ProgressBar className="dashboard-backups__progress-bar" value={ progress } />
+			</VStack>
+			<Spacer marginTop={ 12 }>
+				<Notice variant="info" title={ __( 'Did you know?' ) }>
+					{ __(
+						'We store your site backups securely in the cloud, with multiple copies saved across our global server network, so you will never lose your content.'
+					) }
+				</Notice>
+			</Spacer>
+		</>
+	);
+}
+
+export default SiteBackupProgress;

--- a/client/dashboard/sites/backups/backups-list.tsx
+++ b/client/dashboard/sites/backups/backups-list.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useBackupState } from '../../app/hooks/site-backup-state';
 import { siteRewindableActivityLogEntriesQuery } from '../../app/queries/site-activity-log';
 import DataViewsCard from '../../components/dataviews-card';
@@ -26,7 +26,10 @@ export function BackupsList( {
 		perPage: 10,
 	} );
 
-	const { hasRecentlyCompleted } = useBackupState( site.ID );
+	// Track if user has manually selected something during active backup
+	const hasManualSelectionRef = useRef( false );
+
+	const { backupState, hasRecentlyCompleted } = useBackupState( site.ID );
 
 	const { data: activityLog = [], isLoading: isLoadingActivityLog } = useQuery( {
 		...siteRewindableActivityLogEntriesQuery( site.ID ),
@@ -37,17 +40,31 @@ export function BackupsList( {
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( activityLog, view, fields );
 
 	useEffect( () => {
-		if ( ! isLoadingActivityLog && activityLog.length > 0 && ! selectedBackup ) {
-			const firstBackup = activityLog[ 0 ];
-			setSelectedBackup( firstBackup );
+		if ( ! isLoadingActivityLog && activityLog.length > 0 ) {
+			// Unselect item when backup becomes active (to show progress view), but only if user hasn't manually selected
+			if ( backupState !== 'default' && selectedBackup && ! hasManualSelectionRef.current ) {
+				setSelectedBackup( null );
+			}
+
+			// Auto-select first item when no item is selected and no backup is active
+			else if ( ! selectedBackup && backupState === 'default' ) {
+				setSelectedBackup( activityLog[ 0 ] );
+				hasManualSelectionRef.current = false; // Reset manual selection flag
+			}
 		}
-	}, [ isLoadingActivityLog, activityLog, selectedBackup, setSelectedBackup ] );
+	}, [ isLoadingActivityLog, activityLog, selectedBackup, setSelectedBackup, backupState ] );
 
 	const onChangeSelection = ( selection: string[] ) => {
 		const backup =
 			selection.length > 0
 				? activityLog.find( ( item ) => item.activity_id === selection[ 0 ] ) || null
 				: null;
+
+		// Mark that user has made a manual selection during active backup
+		if ( backupState !== 'default' ) {
+			hasManualSelectionRef.current = true;
+		}
+
 		setSelectedBackup( backup );
 	};
 

--- a/client/dashboard/sites/backups/backups-progress-illustration.svg
+++ b/client/dashboard/sites/backups/backups-progress-illustration.svg
@@ -1,0 +1,28 @@
+<svg width="408" height="280" viewBox="0 0 408 280" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="408" height="280" fill="white"/>
+<rect x="82" y="43" width="189" height="126" rx="6" fill="white" stroke="#F0F0F0"/>
+<rect x="96" y="57" width="189" height="126" rx="6" fill="white" stroke="#DDDDDD"/>
+<rect x="110" y="71" width="189" height="126" rx="6" fill="white" stroke="url(#paint0_linear_5264_1413)"/>
+<circle cx="124" cy="85" r="3" stroke="#3858E9"/>
+<circle cx="136" cy="85" r="3" stroke="#3858E9"/>
+<circle cx="148" cy="85" r="3" stroke="#3858E9"/>
+<path d="M233.911 128.817C233.911 115.285 222.555 105 207.958 105C196.063 105 185.79 112.578 183.088 122.862H182.008C171.191 122.862 162 132.063 162 143.432C162 154.8 171.191 164 182.006 164H230.666C240.399 164 247.968 155.88 247.968 146.138C248.51 137.478 242.022 130.442 233.911 128.817Z" stroke="url(#paint1_linear_5264_1413)"/>
+<rect x="194" y="156" width="22" height="15" fill="white"/>
+<path d="M193.686 146L204.293 135.393C204.683 135.003 205.317 135.003 205.707 135.393L216.314 146" stroke="#3858E9" stroke-linecap="round"/>
+<path d="M327 230H211C207.686 230 205 227.314 205 224V135" stroke="url(#paint2_linear_5264_1413)" stroke-linecap="round"/>
+<circle cx="263" cy="230" r="8" fill="#069E08"/>
+<defs>
+<linearGradient id="paint0_linear_5264_1413" x1="123.263" y1="121.4" x2="282.468" y2="122.198" gradientUnits="userSpaceOnUse">
+<stop stop-color="#3858E9"/>
+<stop offset="1" stop-color="#069E08"/>
+</linearGradient>
+<linearGradient id="paint1_linear_5264_1413" x1="168.035" y1="128.6" x2="240.477" y2="128.953" gradientUnits="userSpaceOnUse">
+<stop stop-color="#3858E9"/>
+<stop offset="1" stop-color="#069E08"/>
+</linearGradient>
+<linearGradient id="paint2_linear_5264_1413" x1="213.256" y1="173.4" x2="306.335" y2="173.758" gradientUnits="userSpaceOnUse">
+<stop stop-color="#3858E9"/>
+<stop offset="1" stop-color="#069E08"/>
+</linearGradient>
+</defs>
+</svg>

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -4,6 +4,7 @@ import { __experimentalGrid as Grid, __experimentalText as Text } from '@wordpre
 import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 import { useState } from 'react';
+import { useBackupState } from '../../app/hooks/site-backup-state';
 import { siteBySlugQuery } from '../../app/queries/site';
 import { siteRoute } from '../../app/router/sites';
 import { Callout } from '../../components/callout';
@@ -15,6 +16,7 @@ import { HostingFeatures } from '../../data/constants';
 import { hasHostingFeature } from '../../utils/site-features';
 import { BackupDetails } from './backup-details';
 import { BackupNowButton } from './backup-now-button';
+import BackupProgress from './backup-progress';
 import illustrationUrl from './backups-callout-illustration.svg';
 import { BackupsList } from './backups-list';
 import './style.scss';
@@ -63,6 +65,8 @@ export function BackupsListPage() {
 	const [ selectedBackup, setSelectedBackup ] = useState< ActivityLogEntry | null >( null );
 
 	const hasBackups = hasHostingFeature( site, HostingFeatures.BACKUPS );
+	const { backupState } = useBackupState( site.ID );
+	const isRunningBackup = backupState !== 'default';
 
 	return (
 		<PageLayout
@@ -80,7 +84,8 @@ export function BackupsListPage() {
 						selectedBackup={ selectedBackup }
 						setSelectedBackup={ setSelectedBackup }
 					/>
-					{ selectedBackup && <BackupDetails backup={ selectedBackup } site={ site } /> }
+					{ selectedBackup ? <BackupDetails backup={ selectedBackup } site={ site } /> : null }
+					{ ! selectedBackup && isRunningBackup ? <BackupProgress site={ site } /> : null }
 				</Grid>
 			) }
 		</PageLayout>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-290

## Proposed Changes

* Implement backup progress display in the dashboard

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
