### PR TITLE
A4A: Display Pressable migration card & banners only for agencies with > 50 sites

### DIFF
--- a/client/a8c-for-agencies/components/pressable-premium-plan-migration/banner/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-premium-plan-migration/banner/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { formatCurrency } from '@automattic/number-formatters';
 import { Button } from '@wordpress/components';
 import { Icon, chevronDown } from '@wordpress/icons';
@@ -13,6 +12,7 @@ import {
 import MigrationIncentiveIcon from 'calypso/assets/images/a8c-for-agencies/migration-incentive-icon.svg';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { useShowMigrationIncentive } from '../hook/use-show-migration-incentive';
 
 import './style.scss';
 
@@ -24,13 +24,13 @@ export default function PressablePremiumPlanMigrationBanner( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const isFeatureEnabled = isEnabled( 'pressable-premium-plan' );
-
 	const [ isExpanded, setIsExpanded ] = useState( true );
 
 	const onToggleView = useCallback( () => {
 		setIsExpanded( ( isExpanded ) => ! isExpanded );
 	}, [] );
+
+	const showMigrationIncentive = useShowMigrationIncentive();
 
 	const handleReferClient = useCallback( () => {
 		dispatch(
@@ -77,7 +77,7 @@ export default function PressablePremiumPlanMigrationBanner( {
 		</span>
 	);
 
-	if ( ! isFeatureEnabled ) {
+	if ( ! showMigrationIncentive ) {
 		return null;
 	}
 

--- a/client/a8c-for-agencies/components/pressable-premium-plan-migration/card/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-premium-plan-migration/card/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { formatCurrency } from '@automattic/number-formatters';
 import { Card, Button } from '@wordpress/components';
 import { close } from '@wordpress/icons';
@@ -12,6 +11,7 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
+import { useShowMigrationIncentive } from '../hook/use-show-migration-incentive';
 
 import './style.scss';
 
@@ -23,7 +23,7 @@ export default function PressablePremiumPlanMigrationCard() {
 
 	const isDismissed = useSelector( ( state ) => getPreference( state, DISMISSED_PREFERENCE ) );
 
-	const isFeatureEnabled = isEnabled( 'pressable-premium-plan' );
+	const showMigrationIncentive = useShowMigrationIncentive();
 
 	const onDismiss = useCallback( () => {
 		dispatch(
@@ -47,7 +47,7 @@ export default function PressablePremiumPlanMigrationCard() {
 		// TODO: Add chat to us logic
 	}, [ dispatch ] );
 
-	if ( isDismissed || ! isFeatureEnabled ) {
+	if ( isDismissed || ! showMigrationIncentive ) {
 		return null;
 	}
 

--- a/client/a8c-for-agencies/components/pressable-premium-plan-migration/card/style.scss
+++ b/client/a8c-for-agencies/components/pressable-premium-plan-migration/card/style.scss
@@ -51,3 +51,7 @@ $pressable-card-background: #050C29;
 .is-light svg {
 	fill: var(--color-text-white);
 }
+
+.is-light svg {
+	fill: var(--color-text-white);
+}

--- a/client/a8c-for-agencies/components/pressable-premium-plan-migration/card/style.scss
+++ b/client/a8c-for-agencies/components/pressable-premium-plan-migration/card/style.scss
@@ -51,7 +51,3 @@ $pressable-card-background: #050C29;
 .is-light svg {
 	fill: var(--color-text-white);
 }
-
-.is-light svg {
-	fill: var(--color-text-white);
-}

--- a/client/a8c-for-agencies/components/pressable-premium-plan-migration/hook/use-show-migration-incentive.ts
+++ b/client/a8c-for-agencies/components/pressable-premium-plan-migration/hook/use-show-migration-incentive.ts
@@ -1,0 +1,17 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+export function useShowMigrationIncentive() {
+	const isFeatureEnabled = isEnabled( 'pressable-premium-plan' );
+
+	const agency = useSelector( getActiveAgency );
+	const numberSites = agency?.signup_meta?.number_sites;
+
+	// Show the migration incentive if the agency has 51-100 sites.
+	// Also, show if the agency has not set the number of sites.
+	// This is to handle old signups without the number_sites field.
+	const showMigrationIncentive = numberSites === '51-100' || numberSites === '';
+
+	return isFeatureEnabled && showMigrationIncentive;
+}


### PR DESCRIPTION
This PR is built on top of https://github.com/Automattic/wp-calypso/pull/105326

Resolves https://linear.app/a8c/issue/A4A-1490/show-the-banner-and-card-only-if-the-agency-has-reported-to-manage-50

## Proposed Changes

* This PR implements changes to display the Pressable migration card & banners only for agencies with > 50 sites. We will also display this if the number of sites is set to empty to accommodate older signups. 

## Why are these changes being made?

* To show the Pressable migration card & banners only for agencies with > 50 sites. 

## Testing Instructions

* You might have to start the server locally to test it, as the new sign-ups don't work on the live links.
* Verify the [card](https://github.com/Automattic/wp-calypso/pull/105326) and [banners](https://github.com/Automattic/wp-calypso/pull/105323) are displayed for your agency. This is displayed because your agency is old and doesn't have the `number_sites` in the /agency endpoint. You can check the API response to verify this.
* Sign up to A4A using a new account, select "51-100" as the number of sites in the sign-up form. 
* Verify the [card](https://github.com/Automattic/wp-calypso/pull/105326) and [banners](https://github.com/Automattic/wp-calypso/pull/105323) are displayed for your agency. This is displayed because your agency reported having "51-100" sites. You can check the API response to verify this.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
