### PR TITLE
A4A > Marketplace: Fix Premier Agency Hosting & Premium Plans responsiveness

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hero-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hero-section/style.scss
@@ -8,12 +8,16 @@ $tab-background-selected: var(--color-surface);
 .hosting-hero-section {
 	max-width: 1500px;
 	margin-inline: auto;
-	padding: 24px 32px 0;
+	padding: 24px 16px 0;
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
 	gap: 39px;
 	transition: height .25s ease-out;
+
+	@include break-medium {
+		padding-inline: 32px;
+	}
 
 	.a4a-migration-offer-v3,
 	.pressable-premium-plan-migration {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/common/hosting-plan-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/common/hosting-plan-section/style.scss
@@ -48,7 +48,7 @@
 .hosting-plan-section__main {
 	border-radius: 8px;
 	background-color: var( --color-primary-0 );
-	padding: 24px;
+	padding: 8px;
 	max-width: 100%;
 	overflow: hidden;
 
@@ -72,10 +72,14 @@
 .hosting-plan-section__card {
 	border-radius: 8px;
 	box-shadow: 0 3px 1px 0 #0000000a;
-	padding: 32px;
+	padding: 16px;
 	background-color: var( --color-surface );
 	max-width: 100%;
 	overflow: hidden;
+
+	@include break-medium {
+		padding: 32px;
+	}
 }
 
 .hosting-plan-section__details {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/style.scss
@@ -74,10 +74,18 @@
 
 .premium-plan-section__cta-buttons {
 	@extend .flex-column-gap-16;
+
+	.components-button.premium-plan-section__cta-button {
+		white-space: normal;
+		text-align: center;
+	}
 }
 
 .premium-plan-section__two-columns-list {
 	display: grid;
-	grid-template-rows: repeat(6, 1fr);
-	grid-auto-flow: column;
+
+	@include break-wide {
+		grid-template-rows: repeat(6, 1fr);
+		grid-auto-flow: column;
+	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/style.scss
@@ -28,6 +28,15 @@
 		button {
 			flex: 1;
 			margin: 0 7px;
+			min-width: 200px;
+
+			@include break-mobile {
+				min-width: 300px;
+			}
+
+			@include break-large {
+				min-width: unset;
+			}
 
 			&:hover {
 				background-color: initial;

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { useMobileBreakpoint } from '@automattic/viewport-react';
+import { useMobileBreakpoint, useDesktopBreakpoint } from '@automattic/viewport-react';
 import { RadioControl, TabPanel } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -55,6 +55,7 @@ export default function PlanSelectionFilter( {
 	const [ disableStandardTab, setDisableStandardTab ] = useState( false );
 
 	const isMobile = useMobileBreakpoint();
+	const isDesktop = useDesktopBreakpoint();
 
 	const isPremiumPlanTab = selectedTab === PLAN_CATEGORY_PREMIUM;
 
@@ -189,35 +190,39 @@ export default function PlanSelectionFilter( {
 				? [
 						{
 							name: PLAN_CATEGORY_SIGNATURE,
-							title: translate( 'Signature Plans 1-10' ),
+							title: isDesktop
+								? translate( 'Signature Plans 1-10' )
+								: translate( 'Signature 1-10' ),
 							disabled: disableStandardTab,
 						},
 						{
 							name: PLAN_CATEGORY_SIGNATURE_HIGH,
-							title: translate( 'Signature Plans 11-17' ),
+							title: isDesktop
+								? translate( 'Signature Plans 11-17' )
+								: translate( 'Signature 11-17' ),
 						},
 				  ]
 				: [
 						{
 							name: PLAN_CATEGORY_STANDARD,
-							title: translate( 'Signature Plans' ),
+							title: isDesktop ? translate( 'Signature Plans' ) : translate( 'Signature' ),
 							disabled: disableStandardTab,
 						},
 						{
 							name: PLAN_CATEGORY_ENTERPRISE,
-							title: translate( 'Enterprise Plans' ),
+							title: isDesktop ? translate( 'Enterprise Plans' ) : translate( 'Enterprise' ),
 						},
 				  ] ),
 			...( isPressablePremiumPlanEnabled
 				? [
 						{
 							name: PLAN_CATEGORY_PREMIUM,
-							title: translate( 'Premium Plans' ),
+							title: isDesktop ? translate( 'Premium Plans' ) : translate( 'Premium' ),
 						},
 				  ]
 				: [] ),
 		],
-		[ areSignaturePlans, disableStandardTab, isPressablePremiumPlanEnabled, translate ]
+		[ areSignaturePlans, disableStandardTab, isPressablePremiumPlanEnabled, translate, isDesktop ]
 	);
 
 	if ( isLoading ) {


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1476/fix-the-mobile-view-for-premium-plans-section

## Proposed Changes

This PR fixes the responsiveness of the "Premier Agency Hosting" & "Premium Plans" sections.

## Why are these changes being made?

* To fix the responsiveness of the "Premier Agency Hosting" & "Premium Plans" sections.

## Testing Instructions

* Open the A4A live link
* Go to Marketplace: Premier Agency Hosting > Click the "Premium Plans" tab > Verify it looks good on all the screens. Also, verify the plan names are updated on small screens:

Large screen:

<img width="1920" height="747" alt="Screenshot 2025-08-26 at 9 03 35 AM" src="https://github.com/user-attachments/assets/cc8a1d45-fe51-4c44-a98c-0ea0f69f8bd2" />

Mobile screen:

<img width="236" height="625" alt="Screenshot 2025-08-26 at 9 01 07 AM" src="https://github.com/user-attachments/assets/fd7fd3f8-64ee-4f75-ab28-0017c8ebe558" />

Tablet screen:

<img width="382" height="652" alt="Screenshot 2025-08-26 at 9 02 50 AM" src="https://github.com/user-attachments/assets/4983cd2e-1474-40bb-8265-fb18f9121393" />

* Toggle the refer mode > Verify the plan names are updated on small screens:

Large screen: 

<img width="1919" height="755" alt="Screenshot 2025-08-26 at 9 19 35 AM" src="https://github.com/user-attachments/assets/08fd1c37-d4e8-4e24-ae2e-ef1c3fd45a41" />

Mobile screen:

<img width="254" height="400" alt="Screenshot 2025-08-26 at 9 18 16 AM" src="https://github.com/user-attachments/assets/52dadd7f-3be8-4557-b962-59fd94aa8418" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
