### PR TITLE
Experiment streamlining the plans grid + checkout: Restrict solution for the onboarding-pm flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -229,7 +229,7 @@ function UnifiedPlansStep( {
 		getCurrentUserSiteCount( state ) ? '/sites/' : null
 	);
 	const [ isStreamlinedPriceExperimentLoading, streamlinedPriceExperimentAssignment ] =
-		useStreamlinedPriceExperiment();
+		useStreamlinedPriceExperiment( flowName );
 
 	useSiteGlobalStylesOnPersonal();
 

--- a/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
@@ -3,16 +3,19 @@ import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 
-export function useStreamlinedPriceExperiment(): [ boolean, string | null ] {
-	const variationName = isEligibleForExperiment() ? 'plans_1Y_checkout_radio' : null;
+export function useStreamlinedPriceExperiment(
+	flowName?: string | null
+): [ boolean, string | null ] {
+	const variationName = isEligibleForExperiment( flowName ) ? 'plans_1Y_checkout_radio' : null;
 
 	return [ false, variationName ];
 }
 
-function isEligibleForExperiment(): boolean {
+function isEligibleForExperiment( flowName?: string | null ): boolean {
 	const flowFromStorage = getSignupCompleteFlowName(); // The flow for the Checkout page
 	const flowFromURL = getFlowFromURL(); // The flow for the Plans step
-	const flow = flowFromStorage || flowFromURL;
+	const flow = flowName || flowFromStorage || flowFromURL;
+
 	// Only onboarding flow is eligible for streamlined pricing. Akismet/Jetpack checkouts are excluded as well.
 	return flow !== 'onboarding-pm' && ! isAkismetCheckout() && ! isJetpackCheckout();
 }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -478,12 +478,20 @@ const PlansFeaturesMain = ( {
 	const showStreamlinedPriceExperiment =
 		isInSignup && isStreamlinedPricePlansTreatment( streamlinedPriceExperimentAssignment );
 
-	let hidePlanSelector = false;
-	const enableTermSavingsPriceDisplay = true;
+	let hidePlanSelector = true;
+	let enableTermSavingsPriceDisplay = true;
 	// In the "purchase a plan and free domain" flow we do not want to show
 	// monthly plans because monthly plans do not come with a free domain.
-	if ( redirectToAddDomainFlow !== undefined || hidePlanTypeSelector ) {
-		hidePlanSelector = true;
+	// We are also hiding the plan interval selector and showing terms savings prices
+	// for the compatible streamlined price experiment variations.
+	if (
+		redirectToAddDomainFlow === undefined &&
+		! hidePlanTypeSelector &&
+		! isStreamlinedPriceExperimentLoading &&
+		! showStreamlinedPriceExperiment
+	) {
+		hidePlanSelector = false;
+		enableTermSavingsPriceDisplay = false;
 	}
 
 	let _customerType = chooseDefaultCustomerType( {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -473,7 +473,7 @@ const PlansFeaturesMain = ( {
 	);
 
 	const [ isStreamlinedPriceExperimentLoading, streamlinedPriceExperimentAssignment ] =
-		useStreamlinedPriceExperiment();
+		useStreamlinedPriceExperiment( flowName );
 
 	const showStreamlinedPriceExperiment =
 		isInSignup && isStreamlinedPricePlansTreatment( streamlinedPriceExperimentAssignment );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTOBRD-288](https://linear.app/a8c/issue/DOTOBRD-288/implement-the-winning-variation-on-all-flows-except-onboarding-pm)

## Proposed Changes

* follow-up fix for https://github.com/Automattic/wp-calypso/pull/105338 where the streamlined pricing is not restricted on the `onboarding-pm` flow

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/onboarding/plans`
* You should see the streamlined pricing
<img width="1503" height="1265" alt="Screenshot 2025-08-26 at 11 25 31" src="https://github.com/user-attachments/assets/4593693b-d50d-4c8a-8df0-197d7b8389ac" />

* Go to `/start/onboarding-pm/plans`
* You should not see the streamlined pricing
<img width="1503" height="1271" alt="Screenshot 2025-08-26 at 11 20 54" src="https://github.com/user-attachments/assets/588bf469-0b24-4ac0-a265-f80f23d8083f" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
